### PR TITLE
Implement function to convert an existing DataTable to Pandas DataFrame

### DIFF
--- a/c/datatable_rbind.c
+++ b/c/datatable_rbind.c
@@ -56,6 +56,7 @@ dt_rbind(DataTable *dt, DataTable **dts, int **cols, int ndts, int ncols)
             col->alloc_size = 0;
             col->stype = 0;
             col->mtype = MT_DATA;
+            col->refcount = 1;
             for (int j = 0; j < ndts; j++) {
                 if (cols[i][j] >= 0) {
                     col->stype = dts[j]->columns[cols[i][j]]->stype;

--- a/c/datatablemodule.c
+++ b/c/datatablemodule.c
@@ -103,6 +103,7 @@ PyObject *dt_from_memmap(UU, PyObject *args)
         dt->columns[i]->mtype = MT_MMAP;
         dt->columns[i]->meta = NULL;
         dt->columns[i]->alloc_size = (size_t) filesize;
+        dt->columns[i]->refcount = 1;
     }
 
     dt->nrows = nrows;


### PR DESCRIPTION
This is only an initial implementation. There are several drawbacks:
  * NAs within boolean columns do not work properly
  * within real columns, NAs get converted to NaNs
  * for integer columns, NAs become float NaNs as well, and the column is cast to float type (this is a drawback of Pandas)
  * string columns cannot be converted
  * currently view datatables do not get converted correctly (requires fixing #55 first)
  * conversion to Numpy works reasonably well, but then Pandas makes a full copy of the input anyways (which is slow). On Stackoverflow they suggest there is no way around it (short of fixing Pandas itself). Which is not going to happen since Pandas does copies for every operation anyways, so who cares about yet another one...

Closes #59 