### PR TITLE
Make gaps in structure definitions explicit; eliminate warnings stemming from Python.h include files; restore warnings -Wpadded and -Wreserved-id-macro

### DIFF
--- a/c/column.h
+++ b/c/column.h
@@ -50,6 +50,7 @@ typedef struct Column {
     int     refcount;    // 4
     MType   mtype;       // 1
     SType   stype;       // 1
+    int16_t _padding;    // 2
 } Column;
 
 

--- a/c/fread.h
+++ b/c/fread.h
@@ -60,6 +60,23 @@ typedef struct freadMainArgs
   // with `filename`.
   const char *input;
 
+  // Maximum number of rows to read, or INT64_MAX to read the entire dataset.
+  // Note that even if `nrowLimit = 0`, fread() will scan a sample of rows in
+  // the file to detect column names and types (and other parsing settings).
+  int64_t nrowLimit;
+
+  // Number of input lines to skip when reading the file.
+  int64_t skipNrow;
+
+  // Skip to the line containing this string. This parameter cannot be used
+  // with `skipLines`.
+  const char *skipString;
+
+  // NULL-terminated list of strings that should be converted into NA values.
+  // The last entry in this array is NULL (sentinel), which lets us know where
+  // the array ends.
+  const char * const* NAstrings;
+
   // Character to use for a field separator. Multi-character separators are not
   // supported. If `sep` is '\0', then fread will autodetect it. A quotation
   // mark '"' is not allowed as field separator.
@@ -80,23 +97,6 @@ typedef struct freadMainArgs
   // Is there a header at the beginning of the file?
   // 0 = no, 1 = yes, -128 = autodetect
   int8_t header;
-
-  // Maximum number of rows to read, or INT64_MAX to read the entire dataset.
-  // Note that even if `nrowLimit = 0`, fread() will scan a sample of rows in
-  // the file to detect column names and types (and other parsing settings).
-  int64_t nrowLimit;
-
-  // Number of input lines to skip when reading the file.
-  int64_t skipNrow;
-
-  // Skip to the line containing this string. This parameter cannot be used
-  // with `skipLines`.
-  const char *skipString;
-
-  // NULL-terminated list of strings that should be converted into NA values.
-  // The last entry in this array is NULL (sentinel), which lets us know where
-  // the array ends.
-  const char * const* NAstrings;
 
   // Strip the whitespace from fields (usually True).
   _Bool stripWhite;
@@ -126,6 +126,7 @@ typedef struct freadMainArgs
   // leaks would occur.
   _Bool warningsAreErrors;
 
+  char _padding[2];
 
   // Any additional implementation-specific parameters.
   EXTRA_FIELDS

--- a/c/rowmapping.h
+++ b/c/rowmapping.h
@@ -47,13 +47,14 @@ typedef enum RowMappingType {
  *     do simple addition `start + step`.
  */
 typedef struct RowMapping {
-    RowMappingType type;
     int64_t length;
     union {
         int32_t *ind32;
         int64_t *ind64;
         struct { int64_t start, step; } slice;
     };
+    RowMappingType type;
+    int32_t _padding;
 } RowMapping;
 
 

--- a/c/types.c
+++ b/c/types.c
@@ -78,7 +78,7 @@ void init_types(void)
     NA_F8 = ((_dbl){ .i = NA_F8_BITS }).f;
 
     #define STI(T, code, csize, msize, vw, ltype, na) \
-        stype_info[T] = (STypeInfo){code, csize, msize, vw, ltype, na}
+        stype_info[T] = (STypeInfo){csize, msize, na, code, ltype, vw, 0}
     STI(ST_VOID,              "---", 0, 0,                   0, 0,           NULL);
     STI(ST_BOOLEAN_I1,        "i1b", 1, 0,                   0, LT_BOOLEAN,  &NA_I1);
     STI(ST_INTEGER_I1,        "i1i", 1, 0,                   0, LT_INTEGER,  &NA_I1);

--- a/c/types.h
+++ b/c/types.h
@@ -356,12 +356,13 @@ typedef enum SType {
  *
  */
 typedef struct STypeInfo {
-    char        code[4];
     size_t      elemsize;
     size_t      metasize;
-    _Bool       varwidth;
-    LType       ltype;
     const void *na;
+    char        code[4];
+    LType       ltype;
+    _Bool       varwidth;
+    int16_t     _padding;
 } STypeInfo;
 
 extern STypeInfo stype_info[DT_STYPES_COUNT];
@@ -406,6 +407,7 @@ typedef struct EnumMeta {     // ST_STRING_UX_ENUM
     int64_t offoff;
     int64_t dataoff;
     int32_t nlevels;
+    char _padding[4];
 } EnumMeta;
 
 

--- a/c/utils.h
+++ b/c/utils.h
@@ -74,12 +74,12 @@ float max_f4(float a, float b);
  **/
 #define dtmalloc(ptr, T, n) do {                                               \
     ptr = (T*) _dt_malloc((size_t)(n) * SIZEOF(T));                            \
-    if (ptr == _NULL) return _NULL;                                            \
+    if (ptr == zNULL) return zNULL;                                            \
 } while(0)
 
 #define dtmalloc_g(ptr, T, n) do {                                             \
     ptr = (T*) _dt_malloc((size_t)(n) * SIZEOF(T));                            \
-    if (ptr == _NULL) goto fail;                                               \
+    if (ptr == zNULL) goto fail;                                               \
 } while(0)
 
 
@@ -98,12 +98,12 @@ float max_f4(float a, float b);
  */
 #define dtrealloc(ptr, T, n) do {                                              \
     ptr = (T*) _dt_realloc(ptr, (size_t)(n) * SIZEOF(T));                      \
-    if (ptr == _NULL) return _NULL;                                            \
+    if (ptr == zNULL) return zNULL;                                            \
 } while(0)
 
 #define dtrealloc_g(ptr, T, n) do {                                            \
     ptr = (T*) _dt_realloc(ptr, (size_t)(n) * SIZEOF(T));                      \
-    if (ptr == _NULL) goto fail;                                               \
+    if (ptr == zNULL) goto fail;                                               \
 } while(0)
 
 
@@ -113,12 +113,12 @@ float max_f4(float a, float b);
  */
 #define dtcalloc(ptr, T, n) do {                                               \
     ptr = (T*) _dt_calloc((size_t)(n), SIZEOF(T));                             \
-    if (ptr == _NULL) return _NULL;                                            \
+    if (ptr == zNULL) return zNULL;                                            \
 } while(0)
 
 #define dtcalloc_g(ptr, T, n) do {                                             \
     ptr = (T*) _dt_calloc((size_t)(n), SIZEOF(T));                             \
-    if (ptr == _NULL) goto fail;                                               \
+    if (ptr == zNULL) goto fail;                                               \
 } while(0)
 
 
@@ -129,7 +129,7 @@ float max_f4(float a, float b);
  **/
 #define dtfree(ptr) do {                                                       \
     _dt_free(ptr);                                                             \
-    ptr = _NULL;                                                               \
+    ptr = zNULL;                                                               \
 } while(0)
 
 
@@ -150,9 +150,9 @@ void* _dt_malloc(size_t n);
 void* _dt_realloc(void *ptr, size_t n);
 void  _dt_free(void *ptr);
 #ifdef __cplusplus
-    #define _NULL nullptr
+    #define zNULL nullptr
 #else
-    #define _NULL NULL
+    #define zNULL NULL
 #endif
 
 

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ Build script for the `datatable` module.
 import os
 import re
 import subprocess
+import sysconfig
 from setuptools import setup, find_packages
 from distutils.core import Extension
 
@@ -72,7 +73,11 @@ else:
                        "http://releases.llvm.org/download.html#4.0.0")
 
 # Compiler
-os.environ["CC"] = clang + " -fopenmp"
+os.environ["CC"] = clang + " -fopenmp "
+if sysconfig.get_config_var("CONFINCLUDEPY"):
+    # Marking this directory as "isystem" prevents Clang from issuing warnings
+    # for those files
+    os.environ["CC"] += "-isystem " + sysconfig.get_config_var("CONFINCLUDEPY")
 # Linker flags
 os.environ["LDFLAGS"] = "-L%s -Wl,-rpath,%s" % (libs, libs)
 # Force to build for a 64-bit platform only
@@ -85,8 +90,6 @@ os.environ["LLVM_CONFIG"] = llvm_config
 # Settings for building the extension
 #-------------------------------------------------------------------------------
 # Ignored warnings:
-#   -Wreserved-id-macro : triggers for python internals
-#   -Wpadded: warning about gaps in a struct, which are normal
 #   -Wpointer-arith: this warns about treating (void*) as
 #       (char*), which is a GNU extension. However since we
 #       only ever want to compile in GCC / CLang, such use is
@@ -103,8 +106,6 @@ os.environ["LLVM_CONFIG"] = llvm_config
 #       does not suffer from this drawback.
 extra_compile_args = [
     "-Weverything",
-    "-Wno-reserved-id-macro",
-    "-Wno-padded",
     "-Wno-pointer-arith",
     "-Wno-covered-switch-default",
     "-Wno-float-equal",


### PR DESCRIPTION
Closes #56