### PR TITLE
Handle non-ASCII strings in fread

### DIFF
--- a/c/datatablemodule.c
+++ b/c/datatablemodule.c
@@ -3,6 +3,7 @@
 #include "py_columnset.h"
 #include "py_datatable.h"
 #include "py_datawindow.h"
+#include "py_encodings.h"
 #include "py_fread.h"
 #include "py_rowmapping.h"
 #include "py_types.h"
@@ -188,6 +189,7 @@ PyInit__datatable(void) {
     if (!init_py_types(m)) return NULL;
     if (!init_py_column(m)) return NULL;
     if (!init_py_columnset(m)) return NULL;
+    if (!init_py_encodings(m)) return NULL;
 
     return m;
 }

--- a/c/encodings.c
+++ b/c/encodings.c
@@ -1,0 +1,96 @@
+#include <string.h>
+#include "encodings.h"
+
+
+
+/**
+ * Decode a string from the provided single-byte character set. On success
+ * writes the UTF-8-encoded string to `dest` and returns the length of the new
+ * string in bytes. On failure returns -1 - length of the string that was
+ * succesfully encoded until the error occurred.
+ *
+ * @param src
+ *     Memory buffer containing byte-string in a SBCS code page given by `map`.
+ *
+ * @param len
+ *     Length of the byte-string `src`, in bytes.
+ *
+ * @param dest
+ *     Memory buffer where the decoded UTF-8 string will be written. This buffer
+ *     should be preallocated to allow writing of at least `len * 3` bytes
+ *     (worst-case scenario).
+ *
+ * @param map
+ *     Mapping of all 256 byte values in this SBCS into UTF-8 bytes represented
+ *     as `uint32_t` constants. The following assumption about this mapping are
+ *     made: values 0-127 are mapped to themselves; if some value in the range
+ *     128-255 maps to 0 it means this byte is invalid in this code page; all
+ *     values in the range 128-255 map to either 2- or 3-byte-long UTF-8 byte
+ *     sequences.
+ */
+int decode_sbcs(
+    const unsigned char *restrict src, int len,
+    unsigned char *restrict dest, uint32_t *map
+) {
+    const unsigned char *end = src + len;
+    unsigned char *d = dest;
+    for (; src < end; src++) {
+        unsigned char ch = *src;
+        if (ch < 0x80) {
+            *d++ = ch;
+        } else {
+            uint32_t m = map[ch];
+            if (m == 0) return -(int)(1 + d - dest);
+            int s = 2 + ((m & 0xFF0000) != 0);
+            memcpy(d, &m, s);
+            d += s;
+        }
+    }
+    return (int)(d - dest);
+}
+
+
+/**
+ * Check whether the memory buffer contains a valid UTF-8 string.
+ */
+int is_valid_utf8(const unsigned char *restrict src, size_t len)
+{
+    const unsigned char *ch = src;
+    const unsigned char *end = src + len;
+    while (ch < end) {
+        unsigned char c = *ch;
+        if (c < 0x80) {
+            ch++;
+        } else {
+            unsigned char cc = ch[1];
+            if ((c & 0xE0) == 0xC0) {
+                // 110xxxxx 10xxxxxx
+                if ((cc & 0xC0) != 0x80 ||
+                    (c & 0xFE) == 0xC0)
+                    return 0;
+                ch += 2;
+            } else if ((c & 0xF0) == 0xE0) {
+                // 1110xxxx 10xxxxxx 10xxxxxx
+                if ((cc & 0xC0) != 0x80 ||
+                    (ch[2] & 0xC0) != 0x80 ||
+                    (c == 0xE0 && (cc & 0xE0) == 0x80) ||  // overlong
+                    (c == 0xED && (cc & 0xE0) == 0xA0) ||  // surrogate
+                    (c == 0xEF && cc == 0xBF && (ch[2] & 0xFE) == 0xBE))
+                    return 0;
+                ch += 3;
+            } else if ((c & 0xF8) == 0xF0) {
+                // 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
+                if ((cc & 0xC0) != 0x80 ||
+                    (ch[2] & 0xC0) != 0x80 ||
+                    (ch[3] & 0xC0) != 0x80 ||
+                    (c == 0xF0 && (cc & 0xF0) == 0x80) ||  // overlong
+                    (c == 0xF4 && cc > 0x8F) ||  // unmapped
+                    c > 0xF4)
+                    return 0;
+                ch += 4;
+            } else
+                return 0;
+        }
+    }
+    return (ch == end);
+}

--- a/c/encodings.h
+++ b/c/encodings.h
@@ -1,0 +1,11 @@
+#ifndef dt_ENCODINGS_H
+#define dt_ENCODINGS_H
+#include <stdint.h>
+
+
+int is_valid_utf8(const unsigned char *restrict src, size_t len);
+
+int decode_sbcs(const unsigned char *restrict src, int len,
+                unsigned char *restrict dest, uint32_t *map);
+
+#endif

--- a/c/fread.c
+++ b/c/fread.c
@@ -1814,12 +1814,21 @@ int freadMain(freadMainArgs _args)
           (rowSize1 && !myBuff1) || !myBuff0) stopTeam = true;
 
       ThreadLocalFreadParsingContext ctx = {
-        .anchor = NULL, .threadn = (size_t)me,
-        .buff8 = myBuff8, .buff4 = myBuff4, .buff1 = myBuff1,
-        .rowSize8 = rowSize8, .rowSize4 = rowSize4, .rowSize1 = rowSize1,
-        .DTi = 0, .nRows = allocnrow, .stopTeam = &stopTeam,
+        .anchor = NULL,
+        .buff8 = myBuff8,
+        .buff4 = myBuff4,
+        .buff1 = myBuff1,
+        .rowSize8 = rowSize8,
+        .rowSize4 = rowSize4,
+        .rowSize1 = rowSize1,
+        .DTi = 0,
+        .nRows = allocnrow,
+        .threadn = me,
+        .quoteRule = quoteRule,
+        .stopTeam = &stopTeam,
         #ifndef DTPY
-        .nStringCols = nStringCols, .nNonStringCols = nNonStringCols
+        .nStringCols = nStringCols,
+        .nNonStringCols = nNonStringCols
         #endif
       };
       prepareThreadContext(&ctx);

--- a/c/fread.h
+++ b/c/fread.h
@@ -163,12 +163,14 @@ typedef struct ThreadLocalFreadParsingContext
   // size of each `buffX` is thus at least `nRows * rowSizeX`.
   size_t nRows;
 
-  size_t threadn;
-
   // Reference to the flag that controls the parser's execution. Setting this
   // flag to true will force parsing of the CSV file to terminate in the near
   // future.
   _Bool *stopTeam;
+
+  int threadn;
+
+  int quoteRule;
 
   // Any additional implementation-specific parameters.
   FREAD_PUSH_BUFFERS_EXTRA_FIELDS

--- a/c/myassert.h
+++ b/c/myassert.h
@@ -1,0 +1,5 @@
+#ifdef NDEBUG
+    // Macro NDEBUG, if present, disables all assert statements.
+    #undef NDEBUG
+#endif
+#include <assert.h>  // static_assert

--- a/c/py_encodings.c
+++ b/c/py_encodings.c
@@ -1,0 +1,51 @@
+#include "myassert.h"
+#include "py_encodings.h"
+#include "py_utils.h"
+
+
+static uint32_t win1252_map[256];
+static uint32_t win1251_map[256];
+
+static void initialize_map(uint32_t *map, int n, const char *encoding)
+{
+    for (int i = 0; i < n; i++) {
+        PyObject *string = PyUnicode_Decode((const char*)&i, 4, encoding, "ignore");
+        PyObject *bytes = PyUnicode_AsEncodedString(string, "utf-8", "ignore");
+        char *raw = PyBytes_AsString(bytes);  // borrowed ref
+        memcpy(map + i, raw, 4);
+        Py_DECREF(string);
+        Py_DECREF(bytes);
+    }
+}
+
+int decode_windows1252(const unsigned char *restrict src, int len,
+                       unsigned char *restrict dest)
+{
+    return decode_sbcs(src, len, dest, win1252_map);
+}
+
+int decode_windows1251(const unsigned char *restrict src, int len,
+                       unsigned char *restrict dest)
+{
+    return decode_sbcs(src, len, dest, win1251_map);
+}
+
+
+
+// Module initialization
+int init_py_encodings(UU)
+{
+    initialize_map(win1252_map, 256, "Windows-1252");
+    initialize_map(win1251_map, 256, "Windows-1251");
+
+    // Sanity checks
+    for (int k = 0; k < 2; k++) {
+        uint32_t *map = (k == 0)? win1252_map : win1251_map;
+        for (unsigned int i = 0; i < 256; i++) {
+            if (i < 0x80) assert(map[i] == i);
+            if (i && map[i] == 0) map[i] = 0x00BDBFEF;  // U+FFFD
+            assert((map[i] & 0xFF000000) == 0);
+        }
+    }
+    return 1;
+}

--- a/c/py_encodings.h
+++ b/c/py_encodings.h
@@ -1,0 +1,15 @@
+#ifndef dt_PY_ENCODINGS_H
+#define dt_PY_ENCODINGS_H
+#include <Python.h>
+#include "encodings.h"
+
+
+int init_py_encodings(PyObject *module);
+
+int decode_windows1252(const unsigned char *restrict src, int len,
+                       unsigned char *restrict dest);
+int decode_windows1251(const unsigned char *restrict src, int len,
+                       unsigned char *restrict dest);
+
+
+#endif

--- a/c/types.c
+++ b/c/types.c
@@ -1,8 +1,4 @@
-#ifdef NDEBUG
-    // Macro NDEBUG, if present, disables all assert statements.
-    #undef NDEBUG
-#endif
-#include <assert.h>  // static_assert
+#include "myassert.h"
 #include "types.h"
 
 

--- a/datatable/fread.py
+++ b/datatable/fread.py
@@ -21,10 +21,10 @@ def fread(filename="", **params):
 class FReader(object):
 
     @typed(filename=str, text=str, sep=str, max_nrows=int, header=bool,
-           na_strings=[str], fill=bool, show_progress=bool)
+           na_strings=[str], fill=bool, show_progress=bool, encoding=str)
     def __init__(self, filename=None, text=None, sep=None, max_nrows=None,
                  header=None, na_strings=None, verbose=False, fill=False,
-                 show_progress=term.is_a_tty, **args):
+                 show_progress=term.is_a_tty, encoding=None, **args):
         self._filename = None   # type: str
         self._text = None       # type: str
         self._sep = None        # type: str
@@ -34,6 +34,7 @@ class FReader(object):
         self._verbose = False   # type: bool
         self._fill = False      # type: bool
         self._show_progress = True  # type: bool
+        self._encoding = encoding
 
         self._log_newline = True
         self._colnames = None


### PR DESCRIPTION
In fread check whether string fields contain valid UTF-8, and if not decode them from windows-1252 encoding (will be configurable in the future).
Closes #74 