### PR TITLE
[BUILD] Versioning schema

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ import subprocess
 import sysconfig
 from setuptools import setup, find_packages
 from distutils.core import Extension
-
+from sys import stderr
 
 # Determine the version
 version = None
@@ -25,7 +25,9 @@ with open("datatable/__version__.py") as f:
             break
 if version is None:
     raise RuntimeError("Could not detect version from the __version__.py file")
-
+## Append build suffix if necessary
+if os.environ.get("CI_VERSION_SUFFIX"):
+    version = "%s+%s" % (version, os.environ["CI_VERSION_SUFFIX"])
 
 # Find all C source files in the "c/" directory
 c_sources = []
@@ -36,7 +38,7 @@ for root, dirs, files in os.walk("c"):
 
 # Find python source directories
 packages = find_packages(exclude=["tests", "temp", "c"])
-print("\nFound packages: %r\n" % packages)
+print("\nFound packages: %r\n" % packages, file=stderr)
 
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
The schema:
  - repo contains current version string in file `datable/__version__.py`(e.g., 1.0.0)
   - internal builds append additional string based on "BRANCH_NAME_BUILD_ID", (e.g, 1.0.0+master-33)
  - python setup corrects the build name based on PEP440 (https://www.python.org/dev/peps/pep-0440/)
        (e.g., 1.0.0+master.33)
  - Jenkinsfile is using `python setup.py --version` to get correct version and upload it to correct
        location in S3