### PR TITLE
Implement numeric type-casts between different stypes

### DIFF
--- a/c/column.c
+++ b/c/column.c
@@ -371,17 +371,6 @@ Column* column_extract(Column *self, RowIndex *rowindex)
 
 
 
-Column* column_cast(Column *self, SType stype)
-{
-    // Not implemented :(
-    (void)self;
-    (void)stype;
-    dterrv("Unable to cast from stype=%d into stype=%d", self->stype, stype);
-    return NULL;
-}
-
-
-
 RowIndex* column_sort(Column *col, int64_t nrows)
 {
     assert(col->nrows == nrows);

--- a/c/column.h
+++ b/c/column.h
@@ -86,5 +86,6 @@ size_t column_i4s_padding(size_t datasize);
 Column* column_incref(Column *self);
 void column_decref(Column *self);
 
+void init_column_cast_functions(void);
 
 #endif

--- a/c/column_cast.c
+++ b/c/column_cast.c
@@ -1,0 +1,235 @@
+#include <string.h>    // memcpy
+#include "column.h"
+#include "myassert.h"
+#include "utils.h"
+
+typedef Column* (*castfn_ptr)(Column*, Column*);
+static castfn_ptr softcasts[DT_STYPES_COUNT][DT_STYPES_COUNT];
+static castfn_ptr hardcasts[DT_STYPES_COUNT][DT_STYPES_COUNT];
+
+
+/**
+ * Convert column `self` into type `stype`. The conversion does not happen
+ * in-place, instead a new Column object is always created. If `stype` is the
+ * same as the current Column's `stype` then a plain clone will be returned.
+ *
+ * If the requested conversion has not been implemented yet, an exception will
+ * be raised and NULL pointer returned.
+ */
+Column* column_cast(Column *self, SType stype)
+{
+    castfn_ptr converter = hardcasts[self->stype][stype];
+    if (converter) {
+        Column *res = make_data_column(stype, (size_t) self->nrows);
+        if (res == NULL) return NULL;
+        return converter(self, res);
+    } else if (self->stype == stype) {
+        return column_copy(self);
+    } else {
+        dterrv("Unable to cast from stype=%d into stype=%d", self->stype, stype);
+    }
+}
+
+
+
+
+//---- ST_BOOLEAN_I1 -----------------------------------------------------------
+
+static Column* easy_i1b_to_i1i(Column *self, Column *res)
+{
+    memcpy(res->data, self->data, self->alloc_size);
+    return res;
+}
+
+
+//---- ST_INTEGER_I1 -----------------------------------------------------------
+
+static Column* easy_i1i_to_i2i(Column *self, Column *res)
+{
+    int8_t *src_data = (int8_t*) self->data;
+    int16_t *res_data = (int16_t*) res->data;
+    for (int64_t i = 0; i < self->nrows; i++)
+        res_data[i] = src_data[i];
+    return res;
+}
+
+static Column* easy_i1i_to_i4i(Column *self, Column *res)
+{
+    int8_t *src_data = (int8_t*) self->data;
+    int32_t *res_data = (int32_t*) res->data;
+    for (int64_t i = 0; i < self->nrows; i++)
+        res_data[i] = src_data[i];
+    return res;
+}
+
+static Column* easy_i1i_to_i8i(Column *self, Column *res)
+{
+    int8_t *src_data = (int8_t*) self->data;
+    int64_t *res_data = (int64_t*) res->data;
+    for (int64_t i = 0; i < self->nrows; i++)
+        res_data[i] = src_data[i];
+    return res;
+}
+
+static Column* easy_i1i_to_f4r(Column *self, Column *res)
+{
+    int8_t *src_data = (int8_t*) self->data;
+    float *res_data = (float*) res->data;
+    for (int64_t i = 0; i < self->nrows; i++)
+        res_data[i] = src_data[i];
+    return res;
+}
+
+static Column* easy_i1i_to_f8r(Column *self, Column *res)
+{
+    int8_t *src_data = (int8_t*) self->data;
+    double *res_data = (double*) res->data;
+    for (int64_t i = 0; i < self->nrows; i++)
+        res_data[i] = src_data[i];
+    return res;
+}
+
+
+//---- ST_INTEGER_I2 -----------------------------------------------------------
+
+static Column* easy_i2i_to_i4i(Column *self, Column *res)
+{
+    int16_t *src_data = (int16_t*) self->data;
+    int32_t *res_data = (int32_t*) res->data;
+    for (int64_t i = 0; i < self->nrows; i++)
+        res_data[i] = src_data[i];
+    return res;
+}
+
+static Column* easy_i2i_to_i8i(Column *self, Column *res)
+{
+    int16_t *src_data = (int16_t*) self->data;
+    int64_t *res_data = (int64_t*) res->data;
+    for (int64_t i = 0; i < self->nrows; i++)
+        res_data[i] = src_data[i];
+    return res;
+}
+
+static Column* easy_i2i_to_f4r(Column *self, Column *res)
+{
+    int16_t *src_data = (int16_t*) self->data;
+    float *res_data = (float*) res->data;
+    for (int64_t i = 0; i < self->nrows; i++)
+        res_data[i] = src_data[i];
+    return res;
+}
+
+static Column* easy_i2i_to_f8r(Column *self, Column *res)
+{
+    int16_t *src_data = (int16_t*) self->data;
+    double *res_data = (double*) res->data;
+    for (int64_t i = 0; i < self->nrows; i++)
+        res_data[i] = src_data[i];
+    return res;
+}
+
+
+//---- ST_INTEGER_I4 -----------------------------------------------------------
+
+static Column* easy_i4i_to_i8i(Column *self, Column *res)
+{
+    int32_t *src_data = (int32_t*) self->data;
+    int64_t *res_data = (int64_t*) res->data;
+    for (int64_t i = 0; i < self->nrows; i++)
+        res_data[i] = src_data[i];
+    return res;
+}
+
+static Column* easy_i4i_to_f4r(Column *self, Column *res)
+{
+    int32_t *src_data = (int32_t*) self->data;
+    float *res_data = (float*) res->data;
+    for (int64_t i = 0; i < self->nrows; i++)
+        res_data[i] = src_data[i];
+    return res;
+}
+
+static Column* easy_i4i_to_f8r(Column *self, Column *res)
+{
+    int32_t *src_data = (int32_t*) self->data;
+    double *res_data = (double*) res->data;
+    for (int64_t i = 0; i < self->nrows; i++)
+        res_data[i] = src_data[i];
+    return res;
+}
+
+
+//---- ST_INTEGER_I8 -----------------------------------------------------------
+
+static Column* easy_i8i_to_f4r(Column *self, Column *res)
+{
+    int64_t *src_data = (int64_t*) self->data;
+    float *res_data = (float*) res->data;
+    for (int64_t i = 0; i < self->nrows; i++)
+        res_data[i] = src_data[i];
+    return res;
+}
+
+static Column* easy_i8i_to_f8r(Column *self, Column *res)
+{
+    int64_t *src_data = (int64_t*) self->data;
+    double *res_data = (double*) res->data;
+    for (int64_t i = 0; i < self->nrows; i++)
+        res_data[i] = src_data[i];
+    return res;
+}
+
+
+//---- ST_REAL_F4 --------------------------------------------------------------
+
+static Column* easy_f4r_to_f8r(Column *self, Column *res)
+{
+    float *src_data = (float*) self->data;
+    double *res_data = (double*) res->data;
+    for (int64_t i = 0; i < self->nrows; i++)
+        res_data[i] = (double) src_data[i];
+    return res;
+}
+
+
+
+
+/**
+ * This function has to be called only once, during module initialization.
+ */
+void init_column_cast_functions(void)
+{
+    for (SType s = 0; s < DT_STYPES_COUNT; s++) {
+        for (SType t = 0; t < DT_STYPES_COUNT; t++) {
+            softcasts[s][t] = NULL;
+            hardcasts[s][t] = NULL;
+        }
+    }
+    // Register all implemented converters
+    hardcasts[ST_BOOLEAN_I1][ST_INTEGER_I1] = easy_i1b_to_i1i;
+    hardcasts[ST_BOOLEAN_I1][ST_INTEGER_I2] = easy_i1i_to_i2i;
+    hardcasts[ST_BOOLEAN_I1][ST_INTEGER_I4] = easy_i1i_to_i4i;
+    hardcasts[ST_BOOLEAN_I1][ST_INTEGER_I8] = easy_i1i_to_i8i;
+    hardcasts[ST_BOOLEAN_I1][ST_REAL_F4] = easy_i1i_to_f4r;
+    hardcasts[ST_BOOLEAN_I1][ST_REAL_F8] = easy_i1i_to_f8r;
+
+    hardcasts[ST_INTEGER_I1][ST_INTEGER_I2] = easy_i1i_to_i2i;
+    hardcasts[ST_INTEGER_I1][ST_INTEGER_I4] = easy_i1i_to_i4i;
+    hardcasts[ST_INTEGER_I1][ST_INTEGER_I8] = easy_i1i_to_i8i;
+    hardcasts[ST_INTEGER_I1][ST_REAL_F4] = easy_i1i_to_f4r;
+    hardcasts[ST_INTEGER_I1][ST_REAL_F8] = easy_i1i_to_f8r;
+
+    hardcasts[ST_INTEGER_I2][ST_INTEGER_I4] = easy_i2i_to_i4i;
+    hardcasts[ST_INTEGER_I2][ST_INTEGER_I8] = easy_i2i_to_i8i;
+    hardcasts[ST_INTEGER_I2][ST_REAL_F4] = easy_i2i_to_f4r;
+    hardcasts[ST_INTEGER_I2][ST_REAL_F8] = easy_i2i_to_f8r;
+
+    hardcasts[ST_INTEGER_I4][ST_INTEGER_I8] = easy_i4i_to_i8i;
+    hardcasts[ST_INTEGER_I4][ST_REAL_F4] = easy_i4i_to_f4r;
+    hardcasts[ST_INTEGER_I4][ST_REAL_F8] = easy_i4i_to_f8r;
+
+    hardcasts[ST_INTEGER_I8][ST_REAL_F4] = easy_i8i_to_f4r;
+    hardcasts[ST_INTEGER_I8][ST_REAL_F8] = easy_i8i_to_f8r;
+
+    hardcasts[ST_REAL_F4][ST_REAL_F8] = easy_f4r_to_f8r;
+}

--- a/c/py_column.c
+++ b/c/py_column.c
@@ -235,6 +235,8 @@ PyTypeObject Column_PyType = {
 
 
 int init_py_column(PyObject *module) {
+    init_column_cast_functions();
+
     // Register Column_PyType on the module
     Column_PyType.tp_new = PyType_GenericNew;
     if (PyType_Ready(&Column_PyType) < 0) return 0;


### PR DESCRIPTION
This PR only provides conversions between numeric types, and only in the direction of enlarging (i.e `i1b -> i1i -> i2i -> i4i -> i8i -> f4r -> f8r`). Implementing ALL converters is a much harder task, which should better be split across multiple issues/PRs.

Notably, we do not implement conversion to/from string types here.

Closes #115 