### PR TITLE
Eliminate instances of arithmetics on void* pointers. 

### DIFF
--- a/c/py_datawindow.c
+++ b/c/py_datawindow.c
@@ -189,8 +189,8 @@ static int _init_hexview(
         PyList_SET_ITEM(stypes, i, incref(py_stype_names[ST_STRING_FCHAR]));
     }
 
-    uint8_t *coldata = (uint8_t*)(column->data + 16 * row0);
-    uint8_t *coldata_end = (uint8_t*)(column->data + column->alloc_size);
+    uint8_t *coldata = (uint8_t*) add_ptr(column->data, 16 * row0);
+    uint8_t *coldata_end = (uint8_t*) add_ptr(column->data, column->alloc_size);
     // printf("coldata = %p, end = %p\n", coldata, coldata_end);
     viewdata = TRY(PyList_New(ncols));
     for (int i = 0; i < ncols; i++) {

--- a/c/py_types.c
+++ b/c/py_types.c
@@ -83,12 +83,12 @@ static PyObject* stype_real_i64_tostring(Column *col, int64_t row)
 static PyObject* stype_vchar_i32_tostring(Column *col, int64_t row)
 {
     int32_t offoff = (int32_t) ((VarcharMeta*) col->meta)->offoff;
-    int32_t *offsets = (int32_t*)(col->data + offoff);
+    int32_t *offsets = (int32_t*) add_ptr(col->data, offoff);
     if (offsets[row] < 0)
         return none();
     int32_t start = row == 0? 0 : abs(offsets[row - 1]) - 1;
     int32_t len = offsets[row] - 1 - start;
-    return PyUnicode_FromStringAndSize(col->data + start, len);
+    return PyUnicode_FromStringAndSize(add_ptr(col->data, start), len);
 }
 
 static PyObject* stype_object_pyptr_tostring(Column *col, int64_t row)

--- a/c/types.c
+++ b/c/types.c
@@ -29,7 +29,7 @@ dt_static_assert(sizeof(int64_t) == 8, "int64_t should be 8-byte");
 dt_static_assert(sizeof(float) == 4, "float should be 4-byte");
 dt_static_assert(sizeof(double) == 8, "double should be 8-byte");
 dt_static_assert(sizeof(char) == sizeof(unsigned char), "char != uchar");
-dt_static_assert(sizeof(void) == 1, "sizeof(void) != 1");
+dt_static_assert(sizeof(char) == 1, "sizeof(char) != 1");
 // Used in llvm.py
 dt_static_assert(sizeof(long long int) == 8, "llint should be 8-byte");
 

--- a/c/utils.c
+++ b/c/utils.c
@@ -45,6 +45,6 @@ void set_value(void * restrict ptr, const void * restrict value,
     size_t final_sz = sz * count;
     for (size_t i = sz; i < final_sz; i <<= 1) {
         size_t writesz = i < final_sz - i ? i : final_sz - i;
-        memcpy(ptr + i, ptr, writesz);
+        memcpy(add_ptr(ptr, i), ptr, writesz);
     }
 }

--- a/setup.py
+++ b/setup.py
@@ -92,10 +92,6 @@ os.environ["LLVM_CONFIG"] = llvm_config
 # Settings for building the extension
 #-------------------------------------------------------------------------------
 # Ignored warnings:
-#   -Wpointer-arith: this warns about treating (void*) as
-#       (char*), which is a GNU extension. However since we
-#       only ever want to compile in GCC / CLang, such use is
-#       appropriate.
 #   -Wcovered-switch-default: we add `default` statement to
 #       an exhaustive switch to guard against memory
 #       corruption and careless enum definition expansion.
@@ -110,7 +106,6 @@ extra_compile_args = [
     "-DDTPY",
     "-DNONDEBUG",
     "-Weverything",
-    "-Wno-pointer-arith",
     "-Wno-covered-switch-default",
     "-Wno-float-equal",
     "-Wno-gnu-statement-expression",


### PR DESCRIPTION
Enable warning `-Wpointer-arith`, which should no longer trigger anywhere in the code.

Closes #142