### PR TITLE
Fix a bug in datatable.open() which prevented from reading all-numeric files

### DIFF
--- a/datatable/nff.py
+++ b/datatable/nff.py
@@ -76,7 +76,8 @@ def open(path):
             else:
                 raise ValueError("Unknown NFF format: %s" % info[0])
 
-        f0 = fread("_meta.nff", sep=",")
+        f0 = fread("_meta.nff", sep=",",
+                   columns=lambda i, name, type: (name, str))
         f1 = f0(select=["filename", "stype", "meta"])
         colnames = f0["colname"].topython()[0]
         _dt = _datatable.datatable_load(f1.internal, nrows)


### PR DESCRIPTION
The problem was that if the meta column contained no metas, then the type of the column was auto-detected as boolean. Now we force it as string.
This commit also adds explicit error messages to `datatable_open()` so that it is easier to see what the problem is.

Closes #158