### PR TITLE
Improve speed of sorting boolean columns.

### DIFF
--- a/tests/benchmarks/bench_sort_bool.py
+++ b/tests/benchmarks/bench_sort_bool.py
@@ -17,32 +17,32 @@ def src(numpy, benchmark, request):
     return a
 
 
-def test_sort_bool_datatable(benchmark, src):
+def test_datatable(benchmark, src):
     benchmark.name = "datatable"
     d = datatable.DataTable(src)
     assert d.types == ("bool",)
     benchmark(lambda: d(sort=0))
 
 
-def test_sort_bool_numpy(benchmark, src):
+def test_numpy(benchmark, src):
     benchmark.name = "numpy"
     a = src
     benchmark(lambda: a.sort())
 
 
-def test_sort_bool_pandas(benchmark, src, pandas):
+def test_pandas(benchmark, src, pandas):
     benchmark.name = "pandas"
     p = pandas.DataFrame(src)
     benchmark(lambda: p.sort_values(0))
 
 
-def test_sort_bool_python(benchmark, src):
+def test_python(benchmark, src):
     benchmark.name = "python"
     p = src.tolist()
     benchmark(lambda: sorted(p))
 
 
-# def test_sort_bool_h2o(benchmark, src, h2o):
+# def test_h2o(benchmark, src, h2o):
 #     benchmark.name = "h2o"
 #     h = h2o.H2OFrame(src)
 #     benchmark(lambda: h.sort(0).refresh())

--- a/tests/test_dt_sort.py
+++ b/tests/test_dt_sort.py
@@ -230,6 +230,7 @@ def test_i1b_large(n):
     assert d1.stypes == d0.stypes
     assert d1.names == d0.names
     assert d1.internal.isview
+    assert d0.internal.check()
     assert d1.internal.check()
     nn = 2 * n
     assert d1.topython() == [[None] * nn + [False] * nn + [True] * nn]


### PR DESCRIPTION
Avoid preparing boolean column by copying it into an intermediate buffer -- instead apply a smart transform to the values. This improves efficiency by ~25%

Closes #252 