### PR TITLE
Implement middle-out insert sort as a 'microbenchmark'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,8 @@ datatable.iml
 
 # Landfill area
 temp/*
+
+
+# Microbenchmarks
+microbench/insertsort/isort
+microbench/insertsort/isort.o

--- a/c/sort.c
+++ b/c/sort.c
@@ -394,10 +394,10 @@ static int _compare_offstrings(
 
 
 /**
- * Boolean columns have only 3 distinct values, -(INT8_MAX+1), 0 and 1. The
- * transform `((uint8_t)x + 0xBF) >> 6` converts these to 0, 2 and 3
- * respectively, provided that the addition in parentheses is done as addition
- * of unsigned bytes (i.e. modulo 256).
+ * Boolean columns have only 3 distinct values: -128, 0 and 1. The transform
+ * `(x + 0xBF) >> 6` converts these to 0, 2 and 3 respectively, provided that
+ * the addition in parentheses is done as addition of unsigned bytes (i.e.
+ * modulo 256).
  */
 static void prepare_input_b1(const Column *col, int32_t *ordering, size_t n,
                              SortContext *sc)

--- a/microbench/insertsort/Makefile
+++ b/microbench/insertsort/Makefile
@@ -7,6 +7,19 @@ LIBRARIES :=
 CCFLAGS :=
 LDFLAGS :=
 
+ifdef iters
+	ITERS := iters=$(iters)
+endif
+
+ifdef size
+	SIZE := size=$(size)
+endif
+
+ifdef batches
+	BATCHES := batches=$(batches)
+endif
+
+
 #-------------------------------------------------------------------------------
 
 build: isort
@@ -21,4 +34,7 @@ clean:
 	rm -f isort.o isort
 
 run: build
-	./isort
+	./isort $(ITERS) $(SIZE) $(BATCHES)
+
+munch: build
+	python ../munch.py ./isort size={N} $(ITERS) $(BATCHES)

--- a/microbench/insertsort/isort.c
+++ b/microbench/insertsort/isort.c
@@ -3,16 +3,19 @@
 // Micro benchmark for insert-sort function.
 // Example:
 //
-//     ./isort size=64 iters=100000 kernel=0
+//     make run size=64 batches=100 iters=1000
 //
-// Will run the benchmark 100,000 times on an array of 64 integers using
-// "kernel 0". Here "kernel 0" is the original function taken from forder.c,
-// and all other kernels are various attempts at improving the original kernel.
+// Will run the benchmark 100 times, each time doing 1000 iterations, working
+// on an array of 64 integers. This will be done for each available "kernel":
+//     iinsert0: original function taken from forder.c,
+//     iinsert2: an attempt to optimize iinsert0
+//     iinsert3: two-way insert sort from Knuth Vol.3
 //
 //==============================================================================
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdint.h>
+#include <assert.h>
 #include "utils.h"
 
 
@@ -35,41 +38,76 @@ static void iinsert0(int *x, int *o, int n)
     }
 }
 
-static void iinsert1(int *x, uint8_t *o, uint8_t n)
-{
-    for (uint8_t i = 1; i < n; i++) {
-        int xtmp = x[i];
-        if (xtmp < x[i-1]) {
-            uint8_t j = i - 1;
-            uint8_t otmp = o[i];
-            while (j >= 0 && xtmp < x[j]) {
-                x[j+1] = x[j];
-                o[j+1] = o[j];
-                j--;
-            }
-            x[j+1] = xtmp;
-            o[j+1] = otmp;
-        }
-    }
-}
 
-
-static void iinsert2(const int *x, int *y, int n, int* restrict tmp)
+static void iinsert2(const int *x, int *o, int n, int* restrict t)
 {
-    tmp[0] = 0;
+    t[0] = 0;
     for (int i = 1; i < n; i++) {
         int xi = x[i];
         int j = i;
-        while (j && xi < x[tmp[j - 1]]) {
-            tmp[j] = tmp[j - 1];
+        while (j && xi < x[t[j - 1]]) {
+            t[j] = t[j - 1];
             j--;
         }
-        tmp[j] = i;
+        t[j] = i;
     }
     for (int i = 0; i < n; i++) {
-        tmp[i] = y[tmp[i]];
+        t[i] = o[t[i]];
     }
-    memcpy(y, tmp, n * sizeof(int));
+    memcpy(o, t, n * sizeof(int));
+}
+
+
+// Two-way insert sort (see Knuth Vol.3)
+static void iinsert3(const int *x, int *o, int n, int *restrict t)
+{
+    t[n] = 0;
+    int r = n, l = n, j, xr, xl;
+    xr = xl = x[0];
+    for (int i = 1; i < n; i++) {
+        int xi = x[i];
+        if (xi >= xr) {
+            t[++r] = i;
+            xr = xi;
+        } else if (xi < xl) {
+            t[--l] = i;
+            xl = xi;
+        } else {
+            // Compute `j` such that `xi` has to be inserted between elements
+            // `j` and `j-1`, i.e. such that `x[t[j-1]] <= xi < x[t[j]]`.
+            if (xi < x[t[n]]) {
+                j = n - 1;
+                while (xi < x[t[j]]) j--;
+                j++;
+            } else {
+                j = n + 1;
+                while (xi >= x[t[j]]) j++;
+            }
+            // assert(x[t[j - 1]] <= xi && xi < x[t[j]]);
+            int rshift = r - j + 1;
+            int lshift = j - l;
+            if (rshift <= lshift) {
+                // shift elements [j .. r] upwards by 1
+                for (int k = r; k >= j; k--) {
+                    t[k + 1] = t[k];
+                }
+                r++;
+                t[j] = i;
+            } else {
+                // shift elements [l .. j-1] downwards by 1
+                for (int k = l; k < j; k++) {
+                    t[k - 1] = t[k];
+                }
+                l--;
+                t[j-1] = i;
+            }
+        }
+    }
+    // assert(r - l + 1 == n);
+    for (int i = l; i <= r; i++) {
+        t[i] = o[t[i]];
+    }
+    memcpy(o, t + l, n * sizeof(int));
 }
 
 
@@ -81,71 +119,102 @@ int main(int argc, char **argv)
 {
     // Parse command-line arguments
     int size = getCmdArgInt(argc, argv, "size", 64);
-    int iters = getCmdArgInt(argc, argv, "iters", 1000000);
-    int kernel = getCmdArgInt(argc, argv, "kernel", 0);
-    printf("Array size = %d\n", size);
-    printf("Number of iterations = %d\n", iters);
-    printf("Kernel = %d\n", kernel);
+    int iters = getCmdArgInt(argc, argv, "iters", 1000);
+    int nbatches = getCmdArgInt(argc, argv, "batches", 100);
+    printf("Array size = %d ints\n", size);
+    printf("Number of batches = %d\n", nbatches);
+    printf("Number of iterations per batch = %d\n", iters);
 
-    // Prepare data array
-    srand(123456789);
-    size_t alloc_size = (size_t)size * sizeof(int);
-    int *x = malloc(alloc_size);
-    int *y = malloc(alloc_size);
-    for (int i = 0; i < size; i++) {
-        x[i] = rand();
-        y[i] = i * 1000;
-    }
-    int *wx = malloc(alloc_size);
-    int *wy = malloc(alloc_size);
-    int *tmp = malloc(alloc_size);
+    double total_time0 = 0, min_time0 = 0, max_time0 = 0;
+    double total_time2 = 0, min_time2 = 0, max_time2 = 0;
+    double total_time3 = 0, min_time3 = 0, max_time3 = 0;
 
-    // Check correctness
-    memcpy(wx, x, alloc_size);
-    memcpy(wy, y, alloc_size);
-    iinsert0(wx, wy, size);
-    int *copy = malloc(alloc_size);
-    memcpy(copy, wy, alloc_size);
-    memcpy(wx, x, alloc_size);
-    memcpy(wy, y, alloc_size);
-    iinsert2(wx, wy, size, tmp);
-    for (int i = 0; i < size; i++) {
-        if (copy[i] != wy[i]) {
-            printf("Results are different!\n");
-            printf("Input x: ["); for(int i = 0; i < size; i++) printf("%d, ", x[i]); printf("]\n");
-            printf("Out 1: ["); for(int i = 0; i < size; i++) printf("%d, ", copy[i]); printf("]\n");
-            printf("Out 2: ["); for(int i = 0; i < size; i++) printf("%d, ", wy[i]); printf("]\n");
-            break;
+    for (int b = 0; b < nbatches; b++)
+    {
+        // Prepare data array
+        // srand(123456789);
+        size_t alloc_size = (size_t)size * sizeof(int);
+        int *x = malloc(alloc_size);
+        int *y = malloc(alloc_size);
+        for (int i = 0; i < size; i++) {
+            x[i] = rand();
+            y[i] = i;
         }
-    }
+        int *wx = malloc(alloc_size);
+        int *wy = malloc(alloc_size);
+        int *tmp = malloc(alloc_size * 2);
 
-    // Run the kernel
-    printf("Running... ");
-    fflush(stdout);
-    start_timer();
-    if (kernel == 0) {
+        // Check correctness
+        memcpy(wx, x, alloc_size);
+        memcpy(wy, y, alloc_size);
+        iinsert0(wx, wy, size);
+        int *copy1 = malloc(alloc_size);
+        memcpy(copy1, wy, alloc_size);
+        memcpy(wx, x, alloc_size);
+        memcpy(wy, y, alloc_size);
+        iinsert2(wx, wy, size, tmp);
+        int *copy2 = malloc(alloc_size);
+        memcpy(copy2, wy, alloc_size);
+        memcpy(wx, x, alloc_size);
+        memcpy(wy, y, alloc_size);
+        iinsert3(wx, wy, size, tmp);
+        for (int i = 0; i < size; i++) {
+            if (copy1[i] != wy[i] || copy2[i] != wy[i] || (i > 0 &&
+                    !(x[wy[i]] > x[wy[i-1]] || (x[wy[i]] == x[wy[i-1]] && wy[i] > wy[i-1]))
+                    )
+            ) {
+                printf("Results are different! (at i = %d)\n", i);
+                printf("  Input x: ["); for(int i = 0; i < size; i++) printf("%d, ", x[i]); printf("]\n");
+                printf("  Sorted x: ["); for(int i = 0; i < size; i++) printf("%d, ", x[wy[i]]); printf("]\n");
+                printf("  Out 1: ["); for(int i = 0; i < size; i++) printf("%d, ", copy1[i]); printf("]\n");
+                printf("  Out 2: ["); for(int i = 0; i < size; i++) printf("%d, ", copy2[i]); printf("]\n");
+                printf("  Out 3: ["); for(int i = 0; i < size; i++) printf("%d, ", wy[i]); printf("]\n");
+                return 1;
+            }
+        }
+
+        // Kernel 0
+        start_timer();
         for (int i = 0; i < iters; i++) {
             memcpy(wx, x, alloc_size);
             memcpy(wy, y, alloc_size);
             iinsert0(wx, wy, size);
         }
-    }
-    else if (kernel == 1) {
-        // This kernel is very slow, and not entirely correct...
-        uint8_t *y8 = malloc((size_t)size);
-        for (int i = 0; i < iters; i++) {
-            memcpy(wx, x, alloc_size);
-            iinsert1(wx, y8, (uint8_t)size);
-        }
-    }
-    else if (kernel == 2) {
+        double t0 = get_timer_iter(iters);
+        total_time0 += t0;
+        if (b == 0 || t0 < min_time0) min_time0 = t0;
+        if (b == 0 || t0 > max_time0) max_time0 = t0;
+
+        // Kernel 2
+        start_timer();
         for (int i = 0; i < iters; i++) {
             memcpy(wx, x, alloc_size);
             memcpy(wy, y, alloc_size);
             iinsert2(wx, wy, size, tmp);
         }
-    }
-    stop_timeri(iters);
+        double t2 = get_timer_iter(iters);
+        total_time2 += t2;
+        if (b == 0 || t2 < min_time2) min_time2 = t2;
+        if (b == 0 || t2 > max_time2) max_time2 = t2;
 
+        // Kernel 3
+        start_timer();
+        for (int i = 0; i < iters; i++) {
+            memcpy(wx, x, alloc_size);
+            memcpy(wy, y, alloc_size);
+            iinsert3(wx, wy, size, tmp);
+        }
+        double t3 = get_timer_iter(iters);
+        total_time3 += t3;
+        if (b == 0 || t3 < min_time3) min_time3 = t3;
+        if (b == 0 || t3 > max_time3) max_time3 = t3;
+    }
+
+    printf("@ iinsert0:  mean = %.2f ns,  min = %.2f ns, max = %.2f ns\n",
+           total_time0 / nbatches, min_time0, max_time0);
+    printf("@ iinsert2:  mean = %.2f ns,  min = %.2f ns, max = %.2f ns\n",
+           total_time2 / nbatches, min_time2, max_time2);
+    printf("@ iinsert3:  mean = %.2f ns,  min = %.2f ns, max = %.2f ns\n",
+           total_time3 / nbatches, min_time3, max_time3);
     return 0;
 }

--- a/microbench/munch.py
+++ b/microbench/munch.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+# Copyright 2017 H2O.ai; Apache License Version 2.0;  -*- encoding: utf-8 -*-
+import re
+import subprocess
+import sys
+
+
+if __name__ == "__main__":
+    headers_printed = False
+    for n in list(range(2, 17)) + [20, 24, 28, 32, 48, 64, 96, 128, 150, 200]:
+        cmd = [c.replace("{N}", str(n)) for c in sys.argv[1:]]
+        out = subprocess.check_output(cmd).decode()
+        headers = []
+        values = []
+        for line in out.split("\n"):
+            mm = re.search(r"^@\s*(\w+).*?\b(\d+(?:\.\d+)?)\b", line)
+            if mm:
+                name = mm.group(1)
+                value = mm.group(2)
+                headers.append(name)
+                values.append(value)
+        if not headers_printed:
+            headers_printed = True
+            print(" n" + " " * 7, end="")
+            for h in headers:
+                print("| %12s " % h, end="")
+            print()
+            print("-" * 9, end="")
+            for s in range(len(headers)):
+                print("+" + "-" * 14, end="")
+            print()
+        print(" %-7d " % n, end="")
+        for v in values:
+            print("| %12s " % v, end="")
+        print()

--- a/microbench/utils.h
+++ b/microbench/utils.h
@@ -70,6 +70,10 @@ void stop_timeri(int iters) {
     double delta = now() - timer;
     printf("Time per iteration = %g ns\n", delta * 1e9 / iters);
 }
+double get_timer_iter(int iters) {
+    double delta = now() - timer;
+    return delta * 1e9 / iters;
+}
 
 
 #endif


### PR DESCRIPTION
The comparison with existing insert sort routines yields the following table:
```
 n       |     iinsert0 |     iinsert2 |     iinsert3 
---------+--------------+--------------+--------------
 2       |        15.62 |        25.99 |        24.83 
 3       |        21.21 |        29.97 |        29.09 
 4       |        28.38 |        37.83 |        35.69 
 5       |        39.85 |        48.34 |        44.97 
 6       |        75.59 |        79.88 |        84.18 
 7       |        78.79 |       101.32 |        74.39 
 8       |       128.62 |       119.13 |       105.72 
 9       |       105.13 |       111.59 |        95.80 
 10      |       130.11 |       124.50 |       104.35 
 11      |       147.89 |       158.08 |       142.50 
 12      |       186.79 |       182.83 |       156.42 
 13      |       189.75 |       238.02 |       174.99 
 14      |       259.48 |       248.71 |       178.59 
 15      |       255.24 |       281.12 |       248.30 
 16      |       310.91 |       271.33 |       196.55 
 20      |       426.47 |       432.96 |       290.83 
 24      |       542.61 |       608.68 |       381.90 
 28      |       817.32 |       820.87 |       505.42 
 32      |      1062.46 |       960.60 |       631.88 
 48      |      2274.91 |      2152.42 |      1272.92 
 64      |      3873.76 |      3794.65 |      2099.27 
 96      |      8477.15 |      7541.67 |      4629.20 
 128     |     15062.68 |     12974.31 |      8417.52 
 150     |     19788.88 |     16826.58 |     11488.08 
 200     |     33901.90 |     28364.41 |     20313.02 
```
(each measurement is the average run time in ns, across 100 batches of 1000 iterations each).

Closes #254