### PR TITLE
plural_form() now also accepts a number only, in which case it returns it with thousand separators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ test:
 	$(MAKE) test_install
 	rm -rf build/test-reports 2>/dev/null
 	mkdir -p build/test-reports/
-	$(PYTHON) -m pytest -rxs \
+	$(PYTHON) -m pytest -ra \
 		--benchmark-skip \
 		--junit-prefix=$(OS) \
 		--junitxml=build/test-reports/TEST-datatable.xml \
@@ -60,7 +60,7 @@ test:
 
 .PHONY: benchmark
 benchmark:
-	$(PYTHON) -m pytest -rxs --benchmark-only
+	$(PYTHON) -m pytest -ra --benchmark-only
 
 
 .PHONY: debug

--- a/datatable/utils/misc.py
+++ b/datatable/utils/misc.py
@@ -7,11 +7,14 @@ __all__ = ("clamp", "normalize_slice", "plural_form", "load_module",
            "humanize_bytes")
 
 
-def plural_form(n, singular, plural=None):
+def plural_form(n, singular=None, plural=None):
     nabs = abs(n)
 
     if nabs == 1:
-        return "%d %s" % (n, singular)
+        if singular:
+            return "%d %s" % (n, singular)
+        else:
+            return str(n)
     else:
         if nabs < 100000:
             nstr = str(n)
@@ -26,6 +29,9 @@ def plural_form(n, singular, plural=None):
                     nabs = nabs // 1000
             if n < 0:
                 nstr = "-" + nstr
+
+        if not singular:
+            return nstr
 
         if not plural:
             last_letter = singular[-1]

--- a/tests/test_utils_misc.py
+++ b/tests/test_utils_misc.py
@@ -28,6 +28,7 @@ def test_plural_form():
     assert plural(4, "mesh") == "4 meshes"
     assert plural(5, "branch") == "5 branches"
     assert plural(1, "foot", "feet") == "1 foot"
+    assert plural(-1, "foot", "feet") == "-1 foot"
     assert plural(7, "foot", "feet") == "7 feet"
 
 
@@ -49,6 +50,8 @@ def test_plural_form2():
     assert plural(-100, "cow") == "-100 cows"
     assert plural(-99999, "cow") == "-99999 cows"
     assert plural(-1234567890, "cow") == "-1,234,567,890 cows"
+    assert plural(1000) == "1000"
+    assert plural(123345700) == "123,345,700"
 
 
 def test_clamp():


### PR DESCRIPTION
Closes #269