### PR TITLE
Fixed "directory not found" issue when loading from Dockerfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -252,7 +252,7 @@ def linkFolders(sourceDir, targetDir) {
 }
 
 	       
-static makeDockerArgs(linkMap, sourceDir, targetDir) {
+def makeDockerArgs(linkMap, sourceDir, targetDir) {
     def out = ""
     linkMap.each { key, value ->
         out += "-v ${sourceDir}/${key}:${targetDir}/${value} "


### PR DESCRIPTION
Jenkinsfile now creates a symlink directory structure in /tmp to properly execute test_fread_large.py
An equivalent directory structure is made by mounting relevant folders when using a Docker

WIP towards #248 
