### PR TITLE
Fix crash when stats functions were applied to a string column

### DIFF
--- a/c/column.c
+++ b/c/column.c
@@ -32,12 +32,18 @@ Column* make_data_column(SType stype, size_t nrows)
     col->meta = NULL;
     col->filename = NULL;
     col->nrows = (int64_t) nrows;
-    col->alloc_size = stype_info[stype].elemsize * nrows;
+    col->alloc_size = stype_info[stype].elemsize * nrows +
+                      (stype == ST_STRING_I4_VCHAR ? column_i4s_padding(0) :
+                       stype == ST_STRING_I8_VCHAR ? column_i8s_padding(0) : 0);
     col->refcount = 1;
     col->mtype = MT_DATA;
     col->stype = stype;
-    dtmalloc(col->meta, void, stype_info[stype].metasize);
     dtmalloc(col->data, void, col->alloc_size);
+    dtcalloc(col->meta, void, stype_info[stype].metasize);
+    if (stype == ST_STRING_I4_VCHAR)
+        ((VarcharMeta*) col->meta)->offoff = (int64_t) column_i4s_padding(0);
+    if (stype == ST_STRING_I8_VCHAR)
+        ((VarcharMeta*) col->meta)->offoff = (int64_t) column_i8s_padding(0);
     return col;
 }
 

--- a/c/stats.c
+++ b/c/stats.c
@@ -3,10 +3,10 @@
  * Source:
  *     https://www.johndcook.com/blog/standard_deviation/
  */
-
+#include <math.h>
+#include <stdio.h>
 #include "stats.h"
 #include "utils.h"
-#include <math.h>
 
 #define M_MIN      (1 << C_MIN)
 #define M_MAX      (1 << C_MAX)
@@ -149,7 +149,12 @@ Column* make_cstat_column(const Stats *self, const CStat s) {
         val_size = stype_info[stype].elemsize;
     }
     Column *out = make_data_column(stype, 1);
-    memcpy(out->data, val, val_size);
+    if (val) {
+        memcpy(out->data, val, val_size);
+    } else {
+        // For ST_STRING_I(4|8)_VCHAR stypes
+        memset(out->data, 0xFF, out->alloc_size);
+    }
     return out;
 }
 

--- a/tests/test_dt_stats.py
+++ b/tests/test_dt_stats.py
@@ -63,10 +63,18 @@ def test_dt_min(src):
     dtr = dt0.min()
     assert dtr.internal.check()
     assert list(dtr.stypes) == [min_max_stype(s) for s in dt0.stypes]
-    assert dtr.shape == (1, dt0.shape[1])
+    assert dtr.shape == (1, dt0.ncols)
     for i in range(dt0.ncols):
         assert dt0.names[i] == dtr.names[i]
     assert dtr.topython() == [t_min(src)]
+
+
+def test_dt_str():
+    dt0 = dt.DataTable([[1, 5, 3, 9, -2], list("abcde")])
+    dtr = dt0.min()
+    assert dtr.internal.check()
+    assert dtr.topython() == [[-2], [None]]
+
 
 
 #-------------------------------------------------------------------------------
@@ -87,7 +95,7 @@ def test_dt_max(src):
     dtr = dt0.max()
     assert dtr.internal.check()
     assert list(dtr.stypes) == [min_max_stype(s) for s in dt0.stypes]
-    assert dtr.shape == (1, dt0.shape[1])
+    assert dtr.shape == (1, dt0.ncols)
     for i in range(dt0.ncols):
         assert dt0.names[i] == dtr.names[i]
     assert dtr.topython() == [t_max(src)]
@@ -111,7 +119,7 @@ def test_dt_mean(src):
     dtr = dt0.mean()
     assert dtr.internal.check()
     assert list(dtr.stypes) == [mean_sd_stype(s) for s in dt0.stypes]
-    assert dtr.shape == (1, dt0.shape[1])
+    assert dtr.shape == (1, dt0.ncols)
     assert dt0.names == dtr.names
     assert list_equals(dtr.topython(), [t_mean(src)])
 
@@ -156,7 +164,7 @@ def test_dt_sd(src):
     dtr = dt0.sd()
     assert dtr.internal.check()
     assert list(dtr.stypes) == [mean_sd_stype(s) for s in dt0.stypes]
-    assert dtr.shape == (1, dt0.shape[1])
+    assert dtr.shape == (1, dt0.ncols)
     assert dt0.names == dtr.names
     assert list_equals(dtr.topython(), [t_sd(src)])
 


### PR DESCRIPTION
* Calling `.min()`, `.max()`, `.sd()` on a string column (or on a DataTable containing string columns) no longer produces a segfault.
* Tweaked column creation method in `column.c` to allocate padding space for string columns. Now calling `make_data_column()` with string stype will allocate enough memory to hold NA-or-blank-only array.

Closes #312