### PR TITLE
Transpose the result of dt.DataTable(numpy_array)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   decimal (default) or hexadecimal format.
 - Csv writer now uses the "dragonfly" algorithm for writing doubles, which is faster
   than all known alternatives.
+- It is now allowed to pass a single-row numpy array as an argument to `dt(rows=...)`,
+  which will be treated the same as if it was a single-column array.
 
 #### Changed
 - `datatable` will no longer attempt to distinguish between NA and NAN floating-point values.
+- Constructing DataTable from a 2D numpy array now preserves shape of that array. At the same
+  time it is no longer true that `arr.tolist() == numpy.array(DataTable(arr)).tolist()`: the
+  list will be transposed.
 
 
 ### [v0.2.1](https://github.com/h2oai/datatable/compare/v0.2.1...v0.2.0) — 2017-09-11

--- a/datatable/dt.py
+++ b/datatable/dt.py
@@ -208,17 +208,19 @@ class DataTable(object):
         if dim == 0:
             arr = arr.reshape((1, 1))
         if dim == 1:
-            arr = arr.reshape((1, len(arr)))
+            arr = arr.reshape((len(arr), 1))
         if not arr.dtype.isnative:
             arr = arr.byteswap().newbyteorder()
 
-        ncols = len(arr)
+        ncols = arr.shape[1]
         if is_type(arr, NumpyMaskedArray_t):
-            dt = c.datatable_from_buffers([arr.data[i] for i in range(ncols)])
-            mask = c.datatable_from_buffers([arr.mask[i] for i in range(ncols)])
+            dt = c.datatable_from_buffers([arr.data[:, i]
+                                           for i in range(ncols)])
+            mask = c.datatable_from_buffers([arr.mask[:, i]
+                                             for i in range(ncols)])
             dt.apply_na_mask(mask)
         else:
-            dt = c.datatable_from_buffers([arr[i] for i in range(ncols)])
+            dt = c.datatable_from_buffers([arr[:, i] for i in range(ncols)])
 
         self._fill_from_dt(dt, names=["C%d" % i for i in range(1, ncols + 1)])
 

--- a/datatable/graph/rows_node.py
+++ b/datatable/graph/rows_node.py
@@ -474,9 +474,11 @@ def make_rowfilter(rows, dt, cmod, _nested=False):
     if is_type(rows, NumpyArray_t):
         arr = rows
         if not (len(arr.shape) == 1 or
-                len(arr.shape) == 2 and arr.shape[0] == 1):
+                len(arr.shape) == 2 and min(arr.shape) == 1):
             raise TValueError("Only a single-dimensional numpy.array is allowed"
                               " as a `rows` argument, got %r" % arr)
+        if len(arr.shape) == 2 and arr.shape[1] > 1:
+            arr = arr.T
         if not (str(arr.dtype) == "bool" or str(arr.dtype).startswith("int")):
             raise TValueError("Either a boolean or an integer numpy.array is "
                               "expected for `rows` argument, got %r" % arr)

--- a/tests/munging/test_dt_rows.py
+++ b/tests/munging/test_dt_rows.py
@@ -298,10 +298,14 @@ def test_rows_int_numpy_array(dt0, numpy):
     assert dt2.internal.check()
     assert dt1.shape == dt2.shape
     assert dt1.topython() == dt2.topython()
+    dt3 = dt0(rows=numpy.array([[7], [1], [0], [3]]))
+    assert dt3.internal.check()
+    assert dt3.shape == dt2.shape
+    assert dt3.topython() == dt2.topython()
 
 
 def test_rows_int_numpy_array_errors(dt0, numpy):
-    assert_valueerror(dt0, numpy.array([[1], [2], [3]]),
+    assert_valueerror(dt0, numpy.array([[1, 2], [2, 1], [3, 3]]),
                       "Only a single-dimensional numpy.array is allowed as a "
                       "`rows` argument")
     assert_valueerror(dt0, numpy.array([[[4, 0, 1]]]),

--- a/tests/test_dt_create.py
+++ b/tests/test_dt_create.py
@@ -135,10 +135,10 @@ def test_create_from_1d_numpy_array(numpy):
 def test_create_from_2d_numpy_array(numpy):
     a = numpy.array([[5, 4, 3, 10, 12], [-2, -1, 0, 1, 7]])
     d = dt.DataTable(a)
-    assert d.shape == (5, 2)
-    assert d.names == ("C1", "C2")
+    assert d.shape == a.shape
+    assert d.names == ("C1", "C2", "C3", "C4", "C5")
     assert d.internal.check()
-    assert d.topython() == a.tolist()
+    assert d.topython() == a.T.tolist()
 
 
 def test_create_from_3d_numpy_array(numpy):


### PR DESCRIPTION
* Constructing DataTable from a 2D numpy array now preserves shape of that array. At the same time it is no longer true that `arr.tolist() == numpy.array(DataTable(arr)).tolist()`: the list will be transposed.
* It is now allowed to pass a single-row numpy array as an argument to `dt(rows=...)`, which will be treated the same as if it was a single-column array.

Closes #403 