### PR TITLE
When converting big integers into a DataTable, turn them into infinities rather than throwing an exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Converting a DataTable into a numpy array now also preserves shape. At the same time it is
   no longer true that `dt.topython() == dt.tonumpy().tolist()`: the list will be transposed.
 
+#### Fixed
+- `datatable` will now convert huge integers into double `inf` values instead of raising an exception.
+
 
 ### [v0.2.1](https://github.com/h2oai/datatable/compare/v0.2.1...v0.2.0) — 2017-09-11
 #### Added

--- a/tests/test_dt_create.py
+++ b/tests/test_dt_create.py
@@ -228,3 +228,13 @@ def test_issue_42():
     assert d.shape == (4, 1)
     assert d.types == ("str", )
     assert d.internal.check()
+
+
+def test_issue_409():
+    from math import inf, copysign
+    d = dt.DataTable([10**333, -10**333, 10**-333, -10**-333])
+    assert d.internal.check()
+    assert d.types == ("real", )
+    p = d.topython()
+    assert p == [[inf, -inf, 0.0, -0.0]]
+    assert copysign(1, p[0][-1]) == -1


### PR DESCRIPTION

Closes #409