### PR TITLE
Improve rounding behavior in Dragonfly algorithm

### DIFF
--- a/tests/test_tocsv.py
+++ b/tests/test_tocsv.py
@@ -52,6 +52,17 @@ def test_save_floats():
     assert d.to_csv(hex=True).split("\n") == dd.to_csv(hex=True).split("\n")
 
 
+def test_save_double2():
+    src = [10**p for p in range(-307, 308)]
+    res = (["1e%02d" % i for i in range(-307, -4)] +
+           ["0.0001", "0.001", "0.01", "0.1"] +
+           [str(10**i) for i in range(15)] +
+           ["1e+%02d" % i for i in range(15, 308)])
+    d = dt.DataTable(src)
+    assert d.stypes == ("f8r", )
+    assert d.to_csv().split("\n")[1:-1] == res
+
+
 def pyhex(v):
     """
     Normalize Python's "hex" representation by removing trailing zeros. For


### PR DESCRIPTION
Now if epsilon is in the range 50..100, we will also attempt to round to multiples of 200. For example, if D = 10000000000000055 and eps=70, then previously both D = 10000000000000000 and D = 10000000000000100 were viable roundings. The latter was chosen because 55 is closer to 100 than to 0. However a better strategy is always to prefer the candidate with more 0s. In order to achieve that, we now try to round to 200s.

Closes #416