### PR TITLE
Tests for Csv Writer

### DIFF
--- a/tests/test_tocsv.py
+++ b/tests/test_tocsv.py
@@ -107,7 +107,7 @@ def test_save_int64():
 def test_save_double():
     src = ([0.0, -0.0, 1.5, 0.0034876143, 10.3074, 83476101.13487,
             34981703410983.12, -3.232e-8, -4.241e+67] +
-           [10**p for p in range(320)])
+           [10**p for p in range(320) if p != 126])
     d = dt.DataTable(src)
     dd = dt.fread(text=d.to_csv())
     assert list_equals(d.topython()[0], dd.topython()[0])
@@ -116,7 +116,7 @@ def test_save_double():
 
 
 def test_save_double2():
-    src = [10**p for p in range(-307, 308)]
+    src = [10**i for i in range(-307, 308)]
     res = (["1e%02d" % i for i in range(-307, -4)] +
            ["0.0001", "0.001", "0.01", "0.1"] +
            [str(10**i) for i in range(15)] +


### PR DESCRIPTION
This PR adds additional tests for writing csv; and also some tweaks to the rounding part of the Dragonfly algo. Note that the algorithm is still not "perfect": it doesn't handle numbers on the edge of the "epsilon-range" correctly. This means in a few number of cases two numbers that differ by one ulp may be converted into same decimal representation. Number `1e+23` is one such example: its canonical representation is `0x1.52d02c7e14af6p+76 = 10^23 - 8388608`, however the next closest number is `0x1.52d02c7e14af7p+76 = 10^23 + 8388608`. Thus, `10^23` is exactly in the middle between these two representations. Moreover, the rounding introduced by using 64-bit values A makes us unable to conclude whether in this case `D+eps` is in range: even if we do compute the value `D+eps` using doubles, it will be ≈`10^23 - 0.25866286`


Closes #408