### PR TITLE
Add new parameter _strategy for CsvWriter

### DIFF
--- a/c/csv/py_csv.cxx
+++ b/c/csv/py_csv.cxx
@@ -29,12 +29,16 @@ PyObject* pywrite_csv(UU, PyObject *args)
     pydt = PyObject_GetAttrString(pywriter, "datatable");
     dt = datatable_unwrapx(pydt);
     std::string filename = get_attr_string(pywriter, "path");
+    std::string strategy = get_attr_string(pywriter, "_strategy");
 
     // Create the CsvWriter object
     CsvWriter cwriter(dt, filename);
     cwriter.set_logger(pywriter);
     cwriter.set_verbose(get_attr_bool(pywriter, "verbose"));
     cwriter.set_usehex(get_attr_bool(pywriter, "hex"));
+    cwriter.set_strategy((strategy == "mmap")  ? WRITE_STRATEGY_MMAP :
+                         (strategy == "write") ? WRITE_STRATEGY_WRITE :
+                                                 WRITE_STRATEGY_AUTO);
 
     std::vector<std::string> colnames;
     get_attr_stringlist(pywriter, "column_names", colnames);

--- a/c/csv/writer.cxx
+++ b/c/csv/writer.cxx
@@ -545,16 +545,24 @@ void CsvWriter::create_target(size_t size)
   if (path.empty()) {
     wb = new MemoryWritableBuffer(size);
   } else {
-    #ifdef __APPLE__
+    if (strategy == WRITE_STRATEGY_AUTO) {
+      #ifdef __APPLE__
+        strategy = WRITE_STRATEGY_WRITE;
+      #else
+        strategy = WRITE_STRATEGY_MMAP;
+      #endif
+    }
+    if (strategy == WRITE_STRATEGY_WRITE) {
       VLOG("Creating an empty destination file %s. If the file already exists "
            "it will be truncated.\n", path.c_str());
       wb = new FileWritableBuffer(path);
-    #else
-      VLOG("Creating destination file %s of size %s. If the file already "
-           "exists it will be overwritten.\n",
+    }
+    if (strategy == WRITE_STRATEGY_MMAP) {
+      VLOG("Creating and memory-mapping destination file %s of size %s. If the "
+           "file already exists it will be overwritten.\n",
            path.c_str(), filesize_to_str(size));
       wb = new MmapWritableBuffer(path, size);
-    #endif
+    }
   }
   t_create_target = checkpoint();
 }

--- a/c/csv/writer.h
+++ b/c/csv/writer.h
@@ -23,6 +23,11 @@
 #include "memorybuf.h"
 #include "utils.h"
 
+#define WRITE_STRATEGY_AUTO  0
+#define WRITE_STRATEGY_MMAP  1
+#define WRITE_STRATEGY_WRITE 2
+
+
 class CsvColumn;
 
 class CsvWriter {
@@ -32,9 +37,10 @@ class CsvWriter {
   std::vector<std::string> column_names;
   void *logger;
   int nthreads;
+  int8_t strategy;
   bool usehex;
   bool verbose;
-  __attribute__((unused)) char _padding[2];
+  __attribute__((unused)) char _padding[1];
 
   // Intermediate values used while writing the file
   WritableBuffer* wb;
@@ -59,6 +65,7 @@ public:
   void set_nthreads(int n) { nthreads = n; }
   void set_usehex(bool v) { usehex = v; }
   void set_verbose(bool v) { verbose = v; }
+  void set_strategy(int s) { strategy = static_cast<int8_t>(s); }
   void set_column_names(std::vector<std::string>& names) {
     column_names = std::move(names);
   }

--- a/datatable/csv.py
+++ b/datatable/csv.py
@@ -9,7 +9,7 @@ __all__ = ("write_csv", "CsvWriter")
 
 
 
-def write_csv(dt, path="", nthreads=0, hex=False, verbose=False):
+def write_csv(dt, path="", nthreads=0, hex=False, verbose=False, **kwargs):
     """
     Write the DataTable into the provided file in CSV format.
 
@@ -37,20 +37,22 @@ def write_csv(dt, path="", nthreads=0, hex=False, verbose=False):
     """
     if path.startswith("~"):
         path = os.path.expanduser(path)
-    writer = CsvWriter(dt, path, nthreads, hex, verbose)
+    writer = CsvWriter(dt, path, nthreads, hex, verbose, **kwargs)
     return writer.write()
 
 
 
 class CsvWriter(object):
 
-    def __init__(self, datatable, path, nthreads=0, hex=False, verbose=False):
+    def __init__(self, datatable, path, nthreads=0, hex=False, verbose=False,
+                 _strategy="auto"):
         self.datatable = datatable.internal
         self.column_names = datatable.names
         self.nthreads = nthreads
         self.path = path
         self.hex = hex
         self.verbose = verbose
+        self._strategy = _strategy
         self._log_newline = False
 
     def write(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,10 @@
 # This file is used by `pytest` to define common fixtures shared across all
 # tests.
 #-------------------------------------------------------------------------------
+import os
 import sys
 import pytest
+import tempfile as mod_tempfile
 
 
 @pytest.fixture(autouse=True, scope="session")
@@ -54,3 +56,11 @@ def h2o():
             pytest.skip("h2o version 3.14+ is required, you have %s" % v)
     except ImportError:
         pytest.skip("h2o module is required for this test")
+
+
+@pytest.fixture(scope="function")
+def tempfile():
+    fd, fname = mod_tempfile.mkstemp()
+    os.close(fd)
+    yield fname
+    os.unlink(fname)

--- a/tests/test_tocsv.py
+++ b/tests/test_tocsv.py
@@ -21,6 +21,8 @@ def pyhex(v):
 
 
 #-------------------------------------------------------------------------------
+# Test generic saving
+#-------------------------------------------------------------------------------
 
 def test_save_simple():
     d = dt.DataTable([[1, 4, 5], [True, False, None], ["foo", None, "bar"]],
@@ -58,6 +60,24 @@ def test_write_spacenames():
     dd = dt.fread(text=d.to_csv())
     assert d.topython() == dd.topython()
 
+
+def test_strategy(capsys, tempfile):
+    """Check that the _strategy parameter is respected."""
+    d = dt.DataTable({"A": [5, 6, 10, 12], "B": ["one", "two", "tree", "for"]})
+    d.to_csv(tempfile, _strategy="mmap", verbose=True)
+    out, err = capsys.readouterr()
+    assert err == ""
+    assert ("Creating and memory-mapping destination file " + tempfile) in out
+    d.to_csv(tempfile, _strategy="write", verbose=True)
+    out, err = capsys.readouterr()
+    assert err == ""
+    assert ("Creating an empty destination file " + tempfile) in out
+
+
+
+#-------------------------------------------------------------------------------
+# Test writing different data types
+#-------------------------------------------------------------------------------
 
 def test_save_bool():
     d = dt.DataTable([True, False, None, None, False, False, True, False])


### PR DESCRIPTION
By default, CsvWriter automatically chooses which writing algorithm to use. This parameter allows the user to override that choice. Possible values are: `"mmap"` and `"write"`.

Closes #433