### PR TITLE
Make Column::stype a private field, and instead provide a getter

### DIFF
--- a/c/column.h
+++ b/c/column.h
@@ -68,9 +68,9 @@ public:  // TODO: convert these into private
     int64_t nrows;       // 8
     Stats*  stats;       // 8
     int     refcount;    // 4
-    SType   stype;       // 1
 
 private:
+    SType   _stype;      // 1
     __attribute__((unused)) char _padding[3];
 
     Column(size_t nrows_, SType stype_); // helper for other constructors
@@ -83,6 +83,7 @@ public:
     Column(const char*, SType, size_t, const char*); // Load from disk
     explicit Column(const Column&);
 
+    SType stype() const;
     void* data() const;
     void* data_at(size_t) const;
     size_t alloc_size() const;

--- a/c/column_cast.cc
+++ b/c/column_cast.cc
@@ -17,15 +17,15 @@ static castfn_ptr hardcasts[DT_STYPES_COUNT][DT_STYPES_COUNT];
  */
 Column* Column::cast(SType new_stype)
 {
-    castfn_ptr converter = hardcasts[this->stype][new_stype];
+    castfn_ptr converter = hardcasts[_stype][new_stype];
     if (converter) {
         Column *res = new Column(new_stype, (size_t) this->nrows);
         if (res == NULL) return NULL;
         return converter(this, res);
-    } else if (this->stype == new_stype) {
+    } else if (_stype == new_stype) {
         return new Column(*this);
     } else {
-        dterrv("Unable to cast from stype=%d into stype=%d", this->stype, new_stype);
+        dterrv("Unable to cast from stype=%d into stype=%d", _stype, new_stype);
     }
 }
 

--- a/c/csv/writer.cc
+++ b/c/csv/writer.cc
@@ -53,9 +53,9 @@ public:
   CsvColumn(Column *col) {
     data = col->data();
     strbuf = NULL;
-    writer = writers_per_stype[col->stype];
-    if (!writer) throw Error("Cannot write type %d", col->stype);
-    if (col->stype == ST_STRING_I4_VCHAR) {
+    writer = writers_per_stype[col->stype()];
+    if (!writer) throw Error("Cannot write type %d", col->stype());
+    if (col->stype() == ST_STRING_I4_VCHAR) {
       strbuf = reinterpret_cast<char*>(data) - 1;
       data = strbuf + 1 + ((VarcharMeta*)col->meta)->offoff;
     }
@@ -511,7 +511,7 @@ size_t CsvWriter::estimate_output_size()
   size_t total_string_size = 0;
   for (size_t i = 0; i < ncols; i++) {
     Column *col = dt->columns[i];
-    SType stype = col->stype;
+    SType stype = col->stype();
     bool stype_i4s = (stype == ST_STRING_I4_VCHAR);
     bool stype_i8s = (stype == ST_STRING_I8_VCHAR);
     if (stype_i4s || stype_i8s) {
@@ -652,7 +652,7 @@ void CsvWriter::create_column_writers(size_t ncols)
   writers_per_stype[ST_REAL_F8] = usehex? write_f8_hex : write_f8_dec;
   for (int64_t i = 0; i < dt->ncols; i++) {
     Column *dtcol = dt->columns[i];
-    SType stype = dtcol->stype;
+    SType stype = dtcol->stype();
     CsvColumn *csvcol = new CsvColumn(dtcol);
     columns.push_back(csvcol);
     if (stype == ST_STRING_I4_VCHAR || stype == ST_STRING_I8_VCHAR) {

--- a/c/datatable.cc
+++ b/c/datatable.cc
@@ -115,7 +115,7 @@ DataTable* DataTable::apply_na_mask(DataTable *mask)
         throw new Error("Neither target DataTable nor a mask can be views");
     }
     for (int64_t i = 0; i < ncols; ++i) {
-        if (mask->columns[i]->stype != ST_BOOLEAN_I1)
+        if (mask->columns[i]->stype() != ST_BOOLEAN_I1)
             dterrv("Column %lld in mask is not of a boolean type", i);
     }
 
@@ -124,7 +124,7 @@ DataTable* DataTable::apply_na_mask(DataTable *mask)
         Column *col = columns[i];
         col->stats->reset();
         uint8_t *mdata = (uint8_t*) mask->columns[i]->data();
-        switch (col->stype) {
+        switch (col->stype()) {
             case ST_BOOLEAN_I1:
             case ST_INTEGER_I1: {
                 uint8_t *cdata = (uint8_t*) col->data();
@@ -147,7 +147,7 @@ DataTable* DataTable::apply_na_mask(DataTable *mask)
             case ST_REAL_F4:
             case ST_INTEGER_I4: {
                 uint32_t *cdata = (uint32_t*) col->data();
-                uint32_t na = col->stype == ST_REAL_F4 ?
+                uint32_t na = col->stype() == ST_REAL_F4 ?
                               NA_F4_BITS :
                               static_cast<uint32_t>(GETNA<int32_t>());
                 #pragma omp parallel for schedule(dynamic,1024)
@@ -159,7 +159,7 @@ DataTable* DataTable::apply_na_mask(DataTable *mask)
             case ST_REAL_F8:
             case ST_INTEGER_I8: {
                 uint64_t *cdata = (uint64_t*) col->data();
-                uint64_t na = col->stype == ST_REAL_F8 ?
+                uint64_t na = col->stype() == ST_REAL_F8 ?
                               NA_F8_BITS :
                               static_cast<uint32_t>(GETNA<int32_t>());
                 #pragma omp parallel for schedule(dynamic,1024)
@@ -194,7 +194,7 @@ DataTable* DataTable::apply_na_mask(DataTable *mask)
                 break;
             }
             default:
-                throw new Error("Column type %d not supported", col->stype);
+                throw new Error("Column type %d not supported", col->stype());
         }
 
     }

--- a/c/datatable_check.cc
+++ b/c/datatable_check.cc
@@ -249,7 +249,7 @@ int DataTable::verify_integrity(char **errors)
     for (int64_t i = 0; i < ncols; i++) {
         Column *col = columns[i];
         Stats *stat = rowindex != NULL ? stats[i] : col->stats;
-        SType stype = col->stype;
+        SType stype = col->stype();
 
         /*
         TODO: move into Column::check_integrity()

--- a/c/datatable_load.cc
+++ b/c/datatable_load.cc
@@ -32,11 +32,11 @@ DataTable* DataTable::load(DataTable *colspec, int64_t nrows)
     Column *colf = colspec->columns[0];
     Column *cols = colspec->columns[1];
     Column *colm = colspec->columns[2];
-    if (colf->stype != ST_STRING_I4_VCHAR ||
-        cols->stype != ST_STRING_I4_VCHAR ||
-        colm->stype != ST_STRING_I4_VCHAR) {
+    if (colf->stype() != ST_STRING_I4_VCHAR ||
+        cols->stype() != ST_STRING_I4_VCHAR ||
+        colm->stype() != ST_STRING_I4_VCHAR) {
         throw new Error("String columns are expected in colspec table, instead got "
-               "%d, %d and %d", colf->stype, cols->stype, colm->stype);
+               "%d, %d and %d", colf->stype(), cols->stype(), colm->stype());
     }
 
     int64_t oof = ((VarcharMeta*) colf->meta)->offoff;

--- a/c/py_column.cc
+++ b/c/py_column.cc
@@ -26,13 +26,13 @@ static PyObject* get_mtype(Column_PyObject *self) {
 
 DT_DOCS(stype, "'Storage' type of the column")
 static PyObject* get_stype(Column_PyObject *self) {
-    return incref(py_stype_names[self->ref->stype]);
+    return incref(py_stype_names[self->ref->stype()]);
 }
 
 
 DT_DOCS(ltype, "'Logical' type of the column")
 static PyObject* get_ltype(Column_PyObject *self) {
-    return incref(py_ltype_names[stype_info[self->ref->stype].ltype]);
+    return incref(py_ltype_names[stype_info[self->ref->stype()].ltype]);
 }
 
 
@@ -53,7 +53,7 @@ DT_DOCS(meta, "String representation of the column's `meta` struct")
 static PyObject* get_meta(Column_PyObject *self) {
     Column *col = self->ref;
     void *meta = col->meta;
-    switch (col->stype) {
+    switch (col->stype()) {
         case ST_STRING_I4_VCHAR:
         case ST_STRING_I8_VCHAR:
             return PyUnicode_FromFormat("offoff=%lld",

--- a/c/py_datatable.c
+++ b/c/py_datatable.c
@@ -87,7 +87,7 @@ static PyObject* get_types(DataTable_PyObject *self)
     PyObject *list = PyTuple_New((Py_ssize_t) i);
     if (list == NULL) return NULL;
     while (--i >= 0) {
-        SType st = self->ref->columns[i]->stype;
+        SType st = self->ref->columns[i]->stype();
         LType lt = stype_info[st].ltype;
         PyTuple_SET_ITEM(list, i, incref(py_ltype_names[lt]));
     }
@@ -103,7 +103,7 @@ static PyObject* get_stypes(DataTable_PyObject *self)
     PyObject *list = PyTuple_New((Py_ssize_t) i);
     if (list == NULL) return NULL;
     while (--i >= 0) {
-        SType st = dt->columns[i]->stype;
+        SType st = dt->columns[i]->stype();
         PyTuple_SET_ITEM(list, i, incref(py_stype_names[st]));
     }
     return list;

--- a/c/py_datawindow.c
+++ b/c/py_datawindow.c
@@ -116,7 +116,7 @@ static int _init_(DataWindow_PyObject *self, PyObject *args, PyObject *kwds)
                            rindex_is_arr32? rindexarr32[j] :
                            rindex_is_arr64? (int64_t) rindexarr64[j] :
                                             rindexstart + rindexstep * j;
-            PyObject *value = py_stype_formatters[col->stype](col, irow);
+            PyObject *value = py_stype_formatters[col->stype()](col, irow);
             if (value == NULL) goto fail;
             PyList_SET_ITEM(py_coldata, n_init_rows++, value);
         }
@@ -128,7 +128,7 @@ static int _init_(DataWindow_PyObject *self, PyObject *args, PyObject *kwds)
     if (stypes == NULL || ltypes == NULL) goto fail;
     for (int64_t i = col0; i < col1; i++) {
         Column *col = dt->columns[i];
-        SType stype = col->stype;
+        SType stype = col->stype();
         LType ltype = stype_info[stype].ltype;
         PyList_SET_ITEM(ltypes, i - col0, incref(py_ltype_names[ltype]));
         PyList_SET_ITEM(stypes, i - col0, incref(py_stype_names[stype]));
@@ -330,17 +330,17 @@ static int _check_consistency(
     // check each column within the window for correctness
     for (int64_t i = col0; i < col1; ++i) {
         Column *col = dt->columns[i];
-        if (col->stype < 1 || col->stype >= DT_STYPES_COUNT) {
+        if (col->stype() < 1 || col->stype() >= DT_STYPES_COUNT) {
             PyErr_Format(PyExc_RuntimeError,
                 "Invalid datatable: column %ld has unknown type %d",
-                i, col->stype);
+                i, col->stype());
             return 0;
         }
-        if (col->meta == NULL && stype_info[col->stype].metasize > 0) {
+        if (col->meta == NULL && stype_info[col->stype()].metasize > 0) {
             PyErr_Format(PyExc_RuntimeError,
                 "Invalid datatable: column %ld has type %s but meta info is "
                 "missing",
-                i, stype_info[col->stype].code);
+                i, stype_info[col->stype()].code);
             return 0;
         }
     }

--- a/c/py_fread.c
+++ b/c/py_fread.c
@@ -209,7 +209,7 @@ Column* realloc_column(Column *col, SType stype, size_t nrows, int j)
 
     size_t new_alloc_size = stype_info[stype].elemsize * nrows;
     col->mbuf->resize(new_alloc_size);
-    col->stype = stype;
+    col->_stype = stype;
     col->nrows = (int64_t) nrows;
     return col;
 }

--- a/c/py_rowindex.c
+++ b/c/py_rowindex.c
@@ -187,7 +187,7 @@ PyObject* pyrowindex_from_boolcolumn(UU, PyObject *args)
         return NULL;
     }
     Column *col = dt->columns[0];
-    if (col->stype != ST_BOOLEAN_I1) {
+    if (col->stype() != ST_BOOLEAN_I1) {
         PyErr_SetString(PyExc_ValueError, "A boolean column is required");
         return NULL;
     }
@@ -218,7 +218,7 @@ PyObject* pyrowindex_from_intcolumn(UU, PyObject *args)
         return NULL;
     }
     Column *col = dt->columns[0];
-    if (stype_info[col->stype].ltype != LT_INTEGER) {
+    if (stype_info[col->stype()].ltype != LT_INTEGER) {
         PyErr_SetString(PyExc_ValueError, "An integer column is required");
         return NULL;
     }

--- a/c/py_types.c
+++ b/c/py_types.c
@@ -96,7 +96,7 @@ static PyObject* stype_object_pyptr_tostring(Column *col, int64_t row)
 static PyObject* stype_notimpl(Column *col, UNUSED(int64_t row))
 {
     PyErr_Format(PyExc_NotImplementedError,
-                 "Cannot stringify column of type %d", col->stype);
+                 "Cannot stringify column of type %d", col->stype());
     return NULL;
 }
 

--- a/c/rowindex.cxx
+++ b/c/rowindex.cxx
@@ -250,7 +250,7 @@ RowIndex:: RowIndex(int64_t *array, int64_t n, int issorted) :
  */
 RowIndex* RowIndex::from_boolcolumn(Column *col, int64_t nrows)
 {
-    if (stype_info[col->stype].ltype != LT_BOOLEAN)
+    if (stype_info[col->stype()].ltype != LT_BOOLEAN)
         throw new Error("Column is not of boolean type");
     int8_t *data = (int8_t*) col->data();
     int64_t nout = 0;
@@ -295,7 +295,7 @@ RowIndex* RowIndex::from_boolcolumn(Column *col, int64_t nrows)
 RowIndex* RowIndex::from_column_with_rowindex(Column *col, RowIndex *rowindex)
 {
     RowIndex* res = NULL;
-    switch(stype_info[col->stype].ltype) {
+    switch(stype_info[col->stype()].ltype) {
     case LT_BOOLEAN: {
         int8_t *data = (int8_t*) col->data();
         int64_t nouts = 0;
@@ -357,17 +357,17 @@ RowIndex* RowIndex::from_column_with_rowindex(Column *col, RowIndex *rowindex)
  */
 RowIndex* RowIndex::from_intcolumn(Column *col, int is_temp_column)
 {
-    if (stype_info[col->stype].ltype != LT_INTEGER)
+    if (stype_info[col->stype()].ltype != LT_INTEGER)
         throw new Error("Column is not of integer type");
 
     RowIndex* res = NULL;
-    if (col->stype == ST_INTEGER_I1 || col->stype == ST_INTEGER_I2) {
+    if (col->stype() == ST_INTEGER_I1 || col->stype() == ST_INTEGER_I2) {
         col = col->cast(ST_INTEGER_I4);
         is_temp_column = 2;
     }
 
     int64_t nrows = col->nrows;
-    if (col->stype == ST_INTEGER_I8) {
+    if (col->stype() == ST_INTEGER_I8) {
         int64_t *arr64 = NULL;
         if (is_temp_column) {
             arr64 = (int64_t*) col->data();
@@ -379,7 +379,7 @@ RowIndex* RowIndex::from_intcolumn(Column *col, int is_temp_column)
         res = new RowIndex(arr64, nrows, 0);
         res->compactify();
     } else
-    if (col->stype == ST_INTEGER_I4) {
+    if (col->stype() == ST_INTEGER_I4) {
         int32_t *arr32 = NULL;
         if (is_temp_column) {
             arr32 = (int32_t*) col->data();

--- a/c/sort.c
+++ b/c/sort.c
@@ -275,7 +275,7 @@ RowIndex* Column::sort(Column *col, RowIndex *rowindex)
             ri->decref();
         }
     }
-    SType stype = col->stype;
+    SType stype = col->stype();
     prepare_inp_fn prepfn = prepare_inp_fns[stype];
     SortContext *sc = NULL;
     dtcalloc(sc, SortContext, 1);

--- a/c/stats.cc
+++ b/c/stats.cc
@@ -214,15 +214,15 @@ Column* Stats::countna_column() {
 }
 
 Column* Stats::min_column() {
-    return make_na_stat_column(_ref_col->stype);
+    return make_na_stat_column(_ref_col->stype());
 }
 
 Column* Stats::max_column() {
-    return make_na_stat_column(_ref_col->stype);
+    return make_na_stat_column(_ref_col->stype());
 }
 
 Column* Stats::sum_column() {
-    return make_na_stat_column(_ref_col->stype);
+    return make_na_stat_column(_ref_col->stype());
 }
 //---------------------------------------------------
 
@@ -347,7 +347,7 @@ NumericalStats<T, A>::NumericalStats(const Column *col, const RowIndex *ri)
 //-------------- Get Stat as a Column ---------------
 template <typename T, typename A>
 Column* NumericalStats<T, A>::min_column() {
-    const SType stype = _ref_col->stype;
+    const SType stype = _ref_col->stype();
     if (stype == ST_VOID) return NULL;
     Column* out = new Column(stype, 1);
     *((T*)(out->data())) = min<T>();
@@ -356,7 +356,7 @@ Column* NumericalStats<T, A>::min_column() {
 
 template <typename T, typename A>
 Column* NumericalStats<T, A>::max_column() {
-    const SType stype = _ref_col->stype;
+    const SType stype = _ref_col->stype();
     if (stype == ST_VOID) return NULL;
     Column* out = new Column(stype, 1);
     *((T*)(out->data())) = max<T>();
@@ -529,23 +529,15 @@ void BooleanStats::compute_numerical_stats() {
  */
 Stats* Stats::construct(const Column *col, const RowIndex *ri) {
     if (col == NULL) return new Stats(NULL, NULL);
-    switch(col->stype) {
-    case ST_BOOLEAN_I1:
-        return new BooleanStats(col, ri);
-    case ST_INTEGER_I1:
-        return new IntegerStats<int8_t>(col, ri);
-    case ST_INTEGER_I2:
-        return new IntegerStats<int16_t>(col, ri);
-    case ST_INTEGER_I4:
-        return new IntegerStats<int32_t>(col, ri);
-    case ST_INTEGER_I8:
-        return new IntegerStats<int64_t>(col, ri);
-    case ST_REAL_F4:
-        return new RealStats<float>(col, ri);
-    case ST_REAL_F8:
-        return new RealStats<double>(col, ri);
-    default:
-        return new Stats(col, ri);
+    switch(col->stype()) {
+        case ST_BOOLEAN_I1: return new BooleanStats(col, ri);
+        case ST_INTEGER_I1: return new IntegerStats<int8_t>(col, ri);
+        case ST_INTEGER_I2: return new IntegerStats<int16_t>(col, ri);
+        case ST_INTEGER_I4: return new IntegerStats<int32_t>(col, ri);
+        case ST_INTEGER_I8: return new IntegerStats<int64_t>(col, ri);
+        case ST_REAL_F4:    return new RealStats<float>(col, ri);
+        case ST_REAL_F8:    return new RealStats<double>(col, ri);
+        default:            return new Stats(col, ri);
     }
 }
 


### PR DESCRIPTION
This is a prerequisite for converting Column into an hierarchy of classes.