### PR TITLE
Add reference counter to MemoryBuffer

### DIFF
--- a/c/column.cc
+++ b/c/column.cc
@@ -528,7 +528,7 @@ void Column::decref() {
     if (refcount <= 0) {
         dtfree(meta);
         Stats::destruct(stats);
-        delete mbuf;
+        mbuf->release();
         delete this;
     }
 }

--- a/c/column_string.cc
+++ b/c/column_string.cc
@@ -39,7 +39,7 @@ SType StringColumn<T>::stype() const {
 
 template <typename T>
 StringColumn<T>::~StringColumn() {
-  delete strbuf;
+  if (strbuf) strbuf->release();
 }
 
 

--- a/c/py_fread.c
+++ b/c/py_fread.c
@@ -388,7 +388,7 @@ void setFinalNrow(size_t nrows) {
                 int ret = rename(fname, fname2);
                 if (ret == -1) printf("Unable to rename: %d\n", errno);
             } else {
-                delete col->mbuf;
+                col->mbuf->release();
             }
             col->mbuf = new MemoryMemBuf(final_ptr, final_size);
             col->nrows = (int64_t) nrows;


### PR DESCRIPTION
In order to "delete" a `MemoryBuffer*` object one now has to call `membuf->release()` (using the `delete` operator is prohibited).
In order to acquire a new reference to the `MemoryBuffer*` object, call `membuf->newref()`. This is equivalent to making a shallow copy.