### PR TITLE
RowIndexes are now contained in columns.

### DIFF
--- a/c/column.h
+++ b/c/column.h
@@ -53,10 +53,10 @@ class Stats;
  *     depends on the `stype`.
  *
  */
-class Column
-{
+class Column {
 protected:
   MemoryBuffer *mbuf;
+  RowIndex *ri;
 
 public:  // TODO: convert these into private
   void   *meta;        // 8
@@ -79,9 +79,11 @@ public:
   virtual ~Column();
 
   virtual SType stype() const;
-  void* data() const;
-  void* data_at(size_t) const;
+  inline void* data() const { return mbuf->get(); }
+  inline void* data_at(size_t i) const { return mbuf->at(i); }
+  inline RowIndex* rowindex() const { return ri; }
   size_t alloc_size() const;
+  int64_t data_nrows() const;
   PyObject* mbuf_repr() const;
   int mbuf_refcount() const;
 
@@ -92,16 +94,17 @@ public:
   void resize_and_fill(int64_t nrows);
 
   Column* shallowcopy();
+  Column* shallowcopy(RowIndex*);
   Column* deepcopy();
   Column* cast(SType);
   Column* rbind(Column**);
-  Column* extract(RowIndex* = NULL);
+  Column* extract();
   Column* save_to_disk(const char*);
   size_t i4s_datasize();
   size_t i8s_datasize();
   size_t get_allocsize();
+  RowIndex* sort() const;
 
-  static RowIndex* sort(Column*, RowIndex*);
   static size_t i4s_padding(size_t datasize);
   static size_t i8s_padding(size_t datasize);
 

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -47,9 +47,8 @@ public:
     int64_t     ncols;
     RowIndex   *rowindex;
     Column    **columns;
-    Stats     **stats;
 
-    DataTable(Column**, RowIndex* = NULL);
+    DataTable(Column**);
     ~DataTable();
     DataTable* delete_columns(int*, int);
     DataTable* apply_na_mask(DataTable*);

--- a/c/datatable_cbind.cc
+++ b/c/datatable_cbind.cc
@@ -36,19 +36,10 @@ DataTable* DataTable::cbind(DataTable **dts, int ndts)
     for (int i = 0; i < ndts; ++i) {
         int64_t ncolsi = dts[i]->ncols;
         int64_t nrowsi = dts[i]->nrows;
-        if (dts[i]->rowindex) {
-            RowIndex *ri = dts[i]->rowindex;
-            for (int64_t ii = 0; ii < ncolsi; ++ii) {
-                Column *c = dts[i]->columns[ii]->extract(ri);
-                if (nrowsi < t_nrows) c->resize_and_fill(t_nrows);
-                columns[j++] = c;
-            }
-        } else {
-            for (int64_t ii = 0; ii < ncolsi; ++ii) {
-                Column *c = dts[i]->columns[ii]->shallowcopy();
-                if (nrowsi < t_nrows) c->resize_and_fill(t_nrows);
-                columns[j++] = c;
-            }
+        for (int64_t ii = 0; ii < ncolsi; ++ii) {
+            Column *c = dts[i]->columns[ii]->extract();
+            if (nrowsi < t_nrows) c->resize_and_fill(t_nrows);
+            columns[j++] = c;
         }
     }
     assert(j == t_ncols);

--- a/c/datatable_check.cc
+++ b/c/datatable_check.cc
@@ -137,23 +137,6 @@ int DataTable::verify_integrity(char **errors)
         return 1;
     }
 
-    if (rowindex == NULL && stats != NULL) {
-        ERR("`stats` array is not NULL when rowindex is NULL");
-    } else if (rowindex != NULL && stats == NULL) {
-        ERR("`stats` array is NULL when rowindex is not NULL");
-    } else if (rowindex != NULL && stats != NULL){
-        size_t n_stats_allocd = array_size(stats, sizeof(Stats*));
-
-        if ((!stats || !n_stats_allocd) && ncols > 0) {
-            ERR("Stats array is not allocated\n");
-        }
-
-        if (ncols > (int64_t) n_stats_allocd) {
-            ERR("Size of the `stats` array %lld is smaller than the number of "
-                "columns %lld (and rowindex is not NULL)\n", (int64_t) n_stats_allocd, ncols);
-        }
-    }
-
     // Check that each Column is not NULL
     for (int64_t i = 0; i < ncols; i++) {
         if (columns[i] == NULL) {
@@ -248,8 +231,9 @@ int DataTable::verify_integrity(char **errors)
     // Check each individual column
     for (int64_t i = 0; i < ncols; i++) {
         Column *col = columns[i];
-        Stats *stat = rowindex != NULL ? stats[i] : col->stats;
+        Stats *stat = col->stats;
         SType stype = col->stype();
+        int64_t data_nrows = col->data_nrows();
 
         /*
         TODO: move into Column::check_integrity()
@@ -271,14 +255,26 @@ int DataTable::verify_integrity(char **errors)
             ERR("Invalid storage type %d in column %lld\n", stype, i);
             continue;
         }
-        if (rowindex == NULL && col->nrows != nrows) {
+        if (col->nrows != nrows) {
             ERR("Column %lld has nrows=%lld, while the datatable has %lld rows\n",
                 i, col->nrows, nrows);
             continue;
         }
-        if (rowindex != NULL && col->nrows > 0 && col->nrows <= maxrow) {
-            ERR("Column %lld has nrows=%lld, but rowindex references row %lld\n",
-                i, col->nrows, maxrow);
+        if (rowindex == NULL && col->nrows != data_nrows) {
+            ERR("Column %lld has nrows=%lld, while the "
+                "internal memory buffer has %lld rows\n",
+                i, col->nrows, data_nrows);
+            continue;
+        }
+        if (rowindex != nullptr && col->nrows != rowindex->length) {
+            ERR("Column %lld has nrows=%lld, while the rowindex has %lld rows\n",
+                i, col->nrows, rowindex->length);
+            continue;
+        }
+        if (rowindex != NULL && data_nrows > 0 && data_nrows <= maxrow) {
+            ERR("Internal memory buffer of column %lld has nrows=%lld, but "
+                "rowindex references row %lld\n",
+                i, data_nrows, maxrow);
             continue;
         }
         if (col->mbuf_refcount() <= 0) {
@@ -346,7 +342,7 @@ int DataTable::verify_integrity(char **errors)
         size_t elemsize = stype_info[stype].elemsize;
         if (stype == ST_STRING_FCHAR)
             elemsize = (size_t) ((FixcharMeta*) col->meta)->n;
-        size_t exp_allocsize = elemsize * (size_t)col->nrows;
+        size_t exp_allocsize = elemsize * (size_t) data_nrows;
         if (offoff > 0)
             exp_allocsize += (size_t)offoff;
         if (col->alloc_size() != exp_allocsize) {
@@ -364,7 +360,7 @@ int DataTable::verify_integrity(char **errors)
         // Verify that a boolean column has only values 0, 1 and NA_I1
         if (stype == ST_BOOLEAN_I1) {
             int8_t *data = (int8_t*) col->data();
-            for (int64_t j = 0; j < col->nrows; j++) {
+            for (int64_t j = 0; j < data_nrows; j++) {
                 int8_t x = data[j];
                 if (!(x == NA_I1 || x == 0 || x == 1)) {
                     ERR("Boolean column %lld has value %d in row %lld\n",
@@ -381,7 +377,7 @@ int DataTable::verify_integrity(char **errors)
                     ERR("Number -1 was not found in front of the offsets " \
                         "section\n");                                      \
                 }                                                          \
-                for (int64_t j = 0; j < col->nrows; j++) {                 \
+                for (int64_t j = 0; j < data_nrows; j++) {                 \
                     T oj = offsets[j];                                     \
                     if (oj < 0 ? (oj != -lastoff) : (oj < lastoff)) {      \
                         ERR("Invalid offset in column %lld row %lld: "     \

--- a/c/datatable_rbind.cc
+++ b/c/datatable_rbind.cc
@@ -52,10 +52,8 @@ DataTable::rbind(DataTable **dts, int **cols, int ndts, int64_t new_ncols)
         for (int j = 0; j < ndts; ++j) {
             if (cols[i][j] < 0) {
                 cols0[j] = Column::new_data_column(ST_VOID, dts[j]->nrows);
-            } else if (dts[j]->rowindex) {
-                cols0[j] = dts[j]->columns[cols[i][j]]->extract(dts[j]->rowindex);
             } else {
-                cols0[j] = dts[j]->columns[cols[i][j]]->shallowcopy();
+                cols0[j] = dts[j]->columns[cols[i][j]]->extract();
             }
         }
         ret = col0->rbind(cols0);

--- a/c/py_buffers.c
+++ b/c/py_buffers.c
@@ -357,9 +357,7 @@ static int dt_getbuffer(DataTable_PyObject *self, Py_buffer *view, int flags)
     // Construct the data buffer
     for (size_t i = 0; i < ncols; i++) {
         Column *col = dt->columns[i];
-        if (dt->rowindex) {
-            col = col->extract(dt->rowindex);
-        }
+        col = col->extract();
         if (col->stype() == stype) {
             assert(col->alloc_size() == colsize);
             memcpy(add_ptr(buf, i * colsize), col->data(), colsize);
@@ -370,9 +368,7 @@ static int dt_getbuffer(DataTable_PyObject *self, Py_buffer *view, int flags)
             memcpy(add_ptr(buf, i * colsize), newcol->data(), colsize);
             delete newcol;
         }
-        if (dt->rowindex) {
-            delete col;
-        }
+        delete col;
     }
 
     // Fill in the `view` struct

--- a/c/py_rowindex.c
+++ b/c/py_rowindex.c
@@ -193,7 +193,7 @@ PyObject* pyrowindex_from_boolcolumn(UU, PyObject *args)
     }
 
     RowIndex *rowindex = dt->rowindex
-        ? RowIndex::from_column_with_rowindex(col, dt->rowindex)
+        ? RowIndex::from_column(col)
         : RowIndex::from_boolcolumn(col, dt->nrows);
 
     return py(rowindex);
@@ -224,7 +224,7 @@ PyObject* pyrowindex_from_intcolumn(UU, PyObject *args)
     }
 
     RowIndex *rowindex = dt->rowindex
-        ? RowIndex::from_column_with_rowindex(col, dt->rowindex)
+        ? RowIndex::from_column(col)
         : RowIndex::from_intcolumn(col, 0);
 
     if (rowindex->min < 0 || rowindex->max >= target_nrows) {

--- a/c/rowindex.cxx
+++ b/c/rowindex.cxx
@@ -292,8 +292,9 @@ RowIndex* RowIndex::from_boolcolumn(Column *col, int64_t nrows)
  * need to construct a RowIndex from a "view" column, then this column can
  * be mapped to a pair of source data column and a rowindex object.
  */
-RowIndex* RowIndex::from_column_with_rowindex(Column *col, RowIndex *rowindex)
+RowIndex* RowIndex::from_column(Column *col)
 {
+    RowIndex* rowindex = col->rowindex();
     RowIndex* res = NULL;
     switch(stype_info[col->stype()].ltype) {
     case LT_BOOLEAN: {
@@ -335,7 +336,7 @@ RowIndex* RowIndex::from_column_with_rowindex(Column *col, RowIndex *rowindex)
     } break;
 
     case LT_INTEGER: {
-        Column *newcol = col->extract(rowindex);
+        Column *newcol = col->extract();
         res = from_intcolumn(newcol, 1);
         delete newcol;
     } break;
@@ -443,8 +444,9 @@ RowIndex::RowIndex(RowIndex* other) :
  */
 RowIndex* RowIndex::merge(RowIndex *ri_ab, RowIndex *ri_bc)
 {
-    if (ri_ab == NULL) return new RowIndex(ri_bc);
-    if (ri_bc == NULL) return new RowIndex(ri_ab);
+    if (ri_ab == nullptr && ri_bc == nullptr) return nullptr;
+    if (ri_ab == nullptr) return new RowIndex(ri_bc);
+    if (ri_bc == nullptr) return new RowIndex(ri_ab);
 
     int64_t n = ri_bc->length;
     RowIndexType type_bc = ri_bc->type;

--- a/c/rowindex.h
+++ b/c/rowindex.h
@@ -82,7 +82,7 @@ public:
     static RowIndex* merge(RowIndex*, RowIndex*);
     static RowIndex* from_intcolumn(Column*, int);
     static RowIndex* from_boolcolumn(Column*, int64_t);
-    static RowIndex* from_column_with_rowindex(Column*, RowIndex*);
+    static RowIndex* from_column(Column*);
     static RowIndex* from_filterfn32(rowindex_filterfn32*, int64_t, int);
     static RowIndex* from_filterfn64(rowindex_filterfn64*, int64_t, int);
 private:

--- a/c/stats.h
+++ b/c/stats.h
@@ -31,7 +31,7 @@ class RowIndex;
  */
 class Stats {
 public:
-    static Stats* construct(const Column*, const RowIndex*);
+    static Stats* construct(Column*);
     static void destruct(Stats*);
 
     virtual void reset();
@@ -62,9 +62,8 @@ protected:
     double _sd;
     int64_t _countna;
     const Column* _ref_col;
-    const RowIndex* _ref_ri;
 
-    Stats(const Column*, const RowIndex*);
+    Stats(Column*);
     virtual ~Stats();
 
     //================== Get Stat as a Column ===================


### PR DESCRIPTION
A DataTable's rowindex address should be equal to each column's reference.

The field `nrows` now corresponds to RowIndex::length when the rowindex is not null. Use Column::data_nrows() to get the total number of rows in the column's memory buffer.
Refactored various methods to remove superflous RowIndex parameters.
(Closes #444)