### PR TITLE
Move apply_na_mask functionality into the Column's subclasses

### DIFF
--- a/c/column.h
+++ b/c/column.h
@@ -104,6 +104,13 @@ public:
   virtual void resize_and_fill(int64_t nrows) = 0;
 
   /**
+   * Modify the Column, replacing values specified by the provided `mask` with
+   * NAs. The `mask` column must have the same number of rows as the current,
+   * and neither of them can have a RowIndex.
+   */
+  virtual void apply_na_mask(const BoolColumn* mask) = 0;
+
+  /**
    * Create a shallow copy of this Column, possibly applying the provided
    * RowIndex. The copy is "shallow" in the sense that the main data buffer
    * is copied by-reference. If this column has a rowindex, and the user
@@ -198,6 +205,7 @@ public:
 
   int64_t data_nrows() const override;
   void resize_and_fill(int64_t nrows) override;
+  void apply_na_mask(const BoolColumn* mask) override;
 
 protected:
   static constexpr T na_elem = GETNA<T>();
@@ -343,6 +351,7 @@ public:
   SType stype() const override;
   Column* extract_simple_slice(RowIndex*) const;
   void resize_and_fill(int64_t nrows) override;
+  void apply_na_mask(const BoolColumn* mask) override;
 
   size_t datasize();
   int64_t data_nrows() const override;
@@ -374,6 +383,8 @@ extern template class StringColumn<int64_t>;
 
 //==============================================================================
 
+// "Fake" column, its only use is to serve as a placeholder for a Column with an
+// unknown type. This column cannot be put into a DataTable.
 class VoidColumn : public Column {
 public:
   VoidColumn(int64_t nrows = 0) : Column(nrows) {}
@@ -381,6 +392,7 @@ public:
   int64_t data_nrows() const override { return nrows; }
   void resize_and_fill(int64_t) override {}
   void rbind_impl(const std::vector<const Column*>&, int64_t, bool) override {}
+  void apply_na_mask(const BoolColumn*) override {}
 };
 
 

--- a/c/column_fw.cc
+++ b/c/column_fw.cc
@@ -147,6 +147,18 @@ int64_t FwColumn<T>::data_nrows() const {
 }
 
 
+template <typename T>
+void FwColumn<T>::apply_na_mask(const BoolColumn* mask) {
+  const int8_t* maskdata = mask->elements();
+  constexpr T na = GETNA<T>();
+  T* coldata = this->elements();
+  #pragma omp parallel for schedule(dynamic, 1024)
+  for (int64_t j = 0; j < nrows; ++j) {
+    if (maskdata[j] == 1) coldata[j] = na;
+  }
+}
+
+
 // Explicit instantiations
 template class FwColumn<int8_t>;
 template class FwColumn<int16_t>;

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -51,7 +51,7 @@ public:
     DataTable(Column**);
     ~DataTable();
     DataTable* delete_columns(int*, int);
-    DataTable* apply_na_mask(DataTable*);
+    void apply_na_mask(DataTable* mask);
     void reify();
     DataTable* rbind(DataTable**, int**, int, int64_t);
     DataTable* cbind(DataTable**, int);

--- a/c/py_datatable.c
+++ b/c/py_datatable.c
@@ -419,12 +419,14 @@ static PyObject* meth_materialize(DataTable_PyObject *self, PyObject *args)
 DT_DOCS(apply_na_mask, "")
 static PyObject* meth_apply_na_mask(DataTable_PyObject *self, PyObject *args)
 {
+  CATCH_EXCEPTIONS(
     DataTable *dt = self->ref;
     DataTable *mask = NULL;
     if (!PyArg_ParseTuple(args, "O&", &dt_unwrap, &mask)) return NULL;
 
-    DataTable *res = dt->apply_na_mask(mask);
-    return (res == NULL) ? NULL : none();
+    dt->apply_na_mask(mask);
+    return none();
+  )
 }
 
 

--- a/c/py_utils.h
+++ b/c/py_utils.h
@@ -105,6 +105,16 @@ PyObject* decref(PyObject *x);
 })
 
 
+#define CATCH_EXCEPTIONS(CODE)                                                 \
+    try {                                                                      \
+        CODE                                                                   \
+    } catch (const std::exception& e) {                                        \
+        PyErr_SetString(PyExc_RuntimeError, e.what());                         \
+        return NULL;                                                           \
+    }
+
+
+
 bool    get_attr_bool(PyObject *pyobj, const char *attr, bool dflt=false);
 int64_t get_attr_int64(PyObject *pyobj, const char *attr, int64_t dflt=0);
 std::string get_attr_string(PyObject *pyobj, const char *attr);


### PR DESCRIPTION
Also adding the `CATCH_EXCEPTIONS` macro to conveniently catch all exceptions at the py-C code and convert them into `return NULL`s (with proper error message set).

Closes #467