### PR TITLE
Add enums `stype` and `ltype`

### DIFF
--- a/c/column_from_pylist.cc
+++ b/c/column_from_pylist.cc
@@ -104,7 +104,7 @@ static bool parse_as_double(PyObject* list, MemoryBuffer* membuf, int64_t& from)
   // Largest integer that can still be represented as double without loss of
   // precision. Thus, (2^53 + 1) is the first integer that cannot be stored in
   // a double and retrieved back: `(long)((double)(maxlong + 1)) != maxlong`.
-  constexpr double maxlong = 9007199254740992;  // = 2^53
+  // constexpr double maxlong = 9007199254740992;  // = 2^53
 
   for (int j = 0; j < 2; ++j) {
     int64_t ifrom = j ? 0 : from;

--- a/c/column_fw.cc
+++ b/c/column_fw.cc
@@ -36,7 +36,7 @@ void FwColumn<T>::replace_buffer(MemoryBuffer* new_mbuf, MemoryBuffer*) {
   MemoryBuffer* t = new_mbuf->shallowcopy();
   if (mbuf) mbuf->release();
   mbuf = t;
-  nrows = mbuf->size() / sizeof(T);
+  nrows = static_cast<int64_t>(mbuf->size() / sizeof(T));
 }
 
 

--- a/c/py_types.c
+++ b/c/py_types.c
@@ -142,7 +142,6 @@ int init_py_types(UU)
     py_stype_formatters[ST_STRING_U2_ENUM]     = stype_notimpl;
     py_stype_formatters[ST_STRING_U4_ENUM]     = stype_notimpl;
     py_stype_formatters[ST_DATETIME_I8_EPOCH]  = stype_notimpl;
-    py_stype_formatters[ST_DATETIME_I8_PRTMN]  = stype_notimpl;
     py_stype_formatters[ST_DATETIME_I4_TIME]   = stype_notimpl;
     py_stype_formatters[ST_DATETIME_I4_DATE]   = stype_notimpl;
     py_stype_formatters[ST_DATETIME_I2_MONTH]  = stype_notimpl;

--- a/c/types.c
+++ b/c/types.c
@@ -52,31 +52,30 @@ static SType stype_upcast_map[DT_STYPES_COUNT][DT_STYPES_COUNT];
 
 void init_types(void)
 {
-    #define STI(T, code, csize, msize, vw, ltype, na) \
-        stype_info[T] = (STypeInfo){csize, msize, na, code, ltype, vw, 0}
-    STI(ST_VOID,              "---", 0, 0,                   0, LT_MU,       NULL);
-    STI(ST_BOOLEAN_I1,        "i1b", 1, 0,                   0, LT_BOOLEAN,  &NA_I1);
-    STI(ST_INTEGER_I1,        "i1i", 1, 0,                   0, LT_INTEGER,  &NA_I1);
-    STI(ST_INTEGER_I2,        "i2i", 2, 0,                   0, LT_INTEGER,  &NA_I2);
-    STI(ST_INTEGER_I4,        "i4i", 4, 0,                   0, LT_INTEGER,  &NA_I4);
-    STI(ST_INTEGER_I8,        "i8i", 8, 0,                   0, LT_INTEGER,  &NA_I8);
-    STI(ST_REAL_F4,           "f4r", 4, 0,                   0, LT_REAL,     &NA_F4);
-    STI(ST_REAL_F8,           "f8r", 8, 0,                   0, LT_REAL,     &NA_F8);
-    STI(ST_REAL_I2,           "i2r", 2, sizeof(DecimalMeta), 0, LT_REAL,     &NA_I2);
-    STI(ST_REAL_I4,           "i4r", 4, sizeof(DecimalMeta), 0, LT_REAL,     &NA_I4);
-    STI(ST_REAL_I8,           "i8r", 8, sizeof(DecimalMeta), 0, LT_REAL,     &NA_I8);
-    STI(ST_STRING_I4_VCHAR,   "i4s", 4, sizeof(VarcharMeta), 1, LT_STRING,   NULL);
-    STI(ST_STRING_I8_VCHAR,   "i8s", 8, sizeof(VarcharMeta), 1, LT_STRING,   NULL);
-    STI(ST_STRING_FCHAR,      "c#s", 0, sizeof(FixcharMeta), 0, LT_STRING,   NULL);
-    STI(ST_STRING_U1_ENUM,    "u1e", 1, sizeof(EnumMeta),    1, LT_STRING,   &NA_U1);
-    STI(ST_STRING_U2_ENUM,    "u2e", 2, sizeof(EnumMeta),    1, LT_STRING,   &NA_U2);
-    STI(ST_STRING_U4_ENUM,    "u4e", 4, sizeof(EnumMeta),    1, LT_STRING,   &NA_U4);
-    STI(ST_DATETIME_I8_EPOCH, "i8d", 8, 0,                   0, LT_DATETIME, &NA_I8);
-    STI(ST_DATETIME_I8_PRTMN, "i8w", 8, 0,                   0, LT_DATETIME, &NA_I8);
-    STI(ST_DATETIME_I4_TIME,  "i4t", 4, 0,                   0, LT_DATETIME, &NA_I4);
-    STI(ST_DATETIME_I4_DATE,  "i4d", 4, 0,                   0, LT_DATETIME, &NA_I4);
-    STI(ST_DATETIME_I2_MONTH, "i2d", 2, 0,                   0, LT_DATETIME, &NA_I2);
-    STI(ST_OBJECT_PYPTR,      "p8p", 8, 0,                   0, LT_OBJECT,   NULL);
+    #define STI(T, code, code2, csize, msize, vw, ltype, na) \
+        stype_info[T] = (STypeInfo){csize, msize, na, code, code2, ltype, vw}
+    STI(ST_VOID,              "---", "--", 0, 0,                   0, LT_MU,       NULL);
+    STI(ST_BOOLEAN_I1,        "i1b", "b1", 1, 0,                   0, LT_BOOLEAN,  &NA_I1);
+    STI(ST_INTEGER_I1,        "i1i", "i1", 1, 0,                   0, LT_INTEGER,  &NA_I1);
+    STI(ST_INTEGER_I2,        "i2i", "i2", 2, 0,                   0, LT_INTEGER,  &NA_I2);
+    STI(ST_INTEGER_I4,        "i4i", "i4", 4, 0,                   0, LT_INTEGER,  &NA_I4);
+    STI(ST_INTEGER_I8,        "i8i", "i8", 8, 0,                   0, LT_INTEGER,  &NA_I8);
+    STI(ST_REAL_F4,           "f4r", "r4", 4, 0,                   0, LT_REAL,     &NA_F4);
+    STI(ST_REAL_F8,           "f8r", "r8", 8, 0,                   0, LT_REAL,     &NA_F8);
+    STI(ST_REAL_I2,           "i2r", "d2", 2, sizeof(DecimalMeta), 0, LT_REAL,     &NA_I2);
+    STI(ST_REAL_I4,           "i4r", "d4", 4, sizeof(DecimalMeta), 0, LT_REAL,     &NA_I4);
+    STI(ST_REAL_I8,           "i8r", "d8", 8, sizeof(DecimalMeta), 0, LT_REAL,     &NA_I8);
+    STI(ST_STRING_I4_VCHAR,   "i4s", "s4", 4, sizeof(VarcharMeta), 1, LT_STRING,   NULL);
+    STI(ST_STRING_I8_VCHAR,   "i8s", "s8", 8, sizeof(VarcharMeta), 1, LT_STRING,   NULL);
+    STI(ST_STRING_FCHAR,      "c#s", "sx", 0, sizeof(FixcharMeta), 0, LT_STRING,   NULL);
+    STI(ST_STRING_U1_ENUM,    "u1e", "e1", 1, sizeof(EnumMeta),    1, LT_STRING,   &NA_U1);
+    STI(ST_STRING_U2_ENUM,    "u2e", "e2", 2, sizeof(EnumMeta),    1, LT_STRING,   &NA_U2);
+    STI(ST_STRING_U4_ENUM,    "u4e", "e4", 4, sizeof(EnumMeta),    1, LT_STRING,   &NA_U4);
+    STI(ST_DATETIME_I8_EPOCH, "i8d", "t8", 8, 0,                   0, LT_DATETIME, &NA_I8);
+    STI(ST_DATETIME_I4_TIME,  "i4t", "T4", 4, 0,                   0, LT_DATETIME, &NA_I4);
+    STI(ST_DATETIME_I4_DATE,  "i4d", "t4", 4, 0,                   0, LT_DATETIME, &NA_I4);
+    STI(ST_DATETIME_I2_MONTH, "i2d", "t2", 2, 0,                   0, LT_DATETIME, &NA_I2);
+    STI(ST_OBJECT_PYPTR,      "p8p", "o8", 8, 0,                   0, LT_OBJECT,   NULL);
     #undef STI
 
     #define UPCAST(stype1, stype2, stypeR)         \
@@ -158,8 +157,6 @@ SType stype_from_string(const char *s)
             if (s1 == '2') return ST_DATETIME_I2_MONTH;
             if (s1 == '4') return ST_DATETIME_I4_DATE;
             if (s1 == '8') return ST_DATETIME_I8_EPOCH;
-        } else if (s2 == 'w') {
-            if (s1 == '8') return ST_DATETIME_I8_PRTMN;
         } else if (s2 == 't') {
             if (s1 == '4') return ST_DATETIME_I4_TIME;
         }

--- a/c/types.h
+++ b/c/types.h
@@ -251,28 +251,6 @@ typedef enum LType {
  *     allowed time range is ≈290,000 years around the epoch. The time is
  *     assumed to be in UTC, and does not allow specifying a time zone.
  *
- * ST_DATETIME_I8_PRTMN
- *     elem: int64_t (8 bytes)
- *     NA:   -2**63
- *     Timestamp, stored as YYYYMMDDhhmmssmmmuuu, i.e. concatenated date parts.
- *     The widths of each subfield are:
- *         YYYY: years,        18 bits (signed)
- *           MM: months,        4 bits
- *           DD: days,          5 bits
- *           hh: hours,         5 bits
- *           mm: minutes,       6 bits
- *           ss: seconds,       6 bits
- *          mmm: milliseconds, 10 bits
- *          uuu: microseconds, 10 bits
- *     The allowed time range is ≈131,000 years around the epoch. The time is
- *     in UTC, and does not allow specifying a time zone.
- *
- * ST_DATETIME_I4_TIME
- *     elem: int32_t (4 bytes)
- *     NA:   -2**31
- *     Time only: the number of milliseconds since midnight. The allowed time
- *     range is ≈24 days.
- *
  * ST_DATETIME_I4_DATE
  *     elem: int32_t (4 bytes)
  *     NA:   -2**31
@@ -287,6 +265,12 @@ typedef enum LType {
  *     This type is specifically designed for business applications. It allows
  *     adding/subtraction in monthly/yearly intervals (other datetime types do
  *     not allow that since months/years have uneven lengths).
+ *
+ * ST_DATETIME_I4_TIME
+ *     elem: int32_t (4 bytes)
+ *     NA:   -2**31
+ *     Time only: the number of milliseconds since midnight. The allowed time
+ *     range is ≈24 days.
  *
  *
  * -----------------------------------------------------------------------------
@@ -315,11 +299,10 @@ typedef enum SType {
     ST_STRING_U2_ENUM    = 15,
     ST_STRING_U4_ENUM    = 16,
     ST_DATETIME_I8_EPOCH = 17,
-    ST_DATETIME_I8_PRTMN = 18,
-    ST_DATETIME_I4_TIME  = 19,
-    ST_DATETIME_I4_DATE  = 20,
-    ST_DATETIME_I2_MONTH = 21,
-    ST_OBJECT_PYPTR      = 22,
+    ST_DATETIME_I4_TIME  = 18,
+    ST_DATETIME_I4_DATE  = 19,
+    ST_DATETIME_I2_MONTH = 20,
+    ST_OBJECT_PYPTR      = 21,
 } __attribute__ ((__packed__)) SType;
 
 #define DT_STYPES_COUNT  (ST_OBJECT_PYPTR + 1)
@@ -361,9 +344,10 @@ typedef struct STypeInfo {
     size_t      metasize;
     const void *na;
     char        code[4];
+    char        code2[3];
     LType       ltype;
     bool        varwidth;
-    int16_t     _padding;
+    int64_t : 56;  // padding
 } STypeInfo;
 
 extern STypeInfo stype_info[DT_STYPES_COUNT];

--- a/datatable/__init__.py
+++ b/datatable/__init__.py
@@ -6,9 +6,10 @@ from .dt import DataTable
 from .fread import fread, FReader
 from .nff import save, open
 from .expr import mean, min, max, sd, isna
+from .types import stype, ltype
 
 __all__ = ("__version__", "DataTable", "max", "mean", "min", "open", "sd",
-           "isna", "fread", "FReader", "save")
+           "isna", "fread", "FReader", "save", "stype", "ltype")
 
 
 DataTable.__module__ = "datatable"

--- a/datatable/expr/consts.py
+++ b/datatable/expr/consts.py
@@ -21,7 +21,6 @@ nas_map = {
     "u2e": "NA_U2",
     "u4e": "NA_U4",
     "i8d": "NA_I8",
-    "i8w": "NA_I8",
     "i4t": "NA_I4",
     "i4d": "NA_I4",
     "i2d": "NA_I2",
@@ -47,7 +46,6 @@ ctypes_map = {
     "u2e": "uint16_t",
     "u4e": "uint32_t",
     "i8d": "int64_t",
-    "i8w": "int64_t",
     "i4t": "int32_t",
     "i4d": "int32_t",
     "i2d": "int16_t",
@@ -73,11 +71,10 @@ itypes_map = {
     "u2e": 15,
     "u4e": 16,
     "i8d": 17,
-    "i8w": 18,
-    "i4t": 19,
-    "i4d": 20,
-    "i2d": 21,
-    "p8p": 22,
+    "i4t": 18,
+    "i4d": 19,
+    "i2d": 20,
+    "p8p": 21,
 }
 
 

--- a/datatable/types.py
+++ b/datatable/types.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3                                         # encoding: utf-8
+#-------------------------------------------------------------------------------
+# Copyright 2017 H2O.ai
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
+import ctypes
+import enum
+from datatable.utils.typechecks import TValueError
+
+__all__ = ("stype", "ltype")
+
+
+
+@enum.unique
+class stype(enum.Enum):
+    """
+    Enumeration of possible "storage" types of columns in a DataTable.
+
+    Each column in a DataTable is a vector of values of the same type. We call
+    this column's type the "stype". Most stypes correspond to primitive C types,
+    such as ``int32_t`` or ``double``. However some stypes (corresponding to
+    strings and categoricals) have a more complicated underlying structure.
+
+    Notably, :module:`datatable` does not support arbitrary structures as
+    elements of a Column, so the set of stypes is small.
+
+    Examples
+    --------
+    >>> dt.stype.int16
+    stype.int16
+
+    You can convert strings and Python primitive types (and even numpy dtypes)
+    into stypes:
+
+    >>> dt.stype(str)
+    stype.str64
+    >>> dt.stype("double")
+    stype.float64
+    >>> dt.stype(numpy.dtype("object"))
+    stype.obj
+    >>> dt.stype("i4")
+    stype.int32
+
+    Each stype has the following properties: `.ltype` returns the corresponding
+    :class:`ltype`, `.code` gives 2-character short code of the stype, and
+    `.ctype` returns the `ctypes` object that describes the underlying data.
+
+    >>> dt.stype.int16.code
+    'i2'
+    >>> dt.stype.int16.ltype
+    ltype.int
+    >>> dt.stype.int16.ctype
+    <class 'ctypes.c_short'>
+    >>> dt.stype.int16.struct
+    '=h'
+    """
+    bool = 1
+    int8 = 2
+    int16 = 3
+    int32 = 4
+    int64 = 5
+    float32 = 6
+    float64 = 7
+    str32 = 11
+    str64 = 12
+    obj = 21
+
+    def __repr__(self):
+        return str(self)
+
+    @property
+    def code(self):
+        """
+        Short string representation of the stype, each code has exactly 2 chars.
+        """
+        return _stype_2_short[self]
+
+    @property
+    def ltype(self):
+        """
+        :class:`ltype` corresponding to this stype. Several stypes may map to
+        the same ltype, whereas each stype is described by exactly one ltype.
+        """
+        return _stype_2_ltype[self]
+
+    @property
+    def ctype(self):
+        """
+        :module:`ctypes` class that describes the C-level type of each element
+        in a column with this stype.
+
+        For non-fixed-width columns (such as `str32`) this will return the ctype
+        of only the fixed-width component of that column. Thus,
+        ``stype.str32.ctype == ctypes.c_int32``.
+        """
+        return _stype_2_ctype[self]
+
+    @property
+    def struct(self):
+        """
+        :module:`struct` format string corresponding to this stype.
+
+        For non-fixed-width columns (such as `str32`) this will return the
+        format string of only the fixed-width component of that column. Thus,
+        ``stype.str32.struct == '=i'``.
+        """
+        return _stype_2_struct[self]
+
+
+
+#-------------------------------------------------------------------------------
+
+@enum.unique
+class ltype(enum.Enum):
+    """
+    Enumeration of possible "logical" types of a column.
+
+    Logical type is the type stripped away from the details of its physical
+    storage. For example, ``ltype.int`` represents an integer. Under the hood,
+    this integer can be stored in several "physical" formats: from
+    ``stype.int8`` to ``stype.int64``. Thus, there is a one-to-many relationship
+    between ltypes and stypes.
+
+    Examples
+    --------
+    >>> dt.ltype.bool
+    ltype.bool
+    >>> dt.ltype("int32")
+    ltype.int
+
+    For each ltype, you can find the set of stypes that correspond to it:
+
+    >>> dt.ltype.real.stypes
+    [stype.float32, stype.float64]
+    >>> dt.ltype.time.stypes
+    []
+    """
+    bool = 1
+    int = 2
+    real = 3
+    str = 4
+    time = 5
+    obj = 7
+
+    def __repr__(self):
+        return str(self)
+
+    @property
+    def stypes(self):
+        """List of stypes that represent this ltype."""
+        return [k for k, v in _stype_2_ltype.items() if v == self]
+
+
+
+#-------------------------------------------------------------------------------
+
+def ___new___(cls, value):
+    # We're re-implementing Enum.__new__() method, which is called by the
+    # metaclass' `__call__` (for example `stype(5)` or `stype("int64")`).
+    # Also called by pickle.
+    if type(value) is cls:
+        return value
+    try:
+        if value in cls._value2member_map_ and type(value) is not bool:
+            return cls._value2member_map_[value]
+    except TypeError:
+        # `value` is not hasheable -- not valid for our enum. Pass-through
+        # and raise the TValueError below.
+        pass
+    raise TValueError("`%r` does not map to any %s" % (value, cls.__name__))
+
+
+setattr(stype, "__new__", ___new___)
+setattr(ltype, "__new__", ___new___)
+
+
+_stype_2_short = {
+    stype.bool: "b1",
+    stype.int8: "i1",
+    stype.int16: "i2",
+    stype.int32: "i4",
+    stype.int64: "i8",
+    stype.float32: "r4",
+    stype.float64: "r8",
+    stype.str32: "s4",
+    stype.str64: "s8",
+    stype.obj: "o8",
+}
+
+_stype_2_ltype = {
+    stype.bool: ltype.bool,
+    stype.int8: ltype.int,
+    stype.int16: ltype.int,
+    stype.int32: ltype.int,
+    stype.int64: ltype.int,
+    stype.float32: ltype.real,
+    stype.float64: ltype.real,
+    stype.str32: ltype.str,
+    stype.str64: ltype.str,
+    stype.obj: ltype.obj,
+}
+
+_stype_2_ctype = {
+    stype.bool: ctypes.c_int8,
+    stype.int8: ctypes.c_int8,
+    stype.int16: ctypes.c_int16,
+    stype.int32: ctypes.c_int32,
+    stype.int64: ctypes.c_int64,
+    stype.float32: ctypes.c_float,
+    stype.float64: ctypes.c_double,
+    stype.str32: ctypes.c_int32,
+    stype.str64: ctypes.c_int64,
+    stype.obj: ctypes.py_object,
+}
+
+_stype_2_struct = {
+    stype.bool: "b",
+    stype.int8: "b",
+    stype.int16: "=h",
+    stype.int32: "=i",
+    stype.int64: "=q",
+    stype.float32: "=f",
+    stype.float64: "=d",
+    stype.str32: "=i",
+    stype.str64: "=q",
+    stype.obj: "O",
+}
+
+
+def _additional_stype_members():
+    for v in stype:
+        yield (v.name, v)
+    for st, code in _stype_2_short.items():
+        yield (code, st)
+    yield (bool, stype.bool)
+    yield ("boolean", stype.bool)
+    yield (int, stype.int64)
+    yield ("int", stype.int64)
+    yield ("integer", stype.int64)
+    yield (float, stype.float64)
+    yield ("float", stype.float64)
+    yield ("real", stype.float64)
+    yield (str, stype.str64)
+    yield ("str", stype.str64)
+    yield ("string", stype.str64)
+    yield (object, stype.obj)
+    yield ("object", stype.obj)
+    try:
+        import numpy as np
+        yield (np.dtype("bool"), stype.bool)
+        yield (np.dtype("int8"), stype.int8)
+        yield (np.dtype("int16"), stype.int16)
+        yield (np.dtype("int32"), stype.int32)
+        yield (np.dtype("int64"), stype.int64)
+        yield (np.dtype("float32"), stype.float32)
+        yield (np.dtype("float64"), stype.float64)
+        yield (np.dtype("str"), stype.str64)
+        yield (np.dtype("object"), stype.obj)
+    except ImportError:  # pragma: no cover
+        pass
+
+
+for k, st in _additional_stype_members():
+    assert type(st) is stype
+    stype._value2member_map_[k] = st
+    ltype._value2member_map_[k] = st.ltype

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -5,6 +5,7 @@ import re
 
 import pytest
 import datatable
+from datatable.utils.typechecks import TValueError
 
 expr_consts = datatable.expr.consts
 
@@ -14,19 +15,22 @@ expr_consts = datatable.expr.consts
 #-------------------------------------------------------------------------------
 
 @pytest.fixture()
-def stypes():
+def c_stypes():
     """
     Create a dictionary whose keys are 3-char stype codes (eg. 'i8i' or 'f4r'),
     and values are dictionaries with the following properties:
         * sname (str): the 'ST_*' C name of the enum constant
         * itype (int): integer value of the stype constant
         * stype (str): 3-character string code of the SType
+        * code2 (str): 2-character string code of the SType
         * ctype (str): C-type of a single element in this column
         * elemsize (int): size in bytes of each element in this column
         * meta (str): name of the C meta class (or empty string)
         * varwidth (bool): is this a variable-width SType?
         * ltype (str): name of the C enum constant with the LType corresponding
           to the current SType
+
+    This dictionary is made from files "c/types.h" and "c/types.c".
     """
     stypes = {}
 
@@ -44,10 +48,18 @@ def stypes():
     file2 = os.path.join(os.path.dirname(__file__), "..", "c", "types.c")
     with open(file2, "r") as f:
         txt2 = f.read()
-    mm = re.findall(r"STI\((\w+),\s*\"(...)\",\s*(\d+),\s*(?:0|sizeof\((\w+)\))"
-                    r",\s*(\d),\s*(?:0|(\w+)),\s*&?(\w+)\)", txt2)
-    for name, ctype, elemsize, meta, varwidth, ltype, na in mm:
-        stypes[name]["stype"] = ctype
+    mm = re.findall(r"STI\((\w+),\s*"
+                    r'"(...)",\s*'
+                    r'"(..)",\s*'
+                    r"(\d+),\s*"
+                    r"(?:0|sizeof\((\w+)\)),\s*"
+                    r"(\d),\s*"
+                    r"(?:0|(\w+)),\s*"
+                    r"&?(\w+)\)",
+                    txt2)
+    for name, code3, code2, elemsize, meta, varwidth, ltype, na in mm:
+        stypes[name]["stype"] = code3
+        stypes[name]["code2"] = code2
         stypes[name]["elemsize"] = int(elemsize)
         stypes[name]["meta"] = meta
         stypes[name]["varwidth"] = bool(int(varwidth))
@@ -68,31 +80,239 @@ def stypes():
     return {st["stype"]: st for st in stypes.values() if st["stype"] != "---"}
 
 
+@pytest.fixture()
+def c_stypes2(c_stypes):
+    """Same as c_stypes, but keyed to 'code2' field."""
+    return {v["code2"]: v for v in c_stypes.values()}
+
+
 
 #-------------------------------------------------------------------------------
-# The tests
+# Tests (old)
 #-------------------------------------------------------------------------------
 
-def test_consts_py_nas_map(stypes):
+def test_consts_py_nas_map(c_stypes):
     nas_map = expr_consts.nas_map
     for stype, na in nas_map.items():
         if stype == "p8p" or stype == "c#s":
             assert na == "NULL"
         else:
             assert na == "NA_" + stype[:2].upper()
-    assert set(nas_map.keys()) == set(stypes.keys())
+    assert set(nas_map.keys()) == set(c_stypes.keys())
 
 
-def test_consts_py_ctypes_map(stypes):
+def test_consts_py_ctypes_map(c_stypes):
     ctypes_map = expr_consts.ctypes_map
     for stype, ctype in ctypes_map.items():
-        assert stypes[stype]["ctype"] == ctype
-    assert set(ctypes_map.keys()) == set(stypes.keys())
+        assert c_stypes[stype]["ctype"] == ctype
+    assert set(ctypes_map.keys()) == set(c_stypes.keys())
 
 
-def test_consts_py_itypes_map(stypes):
+def test_consts_py_itypes_map(c_stypes):
     itypes_map = expr_consts.itypes_map
     for stype, itype in itypes_map.items():
-        assert stypes[stype]["itype"] == itype
-    assert set(itypes_map.keys()) == set(stypes.keys())
+        assert c_stypes[stype]["itype"] == itype
+    assert set(itypes_map.keys()) == set(c_stypes.keys())
 
+
+
+#-------------------------------------------------------------------------------
+# Test stype enum
+#-------------------------------------------------------------------------------
+
+def test_stype():
+    from datatable import stype
+    assert stype.bool
+    assert stype.int8
+    assert stype.int16
+    assert stype.int32
+    assert stype.int64
+    assert stype.float32
+    assert stype.float64
+    assert stype.str32
+    assert stype.str64
+    assert stype.obj
+    # When new stypes are added, don't forget to update this test suite
+    assert len(stype) == 10
+
+
+def test_stype_names():
+    from datatable import stype
+    assert stype.bool.name == "bool"
+    assert stype.int8.name == "int8"
+    assert stype.int16.name == "int16"
+    assert stype.int32.name == "int32"
+    assert stype.int64.name == "int64"
+    assert stype.float32.name == "float32"
+    assert stype.float64.name == "float64"
+    assert stype.str32.name == "str32"
+    assert stype.str64.name == "str64"
+    assert stype.obj.name == "obj"
+
+
+def test_stype_repr():
+    from datatable import stype
+    for st in stype:
+        assert repr(st) == str(st) == "stype." + st.name
+
+
+def test_stype_codes():
+    from datatable import stype
+    assert stype.bool.code == "b1"
+    assert stype.int8.code == "i1"
+    assert stype.int16.code == "i2"
+    assert stype.int32.code == "i4"
+    assert stype.int64.code == "i8"
+    assert stype.float32.code == "r4"
+    assert stype.float64.code == "r8"
+    assert stype.str32.code == "s4"
+    assert stype.str64.code == "s8"
+    assert stype.obj.code == "o8"
+
+
+def test_stype_values(c_stypes2):
+    from datatable import stype
+    for st in stype:
+        assert st.value == c_stypes2[st.code]["itype"]
+
+
+def test_stype_sizes(c_stypes2):
+    from datatable import stype
+    for st in stype:
+        assert int(st.code[1:]) == c_stypes2[st.code]["elemsize"]
+
+
+def test_stype_ctypes():
+    from datatable import stype
+    import ctypes
+    assert stype.bool.ctype == ctypes.c_int8
+    assert stype.int8.ctype == ctypes.c_int8
+    assert stype.int16.ctype == ctypes.c_int16
+    assert stype.int32.ctype == ctypes.c_int32
+    assert stype.int64.ctype == ctypes.c_int64
+    assert stype.float32.ctype == ctypes.c_float
+    assert stype.float64.ctype == ctypes.c_double
+    assert stype.str32.ctype == ctypes.c_int32
+    assert stype.str64.ctype == ctypes.c_int64
+    assert stype.obj.ctype == ctypes.py_object
+
+
+def test_stype_struct():
+    from datatable import stype
+    assert stype.bool.struct == "b"
+    assert stype.int8.struct == "b"
+    assert stype.int16.struct == "=h"
+    assert stype.int32.struct == "=i"
+    assert stype.int64.struct == "=q"
+    assert stype.float32.struct == "=f"
+    assert stype.float64.struct == "=d"
+    assert stype.str32.struct == "=i"
+    assert stype.str64.struct == "=q"
+    assert stype.obj.struct == "O"
+
+
+def test_stype_instantiate():
+    from datatable import stype
+    for st in stype:
+        assert stype(st) is st
+        assert stype(st.value) is st
+    assert stype(bool) is stype.bool
+    assert stype("b1") is stype.bool
+    assert stype("bool") is stype.bool
+    assert stype("boolean") is stype.bool
+    assert stype(int) is stype.int64
+    assert stype("int") is stype.int64
+    assert stype("integer") is stype.int64
+    assert stype("int8") is stype.int8
+    assert stype("int16") is stype.int16
+    assert stype("int32") is stype.int32
+    assert stype("int64") is stype.int64
+    assert stype(float) is stype.float64
+    assert stype("real") is stype.float64
+    assert stype("float") is stype.float64
+    assert stype("float32") is stype.float32
+    assert stype("float64") is stype.float64
+    assert stype(str) is stype.str64
+    assert stype("str") is stype.str64
+    assert stype("str32") is stype.str32
+    assert stype("str64") is stype.str64
+    assert stype(object) is stype.obj
+    assert stype("obj") is stype.obj
+    assert stype("object") is stype.obj
+
+
+def test_stype_instantiate_from_numpy(numpy):
+    from datatable import stype
+    assert stype(numpy.dtype("bool")) is stype.bool
+    assert stype(numpy.dtype("int8")) is stype.int8
+    assert stype(numpy.dtype("int16")) is stype.int16
+    assert stype(numpy.dtype("int32")) is stype.int32
+    assert stype(numpy.dtype("int64")) is stype.int64
+    assert stype(numpy.dtype("float32")) is stype.float32
+    assert stype(numpy.dtype("float64")) is stype.float64
+    assert stype(numpy.dtype("str")) is stype.str64
+    assert stype(numpy.dtype("object")) is stype.obj
+
+
+def test_stype_instantiate_bad():
+    from datatable import stype
+    with pytest.raises(TValueError):
+        print(stype(-1))
+    with pytest.raises(TValueError):
+        print(stype(0))
+    with pytest.raises(TValueError):
+        print(stype(["i", "4"]))
+    with pytest.raises(TValueError):
+        print(stype(1.5))
+    with pytest.raises(TValueError):
+        print(stype(True))
+
+
+
+#-------------------------------------------------------------------------------
+# Test ltype enum
+#-------------------------------------------------------------------------------
+
+def test_ltype():
+    from datatable import ltype
+    assert ltype.bool
+    assert ltype.int
+    assert ltype.real
+    assert ltype.time
+    assert ltype.str
+    assert ltype.obj
+    # When new stypes are added, don't forget to update this test suite
+    assert len(ltype) == 6
+
+
+def test_ltype_names():
+    from datatable import ltype
+    assert ltype.bool.name is "bool"
+    assert ltype.int.name is "int"
+    assert ltype.real.name is "real"
+    assert ltype.time.name is "time"
+    assert ltype.str.name is "str"
+    assert ltype.obj.name is "obj"
+
+
+def test_ltype_repr():
+    from datatable import ltype
+    for lt in ltype:
+        assert repr(lt) == str(lt) == "ltype." + lt.name
+
+
+def test_stype_ltypes(c_stypes2):
+    from datatable import stype, ltype
+    for st in stype:
+        assert st.ltype is ltype(c_stypes2[st.code]["ltype"][3:].lower())
+
+
+def test_ltype_stypes():
+    from datatable import stype, ltype
+    assert ltype.bool.stypes == [stype.bool]
+    assert ltype.int.stypes == [stype.int8, stype.int16, stype.int32,
+                                stype.int64]
+    assert ltype.real.stypes == [stype.float32, stype.float64]
+    assert ltype.str.stypes == [stype.str32, stype.str64]
+    assert ltype.time.stypes == []
+    assert ltype.obj.stypes == [stype.obj]


### PR DESCRIPTION
- Expose enums at datatable's top level
- Add documentation for the enums
- Add exhaustive unit tests for those enums
- Remove stype ST_DATETIME_I8_PRTMN (the "epoch" datetime is just as good)
- Fix 2 warnings in column_fw.cc and column_from_pylist.cc

These new enums / 2-character codes are not used anywhere yet: this is deferred to subsequent PRs. The intention however is that the new enums will eventually be used everywhere in the Python code.

Closes #471