### PR TITLE
Bump version number to 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### [Unreleased](https://github.com/h2oai/datatable/compare/HEAD...v0.2.2)
 
-### [Unreleased](https://github.com/h2oai/datatable/compare/HEAD...v0.2.1)
+
+### [v0.2.2](https://github.com/h2oai/datatable/compare/v0.2.2...v0.2.1) — 2017-10-18
 #### Added
 - Ability to write DataTable into a CSV file: the `.to_csv()` method. The CSV writer
   is multi-threaded and extremely fast.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,8 +13,8 @@ def linkMap = [ "Data" : "h2oai-benchmarks/Data",
 		"smalldata" : "h2o-3/smalldata",
 		"bigdata" : "h2o-3/bigdata",
 		"fread" : "h2o-3/fread" ]
-		   
-def largeTestsRootEnv = returnIfModified("(py_)?fread\\..*", targetDir)
+
+def largeTestsRootEnv = returnIfModified("(py_)?fread\\..*|__version__\\.py", targetDir)
 def dockerArgs = ""
 if (!largeTestsRootEnv.isEmpty()) {
     linkFolders(sourceDir, targetDir)
@@ -48,7 +48,7 @@ pipeline {
                     sh """
                             export CI_VERSION_SUFFIX=${ciVersionSuffix}
                             make mrproper
-                            make build > stage_build_with_omp_on_linux_output 
+                            make build > stage_build_with_omp_on_linux_output
                             touch LICENSE
                             python setup.py bdist_wheel >> stage_build_with_omp_on_linux_output.txt
                             python setup.py --version > dist/VERSION.txt
@@ -151,7 +151,7 @@ pipeline {
                         mkdir out; mv dist/* out/
                         make clean
                         export CI_VERSION_SUFFIX=${utilsLib.getCiVersionSuffix()}.noomp
-                        DTNOOPENMP=1 python setup.py bdist_wheel -d dist_noomp 
+                        DTNOOPENMP=1 python setup.py bdist_wheel -d dist_noomp
                         mkdir dist; mv dist_noomp/*whl dist/
                         mv out/* dist/
                     """
@@ -275,10 +275,10 @@ def linkFolders(sourceDir, targetDir) {
     node {
         sh """
             mkdir ${targetDir} || true
-        
+
             mkdir ${targetDir}/h2oai-benchmarks || true
             ln -sf ${sourceDir}/Data ${targetDir}/h2oai-benchmarks
-        
+
             mkdir ${targetDir}/h2o-3 || true
             ln -sf ${sourceDir}/smalldata ${targetDir}/h2o-3
             ln -sf ${sourceDir}/bigdata ${targetDir}/h2o-3
@@ -287,7 +287,7 @@ def linkFolders(sourceDir, targetDir) {
     }
 }
 
-	       
+
 def makeDockerArgs(linkMap, sourceDir, targetDir) {
     def out = ""
     linkMap.each { key, value ->

--- a/datatable/__version__.py
+++ b/datatable/__version__.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 # Copyright 2017 H2O.ai; Apache License Version 2.0;  -*- encoding: utf-8 -*-
 
-version = "0.2.1"
+version = "0.2.2"


### PR DESCRIPTION
Also adding `__version__.py` to the pattern that triggers "Large Fread Test" -- we want to be sure that upon releasing of a new version the most thorough test suite is run.