### PR TITLE
Cleanup and documenting the MemoryBuffer class

### DIFF
--- a/c/column.cc
+++ b/c/column.cc
@@ -190,7 +190,7 @@ Column* Column::deepcopy() const
 {
   Column* col = new_column(stype());
   col->nrows = nrows;
-  col->mbuf = new MemoryMemBuf(*mbuf);
+  col->mbuf = mbuf->deepcopy();
   if (meta) {
     memcpy(col->meta, meta, stype_info[stype()].metasize);
   }


### PR DESCRIPTION
* Replace `MemoryMemBuf`'s copy-constructor with a `deepcopy()` method
* Remove `StringMemBuf` class (merged into `ExternalMemBuf`)
* Allow creating `ExternalMemBuf` based on simple `void*` pointer, without the guard afforded by a Py_buffer structure.
* Better documentation for classes in "memorybuf.h"