### PR TITLE
Refactor integrity checks

### DIFF
--- a/c/column.cc
+++ b/c/column.cc
@@ -541,106 +541,76 @@ void Column::cast_into(PyObjectColumn*) const        { throw Error("Cannot cast 
 
 
 
-int Column::verify_integrity(
-    std::vector<char> *errors, int max_errors, const char *name) const
+//------------------------------------------------------------------------------
+// Integrity checks
+//------------------------------------------------------------------------------
+
+bool Column::verify_integrity(IntegrityCheckContext& icc,
+                              const std::string& name) const
 {
-  int nerrors = 0;
-  if (errors == nullptr) return nerrors; // TODO: do something different?
-  /**
-   * Sanity checks. Nothing else is checked if these don't pass.
-   */
-  // Check that the number of rows is nonnegative
+  int nerrors = icc.n_errors();
+  auto end = icc.end();
+
   if (nrows < 0) {
-    ERR("%s reports a negative value for `nrows: %lld\n", name, nrows);
-    return nerrors;
+    icc << name << " has a negative value for `nrows`: " <<  nrows << end;
   }
-
-  // Check MemoryBuffer
-  const char *mbuf_name = "MemoryBuffer";
-  // Ensure that the MemoryBuffer is not null
   if (mbuf == nullptr) {
-    ERR("%s reference in %s is null\n", mbuf_name, name);
-    return nerrors;
+    icc << name << " has a null internal memory buffer" << end;
+  } else {
+    mbuf->verify_integrity(icc);
   }
-  int mbuf_nerrors = mbuf->verify_integrity(errors, max_errors - nerrors, mbuf_name);
-  if (mbuf_nerrors > 0) {
-    return nerrors + mbuf_nerrors;
-  }
-
-  // Check meta
-  int meta_nerrors = verify_meta_integrity(errors, max_errors - nerrors, name);
-  if (meta_nerrors > 0) {
-    return nerrors + meta_nerrors;
-  }
+  if (icc.has_errors(nerrors)) return false;
 
   // data_nrows() may use the value in `meta`, so `meta` should be checked
   // before using this method
   int64_t mbuf_nrows = data_nrows();
 
   // Check RowIndex
-  const char *ri_name = "RowIndex";
-  RowIndex *col_ri = rowindex();
+  RowIndex* col_ri = rowindex();
   if (col_ri != nullptr) { // rowindexes are allowed to be null
     // RowIndex check
-    int ri_nerrors = col_ri->verify_integrity(errors, max_errors - nerrors, ri_name);
-    if (ri_nerrors > 0) {
-      return nerrors + ri_nerrors;
-    }
+    bool ok = col_ri->verify_integrity(icc);
+    if (!ok) return false;
 
     // Check that the length of the RowIndex corresponds to `nrows`
     if (nrows != col_ri->length) {
-      ERR("Mismatch in reported number of rows: "
-          "%s reports %lld, %s reports %lld\n", name, nrows, ri_name, col_ri->length);
-    }
-
-    // Check that the RowIndex length is zero if the memory buffer's row length
-    // is zero
-    if (mbuf_nrows == 0 && col_ri->length > 0) {
-      ERR("Length of %s in %s must be zero when %s's row length is zero: "
-          "found %lld instead", ri_name, name, mbuf_name, col_ri->length);
+      icc << "Mismatch in reported number of rows: " << name << " has "
+          << "nrows=" << nrows << ", while its rowindex.length="
+          << col_ri->length << end;
     }
 
     // Check that the maximum value of the RowIndex does not exceed the maximum
     // row number in the memory buffer
-    if (mbuf_nrows != 0 && mbuf_nrows <= col_ri->max) {
-      ERR("Maximum row number of %s exceeds number of rows in %s of %s: "
-          "%lld vs %lld\n", ri_name, mbuf_name, name, col_ri->max, mbuf_nrows);
+    if (col_ri->max >= mbuf_nrows && col_ri->max > 0) {
+      icc << "Maximum row number in the rowindex of " << name << " exceeds the "
+          << "number of rows in the underlying memory buffer: max(rowindex)="
+          << col_ri->max << ", and nrows(membuf)=" << mbuf_nrows << end;
     }
-  } else {
+  }
+  else {
     // Check that nrows is a correct representation of mbuf's size
     if (nrows != mbuf_nrows) {
-      ERR("Mismatch between reported number of rows: "
-          "%s reports %lld, %s reports %lld\n", name, nrows, mbuf_name, mbuf_nrows);
+      icc << "Mismatch between reported number of rows: " << name
+          << " has nrows=" << nrows << " and MemoryBuffer has data for "
+          << mbuf_nrows << " rows" << end;
     }
   }
-
-  if (nerrors) return nerrors;
+  if (icc.has_errors(nerrors)) return false;
 
   // Check Stats
-  const char* stats_name = "Stats";
   if (stats == nullptr) {
-    ERR("reference of %s in %s is null\n", stats_name, name);
-    return nerrors;
-  }
-
-  int stats_nerrors = stats->verify_integrity(errors, max_errors - nerrors, stats_name);
-  if (stats_nerrors > 0) {
-    return nerrors + stats_nerrors;
+    icc << "Stats in " << name << " is null" << end;
+    return false;
+  } else {
+    bool r = stats->verify_integrity(icc);
+    if (!r) return false;
   }
 
   // Check that the Stats instance's column reference points to this instance
   if (!(stats->is_void() || stats->column_ref() == this)) {
-    ERR("Column reference in %s does not point to %s: expected %p, "
-        "but found %p\n", stats_name, name, this, stats->column_ref());
+    icc << name << " is not linked properly with its stats: the back-reference "
+        << "to column in Stats object is " << stats->column_ref() << ", while "
+        << "the Column instance is " << this << end;
   }
-  return nerrors;
+  return !icc.has_errors(nerrors);
 }
-
-/**
- * Helper method that checks the structure of the `meta` and ensures that it
- * coincides with the current state of the column
- */
-int Column::verify_meta_integrity(std::vector<char>*, int, const char*) const {
-  return 0;
-}
-

--- a/c/column.h
+++ b/c/column.h
@@ -160,10 +160,13 @@ public:
   static size_t i4s_padding(size_t datasize);
   static size_t i8s_padding(size_t datasize);
 
- /**
-  * See DataTable::verify_integrity for method description
-  */
-  virtual int verify_integrity(std::vector<char>*, int, const char* = "Column") const;
+  /**
+   * Check that the data in this Column object is correct. Use the provided
+   * `IntegrityCheckContext` to report any errors, and `name` is the name of
+   * the column to be used in the output messages.
+   */
+  virtual bool verify_integrity(IntegrityCheckContext&,
+                                const std::string& name = "Column") const;
 
 protected:
   Column(int64_t nrows);
@@ -191,12 +194,6 @@ protected:
   virtual void cast_into(StringColumn<int32_t>*) const;
   virtual void cast_into(StringColumn<int64_t>*) const;
   virtual void cast_into(PyObjectColumn*) const;
-
-  /**
-   * Helper function that checks for meta integrity. Parameters are equivalent
-   * to those in Column::verify_integrity
-   */
-  virtual int verify_meta_integrity(std::vector<char>*, int, const char* = "Column") const;
 
 private:
   static size_t allocsize0(SType, int64_t nrows);
@@ -265,7 +262,8 @@ protected:
   // void cast_into(StringColumn<int32_t>*) const;
   // void cast_into(StringColumn<int64_t>*) const;
 
-  int verify_integrity(std::vector<char>*, int, const char* = "Column") const override;
+  bool verify_integrity(IntegrityCheckContext&,
+                        const std::string& name = "Column") const override;
 };
 
 
@@ -381,7 +379,8 @@ public:
   char* strdata() const;
   T* offsets() const;
 
-  int verify_integrity(std::vector<char>*, int, const char* = "Column") const override;
+  bool verify_integrity(IntegrityCheckContext&,
+                        const std::string& name = "Column") const override;
 
 protected:
   void rbind_impl(const std::vector<const Column*>& columns, int64_t nrows,
@@ -397,8 +396,6 @@ protected:
   void cast_into(PyObjectColumn*) const override;
   // void cast_into(StringColumn<int32_t>*) const;
   // void cast_into(StringColumn<int64_t>*) const;
-
-  int verify_meta_integrity(std::vector<char>*, int, const char* = "Column") const override;
 };
 
 

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -1,7 +1,23 @@
+//------------------------------------------------------------------------------
+//  Copyright 2017 H2O.ai
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//------------------------------------------------------------------------------
 #ifndef dt_DATATABLE_H
 #define dt_DATATABLE_H
 #include <inttypes.h>
 #include <vector>
+#include "datatable_check.h"
 #include "stats.h"
 #include "types.h"
 #include "column.h"
@@ -57,7 +73,7 @@ public:
     DataTable* rbind(DataTable**, int**, int, int64_t);
     DataTable* cbind(DataTable**, int);
     size_t memory_footprint();
-    int verify_integrity(std::vector<char>*, int, const char* = "DataTable") const;
+    bool verify_integrity(IntegrityCheckContext& icc) const;
 
     static DataTable* load(DataTable*, int64_t);
 };

--- a/c/datatable_check.cc
+++ b/c/datatable_check.cc
@@ -1,4 +1,21 @@
+//------------------------------------------------------------------------------
+//  Copyright 2017 H2O.ai
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//------------------------------------------------------------------------------
 #include "datatable_check.h"
+// #include <limits>    // std::numeric_limits
+#include "utils.h"
 
 
 /**
@@ -12,7 +29,7 @@ size_t array_size(void *ptr, size_t elemsize) {
     return ptr == NULL? 0 : malloc_size(ptr) / elemsize;
 }
 
-
+/*
 __attribute__ ((format (printf, 2, 0)))
 void push_error(std::vector<char> *out, const char* format, ...) {
   if (out == nullptr) return;
@@ -28,7 +45,7 @@ void push_error(std::vector<char> *out, const char* format, ...) {
   out->resize(len + add_len);
   memcpy(out->data() + len, buf, add_len);
 }
-
+*/
 
 char*
 repr_utf8(const unsigned char* ptr0, const unsigned char* ptr1) {
@@ -51,3 +68,60 @@ repr_utf8(const unsigned char* ptr0, const unsigned char* ptr1) {
     return buf;
 }
 
+const EndOfError IntegrityCheckContext::eoe;
+
+
+IntegrityCheckContext::IntegrityCheckContext(int max) {
+  if (max < 0) max = 10000;
+  max_errors = max;
+  num_errors = 0;
+}
+
+
+IntegrityCheckContext& IntegrityCheckContext::operator<<(const std::string& s) {
+  if (num_errors < max_errors)
+    error_stream << s;
+  return *this;
+}
+
+IntegrityCheckContext& IntegrityCheckContext::operator<<(const char* s) {
+  if (num_errors < max_errors)
+    error_stream << s;
+  return *this;
+}
+
+IntegrityCheckContext& IntegrityCheckContext::operator<<(const void* s) {
+  if (num_errors < max_errors)
+    error_stream << s;
+  return *this;
+}
+
+IntegrityCheckContext& IntegrityCheckContext::operator<<(int64_t num) {
+  if (num_errors < max_errors)
+    error_stream << num;
+  return *this;
+}
+
+IntegrityCheckContext& IntegrityCheckContext::operator<<(int32_t num) {
+  if (num_errors < max_errors)
+    error_stream << num;
+  return *this;
+}
+
+IntegrityCheckContext& IntegrityCheckContext::operator<<(int8_t num) {
+  if (num_errors < max_errors)
+    error_stream << num;
+  return *this;
+}
+
+IntegrityCheckContext& IntegrityCheckContext::operator<<(size_t num) {
+  if (num_errors < max_errors)
+    error_stream << num;
+  return *this;
+}
+
+void IntegrityCheckContext::operator<<(const EndOfError&) {
+  if (num_errors < max_errors)
+    error_stream << "\n";
+  num_errors++;
+}

--- a/c/datatable_check.h
+++ b/c/datatable_check.h
@@ -1,19 +1,67 @@
-#ifndef C_DATATABLE_CHECK_H_
-#define C_DATATABLE_CHECK_H_
+//------------------------------------------------------------------------------
+//  Copyright 2017 H2O.ai
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//------------------------------------------------------------------------------
+// See `meth_check()` in "py_datatable.c"
+//
+#ifndef dt_DATATABLE_CHECK_H
+#define dt_DATATABLE_CHECK_H
+#include <string>
+#include <sstream>
+// #include <vector>
 
-#include <vector>
+// "Sentinent" object to
+class EndOfError {};
+
+
+class IntegrityCheckContext
+{
+  static const EndOfError eoe;
+  std::ostringstream error_stream;
+  int num_errors;
+  int max_errors;
+
+public:
+  IntegrityCheckContext(int max);
+  bool has_errors(int n = 0) const { return num_errors > n; }
+  int n_errors() const { return num_errors; }
+  const EndOfError& end() const { return eoe; }
+  const std::ostringstream& errors() const { return error_stream; }
+
+  IntegrityCheckContext& operator<<(const std::string&);
+  IntegrityCheckContext& operator<<(const char*);
+  IntegrityCheckContext& operator<<(const void*);
+  IntegrityCheckContext& operator<<(int64_t);
+  IntegrityCheckContext& operator<<(int32_t);
+  IntegrityCheckContext& operator<<(int8_t);
+  IntegrityCheckContext& operator<<(size_t);
+  void operator<<(const EndOfError&);
+};
+
+
 
 #ifdef __APPLE__
-    #include <malloc/malloc.h>  // size_t malloc_size(const void *)
+  #include <malloc/malloc.h>  // size_t malloc_size(const void *)
 #elif defined _WIN32
-    #include <malloc.h>  // size_t _msize(void *)
-    #define malloc_size  _msize
+  #include <malloc.h>  // size_t _msize(void *)
+  #define malloc_size  _msize
 #elif defined __linux__
-    #include <malloc.h>  // size_t malloc_usable_size(void *) __THROW
-    #define malloc_size  malloc_usable_size
+  #include <malloc.h>  // size_t malloc_usable_size(void *) __THROW
+  #define malloc_size  malloc_usable_size
 #else
-    #define malloc_size(p)  0
-    #define MALLOC_SIZE_UNAVAILABLE
+  #define malloc_size(p)  0
+  #define MALLOC_SIZE_UNAVAILABLE
 #endif
 
 char*
@@ -28,4 +76,5 @@ size_t array_size(void *ptr, size_t elemsize);
     push_error(errors, __VA_ARGS__);                                            \
   } while(0)
 
-#endif /* C_DATATABLE_CHECK_H_ */
+
+#endif

--- a/c/memorybuf.h
+++ b/c/memorybuf.h
@@ -191,7 +191,8 @@ public:
   int get_refcount() const;
 
 
-  int verify_integrity(std::vector<char>*, int, const char* = "MemoryBuffer") const;
+  virtual bool verify_integrity(IntegrityCheckContext&,
+                                const std::string& name = "MemoryBuffer") const;
 
 
   //--- Internal ---------------------------------------------------------------
@@ -222,7 +223,7 @@ public:
 
   /**
    * Create MemoryMemBuf of size `n` and baised on the pointer `ptr`. An
-   * exception will be raised if `n` is positive and `ptr` is is null. This
+   * exception will be raised if `n` is positive and `ptr` is null. This
    * constructor assumes ownership of pointer `ptr` and will free it when
    * MemoryMemBuf is deleted. If you don't want MemoryMemBuf to assume
    * ownership of the pointer, then use :class:`ExternalMemBuf` instead.
@@ -231,6 +232,8 @@ public:
 
   virtual void resize(size_t n) override;
   virtual PyObject* pyrepr() const override;
+  bool verify_integrity(IntegrityCheckContext&,
+                        const std::string& n = "MemoryBuffer") const override;
 
 private:
   virtual ~MemoryMemBuf();
@@ -278,6 +281,8 @@ public:
 
   virtual size_t memory_footprint() const override;
   virtual PyObject* pyrepr() const override;
+  bool verify_integrity(IntegrityCheckContext&,
+                        const std::string& n = "MemoryBuffer") const override;
 
 private:
   virtual ~ExternalMemBuf() override;
@@ -316,6 +321,8 @@ public:
   virtual void resize(size_t n) override;
   virtual size_t memory_footprint() const override;
   virtual PyObject* pyrepr() const override;
+  bool verify_integrity(IntegrityCheckContext&,
+                        const std::string& n = "MemoryBuffer") const override;
 
 private:
   virtual ~MemmapMemBuf();

--- a/c/rowindex.h
+++ b/c/rowindex.h
@@ -8,9 +8,9 @@
 //==============================================================================
 
 typedef enum RowIndexType {
-    RI_ARR32 = 1,
-    RI_ARR64 = 2,
-    RI_SLICE = 3,
+  RI_ARR32 = 1,
+  RI_ARR64 = 2,
+  RI_SLICE = 3,
 } RowIndexType;
 
 typedef int (rowindex_filterfn32)(int64_t, int64_t, int32_t*, int32_t*);
@@ -56,40 +56,43 @@ typedef int (rowindex_filterfn64)(int64_t, int64_t, int64_t*, int32_t*);
  *     Number of references to this RowIndex object. When this count reaches 0
  *     the object can be deallocated.
  */
-class RowIndex {
+class RowIndex
+{
 public:
-    int64_t length;
-    int64_t min;
-    int64_t max;
-    union {
-        int32_t *ind32;
-        int64_t *ind64;
-        struct { int64_t start, step; } slice;
-    };
-    RowIndexType type;
-    int32_t refcount;
-    RowIndex(int64_t, int64_t, int64_t); // from slice
-    RowIndex(int64_t*, int64_t*, int64_t*, int64_t); // from list of slices
-    RowIndex(int64_t*, int64_t, int);
-    RowIndex(int32_t*, int64_t, int);
-    RowIndex(const RowIndex&);
-    RowIndex(RowIndex*);
-    RowIndex* expand();
-    void compactify();
-    size_t alloc_size();
-    RowIndex* shallowcopy();
-    void release();
+  int64_t length;
+  int64_t min;
+  int64_t max;
+  union {
+    int32_t *ind32;
+    int64_t *ind64;
+    struct { int64_t start, step; } slice;
+  };
+  RowIndexType type;
+  int32_t refcount;
+  RowIndex(int64_t, int64_t, int64_t); // from slice
+  RowIndex(int64_t*, int64_t*, int64_t*, int64_t); // from list of slices
+  RowIndex(int64_t*, int64_t, int);
+  RowIndex(int32_t*, int64_t, int);
+  RowIndex(const RowIndex&);
+  RowIndex(RowIndex*);
+  RowIndex* expand();
+  void compactify();
+  size_t alloc_size();
+  RowIndex* shallowcopy();
+  void release();
 
-    int verify_integrity(std::vector<char>*, int, const char* = "RowIndex") const;
+  bool verify_integrity(IntegrityCheckContext&,
+                        const std::string& name = "RowIndex") const;
 
-    static RowIndex* merge(RowIndex*, RowIndex*);
-    static RowIndex* from_intcolumn(Column*, int);
-    static RowIndex* from_boolcolumn(Column*, int64_t);
-    static RowIndex* from_column(Column*);
-    static RowIndex* from_filterfn32(rowindex_filterfn32*, int64_t, int);
-    static RowIndex* from_filterfn64(rowindex_filterfn64*, int64_t, int);
+  static RowIndex* merge(RowIndex*, RowIndex*);
+  static RowIndex* from_intcolumn(Column*, int);
+  static RowIndex* from_boolcolumn(Column*, int64_t);
+  static RowIndex* from_column(Column*);
+  static RowIndex* from_filterfn32(rowindex_filterfn32*, int64_t, int);
+  static RowIndex* from_filterfn64(rowindex_filterfn64*, int64_t, int);
+
 private:
-    ~RowIndex();
+  ~RowIndex();
 };
 
 

--- a/c/stats.cc
+++ b/c/stats.cc
@@ -267,12 +267,14 @@ STAT_DATATABLE(sum)
 /**
  * See DataTable::verify_integrity for method description
  */
-int Stats::verify_integrity(
-    std::vector<char>*, int, const char*) const
+bool Stats::verify_integrity(IntegrityCheckContext&,
+                             const std::string&) const
 {
   // TODO: add checks (necessary when merge_stats is implemented)
-  return 0;
+  return true;
 }
+
+
 
 //==============================================================================
 // NumericalStats

--- a/c/stats.h
+++ b/c/stats.h
@@ -1,16 +1,12 @@
-#ifndef STATS_H
-#define STATS_H
-
+#ifndef dt_STATS_H
+#define dt_STATS_H
 #include <stddef.h>
 #include <stdint.h>
 #include <vector>
-#include "types.h"
 #include "datatable.h"
 #include "rowindex.h"
+#include "types.h"
 
-class DataTable;
-class Column;
-class RowIndex;
 
 /**
  * Statistics Container
@@ -60,7 +56,8 @@ public:
     static DataTable* sum_datatable    ( const DataTable*);
     //===========================================================
 
-    int verify_integrity(std::vector<char>*, int, const char* = "Stats") const;
+  bool verify_integrity(IntegrityCheckContext&,
+                        const std::string& name = "Stats") const;
 protected:
     double _mean;
     double _sd;

--- a/c/utils.h
+++ b/c/utils.h
@@ -3,15 +3,16 @@
 //==============================================================================
 #ifndef dt_UTILS_H
 #define dt_UTILS_H
-#include <stdexcept>
-#include <exception>
-#include <mutex>
 #include <stddef.h>
 #include <stdio.h>   // vsnprintf
 #include <stdint.h>
 #include <stdio.h>   // vsnprintf
 #include <errno.h>   // errno
 #include <string.h>  // strerr
+#include <exception>
+#include <mutex>
+#include <stdexcept>
+#include <string>
 
 // On Windows variables of type `size_t` cannot be printed with "%zu" in the
 // `snprintf()` function. For those variables we will cast them into
@@ -24,6 +25,10 @@ int64_t max(int64_t a, int64_t b);
 float max_f4(float a, float b);
 double wallclock(void);
 const char* filesize_to_str(size_t filesize);
+
+inline std::string operator "" _s(const char* str, size_t len) {
+  return std::string(str, len);
+}
 
 
 /**


### PR DESCRIPTION
* Add class `IntegrityCheckContext` which holds all the error messages.
* The signatures of all integrity-checking methods in all classes were changed into the following: `bool verify_integrity(IntegrityCheckContext& icc, const std::string& name) const`
* Macro `ERR` was removed; instead the errors should be "streamed" into the `IntegrityCheckContext&` object: `icc << "Bad value: " << value << icc.end();` (where "end" signifies the end of each error).
* Added integrity checks for memory buffers.


Closes #482 