### PR TITLE
Allow columns in the datatable to be renamed by setting .names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Enums `stype` and `ltype` that encapsulate the type-system of the `datatable`
   module.
 - It is now possible to fread from a `bytes` object.
+- Allow columns to be renamed by setting the `names` property on the datatable.
 
 #### Changed
 - When writing "round" doubles/floats to CSV, they'll now always have trailing zero.

--- a/datatable/dt.py
+++ b/datatable/dt.py
@@ -4,7 +4,7 @@ import collections
 import time
 import sys
 from types import GeneratorType
-from typing import Tuple, Dict
+from typing import Tuple, Dict, List, Union
 
 # noinspection PyUnresolvedReferences
 import datatable.lib._datatable as c
@@ -98,6 +98,18 @@ class DataTable(object):
     def internal(self):
         """Access to the underlying C DataTable object."""
         return self._dt
+
+
+    #---------------------------------------------------------------------------
+    # Property setters
+    #---------------------------------------------------------------------------
+
+    @names.setter
+    @typed()
+    def names(self, newnames: Union[List[str], Tuple[str, ...]]):
+        """Rename the columns of the DataTable."""
+        self.rename(newnames)
+
 
 
     #---------------------------------------------------------------------------
@@ -593,18 +605,25 @@ class DataTable(object):
 
 
 
-    @typed(columns={U(str, int): str})
-    def rename(self, columns):
+    @typed()
+    def rename(self, columns: Union[Dict[str, str], Dict[int, str], List[str],
+                                    Tuple[str, ...]]):
         """
         Rename columns of the datatable.
 
         :param columns: dictionary of the {old_name: new_name} entries.
         :returns: None
         """
-        names = list(self._names)
-        for oldname, newname in columns.items():
-            idx = self.colindex(oldname)
-            names[idx] = newname
+        if isinstance(columns, (list, tuple)):
+            names = columns
+            if len(names) != self._ncols:
+                raise TValueError("Cannot rename columns to %r: expected %s"
+                                  % (names, plural(self._ncols, "name")))
+        else:
+            names = list(self._names)
+            for oldname, newname in columns.items():
+                idx = self.colindex(oldname)
+                names[idx] = newname
         self._fill_from_dt(self._dt, names=names)
 
 

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -225,13 +225,42 @@ def test_column_hexview(dt0, patched_terminal, capsys):
 def test_rename():
     d0 = dt.DataTable([[1], [2], ["hello"]])
     assert d0.names == ("C1", "C2", "C3")
-    d0.rename({0: "x", "C2": "y", -1: "z"})
+    d0.rename({0: "x", -1: "z"})
+    d0.rename({"C2": "y"})
     assert d0.names == ("x", "y", "z")
+    assert d0.colindex("x") == 0
+    assert d0.colindex("y") == 1
+    assert d0.colindex("z") == 2
+
+
+@pytest.mark.run(order=8.1)
+def test_rename_bad():
+    d0 = dt.DataTable([[1], [2], ["hello"]], colnames=("a", "b", "c"))
     with pytest.raises(TypeError):
-        d0.rename(["a", "b"])
+        d0.rename({"a", "b"})
     with pytest.raises(ValueError) as e:
         d0.rename({"xxx": "yyy"})
     assert "Column `xxx` does not exist" in str(e.value)
+    with pytest.raises(ValueError) as e:
+        d0.names = ['1', '2', '3', '5']
+    assert ("Cannot rename columns to ['1', '2', '3', '5']: "
+            "expected 3 names" in str(e.value))
+    with pytest.raises(ValueError) as e:
+        d0.names = ('k', )
+    assert ("Cannot rename columns to ('k',): "
+            "expected 3 names" in str(e.value))
+
+
+@pytest.mark.run(order=8.2)
+def test_rename_setter():
+    d0 = dt.DataTable([[7], [2], [5]])
+    d0.names = ("A", "B", "E")
+    d0.names = ["a", "c", "e"]
+    assert d0.internal.check()
+    assert d0.names == ("a", "c", "e")
+    assert d0.colindex("a") == 0
+    assert d0.colindex("c") == 1
+    assert d0.colindex("e") == 2
 
 
 @pytest.mark.run(order=9)


### PR DESCRIPTION
Closes #533