### PR TITLE
Make memory-mapping files lazy.

### DIFF
--- a/c/column.cc
+++ b/c/column.cc
@@ -132,10 +132,10 @@ Column* Column::open_mmap_column(SType stype, int64_t nrows,
   Column* col = new_column(stype);
   col->nrows = nrows;
   col->mbuf = new MemmapMemBuf(filename);
-  if (col->alloc_size() < allocsize0(stype, nrows)) {
-    throw Error("File %s has size %zu, which is not sufficient for a column"
-                " with %zd rows", filename, col->alloc_size(), nrows);
-  }
+  // if (col->alloc_size() < allocsize0(stype, nrows)) {
+  //   throw Error("File %s has size %zu, which is not sufficient for a column"
+  //               " with %zd rows", filename, col->alloc_size(), nrows);
+  // }
   // Deserialize the meta information, if needed
   if (stype == ST_STRING_I4_VCHAR || stype == ST_STRING_I8_VCHAR) {
     if (strncmp(ms, "offoff=", 7) != 0)

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -82,7 +82,7 @@ public:
 
     bool verify_integrity(IntegrityCheckContext& icc) const;
 
-    static DataTable* load(DataTable*, int64_t);
+    static DataTable* load(DataTable* schema, int64_t nrows, const char* path);
 };
 
 

--- a/c/datatable_load.cc
+++ b/c/datatable_load.cc
@@ -18,7 +18,7 @@
  * nrows
  *     Number of rows in the stored datatable.
  */
-DataTable* DataTable::load(DataTable *colspec, int64_t nrows)
+DataTable* DataTable::load(DataTable *colspec, int64_t nrows, const char* path)
 {
     int64_t ncols = colspec->nrows;
     Column **columns = NULL;
@@ -46,8 +46,18 @@ DataTable* DataTable::load(DataTable *colspec, int64_t nrows)
     int32_t *offs = (int32_t*) cols->data_at(static_cast<size_t>(oos));
     int32_t *offm = (int32_t*) colm->data_at(static_cast<size_t>(oom));
 
-    static char filename[101];
+    static char filename[1001];
     static char metastr[101];
+    size_t len = strlen(path);
+    if (len > 900) throw Error("The path is too long: %s", path);
+    if (len > 0) {
+        strcpy(filename, path);
+        if (filename[len - 1] != '/') {
+            filename[len] = '/';
+            len++;
+        }
+    }
+    char* ffilename = filename + len;
     for (int64_t i = 0; i < ncols; ++i)
     {
         // Extract filename
@@ -55,8 +65,8 @@ DataTable* DataTable::load(DataTable *colspec, int64_t nrows)
         int32_t fend = abs(offf[i]) - 1;
         int32_t flen = fend - fsta;
         if (flen > 100) throw Error("Filename is too long: %d", flen);
-        memcpy(filename, colf->data_at(static_cast<size_t>(fsta)), (size_t) flen);
-        filename[flen] = '\0';
+        memcpy(ffilename, colf->data_at(static_cast<size_t>(fsta)), (size_t) flen);
+        ffilename[flen] = '\0';
 
         // Extract stype
         int32_t ssta = abs(offs[i - 1]) - 1;

--- a/c/file.cc
+++ b/c/file.cc
@@ -68,6 +68,17 @@ size_t File::size() const {
   return static_cast<size_t>(statbuf.st_size);
 }
 
+// Same as `size()`, but static (i.e. no need to open the file).
+size_t File::asize(const std::string& filename) {
+  struct stat statbuf;
+  int ret = stat(filename.c_str(), &statbuf);
+  if (ret == -1) {
+    throw Error("Unable to obtain size of %s: [errno %d] %s",
+                filename.c_str(), errno, strerror(errno));
+  }
+  return static_cast<size_t>(statbuf.st_size);
+}
+
 const char* File::cname() const {
   return name.c_str();
 }

--- a/c/file.h
+++ b/c/file.h
@@ -38,6 +38,7 @@ public:
 
   int descriptor() const;
   size_t size() const;
+  static size_t asize(const std::string& filename);
   void resize(size_t newsize);
   void assert_is_not_dir() const;
   const char* cname() const;

--- a/c/memorybuf.h
+++ b/c/memorybuf.h
@@ -62,10 +62,10 @@ public:
    * The multiple `at()` methods all do the same, they exist only to spare the
    * user from having to cast their integer offset into a proper integer type.
    */
-  virtual void* get() const = 0;
-  void* at(size_t offset) const;
-  void* at(int64_t offset) const;
-  void* at(int32_t offset) const;
+  virtual void* get() = 0;
+  void* at(size_t offset);
+  void* at(int64_t offset);
+  void* at(int32_t offset);
 
   /**
    * Treats the memory buffer as an array `T[]` and retrieves / sets its `i`-th
@@ -77,14 +77,14 @@ public:
    * responsibility of the caller to ensure that `i * sizeof(T) < size()`.
    * Failure to do so will lead to memory corruption / seg.fault.
    */
-  template <typename T> T get_elem(int64_t i) const;
+  template <typename T> T get_elem(int64_t i);
   template <typename T> void set_elem(int64_t i, T value);
 
   /**
    * Returns the allocation size of the underlying memory buffer. This should be
    * zero if memory is unallocated.
    */
-  virtual size_t size() const = 0;
+  virtual size_t size() = 0;
 
   /**
    * Returns the best estimate of this object's total size in memory. This is
@@ -161,7 +161,7 @@ public:
    * MemoryBuffer. Note that a "deep" copy is always an instance of MemoryMemBuf
    * class, regardless of the class of the current object.
    */
-  MemoryMemBuf* deepcopy() const;
+  MemoryMemBuf* deepcopy();
 
   /**
    * This method should be called where you would normally say `delete membuf;`.
@@ -220,8 +220,8 @@ public:
    */
   MemoryMemBuf(void* ptr, size_t n);
 
-  void* get() const override;
-  size_t size() const override;
+  void* get() override;
+  size_t size() override;
   size_t memory_footprint() const override;
   PyObject* pyrepr() const override;
   virtual void resize(size_t n) override;
@@ -275,8 +275,8 @@ public:
    */
   ExternalMemBuf(const char* cstr);
 
-  void* get() const override;
-  size_t size() const override;
+  void* get() override;
+  size_t size() override;
   size_t memory_footprint() const override;
   PyObject* pyrepr() const override;
   bool verify_integrity(IntegrityCheckContext&,
@@ -301,8 +301,8 @@ private:
  */
 class MemmapMemBuf : public MemoryBuffer
 {
-  void* buf;
-  size_t allocsize;
+  void* mmp;
+  size_t mmpsize;
   const std::string filename;
 
 public:
@@ -313,8 +313,8 @@ public:
   MemmapMemBuf(const std::string& file);
   MemmapMemBuf(const std::string& file, size_t n);
 
-  void* get() const override;
-  size_t size() const override;
+  void* get() override;
+  size_t size() override;
   virtual void resize(size_t n) override;
   virtual size_t memory_footprint() const override;
   virtual PyObject* pyrepr() const override;
@@ -333,6 +333,7 @@ protected:
    */
   MemmapMemBuf(const std::string& path, size_t n, bool create);
   virtual ~MemmapMemBuf();
+  virtual void memmap();
 };
 
 
@@ -360,6 +361,7 @@ public:
 
 protected:
   virtual ~OvermapMemBuf();
+  void memmap() override;
 };
 
 
@@ -367,7 +369,7 @@ protected:
 //==============================================================================
 // Template implementations
 
-template <typename T> T MemoryBuffer::get_elem(int64_t i) const {
+template <typename T> T MemoryBuffer::get_elem(int64_t i) {
   return (static_cast<T*>(get()))[i];
 }
 

--- a/c/py_datatable.c
+++ b/c/py_datatable.c
@@ -230,15 +230,16 @@ PyObject* pydatatable_assemble(UU, PyObject *args)
 
 
 
-PyObject* pydatatable_load(UU, PyObject *args)
+PyObject* pydatatable_load(PyObject*, PyObject* args)
 {
   CATCH_EXCEPTIONS(
     DataTable *colspec;
     int64_t nrows;
-    if (!PyArg_ParseTuple(args, "O&n:datatable_load",
-                          &dt_unwrap, &colspec, &nrows))
+    const char* path;
+    if (!PyArg_ParseTuple(args, "O&ns:datatable_load",
+                          &dt_unwrap, &colspec, &nrows, &path))
         return NULL;
-    return py(DataTable::load(colspec, nrows));
+    return py(DataTable::load(colspec, nrows, path));
   );
 }
 

--- a/datatable/nff.py
+++ b/datatable/nff.py
@@ -53,10 +53,11 @@ def open(path):
         path = os.path.expanduser(path)
         if not os.path.isdir(path):
             raise ValueError("%s is not a valid directory" % path)
-        os.chdir(path)
+        # os.chdir(path)
 
         nrows = 0
-        with _builtin_open("_meta.nff") as inp:
+        metafile = os.path.join(path, "_meta.nff")
+        with _builtin_open(metafile) as inp:
             info = []
             for line in inp:
                 if line.startswith("#"):
@@ -76,11 +77,11 @@ def open(path):
             else:
                 raise ValueError("Unknown NFF format: %s" % info[0])
 
-        f0 = fread("_meta.nff", sep=",",
+        f0 = fread(metafile, sep=",",
                    columns=lambda i, name, type: (name, str))
         f1 = f0(select=["filename", "stype", "meta"])
         colnames = f0["colname"].topython()[0]
-        _dt = _datatable.datatable_load(f1.internal, nrows)
+        _dt = _datatable.datatable_load(f1.internal, nrows, path)
         dt = DataTable(_dt, colnames=colnames)
         assert dt.nrows == nrows, "Wrong number of rows read: %d" % dt.nrows
         return dt


### PR DESCRIPTION
In particular, when opening a dataset with many columns, we end up spending too much time memory-mapping them too many times. This PR defers that action until the column's data is actually needed.

This may help with #490