### PR TITLE
Rename parameter colnames= in DataTable constructor to names=

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `df.stypes` now returns a tuple of `stype` elements (previously it was returning
   a list of strings). Likewise, `df.types` was renamed into `df.ltypes` and now it
   returns a tuple of `ltype` elements instead of strings.
+- Parameter `colnames=` in DataTable constructor was renamed to `names=`. The old
+  parameter may still be used, but it will result in a warning.
 
 #### Fixed
 - `datatable` will no longer cause the C locale settings to change upon importing.

--- a/benchmarks/bench_tocsv_bool.py
+++ b/benchmarks/bench_tocsv_bool.py
@@ -25,7 +25,7 @@ def src(numpy, request):
         numpy.random.randn(n) > 0,
         numpy.random.randn(n) > 0,
     ]
-    dts = [datatable.DataTable(x, colnames=["C%d" % i])
+    dts = [datatable.DataTable(x, names=["C%d" % i])
            for i, x in enumerate(cols)]
     return datatable.DataTable().cbind(*dts)
 

--- a/benchmarks/bench_tocsv_double.py
+++ b/benchmarks/bench_tocsv_double.py
@@ -25,7 +25,7 @@ def src(numpy, request):
         numpy.random.randn(n) * 10.0**numpy.random.randint(-308, 308, size=n),
         numpy.random.randn(n) * 10.0**numpy.random.randint(-10, 10, size=n),
     ]
-    dts = [datatable.DataTable(x, colnames=["C%d" % i])
+    dts = [datatable.DataTable(x, names=["C%d" % i])
            for i, x in enumerate(cols)]
     return datatable.DataTable().cbind(*dts)
 

--- a/benchmarks/bench_tocsv_int32.py
+++ b/benchmarks/bench_tocsv_int32.py
@@ -25,7 +25,7 @@ def src(numpy, request):
         numpy.random.randint(2**31, size=n, dtype="int32"),
         numpy.random.randint(-2**31, 2**31, size=n, dtype="int32"),
     ]
-    dts = [datatable.DataTable(x, colnames=["C%d" % i])
+    dts = [datatable.DataTable(x, names=["C%d" % i])
            for i, x in enumerate(cols)]
     return datatable.DataTable().cbind(*dts)
 

--- a/datatable/fread.py
+++ b/datatable/fread.py
@@ -299,7 +299,7 @@ class FReader(object):
 
     def read(self):
         _dt = c.fread(self)
-        dt = DataTable(_dt, colnames=self._colnames)
+        dt = DataTable(_dt, names=self._colnames)
         if self._tempfile:
             if self._verbose:
                 self.logger.debug("Removing temporary file %s\n"

--- a/datatable/graph/__init__.py
+++ b/datatable/graph/__init__.py
@@ -43,7 +43,7 @@ def make_datatable(dt, rows, select, sort):
         rowindex = rows_node.get_final_rowindex()
         columns = cols_node.get_result()
         res_dt = _datatable.datatable_assemble(rowindex, columns)
-        return datatable.DataTable(res_dt, colnames=cols_node.column_names)
+        return datatable.DataTable(res_dt, names=cols_node.column_names)
 
     # Select computed columns + all rows from datatable which is not a view --
     # in this case the rowindex is None, and the selected columns can be copied
@@ -52,7 +52,7 @@ def make_datatable(dt, rows, select, sort):
     if isinstance(rows_node, AllRFNode) and not dt.internal.isview:
         columns = cols_node.get_result()
         res_dt = _datatable.datatable_assemble(None, columns)
-        return datatable.DataTable(res_dt, colnames=cols_node.column_names)
+        return datatable.DataTable(res_dt, names=cols_node.column_names)
 
     raise RuntimeError(  # pragma: no cover
         "Unable to handle input (rows=%r, select=%r)"

--- a/datatable/nff.py
+++ b/datatable/nff.py
@@ -82,7 +82,7 @@ def open(path):
         f1 = f0(select=["filename", "stype", "meta"])
         colnames = f0["colname"].topython()[0]
         _dt = _datatable.datatable_load(f1.internal, nrows, path)
-        dt = DataTable(_dt, colnames=colnames)
+        dt = DataTable(_dt, names=colnames)
         assert dt.nrows == nrows, "Wrong number of rows read: %d" % dt.nrows
         return dt
     finally:

--- a/tests/munging/test_dt_append.py
+++ b/tests/munging/test_dt_append.py
@@ -56,10 +56,10 @@ def test_append_fails():
 
 
 def test_append_bynumbers():
-    dt0 = dt.DataTable([[1, 2, 3], [7, 7, 0]], colnames=["A", "V"])
-    dt1 = dt.DataTable([[10, -1], [3, -1]], colnames=["C", "Z"])
+    dt0 = dt.DataTable([[1, 2, 3], [7, 7, 0]], names=["A", "V"])
+    dt1 = dt.DataTable([[10, -1], [3, -1]], names=["C", "Z"])
     dtr = dt.DataTable([[1, 2, 3, 10, -1], [7, 7, 0, 3, -1]],
-                       colnames=["A", "V"])
+                       names=["A", "V"])
     dt0.append(dt1, bynames=False)
     assert_equals(dt0, dtr)
 
@@ -109,22 +109,22 @@ def test_not_inplace():
 
 
 def test_repeating_names():
-    dt0 = dt.DataTable([[5], [6], [7], [4]], colnames=["x", "y", "x", "x"])
-    dt1 = dt.DataTable([[4], [3], [2]], colnames=["y", "x", "x"])
-    dtr = dt.DataTable([[5, 3], [6, 4], [7, 2], [4, None]], colnames="xyxx")
+    dt0 = dt.DataTable([[5], [6], [7], [4]], names=["x", "y", "x", "x"])
+    dt1 = dt.DataTable([[4], [3], [2]], names=["y", "x", "x"])
+    dtr = dt.DataTable([[5, 3], [6, 4], [7, 2], [4, None]], names="xyxx")
     dt0.append(dt1, force=True)
     assert_equals(dt0, dtr)
 
     dt0 = dt.DataTable({"a": [23]})
-    dt1 = dt.DataTable([[2], [4], [8]], colnames="aaa")
-    dtr = dt.DataTable([[23, 2], [None, 4], [None, 8]], colnames="aaa")
+    dt1 = dt.DataTable([[2], [4], [8]], names="aaa")
+    dtr = dt.DataTable([[23, 2], [None, 4], [None, 8]], names="aaa")
     dt0.append(dt1, force=True)
     assert_equals(dt0, dtr)
 
-    dt0 = dt.DataTable([[22], [44], [88]], colnames="aba")
-    dt1 = dt.DataTable([[2], [4], [8]], colnames="aaa")
+    dt0 = dt.DataTable([[22], [44], [88]], names="aba")
+    dt1 = dt.DataTable([[2], [4], [8]], names="aaa")
     dtr = dt.DataTable([[22, 2], [44, None], [88, 4], [None, 8]],
-                       colnames=["a", "b", "a", "a"])
+                       names=["a", "b", "a", "a"])
     dt0.append(dt1, force=True)
     assert_equals(dt0, dtr)
 

--- a/tests/munging/test_dt_cbind.py
+++ b/tests/munging/test_dt_cbind.py
@@ -33,7 +33,7 @@ def test_cbind_simple():
     d1 = dt.DataTable([4, 5, 6])
     dt_compute_stats(d0, d1)
     d0.cbind(d1)
-    dr = dt.DataTable([[1, 2, 3], [4, 5, 6]], colnames=["C1", "C1"])
+    dr = dt.DataTable([[1, 2, 3], [4, 5, 6]], names=["C1", "C1"])
     assert_equals(d0, dr)
 
 
@@ -48,7 +48,7 @@ def test_cbind_self():
     d0 = dt.DataTable({"fun": [1, 2, 3]})
     dt_compute_stats(d0)
     d0.cbind(d0).cbind(d0).cbind(d0)
-    dr = dt.DataTable([[1, 2, 3]] * 8, colnames=["fun"] * 8)
+    dr = dt.DataTable([[1, 2, 3]] * 8, names=["fun"] * 8)
     assert_equals(d0, dr)
 
 
@@ -81,7 +81,7 @@ def test_cbind_forced1():
     d1 = dt.DataTable([4, 5])
     dt_compute_stats(d0, d1)
     d0.cbind(d1, force=True)
-    dr = dt.DataTable([[1, 2, 3], [4, 5, None]], colnames=["C1", "C1"])
+    dr = dt.DataTable([[1, 2, 3], [4, 5, None]], names=["C1", "C1"])
     assert_equals(d0, dr)
 
 

--- a/tests/munging/test_dt_cols.py
+++ b/tests/munging/test_dt_cols.py
@@ -21,7 +21,7 @@ def tbl0():
 
 @pytest.fixture()
 def dt0(tbl0):
-    return dt.DataTable(tbl0, colnames=["A", "B", "C", "D"])
+    return dt.DataTable(tbl0, names=["A", "B", "C", "D"])
 
 def as_list(datatable):
     nrows, ncols = datatable.shape

--- a/tests/munging/test_dt_rows.py
+++ b/tests/munging/test_dt_rows.py
@@ -17,7 +17,7 @@ def dt0():
         [0,   1,   1,  None,    0,  0,    1, None,   1,    1],  # bool
         [7, -11,   9, 10000, None,  0,    0,   -1,   1, None],  # int
         [5,   1, 1.3,   0.1,  1e5,  0, -2.6,  -14, nan,    2],  # real
-    ], colnames=["colA", "colB", "colC"])
+    ], names=["colA", "colB", "colC"])
 
 
 def assert_valueerror(datatable, rows, error_message):

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -21,7 +21,7 @@ def dt0():
         [None, None, None, None],
         [0, 0, 0, 0],
         ["1", "2", "hello", "world"],
-    ], colnames=list("ABCDEFG"))
+    ], names=list("ABCDEFG"))
 
 
 @pytest.fixture()
@@ -141,7 +141,7 @@ def test_dt_delitem():
     """
     def smalldt():
         return dt.DataTable([[i] for i in range(16)],
-                            colnames="ABCDEFGHIJKLMNOP")
+                            names="ABCDEFGHIJKLMNOP")
 
     d0 = smalldt()
     del d0["A"]
@@ -235,7 +235,7 @@ def test_rename():
 
 @pytest.mark.run(order=8.1)
 def test_rename_bad():
-    d0 = dt.DataTable([[1], [2], ["hello"]], colnames=("a", "b", "c"))
+    d0 = dt.DataTable([[1], [2], ["hello"]], names=("a", "b", "c"))
     with pytest.raises(TypeError):
         d0.rename({"a", "b"})
     with pytest.raises(ValueError) as e:
@@ -293,7 +293,7 @@ def test_topandas():
 def test_topandas_view():
     d0 = dt.DataTable([[1, 5, 2, 0, 199, -12],
                        ["alpha", "beta", None, "delta", "epsilon", "zeta"],
-                       [.3, 1e2, -.5, 1.9, 2.2, 7.9]], colnames=["A", "b", "c"])
+                       [.3, 1e2, -.5, 1.9, 2.2, 7.9]], names=["A", "b", "c"])
     d1 = d0[::-2, :]
     p1 = d1.topandas()
     assert p1.shape == d1.shape
@@ -306,7 +306,7 @@ def test_topython():
     src = [[-1, 0, 1, 3],
            ["cat", "dog", "mouse", "elephant"],
            [False, True, None, True]]
-    d0 = dt.DataTable(src, colnames=["A", "B", "C"])
+    d0 = dt.DataTable(src, names=["A", "B", "C"])
     assert d0.ltypes == (ltype.int, ltype.str, ltype.bool)
     a0 = d0.topython()
     assert len(a0) == 3

--- a/tests/test_dt_create.py
+++ b/tests/test_dt_create.py
@@ -20,7 +20,7 @@ def test_create_from_list():
 
 
 def test_create_from_list_of_lists():
-    d1 = dt.DataTable([[1, 2], [True, False], [.3, -0]], colnames="ABC")
+    d1 = dt.DataTable([[1, 2], [True, False], [.3, -0]], names="ABC")
     assert d1.shape == (2, 3)
     assert d1.names == ("A", "B", "C")
     assert d1.ltypes == (ltype.int, ltype.bool, ltype.real)
@@ -117,7 +117,7 @@ def test_create_from_pandas_series(pandas):
 
 def test_create_from_pandas_with_names(pandas):
     p = pandas.DataFrame({"A": [2, 5, 8], "B": ["e", "r", "qq"]})
-    d = dt.DataTable(p, colnames=["miniature", "miniscule"])
+    d = dt.DataTable(p, names=["miniature", "miniscule"])
     assert d.shape == (3, 2)
     assert same_iterables(d.names, ("miniature", "miniscule"))
     assert d.internal.check()
@@ -125,7 +125,7 @@ def test_create_from_pandas_with_names(pandas):
 
 def test_create_from_pandas_series_with_names(pandas):
     p = pandas.Series([10000, 5, 19, -12])
-    d = dt.DataTable(p, colnames=["ha!"])
+    d = dt.DataTable(p, names=["ha!"])
     assert d.internal.check()
     assert d.shape == (4, 1)
     assert d.names == ("ha!", )
@@ -230,7 +230,7 @@ def test_create_from_masked_numpy_array4(numpy):
 
 def test_create_from_numpy_array_with_names(numpy):
     a = numpy.array([1, 2, 3])
-    d = dt.DataTable(a, colnames=["gargantuan"])
+    d = dt.DataTable(a, names=["gargantuan"])
     assert d.shape == (3, 1)
     assert d.names == ("gargantuan", )
     assert d.internal.check()

--- a/tests/test_dt_sort.py
+++ b/tests/test_dt_sort.py
@@ -54,7 +54,7 @@ def test_int32_small_stable():
     d0 = datatable.DataTable([
         [5, 3, 5, None, 1000000, None, 3, None],
         [1, 5, 10, 20, 50, 100, 200, 500]
-    ], colnames=["A", "B"])
+    ], names=["A", "B"])
     d1 = d0.sort("A")
     assert d1.internal.check()
     assert d1.topython() == [
@@ -169,7 +169,7 @@ def test_int8_small_stable():
     d0 = datatable.DataTable([
         [5, 3, 5, None, 100, None, 3, None],
         [1, 5, 10, 20, 50, 100, 200, 500]
-    ], colnames=["A", "B"])
+    ], names=["A", "B"])
     d1 = d0(sort="A")
     assert d1.internal.check()
     assert d1.topython() == [
@@ -240,7 +240,7 @@ def test_bool8_large(n):
 @pytest.mark.parametrize("n", [254, 255, 256, 257, 258, 1000, 10000])
 def test_bool8_large_stable(n):
     d0 = datatable.DataTable([[True, False, None] * n, list(range(3 * n))],
-                             colnames=["A", "B"])
+                             names=["A", "B"])
     assert d0.stypes[0] == stype.bool8
     d1 = d0(sort="A", select="B")
     assert d1.internal.isview
@@ -283,7 +283,7 @@ def test_int16_large():
 @pytest.mark.parametrize("n", [100, 150, 200, 500, 1000, 200000])
 def test_int16_large_stable(n):
     d0 = datatable.DataTable([[-5, None, 5, -999, 1000] * n,
-                              list(range(n * 5))], colnames=["A", "B"])
+                              list(range(n * 5))], names=["A", "B"])
     assert d0.stypes[0] == stype.int16
     d1 = d0(sort="A", select="B")
     assert d1.internal.check()

--- a/tests/test_tocsv.py
+++ b/tests/test_tocsv.py
@@ -27,7 +27,7 @@ def pyhex(v):
 
 def test_save_simple():
     d = dt.DataTable([[1, 4, 5], [True, False, None], ["foo", None, "bar"]],
-                     colnames=["A", "B", "C"])
+                     names=["A", "B", "C"])
     out = d.to_csv()
     assert out == "A,B,C\n1,1,foo\n4,0,\n5,,bar\n"
 
@@ -276,7 +276,7 @@ def test_save_strings():
     src2 = ["", "empty", "None", None, "   with whitespace ", "with,commas",
             "\twith tabs\t", '"oh-no', "single'quote", "'squoted'",
             "\0bwahaha!", "?", "here be dragons"]
-    d = dt.DataTable([src1, src2], colnames=["A", "B"])
+    d = dt.DataTable([src1, src2], names=["A", "B"])
     assert d.stypes == (stype.str32, stype.str32)
     assert d.internal.check()
     assert d.to_csv().split("\n") == [


### PR DESCRIPTION
Now construction of a DataTable with column names is done as follows:
```
import datatable as dt
d = dt.DataTable([[1, 2, 3], ["a", "b", "c"]], names=["A", "B"])
assert d.names == ("A", "B")
```

This is to keep in sync with the terminology used in datatable object itself: dt.names gives the column names in existing DataTable, so the same should be used in constructor, for consistency.

The old parameter `colnames` can still be used, but it will show a warning.

Closes #536 