### PR TITLE
Implement column names deduplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   returns a tuple of `ltype` elements instead of strings.
 - Parameter `colnames=` in DataTable constructor was renamed to `names=`. The old
   parameter may still be used, but it will result in a warning.
+- DataTable can no longer have duplicate column names. If such names are given,
+  they will be mangled to make them unique, and a warning will be issued.
+- Special characters (in the ASCII range `\x00 - \x1F`) are no longer permitted in
+  the column names. If encountered, they will be replaced with a dot `.`.
 
 #### Fixed
 - `datatable` will no longer cause the C locale settings to change upon importing.

--- a/tests/munging/test_dt_append.py
+++ b/tests/munging/test_dt_append.py
@@ -109,24 +109,27 @@ def test_not_inplace():
 
 
 def test_repeating_names():
-    dt0 = dt.DataTable([[5], [6], [7], [4]], names=["x", "y", "x", "x"])
-    dt1 = dt.DataTable([[4], [3], [2]], names=["y", "x", "x"])
-    dtr = dt.DataTable([[5, 3], [6, 4], [7, 2], [4, None]], names="xyxx")
-    dt0.append(dt1, force=True)
-    assert_equals(dt0, dtr)
+    # Warnings about repeated names -- ignore
+    with pytest.warns(UserWarning):
+        dt0 = dt.DataTable([[5], [6], [7], [4]], names=["x", "y", "x", "x"])
+        dt1 = dt.DataTable([[4], [3], [2]], names=["y", "x", "x"])
+        dtr = dt.DataTable([[5, 3], [6, 4], [7, 2], [4, None]],
+                           names=["x", "y", "x.1", "x.2"])
+        dt0.append(dt1, force=True)
+        assert_equals(dt0, dtr)
 
-    dt0 = dt.DataTable({"a": [23]})
-    dt1 = dt.DataTable([[2], [4], [8]], names="aaa")
-    dtr = dt.DataTable([[23, 2], [None, 4], [None, 8]], names="aaa")
-    dt0.append(dt1, force=True)
-    assert_equals(dt0, dtr)
+        dt0 = dt.DataTable({"a": [23]})
+        dt1 = dt.DataTable([[2], [4], [8]], names="aaa")
+        dtr = dt.DataTable([[23, 2], [None, 4], [None, 8]], names="aaa")
+        dt0.append(dt1, force=True)
+        assert_equals(dt0, dtr)
 
-    dt0 = dt.DataTable([[22], [44], [88]], names="aba")
-    dt1 = dt.DataTable([[2], [4], [8]], names="aaa")
-    dtr = dt.DataTable([[22, 2], [44, None], [88, 4], [None, 8]],
-                       names=["a", "b", "a", "a"])
-    dt0.append(dt1, force=True)
-    assert_equals(dt0, dtr)
+        dt0 = dt.DataTable([[22], [44], [88]], names="aba")
+        dt1 = dt.DataTable([[2], [4], [8]], names="aaa")
+        dtr = dt.DataTable([[22, 2], [44, None], [88, 4], [None, 8]],
+                           names=["a", "b", "a", "a"])
+        dt0.append(dt1, force=True)
+        assert_equals(dt0, dtr)
 
 
 def test_append_strings():

--- a/tests/munging/test_dt_cbind.py
+++ b/tests/munging/test_dt_cbind.py
@@ -32,8 +32,9 @@ def test_cbind_simple():
     d0 = dt.DataTable([1, 2, 3])
     d1 = dt.DataTable([4, 5, 6])
     dt_compute_stats(d0, d1)
-    d0.cbind(d1)
-    dr = dt.DataTable([[1, 2, 3], [4, 5, 6]], names=["C1", "C1"])
+    with pytest.warns(UserWarning):
+        d0.cbind(d1)
+    dr = dt.DataTable([[1, 2, 3], [4, 5, 6]], names=["C1", "C2"])
     assert_equals(d0, dr)
 
 
@@ -47,8 +48,10 @@ def test_cbind_empty():
 def test_cbind_self():
     d0 = dt.DataTable({"fun": [1, 2, 3]})
     dt_compute_stats(d0)
-    d0.cbind(d0).cbind(d0).cbind(d0)
-    dr = dt.DataTable([[1, 2, 3]] * 8, names=["fun"] * 8)
+    with pytest.warns(UserWarning):
+        d0.cbind(d0).cbind(d0).cbind(d0)
+    dr = dt.DataTable([[1, 2, 3]] * 8,
+                      names=["fun"] + ["fun.%d" % i for i in range(1, 8)])
     assert_equals(d0, dr)
 
 
@@ -80,8 +83,9 @@ def test_cbind_forced1():
     d0 = dt.DataTable([1, 2, 3])
     d1 = dt.DataTable([4, 5])
     dt_compute_stats(d0, d1)
-    d0.cbind(d1, force=True)
-    dr = dt.DataTable([[1, 2, 3], [4, 5, None]], names=["C1", "C1"])
+    with pytest.warns(UserWarning):
+        d0.cbind(d1, force=True)
+    dr = dt.DataTable([[1, 2, 3], [4, 5, None]], names=["C1", "C2"])
     assert_equals(d0, dr)
 
 

--- a/tests/test_dt_create.py
+++ b/tests/test_dt_create.py
@@ -270,3 +270,26 @@ def test_issue_409():
     p = d.topython()
     assert p == [[inf, -inf, 0.0, -0.0]]
     assert copysign(1, p[0][-1]) == -1
+
+
+def test_duplicate_names1():
+    with pytest.warns(UserWarning) as ws:
+        d = dt.DataTable([[1], [2], [3]], names=["A", "A", "A"])
+        assert d.names == ("A", "A.1", "A.2")
+    assert len(ws) == 1
+    assert "Duplicate column names found: ['A', 'A']" in ws[0].message.args[0]
+
+
+def test_duplicate_names2():
+    with pytest.warns(UserWarning):
+        d = dt.DataTable([[1], [2], [3], [4]], names=("A", "A.1", "A", "A.2"))
+        assert d.names == ("A", "A.1", "A.2", "A.3")
+
+
+def test_special_characters_in_names():
+    d = dt.DataTable([[1], [2], [3], [4]],
+                     names=("".join(chr(i) for i in range(32)),
+                            "help\nneeded",
+                            "foo\t\tbar\t \tbaz",
+                            "A\n\rB\n\rC\n\rD\n\r"))
+    assert d.names == (".", "help.needed", "foo.bar. .baz", "A.B.C.D.")


### PR DESCRIPTION
* Duplicate column names are no longer possible in a DataTable. Column names in a DataTable will be automatically deduplicated.
* Special characters in column names are no longer allowed. They will be automatically replaced with dots (`.`).

Closes #564 
