### PR TITLE
Format DTPRINT messages in fread, so that they don't contain extraneous newlines

### DIFF
--- a/c/fread.h
+++ b/c/fread.h
@@ -335,7 +335,7 @@ void freeThreadContext(ThreadLocalFreadParsingContext *ctx);
 /**
  * Progress-reporting function.
  */
-void progress(double percent/*[0,1]*/, double ETA/*secs*/);
+void progress(double percent/*[0, 100]*/);
 
 
 void freadCleanup(void);

--- a/c/py_fread.c
+++ b/c/py_fread.c
@@ -152,6 +152,8 @@ PyObject* pyfread(PyObject*, PyObject *args)
     frargs->warningsAreErrors = 0;
     if (frargs->nrowLimit < 0)
         frargs->nrowLimit = LONG_MAX;
+    if (frargs->skipNrow < 0)
+        frargs->skipNrow = 0;
 
     frargs->freader = freader;
     Py_INCREF(freader);
@@ -159,9 +161,9 @@ PyObject* pyfread(PyObject*, PyObject *args)
     if (input) {
       mbuf = new ExternalMemBuf(input);
     } else if (filename) {
-      if (verbose) DTPRINT("  Opening file %s\n", filename);
+      if (verbose) DTPRINT("  Opening file %s", filename);
       mbuf = new OvermapMemBuf(filename, 1);
-      if (verbose) DTPRINT("  File opened, size: %s\n", filesize_to_str(mbuf->size() - 1));
+      if (verbose) DTPRINT("  File opened, size: %s", filesize_to_str(mbuf->size() - 1));
     } else {
       throw ValueError() << "Neither filename nor input were provided";
     }
@@ -342,7 +344,7 @@ size_t allocateDT(int8_t *types_, int8_t *sizes_, int ncols_, int ndrop_,
     // `prepareThreadContext` and `postprocessBuffer`), as well as allocating
     // the `Column**` array.
     if (ncols == 0) {
-        // DTPRINT("Writing the DataTable into %s\n", targetdir);
+        // DTPRINT("Writing the DataTable into %s", targetdir);
         assert(dt == NULL);
         ncols = ncols_;
 
@@ -695,9 +697,7 @@ void pushBuffer(ThreadLocalFreadParsingContext *ctx)
 }
 
 
-void progress(double percent/*[0,1]*/, double ETA/*secs*/)
-{
-    (void)ETA;
+void progress(double percent/*[0,100]*/) {
     PyObject_CallMethod(freader, "_progress", "d", percent);
 }
 

--- a/datatable/fread.py
+++ b/datatable/fread.py
@@ -302,7 +302,7 @@ class FReader(object):
         dt = DataTable(_dt, names=self._colnames)
         if self._tempfile:
             if self._verbose:
-                self.logger.debug("Removing temporary file %s\n"
+                self.logger.debug("Removing temporary file %s"
                                   % self._tempfile)
             try:
                 os.remove(self._tempfile)
@@ -320,7 +320,7 @@ class FReader(object):
         reached the specified level (expressed as a number from 0 to 100.0).
         """
         bs = self._bar_symbols
-        s0 = "Reading file: "
+        s0 = "  Reading file: "
         s1 = " %3d%%" % int(percent)
         line_width = min(100, term.width)
         bar_width = line_width - len(s0) - len(s1) - 2
@@ -344,17 +344,17 @@ class FReader(object):
         handle a dataset of the requested size.
         """
         if self.verbose:
-            self.logger.debug("  The DataTable is estimated to require %s\n"
+            self.logger.debug("  The DataTable is estimated to require %s"
                               % humanize_bytes(estimated_size))
         vm = psutil.virtual_memory()
         if self.verbose:
-            self.logger.debug("  Memory available = %s (out of %s)\n"
+            self.logger.debug("  Memory available = %s (out of %s)"
                               % (humanize_bytes(vm.available),
                                  humanize_bytes(vm.total)))
         if (estimated_size < vm.available and self._save_to is None or
                 self._save_to == "memory"):
             if self.verbose:
-                self.logger.debug("  DataTable will be loaded into memory\n")
+                self.logger.debug("  DataTable will be loaded into memory")
             return None
         else:
             if self._save_to:
@@ -364,12 +364,12 @@ class FReader(object):
                 tmpdir = tempfile.mkdtemp()
             du = psutil.disk_usage(tmpdir)
             if self.verbose:
-                self.logger.debug("  Free disk space on drive %s = %s\n"
+                self.logger.debug("  Free disk space on drive %s = %s"
                                   % (os.path.splitdrive(tmpdir)[0] or "/",
                                      humanize_bytes(du.free)))
             if du.free > estimated_size or self._save_to:
                 if self.verbose:
-                    self.logger.debug("  DataTable will be stored in %s\n"
+                    self.logger.debug("  DataTable will be stored in %s"
                                       % tmpdir)
                 return tmpdir
         raise RuntimeError("The DataTable is estimated to require at lest %s "
@@ -430,7 +430,7 @@ class FReader(object):
                 raise TValueError("Zip file %s is empty" % filename)
             self._tempdir = tempfile.mkdtemp()
             if self._verbose:
-                self.logger.debug("Extracting %s to temporary directory %s\n"
+                self.logger.debug("Extracting %s to temporary directory %s"
                                   % (filename, self._tempdir))
             self._tempfile = zf.extract(zff[0], path=self._tempdir)
 
@@ -438,7 +438,7 @@ class FReader(object):
             import gzip
             zf = gzip.GzipFile(filename)
             if self._verbose:
-                self.logger.debug("Extracting %s into memory\n" % filename)
+                self.logger.debug("Extracting %s into memory" % filename)
             self._text = zf.read()
 
 
@@ -593,14 +593,8 @@ class FReader(object):
 
 
 class _DefaultLogger:
-    def __init__(self):
-        self._log_newline = False
-
     def debug(self, message):
-        if self._log_newline:
-            print("  ", end="")
-        self._log_newline = message.endswith("\n")
-        print(_log_color(message), end="", flush=True)
+        print(_log_color(message), flush=True)
 
     def warn(self, message):
         warnings.warn(message)

--- a/tests/test_fread.py
+++ b/tests/test_fread.py
@@ -74,10 +74,13 @@ def test_logger():
     class MyLogger:
         def __init__(self):
             self.count = 0
+            self.msg = ""
 
         def debug(self, msg):
+            self.msg += msg + "\n"
             self.count += 1
 
     lg = MyLogger()
     datatable.fread(text="A\n1\n2\n3", logger=lg)
     assert lg.count > 10
+    assert "\n\n" not in lg.msg


### PR DESCRIPTION
Also the following minor fixes:
* Type codes are printed with character codes, rather than numbers. This is more understandable to the end users, and allows to have more than 10 ct_types.
* Progress bar always reaches 100% when reading (previously the last tick was skipped).

Closes #566 