### PR TITLE
Memory Map Manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   module.
 - It is now possible to fread from a `bytes` object.
 - Allow columns to be renamed by setting the `names` property on the datatable.
+- Internal "MemoryMapManager" will make datatable more robust when opening a
+  frame with many columns on Linux systems. In particular, error 12 "not enough
+  memory" should become much more rare now.
 
 #### Changed
 - When writing "round" doubles/floats to CSV, they'll now always have trailing zero.

--- a/c/fread.c
+++ b/c/fread.c
@@ -2021,7 +2021,7 @@ int freadMain(freadMainArgs _args)
     // Push out all buffers one last time.
     if (myNrow) {
       pushBuffer(&ctx);
-      if (me == 0 && args.showProgress) {
+      if (me == 0 && hasPrinted) {
         progress(100.0);
       }
     }

--- a/c/memorybuf.h
+++ b/c/memorybuf.h
@@ -347,6 +347,7 @@ protected:
   MemmapMemBuf(const std::string& path, size_t n, bool create);
   virtual ~MemmapMemBuf() override;
   virtual void memmap();
+  void memunmap();
 };
 
 

--- a/c/mmm.cc
+++ b/c/mmm.cc
@@ -34,17 +34,18 @@ MemoryMapManager* MemoryMapManager::get() {
 
 
 void MemoryMapManager::add_entry(MemoryMapWorker* obj, size_t mmapsize) {
+  count++;
   if (count == entries.size()) {
     entries.reserve(count * 2);
   }
   entries[count].size = mmapsize;
   entries[count].obj = obj;
   obj->save_entry_index(count);
-  count++;
 }
 
 
 void MemoryMapManager::del_entry(size_t i) {
+  if (i == 0) return;
   count--;
   if (i < count) {
     entries[i].size = entries[count].size;
@@ -74,10 +75,10 @@ void MemoryMapManager::freeup_memory() {
 
 
 void MemoryMapManager::sort_entries() {
-  auto start = entries.begin();
+  auto start = entries.begin() + 1;
   auto end = start + static_cast<ptrdiff_t>(count);
   std::sort(start, end, [](const MmmEntry& a, const MmmEntry& b) -> bool {
-    return a.size > b.size;
+    return a.size >= b.size;
   });
 }
 

--- a/c/mmm.h
+++ b/c/mmm.h
@@ -34,25 +34,20 @@ public:
 
 
 class MemoryMapManager {
-  std::vector<MmmEntry> entries;
+  std::vector<MmmEntry> entries;  // 0th entry always remains empty.
   size_t count;  // Number of items currently in the `entries` array.
 
-  static const size_t n_entries_to_purge = 128;
-
-  MemoryMapManager(size_t nelems);
 public:
   static MemoryMapManager* get();
-
   void add_entry(MemoryMapWorker* obj, size_t size);
   void del_entry(size_t i);
   void freeup_memory();
 
 private:
+  static const size_t n_entries_to_purge = 128;
+  MemoryMapManager(size_t nelems);
   void sort_entries();
 };
-
-
-extern MemoryMapManager mmapmanager;
 
 
 #endif

--- a/c/py_column.h
+++ b/c/py_column.h
@@ -71,7 +71,11 @@ DECLARE_GETTER(
 
 DECLARE_GETTER(
   data_pointer,
-  "Pointer (cast to long int) to the column's internal memory buffer")
+  "Pointer (cast to int64_t) to the column's internal memory buffer.\n"
+  "This pointer may only be used immediately upon acquiral. The pointer may \n"
+  "become invalid if the column is modified or garbage-collected, and also \n"
+  "when .data_pointer of some other column is accessed. Reading from an \n"
+  "invalid pointer may return incorrect data, or result in a seg.fault.")
 
 DECLARE_GETTER(
   refcount,


### PR DESCRIPTION
Introduce the `MemoryMapManager` class, which holds information about all (or most) memory maps currently held by the process. If we ever run into "errno 12" (not enough memory) when opening a memory map, this class has the ability to request some of the entries to become unmapped, allowing new entries to be created. This should eliminate most of the "Errno 12" errors.

Closes #490