### PR TITLE
Removed unused parameters

### DIFF
--- a/c/column.cc
+++ b/c/column.cc
@@ -96,8 +96,7 @@ void Column::save_to_disk(const char* filename) {
  * valid values, and that the extra parameters match the buffer's contents).
  */
 Column* Column::open_mmap_column(SType stype, int64_t nrows,
-                                 const std::string& filename,
-                                 const std::string& ms)
+                                 const std::string& filename)
 {
   Column* col = new_column(stype);
   col->nrows = nrows;
@@ -109,12 +108,13 @@ Column* Column::open_mmap_column(SType stype, int64_t nrows,
 /**
  * Construct a column from the externally provided buffer.
  */
-Column* Column::new_xbuf_column(SType stype, int64_t nrows, void* pybuffer,
-                                void* data, size_t a_size)
+Column* Column::new_xbuf_column(SType stype,
+                                int64_t nrows,
+                                Py_buffer* pybuffer)
 {
   Column* col = new_column(stype);
   col->nrows = nrows;
-  col->init_xbuf(pybuffer, data);
+  col->init_xbuf(pybuffer);
   return col;
 }
 

--- a/c/column.h
+++ b/c/column.h
@@ -74,10 +74,8 @@ public:
   static Column* new_data_column(SType, int64_t nrows);
   static Column* new_na_column(SType, int64_t nrows);
   static Column* new_mmap_column(SType, int64_t nrows, const std::string& filename);
-  static Column* open_mmap_column(SType, int64_t nrows, const std::string& filename,
-                                  const std::string& metastr);
-  static Column* new_xbuf_column(SType, int64_t nrows, void* pybuffer,
-                                 void* data, size_t datasize);
+  static Column* open_mmap_column(SType, int64_t nrows, const std::string& filename);
+  static Column* new_xbuf_column(SType, int64_t nrows, Py_buffer* pybuffer);
   static Column* from_pylist(PyObject* list, int stype0 = 0, int ltype0 = 0);
 
   Column(const Column&) = delete;
@@ -208,7 +206,7 @@ protected:
   virtual void init_data() = 0;
   virtual void init_mmap(const std::string& filename) = 0;
   virtual void open_mmap(const std::string& filename) = 0;
-  virtual void init_xbuf(void* pybuffer, void* data) = 0;
+  virtual void init_xbuf(Py_buffer* pybuffer) = 0;
   virtual void rbind_impl(const std::vector<const Column*>& columns,
                           int64_t nrows, bool isempty) = 0;
 
@@ -283,7 +281,7 @@ protected:
   void init_data() override;
   void init_mmap(const std::string& filename) override;
   void open_mmap(const std::string& filename) override;
-  void init_xbuf(void* pybuffer, void* data) override;
+  void init_xbuf(Py_buffer* pybuffer) override;
   static constexpr T na_elem = GETNA<T>();
   void rbind_impl(const std::vector<const Column*>& columns, int64_t nrows,
                   bool isempty) override;
@@ -522,7 +520,7 @@ protected:
   void init_data() override;
   void init_mmap(const std::string& filename) override;
   void open_mmap(const std::string& filename) override;
-  void init_xbuf(void* pybuffer, void* data) override;
+  void init_xbuf(Py_buffer* pybuffer) override;
 
   void rbind_impl(const std::vector<const Column*>& columns, int64_t nrows,
                   bool isempty) override;
@@ -576,7 +574,7 @@ protected:
   void init_data() override {}
   void init_mmap(const std::string&) override {}
   void open_mmap(const std::string&) override {}
-  void init_xbuf(void*, void*) override {}
+  void init_xbuf(Py_buffer*) override {}
 
   Stats* get_stats() const override { return nullptr; }
   void fill_na() override {}

--- a/c/column_fw.cc
+++ b/c/column_fw.cc
@@ -71,10 +71,16 @@ void FwColumn<T>::open_mmap(const std::string& filename) {
 }
 
 template <typename T>
-void FwColumn<T>::init_xbuf(void* pybuffer, void* data) {
+void FwColumn<T>::init_xbuf(Py_buffer* pybuffer) {
   assert(ri == nullptr);
   assert(mbuf == nullptr);
-  mbuf = new ExternalMemBuf(data, pybuffer, static_cast<size_t>(nrows) * elemsize());
+  size_t exp_buf_len = static_cast<size_t>(nrows) * elemsize();
+  if (static_cast<size_t>(pybuffer->len) != exp_buf_len) {
+    throw Error() << "PyBuffer cannot be used to create a column of " << nrows
+                  << " rows: buffer length is " << static_cast<size_t>(pybuffer->len)
+                  << ", expected " << exp_buf_len;
+  }
+  mbuf = new ExternalMemBuf(pybuffer->buf, pybuffer, exp_buf_len);
 }
 
 

--- a/c/column_string.cc
+++ b/c/column_string.cc
@@ -95,7 +95,7 @@ void StringColumn<T>::open_mmap(const std::string& filename) {
 // Not implemented (should it be?) see method signature in `Column` for
 // parameter definitions.
 template <typename T>
-void StringColumn<T>::init_xbuf(void*, void*) {
+void StringColumn<T>::init_xbuf(Py_buffer*) {
   throw Error() << "String columns are incompatible with external buffers";
 }
 

--- a/c/datatable_load.cc
+++ b/c/datatable_load.cc
@@ -31,25 +31,20 @@ DataTable* DataTable::load(DataTable* colspec, int64_t nrows, const std::string&
     }
     SType stypef = colspec->columns[0]->stype();
     SType stypes = colspec->columns[1]->stype();
-    SType stypem = colspec->columns[2]->stype();
     if (stypef != ST_STRING_I4_VCHAR ||
-        stypes != ST_STRING_I4_VCHAR ||
-        stypem != ST_STRING_I4_VCHAR) {
+        stypes != ST_STRING_I4_VCHAR) {
         throw ValueError() << "String columns are expected in colspec table, "
-                           << "instead got " << stypef << ", "
-                           << stypes << ", and " << stypem;
+                           << "instead got " << stypef << " and "
+                           << stypes;
     }
 
     StringColumn<int32_t>* colf =
         static_cast<StringColumn<int32_t>*>(colspec->columns[0]);
     StringColumn<int32_t>* cols =
         static_cast<StringColumn<int32_t>*>(colspec->columns[1]);
-    StringColumn<int32_t>* colm =
-        static_cast<StringColumn<int32_t>*>(colspec->columns[2]);
 
     int32_t* offf = colf->offsets();
     int32_t* offs = cols->offsets();
-    int32_t* offm = colm->offsets();
 
 
     /*static char filename[1001];
@@ -87,17 +82,8 @@ DataTable* DataTable::load(DataTable* colspec, int64_t nrows, const std::string&
             throw ValueError() << "Unrecognized stype: " << stype_str;
         }
 
-        // Extract meta info (as a string)
-        size_t msta = static_cast<size_t>(abs(offm[i - 1]));
-        size_t mend = static_cast<size_t>(abs(offm[i]));
-        size_t mlen = static_cast<size_t>(mend - msta);
-        /*if (mlen > 100) {
-            throw ValueError() << "Meta string is too long: " << mlen;
-        }*/
-        std::string metastr(colm->strdata() + msta, mlen);
-
         // Load the column
-        columns[i] = Column::open_mmap_column(stype, nrows, filename, metastr);
+        columns[i] = Column::open_mmap_column(stype, nrows, filename);
     }
 
     return new DataTable(columns);

--- a/c/py_buffers.cc
+++ b/c/py_buffers.cc
@@ -90,8 +90,7 @@ PyObject* pydatatable_from_buffers(PyObject*, PyObject* args)
       int64_t nrows = view->len / view->itemsize;
       if (stype == ST_VOID) return nullptr;
       if (view->strides == nullptr) {
-        columns[i] = Column::new_xbuf_column(stype, nrows, view, view->buf,
-                                             static_cast<size_t>(view->len));
+        columns[i] = Column::new_xbuf_column(stype, nrows, view);
       } else {
         columns[i] = Column::new_data_column(stype, nrows);
         int64_t stride = view->strides[0] / view->itemsize;


### PR DESCRIPTION
Refactored `xbuf` methods to exclusively apply to Python buffers since that is its only current application (should probably be renamed).