### PR TITLE
Improve handling of duplicate column names in fread(columns={...})

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - creating a DataTable from pandas.Series with explicit `colnames` will no longer
   ignore those column names.
 - fread(fill=True) will correctly fill missing fields with NAs.
+- fread(columns=set(...)) will correctly handle the case when the input contains
+  multiple columns with the same names.
 
 
 

--- a/datatable/fread.py
+++ b/datatable/fread.py
@@ -486,16 +486,20 @@ class FReader(object):
             return
 
         if isinstance(colspec, set):
-            cols = set(colspec)  # Make a copy, so that we can modify it freely
+            # Make a copy of the `colspec`, in order to check whether all the
+            # columns requested by the user were found, and issue a warning
+            # otherwise.
+            colsfound = set(colspec)
             for i in range(n):
-                if colnames[i] in cols:
-                    cols.remove(colnames[i])
+                if colnames[i] in colspec:
+                    if colnames[i] in colsfound:
+                        colsfound.remove(colnames[i])
                     self._colnames.append(colnames[i])
                 else:
                     coltypes[i] = 0
-            if cols:
+            if colsfound:
                 warnings.warn("Column(s) %r not found in the input file" %
-                              list(cols))
+                              list(colsfound))
             return
 
         if isinstance(colspec, list):


### PR DESCRIPTION
* Now if the input contains columns with same names, and fread is called with
  columns argument of type set, then all columns with the same name will be
  included/excluded in the output.
* Added many tests for fread with columns argument

Closes #577