### PR TITLE
`StringColumn`s now use two `MemoryBuffer`s

### DIFF
--- a/c/column.cc
+++ b/c/column.cc
@@ -80,7 +80,7 @@ Column* Column::new_mmap_column(SType stype, int64_t nrows,
  * file).
  * If a file with the given name already exists, it will be overwritten.
  */
-void Column::save_to_disk(const char* filename) {
+void Column::save_to_disk(const std::string& filename) {
   assert(mbuf != nullptr);
   mbuf->save_to_disk(filename);
 }
@@ -178,7 +178,6 @@ Column* Column::rbind(const std::vector<const Column*>& columns)
 {
     // Is the current column "empty" ?
     bool col_empty = (stype() == ST_VOID);
-
     // Compute the final number of rows and stype
     int64_t new_nrows = this->nrows;
     SType new_stype = std::max(stype(), ST_BOOLEAN_I1);
@@ -195,12 +194,11 @@ Column* Column::rbind(const std::vector<const Column*>& columns)
         // FIXME: this is not filled with NAs!
         res = Column::new_data_column(new_stype, this->nrows);
     } else if (stype() == new_stype) {
-        mbuf = mbuf->safe_resize(mbuf->size());  // ensure mbuf is writable
         res = this;
     } else {
         res = this->cast(new_stype);
     }
-    assert(res->stype() == new_stype && !res->mbuf->is_readonly());
+    assert(res->stype() == new_stype);
 
     // TODO: Temporary Fix. To be resolved in #301
     if (res->stats != nullptr) res->stats->reset();
@@ -391,7 +389,7 @@ bool Column::verify_integrity(IntegrityCheckContext& icc,
     // Check that nrows is a correct representation of mbuf's size
     if (nrows != mbuf_nrows) {
       icc << "Mismatch between reported number of rows: " << name
-          << " has nrows=" << nrows << " and MemoryBuffer has data for "
+          << " has nrows=" << nrows << " but MemoryBuffer has data for "
           << mbuf_nrows << " rows" << end;
     }
   }

--- a/c/column.h
+++ b/c/column.h
@@ -168,7 +168,7 @@ public:
    */
   virtual void reify() = 0;
 
-  void save_to_disk(const char*);
+  virtual void save_to_disk(const std::string&);
 
   RowIndex* sort() const;
 
@@ -485,17 +485,15 @@ protected:
 template <typename T> class StringColumn : public Column
 {
   MemoryBuffer *strbuf;
-  T offoff;
-  int64_t pad_ : 64 - (sizeof(T) % 8) * 8;
 
 public:
   StringColumn(int64_t nrows,
-      MemoryBuffer* = nullptr);
+      MemoryBuffer* offbuf = nullptr, MemoryBuffer* strbuf = nullptr);
   virtual ~StringColumn();
+  void save_to_disk(const std::string& filename) override;
   void replace_buffer(MemoryBuffer*, MemoryBuffer*) override;
 
   SType stype() const override;
-  inline T meta() const { return offoff; }
   size_t elemsize() const override;
   bool is_fixedwidth() const override;
 
@@ -543,7 +541,7 @@ protected:
 
   friend Column;
   friend Column* try_to_resolve_object_column(Column*);
-  friend void setFinalNrow(size_t);
+  friend Column* alloc_column(SType, size_t, int);
 };
 
 

--- a/c/column_from_pylist.cc
+++ b/c/column_from_pylist.cc
@@ -149,7 +149,7 @@ static bool parse_as_str(PyObject* list, MemoryBuffer* offbuf,
                          MemoryBuffer*& strbuf)
 {
   int64_t nrows = Py_SIZE(list);
-  offbuf->resize(static_cast<size_t>(nrows + 1) * sizeof(T));
+  offbuf->resize((static_cast<size_t>(nrows) + 1) * sizeof(T));
   T* offsets = static_cast<T*>(offbuf->get()) + 1;
   offsets[-1] = -1;
   if (strbuf == nullptr) {
@@ -270,8 +270,6 @@ Column* Column::from_pylist(PyObject* list, int stype0, int ltype0)
     if (ret) {
       Column* col = Column::new_column(static_cast<SType>(stype));
       col->replace_buffer(membuf, strbuf);
-      if (membuf) membuf->release();
-      if (strbuf) strbuf->release();
       return col;
     }
     stype = find_next_stype(stype, stype0, ltype0);

--- a/c/py_column.cc
+++ b/c/py_column.cc
@@ -71,20 +71,10 @@ PyObject* get_data_pointer(pycolumn::obj* self) {
 }
 
 
-PyObject* get_meta(pycolumn::obj* self) {
-  Column* col = self->ref;
-  switch (col->stype()) {
-    case ST_STRING_I4_VCHAR: {
-      auto scol = static_cast<StringColumn<int32_t>*>(col);
-      return PyUnicode_FromFormat("offoff=%lld", scol->meta());
-    }
-    case ST_STRING_I8_VCHAR: {
-      auto scol = static_cast<StringColumn<int64_t>*>(col);
-      return PyUnicode_FromFormat("offoff=%lld", scol->meta());
-    }
-    default:
-      return none();
-  }
+PyObject* get_meta(pycolumn::obj*) {
+  // Does nothing after the removal of metas in StringColumns.
+  // Might be used when fixed-point decimals are implemented
+  return none();
 }
 
 

--- a/c/py_fread.h
+++ b/c/py_fread.h
@@ -1,6 +1,7 @@
 #ifndef dt_FREAD_IMPL_H
 #define dt_FREAD_IMPL_H
 #include <Python.h>
+#include "memorybuf.h"
 
 
 #define FREAD_MAIN_ARGS_EXTRA_FIELDS  PyObject *freader;
@@ -30,8 +31,9 @@
 //         other threads is allowed to initiate a memcopy.
 //
 typedef struct StrBuf {
-    char *buf;
-    size_t size;
+    MemoryBuffer* mbuf;
+    //char *buf;
+    //size_t size;
     size_t ptr;
     int idx8;
     int idxdt;

--- a/c/py_types.c
+++ b/c/py_types.c
@@ -85,13 +85,14 @@ static PyObject* stype_real_i64_tostring(UNUSED(Column *col), UNUSED(int64_t row
 
 static PyObject* stype_vchar_i32_tostring(Column *col, int64_t row)
 {
-    int32_t offoff = static_cast<StringColumn<int32_t>*>(col)->meta();
-    int32_t *offsets = (int32_t*) add_ptr(col->data(), offoff);
-    if (offsets[row] < 0)
-        return none();
-    int32_t start = row == 0? 0 : abs(offsets[row - 1]) - 1;
-    int32_t len = offsets[row] - 1 - start;
-    return PyUnicode_FromStringAndSize((char*)(col->data()) + (size_t)start, len);
+  StringColumn<int32_t>* str_col = static_cast<StringColumn<int32_t>*>(col);
+  int32_t* offsets = str_col->offsets();
+  if (offsets[row] < 0)
+      return none();
+  int32_t start = abs(offsets[row - 1]);
+  int32_t len = offsets[row] - start;
+  return PyUnicode_FromStringAndSize(str_col->strdata() +
+      static_cast<size_t>(start), len);
 }
 
 static PyObject* stype_object_pyptr_tostring(Column *col, int64_t row)

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -197,13 +197,13 @@ def test_column_hexview(dt0, patched_terminal, capsys):
     print(out)
     assert ("Column 6\n"
             "Ltype: str, Stype: i4s, Mtype: data\n"
-            "Bytes: 32\n"
-            "Meta: offoff=16\n"
+            "Bytes: 20\n"
+            "Meta: None\n"
             "Refcnt: 1\n"
             "     00  01  02  03  04  05  06  07  08  09  0A  0B  0C  0D  0E  0F                  \n"
             "---  --  --  --  --  --  --  --  --  --  --  --  --  --  --  --  --  ----------------\n"
-            "000  31  32  68  65  6C  6C  6F  77  6F  72  6C  64  FF  FF  FF  FF  12helloworldÿÿÿÿ\n"
-            "010  02  00  00  00  03  00  00  00  08  00  00  00  0D  00  00  00  ................\n"
+            "000  FF  FF  FF  FF  02  00  00  00  03  00  00  00  08  00  00  00  ÿÿÿÿ............\n"
+            "010  0D  00  00  00                                                  ....            \n"
             in out)
 
     with pytest.raises(ValueError) as e:


### PR DESCRIPTION
...one for its offsets (`mbuf`) and one for its strings (`strdata`). The use of an offset field or padding is no longer needed.

Every offset buffer (retrieved through the `offsets` method) begins with a `-1` value. Thus it should be impossible for a `StringColumn` to have an empty offset buffer. This also implies that the buffer will have a length of `nrows` + 1.
The initial `-1` value is ignored as a logical entity in the `StringColumn`, meaning that `data_nrows()` will return `nrows` instead of `nrows` + 1. The `offsets` method also returns a pointer to the value after the `-1` (making `offsets()[-1]` a valid statement).

The string buffer is retrieved through the `strdata` method, but the resulting pointer points to the value 1 byte BEFORE the initial character. Thus, `strdata()[0]` may result in a segfault.

Other notable modifications:
  - String columns are stored over two files: file `X` contains the offset data and file `X_str` contains the string data. The `_str` extension is necessary and should never be removed.
  - The `StrBuf` struct used in `py_fread.c` now uses `MemoryBuffer` references instead of a character array. This allows for the algorithm to write strings directly into the destination column instead of storing it inside a temporary file.
  - A result of the above change is that some `goto` labels are never reached. I wrapped the affected functions in try-catch blocks (The macros in `exceptions.h` cannot be used due to the need of some post-error cleanup).
  - Sorting methods have gotten uglier due to the need to cast columns into a `StringColumn`. Additional "if" statements were written to account for the new structural differences in the `StringColumn`s. We should look into modularizing the `sort` method.

(#552)