### PR TITLE
`fread` now automatically skips Ctrl+Z / NUL characters at the end of the input file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - It is now possible to supply string argument to `dt.DataTable` constructor,
   which in turn will try to interpret that argument via `fread`.
 - `fread` can now read compressed `.xz` files.
+- `fread` now automatically skips Ctrl+Z / NUL characters at the end of the file.
 
 #### Changed
 - When writing "round" doubles/floats to CSV, they'll now always have trailing zero.

--- a/c/fread.c
+++ b/c/fread.c
@@ -1042,6 +1042,14 @@ int freadMain(freadMainArgs _args)
   else if (fileSize >= 2 && sof[0] + sof[1] == '\xFE' + '\xFF') {  // either 0xFE 0xFF or 0xFF 0xFE
     STOP("File is encoded in UTF-16, this encoding is not supported by fread(). Please recode the file to UTF-8.");
   }
+  if (eof[-1] == '\x1A' || eof[-1] == '\0') {
+    char c = eof[-1];
+    while (eof > sof && eof[-1] == c) eof--;
+    if (verbose) DTPRINT("  Last byte(s) of input found to be %s and removed.\n",
+                         c? "0x1A (Ctrl+Z)" : "0x00 (NUL)");
+    *const_cast<char*>(eof) = '\0';
+  }
+  if (eof<=sof) STOP("Input is empty after removing BOM and any terminal control characters");
 
 
   //*********************************************************************************************

--- a/tests/test_fread.py
+++ b/tests/test_fread.py
@@ -133,9 +133,8 @@ def test_fread_columns_fn1():
 
 
 
-
 #-------------------------------------------------------------------------------
-# Other
+# Misc
 #-------------------------------------------------------------------------------
 
 def test_fread_hex():
@@ -209,3 +208,20 @@ def test_fread_fillna():
     assert d.internal.check()
     p = d[1:, 1:].topython()
     assert p == [[None] * 4] * 8
+
+
+def test_fread_CtrlZ():
+    """Check that Ctrl+Z characters at the end of the file are removed"""
+    src = b"A,B,C\n1,2,3\x1A\x1A"
+    d0 = dt.fread(text=src)
+    assert d0.internal.check()
+    assert d0.ltypes == (dt.ltype.int, dt.ltype.int, dt.ltype.int)
+    assert d0.topython() == [[1], [2], [3]]
+
+
+def test_fread_NUL():
+    """Check that NUL characters at the end of the file are removed"""
+    d0 = dt.fread(text=b"A,B\n2.3,5\0\0\0\0\0\0\0\0\0\0")
+    assert d0.internal.check()
+    assert d0.ltypes == (dt.ltype.real, dt.ltype.int)
+    assert d0.topython() == [[2.3], [5]]


### PR DESCRIPTION
Closes #590