### PR TITLE
Fread can now read single-column files with blank lines.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `fread` now automatically skips Ctrl+Z / NUL characters at the end of the file.
 - It is now possible to create a datatable from string numpy array.
 - Added parameters `skip_blank_lines`, `strip_white`, `quotechar` and `dec` to fread.
+- Single-column files with blank lines can now be read successfully.
 
 #### Changed
 - When writing "round" doubles/floats to CSV, they'll now always have trailing zero.

--- a/c/fread.c
+++ b/c/fread.c
@@ -1113,19 +1113,21 @@ int freadMain(freadMainArgs _args)
     eolLen = 1;
     if (eol=='\r') {
       if (ch+1<eof && *(ch+1)=='\n') {
-        if (verbose) DTPRINT("  Detected eol as \\r\\n (CRLF) in that order, the Windows standard.");
+        if (verbose) DTPRINT("  Detected eol as \\r\\n (CRLF).");
         eol2='\n'; eolLen=2;
       } else {
         if (ch+1<eof && *(ch+1)=='\r')
           STOP("Line ending is \\r\\r\\n. R's download.file() appears to add the extra \\r in text mode on Windows. Please download again in binary mode (mode='wb') which might be faster too. Alternatively, pass the URL directly to fread and it will download the file in binary mode for you.");
           // NB: on Windows, download.file from file: seems to condense \r\r too. So
-        if (verbose) DTPRINT("Detected eol as \\r only (no \\n or \\r afterwards). An old Mac 9 standard, discontinued in 2002 according to Wikipedia.");
+        if (verbose) DTPRINT("  Detected eol as \\r only.");
       }
     } else {
       if (ch+1<eof && *(ch+1)=='\r') {
-        DTWARN("Detected eol as \\n\\r, a highly unusual line ending. According to Wikipedia the Acorn BBC used this. If it is intended that the first column on the next row is a character column where the first character of the field value is \\r (why?) then the first column should start with a quote (i.e. 'protected'). Proceeding with attempt to read the file.");
+        if (verbose) DTPRINT("  Detected eol as \\n\\r.");
         eol2='\r'; eolLen=2;
-      } else if (verbose) DTPRINT("  Detected eol as \\n only (no \\r afterwards), the UNIX and Mac standard.");
+      } else {
+        if (verbose) DTPRINT("  Detected eol as \\n only.");
+      }
     }
   }
 
@@ -1864,7 +1866,8 @@ int freadMain(freadMainArgs _args)
         if (sep==' ') while (*tch==' ') tch++;  // multiple sep=' ' at the tlineStart does not mean sep(!)
         skip_white(&tch);  // solely for blank lines otherwise could leave to field processors which handle leading white
         if (on_eol(tch)) {
-          if (skipEmptyLines) { skip_eol(&tch); continue; }
+          if (ncol == 1) {}
+          else if (skipEmptyLines) { skip_eol(&tch); continue; }
           else if (!fill) {
             #pragma omp critical
             if (!stopTeam) {
@@ -1943,7 +1946,7 @@ int freadMain(freadMainArgs _args)
 
         if (j < ncol)  {
           // not enough columns observed
-          if (!fill) {
+          if (!fill && ncol > 1) {
             #pragma omp critical
             if (!stopTeam) {
               stopTeam = true;

--- a/tests/test_fread.py
+++ b/tests/test_fread.py
@@ -352,3 +352,19 @@ def test_fread_NUL():
     assert d0.internal.check()
     assert d0.ltypes == (dt.ltype.real, dt.ltype.int)
     assert d0.topython() == [[2.3], [5]]
+
+
+def test_fread_1col():
+    """Check that it is possible to read 1-column file witn NAs."""
+    d0 = dt.fread(text="A\n1\n2\n\n4\n\n5\n\n")
+    assert d0.internal.check()
+    assert d0.names == ("A",)
+    assert d0.topython() == [[1, 2, None, 4, None, 5, None]]
+    d1 = dt.fread("QUOTE\n"
+                  "If you think\n"
+                  "you can do it,\n\n"
+                  "you can.\n\n", sep="\n")
+    assert d1.internal.check()
+    assert d1.names == ("QUOTE",)
+    assert d1.topython() == [["If you think", "you can do it,", "",
+                              "you can.", ""]]

--- a/tests/test_fread_small.py
+++ b/tests/test_fread_small.py
@@ -9,6 +9,7 @@ import random
 alphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 
 def random_string(n):
+    """Return random string of `n` characters."""
     return "".join(random.choice(alphabet) for _ in range(n))
 
 


### PR DESCRIPTION
The blank lines are treated same way as empty values in multi-column files, i.e.
```
A,B
1,2
,
5,6
```
was valid before (second row becoming 2 NAs). Now the following is also valid:
```
A
1

5
```
(second row becoming an NA).

This PR also removes warning about \r\n being "weird", nor does it attempt to
educate (inaccurately) the user about which newlines are used where.

Closes #599