### PR TITLE
Add ability to use file objects in fread

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -14,7 +14,7 @@
     <inspection_tool class="PyRedundantParenthesesInspection" enabled="true" level="WEAK WARNING" enabled_by_default="true">
       <option name="myIgnoreTupleInReturn" value="true" />
     </inspection_tool>
-    <inspection_tool class="SpellCheckingInspection" enabled="true" level="TYPO" enabled_by_default="true">
+    <inspection_tool class="SpellCheckingInspection" enabled="false" level="TYPO" enabled_by_default="false">
       <option name="processCode" value="false" />
       <option name="processLiterals" value="true" />
       <option name="processComments" value="true" />

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   automatically. The `url` parameter downloads file from HTTP/HTTPS/FTP server
   into a temporary location and reads it from there. The `cmd` parameter executes
   the provided shell command and then reads the data from the stdout.
+- It is now possible to pass `file` objects to `fread` (or any objects exposing
+  method `read()`).
+- File path given to `fread` can now transparently select files within .zip archives.
+  This doesn't work with archives-within-archives.
 
 #### Changed
 - When writing "round" doubles/floats to CSV, they'll now always have trailing zero.

--- a/c/memorybuf.cc
+++ b/c/memorybuf.cc
@@ -292,15 +292,16 @@ bool ExternalMemBuf::verify_integrity(IntegrityCheckContext& icc,
 //==============================================================================
 
 MemmapMemBuf::MemmapMemBuf(const std::string& path)
-    : MemmapMemBuf(path, 0, false) {}
+    : MemmapMemBuf(path, 0, -1, false) {}
 
 
-MemmapMemBuf::MemmapMemBuf(const std::string& path, size_t n)
-    : MemmapMemBuf(path, n, true) {}
+MemmapMemBuf::MemmapMemBuf(const std::string& path, size_t n, int fileno)
+    : MemmapMemBuf(path, n, fileno, true) {}
 
 
-MemmapMemBuf::MemmapMemBuf(const std::string& path, size_t n, bool create)
-    : mmp(nullptr), mmpsize(0), filename(path)
+MemmapMemBuf::MemmapMemBuf(
+    const std::string& path, size_t n, int fileno, bool create
+  ) : mmp(nullptr), mmpsize(0), filename(path), fd(fileno)
 {
   readonly = !create;
   mmpsize = n;
@@ -320,7 +321,7 @@ void MemmapMemBuf::memmap()
   assert(mmp == nullptr);
   bool create = !readonly;
   size_t n = mmpsize;
-  File file(filename, create? File::CREATE : File::READ);
+  File file(filename, create? File::CREATE : File::READ, fd);
   file.assert_is_not_dir();
   if (create) {
     file.resize(n);
@@ -449,8 +450,8 @@ bool MemmapMemBuf::verify_integrity(IntegrityCheckContext& icc,
 // MemoryBuffer based on an "overmapped" memmapped file
 //==============================================================================
 
-OvermapMemBuf::OvermapMemBuf(const std::string& path, size_t xn)
-    : MemmapMemBuf(path, xn, false), xbuf(nullptr), xbuf_size(xn) {}
+OvermapMemBuf::OvermapMemBuf(const std::string& path, size_t xn, int fd)
+    : MemmapMemBuf(path, xn, fd, false), xbuf(nullptr), xbuf_size(xn) {}
 
 
 void OvermapMemBuf::memmap()

--- a/c/memorybuf.h
+++ b/c/memorybuf.h
@@ -313,6 +313,8 @@ class MemmapMemBuf : public MemoryBuffer, MemoryMapWorker
   size_t mmpsize;
   const std::string filename;
   size_t mmm_index;
+  int fd;
+  int : 32;
 
 public:
   /**
@@ -320,7 +322,7 @@ public:
    * file of size `n` and then memory-map it (second constructor).
    */
   MemmapMemBuf(const std::string& file);
-  MemmapMemBuf(const std::string& file, size_t n);
+  MemmapMemBuf(const std::string& file, size_t n, int fd = -1);
 
   void* get() override;
   size_t size() override;
@@ -344,7 +346,7 @@ protected:
    * in bytes. Conversely, when `create` is false, then `path` must correspond
    * to an existing accessible file, and parameter `n` is ignored.
    */
-  MemmapMemBuf(const std::string& path, size_t n, bool create);
+  MemmapMemBuf(const std::string& path, size_t n, int fd, bool create);
   virtual ~MemmapMemBuf() override;
   virtual void memmap();
   void memunmap();
@@ -364,7 +366,7 @@ class OvermapMemBuf : public MemmapMemBuf
   size_t xbuf_size;
 
 public:
-  OvermapMemBuf(const std::string& path, size_t n);
+  OvermapMemBuf(const std::string& path, size_t n, int fd = -1);
 
   virtual void resize(size_t n) override;
   virtual size_t memory_footprint() const override;

--- a/c/py_fread.c
+++ b/c/py_fread.c
@@ -133,6 +133,8 @@ PyObject* pyfread(PyObject*, PyObject *args)
     na_strings = pyfreader.attr("na_strings").as_cstringlist();
     verbose = pyfreader.attr("verbose").as_bool();
     flogger = pyfreader.attr("logger").as_pyobject();
+    int64_t fileno64 = pyfreader.attr("_fileno").as_int64();
+    int fileno = fileno64 < 0? -1 : static_cast<int>(fileno64);
 
     frargs->sep = pyfreader.attr("sep").as_char();
     frargs->dec = pyfreader.attr("dec").as_char();
@@ -160,8 +162,8 @@ PyObject* pyfread(PyObject*, PyObject *args)
     if (input) {
       mbuf = new ExternalMemBuf(input);
     } else if (filename) {
-      if (verbose) DTPRINT("  Opening file %s", filename);
-      mbuf = new OvermapMemBuf(filename, 1);
+      if (verbose) DTPRINT("  Opening file %s [fd=%d]", filename, fileno);
+      mbuf = new OvermapMemBuf(filename, 1, fileno);
       if (verbose) DTPRINT("  File opened, size: %s", filesize_to_str(mbuf->size() - 1));
     } else {
       throw ValueError() << "Neither filename nor input were provided";

--- a/c/utils/file.h
+++ b/c/utils/file.h
@@ -24,16 +24,17 @@ class File
   std::string name;
   mutable struct stat statbuf;
   int fd;
-  int : 32;
+  int flags;
 
 public:
   static const int READ;
   static const int READWRITE;
   static const int CREATE;
   static const int OVERWRITE;
+  static const int EXTERNALFD;
 
   File(const std::string& file);
-  File(const std::string& file, int flags, mode_t mode = 0666);
+  File(const std::string& file, int flags, int fd = -1, mode_t mode = 0666);
   ~File();
 
   int descriptor() const;

--- a/datatable/__init__.py
+++ b/datatable/__init__.py
@@ -3,13 +3,13 @@
 
 from .__version__ import version as __version__
 from .dt import DataTable
-from .fread import fread, FReader
+from .fread import fread, TextReader
 from .nff import save, open
 from .expr import mean, min, max, sd, isna
 from .types import stype, ltype
 
 __all__ = ("__version__", "DataTable", "max", "mean", "min", "open", "sd",
-           "isna", "fread", "FReader", "save", "stype", "ltype")
+           "isna", "fread", "TextReader", "save", "stype", "ltype")
 
 
 DataTable.__module__ = "datatable"

--- a/tests/test_fread.py
+++ b/tests/test_fread.py
@@ -7,6 +7,30 @@ import random
 import math
 from datatable import stype, ltype
 
+#-------------------------------------------------------------------------------
+# Tests for fread "source" arguments
+#-------------------------------------------------------------------------------
+
+def test_fread_from_stringbuf():
+    from io import StringIO
+    s = StringIO("A,B,C\n1,2,3\n4,5,6")
+    d0 = dt.fread(s)
+    assert d0.internal.check()
+    assert d0.names == ("A", "B", "C")
+    assert d0.topython() == [[1, 4], [2, 5], [3, 6]]
+
+
+def test_fread_from_fileobj(tempfile):
+    with open(tempfile, "w") as f:
+        f.write("A,B,C\nfoo,bar,baz\n")
+
+    with open(tempfile, "r") as f:
+        d0 = dt.fread(f)
+        assert d0.internal.check()
+        assert d0.names == ("A", "B", "C")
+        assert d0.topython() == [["foo"], ["bar"], ["baz"]]
+
+
 
 #-------------------------------------------------------------------------------
 # Tests for the `columns` argument


### PR DESCRIPTION
* `fread` now accepts `file` object as the argument (either unnamed, or in `file=`). If possible, this file will be memory-mapped and read via the underlying file descriptor. Otherwise, we will `read()` the file into memory, and read it from a string (less efficient).
* C classes `MemoryMapMembuf`, `OvermapMemBuf` and `File` now accept an optional `fd` parameter, allowing for files that were opened externally.
* Added ability to address files within `.zip` archives, if there are several.

Closes #612 
Closes #613 