### PR TITLE
More robust newline handling in fread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - fixed bug in fread where string fields starting with "NaN" caused an assertion error.
 - Fixed bug when saving a DataTable with unicode column names into .nff format
   on systems where default encoding is not unicode-aware.
+- More robust newline handling in fread (#634)
 
 
 ### [v0.2.2](https://github.com/h2oai/datatable/compare/v0.2.2...v0.2.1) — 2017-10-18

--- a/c/csv/fread.c
+++ b/c/csv/fread.c
@@ -110,7 +110,9 @@ static inline bool on_eol(const char* ch) {
 
 static inline void skip_eol(const char** pch) {
   const char *ch = *pch;
-  *pch += *ch=='\0'? 1 : eolLen;
+  *pch += *ch=='\n'? 1 + (ch[1]=='\r') :
+          *ch=='\r'? 1 + (ch[1]=='\n') + (ch[1]=='\r' && ch[2]=='\n')*2 :
+                     (*ch=='\0');
 }
 
 


### PR DESCRIPTION
There was a problem where jump within a file could end up within a newline. For example if the file has `\r\r\n` newlines, and we jump at a point which looks like `\r\n`, i.e. we end up inside the newline. In this case we were adding `eolLen` to the current position, which caused the first data character to be accidentally skipped.
New approach is more robust, even if we have different newlines in the file.

Closes #634