### PR TITLE
Fix broken llvmlite dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - GenericReader now supports auto-detecting and reading UTF-16 files.
 - GenericReader now attempts to detect whether the input file is an HTML, and if so
   raises an exception with the appropriate error message.
+- Datatable can now use either llvm-4.0 or llvm-5.0 depending on what the user has.
 
 #### Changed
 - When writing "round" doubles/floats to CSV, they'll now always have trailing zero.


### PR DESCRIPTION
The build script will now look for either env.variable `LLVM4` or `LLVM5`, and will require the correct version of `llvmlite` based on which version of LLVM is available.

Closes #639 