### PR TITLE
Clean up initialization of all input parameters in GenericReader

### DIFF
--- a/c/csv/reader.h
+++ b/c/csv/reader.h
@@ -38,7 +38,30 @@ struct OutputColumn;
  */
 class GenericReader
 {
+  //============================================================================
   // Input parameters
+  //============================================================================
+  // nthreads:
+  //   Number of threads to use; 0 means use maximum possible, negative number
+  //   means use that many less than the maximum. The default is 0.
+  // verbose:
+  //   Print diagnostic information about the parsing process.
+  // sep:
+  //   The separator character. The default is \xFF, which means "auto-detect".
+  //   The `sep` may also be '\n', which indicates "single-line mode" (i.e. the
+  //   lines should not be split into fields). The value `sep=' '` is likewise
+  //   special: multiple space characters are always treated as a single
+  //   separator (i.e. the separator is effectively /\s+/). At the same time the
+  //   `sep` cannot be any of [0-9a-zA-Z'"`].
+  // dec:
+  //   The decimal separator in numbers. Only '.' (default) and ',' are allowed.
+  // quote:
+  //   The quotation mark. Only '"' (default), '\'' and '`' are allowed. In
+  //   addition this can also be '\0', which indicates no quoting is allowed.
+  // header:
+  //   Is the header present? Possible values are 0 (no), 1 (yes), and -128
+  //   (auto-detect, default).
+  //
   public:
     int32_t nthreads;
     bool verbose;
@@ -55,7 +78,8 @@ class GenericReader
     bool show_progress;
     bool fill;
     bool warnings_to_errors;
-    int: 16;
+    bool blank_is_na;
+    bool number_is_na;
 
   // Runtime parameters
   private:
@@ -108,11 +132,20 @@ class GenericReader
 
   // Helper functions
   private:
-    void set_nthreads(int32_t nthreads);
-    void set_verbose(int8_t verbose);
-    void set_fill(int8_t fill);
-    void set_maxnrows(int64_t n);
-    void set_skiplines(int64_t n);
+    void init_verbose();
+    void init_nthreads();
+    void init_fill();
+    void init_maxnrows();
+    void init_skiplines();
+    void init_sep();
+    void init_dec();
+    void init_quote();
+    void init_showprogress();
+    void init_header();
+    void init_nastrings();
+    void init_skipstring();
+    void init_stripwhite();
+    void init_skipblanklines();
 
     void open_input();
     void detect_and_skip_bom();

--- a/c/utils/pyobj.cc
+++ b/c/utils/pyobj.cc
@@ -156,11 +156,11 @@ const char* PyObj::as_cstring(size_t* size) const {
   if (PyUnicode_Check(obj)) {
     if (tmp) throw RuntimeError() << "Cannot convert to string more than once";
     tmp = PyUnicode_AsEncodedString(obj, "utf-8", "strict");
-    if (size) *size = PyBytes_Size(tmp);
+    if (size) *size = static_cast<size_t>(PyBytes_Size(tmp));
     return PyBytes_AsString(tmp);
   }
   if (PyBytes_Check(obj)) {
-    if (size) *size = PyBytes_Size(obj);
+    if (size) *size = static_cast<size_t>(PyBytes_Size(obj));
     return PyBytes_AsString(obj);
   }
   if (obj == Py_None) {
@@ -189,8 +189,14 @@ char* PyObj::as_ccstring() const {
 
 
 char PyObj::as_char() const {
-  const char* src = as_cstring();
-  return src? src[0] : '\0';
+  return as_char('\0', '\0');
+}
+char PyObj::as_char(char ifnone, char ifempty) const {
+  size_t sz = 0;
+  const char* src = as_cstring(&sz);
+  if (src == nullptr) return ifnone;
+  if (sz == 0) return ifempty;
+  return src[0];
 }
 
 

--- a/c/utils/pyobj.h
+++ b/c/utils/pyobj.h
@@ -93,9 +93,11 @@ public:
   char* as_ccstring() const;
 
   /**
-   * If this PyObj is a string, return its first character (or '\0' if the
-   * object is Py_None).
+   * If this PyObj is a string, return its first character. When the python
+   * object is None, the value `ifnone` is returned; and if the string is empty
+   * the value `ifempty`. The no-arguments form uses `ifnone = ifempty = '\0'`.
    */
+  char as_char(char ifnone, char ifempty) const;
   char as_char() const;
 
   PyObject* as_pyobject() const;

--- a/datatable/fread.py
+++ b/datatable/fread.py
@@ -593,8 +593,8 @@ class TextReader(object):
     @quotechar.setter
     @typed()
     def quotechar(self, v: Optional[str]):
-        if v not in {None, "'", '"', "`"}:
-            raise ValueError("quotechar should be one of [\"'`] or None")
+        if v not in {None, "", "'", '"', "`"}:
+            raise ValueError("quotechar should be one of [\"'`] or '' or None")
         self._quotechar = v
 
     @property

--- a/tests/test_fread.py
+++ b/tests/test_fread.py
@@ -449,24 +449,27 @@ def test_fread_quotechar():
     d1 = dt.fread(inp, quotechar="'")
     assert d1.internal.check()
     assert d1.topython() == [["foo", '"bar"', "`baz`"], [1, 2, 3]]
-    d1 = dt.fread(inp, quotechar="`")
-    assert d1.internal.check()
-    assert d1.topython() == [["'foo'", '"bar"', "baz"], [1, 2, 3]]
-    d1 = dt.fread(inp, quotechar=None)
-    assert d1.internal.check()
-    assert d1.topython() == [["'foo'", '"bar"', "`baz`"], [1, 2, 3]]
+    d2 = dt.fread(inp, quotechar="`")
+    assert d2.internal.check()
+    assert d2.topython() == [["'foo'", '"bar"', "baz"], [1, 2, 3]]
+    d3 = dt.fread(inp, quotechar="")
+    assert d3.internal.check()
+    assert d3.topython() == [["'foo'", '"bar"', "`baz`"], [1, 2, 3]]
+    d4 = dt.fread(inp, quotechar=None)
+    assert d4.internal.check()
+    assert d4.topython() == [["'foo'", "bar", "`baz`"], [1, 2, 3]]
 
 
 def test_fread_quotechar_bad():
     for c in "~!@#$%abcd*()-_+=^&:;{}[]\\|,.></?0123456789":
         with pytest.raises(ValueError) as e:
             dt.fread("A,B\n1,2", quotechar=c)
-        assert "quotechar should be one of [\"'`] or None" in str(e.value)
+        assert "quotechar should be one of [\"'`] or '' or None" in str(e.value)
     # Multi-character raises as well
     with pytest.raises(ValueError):
         dt.fread("A,B\n1,2", quotechar="''")
     with pytest.raises(ValueError):
-        dt.fread("A,B\n1,2", quotechar="")
+        dt.fread("A,B\n1,2", quotechar="\0")
 
 
 def test_fread_dec():

--- a/tests/test_fread_small.py
+++ b/tests/test_fread_small.py
@@ -136,7 +136,7 @@ def test_issue641():
 
 def make_seeds():
     # If you want to test a specific seed, uncomment the following line:
-    # return [767904686]
+    # return [1984115291]
     n = 25
     if os.environ.get(root_env_name, "") != "":
         n = 500


### PR DESCRIPTION
This PR centralizes the logic for retrieving the input parameters from the Python TextReader object, verifying their validity and reporting in the verbose stream. It is necessary to do all of this within the GenericReader because many of these parameters are shared across different sub-readers.
