### PR TITLE
Parameters skip_to_line and skip_to_string are now resolved within the GenericReader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   the column names. If encountered, they will be replaced with a dot `.`.
 - Fread now ignores trailing whitespace on each line, even if ' ' separator is used.
 - Fread on an empty file now produces an empty DataTable, instead of an exception.
+- Fread's parameter `skip_lines` was replaced with `skip_to_line`, so that it's
+  more in sync with the similar argument `skip_to_string`.
 
 #### Fixed
 - `datatable` will no longer cause the C locale settings to change upon importing.

--- a/c/csv/reader.h
+++ b/c/csv/reader.h
@@ -38,9 +38,10 @@ struct OutputColumn;
  */
 class GenericReader
 {
-  //============================================================================
+  //----------------------------------------------------------------------------
   // Input parameters
-  //============================================================================
+  //----------------------------------------------------------------------------
+  //
   // nthreads:
   //   Number of threads to use; 0 means use maximum possible, negative number
   //   means use that many less than the maximum. The default is 0.
@@ -58,6 +59,14 @@ class GenericReader
   // quote:
   //   The quotation mark. Only '"' (default), '\'' and '`' are allowed. In
   //   addition this can also be '\0', which indicates no quoting is allowed.
+  // skip_to_line:
+  //   If greater than 1, indicates that the file should be read from starting
+  //   from the requested line. The notion of a "line" corresponds to that of a
+  //   typical text editor: line counting starts from 1, and a new line starts
+  //   whenever one of '\r\n', '\n\r', '\r' or '\n' are encountered. In
+  //   particular sequence '\r\r\n' contains two line separators, not one. If
+  //   skip_to_line is greater than the available number of lines in the file,
+  //   an empty DataTable will be returned.
   // header:
   //   Is the header present? Possible values are 0 (no), 1 (yes), and -128
   //   (auto-detect, default).
@@ -69,7 +78,7 @@ class GenericReader
     char dec;
     char quote;
     int64_t max_nrows;
-    int64_t skip_lines;
+    int64_t skip_to_line;
     const char* skip_string;
     const char* const* na_strings;
     int8_t header;
@@ -81,7 +90,12 @@ class GenericReader
     bool blank_is_na;
     bool number_is_na;
 
+  //----------------------------------------------------------------------------
   // Runtime parameters
+  //----------------------------------------------------------------------------
+  // line:
+  //   Line number (within the original input) of the `offset` pointer.
+  //
   private:
     PyObj logger;
     PyObj freader;
@@ -93,10 +107,13 @@ class GenericReader
     MemoryBuffer* mbuf;
     size_t offset;
     size_t offend;
+    size_t line;
     int32_t fileno;
     int : 32;
 
+  //----------------------------------------------------------------------------
   // Public API
+  //----------------------------------------------------------------------------
   public:
     GenericReader(const PyObj& pyreader);
     ~GenericReader();
@@ -136,7 +153,7 @@ class GenericReader
     void init_nthreads();
     void init_fill();
     void init_maxnrows();
-    void init_skiplines();
+    void init_skiptoline();
     void init_sep();
     void init_dec();
     void init_quote();
@@ -151,6 +168,8 @@ class GenericReader
     void detect_and_skip_bom();
     void skip_initial_whitespace();
     void skip_trailing_whitespace();
+    void skip_to_line_number();
+    void skip_to_line_with_string();
     void decode_utf16();
 
     DataTablePtr read_empty_input();

--- a/datatable/fread.py
+++ b/datatable/fread.py
@@ -55,7 +55,7 @@ def fread(
         show_progress: bool = None,
         encoding: str = None,
         skip_to_string: str = None,
-        skip_lines: int = None,
+        skip_to_line: int = None,
         skip_blank_lines: bool = True,
         strip_white: bool = True,
         quotechar: Optional[str] = '"',
@@ -79,7 +79,7 @@ class TextReader(object):
                  cmd=None, columns=None, sep=None,
                  max_nrows=None, header=None, na_strings=None, verbose=False,
                  fill=False, show_progress=None, encoding=None, dec=".",
-                 skip_to_string=None, skip_lines=None, save_to=None,
+                 skip_to_string=None, skip_to_line=None, save_to=None,
                  nthreads=None, logger=None, skip_blank_lines=True,
                  strip_white=True, quotechar='"', **args):
         self._src = None            # type: str
@@ -99,7 +99,7 @@ class TextReader(object):
         self._show_progress = True  # type: bool
         self._encoding = encoding   # type: str
         self._quotechar = None      # type: str
-        self._skip_lines = None
+        self._skip_to_line = None
         self._skip_blank_lines = True
         self._skip_to_string = None
         self._strip_white = True
@@ -132,7 +132,7 @@ class TextReader(object):
         self.fill = fill
         self.show_progress = show_progress
         self.skip_to_string = skip_to_string
-        self.skip_lines = skip_lines
+        self.skip_to_line = skip_to_line
         self.skip_blank_lines = skip_blank_lines
         self.strip_white = strip_white
         self.quotechar = quotechar
@@ -557,13 +557,13 @@ class TextReader(object):
 
 
     @property
-    def skip_lines(self):
-        return self._skip_lines
+    def skip_to_line(self):
+        return self._skip_to_line
 
-    @skip_lines.setter
+    @skip_to_line.setter
     @typed(n=U(int, None))
-    def skip_lines(self, n):
-        self._skip_lines = n
+    def skip_to_line(self, n):
+        self._skip_to_line = n
 
 
     @property

--- a/tests/test_fread.py
+++ b/tests/test_fread.py
@@ -507,6 +507,29 @@ def test_fread_header():
     assert d1.topython() == [["A", "1"], ["B", "2"]]
 
 
+def test_fread_skip_to_line():
+    d0 = dt.fread("a,z\nv,1\nC,D\n1,2\n", skip_to_line=3)
+    assert d0.internal.check()
+    assert d0.names == ("C", "D")
+    assert d0.topython() == [[1], [2]]
+
+
+def test_fread_skip_to_line_large():
+    d0 = dt.fread("a,b\n1,2\n3,4\n5,6\n", skip_to_line=1000)
+    assert d0.internal.check()
+    assert d0.shape == (0, 0)
+
+
+def test_fread_skip_to_string():
+    d0 = dt.fread("I, the Greatest King of All Times, do hereby proclaim\n"
+                  "that, truly, I am infallible\n\n"
+                  "A,B,C\n"
+                  "1,2,3\n", skip_to_string=",B,")
+    assert d0.internal.check()
+    assert d0.names == ("A", "B", "C")
+    assert d0.topython() == [[1], [2], [3]]
+
+
 
 #-------------------------------------------------------------------------------
 # Misc


### PR DESCRIPTION
* Replaced parameter `skip_lines` with `skip_to_line`.
* Parameters `skip_to_line` and `skip_to_string` are now applied within the GenericReader (since they are common for all readers).
* Added tests for `skip_to_line` and `skip_to_string`.