### PR TITLE
Fix issue with incorrect reallocation of the DataTable when the initial estimate of nrows is too small

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   on systems where default encoding is not unicode-aware.
 - More robust newline handling in fread (#634, #641, #647).
 - Quoted fields are now correctly unquoted in fread.
+- Fixed a bug in fread which occurred if the number of rows in the CSV file was
+  estimated too low (#664).
 
 
 ### [v0.2.2](https://github.com/h2oai/datatable/compare/v0.2.2...v0.2.1) — 2017-10-18

--- a/c/csv/reader_fread.cc
+++ b/c/csv/reader_fread.cc
@@ -127,7 +127,9 @@ Column* FreadReader::realloc_column(Column *col, SType stype, size_t nrows, int 
         return alloc_column(stype, nrows, j);
     }
 
-    size_t new_alloc_size = stype_info[stype].elemsize * nrows;
+    // Buffer in string's column has nrows + 1 elements
+    size_t xnrows = nrows + (stype_info[stype].ltype == LT_STRING);
+    size_t new_alloc_size = stype_info[stype].elemsize * xnrows;
     col->mbuf->resize(new_alloc_size);
     col->nrows = (int64_t) nrows;
     return col;
@@ -192,7 +194,7 @@ void FreadReader::userOverride(int8_t *types_, const char *anchor, int ncols_,
  */
 size_t FreadReader::allocateDT(int ncols_, int ndrop_, size_t nrows)
 {
-    Column **columns = NULL;
+    Column** columns = NULL;
     nstrcols = 0;
 
     // First we need to estimate the size of the dataset that needs to be

--- a/tests/test_fread_small.py
+++ b/tests/test_fread_small.py
@@ -240,6 +240,18 @@ def test_unescaping1():
                               "\r\t\v\a\b\071\uABCD"]]
 
 
+def test_issue664(capsys):
+    f = dt.fread("x\nA B 2\n\ny\n", sep=" ", fill=True, verbose=True,
+                 skip_blank_lines=True)
+    out, err = capsys.readouterr()
+    assert "Too few rows allocated" not in out
+    assert f.internal.check()
+    assert f.shape == (3, 3)
+    assert f.topython() == [["x", "A", "y"],
+                            [None, "B", None],
+                            [None, 2, None]]
+
+
 
 #-------------------------------------------------------------------------------
 # Omnibus Test


### PR DESCRIPTION
There were multiple bugs here:
* Re-allocation of a DataTable when nrows was estimated too low did not work correctly.
* Parameter `skip_blank_lines` was not applied correctly when `sep=' '`.
* The number of extra rows needed to allocate can be estimated precisely if we ran out of rows on the very last chunk.

Closes #664 