### PR TITLE
Chunked reader

### DIFF
--- a/c/csv/worker.h
+++ b/c/csv/worker.h
@@ -108,6 +108,7 @@ public:
   void set_input(const char* ptr, size_t size, int64_t line);
 
   virtual ThreadContextPtr init_thread_context() = 0;
+  virtual void realloc_columns(size_t n) = 0;
   virtual void compute_chunking_strategy();
   virtual const char* adjust_chunk_start(const char* ch, const char* eof);
   void read_all();

--- a/datatable/fread.py
+++ b/datatable/fread.py
@@ -56,7 +56,7 @@ def fread(
         encoding: str = None,
         skip_to_string: str = None,
         skip_to_line: int = None,
-        skip_blank_lines: bool = True,
+        skip_blank_lines: bool = False,
         strip_white: bool = True,
         quotechar: Optional[str] = '"',
         save_to: str = None,

--- a/tests/test_fread_large.py
+++ b/tests/test_fread_large.py
@@ -34,16 +34,23 @@ def get_file_list(*path):
     rootdir = os.path.join(d, *path)
     if not os.path.isdir(rootdir):
         return [failed("Directory '%s' does not exist" % rootdir, rootdir)]
-    exts = [".csv", ".txt", ".tsv", ".data", ".gz", ".zip", ".asv", ".psv",
-            ".scsv", ".hive"]
+    good_extensions = [".csv", ".txt", ".tsv", ".data", ".gz", ".zip", ".asv",
+                       ".psv", ".scsv", ".hive"]
+    bad_extensions = {".gif", ".jpg", ".jpeg", ".pdf", ".svg"}
     out = set()
     for dirname, subdirs, files in os.walk(rootdir):
         for filename in files:
             f = os.path.join(dirname, filename)
+            try:
+                ext = filename[filename.rindex("."):]
+            except ValueError:
+                ext = ""
+            if ext in bad_extensions:
+                continue
             if ("readme" not in filename.lower() and
                     ".svm" not in filename and
                     ".json" not in filename and
-                    any(filename.endswith(ext) for ext in exts)):
+                    ext in good_extensions):
                 if filename.endswith(".zip") and f[:-4] in out:
                     continue
                 if f + ".zip" in out:


### PR DESCRIPTION
Multiple updates to ChunkedReader. It now supports limiting the number of rows read, and deal with the case when the number of rows preallocated is lower than necessary.

This functionality is currently orphaned.

Also the default value of parameter `skip_blank_lines` was changed to `False`: this can better address a "footer" at the end of a csv file.