### PR TITLE
Fix chunk boundaries detection logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   estimated too low (#664).
 - Fixed fread bug where an invalid DataTable was constructed if parameter `max_nrows`
   was used and there were any string columns (#671).
+- Fixed a rare bug in fread which produced error message "Jump X did not finish
+  reading where jump X+1 started" (#682).
 
 
 ### [v0.2.2](https://github.com/h2oai/datatable/compare/v0.2.2...v0.2.1) — 2017-10-18

--- a/c/csv/fread.h
+++ b/c/csv/fread.h
@@ -113,7 +113,7 @@ struct FieldParseContext {
   bool end_of_field();
   const char* end_NA_string(const char*);
   int countfields();
-  bool nextGoodLine(int ncol);
+  bool nextGoodLine(int ncol, bool fill, bool skipBlankLines);
   bool skip_eol();
 };
 

--- a/tests/fread/test_fread_small.py
+++ b/tests/fread/test_fread_small.py
@@ -735,16 +735,3 @@ def test_maxnrows_on_large_dataset():
     assert d0.internal.check()
     assert d0.shape == (5, 3)
     assert d0.topython() == [[0, 1, 2, 3, 4], ["x"] * 5, [True] * 5]
-
-
-@pytest.mark.parametrize("seed", [random.randint(0, 2**31)])
-def test_jump_into_quotes(seed):
-    random.seed(seed)
-    n = 100000
-    src = [str(random.randint(0, 30)) for _ in range(n)]
-    src[0] = "A"
-    txt = "\n\r".join(src)
-    d0 = dt.fread(txt, verbose=True)
-    assert d0.internal.check()
-    assert d0.ltypes == (dt.ltype.int,)
-    assert d0.shape == (n - 1, 1)


### PR DESCRIPTION
This should reduce number of errors about 'Jump X did not finish ...'.
The minimal size of chunk reduced to 128K (it was 2MB).

Closes #682
Note: this also solves https://github.com/Rdatatable/data.table/issues/2267