### PR TITLE
Fix race condition in MemmapMemBuf::memmap()

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@
 import os
 import sys
 import pytest
+import shutil
 import tempfile as mod_tempfile
 
 
@@ -64,3 +65,13 @@ def tempfile():
     os.close(fd)
     yield fname
     os.unlink(fname)
+
+
+@pytest.fixture(scope="function")
+def tempdir():
+    dirname = mod_tempfile.mkdtemp()
+    yield dirname
+    try:
+        shutil.rmtree(dirname)
+    except:
+        pass

--- a/tests/munging/test_dt_rows.py
+++ b/tests/munging/test_dt_rows.py
@@ -420,3 +420,16 @@ def test_rows_bad_arguments(dt0):
                      "Boolean value cannot be used as a `rows` selector")
     assert_typeerror(dt0, False,
                      "Boolean value cannot be used as a `rows` selector")
+
+
+def test_issue689(tempdir):
+    N = 300000  # Must be > 65536
+    data = [i % 8 for i in range(N)]
+    d0 = dt.DataTable(data, names=["A"])
+    dt.save(d0, tempdir)
+    del d0
+    d1 = dt.open(tempdir)
+    # Do not check d1! we want it to be lazy at this point
+    d2 = d1(rows=lambda f: f[0] == 1)
+    assert d2.internal.check()
+    assert d2.shape == (N / 8, 1)


### PR DESCRIPTION
The bug was caused by multiple threads trying to simultaneously eagerize data in a lazy-loaded memory-mapped column. In addition, `mapped` flag was not properly cleared in the `memunmap()` method, which would cause problems as soon as the column gets evicted.

Closes #689