### PR TITLE
Fixed memory leak in PyObjectColumn when passed to numpy via buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   was used and there were any string columns (#671).
 - Fixed a rare bug in fread which produced error message "Jump X did not finish
   reading where jump X+1 started" (#682).
+- Prevented memory leak when using "PyObject" columns in conjunction with numpy.
 
 
 ### [v0.2.2](https://github.com/h2oai/datatable/compare/v0.2.2...v0.2.1) — 2017-10-18


### PR DESCRIPTION
No tests were added, since detecting this leak is very time-consuming operation (see code sample in the issue). Running such test every time would be prohibitively expensive... We could revisit this example when we have a system for executing long-running tests on daily schedule on the server.

Closes #723 