### PR TITLE
New 'fast' target in Makefile which provides faster compilation of source files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,14 @@
-
+BUILDDIR := build/fast
 PYTHON ?= python
 OS := $(shell uname | tr A-Z a-z)
 MODULE ?= .
 
 
-.PHONY: all
+.PHONY: all clean mrproper build install uninstall test_install test \
+		benchmark debug build_noomp bi coverage fast
+.SECONDARY: main-fast
+
+
 all:
 	$(MAKE) clean
 	$(MAKE) build
@@ -12,7 +16,6 @@ all:
 	$(MAKE) test
 
 
-.PHONY: clean
 clean:
 	rm -rf .cache
 	rm -rf .eggs
@@ -24,30 +27,27 @@ clean:
 	find . -type d -name "__pycache__" -exec rm -rf {} +
 
 
-.PHONY: mrproper
 mrproper: clean
 	git clean -f -d -x
 
 
-.PHONY: build
 build:
 	$(PYTHON) setup.py build
 	cp build/lib.*/datatable/lib/_datatable.* datatable/lib/
 
-.PHONY: install
+
 install:
 	$(PYTHON) -m pip install . --upgrade --no-cache-dir
 
 
-.PHONY: uninstall
 uninstall:
 	$(PYTHON) -m pip uninstall datatable -y
 
-.PHONY: test_install
+
 test_install:
 	$(PYTHON) -m pip install ${MODULE}[testing] --no-cache-dir
 
-.PHONY: test
+
 test:
 	$(MAKE) test_install
 	rm -rf build/test-reports 2>/dev/null
@@ -58,31 +58,26 @@ test:
 		tests
 
 
-.PHONY: benchmark
 benchmark:
 	$(PYTHON) -m pytest -ra -v benchmarks
 
 
-.PHONY: debug
 debug:
 	$(MAKE) clean
 	DTDEBUG=1 \
 	$(MAKE) build
 	$(MAKE) install
 
-.PHONY: build_noomp
 build_noomp:
 	DTNOOPENMP=1 \
 	$(MAKE) build
 
 
-.PHONY: bi
 bi:
 	$(MAKE) build
 	$(MAKE) install
 
 
-.PHONY: coverage
 coverage:
 	$(MAKE) clean
 	DTCOVERAGE=1 \
@@ -101,3 +96,285 @@ coverage:
 	lcov --gcov-tool ./llvm-gcov.sh --capture --directory . --output-file build/coverage.info
 	genhtml build/coverage.info --output-directory build/coverage-c
 	mv .coverage build/
+
+
+
+#-------------------------------------------------------------------------------
+# "Fast" (but fragile) datatable build
+#-------------------------------------------------------------------------------
+
+fast_objects = $(addprefix $(BUILDDIR)/, \
+	capi.o                    \
+	column.o                  \
+	column_bool.o             \
+	column_from_pylist.o      \
+	column_fw.o               \
+	column_int.o              \
+	column_pyobj.o            \
+	column_real.o             \
+	column_string.o           \
+	columnset.o               \
+	csv/fread.o               \
+	csv/py_csv.o              \
+	csv/reader.o              \
+	csv/reader_arff.o         \
+	csv/reader_fread.o        \
+	csv/reader_parsers.o      \
+	csv/reader_utils.o        \
+	csv/writer.o              \
+	datatable.o               \
+	datatable_cbind.o         \
+	datatable_check.o         \
+	datatable_load.o          \
+	datatable_rbind.o         \
+	datatablemodule.o         \
+	encodings.o               \
+	expr/binaryop.o           \
+	expr/py_expr.o            \
+	expr/reduceop.o           \
+	expr/unaryop.o            \
+	memorybuf.o               \
+	mmm.o                     \
+	py_buffers.o              \
+	py_column.o               \
+	py_columnset.o            \
+	py_datatable.o            \
+	py_datatable_fromlist.o   \
+	py_datawindow.o           \
+	py_encodings.o            \
+	py_rowindex.o             \
+	py_types.o                \
+	py_utils.o                \
+	rowindex.o                \
+	sort.o                    \
+	stats.o                   \
+	types.o                   \
+	utils.o                   \
+	utils/exceptions.o        \
+	utils/file.o              \
+	utils/pyobj.o             \
+	writebuf.o                \
+	)
+
+fast:
+	$(eval CC := $(shell python setup.py get_CC))
+	$(eval CCFLAGS := $(shell python setup.py get_CCFLAGS))
+	$(eval LDFLAGS := $(shell python setup.py get_LDFLAGS))
+	$(eval EXTEXT := $(shell python setup.py get_EXTEXT))
+	$(eval export CC CCFLAGS LDFLAGS EXTEXT)
+	@echo • Checking dependencies graph
+	@python fastcheck.py
+	@$(MAKE) --no-print-directory main-fast
+
+post-fast:
+	@echo • Copying _datatable.so into ``datatable/lib/_datatable$(EXTEXT)``
+	@cp $(BUILDDIR)/_datatable.so datatable/lib/_datatable$(EXTEXT)
+
+main-fast: $(BUILDDIR)/_datatable.so
+	@echo • Done.
+
+$(BUILDDIR)/_datatable.so: $(fast_objects)
+	@echo • Linking object files into _datatable.so
+	@$(CC) $(LDFLAGS) -o $@ $+
+	@$(MAKE) --no-print-directory post-fast
+
+$(BUILDDIR)/capi.o : c/capi.cc c/rowindex.h c/capi.h c/datatable.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/column.o : c/column.cc c/rowindex.h c/py_utils.h c/utils/file.h c/datatable_check.h c/column.h c/utils.h c/utils/assert.h c/sort.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/column_bool.o : c/column_bool.cc c/column.h c/utils/omp.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/column_from_pylist.o : c/column_from_pylist.cc c/py_types.h c/column.h c/utils.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/column_fw.o : c/column_fw.cc c/column.h c/utils.h c/utils/omp.h c/utils/assert.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/column_int.o : c/column_int.cc c/column.h c/py_types.h c/py_utils.h c/utils/omp.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/column_pyobj.o : c/column_pyobj.cc c/column.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/column_real.o : c/column_real.cc c/column.h c/py_utils.h c/utils/omp.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/column_string.o : c/column_string.cc c/column.h c/datatable_check.h c/encodings.h c/py_utils.h c/utils.h c/utils/assert.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/columnset.o : c/columnset.cc c/columnset.h c/utils.h c/utils/exceptions.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/csv/fread.o : c/csv/fread.cc c/csv/fread.h c/csv/freadLookups.h c/csv/reader.h c/csv/reader_fread.h c/csv/reader_parsers.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/csv/py_csv.o : c/csv/py_csv.cc c/csv/py_csv.h c/csv/reader.h c/csv/writer.h c/py_datatable.h c/py_utils.h c/utils.h c/utils/omp.h c/utils/pyobj.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/csv/reader.o : c/csv/reader.cc c/csv/reader.h c/csv/reader_arff.h c/csv/reader_fread.h c/utils/exceptions.h c/utils/omp.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/csv/reader_arff.o : c/csv/reader_arff.cc c/csv/reader_arff.h c/utils/exceptions.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/csv/reader_fread.o : c/csv/reader_fread.cc c/column.h c/csv/fread.h c/csv/reader.h c/csv/reader_fread.h c/csv/reader_parsers.h c/datatable.h c/py_datatable.h c/py_encodings.h c/py_utils.h c/utils.h c/utils/assert.h c/utils/file.h c/utils/pyobj.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/csv/reader_parsers.o : c/csv/reader_parsers.cc c/csv/reader_parsers.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/csv/reader_utils.o : c/csv/reader_utils.cc c/csv/fread.h c/csv/reader.h c/utils/exceptions.h c/utils/omp.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/csv/writer.o : c/csv/writer.cc c/column.h c/csv/dtoa.h c/csv/itoa.h c/csv/writer.h c/datatable.h c/memorybuf.h c/types.h c/utils.h c/utils/omp.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/datatable.o : c/datatable.cc c/datatable.h c/datatable_check.h c/py_utils.h c/rowindex.h c/types.h c/utils/omp.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/datatable_cbind.o : c/datatable_cbind.cc c/datatable.h c/rowindex.h c/utils.h c/utils/assert.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/datatable_check.o : c/datatable_check.cc c/datatable_check.h c/utils.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/datatable_load.o : c/datatable_load.cc c/datatable.h c/utils.h c/utils/assert.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/datatable_rbind.o : c/datatable_rbind.cc c/column.h c/datatable.h c/utils.h c/utils/assert.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/datatablemodule.o : c/datatablemodule.c c/capi.h c/csv/py_csv.h c/csv/writer.h c/expr/py_expr.h c/py_column.h c/py_columnset.h c/py_datatable.h c/py_datawindow.h c/py_encodings.h c/py_rowindex.h c/py_types.h c/py_utils.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/encodings.o : c/encodings.c c/encodings.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/expr/binaryop.o : c/expr/binaryop.cc c/expr/py_expr.h c/types.h c/utils/exceptions.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/expr/py_expr.o : c/expr/py_expr.cc c/expr/py_expr.h c/py_column.h c/utils/pyobj.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/expr/reduceop.o : c/expr/reduceop.cc c/expr/py_expr.h c/types.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/expr/unaryop.o : c/expr/unaryop.cc c/expr/py_expr.h c/types.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/memorybuf.o : c/memorybuf.cc c/datatable_check.h c/memorybuf.h c/py_utils.h c/utils.h c/utils/assert.h c/utils/file.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/mmm.o : c/mmm.cc c/mmm.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/py_buffers.o : c/py_buffers.cc c/column.h c/encodings.h c/py_column.h c/py_datatable.h c/py_types.h c/py_utils.h c/utils/exceptions.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/py_column.o : c/py_column.cc c/py_column.h c/sort.h c/py_types.h c/writebuf.h c/utils/pyobj.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/py_columnset.o : c/py_columnset.cc c/columnset.h c/py_column.h c/py_columnset.h c/py_datatable.h c/py_rowindex.h c/py_types.h c/py_utils.h c/utils.h c/utils/pyobj.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/py_datatable.o : c/py_datatable.cc c/datatable.h c/datatable_check.h c/py_column.h c/py_columnset.h c/py_datatable.h c/py_datawindow.h c/py_rowindex.h c/py_types.h c/py_utils.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/py_datatable_fromlist.o : c/py_datatable_fromlist.c c/column.h c/memorybuf.h c/py_datatable.h c/py_types.h c/py_utils.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/py_datawindow.o : c/py_datawindow.c c/datatable.h c/py_datatable.h c/py_datawindow.h c/py_types.h c/py_utils.h c/rowindex.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/py_encodings.o : c/py_encodings.c c/py_encodings.h c/py_utils.h c/utils/assert.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/py_rowindex.o : c/py_rowindex.c c/py_column.h c/py_datatable.h c/py_rowindex.h c/py_utils.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/py_types.o : c/py_types.c c/py_types.h c/py_utils.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/py_utils.o : c/py_utils.c c/py_datatable.h c/py_utils.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/rowindex.o : c/rowindex.cc c/datatable_check.h c/rowindex.h c/types.h c/utils.h c/utils/assert.h c/utils/omp.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/sort.o : c/sort.cc c/column.h c/rowindex.h c/sort.h c/types.h c/utils.h c/utils/assert.h c/utils/omp.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/stats.o : c/stats.cc c/column.h c/rowindex.h c/stats.h c/utils.h c/utils/omp.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/types.o : c/types.c c/types.h c/utils.h c/utils/assert.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/utils.o : c/utils.c c/utils.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/utils/exceptions.o : c/utils/exceptions.cc c/utils/exceptions.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/utils/file.o : c/utils/file.cc c/utils.h c/utils/file.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/utils/pyobj.o : c/utils/pyobj.cc c/py_column.h c/py_datatable.h c/py_types.h c/utils/exceptions.h c/utils/pyobj.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/writebuf.o : c/writebuf.cc c/memorybuf.h c/utils.h c/utils/omp.h c/writebuf.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+

--- a/c/capi.h
+++ b/c/capi.h
@@ -7,7 +7,7 @@
 //------------------------------------------------------------------------------
 #ifndef dt_CAPI_H
 #define dt_CAPI_H
-#include "stdint.h"
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/c/column_fw.cc
+++ b/c/column_fw.cc
@@ -6,10 +6,10 @@
 // © H2O.ai 2018
 //------------------------------------------------------------------------------
 #include <type_traits>
-#include "omp.h"
 #include "column.h"
 #include "utils.h"
 #include "utils/assert.h"
+#include "utils/omp.h"
 
 
 

--- a/c/csv/writer.cc
+++ b/c/csv/writer.cc
@@ -8,13 +8,13 @@
 #include "csv/writer.h"
 #include <new>          // placement new
 #include <stdexcept>    // std::runtime_error
+#include <math.h>
 #include <stdint.h>     // int32_t, etc
 #include <stdio.h>      // printf
 #include "column.h"
 #include "csv/dtoa.h"
 #include "csv/itoa.h"
 #include "datatable.h"
-#include "math.h"
 #include "memorybuf.h"
 #include "utils/omp.h"
 #include "types.h"

--- a/c/py_datawindow.c
+++ b/c/py_datawindow.c
@@ -5,12 +5,12 @@
 //
 // © H2O.ai 2018
 //------------------------------------------------------------------------------
+#include "py_datawindow.h"
 #include <Python.h>
+#include <structmember.h>
 #include "datatable.h"
 #include "py_utils.h"
-#include "structmember.h"
 #include "rowindex.h"
-#include "py_datawindow.h"
 #include "py_datatable.h"
 #include "py_types.h"
 

--- a/c/utils/file.h
+++ b/c/utils/file.h
@@ -5,9 +5,9 @@
 //
 // © H2O.ai 2018
 //------------------------------------------------------------------------------
-#ifndef dt_UTILS_FILE_H
-#define dt_UTILS_FILE_H
-#include "sys/stat.h"  // fstat
+#ifndef dt_UTILS_FILE_h
+#define dt_UTILS_FILE_h
+#include <sys/stat.h>  // fstat
 #include <string>      // std::string
 
 

--- a/fastcheck.py
+++ b/fastcheck.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+# © H2O.ai 2018; -*- encoding: utf-8 -*-
+#   This Source Code Form is subject to the terms of the Mozilla Public
+#   License, v. 2.0. If a copy of the MPL was not distributed with this
+#   file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#-------------------------------------------------------------------------------
+import os
+import re
+import sys
+
+rx_include = re.compile(r'#include\s+"(.*?)"')
+
+
+def get_files():
+    sources = []
+    headers = []
+    for dirpath, _, filenames in os.walk("c"):
+        for f in filenames:
+            fullname = os.path.join(dirpath, f)
+            if f.endswith(".h"):
+                headers.append(fullname)
+            elif f.endswith(".c") or f.endswith(".cc"):
+                sources.append(fullname)
+    return (sources, headers)
+
+
+def find_includes(filename):
+    includes = []
+    with open(filename, "r", encoding="utf-8") as inp:
+        for line in inp:
+            line = line.strip()
+            if not line or line.startswith("//"):
+                continue
+            if line.startswith("#"):
+                mm = re.match(rx_include, line)
+                if mm:
+                    includename = os.path.join("c", mm.group(1))
+                    includes.append(includename)
+    return includes
+
+
+def build_headermap(headers):
+    headermap = {}
+    for hfile in headers:
+        headermap[hfile] = None
+    for hfile in headers:
+        inc = find_includes(hfile)
+        for f in inc:
+            assert f != hfile, "File %s includes itself?" % f
+            if f not in headers:
+                raise ValueError("Unknown header \"%s\" included from %s"
+                                 % (f, hfile))
+        headermap[hfile] = set(inc)
+    transitively_extend(headermap)
+    return headermap
+
+
+def build_sourcemap(sources, headermap):
+    sourcemap = {}
+    for sfile in sources:
+        inc = find_includes(sfile)
+        for f in inc:
+            if f not in headermap:
+                raise ValueError("Unknown header \"%s\" included from %s"
+                                 % (f, sfile))
+        sourcemap[sfile] = set(inc)
+    return sourcemap
+
+
+def transitively_extend(nodemap):
+    modified = True
+    while modified:
+        modified = False
+        for node in nodemap:
+            values = nodemap[node]
+            len0 = len(values)
+            for n in list(values):
+                values |= nodemap[n]
+            if len(values) > len0:
+                modified = True
+            nodemap[node] = values
+
+
+def parse_makefile():
+    objects_map = {}
+    with open("Makefile", "r", encoding="utf-8") as inp:
+        read_objects = False
+        for iline, line in enumerate(inp):
+            if read_objects:
+                line = line.strip(" \t\n\\")
+                if line == ")":
+                    read_objects = False
+                else:
+                    objects_map[line] = None
+                continue
+            if line.startswith("fast_objects"):
+                read_objects = True
+                continue
+            if line.startswith("$(BUILDDIR)/"):
+                sline = line.strip()
+                sline = sline[len("$(BUILDDIR)/"):]
+                obj, deps = sline.split(":")
+                obj = obj.strip()
+                if obj == "_datatable.so":
+                    continue
+                if obj not in objects_map:
+                    raise ValueError("Object file `%s` was not declared in "
+                                     "$(fast_objects), however a build target "
+                                     "for it exists (line %d in Makefile):\n%s"
+                                     % (obj, iline + 1, "  " + line))
+                deps = deps.strip()
+                depslist = deps.split(" ")
+                objects_map[obj] = depslist
+        for obj, deps in objects_map.items():
+            if deps is None:
+                raise ValueError("Object file `%s` is present in "
+                                 "$(fast_objects) but there is no "
+                                 "corresponding make target" % obj)
+            assert isinstance(deps, list), "Invalid deps object: %r" % (deps,)
+            if not deps:
+                raise ValueError("Dependencies for object file `%s` are "
+                                 "missing" % obj)
+    return objects_map
+
+
+def verify_dependencies(sourcemap, objmap):
+    # `sourcemap`:
+    #     dict where keys are all .c/.cc filenames in the project, and values
+    #     are sets of includes in each of those files.
+    # `headermap`:
+    #     same as `sourcemap`, but keys are .h files.
+    # `objmap`:
+    #     dictionary where the keys are all object files that are declared in
+    #     the Makefile, and values are all declared dependencies of those
+    #     object files.
+    for srcfile in sourcemap:
+        assert srcfile.startswith("c/")
+        f = srcfile[len("c/"):]
+        if f.endswith(".c"):
+            f = f[:-len(".c")] + ".o"
+        elif f.endswith(".cc"):
+            f = f[:-len(".cc")] + ".o"
+        else:
+            raise ValueError("Unexpected source file name: %s" % srcfile)
+        if f not in objmap:
+            raise ValueError("Source file `%s` has no corresponding "
+                             "`$(BUILDDIR)/%s` target in the Makefile."
+                             % (srcfile, f))
+    for objfile in objmap:
+        deps = objmap[objfile]
+        srcfile = deps[0]
+        makefile_deps = set(deps[1:])
+        if srcfile not in sourcemap:
+            raise ValueError("Unknown dependency `%s` stated for object file "
+                             "`%s` in the Makefile" % (srcfile, objfile))
+        actual_deps = sourcemap[srcfile]
+        if makefile_deps != actual_deps:
+            diff1 = makefile_deps - actual_deps
+            diff2 = actual_deps - makefile_deps
+            if diff1:
+                raise ValueError("Source file `%s` is declared in the Makefile "
+                                 "to depend on %r, while in reality it doesn't "
+                                 "depend on them." % (srcfile, diff1))
+            if diff2:
+                raise ValueError("Source file `%s` depends on %r, however these"
+                                 " dependencies were not declared in the "
+                                 "Makefile.\n"
+                                 "Include the following line in the Makefile:\n"
+                                 "$(BUILDDIR)/%s : %s %s"
+                                 % (srcfile, diff2, objfile, srcfile,
+                                    " ".join(sorted(actual_deps))))
+
+
+def create_build_directories(objmap):
+    dirs = set(os.path.join("build/fast", os.path.dirname(objfile))
+               for objfile in objmap)
+    for d in dirs:
+        os.makedirs(d, exist_ok=True)
+
+
+def main():
+    sources, headers = get_files()
+    headermap = build_headermap(headers)
+    sourcemap = build_sourcemap(sources, headermap)
+    objmap = parse_makefile()
+    verify_dependencies(sourcemap, objmap)
+    create_build_directories(objmap)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except ValueError as e:
+        print("\n  Error: %s" % e)
+        sys.exit(1)

--- a/setup.py
+++ b/setup.py
@@ -14,39 +14,256 @@ import os
 import shutil
 import sys
 import re
-import subprocess
 import sysconfig
+from functools import lru_cache as memoize
 from setuptools import setup, find_packages
 from distutils.core import Extension
 from sys import stderr
 
-curdir = os.path.dirname(os.path.abspath(__file__))
 
-# Determine the version
-version = None
-with open("datatable/__version__.py", encoding="utf-8") as f:
-    rx = re.compile(r"""version\s*=\s*['"]([\d.]*)['"]\s*""")
-    for line in f:
-        mm = re.match(rx, line)
-        if mm is not None:
-            version = mm.group(1)
-            break
-if version is None:
-    raise RuntimeError("Could not detect version from the __version__.py file")
-# Append build suffix if necessary
-if os.environ.get("CI_VERSION_SUFFIX"):
-    version = "%s+%s" % (version, os.environ["CI_VERSION_SUFFIX"])
 
-# Find all C source files in the "c/" directory
-c_sources = []
-for root, dirs, files in os.walk("c"):
-    for name in files:
-        if name.endswith(".c") or name.endswith(".cxx") or name.endswith(".cc"):
-            c_sources.append(os.path.join(root, name))
+#-------------------------------------------------------------------------------
+# Generic helpers
+#-------------------------------------------------------------------------------
 
-# Find python source directories
-packages = find_packages(exclude=["tests", "tests.munging", "temp", "c"])
-print("\nFound packages: %r\n" % packages, file=stderr)
+def get_version():
+    """Determine the package version."""
+    version = None
+    with open("datatable/__version__.py", encoding="utf-8") as f:
+        rx = re.compile(r"""version\s*=\s*['"]([\d.]*)['"]\s*""")
+        for line in f:
+            mm = re.match(rx, line)
+            if mm is not None:
+                version = mm.group(1)
+                break
+    if version is None:
+        raise RuntimeError("Could not detect version from the "
+                           "__version__.py file")
+    # Append build suffix if necessary
+    if os.environ.get("CI_VERSION_SUFFIX"):
+        version = "%s+%s" % (version, os.environ["CI_VERSION_SUFFIX"])
+    return version
+
+
+def get_c_sources():
+    """Find all C source files in the "c/" directory."""
+    c_sources = []
+    for root, dirs, files in os.walk("c"):
+        for name in files:
+            if name.endswith(".c") or name.endswith(".cc"):
+                c_sources.append(os.path.join(root, name))
+    return c_sources
+
+
+def get_py_sources():
+    """Find python source directories."""
+    packages = find_packages(exclude=["tests", "tests.munging", "temp", "c"])
+    print("\nFound packages: %r\n" % packages, file=stderr)
+    return packages
+
+
+def get_test_dependencies():
+    # Test dependencies exposed as extras, based on:
+    # https://stackoverflow.com/questions/29870629
+    return [
+        "pandas",
+        "pytest>=3.1",
+        "pytest-cov",
+        "pytest-benchmark>=3.1",
+        "pytest-ordering>=0.5",
+    ]
+
+
+
+#-------------------------------------------------------------------------------
+# Determine compiler settings
+#-------------------------------------------------------------------------------
+
+@memoize()
+def get_llvm(with_version=False):
+    curdir = os.path.dirname(os.path.abspath(__file__))
+    for LLVMX in ["LLVM4", "LLVM5"]:
+        # Check whether there is 'llvmx' folder in the package folder
+        if LLVMX in os.environ:
+            llvmdir = os.environ[LLVMX]
+        else:
+            d = os.path.join(curdir, "datatable/" + LLVMX.lower())
+            if os.path.isdir(d):
+                llvmdir = d
+            else:
+                continue
+        if not os.path.isdir(llvmdir):
+            raise ValueError("Variable %s = %r is not a directory"
+                             % (LLVMX, llvmdir))
+        if with_version:
+            return llvmdir, LLVMX
+        return llvmdir
+    # Failed to find LLVM
+    raise RuntimeError("Environment variables LLVM4 or LLVM5 are not set. "
+                       "Please set one of these variables to the location of "
+                       "the Clang+Llvm distribution, which you can download "
+                       "from http://releases.llvm.org/download.html")
+
+
+@memoize()
+def get_rpath():
+    if sys.platform == "darwin":
+        return "@loader_path/."
+    else:
+        return "$ORIGIN/."
+
+
+@memoize()
+def get_cc(with_isystem=False):
+    clang = os.path.join(get_llvm(), "bin", "clang++")
+    if not os.path.exists(clang):
+        raise RuntimeError("Cannot find CLang compiler at `%r`" % clang)
+    if with_isystem and sysconfig.get_config_var("CONFINCLUDEPY"):
+        clang += " -isystem " + sysconfig.get_config_var("CONFINCLUDEPY")
+    return clang
+
+
+@memoize()
+def get_default_compile_flags():
+    flags = sysconfig.get_config_var("PY_CFLAGS")
+    # remove -arch XXX flags, and add "-m64" to force 64-bit only builds
+    flags = re.sub(r"-arch \w+\s*", "", flags) + " -m64"
+    # remove -WXXX flags, because we set up all warnings manually afterwards
+    flags = re.sub(r"\s*-W[a-zA-Z\-]+\s*", " ", flags)
+    # remove -O3 flag since we'll be setting it manually to either -O0 or -O3
+    # depending on the debug mode
+    flags = re.sub(r"\s*-O\d\s*", " ", flags)
+    # remove -DNDEBUG so that the program can easier use asserts
+    flags = re.sub(r"\s*-DNDEBUG\s*", " ", flags)
+    return flags
+
+
+@memoize()
+def get_extra_compile_flags():
+    flags = []
+    if sysconfig.get_config_var("CONFINCLUDEPY"):
+        # Marking this directory as "isystem" prevents Clang from issuing
+        # warnings for those files
+        flags += ["-isystem " + sysconfig.get_config_var("CONFINCLUDEPY"),
+                  "-I" + sysconfig.get_config_var("CONFINCLUDEPY")]
+
+    flags += ["-std=gnu++11", "-stdlib=libc++", "-x", "c++"]
+
+    # Path to source files / Python include files
+    flags += ["-Ic",
+              "-I" + os.path.join(sys.prefix, "include")]
+
+    # Include path to C++ header files
+    flags += ["-I" + get_llvm() + "/include/c++/v1",
+              "-isystem " + get_llvm() + "/include/c++/v1"]
+
+    # This macro is needed to combat "-DNDEBUG" flag in default Python. This
+    # flag in turn enables all `assert` statements at the C level.
+    flags += ["-DNONDEBUG"]
+
+    # Enable/disable OpenMP support
+    if "DTNOOPENMP" in os.environ:
+        flags.append("-DDTNOOMP")
+    else:
+        flags.insert(0, "-fopenmp")
+
+    if "DTDEBUG" in os.environ:
+        flags += ["-g", "-ggdb", "-O0"]
+    elif "DTCOVERAGE" in os.environ:
+        flags += ["-g", "--coverage", "-O0"]
+    else:
+        flags += ["-O3"]
+
+    if "CI_EXTRA_COMPILE_ARGS" in os.environ:
+        flags += [os.environ["CI_EXTRA_COMPILE_ARGS"]]
+
+    # Ignored warnings:
+    #   -Wcovered-switch-default: we add `default` statement to
+    #       an exhaustive switch to guard against memory
+    #       corruption and careless enum definition expansion.
+    #   -Wfloat-equal: this warning is just plain wrong...
+    #       Comparing x == 0 or x == 1 is always safe.
+    #   -Wgnu-statement-expression: we use GNU statement-as-
+    #       expression syntax in some macros...
+    #   -Wswitch-enum: generates spurious warnings about missing
+    #       cases even if `default` clause is present. -Wswitch
+    #       does not suffer from this drawback.
+    #   -Wdeprecated: warning about compiling .c files under C++
+    #       mode... we should just rename those files at some point.
+    flags += [
+        "-Weverything",
+        "-Wno-covered-switch-default",
+        "-Wno-float-equal",
+        "-Wno-gnu-statement-expression",
+        "-Wno-switch-enum",
+        "-Wno-old-style-cast",
+        "-Wno-c++98-compat-pedantic",
+        "-Wno-nested-anon-types",
+        "-Wno-c99-extensions",
+        "-Wno-deprecated",
+        "-Werror=implicit-function-declaration",
+        "-Werror=incompatible-pointer-types",
+        "-Wno-weak-vtables",  # TODO: Remove
+        "-Wno-weak-template-vtables",
+    ]
+    return flags
+
+
+@memoize()
+def get_default_link_flags():
+    flags = sysconfig.get_config_var("LDSHARED")
+    # remove the name of the linker program
+    flags = re.sub(r"^\w+[\w\.\-]+\s+", "", flags)
+    # remove -arch XXX flags, and add "-m64" to force 64-bit only builds
+    flags = re.sub(r"-arch \w+\s*", "", flags) + " -m64"
+    # Add "-isystem" path with system libraries
+    flags += " -isystem " + sysconfig.get_config_var("CONFINCLUDEPY")
+    return flags
+
+
+@memoize()
+def get_extra_link_args():
+    flags = ["-L%s" % os.path.join(get_llvm(), "lib"),
+             "-Wl,-rpath,%s" % get_rpath()]
+
+    if sys.platform == "linux":
+        flags += ["-lc++"]
+
+    if not("DTNOOPENMP" in os.environ):
+        flags += ["-fopenmp"]
+
+    if "DTCOVERAGE" in os.environ:
+        flags += ["--coverage", "-O0"]
+        # On linux we need to pass proper flag to clang linker which
+        # is not used for some reason at linux
+        if sys.platform == "linux":
+            flags += ["-shared"]
+    return flags
+
+
+
+#-------------------------------------------------------------------------------
+# Process extra commands
+#-------------------------------------------------------------------------------
+
+argcmd = sys.argv[1] if len(sys.argv) == 2 else ""
+
+if argcmd.startswith("get_"):
+    cmd = argcmd[4:]
+    if cmd == "EXTEXT":
+        print(sysconfig.get_config_var("EXT_SUFFIX"))
+    elif cmd == "CC":
+        print(get_cc())
+    elif cmd == "CCFLAGS":
+        flags = [get_default_compile_flags()] + get_extra_compile_flags()
+        print(" ".join(flags))
+    elif cmd == "LDFLAGS":
+        flags = [get_default_link_flags()] + get_extra_link_args()
+        print(" ".join(flags))
+    else:
+        raise RuntimeError("Unknown setup.py command '%s'" % argcmd)
+    sys.exit(0)
+
 
 
 #-------------------------------------------------------------------------------
@@ -54,66 +271,32 @@ print("\nFound packages: %r\n" % packages, file=stderr)
 #-------------------------------------------------------------------------------
 
 # Verify the LLVM4/LLVM5 installation directory
-for LLVMX in ["LLVM4", "LLVM5"]:
-    # Check whether there is 'llvm4' folder in the package folder
-    if LLVMX not in os.environ:
-        d = os.path.join(curdir, "datatable/" + LLVMX.lower())
-        if os.path.isdir(d):
-            os.environ[LLVMX] = d
-    if LLVMX not in os.environ:
-        continue
-
-    llvmlite_req = ("==0.20.0" if LLVMX == "LLVM4" else
-                    ">=0.21.0" if LLVMX == "LLVM5" else None)
-    llvmx = os.path.expanduser(os.environ[LLVMX])
-    if llvmx.endswith("/"):
-        llvmx = llvmx[:-1]
-    if " " in llvmx:
-        raise ValueError("%s directory %r contains spaces -- this is not "
-                         "supported, please move the folder, or make a symlink "
-                         "or provide a 'short' name (if on Windows)"
-                         % (LLVMX, llvmx))
-    if not os.path.isdir(llvmx):
-        raise ValueError("Variable %s = %r is not a directory"
-                         % (LLVMX, llvmx))
-    llvm_config = os.path.join(llvmx, "bin", "llvm-config")
-    clang = os.path.join(llvmx, "bin", "clang++")
-    libsdir = os.path.join(llvmx, "lib")
-    includes = os.path.join(llvmx, "include")
-    for f in [llvm_config, clang, libsdir, includes]:
-        if not os.path.exists(f):
-            raise RuntimeError("Cannot find %r inside the %s folder. "
-                               "Is this a valid installation?" % (LLVMX, f))
-    ver = subprocess.check_output([llvm_config, "--version"]).decode().strip()
-    if not ver.startswith(LLVMX[-1] + "."):
-        raise RuntimeError("Wrong LLVM version: expected %s.x but found %s"
-                           % (LLVMX[-1], ver))
-
-if not llvmlite_req:
-    raise RuntimeError("Environment variables LLVM4 or LLVM5 are not set. "
-                       "Please set one of these variables to the location of "
-                       "the Clang+Llvm distribution, which you can download "
-                       "from http://releases.llvm.org/download.html")
+llvmx, llvmver = get_llvm(True)
+llvm_config = os.path.join(llvmx, "bin", "llvm-config")
+clang = os.path.join(llvmx, "bin", "clang++")
+libsdir = os.path.join(llvmx, "lib")
+includes = os.path.join(llvmx, "include")
+llvmlite_req = ("==0.20.0" if llvmver == "LLVM4" else
+                ">=0.21.0" if llvmver == "LLVM5" else None)
+for f in [llvm_config, clang, libsdir, includes]:
+    if not os.path.exists(f):
+        raise RuntimeError("Cannot find %s folder. "
+                           "Is this a valid installation?" % f)
 
 # Compiler
-os.environ["CC"] = clang + " "
-os.environ["CXX"] = clang + " "
-if sysconfig.get_config_var("CONFINCLUDEPY"):
-    # Marking this directory as "isystem" prevents Clang from issuing warnings
-    # for those files
-    os.environ["CC"] += "-isystem " + sysconfig.get_config_var("CONFINCLUDEPY")
-    os.environ["CXX"] += "-isystem " + sysconfig.get_config_var("CONFINCLUDEPY")
+os.environ["CC"] = os.environ["CXX"] = get_cc(True)
 
 # Linker
-# os.environ["LDSHARED"] = clang
+# On linux we need to pass proper flag to clang linker which
+# is not used for some reason at linux
+if "DTCOVERAGE" in os.environ and sys.platform == "linux":
+    os.environ["LDSHARED"] = clang
 
 # Compute runtime libpath with respect to bundled LLVM libraries
 if sys.platform == "darwin":
     extra_libs = ["libomp.dylib"]
-    rpath = "@loader_path/."
 else:
     extra_libs = ["libomp.so", "libc++.so.1", "libc++abi.so.1"]
-    rpath = "$ORIGIN/."
 
 # Copy system libraries into the datatable/lib folder, so that they can be
 # packaged with the wheel
@@ -126,105 +309,16 @@ for libname in extra_libs:
         print("Copying %s to %s" % (srcfile, tgtfile), file=stderr)
         shutil.copy(srcfile, tgtfile)
 
-# Add linker flags: path to system libraries, and the rpath
-os.environ["LDFLAGS"] = "-L%s -Wl,-rpath,%s" % (libsdir, rpath)
-
 # Force to build for a 64-bit platform only
 os.environ["ARCHFLAGS"] = "-m64"
 
 # If we need to install llvmlite, this would help
 os.environ["LLVM_CONFIG"] = llvm_config
 
-print("Setting environment variables:")
+print("Setting environment variables:", file=stderr)
 for n in ["CC", "CXX", "LDFLAGS", "ARCHFLAGS", "LLVM_CONFIG"]:
-    print("  %s = %s" % (n, os.environ[n]), file=stderr)
+    print("  %s = %s" % (n, os.environ.get(n, "")), file=stderr)
 
-
-#-------------------------------------------------------------------------------
-# Settings for building the extension
-#-------------------------------------------------------------------------------
-extra_compile_args = ["-std=gnu++11", "-stdlib=libc++", "-x", "c++"]
-
-# Include path to C++ header files
-extra_compile_args += ["-I" + llvmx + "/include/c++/v1",
-                       "-isystem " + llvmx + "/include/c++/v1"]
-
-# This flag becomes C-level macro DTPY, which indicates that we are compiling
-# (Py)datatable. This is used for example in fread.c to distinguish between
-# Python/R datatable.
-extra_compile_args += ["-DDTPY"]
-
-# This macro enables all `assert` statements at the C level. By default they
-# are disabled...
-extra_compile_args += ["-DNONDEBUG"]
-
-# Ignored warnings:
-#   -Wcovered-switch-default: we add `default` statement to
-#       an exhaustive switch to guard against memory
-#       corruption and careless enum definition expansion.
-#   -Wfloat-equal: this warning is just plain wrong...
-#       Comparing x == 0 or x == 1 is always safe.
-#   -Wgnu-statement-expression: we use GNU statement-as-
-#       expression syntax in some macros...
-#   -Wswitch-enum: generates spurious warnings about missing
-#       cases even if `default` clause is present. -Wswitch
-#       does not suffer from this drawback.
-#   -Wdeprecated: warning about compiling .c files under C++
-#       mode... we should just rename those files at some point.
-extra_compile_args += [
-    "-Weverything",
-    "-Wno-covered-switch-default",
-    "-Wno-float-equal",
-    "-Wno-gnu-statement-expression",
-    "-Wno-switch-enum",
-    "-Wno-old-style-cast",
-    "-Wno-c++98-compat-pedantic",
-    "-Wno-nested-anon-types",
-    "-Wno-c99-extensions",
-    "-Wno-deprecated",
-    "-Werror=implicit-function-declaration",
-    "-Werror=incompatible-pointer-types",
-    "-Wno-weak-vtables",  # TODO: Remove
-    "-Wno-weak-template-vtables",
-]
-extra_link_args = [
-    "-v",
-]
-
-if sys.platform == "linux":
-    extra_link_args += ["-lc++"]
-
-if "DTNOOPENMP" in os.environ:
-    extra_compile_args.append("-DDTNOOMP")
-else:
-    extra_compile_args.insert(0, "-fopenmp")
-    extra_link_args.append("-fopenmp")
-
-if "DTCOVERAGE" in os.environ:
-    # On linux we need to pass proper flag to clang linker which
-    # is not used for some reason at linux
-    if sys.platform == "linux":
-        os.environ["LDSHARED"] = clang
-        extra_link_args += ["-shared"]
-    extra_compile_args += ["-g", "--coverage", "-O0"]
-    extra_link_args += ["--coverage", "-O0"]
-
-if "DTDEBUG" in os.environ:
-    extra_compile_args += ["-ggdb", "-O0"]
-
-if "CI_EXTRA_COMPILE_ARGS" in os.environ:
-    extra_compile_args += [os.environ["CI_EXTRA_COMPILE_ARGS"]]
-
-
-# Test dependencies exposed as extras, based on:
-# https://stackoverflow.com/questions/29870629/pip-install-test-dependencies-for-tox-from-setup-py
-test_deps = [
-    "pandas",
-    "pytest>=3.1",
-    "pytest-cov",
-    "pytest-benchmark>=3.1",
-    "pytest-ordering>=0.5",
-]
 
 
 #-------------------------------------------------------------------------------
@@ -232,7 +326,7 @@ test_deps = [
 #-------------------------------------------------------------------------------
 setup(
     name="datatable",
-    version=version,
+    version=get_version(),
 
     description="Python library for fast multi-threaded data manipulation and "
                 "munging.",
@@ -258,7 +352,7 @@ setup(
     keywords=["datatable", "data", "dataframe", "frame", "data.table",
               "munging", "numpy", "pandas", "data processing", "ETL"],
 
-    packages=packages,
+    packages=get_py_sources(),
 
     # Runtime dependencies
     install_requires=[
@@ -268,10 +362,10 @@ setup(
         "psutil"
     ],
 
-    tests_require=test_deps,
+    tests_require=get_test_dependencies(),
 
     extras_require={
-        "testing": test_deps
+        "testing": get_test_dependencies()
     },
 
     zip_safe=True,
@@ -280,9 +374,9 @@ setup(
         Extension(
             "datatable/lib/_datatable",
             include_dirs=["c"],
-            sources=c_sources,
-            extra_compile_args=extra_compile_args,
-            extra_link_args=extra_link_args,
+            sources=get_c_sources(),
+            extra_compile_args=get_extra_compile_flags(),
+            extra_link_args=get_extra_link_args(),
         ),
     ],
 


### PR DESCRIPTION
This PR tries to address the problem with traditional (`setup.py`-based compilation of the extension): the default mechanism recompiles everything from scratch every time. The impact of this was negligible at the beginning of the project, but now there are 50+ source files, and compilation time is no longer trivial. It will get only worse over time.

In order to combat this, this PR proposes new "fast" compilation mode - via builtin Make mechanism - trying to match all the flags and options from the setup.py. The "fast" mode should speed up the development, but is not recommended for building production wheels.