### PR TITLE
Fread: do not forget to empty local buffers when pushing

### DIFF
--- a/c/csv/reader_fread.cc
+++ b/c/csv/reader_fread.cc
@@ -528,6 +528,7 @@ void FreadLocalParseContext::push_buffers() {
     }
     j++;
   }
+  used_nrows = 0;
 }
 
 

--- a/c/csv/reader_utils.cc
+++ b/c/csv/reader_utils.cc
@@ -7,6 +7,7 @@
 //------------------------------------------------------------------------------
 #include "csv/reader.h"
 #include "csv/fread.h"   // temporary
+#include "utils/assert.h"
 #include "utils/exceptions.h"
 #include "utils/omp.h"
 


### PR DESCRIPTION
This internal bug was probably causing unnecessary memory allocations when parsing a file...