### PR TITLE
Smarter dependency resolution mechanism in 'make fast'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,203 +178,242 @@ $(BUILDDIR)/_datatable.so: $(fast_objects)
 	@$(CC) $(LDFLAGS) -o $@ $+
 	@$(MAKE) --no-print-directory post-fast
 
-$(BUILDDIR)/capi.o : c/capi.cc c/rowindex.h c/capi.h c/datatable.h
+capi_h: c/capi.h
+column_h: c/column.h memorybuf_h rowindex_h stats_h types_h
+columnset_h: c/columnset.h column_h datatable_h rowindex_h types_h
+csv_dtoa_h: c/csv/dtoa.h
+csv_fread_h: c/csv/fread.h csv_reader_h memorybuf_h utils_h utils_omp_h
+csv_freadLookups_h: c/csv/freadLookups.h
+csv_itoa_h: c/csv/itoa.h
+csv_py_csv_h: c/csv/py_csv.h py_utils_h
+csv_reader_arff_h: c/csv/reader_arff.h csv_reader_h
+csv_reader_fread_h: c/csv/reader_fread.h csv_fread_h csv_py_csv_h csv_reader_h memorybuf_h
+csv_reader_h: c/csv/reader.h column_h datatable_h memorybuf_h utils_pyobj_h writebuf_h
+csv_reader_parsers_h: c/csv/reader_parsers.h csv_fread_h
+csv_writer_h: c/csv/writer.h datatable_h utils_h writebuf_h
+datatable_check_h: c/datatable_check.h
+datatable_h: c/datatable.h column_h datatable_check_h types_h
+encodings_h: c/encodings.h
+expr_py_expr_h: c/expr/py_expr.h column_h py_utils_h
+memorybuf_h: c/memorybuf.h datatable_check_h mmm_h writebuf_h
+mmm_h: c/mmm.h
+py_column_h: c/py_column.h column_h py_datatable_h py_utils_h
+py_columnset_h: c/py_columnset.h datatable_h py_utils_h rowindex_h
+py_datatable_h: c/py_datatable.h datatable_h py_utils_h
+py_datawindow_h: c/py_datawindow.h
+py_encodings_h: c/py_encodings.h encodings_h
+py_rowindex_h: c/py_rowindex.h rowindex_h
+py_types_h: c/py_types.h datatable_h types_h utils_assert_h
+py_utils_h: c/py_utils.h utils_h utils_exceptions_h
+rowindex_h: c/rowindex.h column_h datatable_h
+sort_h: c/sort.h
+stats_h: c/stats.h datatable_check_h types_h
+types_h: c/types.h
+utils_assert_h: c/utils/assert.h
+utils_exceptions_h: c/utils/exceptions.h types_h
+utils_file_h: c/utils/file.h
+utils_h: c/utils.h utils_exceptions_h
+utils_omp_h: c/utils/omp.h
+utils_pyobj_h: c/utils/pyobj.h
+writebuf_h: c/writebuf.h utils_file_h
+
+
+$(BUILDDIR)/capi.o : c/capi.cc capi_h datatable_h rowindex_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/column.o : c/column.cc c/rowindex.h c/py_utils.h c/utils/file.h c/datatable_check.h c/column.h c/utils.h c/utils/assert.h c/sort.h
+$(BUILDDIR)/column.o : c/column.cc column_h datatable_check_h py_utils_h rowindex_h sort_h utils_h utils_assert_h utils_file_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/column_bool.o : c/column_bool.cc c/column.h c/utils/omp.h
+$(BUILDDIR)/column_bool.o : c/column_bool.cc column_h utils_omp_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/column_from_pylist.o : c/column_from_pylist.cc c/py_types.h c/column.h c/utils.h
+$(BUILDDIR)/column_from_pylist.o : c/column_from_pylist.cc column_h py_types_h utils_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/column_fw.o : c/column_fw.cc c/column.h c/utils.h c/utils/omp.h c/utils/assert.h
+$(BUILDDIR)/column_fw.o : c/column_fw.cc column_h utils_h utils_assert_h utils_omp_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/column_int.o : c/column_int.cc c/column.h c/py_types.h c/py_utils.h c/utils/omp.h
+$(BUILDDIR)/column_int.o : c/column_int.cc column_h py_types_h py_utils_h utils_omp_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/column_pyobj.o : c/column_pyobj.cc c/column.h
+$(BUILDDIR)/column_pyobj.o : c/column_pyobj.cc column_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/column_real.o : c/column_real.cc c/column.h c/py_utils.h c/utils/omp.h
+$(BUILDDIR)/column_real.o : c/column_real.cc column_h py_utils_h utils_omp_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/column_string.o : c/column_string.cc c/column.h c/datatable_check.h c/encodings.h c/py_utils.h c/utils.h c/utils/assert.h
+$(BUILDDIR)/column_string.o : c/column_string.cc column_h datatable_check_h encodings_h py_utils_h utils_h utils_assert_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/columnset.o : c/columnset.cc c/columnset.h c/utils.h c/utils/exceptions.h
+$(BUILDDIR)/columnset.o : c/columnset.cc columnset_h utils_h utils_exceptions_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/csv/fread.o : c/csv/fread.cc c/csv/fread.h c/csv/freadLookups.h c/csv/reader.h c/csv/reader_fread.h c/csv/reader_parsers.h
+$(BUILDDIR)/csv/fread.o : c/csv/fread.cc csv_fread_h csv_freadLookups_h csv_reader_h csv_reader_fread_h csv_reader_parsers_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/csv/py_csv.o : c/csv/py_csv.cc c/csv/py_csv.h c/csv/reader.h c/csv/writer.h c/py_datatable.h c/py_utils.h c/utils.h c/utils/omp.h c/utils/pyobj.h
+$(BUILDDIR)/csv/py_csv.o : c/csv/py_csv.cc csv_py_csv_h csv_reader_h csv_writer_h py_datatable_h py_utils_h utils_h utils_omp_h utils_pyobj_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/csv/reader.o : c/csv/reader.cc c/csv/reader.h c/csv/reader_arff.h c/csv/reader_fread.h c/utils/exceptions.h c/utils/omp.h
+$(BUILDDIR)/csv/reader.o : c/csv/reader.cc csv_reader_h csv_reader_arff_h csv_reader_fread_h utils_exceptions_h utils_omp_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/csv/reader_arff.o : c/csv/reader_arff.cc c/csv/reader_arff.h c/utils/exceptions.h
+$(BUILDDIR)/csv/reader_arff.o : c/csv/reader_arff.cc csv_reader_arff_h utils_exceptions_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/csv/reader_fread.o : c/csv/reader_fread.cc c/column.h c/csv/fread.h c/csv/reader.h c/csv/reader_fread.h c/csv/reader_parsers.h c/datatable.h c/py_datatable.h c/py_encodings.h c/py_utils.h c/utils.h c/utils/assert.h c/utils/file.h c/utils/pyobj.h
+$(BUILDDIR)/csv/reader_fread.o : c/csv/reader_fread.cc column_h csv_fread_h csv_reader_h csv_reader_fread_h csv_reader_parsers_h datatable_h py_datatable_h py_encodings_h py_utils_h utils_h utils_assert_h utils_file_h utils_pyobj_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/csv/reader_parsers.o : c/csv/reader_parsers.cc c/csv/reader_parsers.h
+$(BUILDDIR)/csv/reader_parsers.o : c/csv/reader_parsers.cc csv_reader_parsers_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/csv/reader_utils.o : c/csv/reader_utils.cc c/csv/fread.h c/csv/reader.h c/utils/exceptions.h c/utils/omp.h
+$(BUILDDIR)/csv/reader_utils.o : c/csv/reader_utils.cc csv_fread_h csv_reader_h utils_exceptions_h utils_omp_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/csv/writer.o : c/csv/writer.cc c/column.h c/csv/dtoa.h c/csv/itoa.h c/csv/writer.h c/datatable.h c/memorybuf.h c/types.h c/utils.h c/utils/omp.h
+$(BUILDDIR)/csv/writer.o : c/csv/writer.cc column_h csv_dtoa_h csv_itoa_h csv_writer_h datatable_h memorybuf_h types_h utils_h utils_omp_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/datatable.o : c/datatable.cc c/datatable.h c/datatable_check.h c/py_utils.h c/rowindex.h c/types.h c/utils/omp.h
+$(BUILDDIR)/datatable.o : c/datatable.cc datatable_h datatable_check_h py_utils_h rowindex_h types_h utils_omp_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/datatable_cbind.o : c/datatable_cbind.cc c/datatable.h c/rowindex.h c/utils.h c/utils/assert.h
+$(BUILDDIR)/datatable_cbind.o : c/datatable_cbind.cc datatable_h rowindex_h utils_h utils_assert_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/datatable_check.o : c/datatable_check.cc c/datatable_check.h c/utils.h
+$(BUILDDIR)/datatable_check.o : c/datatable_check.cc datatable_check_h utils_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/datatable_load.o : c/datatable_load.cc c/datatable.h c/utils.h c/utils/assert.h
+$(BUILDDIR)/datatable_load.o : c/datatable_load.cc datatable_h utils_h utils_assert_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/datatable_rbind.o : c/datatable_rbind.cc c/column.h c/datatable.h c/utils.h c/utils/assert.h
+$(BUILDDIR)/datatable_rbind.o : c/datatable_rbind.cc column_h datatable_h utils_h utils_assert_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/datatablemodule.o : c/datatablemodule.c c/capi.h c/csv/py_csv.h c/csv/writer.h c/expr/py_expr.h c/py_column.h c/py_columnset.h c/py_datatable.h c/py_datawindow.h c/py_encodings.h c/py_rowindex.h c/py_types.h c/py_utils.h
+$(BUILDDIR)/datatablemodule.o : c/datatablemodule.c capi_h csv_py_csv_h csv_writer_h expr_py_expr_h py_column_h py_columnset_h py_datatable_h py_datawindow_h py_encodings_h py_rowindex_h py_types_h py_utils_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/encodings.o : c/encodings.c c/encodings.h
+$(BUILDDIR)/encodings.o : c/encodings.c encodings_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/expr/binaryop.o : c/expr/binaryop.cc c/expr/py_expr.h c/types.h c/utils/exceptions.h
+$(BUILDDIR)/expr/binaryop.o : c/expr/binaryop.cc expr_py_expr_h types_h utils_exceptions_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/expr/py_expr.o : c/expr/py_expr.cc c/expr/py_expr.h c/py_column.h c/utils/pyobj.h
+$(BUILDDIR)/expr/py_expr.o : c/expr/py_expr.cc expr_py_expr_h py_column_h utils_pyobj_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/expr/reduceop.o : c/expr/reduceop.cc c/expr/py_expr.h c/types.h
+$(BUILDDIR)/expr/reduceop.o : c/expr/reduceop.cc expr_py_expr_h types_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/expr/unaryop.o : c/expr/unaryop.cc c/expr/py_expr.h c/types.h
+$(BUILDDIR)/expr/unaryop.o : c/expr/unaryop.cc expr_py_expr_h types_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/memorybuf.o : c/memorybuf.cc c/datatable_check.h c/memorybuf.h c/py_utils.h c/utils.h c/utils/assert.h c/utils/file.h
+$(BUILDDIR)/memorybuf.o : c/memorybuf.cc datatable_check_h memorybuf_h py_utils_h utils_h utils_assert_h utils_file_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/mmm.o : c/mmm.cc c/mmm.h
+$(BUILDDIR)/mmm.o : c/mmm.cc mmm_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/py_buffers.o : c/py_buffers.cc c/column.h c/encodings.h c/py_column.h c/py_datatable.h c/py_types.h c/py_utils.h c/utils/exceptions.h
+$(BUILDDIR)/py_buffers.o : c/py_buffers.cc column_h encodings_h py_column_h py_datatable_h py_types_h py_utils_h utils_exceptions_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/py_column.o : c/py_column.cc c/py_column.h c/sort.h c/py_types.h c/writebuf.h c/utils/pyobj.h
+$(BUILDDIR)/py_column.o : c/py_column.cc py_column_h py_types_h sort_h utils_pyobj_h writebuf_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/py_columnset.o : c/py_columnset.cc c/columnset.h c/py_column.h c/py_columnset.h c/py_datatable.h c/py_rowindex.h c/py_types.h c/py_utils.h c/utils.h c/utils/pyobj.h
+$(BUILDDIR)/py_columnset.o : c/py_columnset.cc columnset_h py_column_h py_columnset_h py_datatable_h py_rowindex_h py_types_h py_utils_h utils_h utils_pyobj_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/py_datatable.o : c/py_datatable.cc c/datatable.h c/datatable_check.h c/py_column.h c/py_columnset.h c/py_datatable.h c/py_datawindow.h c/py_rowindex.h c/py_types.h c/py_utils.h
+$(BUILDDIR)/py_datatable.o : c/py_datatable.cc datatable_h datatable_check_h py_column_h py_columnset_h py_datatable_h py_datawindow_h py_rowindex_h py_types_h py_utils_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/py_datatable_fromlist.o : c/py_datatable_fromlist.c c/column.h c/memorybuf.h c/py_datatable.h c/py_types.h c/py_utils.h
+$(BUILDDIR)/py_datatable_fromlist.o : c/py_datatable_fromlist.c column_h memorybuf_h py_datatable_h py_types_h py_utils_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/py_datawindow.o : c/py_datawindow.c c/datatable.h c/py_datatable.h c/py_datawindow.h c/py_types.h c/py_utils.h c/rowindex.h
+$(BUILDDIR)/py_datawindow.o : c/py_datawindow.c datatable_h py_datatable_h py_datawindow_h py_types_h py_utils_h rowindex_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/py_encodings.o : c/py_encodings.c c/py_encodings.h c/py_utils.h c/utils/assert.h
+$(BUILDDIR)/py_encodings.o : c/py_encodings.c py_encodings_h py_utils_h utils_assert_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/py_rowindex.o : c/py_rowindex.c c/py_column.h c/py_datatable.h c/py_rowindex.h c/py_utils.h
+$(BUILDDIR)/py_rowindex.o : c/py_rowindex.c py_column_h py_datatable_h py_rowindex_h py_utils_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/py_types.o : c/py_types.c c/py_types.h c/py_utils.h
+$(BUILDDIR)/py_types.o : c/py_types.c py_types_h py_utils_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/py_utils.o : c/py_utils.c c/py_datatable.h c/py_utils.h
+$(BUILDDIR)/py_utils.o : c/py_utils.c py_datatable_h py_utils_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/rowindex.o : c/rowindex.cc c/datatable_check.h c/rowindex.h c/types.h c/utils.h c/utils/assert.h c/utils/omp.h
+$(BUILDDIR)/rowindex.o : c/rowindex.cc datatable_check_h rowindex_h types_h utils_h utils_assert_h utils_omp_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/sort.o : c/sort.cc c/column.h c/rowindex.h c/sort.h c/types.h c/utils.h c/utils/assert.h c/utils/omp.h
+$(BUILDDIR)/sort.o : c/sort.cc column_h rowindex_h sort_h types_h utils_h utils_assert_h utils_omp_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/stats.o : c/stats.cc c/column.h c/rowindex.h c/stats.h c/utils.h c/utils/omp.h
+$(BUILDDIR)/stats.o : c/stats.cc column_h rowindex_h stats_h utils_h utils_omp_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/types.o : c/types.c c/types.h c/utils.h c/utils/assert.h
+$(BUILDDIR)/types.o : c/types.c types_h utils_h utils_assert_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/utils.o : c/utils.c c/utils.h
+$(BUILDDIR)/utils.o : c/utils.c utils_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/utils/exceptions.o : c/utils/exceptions.cc c/utils/exceptions.h
+$(BUILDDIR)/utils/exceptions.o : c/utils/exceptions.cc utils_exceptions_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/utils/file.o : c/utils/file.cc c/utils.h c/utils/file.h
+$(BUILDDIR)/utils/file.o : c/utils/file.cc utils_h utils_file_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/utils/pyobj.o : c/utils/pyobj.cc c/py_column.h c/py_datatable.h c/py_types.h c/utils/exceptions.h c/utils/pyobj.h
+$(BUILDDIR)/utils/pyobj.o : c/utils/pyobj.cc py_column_h py_datatable_h py_types_h utils_exceptions_h utils_pyobj_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/writebuf.o : c/writebuf.cc c/memorybuf.h c/utils.h c/utils/omp.h c/writebuf.h
+$(BUILDDIR)/writebuf.o : c/writebuf.cc memorybuf_h utils_h utils_omp_h writebuf_h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
-

--- a/fastcheck.py
+++ b/fastcheck.py
@@ -9,9 +9,16 @@ import re
 import sys
 
 rx_include = re.compile(r'#include\s+"(.*?)"')
+rx_targeth = re.compile(r'^(\w+_h)\s*:\s*(.*)')
 
 
 def get_files():
+    """
+    Return the list of all source/header files in `c/` directory.
+
+    The files will have pathnames relative to the current folder, for example
+    "c/csv/reader_utils.cc".
+    """
     sources = []
     headers = []
     for dirpath, _, filenames in os.walk("c"):
@@ -25,6 +32,12 @@ def get_files():
 
 
 def find_includes(filename):
+    """
+    Find user includes (no system includes) requested from given source file.
+
+    All .h files will be given relative to the current folder, e.g.
+    ["c/rowindex.h", "c/column.h"].
+    """
     includes = []
     with open(filename, "r", encoding="utf-8") as inp:
         for line in inp:
@@ -40,6 +53,13 @@ def find_includes(filename):
 
 
 def build_headermap(headers):
+    """
+    Construct dictionary {header_file : set_of_included_files}.
+
+    This function operates on "real" set of includes, in the sense that it
+    parses each header file to check which files are included from there.
+    """
+    # TODO: what happens if some headers are circularly dependent?
     headermap = {}
     for hfile in headers:
         headermap[hfile] = None
@@ -51,38 +71,28 @@ def build_headermap(headers):
                 raise ValueError("Unknown header \"%s\" included from %s"
                                  % (f, hfile))
         headermap[hfile] = set(inc)
-    transitively_extend(headermap)
     return headermap
 
 
-def build_sourcemap(sources, headermap):
+def build_sourcemap(sources):
+    """
+    Similar to build_headermap(), but builds a dictionary of includes from
+    the "source" files (i.e. ".c/.cc" files).
+    """
     sourcemap = {}
     for sfile in sources:
         inc = find_includes(sfile)
-        for f in inc:
-            if f not in headermap:
-                raise ValueError("Unknown header \"%s\" included from %s"
-                                 % (f, sfile))
         sourcemap[sfile] = set(inc)
     return sourcemap
 
 
-def transitively_extend(nodemap):
-    modified = True
-    while modified:
-        modified = False
-        for node in nodemap:
-            values = nodemap[node]
-            len0 = len(values)
-            for n in list(values):
-                values |= nodemap[n]
-            if len(values) > len0:
-                modified = True
-            nodemap[node] = values
-
-
 def parse_makefile():
+    """
+    Parse Makefile in order to detect all declarations related to "fast"
+    compilation.
+    """
     objects_map = {}
+    headers_map = {}
     with open("Makefile", "r", encoding="utf-8") as inp:
         read_objects = False
         for iline, line in enumerate(inp):
@@ -92,11 +102,9 @@ def parse_makefile():
                     read_objects = False
                 else:
                     objects_map[line] = None
-                continue
-            if line.startswith("fast_objects"):
+            elif line.startswith("fast_objects"):
                 read_objects = True
-                continue
-            if line.startswith("$(BUILDDIR)/"):
+            elif line.startswith("$(BUILDDIR)/"):
                 sline = line.strip()
                 sline = sline[len("$(BUILDDIR)/"):]
                 obj, deps = sline.split(":")
@@ -111,6 +119,10 @@ def parse_makefile():
                 deps = deps.strip()
                 depslist = deps.split(" ")
                 objects_map[obj] = depslist
+            else:
+                mm = rx_targeth.match(line)
+                if mm:
+                    headers_map[mm.group(1)] = mm.group(2).split(" ")
         for obj, deps in objects_map.items():
             if deps is None:
                 raise ValueError("Object file `%s` is present in "
@@ -120,55 +132,81 @@ def parse_makefile():
             if not deps:
                 raise ValueError("Dependencies for object file `%s` are "
                                  "missing" % obj)
-    return objects_map
+    return objects_map, headers_map
 
 
-def verify_dependencies(sourcemap, objmap):
-    # `sourcemap`:
-    #     dict where keys are all .c/.cc filenames in the project, and values
-    #     are sets of includes in each of those files.
-    # `headermap`:
-    #     same as `sourcemap`, but keys are .h files.
-    # `objmap`:
-    #     dictionary where the keys are all object files that are declared in
-    #     the Makefile, and values are all declared dependencies of those
-    #     object files.
-    for srcfile in sourcemap:
-        assert srcfile.startswith("c/")
-        f = srcfile[len("c/"):]
-        if f.endswith(".c"):
-            f = f[:-len(".c")] + ".o"
-        elif f.endswith(".cc"):
-            f = f[:-len(".cc")] + ".o"
-        else:
-            raise ValueError("Unexpected source file name: %s" % srcfile)
-        if f not in objmap:
+def headerfile_to_key(hdrfile):
+    assert hdrfile.startswith("c/")
+    return hdrfile[2:].replace(".", "_").replace("/", "_")
+
+
+def sourcefile_to_obj(srcfile):
+    assert srcfile.startswith("c/")
+    if srcfile.endswith(".c"):
+        return srcfile[2:-len(".c")] + ".o"
+    elif srcfile.endswith(".cc"):
+        return srcfile[2:-len(".cc")] + ".o"
+    else:
+        raise ValueError("Unexpected source file name: %s" % srcfile)
+
+
+def verify_dependencies(realsrcs, realhdrs, makeobjs, makehdrs):
+    """
+    realsrcs:
+        dict where keys are names of all .c/.cc files in the project, and values
+        are sets of includes in each of those files.
+    realhdrs:
+        same as `realsrcs`, but keys are .h files.
+    makeobjs:
+        dictionary where the keys are all object files that are declared in
+        the Makefile, and values are all declared dependencies of those
+        object files.
+    makehdrs:
+        dictionary where keys are target names corresponding to each header
+        file, and values are sets of dependencies for those targets
+    """
+    for hdrfile in realhdrs:
+        hdrkey = headerfile_to_key(hdrfile)
+        actual_deps = sorted(realhdrs[hdrfile])
+        expect_deps = [hdrfile] + [headerfile_to_key(k) for k in actual_deps]
+        if hdrkey not in makehdrs:
+            raise ValueError("Missing target '%s' in header file. Include "
+                             "the following line in Makefile:\n"
+                             "%s: %s"
+                             % (hdrkey, hdrkey, " ".join(expect_deps)))
+        make_deps = makehdrs[hdrkey]
+        del makehdrs[hdrkey]
+        if set(make_deps) != set(expect_deps):
+            raise ValueError("Invalid dependencies for target '%s'. Include "
+                             "the following line in Makefile:\n"
+                             "%s: %s"
+                             % (hdrkey, hdrkey, " ".join(expect_deps)))
+    if makehdrs:
+        raise ValueError("Makefile has targets %r which do not correspond to "
+                         "any existing header files." % list(makehdrs.keys()))
+
+    for srcfile in sorted(realsrcs):
+        objkey = sourcefile_to_obj(srcfile)
+        if objkey not in makeobjs:
             raise ValueError("Source file `%s` has no corresponding "
                              "`$(BUILDDIR)/%s` target in the Makefile."
-                             % (srcfile, f))
-    for objfile in objmap:
-        deps = objmap[objfile]
-        srcfile = deps[0]
-        makefile_deps = set(deps[1:])
-        if srcfile not in sourcemap:
-            raise ValueError("Unknown dependency `%s` stated for object file "
-                             "`%s` in the Makefile" % (srcfile, objfile))
-        actual_deps = sourcemap[srcfile]
-        if makefile_deps != actual_deps:
-            diff1 = makefile_deps - actual_deps
-            diff2 = actual_deps - makefile_deps
-            if diff1:
-                raise ValueError("Source file `%s` is declared in the Makefile "
-                                 "to depend on %r, while in reality it doesn't "
-                                 "depend on them." % (srcfile, diff1))
-            if diff2:
-                raise ValueError("Source file `%s` depends on %r, however these"
-                                 " dependencies were not declared in the "
-                                 "Makefile.\n"
-                                 "Include the following line in the Makefile:\n"
-                                 "$(BUILDDIR)/%s : %s %s"
-                                 % (srcfile, diff2, objfile, srcfile,
-                                    " ".join(sorted(actual_deps))))
+                             % (srcfile, objkey))
+        actual_deps = sorted(realsrcs[srcfile])
+        expect_deps = [srcfile] + [headerfile_to_key(h) for h in actual_deps]
+        make_deps = makeobjs[objkey]
+        del makeobjs[objkey]
+        if set(make_deps) != set(expect_deps):
+            # print("$(BUILDDIR)/%s : %s" % (objkey, " ".join(expect_deps)))
+            # print("\t@echo • Compiling $<")
+            # print("\t@$(CC) -c $< $(CCFLAGS) -o $@\n")
+            # continue
+            raise ValueError("Invalid dependencies for object file '%s'. "
+                             "Please include the following line in Makefile:\n"
+                             "$(BUILDDIR)/%s : %s"
+                             % (objkey, objkey, " ".join(expect_deps)))
+    if makeobjs:
+        raise ValueError("Makefile has targets %r which do not correspond to "
+                         "any existing source files." % list(makeobjs.keys()))
 
 
 def create_build_directories(objmap):
@@ -180,10 +218,10 @@ def create_build_directories(objmap):
 
 def main():
     sources, headers = get_files()
-    headermap = build_headermap(headers)
-    sourcemap = build_sourcemap(sources, headermap)
-    objmap = parse_makefile()
-    verify_dependencies(sourcemap, objmap)
+    realhdrs = build_headermap(headers)
+    realsrcs = build_sourcemap(sources)
+    objmap, makehdrs = parse_makefile()
+    verify_dependencies(realsrcs, realhdrs, objmap, makehdrs)
     create_build_directories(objmap)
 
 


### PR DESCRIPTION
Instead of trying to transitively extend the dependency graph ourselves, now rely on Make's built-in mechanism to do the same. This also prevents us from problems with circular dependencies.
In addition, changes to a single source/header file should now affect a single line of Makefile only, which reduces maintenance burden.