### PR TITLE
Columns of type obj64 will no longer be saved, preventing a later crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fread on an empty file now produces an empty DataTable, instead of an exception.
 - Fread's parameter `skip_lines` was replaced with `skip_to_line`, so that it's
   more in sync with the similar argument `skip_to_string`.
+- When saving datatable containing "obj64" columns, they will no longer be saved,
+  and user warning will be shown (previously saving this column would eventually
+  lead to a segfault).
+
 
 #### Fixed
 - `datatable` will no longer cause the C locale settings to change upon importing.

--- a/c/column.h
+++ b/c/column.h
@@ -497,6 +497,7 @@ protected:
   PyObjectColumn();
   // TODO: This should be corrected when PyObjectStats is implemented
   Stats* get_stats() const override { return nullptr; }
+  void open_mmap(const std::string& filename) override;
 
   // void cast_into(BoolColumn*) const override;
   // void cast_into(IntColumn<int8_t>*) const override;

--- a/c/column_fw.cc
+++ b/c/column_fw.cc
@@ -52,8 +52,8 @@ template <typename T>
 void FwColumn<T>::open_mmap(const std::string& filename) {
   assert(!ri && !mbuf);
   mbuf = new MemmapMemBuf(filename);
-  if (mbuf->size() != static_cast<size_t>(nrows) * sizeof(T)) {
-    size_t exp_size = static_cast<size_t>(nrows) * sizeof(T);
+  size_t exp_size = static_cast<size_t>(nrows) * sizeof(T);
+  if (mbuf->size() != exp_size) {
     throw Error() << "File \"" << filename <<
         "\" cannot be used to create a column with " << nrows <<
         " rows. Expected file size of " << exp_size <<
@@ -72,6 +72,7 @@ void FwColumn<T>::init_xbuf(Py_buffer* pybuffer) {
   }
   mbuf = new ExternalMemBuf(pybuffer->buf, pybuffer, exp_buf_len);
 }
+
 
 
 //==============================================================================

--- a/c/column_pyobj.cc
+++ b/c/column_pyobj.cc
@@ -40,6 +40,18 @@ SType PyObjectColumn::stype() const {
 }
 
 
+// "PyObj" columns cannot be properly saved. So if somehow they were, then when
+// opening, we'll just fill the column with NAs.
+void PyObjectColumn::open_mmap(const std::string&) {
+  assert(!ri && !mbuf);
+  mbuf = new MemoryMemBuf(static_cast<size_t>(nrows) * sizeof(PyObject*));
+  PyObject** data = this->elements();
+  for (int64_t i = 0; i < nrows; ++i) {
+    data[i] = Py_None;
+    Py_INCREF(Py_None);
+  }
+}
+
 
 //----- Type casts -------------------------------------------------------------
 

--- a/c/datatable_load.cc
+++ b/c/datatable_load.cc
@@ -80,7 +80,7 @@ DataTable* DataTable::load(DataTable* colspec, int64_t nrows, const std::string&
         size_t ssta = static_cast<size_t>(abs(offs[i - 1]));
         size_t send = static_cast<size_t>(abs(offs[i]));
         size_t slen = static_cast<size_t>(send - ssta);
-        if (slen != 3) {
+        if (!(slen == 3 || slen==2)) {
             throw ValueError() << "Incorrect stype's length: " << slen;
         }
         std::string stype_str(cols->strdata() + ssta, slen);

--- a/c/py_column.cc
+++ b/c/py_column.cc
@@ -62,13 +62,13 @@ PyObject* get_mtype(pycolumn::obj* self) {
 
 PyObject* get_stype(pycolumn::obj* self) {
   SType stype = self->ref->stype();
-  return incref(py_stype_names[stype]);
+  return incref(py_stype_objs[stype]);
 }
 
 
 PyObject* get_ltype(pycolumn::obj* self) {
   SType stype = self->ref->stype();
-  return incref(py_ltype_names[stype_info[stype].ltype]);
+  return incref(py_ltype_objs[stype_info[stype].ltype]);
 }
 
 

--- a/c/types.c
+++ b/c/types.c
@@ -144,47 +144,59 @@ void init_types(void)
  */
 SType stype_from_string(const std::string& str)
 {
-  assert(str.length() == 3);
+  assert(str.length() == 3 || str.length() == 2);
   char s0 = str[0], s1 = str[1], s2 = str[2];
-    if (s0 == 'i') {
-        if (s2 == 'b') {
-            if (s1 == '1') return ST_BOOLEAN_I1;
-        } else if (s2 == 'i') {
-            if (s1 == '1') return ST_INTEGER_I1;
-            if (s1 == '2') return ST_INTEGER_I2;
-            if (s1 == '4') return ST_INTEGER_I4;
-            if (s1 == '8') return ST_INTEGER_I8;
-        } else if (s2 == 'r') {
-            if (s1 == '2') return ST_REAL_I2;
-            if (s1 == '4') return ST_REAL_I4;
-            if (s1 == '8') return ST_REAL_I8;
-        } else if (s2 == 's') {
-            if (s1 == '4') return ST_STRING_I4_VCHAR;
-            if (s1 == '8') return ST_STRING_I8_VCHAR;
-        } else if (s2 == 'd') {
-            if (s1 == '2') return ST_DATETIME_I2_MONTH;
-            if (s1 == '4') return ST_DATETIME_I4_DATE;
-            if (s1 == '8') return ST_DATETIME_I8_EPOCH;
-        } else if (s2 == 't') {
-            if (s1 == '4') return ST_DATETIME_I4_TIME;
-        }
-    } else if (s0 == 'f') {
-        if (s2 == 'r') {
-            if (s1 == '4') return ST_REAL_F4;
-            if (s1 == '8') return ST_REAL_F8;
-        }
-    } else if (s0 == 'u') {
-        if (s2 == 'e') {
-            if (s1 == '1') return ST_STRING_U1_ENUM;
-            if (s1 == '2') return ST_STRING_U2_ENUM;
-            if (s1 == '4') return ST_STRING_U4_ENUM;
-        }
-    } else if (s0 == 'c') {
-        if (s1 == '#' && s2 == 's') return ST_STRING_FCHAR;
-    } else if (s0 == 'p') {
-        if (s1 == '8' && s2 == 'p') return ST_OBJECT_PYPTR;
+  if (s0 == 'i') {
+    if (s2 == 'i' || s2 == '\0') {
+      if (s1 == '1') return ST_INTEGER_I1;
+      if (s1 == '2') return ST_INTEGER_I2;
+      if (s1 == '4') return ST_INTEGER_I4;
+      if (s1 == '8') return ST_INTEGER_I8;
+    } else if (s2 == 'b') {
+      if (s1 == '1') return ST_BOOLEAN_I1;
+    } else if (s2 == 'r') {
+      if (s1 == '2') return ST_REAL_I2;
+      if (s1 == '4') return ST_REAL_I4;
+      if (s1 == '8') return ST_REAL_I8;
+    } else if (s2 == 's') {
+      if (s1 == '4') return ST_STRING_I4_VCHAR;
+      if (s1 == '8') return ST_STRING_I8_VCHAR;
+    } else if (s2 == 'd') {
+      if (s1 == '2') return ST_DATETIME_I2_MONTH;
+      if (s1 == '4') return ST_DATETIME_I4_DATE;
+      if (s1 == '8') return ST_DATETIME_I8_EPOCH;
+    } else if (s2 == 't') {
+      if (s1 == '4') return ST_DATETIME_I4_TIME;
     }
-    return ST_VOID;
+  } else if (s0 == 'r' && s2 == '\0') {
+    if (s1 == '4') return ST_REAL_F4;
+    if (s1 == '8') return ST_REAL_F8;
+  } else if (s0 == 'b' && s2 == '\0') {
+    if (s1 == '1' && s2 == '\0') return ST_BOOLEAN_I1;
+  } else if (s0 == 'o') {
+    if (s1 == '8' && s2 == '\0') return ST_OBJECT_PYPTR;
+  } else if (s0 == 's') {
+    if (s2 == '\0') {
+      if (s1 == '4') return ST_STRING_I4_VCHAR;
+      if (s1 == '8') return ST_STRING_I8_VCHAR;
+    }
+  } else if (s0 == 'f') {
+    if (s2 == 'r') {
+      if (s1 == '4') return ST_REAL_F4;
+      if (s1 == '8') return ST_REAL_F8;
+    }
+  } else if (s0 == 'u') {
+    if (s2 == 'e') {
+      if (s1 == '1') return ST_STRING_U1_ENUM;
+      if (s1 == '2') return ST_STRING_U2_ENUM;
+      if (s1 == '4') return ST_STRING_U4_ENUM;
+    }
+  } else if (s0 == 'c') {
+    if (s1 == '#' && s2 == 's') return ST_STRING_FCHAR;
+  } else if (s0 == 'p') {
+    if (s1 == '8' && s2 == 'p') return ST_OBJECT_PYPTR;
+  }
+  return ST_VOID;
 }
 
 

--- a/datatable/dt.py
+++ b/datatable/dt.py
@@ -846,7 +846,7 @@ def column_hexview(col, dt, colidx):
 
     print("Column %d" % colidx)
     print("Ltype: %s, Stype: %s, Mtype: %s"
-          % (col.ltype, col.stype, col.mtype))
+          % (col.ltype.name, col.stype.name, col.mtype))
     datasize = col.data_size
     print("Bytes: %d" % datasize)
     print("Meta: %s" % col.meta)

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -257,7 +257,7 @@ def test_column_hexview(dt0, patched_terminal, capsys):
     out, err = capsys.readouterr()
     print(out)
     assert ("Column 6\n"
-            "Ltype: str, Stype: i4s, Mtype: data\n"
+            "Ltype: str, Stype: str32, Mtype: data\n"
             "Bytes: 20\n"
             "Meta: None\n"
             "Refcnt: 1\n"
@@ -275,7 +275,7 @@ def test_column_hexview(dt0, patched_terminal, capsys):
     out, err = capsys.readouterr()
     print(out)
     assert ("Column 1\n"
-            "Ltype: bool, Stype: i1b, Mtype: data\n"
+            "Ltype: bool, Stype: bool8, Mtype: data\n"
             "Bytes: 4\n"
             "Meta: None\n"
             "Refcnt: 2\n"


### PR DESCRIPTION
"obj64" columns are arrays of `PyObject*` pointers. Storing these pointers on disk and then later trying to use them -- is a guaranteed recipe for disaster... So this PR prohibits it (however the content of those columns will not be saved).
Perhaps one day we may save those columns via pickling or some other mechanism, however for now this is not a priority.

This PR also changes the following internal details:
* `core.Column`'s `.stype()` will now return an `stype` object, rather than a 3-character old-style string (such as "i4i" etc).
* When saving DataTable into nff format we will now write 2-character `stype.code`s rather than 3-character old-style codes (old style will continue to work, but it is considered deprecated now).

Closes #737