### PR TITLE
Make fread robust towards any exceptions that occur during parsing

### DIFF
--- a/c/csv/reader_fread.cc
+++ b/c/csv/reader_fread.cc
@@ -348,8 +348,8 @@ void FreadReader::userOverride()
 }
 
 
-void FreadReader::progress(double percent/*[0,100]*/) {
-  g.pyreader().invoke("_progress", "(d)", percent);
+void FreadReader::progress(double progress, int statuscode) {
+  g.pyreader().invoke("_progress", "(di)", progress, statuscode);
 }
 
 

--- a/c/csv/reader_fread.h
+++ b/c/csv/reader_fread.h
@@ -84,7 +84,7 @@ private:
   void parse_column_names(FreadTokenizer& ctx);
   void detect_sep(FreadTokenizer& ctx);
   void userOverride();
-  void progress(double percent);
+  void progress(double progress, int status = 0);
   DataTablePtr makeDatatable();
 
   friend FreadLocalParseContext;

--- a/c/utils/exceptions.cc
+++ b/c/utils/exceptions.cc
@@ -131,6 +131,10 @@ void PyError::topython() const {
   exc_traceback = nullptr;
 }
 
+bool PyError::is_keyboard_interrupt() const {
+  return exc_type == PyExc_KeyboardInterrupt;
+}
+
 
 
 //==============================================================================

--- a/c/utils/exceptions.h
+++ b/c/utils/exceptions.h
@@ -92,6 +92,7 @@ public:
   PyError();
   ~PyError();
   void topython() const override;
+  bool is_keyboard_interrupt() const;
 };
 
 


### PR DESCRIPTION
* Fread is now robust w.r.t any Python exception that may occur when fread is running its main data reading loop. This includes `KeyboardInterrupt` exceptions and other problems.
* The progress bar % ratio is now based off the amount of bytes read, not the chunk number. This gives better measurement of the overall progress, although situations were the two measures would give significantly different values are extremely rare...
* It is now possible to interrupt fread's parsing mid-way by pressing Ctrl+C. Previously it was causing an uncaught C++ exception and process crash. (Some long time ago keyboard interrupts were disregarded entirely -- no crash, no stop, no anything).
* If an error occurs during reading, the progress bar will display an appropriate indicator: either `(cancelled)` if the user pressed Ctrl+C, or `(errror)` in all other cases.

Closes #766 