### PR TITLE
Fix bug and improve performance with string sorting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,8 @@ fast_objects = $(addprefix $(BUILDDIR)/, \
 	)
 
 fast:
+	$(eval DTDEBUG := 1)
+	$(eval export DTDEBUG)
 	$(eval CC := $(shell python setup.py get_CC))
 	$(eval CCFLAGS := $(shell python setup.py get_CCFLAGS))
 	$(eval LDFLAGS := $(shell python setup.py get_LDFLAGS))
@@ -184,8 +186,7 @@ fast:
 	$(eval export CC CCFLAGS LDFLAGS EXTEXT)
 	@echo • Checking dependencies graph
 	@python fastcheck.py
-	@DTDEBUG=1 \
-	$(MAKE) --no-print-directory main-fast
+	@$(MAKE) --no-print-directory main-fast
 
 post-fast:
 	@echo • Copying _datatable.so into ``datatable/lib/_datatable$(EXTEXT)``

--- a/c/sort_insert.cc
+++ b/c/sort_insert.cc
@@ -149,7 +149,6 @@ void insert_sort_keys_str(
 ) {
   int j;
   tmp[0] = 0;
-  const uint8_t* strdata1 = strdata - 1;
   for (int i = 1; i < n; ++i) {
     T off0i = std::abs(stroffs[o[i]-1]) + strstart;
     T off1i = stroffs[o[i]];
@@ -157,7 +156,7 @@ void insert_sort_keys_str(
       V k = tmp[j - 1];
       T off0k = std::abs(stroffs[o[k]-1]) + strstart;
       T off1k = stroffs[o[k]];
-      int cmp = _compare_offstrings(strdata1, off0i, off1i, off0k, off1k);
+      int cmp = _compare_offstrings(strdata, off0i, off1i, off0k, off1k);
       if (cmp != 1) break;
       tmp[j] = tmp[j-1];
     }
@@ -176,7 +175,6 @@ void insert_sort_values_str(
 ) {
   int j;
   o[0] = 0;
-  const uint8_t* strdata1 = strdata - 1;
   for (int i = 1; i < n; ++i) {
     T off0i = std::abs(stroffs[i-1]) + strstart;
     T off1i = stroffs[i];
@@ -184,7 +182,7 @@ void insert_sort_values_str(
       V k = o[j - 1];
       T off0k = std::abs(stroffs[k-1]) + strstart;
       T off1k = stroffs[k];
-      int cmp = _compare_offstrings(strdata1, off0i, off1i, off0k, off1k);
+      int cmp = _compare_offstrings(strdata, off0i, off1i, off0k, off1k);
       if (cmp != 1) break;
       o[j] = o[j-1];
     }

--- a/tests/test_dt_sort.py
+++ b/tests/test_dt_sort.py
@@ -491,7 +491,7 @@ def test_str32_small1():
            "Send these, the homeless, tempest-tost to me,",
            "I lift my lamp beside the golden door!'"]
     d0 = datatable.DataTable(src)
-    d1 = d0(sort=0)
+    d1 = d0.sort(0)
     assert d1.internal.check()
     assert d1.topython() == [sorted(src)]
 
@@ -499,7 +499,7 @@ def test_str32_small1():
 def test_str32_small2():
     src = ["Welcome", "Welc", "", None, "Welc", "Welcome!", "Welcame"]
     d0 = datatable.DataTable(src)
-    d1 = d0(sort=0)
+    d1 = d0.sort(0)
     assert d1.internal.check()
     src.remove(None)
     assert d1.topython() == [[None] + sorted(src)]
@@ -509,7 +509,7 @@ def test_str32_large1():
     src = list("dfbvoiqeubvqoiervblkdfbvqoiergqoiufbvladfvboqiervblq"
                "134ty1-394 8n09er8gy209rg hwdoif13-40t 9u13- jdpfver")
     d0 = datatable.DataTable(src)
-    d1 = d0(sort=0)
+    d1 = d0.sort(0)
     assert d1.internal.check()
     assert d1.topython() == [sorted(src)]
 
@@ -550,7 +550,6 @@ def test_str32_large5():
     assert dt0.topython()[0] == sorted(src)
 
 
-@pytest.mark.xfail()
 def test_str32_large6():
     rootdir = os.path.join(os.path.dirname(__file__), "..", "c")
     assert os.path.isdir(rootdir)


### PR DESCRIPTION
New performance measurements when sorting 1M random strings (of random length between 3 and 12 characters):
```
datatable: 0.10875105857849121
numpy    : 0.18305015563964844
Python   : 0.8502099514007568
pandas   : 2.0244977474212646
```

Closes #772 
Closes #770