### PR TITLE
Remove unnecessary progress() call in fread

### DIFF
--- a/c/csv/fread.cc
+++ b/c/csv/fread.cc
@@ -1045,9 +1045,6 @@ DataTablePtr FreadReader::read()
     goto read;   // jump0>0 at this point, set above
   }
 
-  // tell progress meter to finish up; e.g. write final newline
-  // if there's a reread, the progress meter will start again from 0
-  if (g.show_progress && thPush >= 0.75) progress(100.0);
   columns.allocate(row0);
 
   if (firstTime) {


### PR DESCRIPTION
The call used all convention of passing percentage points (100), which resulted in progress reporting 10000% done in DAI 