### PR TITLE
Implement group calculation in sort.cc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,6 +166,7 @@ fast_objects = $(addprefix $(BUILDDIR)/, \
 	rowindex_array.o          \
 	rowindex_slice.o          \
 	sort.o                    \
+	sort_groups.o             \
 	sort_insert.o             \
 	stats.o                   \
 	types.o                   \
@@ -346,7 +347,7 @@ $(BUILDDIR)/rowindex.h: c/rowindex.h $(BUILDDIR)/utils/array.h
 	@echo • Refreshing c/rowindex.h
 	@cp c/rowindex.h $@
 
-$(BUILDDIR)/sort.h: c/sort.h
+$(BUILDDIR)/sort.h: c/sort.h $(BUILDDIR)/utils/array.h
 	@echo • Refreshing c/sort.h
 	@cp c/sort.h $@
 
@@ -646,6 +647,10 @@ $(BUILDDIR)/rowindex_slice.o : c/rowindex_slice.cc $(BUILDDIR)/datatable_check.h
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
 $(BUILDDIR)/sort.o : c/sort.cc $(BUILDDIR)/column.h $(BUILDDIR)/datatable.h $(BUILDDIR)/rowindex.h $(BUILDDIR)/sort.h $(BUILDDIR)/types.h $(BUILDDIR)/utils.h $(BUILDDIR)/utils/array.h $(BUILDDIR)/utils/assert.h $(BUILDDIR)/utils/omp.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/sort_groups.o : c/sort_groups.cc $(BUILDDIR)/sort.h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 

--- a/c/rowindex.h
+++ b/c/rowindex.h
@@ -41,6 +41,7 @@ class RowIndexImpl {
     int64_t length;
     int64_t min;
     int64_t max;
+    arr32_t groups;
 
     RowIndexImpl()
       : type(RowIndexType::RI_UNKNOWN),
@@ -48,6 +49,7 @@ class RowIndexImpl {
         length(0), min(0), max(0) {}
     void acquire() { refcount++; }
     void release() { if (!--refcount) delete this; }
+
     virtual RowIndexImpl* uplift_from(RowIndexImpl*) = 0;
     virtual RowIndexImpl* inverse(int64_t nrows) const = 0;
     virtual size_t memory_footprint() const = 0;
@@ -197,6 +199,8 @@ class RowIndex {
     static RowIndex from_filterfn64(filterfn64* f, int64_t n, bool sorted);
 
     static RowIndex from_column(Column* col);
+
+    void set_groups(arr32_t&& g) { if (impl) impl->groups = std::move(g); }
 
 
     bool operator==(const RowIndex& other) { return impl == other.impl; }

--- a/c/sort.h
+++ b/c/sort.h
@@ -7,40 +7,72 @@
 //------------------------------------------------------------------------------
 #ifndef dt_SORT_h
 #define dt_SORT_h
-#include <stdint.h>
+#include "utils/array.h"  // arr32_t
 
-void* sort_i1(int8_t *x, int32_t n, int32_t **o);
-void* sort_i4(int32_t *x, int32_t n, int32_t **o);
 
+
+class GroupGatherer {
+  private:
+    arr32_t groups;
+    size_t  count;
+    int32_t total_size;
+    bool    _enabled;
+    size_t : 24;
+
+  public:
+    GroupGatherer(bool enabled);
+    bool enabled() const { return _enabled; }
+    void clear();
+    void push(size_t grp);
+    template <typename T, typename V> void from_data(const T*, V*, size_t);
+    template <typename T, typename V> void from_data(const uint8_t*, const T*, T, V*, size_t);
+    void from_groups(const GroupGatherer& gg);
+    arr32_t&& release();
+};
+
+
+
+//------------------------------------------------------------------------------
+// Templates
+//------------------------------------------------------------------------------
 
 template <typename T, typename V>
-void insert_sort_keys_fw(const T* x, V* o, V* oo, int n);
+void insert_sort_keys(const T* x, V* o, V* oo, int n, GroupGatherer& gg);
 
 template <typename T, typename V>
-void insert_sort_values_fw(const T* x, V* o, int n);
+void insert_sort_values(const T* x, V* o, int n, GroupGatherer& gg);
 
 template <typename T, typename V>
-void insert_sort_keys_str(const uint8_t*, const T*, T, V*, V*, int);
+void insert_sort_keys_str(const uint8_t*, const T*, T, V*, V*, int, GroupGatherer&);
 
 template <typename T, typename V>
-void insert_sort_values_str(const uint8_t*, const T*, T, V*, int);
+void insert_sort_values_str(const uint8_t*, const T*, T, V*, int, GroupGatherer&);
+
+template <typename T>
+int compare_offstrings(const uint8_t*, T, T, T, T);
 
 
-extern template void insert_sort_keys_fw(const uint8_t*,  int32_t*, int32_t*, int);
-extern template void insert_sort_keys_fw(const uint16_t*, int32_t*, int32_t*, int);
-extern template void insert_sort_keys_fw(const uint32_t*, int32_t*, int32_t*, int);
-extern template void insert_sort_keys_fw(const uint64_t*, int32_t*, int32_t*, int);
 
-extern template void insert_sort_values_fw(const int8_t*,   int32_t*, int);
-extern template void insert_sort_values_fw(const int16_t*,  int32_t*, int);
-extern template void insert_sort_values_fw(const int32_t*,  int32_t*, int);
-extern template void insert_sort_values_fw(const int64_t*,  int32_t*, int);
-extern template void insert_sort_values_fw(const uint8_t*,  int32_t*, int);
-extern template void insert_sort_values_fw(const uint16_t*, int32_t*, int);
-extern template void insert_sort_values_fw(const uint32_t*, int32_t*, int);
-extern template void insert_sort_values_fw(const uint64_t*, int32_t*, int);
+extern template void insert_sort_keys(const uint8_t*,  int32_t*, int32_t*, int, GroupGatherer&);
+extern template void insert_sort_keys(const uint16_t*, int32_t*, int32_t*, int, GroupGatherer&);
+extern template void insert_sort_keys(const uint32_t*, int32_t*, int32_t*, int, GroupGatherer&);
+extern template void insert_sort_keys(const uint64_t*, int32_t*, int32_t*, int, GroupGatherer&);
 
-extern template void insert_sort_keys_str(const uint8_t*, const int32_t*, int32_t, int32_t*, int32_t*, int);
-extern template void insert_sort_values_str(const uint8_t*, const int32_t*, int32_t, int32_t*, int);
+extern template void insert_sort_values(const uint8_t*,  int32_t*, int, GroupGatherer&);
+extern template void insert_sort_values(const uint16_t*, int32_t*, int, GroupGatherer&);
+extern template void insert_sort_values(const uint32_t*, int32_t*, int, GroupGatherer&);
+extern template void insert_sort_values(const uint64_t*, int32_t*, int, GroupGatherer&);
+
+extern template void insert_sort_keys_str(const uint8_t*, const int32_t*, int32_t, int32_t*, int32_t*, int, GroupGatherer&);
+extern template void insert_sort_values_str(const uint8_t*, const int32_t*, int32_t, int32_t*, int, GroupGatherer&);
+
+extern template int compare_offstrings(const uint8_t*, int32_t, int32_t, int32_t, int32_t);
+
+extern template void GroupGatherer::from_data(const uint8_t*,  int32_t*, size_t);
+extern template void GroupGatherer::from_data(const uint16_t*, int32_t*, size_t);
+extern template void GroupGatherer::from_data(const uint32_t*, int32_t*, size_t);
+extern template void GroupGatherer::from_data(const uint64_t*, int32_t*, size_t);
+extern template void GroupGatherer::from_data(const uint8_t*, const int32_t*, int32_t, int32_t*, size_t);
+
 
 #endif

--- a/c/sort_groups.cc
+++ b/c/sort_groups.cc
@@ -1,0 +1,95 @@
+//------------------------------------------------------------------------------
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// © H2O.ai 2018
+//------------------------------------------------------------------------------
+#include "sort.h"
+#include <utility>  // std::move
+
+
+
+GroupGatherer::GroupGatherer(bool enabled)
+  : _enabled(enabled)
+{
+  if (!enabled) return;
+  groups.resize(16);
+  groups[0] = 0;
+  count = 1;
+  total_size = 0;
+}
+
+
+void GroupGatherer::clear() {
+  count = 1;
+  total_size = 0;
+}
+
+
+void GroupGatherer::push(size_t grp) {
+  if (count == groups.size()) groups.resize(2 * count);
+  total_size += static_cast<int32_t>(grp);
+  groups[count++] = total_size;
+}
+
+
+template <typename T, typename V>
+void GroupGatherer::from_data(const T* data, V* o, size_t n) {
+  if (n == 0) return;
+  T curr_value = data[o[0]];
+  size_t lasti = 0;
+  for (size_t i = 1; i < n; ++i) {
+    T xi = data[o[i]];
+    if (xi != curr_value) {
+      push(i - lasti);
+      curr_value = xi;
+      lasti = i;
+    }
+  }
+  push(n - lasti);
+}
+
+
+template <typename T, typename V>
+void GroupGatherer::from_data(
+  const uint8_t* strdata, const T* stroffs, T start, V* o, size_t n)
+{
+  if (n == 0) return;
+  T olast0 = std::abs(stroffs[o[0] - 1]) + start;
+  T olast1 = stroffs[o[0]];
+  size_t lasti = 0;
+  for (size_t i = 1; i < n; ++i) {
+    T ocurr0 = std::abs(stroffs[o[i] - 1]) + start;
+    T ocurr1 = stroffs[o[i]];
+    if (compare_offstrings(strdata, olast0, olast1, ocurr0, ocurr1)) {
+      push(i - lasti);
+      olast0 = ocurr0;
+      olast1 = ocurr1;
+      lasti = i;
+    }
+  }
+  push(n - lasti);
+}
+
+
+void GroupGatherer::from_groups(const GroupGatherer& gg) {
+  for (size_t i = 1; i < gg.count; ++i) {
+    groups[count++] = total_size + gg.groups[i];
+  }
+  total_size = groups[count - 1];
+}
+
+
+arr32_t&& GroupGatherer::release() {
+  groups.resize(count);
+  return std::move(groups);
+}
+
+
+
+template void GroupGatherer::from_data(const uint8_t*,  int32_t*, size_t);
+template void GroupGatherer::from_data(const uint16_t*, int32_t*, size_t);
+template void GroupGatherer::from_data(const uint32_t*, int32_t*, size_t);
+template void GroupGatherer::from_data(const uint64_t*, int32_t*, size_t);
+template void GroupGatherer::from_data(const uint8_t*, const int32_t*, int32_t, int32_t*, size_t);

--- a/c/utils/array.h
+++ b/c/utils/array.h
@@ -51,11 +51,13 @@ template <typename T> class array
 
   public:
     array(size_t len = 0) : x(nullptr), n(0) { resize(len); }
-    array(array<T>&& other) : array() { swap(*this, other); }
     ~array() { std::free(x); }
     // copy-constructor and assignment are forbidden
     array(const array<T>&) = delete;
     array<T>& operator=(const array<T>&) = delete;
+    // move-constructor and move-assignment are ok
+    array(array<T>&& other) : array() { swap(*this, other); }
+    array<T>& operator=(array<T>&& other) { swap(*this, other); return *this; }
 
     // see https://stackoverflow.com/questions/5695548
     friend void swap(array<T>& first, array<T>& second) noexcept {


### PR DESCRIPTION
This PR implements computing groups during sorting.
Currently there's no way to make use of this functionality (it's a separate issue), so these changes remain largely untested. However it's still useful to commit them into the repo, and then fix later.

Closes #794 