### PR TITLE
Add simple GroupBy node in python, to facilitate grouping operations

### DIFF
--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -321,8 +321,8 @@ class Frame(object):
     #---------------------------------------------------------------------------
 
     def __call__(self, rows=None, select=None, verbose=False, timeit=False,
-                 sort=None, engine=None
-                 #update=None, groupby=None, join=None, limit=None
+                 groupby=None, sort=None, engine=None
+                 #update=None, join=None, limit=None
                  ):
         """
         Perform computation on a datatable, and return the result.
@@ -390,6 +390,30 @@ class Frame(object):
                   datatable -- and returns any of the selectors above. Within
                   the function any operations on the frame will be lazy.
 
+        :param groupby:
+            When this parameter is specified, it will perform a "group-by"
+            operation on the datatable. The ``select``/``update`` clauses in
+            this case may contain only ``Reducer``s, or the columns specified
+            in the groupby, or mappers bound to the columns specified in the
+            groupby. Then each reducer will be executed within the subset of
+            rows for each group. When used with a select clause, the produced
+            datatable will contain as many rows as there are distinct groups
+            in the current datatable. When used with an update clause, the
+            new columns will have constant reduced value within each group.
+            Possible values for the parameter:
+
+                - an integer, specifying column's index
+                - a string, selecting a single column by name
+                - a Mapper object bound to one or more columns of the current
+                  datatable -- the mapped values will be used to produce the
+                  groupby values.
+                - a list or a tuple or a dict of the above. If a dictionary is
+                  given, then it specifies how to rename the columns within
+                  the groupby.
+                - a function taking the current datatable as an argument, and
+                  producing any of the groupby selectors listed above. Within
+                  this function all datatable operations are lazy.
+
         :param sort:
             When specified, the datatable will be sorted. If used with
             ``select``, it will sort the resulting datatable. If there is no
@@ -434,30 +458,6 @@ class Frame(object):
                   datatable -- and returns any of the selectors above. Within
                   the function any operations on the frame will be lazy.
 
-        :param groupby:
-            When this parameter is specified, it will perform a "group-by"
-            operation on the datatable. The ``select``/``update`` clauses in
-            this case may contain only ``Reducer``s, or the columns specified
-            in the groupby, or mappers bound to the columns specified in the
-            groupby. Then each reducer will be executed within the subset of
-            rows for each group. When used with a select clause, the produced
-            datatable will contain as many rows as there are distinct groups
-            in the current datatable. When used with an update clause, the
-            new columns will have constant reduced value within each group.
-            Possible values for the parameter:
-
-                - an integer, specifying column's index
-                - a string, selecting a single column by name
-                - a Mapper object bound to one or more columns of the current
-                  datatable -- the mapped values will be used to produce the
-                  groupby values.
-                - a list or a tuple or a dict of the above. If a dictionary is
-                  given, then it specifies how to rename the columns within
-                  the groupby.
-                - a function taking the current datatable as an argument, and
-                  producing any of the groupby selectors listed above. Within
-                  this function all datatable operations are lazy.
-
         :param join:
             Specifies another datatable to join with. If this parameter is
             given, then the "function" argument within ``rows``, ``select``
@@ -471,7 +471,7 @@ class Frame(object):
             applies that slice to the resulting datatable.
         """
         time0 = time.time() if timeit else 0
-        res = make_datatable(self, rows, select, sort, engine)
+        res = make_datatable(self, rows, select, groupby, sort, engine)
         if timeit:
             print("Time taken: %d ms" % (1000 * (time.time() - time0)))
         return res

--- a/datatable/graph/context.py
+++ b/datatable/graph/context.py
@@ -31,6 +31,10 @@ class EvaluationEngine:
     def make_rowfilter(self, rows):
         return datatable.graph.rows_node.make_rowfilter(rows, self)
 
+    def make_groupby(self, grby):
+        # return None
+        return datatable.graph.groupby_node.make_groupby(grby, self)
+
     def make_columnset(self, cols):
         return datatable.graph.cols_node.make_columnset(cols, self.dt, self)
 

--- a/datatable/graph/groupby_node.py
+++ b/datatable/graph/groupby_node.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+# © H2O.ai 2018; -*- encoding: utf-8 -*-
+#   This Source Code Form is subject to the terms of the Mozilla Public
+#   License, v. 2.0. If a copy of the MPL was not distributed with this
+#   file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#-------------------------------------------------------------------------------
+from .cols_node import process_column
+from datatable.utils.typechecks import TTypeError, TValueError
+
+
+class SimpleGroupbyNode:
+
+    def __init__(self, ee, col):
+        self._engine = ee
+        self._col = col
+
+    def execute(self):
+        df = self._engine.dt
+        rowindex = df.internal.sort(self._col, True)
+        self._engine.rowindex = rowindex
+
+
+
+def make_groupby(grby, ee):
+    if grby is None:
+        return None
+
+    # TODO: change to ee.make_columnset() when we can do multi-col sorts
+    grbycol = process_column(grby, ee.dt)
+    if not isinstance(grbycol, int):
+        raise TTypeError("Currently only single-column group-bys are "
+                         "supported")
+
+    return SimpleGroupbyNode(ee, grbycol)

--- a/tests/munging/test_dt_cols.py
+++ b/tests/munging/test_dt_cols.py
@@ -44,6 +44,7 @@ def assert_typeerror(datatable, cols, error_message):
     assert error_message in str(e.value)
 
 
+
 #-------------------------------------------------------------------------------
 # Run the tests
 #-------------------------------------------------------------------------------
@@ -82,7 +83,7 @@ def test_cols_integer(dt0, tbl0):
         assert dt1.names == ("ABCD"[i], )
         assert not dt1.internal.isview
         assert as_list(dt1)[0] == tbl0[i]
-    assert_valueerror(dt0, 4, "Column index `4` is invalid for a datatable "
+    assert_valueerror(dt0, 4, "Column index `4` is invalid for a frame "
                               "with 4 columns")
     assert_valueerror(dt0, -5, "Column index `-5` is invalid")
 

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -22,3 +22,23 @@ def test_groups_internal1():
     assert ri.ngroups == 5
     assert ri.group_sizes == [1, 2, 4, 1, 2]
     assert ri.group_offsets == [0, 1, 3, 7, 8, 10]
+
+
+def test_groups_internal2():
+    d0 = dt.DataTable([[1,   5,   3,   2,   1,    3,   1,   1,   None],
+                       ["a", "b", "c", "a", None, "f", "b", "h", "d"]],
+                      names=["A", "B"])
+    d1 = d0(groupby="A")
+    assert d1.internal.check()
+    ri = d1.internal.rowindex
+    assert ri.ngroups == 5
+    assert ri.group_sizes == [1, 4, 1, 2, 1]
+    assert d1.topython() == [[None, 1, 1, 1, 1, 2, 3, 3, 5],
+                             ["d", "a", None, "b", "h", "a", "c", "f", "b"]]
+    d2 = d0(groupby="B")
+    assert d2.internal.check()
+    ri = d2.internal.rowindex
+    assert ri.ngroups == 7
+    assert ri.group_sizes == [1, 2, 2, 1, 1, 1, 1]
+    assert d2.topython() == [[1, 1, 2, 5, 1, 3, None, 3, 1],
+                             [None, "a", "a", "b", "b", "c", "d", "f", "h"]]


### PR DESCRIPTION
This PR by itself does not allow any ACTUAL grouping operations to be performed. However it is the last prerequisite step to implement such functionality (see #800). 

Closes #307 