### PR TITLE
.options functionality

### DIFF
--- a/datatable/__init__.py
+++ b/datatable/__init__.py
@@ -11,13 +11,14 @@ from .frame import Frame
 from .expr import mean, min, max, sd, isna
 from .fread import fread, GenericReader
 from .nff import save, open
+from .options import options
 from .types import stype, ltype
 from .utils.typechecks import TTypeError as TypeError
 from .utils.typechecks import TValueError as ValueError
 
 __all__ = ("__version__", "Frame", "max", "mean", "min", "open", "sd",
            "isna", "fread", "GenericReader", "save", "stype", "ltype", "f",
-           "TypeError", "ValueError", "DataTable",
+           "TypeError", "ValueError", "DataTable", "options",
            "bool8", "int8", "int16", "int32", "int64",
            "float32", "float64", "str32", "str64", "obj64")
 

--- a/datatable/options.py
+++ b/datatable/options.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+# © H2O.ai 2018; -*- encoding: utf-8 -*-
+#   This Source Code Form is subject to the terms of the Mozilla Public
+#   License, v. 2.0. If a copy of the MPL was not distributed with this
+#   file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#-------------------------------------------------------------------------------
+from datatable.utils.typechecks import (is_type, name_type, TTypeError,
+                                        TValueError)
+
+__all__ = ("options", )
+
+
+class DtAttributeError(AttributeError):
+    _handle_ = TTypeError._handle_
+
+
+class DtOption:
+    __slots__ = ["value", "type", "default", "doc"]
+
+    def __init__(self, typ, dflt, doc):
+        self.value = dflt
+        self.type = typ
+        self.default = dflt
+        self.doc = doc
+
+
+
+class DtConfig:
+    __slots__ = ["_keyvals", "_prefix"]
+
+    def __init__(self, prefix=""):
+        if prefix:
+            prefix += "."
+        # Use object.__setattr__ instead of our own __setattr__ below; note:
+        # __setattr__ is called for all attributes, regardless of whether they
+        # exist in __dict__ or not.
+        object.__setattr__(self, "_keyvals", {})
+        object.__setattr__(self, "_prefix", prefix)
+
+
+    def __getattr__(self, key):
+        if key:
+            opt = self._get_opt(key)
+            if isinstance(opt, DtOption):
+                return opt.value
+            else:
+                return opt
+        else:
+            res = {}
+            for k, v in self._keyvals.items():
+                if isinstance(v, DtOption):
+                    res[self._prefix + k] = v.value
+                else:
+                    res.update(v.__getattr__(""))
+            return res
+
+
+    def __setattr__(self, key, val):
+        opt = self._get_opt(key)
+        if isinstance(opt, DtOption):
+            if is_type(val, opt.type):
+                opt.value = val
+            else:
+                fullkey = self._prefix + key
+                exptype = name_type(opt.type)
+                acttype = name_type(type(val))
+                raise TTypeError("Invalid value for option `%s`: expected "
+                                 "type %s, got %s instead"
+                                 % (fullkey, exptype, acttype))
+        else:
+            raise DtAttributeError("Cannot modify group of options `%s`"
+                                   % (self._prefix + key))
+
+
+    def __delattr__(self, key):
+        """Deleting an option resets it to default value."""
+        if key:
+            opt = self._get_opt(key)
+            if isinstance(opt, DtOption):
+                opt.value = opt.default
+            else:
+                opt.__delattr__("")
+        else:
+            for o in self._keyvals.values():
+                if isinstance(o, DtOption):
+                    o.value = o.default
+                else:
+                    o.__delattr__("")
+
+
+    def __dir__(self):
+        return list(self._keyvals.keys())
+
+
+    def get(self, key=""):
+        return self.__getattr__(key)
+
+    def set(self, key, val):
+        self.__setattr__(key, val)
+
+    def reset(self, key=""):
+        self.__delattr__(key)
+
+
+    def register_option(self, key, typ, default, doc):
+        assert isinstance(key, str)
+        idot = key.find(".")
+        if idot == 0:
+            raise TValueError("Invalid option name `%s`" % key)
+        elif idot > 0:
+            prekey = key[:idot]
+            preval = self._keyvals.get(prekey, None)
+            if preval is None:
+                preval = DtConfig(self._prefix + prekey)
+                self._keyvals[prekey] = preval
+            if isinstance(preval, DtConfig):
+                subkey = key[idot + 1:]
+                preval.register_option(subkey, typ, default, doc)
+            else:
+                fullkey = self._prefix + key
+                fullprekey = self._prefix + prekey
+                raise TValueError("Cannot register option `%s` because `%s` "
+                                  "is already registered as an option"
+                                  % (fullkey, fullprekey))
+        elif key in self._keyvals:
+            fullkey = self._prefix + key
+            raise TValueError("Option `%s` already registered" % fullkey)
+        elif not is_type(default, typ):
+            raise TValueError("Default value `%s` is not of type %s"
+                              % (default, name_type(typ)))
+        else:
+            opt = DtOption(typ, default, doc)
+            self._keyvals[key] = opt
+
+
+    def _get_opt(self, key):
+        if key in self._keyvals:
+            return self._keyvals[key]
+
+        idot = key.find(".")
+        if idot >= 0:
+            prefix = key[:idot]
+            if prefix in self._keyvals:
+                subkey = key[idot + 1:]
+                return self._keyvals[prefix].__getattr__(subkey)
+
+        fullkey = self._prefix + key
+        raise DtAttributeError("Unknown datatable option `%s`" % fullkey)
+
+
+# Global options store
+options = DtConfig()

--- a/datatable/utils/typechecks.py
+++ b/datatable/utils/typechecks.py
@@ -16,6 +16,7 @@ from datatable.utils.terminal import term
 _tc = typesentry.Config()
 typed = _tc.typed
 is_type = _tc.is_type
+name_type = _tc.name_type
 TTypeError = _tc.TypeError
 TValueError = _tc.ValueError
 
@@ -97,4 +98,4 @@ warnings.showwarning = _showwarning
 
 
 __all__ = ("typed", "is_type", "U", "TTypeError", "TValueError", "TImportError",
-           "Frame_t", "NumpyArray_t", "DatatableWarning", "dtwarn")
+           "Frame_t", "NumpyArray_t", "DatatableWarning", "dtwarn", "name_type")

--- a/tests/test_dt_options.py
+++ b/tests/test_dt_options.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+# © H2O.ai 2018; -*- encoding: utf-8 -*-
+#   This Source Code Form is subject to the terms of the Mozilla Public
+#   License, v. 2.0. If a copy of the MPL was not distributed with this
+#   file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#-------------------------------------------------------------------------------
+import pytest
+import datatable as dt
+
+
+@pytest.mark.run(order=1001)
+def test_options_all():
+    # Update this test every time a new option is added
+    assert dir(dt.options) == []
+
+
+@pytest.mark.run(order=1002)
+def test_option_api():
+    dt.options.register_option("fooo", int, 13, "a dozen")
+    assert "fooo" in dir(dt.options)
+    assert dt.options.fooo == 13
+    assert dt.options.get("fooo") == 13
+    dt.options.fooo = 23
+    assert dt.options.fooo == 23
+    dt.options.set("fooo", 25)
+    assert dt.options.fooo == 25
+    del dt.options.fooo
+    assert dt.options.fooo == 13
+    dt.options.fooo = 0
+    dt.options.reset("fooo")
+    assert dt.options.fooo == 13
+
+
+@pytest.mark.run(order=1003)
+def test_option_bad():
+    with pytest.raises(AttributeError):
+        dt.options.gooo
+
+    with pytest.raises(ValueError) as e:
+        dt.options.register_option("gooo", str, 3, "??")
+    assert "Default value `3` is not of type str" in str(e.value)
+
+    with pytest.raises(ValueError) as e:
+        dt.options.register_option(".hidden", int, 0, "")
+    assert "Invalid option name `.hidden`" in str(e.value)
+
+    dt.options.register_option("gooo", int, 3, "???")
+
+    with pytest.raises(ValueError) as e:
+        dt.options.register_option("gooo", int, 3, "???")
+    assert "Option `gooo` already registered" in str(e.value)
+
+    with pytest.raises(TypeError) as e:
+        dt.options.gooo = 2.5
+    assert ("Invalid value for option `gooo`: expected type int, got float "
+            "instead" in str(e.value))
+
+    with pytest.raises(ValueError) as e:
+        dt.options.register_option("gooo.maxima", int, 0, "")
+    assert ("Cannot register option `gooo.maxima` because `gooo` is already "
+            "registered as an option" in str(e.value))
+
+
+@pytest.mark.run(order=1004)
+def test_options_many():
+    dt.options.register_option("tmp1.alpha", int, 1, "A")
+    dt.options.register_option("tmp1.beta",  int, 2, "B")
+    dt.options.register_option("tmp1.gamma", int, 3, "C")
+    dt.options.register_option("tmp1.delta.x", int, 4, "X")
+    dt.options.register_option("tmp1.delta.y", int, 5, "Y")
+    dt.options.register_option("tmp1.delta.z.zz", int, 6, "Z")
+    for _ in [1, 2]:
+        assert dt.options.tmp1.alpha == 1
+        assert dt.options.tmp1.beta == 2
+        assert dt.options.tmp1.gamma == 3
+        assert dt.options.tmp1.delta.x == 4
+        assert dt.options.tmp1.delta.y == 5
+        assert dt.options.tmp1.delta.z.zz == 6
+        assert set(dir(dt.options.tmp1)) == {"alpha", "beta", "gamma", "delta"}
+        assert set(dt.options.tmp1.get()) == {"tmp1.alpha", "tmp1.beta",
+                                              "tmp1.gamma", "tmp1.delta.x",
+                                              "tmp1.delta.y", "tmp1.delta.z.zz"}
+        dt.options.tmp1.delta.x = 0
+        dt.options.tmp1.delta.z.zz = 0
+        del dt.options.tmp1
+
+
+@pytest.mark.run(order=1004)
+def test_options_many_bad():
+    dt.options.register_option("tmp2.foo.x", int, 4, "")
+    dt.options.register_option("tmp2.foo.y", int, 5, "")
+    dt.options.tmp2.foo.x = 8
+    assert dt.options.tmp2.foo.x == 8
+    assert dt.options.get("tmp2.foo.x") == 8
+    with pytest.raises(AttributeError) as e:
+        dt.options.tmp2.foo = 0
+    assert "Cannot modify group of options `tmp2.foo`" in str(e.value)


### PR DESCRIPTION
Add new global `dt.options`, which can be used to register and maintain global datatable options.

Closes #819