### PR TITLE
Re-disable CentOS-7 builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -236,7 +236,6 @@ pipeline {
                 branch 'master'
                 expression { isRelease }
             }
-            }
             agent {
                 label "linux && docker"
             }


### PR DESCRIPTION
This PR disables "centos-7" stages in the Jenkins build process (unless it is the Release build), thus greatly improving the overall build time. 

In the past weeks we have seen that those build stages sometimes wait in the queue for up to an hour, eventually causing a timeout and build fail.

Even when those stages do work, they add up to 30 minutes on average to the build time, which slows down development of the project significantly. Since the artifacts of centos-7 builds are not needed most of the time, it is better to defer centos-7 builds to release-time only.

Closes #829