### PR TITLE
MixedCSNode now evaluates properly under Eager engine

### DIFF
--- a/datatable/graph/cols_node.py
+++ b/datatable/graph/cols_node.py
@@ -145,7 +145,10 @@ class MixedCSNode(ColumnSetNode):
                                        nrows, fnptr)
 
     def evaluate_eager(self):
-        columns = [e.evaluate_eager() for e in self._elems]
+        _dt = self._dt.internal
+        columns = [core.expr_column(_dt, e) if isinstance(e, int) else
+                   e.evaluate_eager()
+                   for e in self._elems]
         return core.columns_from_columns(columns)
 
     def use_rowindex(self, ri):

--- a/datatable/graph/llvm.py
+++ b/datatable/graph/llvm.py
@@ -9,6 +9,7 @@ import re
 import subprocess
 from llvmlite import binding
 from datatable.utils.terminal import term
+from datatable.utils.typechecks import TValueError
 
 __all__ = ("llvm", )
 
@@ -99,6 +100,8 @@ class Llvm:
     #---------------------------------------------------------------------------
 
     def _c_to_llvm(self, code):
+        if self._clang is None:
+            raise TValueError("LLVM execution engine is not available")
         proc = subprocess.Popen(args=[self._clang, "-x", "c", "-S",
                                       "-emit-llvm", "-o", "-", "-"],
                                 stdin=subprocess.PIPE,


### PR DESCRIPTION
In addition, we now display proper error message if trying to use `engine="llvm"` in a runtime where this engine is not available.

Closes #843