### PR TITLE
Fix excessive memory usage when reading files with lots of columns and few rows

### DIFF
--- a/c/csv/reader_fread.cc
+++ b/c/csv/reader_fread.cc
@@ -401,11 +401,12 @@ FreadLocalParseContext::FreadLocalParseContext(
   skipEmptyLines = f.g.skip_blank_lines;
   numbersMayBeNAs = f.g.number_is_na;
   size_t ncols = columns.size();
+  size_t bufsize = std::min(size_t(4096), f.get_data_size() / (ncols + 1));
   for (size_t i = 0, j = 0; i < ncols; ++i) {
     GReaderColumn& col = columns[i];
     if (!col.presentInBuffer) continue;
     if (col.type == CT_STRING && !col.typeBumped) {
-      strbufs.push_back(StrBuf(4096, j, i));
+      strbufs.push_back(StrBuf(bufsize, j, i));
     }
     ++j;
   }

--- a/c/csv/reader_fread.h
+++ b/c/csv/reader_fread.h
@@ -83,6 +83,7 @@ public:
   int get_nthreads() const { return g.nthreads; }
   double get_mean_line_len() const { return meanLineLen; }
   size_t get_ncols() const { return columns.size(); }
+  size_t get_data_size() const { return g.datasize(); }
   bool get_fill() const { return g.fill; }
   bool get_skip_empty_lines() const { return g.skip_blank_lines; }
 


### PR DESCRIPTION
* `meanLineLen` was not computed correctly when input had just 1 row. This caused wrong estimation of the number of chunks required
* Added diagnostic message (in verbose mode) when the number of threads is reduced due to input having too few rows.
* The amount of memory allocated per-thread is now reduced in case the number of rows is small.

Now the process only uses 464MB of memory to process the input file, which is reasonable. The data was also parsed "correctly" into a `[1 x 798355]` Frame.

Closes #874 