### PR TITLE
Fread will no longer attempt to typebump unless it can be certain that the chunk start is valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   with too many columns and few rows.
 - fixed a possible crash when reading CSV file containing long string fields.
 - fread: NA fields with whitespace were not recognized correctly.
+- fread will no longer emit error messages or type-bump variables due to
+  incorrectly recognized chunk boundaries.
 - Fixed a crash when rbinding string column with non-string: now an exception
   will be thrown instead.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - fread will no longer consume excessive amounts of memory when reading a file
   with too many columns and few rows.
 - fixed a possible crash when reading CSV file containing long string fields.
-
+- fread: NA fields with whitespace were not recognized correctly.
 
 
 ### [v0.3.0](https://github.com/h2oai/datatable/compare/0.3.0...v0.2.2) - 2018-03-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### [Unreleased](https://github.com/h2oai/datatable/compare/HEAD...v0.3.0)
+#### Fixed
+- fread will no longer consume excessive amounts of memory when reading a file
+  with too many columns and few rows.
+- fixed a possible crash when reading CSV file containing long string fields.
 
 
 

--- a/c/csv/chunks.cc
+++ b/c/csv/chunks.cc
@@ -92,18 +92,14 @@ ChunkCoordinates ChunkOrganizer::compute_chunk_boundaries(
 bool ChunkOrganizer::is_ordered(
   const ChunkCoordinates& acc, ChunkCoordinates& xcc)
 {
-  if (acc.start == lastChunkEnd) {
-    if (acc.end) {
-      assert(acc.end >= lastChunkEnd);
-      lastChunkEnd = acc.end;
-    }
-    return true;
-  } else {
-    assert(!xcc.true_start);
-    xcc.start = lastChunkEnd;
-    xcc.true_start = true;
-    return false;
+  bool ordered = (acc.start == lastChunkEnd);
+  xcc.start = lastChunkEnd;
+  xcc.true_start = true;
+  if (ordered && acc.end) {
+    assert(acc.end >= lastChunkEnd);
+    lastChunkEnd = acc.end;
   }
+  return ordered;
 }
 
 

--- a/c/csv/fread.cc
+++ b/c/csv/fread.cc
@@ -206,6 +206,7 @@ class FreadChunkedReader {
             try {
               while (!chunkster->is_ordered(acc, xcc)) {
                 acc = ctx->read_chunk(xcc);
+                if (!acc.end) break;
               }
               if (!acc.end) stopTeam = true;
               ctx->row0 = row0;  // fetch shared row0 (where to write my results to the answer).

--- a/c/csv/fread.cc
+++ b/c/csv/fread.cc
@@ -629,6 +629,7 @@ DataTablePtr FreadReader::read()
             fctx.skip_white();
             if (fctx.end_of_field()) break;
             tch = fctx.end_NA_string(fieldStart);
+            fctx.skip_white();
             if (fctx.end_of_field()) break;
             if (columns[field].type<CT_STRING) {
               tch = fieldStart;

--- a/c/csv/reader.h
+++ b/c/csv/reader.h
@@ -261,7 +261,7 @@ class LocalParseContext {
     virtual ~LocalParseContext();
     virtual field64* next_row();
     virtual void push_buffers() = 0;
-    virtual ChunkCoordinates read_chunk(const ChunkCoordinates& cc) = 0;
+    virtual void read_chunk(const ChunkCoordinates&, ChunkCoordinates&) = 0;
     virtual void orderBuffer() = 0; // { row0 = r0; }
     virtual size_t get_nrows() { return used_nrows; }
     virtual void set_nrows(size_t n) { used_nrows = n; }

--- a/c/csv/reader_fread.cc
+++ b/c/csv/reader_fread.cc
@@ -416,12 +416,16 @@ FreadLocalParseContext::~FreadLocalParseContext() {}
 
 
 
-ChunkCoordinates FreadLocalParseContext::read_chunk(const ChunkCoordinates& cc)
+void FreadLocalParseContext::read_chunk(
+  const ChunkCoordinates& cc, ChunkCoordinates& actual_cc)
 {
+  // If any error in the loop below occurs, we'll do `return;` and the output
+  // variable `actual_cc` will contain `.end = nullptr;`.
+  actual_cc.start = cc.start;
+  actual_cc.end = nullptr;
   size_t ncols = columns.size();
   bool fillme = fill || (columns.size()==1 && !skipEmptyLines);
   bool fastParsingAllowed = (sep != ' ') && !numbersMayBeNAs;
-  bool stopTeam = false;
   const char*& tch = tokenizer.ch;
   tch = cc.start;
   used_nrows = 0;
@@ -458,26 +462,17 @@ ChunkCoordinates FreadLocalParseContext::read_chunk(const ChunkCoordinates& cc)
       else if (tokenizer.skip_eol() && j < ncols) {
         tokenizer.target += columns[j].presentInBuffer;
         j++;
-        if (j==ncols) { used_nrows++; continue; }  // next line. Back up to while (tch<cc.end). Usually happens, fastest path
+        if (j==ncols) { used_nrows++; continue; }  // next line
         tch--;
       }
       else {
-        tch = fieldStart; // restart field as int processor could have moved to A in ",123A,"
+        tch = fieldStart;
       }
-      // if *tch=='\0' then *eof in mind, fall through to below and, if finalByte is set, reread final field
     }
     //*** END TEPID. NOW COLD.
 
-    // Either whitespace surrounds field in which case the processor will fault very quickly, it's numeric but quoted (quote will fault the non-string processor),
-    // it contains an NA string, or there's an out-of-sample type bump needed.
-    // In all those cases we're ok to be a bit slower. The rest of this line will be processed using the slower version.
-    // (End-of-file) is also dealt with now, as could be the highly unusual line ending /n/r
-    // This way (each line has new opportunity of the fast path) if only a little bit of the file is quoted (e.g. just when commas are present as fwrite does)
-    // then a penalty isn't paid everywhere.
-    // TODO: reduce(slowerBranch++). So we can see in verbose mode if this is happening too much.
-
     if (sep==' ') {
-      while (*tch==' ') tch++;  // multiple sep=' ' at the tlineStart does not mean sep. We're at tLineStart because the fast branch above doesn't run when sep=' '
+      while (*tch==' ') tch++;
       fieldStart = tch;
       if (skipEmptyLines && tokenizer.skip_eol()) continue;
     }
@@ -496,9 +491,9 @@ ChunkCoordinates FreadLocalParseContext::read_chunk(const ChunkCoordinates& cc)
             const char* afterSpace = tch;
             tch = tokenizer.end_NA_string(tch);
             tokenizer.skip_white();
-            if (!tokenizer.end_of_field()) tch = afterSpace; // else it is the field_end, we're on closing sep|eol and we'll let processor write appropriate NA as if field was empty
+            if (!tokenizer.end_of_field()) tch = afterSpace;
             if (*tch==quote) { quoted=true; tch++; }
-          } // else Field() handles NA inside it unlike other processors e.g. ,, is interpretted as "" or NA depending on option read inside Field()
+          }
           parsers[newType](tokenizer);
           if (quoted) {
             if (*tch==quote) tch++;
@@ -513,44 +508,43 @@ ChunkCoordinates FreadLocalParseContext::read_chunk(const ChunkCoordinates& cc)
             break;
           }
 
-          // guess is insufficient out-of-sample, type is changed to negative sign and then bumped. Continue to
-          // check that the new type is sufficient for the rest of the column (and any other columns also in out-of-sample bump status) to be
-          // sure a single re-read will definitely work.
+          // Only perform bumping types / quote rules, when we are sure that the
+          // start of the chunk is valid.
+          // Otherwise, we are not able to read the chunk, and therefore return.
           typebump:
-          if (!cc.true_start) {
-            // Forbid bumping types / quote rules, unless we are sure that the
-            // start of the chunk is known precisely...
-            return ChunkCoordinates(cc.start, nullptr);
+          if (cc.true_start) {
+            newType++;
+            if (newType == NUMTYPE) {
+              newType = NUMTYPE - 1;
+              tokenizer.quoteRule++;
+            }
+            tch = fieldStart;
+          } else {
+            return;
           }
-          newType++;
-          if (newType == NUMTYPE) {
-            newType = NUMTYPE - 1;
-            tokenizer.quoteRule++;
-          }
-          tch = fieldStart;
         }
 
-        if (newType != oldType) {          // rare out-of-sample type exception.
-          #pragma omp critical
-          {
-            oldType = types[j];  // fetch shared value again in case another thread bumped it while I was waiting.
-            // Can't print because we're likely not master. So accumulate message and print afterwards.
-            if (verbose) {
-              char temp[1001];
-              int len = snprintf(temp, 1000,
-                "Column %zu (\"%s\") bumped from '%s' to '%s' due to <<%.*s>> on row %llu\n",
-                j+1, columns[j].name.data(), typeName[oldType], typeName[newType],
-                (int)(tch-fieldStart), fieldStart, (llu)(row0+used_nrows));
-              typeBumpMsg = (char*) realloc(typeBumpMsg, typeBumpMsgSize + (size_t)len + 1);
-              strcpy(typeBumpMsg + typeBumpMsgSize, temp);
-              typeBumpMsgSize += (size_t)len;
-            }
-            nTypeBump++;
-            // if (!columns[j].typeBumped) nTypeBumpCols++;
-            types[j] = newType;
-            columns[j].type = newType;
-            columns[j].typeBumped = true;
+        // Type-bump. This may only happen if cc.true_start is true, which flag
+        // is only set to true on one thread at a time. Thus, there is no need
+        // for "critical" section here.
+        if (newType != oldType) {
+          assert(cc.true_start);
+          if (verbose) {
+            // Can't print because we're likely not master. So accumulate
+            // message and print afterwards.
+            char temp[1001];
+            int len = snprintf(temp, 1000,
+              "Column %zu (\"%s\") bumped from '%s' to '%s' due to <<%.*s>> on row %llu\n",
+              j+1, columns[j].name.data(), typeName[oldType], typeName[newType],
+              (int)(tch-fieldStart), fieldStart, (llu)(row0+used_nrows));
+            typeBumpMsg = (char*) realloc(typeBumpMsg, typeBumpMsgSize + (size_t)len + 1);
+            strcpy(typeBumpMsg + typeBumpMsgSize, temp);
+            typeBumpMsgSize += (size_t)len;
           }
+          nTypeBump++;
+          types[j] = newType;
+          columns[j].type = newType;
+          columns[j].typeBumped = true;
         }
         tokenizer.target += columns[j].presentInBuffer;
         j++;
@@ -565,40 +559,38 @@ ChunkCoordinates FreadLocalParseContext::read_chunk(const ChunkCoordinates& cc)
           continue;
         }
         break;
-      }
+      }  // while (j < ncols)
     }
 
-    if (j < ncols)  {
-      // not enough columns observed (including empty line). If fill==true, fields should already have been filled above due to continue inside while(j<ncols)
-      #pragma omp critical
-      if (!stopTeam) {
-        stopTeam = true;
+    if (j < ncols) {
+      // not enough columns observed (including empty line). If fill==true,
+      // fields should already have been filled above due to continue inside
+      // `while (j < ncols)`.
+      if (cc.true_start) {
         snprintf(stopErr, stopErrSize,
           "Expecting %zu cols but row %zu contains only %zu cols (sep='%c'). "
           "Consider fill=true. \"%s\"",
           ncols, row0, j, sep, strlim(tlineStart, 500));
       }
-      break;
+      return;
     }
     if (!(tokenizer.skip_eol() || *tch=='\0')) {
-      #pragma omp critical
-      if (!stopTeam) {
-        stopTeam = true;
+      if (cc.true_start) {
         snprintf(stopErr, stopErrSize,
           "Too many fields on out-of-sample row %zu. Read all %zu "
           "expected columns but more are present. \"%s\"",
           row0, ncols, strlim(tlineStart, 500));
       }
-      break;
+      return;
     }
     used_nrows++;
   }
-  if (stopTeam) {
-    return ChunkCoordinates(cc.start, nullptr);
-  } else {
-    postprocess();
-    return ChunkCoordinates(cc.start, tch);
-  }
+
+  postprocess();
+
+  // Tell the caller where we finished reading the chunk. This is why
+  // the parameter `actual_cc` was passed to this function.
+  actual_cc.end = tch;
 }
 
 
@@ -835,7 +827,7 @@ bool FreadTokenizer::end_of_field() {
 
 const char* FreadTokenizer::end_NA_string(const char* fieldStart) {
   const char* const* nastr = NAstrings;
-  const char* mostConsumed = fieldStart; // tests 1550* includes both 'na' and 'nan' in nastrings. Don't stop after 'na' if 'nan' can be consumed too.
+  const char* mostConsumed = fieldStart;
   while (*nastr) {
     const char* ch1 = fieldStart;
     const char* ch2 = *nastr;

--- a/c/csv/reader_fread.cc
+++ b/c/csv/reader_fread.cc
@@ -494,7 +494,7 @@ ChunkCoordinates FreadLocalParseContext::read_chunk(const ChunkCoordinates& cc)
           if (newType < CT_STRING && newType > CT_DROP) {
             tokenizer.skip_white();
             const char* afterSpace = tch;
-            tch = tokenizer.end_NA_string(fieldStart);
+            tch = tokenizer.end_NA_string(tch);
             tokenizer.skip_white();
             if (!tokenizer.end_of_field()) tch = afterSpace; // else it is the field_end, we're on closing sep|eol and we'll let processor write appropriate NA as if field was empty
             if (*tch==quote) { quoted=true; tch++; }

--- a/c/csv/reader_fread.h
+++ b/c/csv/reader_fread.h
@@ -147,7 +147,7 @@ class FreadLocalParseContext : public LocalParseContext
     FreadLocalParseContext& operator=(const FreadLocalParseContext&) = delete;
     virtual ~FreadLocalParseContext();
     virtual void push_buffers() override;
-    ChunkCoordinates read_chunk(const ChunkCoordinates&) override;
+    void read_chunk(const ChunkCoordinates&, ChunkCoordinates&) override;
     void postprocess();
     void orderBuffer() override;
 };

--- a/tests/fread/test_fread_small.py
+++ b/tests/fread/test_fread_small.py
@@ -622,6 +622,20 @@ def test_unescaping1():
                               "\r\t\v\a\b\071\uABCD"]]
 
 
+def test_whitespace_nas():
+    d0 = dt.fread('A,   B,    C\n'
+                  '17,  34, 2.3\n'
+                  '3.,  NA,   1\n'
+                  'NA ,  2, NA \n'
+                  '0,0.1,0')
+    assert d0.internal.check()
+    assert d0.names == ("A", "B", "C")
+    assert d0.ltypes == (dt.ltype.real,) * 3
+    assert d0.topython() == [[17, 3, None, 0],
+                             [34, None, 2, 0.1],
+                             [2.3, 1, None, 0]]
+
+
 
 #-------------------------------------------------------------------------------
 # Medium-size files (generated)


### PR DESCRIPTION
- Prevent type bumps when the chunk start may be invalid
- Fix bug in order_chunk logic, where an invalid chunk was resetting `lastChunkEnd` variable to 0.
- The errors about too many/too few columns will also no longer be emitted in a situation where the chunk start may be invalid.
- Fixed bug where NA strings surrounded with whitespace were not properly recognized.

Closes #878 