### PR TITLE
Fixed a crash when rbinding string columns with non-string ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### [Unreleased](https://github.com/h2oai/datatable/compare/HEAD...v0.3.0)
-
+#### Fixed
+- Fixed a crash when rbinding string column with non-string: now an exception
+  will be thrown instead.
 
 
 ### [v0.3.0](https://github.com/h2oai/datatable/compare/0.3.0...v0.2.2) - 2018-03-19

--- a/c/column.h
+++ b/c/column.h
@@ -167,7 +167,7 @@ public:
    * Individual entries in the `columns` array may be instances of `VoidColumn,
    * indicating columns that should be replaced with NAs.
    */
-  Column* rbind(const std::vector<const Column*>& columns);
+  Column* rbind(std::vector<const Column*>& columns);
 
   /**
    * "Materialize" the Column. If the Column has no rowindex, this is a no-op.
@@ -237,7 +237,7 @@ protected:
   virtual void init_mmap(const std::string& filename) = 0;
   virtual void open_mmap(const std::string& filename) = 0;
   virtual void init_xbuf(Py_buffer* pybuffer) = 0;
-  virtual void rbind_impl(const std::vector<const Column*>& columns,
+  virtual void rbind_impl(std::vector<const Column*>& columns,
                           int64_t nrows, bool isempty) = 0;
 
   /**
@@ -313,7 +313,7 @@ protected:
   void open_mmap(const std::string& filename) override;
   void init_xbuf(Py_buffer* pybuffer) override;
   static constexpr T na_elem = GETNA<T>();
-  void rbind_impl(const std::vector<const Column*>& columns, int64_t nrows,
+  void rbind_impl(std::vector<const Column*>& columns, int64_t nrows,
                   bool isempty) override;
   void fill_na() override;
 
@@ -606,7 +606,7 @@ protected:
   void open_mmap(const std::string& filename) override;
   void init_xbuf(Py_buffer* pybuffer) override;
 
-  void rbind_impl(const std::vector<const Column*>& columns, int64_t nrows,
+  void rbind_impl(std::vector<const Column*>& columns, int64_t nrows,
                   bool isempty) override;
 
   StringStats<T>* get_stats() const override;
@@ -651,7 +651,7 @@ public:
   int64_t data_nrows() const override { return nrows; }
   void reify() override {}
   void resize_and_fill(int64_t) override {}
-  void rbind_impl(const std::vector<const Column*>&, int64_t, bool) override {}
+  void rbind_impl(std::vector<const Column*>&, int64_t, bool) override {}
   void apply_na_mask(const BoolColumn*) override {}
 protected:
   VoidColumn() {}

--- a/c/column_string.cc
+++ b/c/column_string.cc
@@ -423,7 +423,7 @@ void StringColumn<T>::resize_and_fill(int64_t new_nrows)
 
 
 template <typename T>
-void StringColumn<T>::rbind_impl(const std::vector<const Column*>& columns,
+void StringColumn<T>::rbind_impl(std::vector<const Column*>& columns,
                                  int64_t new_nrows, bool col_empty)
 {
   // Determine the size of the memory to allocate
@@ -434,6 +434,10 @@ void StringColumn<T>::rbind_impl(const std::vector<const Column*>& columns,
   }
   for (const Column* col : columns) {
     if (col->stype() == ST_VOID) continue;
+    if (col->stype() != stype()) {
+      throw NotImplError() << "Unable to rbind column of string type with "
+                              "a column of type " << col->stype();
+    }
     // TODO: replace with datasize(). But: what if col is not a string?
     new_strbuf_size += static_cast<const StringColumn<T>*>(col)->strbuf->size();
   }

--- a/tests/munging/test_dt_append.py
+++ b/tests/munging/test_dt_append.py
@@ -144,7 +144,7 @@ def test_repeating_names():
         assert_equals(dt0, dtr)
 
 
-def test_rbind_strings():
+def test_rbind_strings1():
     dt0 = dt.Frame({"A": ["Nothing's", "wrong", "with", "this", "world"]})
     dt1 = dt.Frame({"A": ["something", "wrong", "with", "humans"]})
     dt0.rbind(dt1)
@@ -152,12 +152,16 @@ def test_rbind_strings():
                           "something", "wrong", "with", "humans"]})
     assert_equals(dt0, dtr)
 
+
+def test_rbind_strings2():
     dt0 = dt.Frame(["a", "bc", None])
     dt1 = dt.Frame([None, "def", "g", None])
     dt0.rbind(dt1)
     dtr = dt.Frame(["a", "bc", None, None, "def", "g", None])
     assert_equals(dt0, dtr)
 
+
+def test_rbind_strings3():
     dt0 = dt.Frame({"A": [1, 5], "B": ["ham", "eggs"]})
     dt1 = dt.Frame({"A": [25], "C": ["spam"]})
     dt0.rbind(dt1, force=True)
@@ -165,6 +169,8 @@ def test_rbind_strings():
                     "C": [None, None, "spam"]})
     assert_equals(dt0, dtr)
 
+
+def test_rbind_strings4():
     dt0 = dt.Frame({"A": ["alpha", None], "C": ["eta", "theta"]})
     dt1 = dt.Frame({"A": [None, "beta"], "B": ["gamma", "delta"]})
     dt2 = dt.Frame({"D": ["psi", "omega"]})
@@ -174,6 +180,16 @@ def test_rbind_strings():
                     "B": [None, None, "gamma", "delta", None, None],
                     "D": [None, None, None, None, "psi", "omega"]})
     assert_equals(dt0, dtr)
+
+
+def test_rbind_strings5():
+    # TODO: fix this test once rbinding strings with non-strings properly
+    #       implemented.
+    f0 = dt.Frame([1, 2, 3])
+    f1 = dt.Frame(["foo", "bra"])
+    with pytest.raises(NotImplementedError):
+        f1.rbind(f0)
+
 
 
 def test_rbind_self():


### PR DESCRIPTION
Note, this merely fixes the crash. It is still not possible to rbind string columns with non-string ones. In order to implement the latter, we need to implement casting from any column into string type.

Closes #880