### PR TITLE
countna() on columns of object type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### [Unreleased](https://github.com/h2oai/datatable/compare/HEAD...v0.3.0)
 #### Added
 - Added ability to delete rows from a view Frame.
+- Implement countna() function for `obj64` columns.
+
+#### Changed
+- When creating a column of "object" type, we will now coerce float "nan"
+  values into `None`s.
 
 #### Fixed
 - fread will no longer consume excessive amounts of memory when reading a file

--- a/c/column.h
+++ b/c/column.h
@@ -539,7 +539,7 @@ public:
 protected:
   PyObjectColumn();
   // TODO: This should be corrected when PyObjectStats is implemented
-  Stats* get_stats() const override { return nullptr; }
+  PyObjectStats* get_stats() const override;
   void open_mmap(const std::string& filename) override;
 
   // void cast_into(BoolColumn*) const override;

--- a/c/column_from_pylist.cc
+++ b/c/column_from_pylist.cc
@@ -378,7 +378,11 @@ static bool parse_as_pyobj(PyyList& list, MemoryBuffer* membuf)
   PyObject** outdata = static_cast<PyObject**>(membuf->get());
 
   for (size_t i = 0; i < nrows; ++i) {
-    outdata[i] = list[i].as_new_ref();
+    PyObj item = list[i];
+    if (item.is_float() && std::isnan(item.as_double())) {
+      item = PyObj::none();
+    }
+    outdata[i] = item.as_pyobject();
   }
   return true;
 }

--- a/c/column_pyobj.cc
+++ b/c/column_pyobj.cc
@@ -64,3 +64,10 @@ void PyObjectColumn::cast_into(PyObjectColumn* target) const {
 }
 
 
+
+//----- Stats ------------------------------------------------------------------
+
+PyObjectStats* PyObjectColumn::get_stats() const {
+  if (stats == nullptr) stats = new PyObjectStats();
+  return static_cast<PyObjectStats*>(stats);
+}

--- a/c/rowindex_array.cc
+++ b/c/rowindex_array.cc
@@ -470,7 +470,8 @@ RowIndexImpl* ArrayRowIndexImpl::inverse(int64_t nrows) const {
 
 
 int64_t ArrayRowIndexImpl::nth(int64_t i) const {
-  return (type == RowIndexType::RI_ARR32)? ind32[i] : ind64[i];
+  size_t zi = static_cast<size_t>(i);
+  return (type == RowIndexType::RI_ARR32)? ind32[zi] : ind64[zi];
 }
 
 

--- a/c/stats.h
+++ b/c/stats.h
@@ -43,11 +43,11 @@ enum Stat {
  *
  *                                +-------+
  *                                | Stats |
- *                                +-------+
- *                                 /     \
- *                 +----------------+   +-------------+
- *                 | NumericalStats |   | StringStats |
- *                 +----------------+   +-------------+
+ *                                +-------+ --------------~
+ *                                 /     \                 \
+ *                 +----------------+   +-------------+   +---------------+
+ *                 | NumericalStats |   | StringStats |   | PyObjectStats |
+ *                 +----------------+   +-------------+   +---------------+
  *                   /           \
  *         +--------------+   +-----------+
  *         | IntegerStats |   | RealStats |
@@ -93,7 +93,7 @@ class Stats {
     void reset();
     virtual void merge_stats(const Stats*);
 
-    virtual size_t memory_footprint() const;
+    virtual size_t memory_footprint() const = 0;
     bool verify_integrity(IntegrityCheckContext&,
                           const std::string& name = "Stats") const;
 
@@ -234,6 +234,20 @@ class StringStats : public Stats {
 extern template class StringStats<int32_t>;
 extern template class StringStats<int64_t>;
 
+
+
+//------------------------------------------------------------------------------
+// PyObjectStats class
+//------------------------------------------------------------------------------
+
+class PyObjectStats : public Stats {
+  public:
+    virtual size_t memory_footprint() const override { return sizeof(*this); }
+
+  protected:
+    void compute_countna(const Column*) override;
+    void compute_sorted_stats(const Column*) override;
+};
 
 
 #endif /* dt_STATS_h */

--- a/c/types.h
+++ b/c/types.h
@@ -289,7 +289,7 @@ typedef enum LType {
  *
  * ST_OBJECT_PTR
  *     elem: PyObject*
- *     NA:   &Py_None
+ *     NA:   Py_None
  *
  */
 typedef enum SType {

--- a/c/utils/pyobj.cc
+++ b/c/utils/pyobj.cc
@@ -63,6 +63,10 @@ PyObj PyObj::fromPyObjectNewRef(PyObject* t) {
   return res;
 }
 
+PyObj PyObj::none() {
+  return PyObj(Py_None);
+}
+
 
 // Note from http://en.cppreference.com/w/cpp/language/copy_elision:
 //

--- a/c/utils/pyobj.h
+++ b/c/utils/pyobj.h
@@ -42,6 +42,7 @@ public:
   PyObj& operator=(PyObj other);
   ~PyObj();
   static PyObj fromPyObjectNewRef(PyObject*);
+  static PyObj none();
 
   friend void swap(PyObj& first, PyObj& second) noexcept {
     using std::swap;

--- a/tests/test_dt_stats.py
+++ b/tests/test_dt_stats.py
@@ -34,6 +34,9 @@ srcs_str = [["foo", None, "bar", "baaz", None],
             ["a", "c", "d", None, "d", None, None, "a", "e", "c", "a", "a"],
             ["leeeeeroy!"]]
 
+srcs_obj = [[1, None, "haha", nan, inf, None, (1, 2)],
+            ["a", "bc", "def", None, -2.5, 3.7]]
+
 srcs_numeric = srcs_bool + srcs_int + srcs_real
 srcs_all = srcs_numeric + srcs_str
 
@@ -225,7 +228,7 @@ def t_count_na(arr):
                for x in arr)
 
 
-@pytest.mark.parametrize("src", srcs_all)
+@pytest.mark.parametrize("src", srcs_all + srcs_obj)
 def test_dt_count_na(src):
     dt0 = dt.Frame(src)
     dtr = dt0.countna()


### PR DESCRIPTION
- Implemented `countna` function for a column of object type (previously it was seg.faulting)
- When creating an object column, we will now convert float "nan" values into NAs (represented as Py_None).

Closes #887