### PR TITLE
Issue889

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   incorrectly recognized chunk boundaries.
 - Fixed a crash when rbinding string column with non-string: now an exception
   will be thrown instead.
+- Calling any stats function on a column of obj64 type will no longer result in
+  a crash.
 
 
 

--- a/c/column.cc
+++ b/c/column.cc
@@ -262,7 +262,7 @@ Column* Column::mean_column() const { return new_na_column(ST_REAL_F8, 1); }
 Column* Column::sd_column() const   { return new_na_column(ST_REAL_F8, 1); }
 Column* Column::min_column() const  { return new_na_column(stype(), 1); }
 Column* Column::max_column() const  { return new_na_column(stype(), 1); }
-Column* Column::mode_column() const { return new_na_column(stype(), 1); }
+Column* Column::mode_column() const { throw NotImplError(); }
 Column* Column::sum_column() const  { return new_na_column(stype(), 1); }
 
 Column* Column::countna_column() const {
@@ -287,7 +287,7 @@ PyObject* Column::mean_pyscalar() const { return none(); }
 PyObject* Column::sd_pyscalar() const { return none(); }
 PyObject* Column::min_pyscalar() const { return none(); }
 PyObject* Column::max_pyscalar() const { return none(); }
-PyObject* Column::mode_pyscalar() const { return none(); }
+PyObject* Column::mode_pyscalar() const { throw NotImplError(); }
 PyObject* Column::sum_pyscalar() const { return none(); }
 PyObject* Column::countna_pyscalar() const { return int_to_py(countna()); }
 PyObject* Column::nunique_pyscalar() const { return int_to_py(nunique()); }

--- a/c/column.h
+++ b/c/column.h
@@ -264,7 +264,7 @@ protected:
 
 
   /**
-   * Sets every row in the column with a NA value. As of now this method
+   * Sets every row in the column to an NA value. As of now this method
    * modifies every element in the column's memory buffer regardless of its
    * refcount or rowindex. Use with caution.
    * This implementation will be made safer after Column::extract is modified
@@ -553,7 +553,7 @@ protected:
   // void cast_into(StringColumn<int32_t>*) const;
   // void cast_into(StringColumn<int64_t>*) const;
 
-  void fill_na() override {}
+  void fill_na() override;
   friend Column;
 };
 

--- a/c/column_pyobj.cc
+++ b/c/column_pyobj.cc
@@ -45,12 +45,18 @@ SType PyObjectColumn::stype() const {
 void PyObjectColumn::open_mmap(const std::string&) {
   assert(!ri && !mbuf);
   mbuf = new MemoryMemBuf(static_cast<size_t>(nrows) * sizeof(PyObject*));
+  fill_na();
+}
+
+
+void PyObjectColumn::fill_na() {
   PyObject** data = this->elements();
   for (int64_t i = 0; i < nrows; ++i) {
     data[i] = Py_None;
-    Py_INCREF(Py_None);
   }
+  Py_None->ob_refcnt += nrows;  // Manually increase ref-count on Py_None
 }
+
 
 
 //----- Type casts -------------------------------------------------------------

--- a/c/datatablemodule.c
+++ b/c/datatablemodule.c
@@ -167,6 +167,7 @@ static PyModuleDef datatablemodule = {
 PyMODINIT_FUNC
 PyInit__datatable(void) {
     init_csvwrite_constants();
+    init_exceptions();
 
     Py_One = PyLong_FromLong(1);
     Py_Zero = PyLong_FromLong(0);

--- a/c/utils/exceptions.cc
+++ b/c/utils/exceptions.cc
@@ -14,8 +14,8 @@
 // Singleton, used to write the current "errno" into the stream
 CErrno Errno;
 
-static PyObject* type_error_class = PyExc_TypeError;
-static PyObject* value_error_class = PyExc_ValueError;
+static PyObject* type_error_class;
+static PyObject* value_error_class;
 
 
 
@@ -154,6 +154,11 @@ Error IOError()       { return Error(PyExc_IOError); }
 
 void replace_typeError(PyObject* obj) { type_error_class = obj; }
 void replace_valueError(PyObject* obj) { value_error_class = obj; }
+
+void init_exceptions() {
+  type_error_class = PyExc_TypeError;
+  value_error_class = PyExc_ValueError;
+}
 
 
 

--- a/c/utils/exceptions.h
+++ b/c/utils/exceptions.h
@@ -108,6 +108,7 @@ Error IOError();
 
 void replace_typeError(PyObject* obj);
 void replace_valueError(PyObject* obj);
+void init_exceptions();
 
 
 //------------------------------------------------------------------------------

--- a/tests/test_dt_stats.py
+++ b/tests/test_dt_stats.py
@@ -351,6 +351,50 @@ def test_empty_frame(st):
     assert f1.nmodal1() == 0
 
 
+def test_object_column():
+    df = dt.Frame([None, nan, 3, "srsh"])
+    assert df.internal.check()
+    assert df.countna1() == 2
+    assert df.min1() is None
+    assert df.max1() is None
+    assert df.mean1() is None
+    assert df.sum1() is None
+    assert df.sd1() is None
+    with pytest.raises(NotImplementedError):
+        df.mode1()
+    with pytest.raises(NotImplementedError):
+        df.nunique1()
+    with pytest.raises(NotImplementedError):
+        df.nmodal1()
+
+
+def test_object_column2():
+    df = dt.Frame([None, nan, 3, "srsh"])
+    f0 = df.countna()
+    assert f0.stypes == (stype.int64, )
+    assert f0.topython() == [[2]]
+    f1 = df.min()
+    assert f1.stypes == (stype.obj64, )
+    assert f1.topython() == [[None]]
+    f2 = df.max()
+    assert f2.stypes == (stype.obj64, )
+    assert f2.topython() == [[None]]
+    f3 = df.sum()
+    assert f3.stypes == (stype.obj64, )
+    assert f3.topython() == [[None]]
+    f4 = df.mean()
+    assert f4.stypes == (stype.float64, )
+    assert f4.topython() == [[None]]
+    f5 = df.sd()
+    assert f5.stypes == (stype.float64, )
+    assert f5.topython() == [[None]]
+    with pytest.raises(NotImplementedError):
+        df.mode()
+    with pytest.raises(NotImplementedError):
+        df.nunique()
+    with pytest.raises(NotImplementedError):
+        df.nmodal()
+
 
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
- Properly implemented `->fill_na()` method for the `PyObjectColumn` class.
- Fix crashes when calling some stats function on an `obj64` column.
- Eliminated warnings in exceptions.cc about "Declaration requires global constructor".

Closes #889