### PR TITLE
Implement logging as an option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 #### Added
 - Added ability to delete rows from a view Frame.
 - Implement countna() function for `obj64` columns.
+- New option `dt.options.core_logger` to help debug datatable.
 
 #### Changed
 - When creating a column of "object" type, we will now coerce float "nan"

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -64,7 +64,7 @@ class DataTable {
     void apply_na_mask(DataTable* mask);
     void replace_rowindex(const RowIndex& newri);
     void reify();
-    DataTable* rbind(DataTable**, int**, int, int64_t);
+    void rbind(DataTable**, int**, int, int64_t);
     DataTable* cbind(DataTable**, int);
     size_t memory_footprint();
 

--- a/c/datatable_rbind.cc
+++ b/c/datatable_rbind.cc
@@ -25,15 +25,14 @@
  * number `cols[i][j]` in datatable `dts[j]` (if `cols[i][j] >= 0`, otherwise
  * NAs).
  */
-DataTable* DataTable::rbind(
-  DataTable** dts, int** cols, int ndts, int64_t new_ncols)
+void DataTable::rbind(DataTable** dts, int** cols, int ndts, int64_t new_ncols)
 {
   assert(new_ncols >= ncols);
 
   // If this is a view datatable, then it must be materialized.
   this->reify();
 
-  dtrealloc(columns, Column*, new_ncols + 1);
+  dtrealloc_x(columns, Column*, new_ncols + 1);
   for (int64_t i = ncols; i < new_ncols; ++i) {
     columns[i] = new VoidColumn(nrows);
   }
@@ -58,5 +57,4 @@ DataTable* DataTable::rbind(
   }
   ncols = new_ncols;
   nrows = new_nrows;
-  return this;
 }

--- a/c/datatablemodule.c
+++ b/c/datatablemodule.c
@@ -137,6 +137,7 @@ static PyMethodDef DatatableModuleMethods[] = {
     METHODv(pydatatable::datatable_from_buffers),
     METHODv(pydatatable::install_buffer_hooks),
     METHODv(set_nthreads),
+    METHODv(set_core_logger),
     METHODv(gread),
     METHOD0_(write_csv),
     METHOD0_(exec_function),

--- a/c/options.cc
+++ b/c/options.cc
@@ -13,6 +13,7 @@ namespace config
 {
 
 static int n_threads = 0;
+PyObject* logger = nullptr;
 
 
 int get_nthreads() {
@@ -35,6 +36,20 @@ void set_nthreads(int nth) {
   omp_set_num_threads(nth);
 }
 
+
+PyObject* get_core_logger() {
+  return logger;
+}
+
+void set_core_logger(PyObject* o) {
+  if (o == Py_None) {
+    logger = nullptr;
+  } else {
+    logger = o;
+    Py_INCREF(o);
+  }
+}
+
 };
 
 
@@ -43,5 +58,12 @@ PyObject* set_nthreads(PyObject*, PyObject* args) {
   int nth;
   if (!PyArg_ParseTuple(args, "i", &nth)) return nullptr;
   config::set_nthreads(nth);
+  return none();
+}
+
+PyObject* set_core_logger(PyObject*, PyObject* args) {
+  PyObject* o;
+  if (!PyArg_ParseTuple(args, "O", &o)) return nullptr;
+  config::set_core_logger(o);
   return none();
 }

--- a/c/options.h
+++ b/c/options.h
@@ -15,6 +15,9 @@ namespace config {
 int get_nthreads();
 void set_nthreads(int nth);
 
+extern PyObject* logger;
+PyObject* get_core_logger();
+void set_core_logger(PyObject*);
 };
 
 
@@ -22,6 +25,11 @@ void set_nthreads(int nth);
 DECLARE_FUNCTION(
   set_nthreads,
   "set_nthreads(nth)\n\n",
+  dt_OPTIONS_cc)
+
+DECLARE_FUNCTION(
+  set_core_logger,
+  "set_core_logger(logger)\n\n",
   dt_OPTIONS_cc)
 
 

--- a/c/py_column.h
+++ b/c/py_column.h
@@ -14,6 +14,7 @@
 
 
 #define BASECLS pycolumn::obj
+#define CLSNAME Column
 #define HOMEFLAG dt_PY_COLUMN_cc
 namespace pycolumn
 {
@@ -108,5 +109,6 @@ DECLARE_FUNCTION(
 
 };  // namespace pycolumn
 #undef BASECLS
+#undef CLSNAME
 #undef HOMEFLAG
 #endif

--- a/c/py_columnset.h
+++ b/c/py_columnset.h
@@ -14,6 +14,7 @@
 
 
 #define BASECLS pycolumnset::obj
+#define CLSNAME ColumnSet
 #define HOMEFLAG dt_PY_COLUMNSET_cc
 namespace pycolumnset
 {
@@ -71,5 +72,6 @@ int static_init(PyObject* module);
 
 };
 #undef BASECLS
+#undef CLSNAME
 #undef HOMEFLAG
 #endif

--- a/c/py_datatable.cc
+++ b/c/py_datatable.cc
@@ -302,13 +302,8 @@ PyObject* rbind(obj* self, PyObject* args) {
     }
     dts[i] = dti;
   }
-  try {
-    DataTable* ret = dt->rbind( dts, cols_to_append, ndts, final_ncols);
-    if (ret == nullptr) return nullptr;
-  } catch (const std::exception& e) {
-    exception_to_python(e);
-    return nullptr;
-  }
+
+  dt->rbind(dts, cols_to_append, ndts, final_ncols);
 
   dtfree(cols_to_append);
   dtfree(dts);

--- a/c/py_datatable.h
+++ b/c/py_datatable.h
@@ -13,6 +13,7 @@
 
 
 #define BASECLS pydatatable::obj
+#define CLSNAME DataTable
 #define HOMEFLAG dt_PY_DATATABLE_cc
 namespace pydatatable
 {
@@ -270,5 +271,6 @@ DECLARE_FUNCTION(
 
 };
 #undef BASECLS
+#undef CLSNAME
 #undef HOMEFLAG
 #endif

--- a/c/py_rowindex.h
+++ b/c/py_rowindex.h
@@ -13,6 +13,7 @@
 
 
 #define BASECLS pyrowindex::obj
+#define CLSNAME RowIndex
 #define HOMEFLAG dt_PY_ROWINDEX_cc
 namespace pyrowindex
 {
@@ -143,4 +144,5 @@ DECLARE_FUNCTION(
 };  // namespace pyrowindex
 #undef HOMEFLAG
 #undef BASECLS
+#undef CLSNAME
 #endif

--- a/c/py_utils.c
+++ b/c/py_utils.c
@@ -110,3 +110,9 @@ void _dt_err_a(const char *format, ...)
     PyErr_FormatV(PyExc_AssertionError, format, vargs);
     va_end(vargs);
 }
+
+
+void log_call(const char* msg) {
+  if (!config::logger) return;
+  PyObject_CallMethod(config::logger, "info", "s", msg);
+}

--- a/c/py_utils.h
+++ b/c/py_utils.h
@@ -35,6 +35,7 @@ void log_call(const char* msg);
         return call;                                                           \
       }                                                                        \
     } catch (const std::exception& e) {                                        \
+      if (config::logger) log_call("error: " log_msg);                         \
       exception_to_python(e);                                                  \
       return NULL;                                                             \
     }                                                                          \

--- a/c/utils.h
+++ b/c/utils.h
@@ -142,6 +142,11 @@ inline std::string operator "" _s(const char* str, size_t len) {
     if (ptr == null && n) goto fail;                                           \
 } while(0)
 
+#define dtrealloc_x(ptr, T, n) do {                                            \
+    ptr = (T*) _dt_realloc(ptr, (size_t)(n) * SIZEOF(T));                      \
+    if (ptr == null && n) throw MemoryError();                                 \
+} while(0)
+
 
 
 /**

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -908,3 +908,8 @@ options.register_option(
         "(default) allows datatable to use the maximum number of threads. "
         "Values less than zero allow to use that fewer threads than the "
         "maximum. Finally, nthreads=1 indicates single-threaded mode.")
+
+options.register_option(
+    "core_logger", xtype=object, default=None, setter=core.set_core_logger,
+    doc="If you set this option to a Logger object, then every call to any "
+        "core function will be recorded via this object.")

--- a/tests/test_dt_options.py
+++ b/tests/test_dt_options.py
@@ -11,7 +11,7 @@ import datatable as dt
 @pytest.mark.run(order=1001)
 def test_options_all():
     # Update this test every time a new option is added
-    assert dir(dt.options) == ["nthreads"]
+    assert set(dir(dt.options)) == {"nthreads", "core_logger"}
 
 
 @pytest.mark.run(order=1002)
@@ -109,3 +109,23 @@ def test_nthreads():
     assert dt.options.nthreads == 1
     del dt.options.nthreads
     assert dt.options.nthreads == 0
+
+@pytest.mark.run(order=1011)
+def test_core_logger():
+    class MyLogger:
+        def __init__(self):
+            self.messages = ""
+        def info(self, msg):
+            self.messages += msg + '\n'
+
+    ml = MyLogger()
+    assert dt.options.core_logger is None
+    dt.options.core_logger = ml
+    assert dt.options.core_logger == ml
+    f0 = dt.Frame([1, 2, 3])
+    assert f0.internal.check()
+    assert "call: DataTable.datatable_from_list(...)" in ml.messages
+    assert "call: DataTable.ncols" in ml.messages
+    assert "call: DataTable.nrows" in ml.messages
+    assert "call: DataTable.check(...)" in ml.messages
+    assert "done: DataTable.check(...)" in ml.messages

--- a/tests/test_dt_options.py
+++ b/tests/test_dt_options.py
@@ -129,3 +129,5 @@ def test_core_logger():
     assert "call: DataTable.nrows" in ml.messages
     assert "call: DataTable.check(...)" in ml.messages
     assert "done: DataTable.check(...)" in ml.messages
+    del dt.options.core_logger
+    assert dt.options.core_logger is None


### PR DESCRIPTION
This adds a new option `dt.options.core_logger` which can be set to a `Logger` instance, and it will be called every time we start/end a call to any core function.