### PR TITLE
Fix crash when materializing view frames with obj columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added ability to delete rows from a view Frame.
 - Implement countna() function for `obj64` columns.
 - New option `dt.options.core_logger` to help debug datatable.
+- New Frame method `.materialize()` to convert a view Frame into a "real" one.
+  This method is noop if applied to a non-view Frame.
 
 #### Changed
 - When creating a column of "object" type, we will now coerce float "nan"
@@ -30,6 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Calling any stats function on a column of obj64 type will no longer result in
   a crash.
 - Columns/rows slices no longer fail on an empty Frame.
+- Fixed crash when materializing a view frame containing obj64 columns.
 
 
 

--- a/c/column.h
+++ b/c/column.h
@@ -304,7 +304,7 @@ public:
   void apply_na_mask(const BoolColumn* mask) override;
   size_t elemsize() const override;
   bool is_fixedwidth() const override;
-  void reify() override;
+  virtual void reify() override;
 
 protected:
   void init_data() override;
@@ -553,6 +553,7 @@ protected:
   // void cast_into(StringColumn<int64_t>*) const;
 
   void fill_na() override;
+  void reify() override;
   friend Column;
 };
 

--- a/c/column_pyobj.cc
+++ b/c/column_pyobj.cc
@@ -58,6 +58,19 @@ void PyObjectColumn::fill_na() {
 }
 
 
+void PyObjectColumn::reify() {
+  if (ri.isabsent()) return;
+  FwColumn<PyObject*>::reify();
+
+  // After regular reification, we need to increment ref-counts for each
+  // element in the column, since we created a new independent reference of
+  // each python object.
+  PyObject** data = this->elements();
+  for (int64_t i = 0; i < nrows; ++i) {
+    Py_INCREF(data[i]);
+  }
+}
+
 
 //----- Type casts -------------------------------------------------------------
 

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -817,6 +817,12 @@ class Frame(object):
         return self._dt.to_scalar()
 
 
+    def materialize(self):
+        if self._dt.isview:
+            self._dt = self._dt.materialize()
+        return self
+
+
     def __sizeof__(self):
         """
         Return the size of this Frame in memory.

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -697,3 +697,24 @@ def test_scalar_on_view(dt0):
     assert dt0[2, 6].scalar() == "hello"
     assert dt0[2::5, 3::7].scalar() == -4
     assert dt0[[3], "G"].scalar() == "world"
+
+
+
+#-------------------------------------------------------------------------------
+# Misc
+#-------------------------------------------------------------------------------
+
+@pytest.mark.run(order=33)
+def test_issue898():
+    """
+    Test that reification of obj column views does not lead to any disastrous
+    results (previously this was crashing).
+    """
+    class A: pass
+    f0 = dt.Frame([A() for i in range(1111)])
+    assert f0.stypes == (dt.stype.obj64, )
+    f1 = f0[:-1, :]
+    del f0
+    f1.materialize()
+    res = f1.topython()
+    del res


### PR DESCRIPTION
* Fix crash which was happening when materializing a view containing obj64 columns. (And if by accident it wasn't crashing, it could have caused action-at-a-distance crashes some time later on).
* Added method `Frame.materialize()` to convert a view Frame into a regular data frame. (This replaces the need to call `Frame(frame.internal.materialize(), names=frame.names)`)

Closes #898