### PR TITLE
Consolidate all type information in the ParsersLibrary class

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -433,7 +433,7 @@ $(BUILDDIR)/csv/reader_arff.h: c/csv/reader_arff.h $(BUILDDIR)/csv/reader.h
 	@echo • Refreshing c/csv/reader_arff.h
 	@cp c/csv/reader_arff.h $@
 
-$(BUILDDIR)/csv/reader_fread.h: c/csv/reader_fread.h $(BUILDDIR)/csv/fread.h $(BUILDDIR)/csv/py_csv.h $(BUILDDIR)/csv/reader.h $(BUILDDIR)/memorybuf.h
+$(BUILDDIR)/csv/reader_fread.h: c/csv/reader_fread.h $(BUILDDIR)/csv/fread.h $(BUILDDIR)/csv/py_csv.h $(BUILDDIR)/csv/reader.h $(BUILDDIR)/csv/reader_parsers.h $(BUILDDIR)/memorybuf.h
 	@echo • Refreshing c/csv/reader_fread.h
 	@cp c/csv/reader_fread.h $@
 
@@ -562,11 +562,11 @@ $(BUILDDIR)/csv/reader_fread.o : c/csv/reader_fread.cc $(BUILDDIR)/column.h $(BU
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/csv/reader_parsers.o : c/csv/reader_parsers.cc $(BUILDDIR)/csv/reader_parsers.h
+$(BUILDDIR)/csv/reader_parsers.o : c/csv/reader_parsers.cc $(BUILDDIR)/csv/reader_parsers.h $(BUILDDIR)/utils/assert.h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/csv/reader_utils.o : c/csv/reader_utils.cc $(BUILDDIR)/csv/fread.h $(BUILDDIR)/csv/reader.h $(BUILDDIR)/utils/assert.h $(BUILDDIR)/utils/exceptions.h $(BUILDDIR)/utils/omp.h
+$(BUILDDIR)/csv/reader_utils.o : c/csv/reader_utils.cc $(BUILDDIR)/csv/fread.h $(BUILDDIR)/csv/reader.h $(BUILDDIR)/csv/reader_parsers.h $(BUILDDIR)/utils/assert.h $(BUILDDIR)/utils/exceptions.h $(BUILDDIR)/utils/omp.h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 

--- a/c/csv/chunks.h
+++ b/c/csv/chunks.h
@@ -11,18 +11,12 @@
 #include "utils/assert.h"
 
 
-// forward declaration
-class LocalParseContext;
-class FreadReader;
-struct FreadTokenizer;
-
-
 //------------------------------------------------------------------------------
 // ChunkCoordinates struct
 //------------------------------------------------------------------------------
 
 /**
- * Helper struct containing the beginning + the end for a chunk.
+ * Helper struct containing the beginning / the end for a chunk.
  *
  * Additional flags `true_start` and `true_end` indicate whether the beginning /
  * end of the chunk are known with certainty or guessed.
@@ -54,6 +48,7 @@ struct ChunkCoordinates {
 //------------------------------------------------------------------------------
 // Base ChunkOrganizer
 //------------------------------------------------------------------------------
+class LocalParseContext;
 
 /**
  * Helper class whose responsibility is to determine how the input should be
@@ -143,6 +138,9 @@ typedef std::unique_ptr<ChunkOrganizer> ChunkOrganizerPtr;
 //------------------------------------------------------------------------------
 // Fread ChunkOrganizer
 //------------------------------------------------------------------------------
+class FreadReader;
+struct FreadTokenizer;
+
 
 class FreadChunkOrganizer : public ChunkOrganizer {
   private:

--- a/c/csv/fread.h
+++ b/c/csv/fread.h
@@ -5,8 +5,8 @@
 //
 // © H2O.ai 2018
 //------------------------------------------------------------------------------
-#ifndef dt_FREAD_H
-#define dt_FREAD_H
+#ifndef dt_FREAD_h
+#define dt_FREAD_h
 #include <stdint.h>  // uint32_t
 #include <stdlib.h>  // size_t
 #include "utils.h"
@@ -14,28 +14,6 @@
 #include "memorybuf.h"
 #include "csv/reader.h"
 
-
-// Ordered hierarchy of types
-typedef enum {
-  NEG            = -1,  // dummy to force signed type; sign bit used for out-of-sample type bump management
-  CT_DROP        = 0,   // skip column requested by user; it is navigated as a string column with the prevailing quoteRule
-  CT_BOOL8_N     = 1,   // int8_t; first enum value must be 1 not 0(=CT_DROP) so that it can be negated to -1.
-  CT_BOOL8_U     = 2,
-  CT_BOOL8_T     = 3,
-  CT_BOOL8_L     = 4,
-  CT_INT32       = 5,   // int32_t
-  CT_INT64       = 6,   // int64_t
-  CT_FLOAT32_HEX = 7,    // float, in hexadecimal format
-  CT_FLOAT64     = 8,   // double (64-bit IEEE 754 float)
-  CT_FLOAT64_EXT = 9,   // double, with various "NaN" literals
-  CT_FLOAT64_HEX = 10,  // double, in hexadecimal format
-  CT_STRING      = 11,  // RelStr struct below
-  NUMTYPE        = 12   // placeholder for the number of types including drop
-} colType;
-
-extern int8_t typeSize[NUMTYPE];
-extern const char typeSymbols[NUMTYPE];
-extern const char typeName[NUMTYPE][10];
 extern const long double pow10lookup[701];
 extern const uint8_t hexdigits[256];
 extern const uint8_t allowedseps[128];
@@ -95,14 +73,6 @@ struct FreadTokenizer {
 typedef void (*ParserFnPtr)(FreadTokenizer& ctx);
 
 
-#define NA_BOOL8         INT8_MIN
-#define NA_INT32         INT32_MIN
-#define NA_INT64         INT64_MIN
-#define NA_FLOAT64_I64   0x7FF00000000007A2
-#define NA_FLOAT32_I32   0x7F8007A2
-#define NA_LENOFF        INT32_MIN  // RelStr.len only; RelStr.off undefined for NA
-#define INF_FLOAT32_I32  0x7F800000
-#define INF_FLOAT64_I64   0x7FF0000000000000
 
 
 

--- a/c/csv/freadLookups.h
+++ b/c/csv/freadLookups.h
@@ -5,8 +5,8 @@
 //
 // © H2O.ai 2018
 //------------------------------------------------------------------------------
-#ifndef dt_FREAD_LOOKUPS_H
-#define dt_FREAD_LOOKUPS_H
+#ifndef dt_FREAD_LOOKUPS_h
+#define dt_FREAD_LOOKUPS_h
 
 // characters re-interpreted as hex digits (or 99 for characters that are not
 // valid digits). Thus, this table maps

--- a/c/csv/reader.h
+++ b/c/csv/reader.h
@@ -285,7 +285,7 @@ typedef std::unique_ptr<LocalParseContext> LocalParseContextPtr;
  *
  * An input column usually translates into an output column in a DataTable
  * returned to the user. The exception to this are "dropped" columns. They are
- * marked with `presentInOutput = false` flag (and have type CT_DROP).
+ * marked with `presentInOutput = false` flag (and have type PT::Drop).
  *
  * Implemented in "csv/reader_utils.cc".
  */
@@ -307,8 +307,10 @@ class GReaderColumn {
     GReaderColumn(const GReaderColumn&) = delete;
     GReaderColumn(GReaderColumn&&);
     virtual ~GReaderColumn();
+    const char* typeName() const;
     size_t elemsize() const;
     size_t getAllocSize() const;
+    bool isstring() const;
     void* data() const { return mbuf->get(); }
     void allocate(size_t nrows);
     MemoryBuffer* extract_databuf();

--- a/c/csv/reader_fread.h
+++ b/c/csv/reader_fread.h
@@ -11,6 +11,7 @@
 #include <vector>        // std::vector
 #include "csv/fread.h"
 #include "csv/reader.h"
+#include "csv/reader_parsers.h"
 #include "csv/py_csv.h"
 #include "memorybuf.h"
 
@@ -42,6 +43,7 @@ class FreadReader
   //     Number of rows in the allocated DataTable
   // meanLineLen:
   //     Average length (in bytes) of a single line in the input file
+  ParserLibrary parserlib;
   GReaderColumns columns;
   char* targetdir;
   const char* eof;
@@ -131,7 +133,7 @@ class FreadLocalParseContext : public LocalParseContext
     GReaderColumns& columns;
     std::vector<StrBuf> strbufs;
     FreadTokenizer tokenizer;
-    ParserFnPtr* parsers;
+    const ParserFnPtr* parsers;
 
     char*& typeBumpMsg;
     size_t& typeBumpMsgSize;
@@ -140,7 +142,7 @@ class FreadLocalParseContext : public LocalParseContext
 
   public:
     FreadLocalParseContext(size_t bcols, size_t brows, FreadReader&, int8_t*,
-                           ParserFnPtr* parsers, char*& typeBumpMsg,
+                           char*& typeBumpMsg,
                            size_t& typeBumpMsgSize, char*& stopErr,
                            size_t& stopErrSize, bool fill);
     FreadLocalParseContext(const FreadLocalParseContext&) = delete;

--- a/c/csv/reader_parsers.h
+++ b/c/csv/reader_parsers.h
@@ -5,13 +5,20 @@
 //
 // © H2O.ai 2018
 //------------------------------------------------------------------------------
-#ifndef dt_CSV_READER_PARSERS_H
-#define dt_CSV_READER_PARSERS_H
-#include <stdint.h>
+#ifndef dt_CSV_READER_PARSERS_h
+#define dt_CSV_READER_PARSERS_h
 #include <string>
 #include <vector>
 #include "csv/fread.h"
 
+
+// In order to add a new type:
+//   - implement a new parser function `void (*)(FreadTokenizer&)`
+//   - add a new identifier into `enum PT`
+//   - declare this parser in `ParserLibrary::init_parsers()`
+//   - add items in `_coltypes_strs` and `_coltypes` in "fread.py"
+//   - update `test_fread_fillna1` in test_fread.py to include the new type
+//
 
 void parse_mu(FreadTokenizer&);
 void parse_bool8_numeric(FreadTokenizer&);
@@ -31,52 +38,123 @@ void parse_string(FreadTokenizer&);
 
 enum class PT : uint8_t {
   Drop,
-  Mu,
-  BoolL,
-  BoolT,
-  BoolU,
+  // Mu,
   Bool01,
+  BoolU,
+  BoolT,
+  BoolL,
   Int32,
   Int64,
-  Float32Plain,
+  // Float32Plain,
   Float32Hex,
   Float64Plain,
   Float64Ext,
   Float64Hex,
   Str32,
+  // Str64,
 };
+
+
+enum class BT : uint8_t {
+  None   = 0,
+  Simple = 1,
+  Normal = 2,
+  Reread = 3,
+};
+
+
+
+//------------------------------------------------------------------------------
+// ParserInfo
+//------------------------------------------------------------------------------
+class ParserLibrary;
 
 
 class ParserInfo {
   public:
     ParserFnPtr fn;
-    std::vector<PT> next_parsers;
     std::string name;
     char code;
-    bool enabled;
+    int8_t elemsize;
+    SType stype;
     PT id;
-    int64_t : 40;
+    int32_t : 32;
 
-    ParserInfo(PT id_, const char* name_, char code_, ParserFnPtr ptr)
-        : fn(ptr), name(name_), code(code_), enabled(true), id(id_) {}
+    ParserInfo() : fn(nullptr), code(0), id(PT::Drop) {}
+    ParserInfo(PT id_, const char* name_, char code_, int8_t sz_, SType st_,
+               ParserFnPtr ptr)
+      : fn(ptr), name(name_), code(code_), elemsize(sz_), stype(st_), id(id_) {}
+
+    const char* cname() const { return name.data(); }
+    bool isstring() const { return id == PT::Str32; }
 };
 
 
-// Singleton class with information about various parsers
-class ParserLibrary {
-  private:
-    std::vector<ParserInfo> parsers;
 
-    ParserLibrary();
-    void add(ParserInfo&& p);
+//------------------------------------------------------------------------------
+// Parser iterators
+//------------------------------------------------------------------------------
+
+class ParserIterator {
+  private:
+    int ipt;
+    const uint8_t ptype;
+    int : 24;
 
   public:
-    static ParserLibrary& get();
+    using value_type = PT;
+    using category_type = std::input_iterator_tag;
+
+    ParserIterator();
+    ParserIterator(PT pt);
+    ParserIterator(const ParserIterator&) = default;
+    ParserIterator& operator=(const ParserIterator&) = default;
+    ~ParserIterator() {}
+    ParserIterator& operator++();
+    bool operator==(const ParserIterator&) const;
+    bool operator!=(const ParserIterator&) const;
+    value_type operator*() const;
+};
+
+class ParserIterable {
+  private:
+    const ParserLibrary& plib;
+    const PT ptype;
+    int64_t : 56;
+
+  public:
+    using iterator = ParserIterator;
+
+    ParserIterable(PT pt, const ParserLibrary& pl);
+    iterator begin() const;
+    iterator end() const;
+};
+
+
+
+//------------------------------------------------------------------------------
+// ParserLibrary
+//------------------------------------------------------------------------------
+
+class ParserLibrary {
+  private:
+    static ParserInfo* parsers;
+    static ParserFnPtr* parser_fns;
+    void init_parsers();
+    int64_t : 64;
+
+  public:
+    static constexpr size_t num_parsers = static_cast<size_t>(PT::Str32) + 1;
+    ParserLibrary();
     ParserLibrary(const ParserLibrary&) = delete;
     void operator=(const ParserLibrary&) = delete;
 
-    ParserInfo& operator[](size_t i) { return parsers[i]; }
-    ~ParserLibrary() {}
+    ParserIterable successor_types(PT pt) const;
+
+    static const ParserFnPtr* get_parser_fns() { return parser_fns; }
+    static const ParserInfo* get_parser_infos() { return parsers; }
+    static const ParserInfo& info(size_t i) { return parsers[i]; }
+    static const ParserInfo& info(int8_t i) { return parsers[i]; }
 };
 
 

--- a/datatable/fread.py
+++ b/datatable/fread.py
@@ -974,7 +974,7 @@ _pathlike = (str, bytes, os.PathLike) if hasattr(os, "PathLike") else \
 
 
 #-------------------------------------------------------------------------------
-# Directly corresponds to `colType` enum in "fread.h"
+# Directly corresponds to `PT` enum in "reader_parsers.h"
 _coltypes_strs = [
     "drop",      # 0
     "bool8n",    # 1

--- a/tests/fread/test_fread_large.py
+++ b/tests/fread/test_fread_large.py
@@ -11,6 +11,7 @@
 import os
 import pytest
 import datatable
+import zipfile
 
 env_coverage = "DTCOVERAGE"
 root_env_name = "DT_LARGE_TESTS_ROOT"
@@ -86,8 +87,11 @@ def f(request):
 @pytest.mark.parametrize("f", get_file_list("h2oai-benchmarks", "Data"),
                          indirect=True)
 def test_h2oai_benchmarks(f):
-    d = datatable.fread(f)
-    assert d.internal.check()
+    try:
+        d = datatable.fread(f)
+        assert d.internal.check()
+    except zipfile.BadZipFile:
+        pytest.skip("Bad zip file error")
 
 
 

--- a/tests/fread/test_fread_small.py
+++ b/tests/fread/test_fread_small.py
@@ -724,7 +724,7 @@ def test_almost_nodata(capsys):
     assert d0.shape == (n, 3)
     assert d0.ltypes == (ltype.int, ltype.str, ltype.str)
     assert d0.topython() == [[2017] * n, m, ["foo"] * n]
-    assert ("Column 2 (\"B\") bumped from 'bool8' to 'string' "
+    assert ("Column 2 (\"B\") bumped from 'Bool8/numeric' to 'Str32' "
             "due to <<gotcha>> on row 109" in out)
 
 


### PR DESCRIPTION
Eliminate global static arrays `parsers`, `typeSymbols`, `typeNames`, `typeSizes`, `coltype_to_stype`, and instead create a single repository of all information about the parsers: the `ParserLibrary` class, which can be accessed either statically or through an instance.

WIP for #657
WIP for #909