### PR TITLE
Convert all assert() statements into exception throws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - When creating a column of "object" type, we will now coerce float "nan"
   values into `None`s.
 - Renamed fread's parameter `strip_white` into `strip_whitespace`.
+- Eliminated all `assert()` statements from C code, and replaced them with
+  exception throws.
 
 #### Fixed
 - fread will no longer consume excessive amounts of memory when reading a file

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ test:
 
 
 benchmark:
-	$(PYTHON) -m pytest -ra -v benchmarks
+	$(PYTHON) -m pytest -ra -x -v benchmarks
 
 
 debug:
@@ -97,11 +97,11 @@ coverage:
 	$(MAKE) build
 	$(MAKE) install
 	$(MAKE) test_install
-	$(PYTHON) -m pytest \
+	$(PYTHON) -m pytest -x \
 		--benchmark-skip \
 		--cov=datatable --cov-report=html:build/coverage-py \
 		tests
-	$(PYTHON) -m pytest \
+	$(PYTHON) -m pytest -x \
 		--benchmark-skip \
 		--cov=datatable --cov-report=xml:build/coverage.xml \
 		tests

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ test:
 	$(MAKE) test_install
 	rm -rf build/test-reports 2>/dev/null
 	mkdir -p build/test-reports/
-	$(PYTHON) -m pytest -ra \
+	$(PYTHON) -m pytest -ra --maxfail=10 \
 		--junit-prefix=$(PLATFORM) \
 		--junitxml=build/test-reports/TEST-datatable.xml \
 		tests

--- a/Makefile
+++ b/Makefile
@@ -401,7 +401,7 @@ $(BUILDDIR)/writebuf.h: c/writebuf.h $(BUILDDIR)/utils/file.h
 	@cp c/writebuf.h $@
 
 
-$(BUILDDIR)/csv/chunks.h: c/csv/chunks.h $(BUILDDIR)/utils/assert.h
+$(BUILDDIR)/csv/chunks.h: c/csv/chunks.h
 	@echo • Refreshing c/csv/chunks.h
 	@cp c/csv/chunks.h $@
 
@@ -468,7 +468,7 @@ $(BUILDDIR)/utils/array.h: c/utils/array.h $(BUILDDIR)/utils/exceptions.h
 	@echo • Refreshing c/utils/array.h
 	@cp c/utils/array.h $@
 
-$(BUILDDIR)/utils/assert.h: c/utils/assert.h
+$(BUILDDIR)/utils/assert.h: c/utils/assert.h $(BUILDDIR)/utils/exceptions.h
 	@echo • Refreshing c/utils/assert.h
 	@cp c/utils/assert.h $@
 
@@ -522,7 +522,7 @@ $(BUILDDIR)/column_int.o : c/column_int.cc $(BUILDDIR)/column.h $(BUILDDIR)/py_t
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/column_pyobj.o : c/column_pyobj.cc $(BUILDDIR)/column.h
+$(BUILDDIR)/column_pyobj.o : c/column_pyobj.cc $(BUILDDIR)/column.h $(BUILDDIR)/utils/assert.h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
@@ -542,7 +542,7 @@ $(BUILDDIR)/csv/chunks.o : c/csv/chunks.cc $(BUILDDIR)/csv/chunks.h $(BUILDDIR)/
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/csv/fread.o : c/csv/fread.cc $(BUILDDIR)/csv/fread.h $(BUILDDIR)/csv/freadLookups.h $(BUILDDIR)/csv/reader.h $(BUILDDIR)/csv/reader_fread.h $(BUILDDIR)/csv/reader_parsers.h $(BUILDDIR)/utils/shared_mutex.h
+$(BUILDDIR)/csv/fread.o : c/csv/fread.cc $(BUILDDIR)/csv/fread.h $(BUILDDIR)/csv/freadLookups.h $(BUILDDIR)/csv/reader.h $(BUILDDIR)/csv/reader_fread.h $(BUILDDIR)/csv/reader_parsers.h $(BUILDDIR)/utils/assert.h $(BUILDDIR)/utils/shared_mutex.h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
@@ -586,7 +586,7 @@ $(BUILDDIR)/datatable_check.o : c/datatable_check.cc $(BUILDDIR)/datatable_check
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/datatable_load.o : c/datatable_load.cc $(BUILDDIR)/datatable.h $(BUILDDIR)/utils.h $(BUILDDIR)/utils/assert.h
+$(BUILDDIR)/datatable_load.o : c/datatable_load.cc $(BUILDDIR)/datatable.h $(BUILDDIR)/utils.h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
@@ -594,7 +594,7 @@ $(BUILDDIR)/datatable_rbind.o : c/datatable_rbind.cc $(BUILDDIR)/column.h $(BUIL
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/datatablemodule.o : c/datatablemodule.c $(BUILDDIR)/capi.h $(BUILDDIR)/csv/py_csv.h $(BUILDDIR)/csv/writer.h $(BUILDDIR)/expr/py_expr.h $(BUILDDIR)/options.h $(BUILDDIR)/py_column.h $(BUILDDIR)/py_columnset.h $(BUILDDIR)/py_datatable.h $(BUILDDIR)/py_datawindow.h $(BUILDDIR)/py_encodings.h $(BUILDDIR)/py_rowindex.h $(BUILDDIR)/py_types.h $(BUILDDIR)/py_utils.h
+$(BUILDDIR)/datatablemodule.o : c/datatablemodule.c $(BUILDDIR)/capi.h $(BUILDDIR)/csv/py_csv.h $(BUILDDIR)/csv/writer.h $(BUILDDIR)/expr/py_expr.h $(BUILDDIR)/options.h $(BUILDDIR)/py_column.h $(BUILDDIR)/py_columnset.h $(BUILDDIR)/py_datatable.h $(BUILDDIR)/py_datawindow.h $(BUILDDIR)/py_encodings.h $(BUILDDIR)/py_rowindex.h $(BUILDDIR)/py_types.h $(BUILDDIR)/py_utils.h $(BUILDDIR)/utils/assert.h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
@@ -618,7 +618,7 @@ $(BUILDDIR)/expr/unaryop.o : c/expr/unaryop.cc $(BUILDDIR)/expr/py_expr.h $(BUIL
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/memorybuf.o : c/memorybuf.cc $(BUILDDIR)/datatable_check.h $(BUILDDIR)/memorybuf.h $(BUILDDIR)/py_utils.h $(BUILDDIR)/utils.h $(BUILDDIR)/utils/assert.h $(BUILDDIR)/utils/file.h
+$(BUILDDIR)/memorybuf.o : c/memorybuf.cc $(BUILDDIR)/datatable_check.h $(BUILDDIR)/memorybuf.h $(BUILDDIR)/py_utils.h $(BUILDDIR)/utils.h $(BUILDDIR)/utils/file.h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
@@ -630,7 +630,7 @@ $(BUILDDIR)/options.o : c/options.cc $(BUILDDIR)/options.h $(BUILDDIR)/utils/exc
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/py_buffers.o : c/py_buffers.cc $(BUILDDIR)/column.h $(BUILDDIR)/encodings.h $(BUILDDIR)/py_column.h $(BUILDDIR)/py_datatable.h $(BUILDDIR)/py_types.h $(BUILDDIR)/py_utils.h $(BUILDDIR)/utils/exceptions.h
+$(BUILDDIR)/py_buffers.o : c/py_buffers.cc $(BUILDDIR)/column.h $(BUILDDIR)/encodings.h $(BUILDDIR)/py_column.h $(BUILDDIR)/py_datatable.h $(BUILDDIR)/py_types.h $(BUILDDIR)/py_utils.h $(BUILDDIR)/utils/exceptions.h $(BUILDDIR)/utils/assert.h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
@@ -682,7 +682,7 @@ $(BUILDDIR)/python/long.o : c/python/long.cc $(BUILDDIR)/python/long.h $(BUILDDI
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/rowindex.o : c/rowindex.cc $(BUILDDIR)/datatable_check.h $(BUILDDIR)/rowindex.h $(BUILDDIR)/utils.h $(BUILDDIR)/utils/assert.h $(BUILDDIR)/utils/omp.h
+$(BUILDDIR)/rowindex.o : c/rowindex.cc $(BUILDDIR)/datatable_check.h $(BUILDDIR)/rowindex.h $(BUILDDIR)/utils.h $(BUILDDIR)/utils/omp.h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
@@ -690,7 +690,7 @@ $(BUILDDIR)/rowindex_array.o : c/rowindex_array.cc $(BUILDDIR)/column.h $(BUILDD
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/rowindex_slice.o : c/rowindex_slice.cc $(BUILDDIR)/datatable_check.h $(BUILDDIR)/rowindex.h $(BUILDDIR)/utils/exceptions.h
+$(BUILDDIR)/rowindex_slice.o : c/rowindex_slice.cc $(BUILDDIR)/datatable_check.h $(BUILDDIR)/rowindex.h $(BUILDDIR)/utils/exceptions.h $(BUILDDIR)/utils/assert.h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 

--- a/c/column.cc
+++ b/c/column.cc
@@ -73,7 +73,7 @@ Column* Column::new_mmap_column(SType stype, int64_t nrows,
  */
 void Column::save_to_disk(const std::string& filename,
                           WritableBuffer::Strategy strategy) {
-  assert(mbuf != nullptr);
+  xassert(mbuf != nullptr);
   mbuf->save_to_disk(filename, strategy);
 }
 
@@ -201,7 +201,7 @@ Column* Column::rbind(std::vector<const Column*>& columns)
   } else {
     res = this->cast(new_stype);
   }
-  assert(res->stype() == new_stype);
+  xassert(res->stype() == new_stype);
 
   // TODO: Temporary Fix. To be resolved in #301
   if (res->stats != nullptr) res->stats->reset();

--- a/c/column_fw.cc
+++ b/c/column_fw.cc
@@ -26,7 +26,7 @@ FwColumn<T>::FwColumn(int64_t nrows_, MemoryBuffer* mb) : Column(nrows_) {
   if (mb == nullptr) {
     mb = new MemoryMemBuf(req_size);
   } else {
-    assert(mb->size() == req_size);
+    xassert(mb->size() == req_size);
   }
   mbuf = mb;
 }
@@ -38,19 +38,19 @@ FwColumn<T>::FwColumn(int64_t nrows_, MemoryBuffer* mb) : Column(nrows_) {
 
 template <typename T>
 void FwColumn<T>::init_data() {
-  assert(!ri && !mbuf);
+  xassert(!ri && !mbuf);
   mbuf = new MemoryMemBuf(static_cast<size_t>(nrows) * elemsize());
 }
 
 template <typename T>
 void FwColumn<T>::init_mmap(const std::string& filename) {
-  assert(!ri && !mbuf);
+  xassert(!ri && !mbuf);
   mbuf = new MemmapMemBuf(filename, static_cast<size_t>(nrows) * elemsize());
 }
 
 template <typename T>
 void FwColumn<T>::open_mmap(const std::string& filename) {
-  assert(!ri && !mbuf);
+  xassert(!ri && !mbuf);
   mbuf = new MemmapMemBuf(filename);
   size_t exp_size = static_cast<size_t>(nrows) * sizeof(T);
   if (mbuf->size() != exp_size) {
@@ -63,7 +63,7 @@ void FwColumn<T>::open_mmap(const std::string& filename) {
 
 template <typename T>
 void FwColumn<T>::init_xbuf(Py_buffer* pybuffer) {
-  assert(!ri && !mbuf);
+  xassert(!ri && !mbuf);
   size_t exp_buf_len = static_cast<size_t>(nrows) * elemsize();
   if (static_cast<size_t>(pybuffer->len) != exp_buf_len) {
     throw Error() << "PyBuffer cannot be used to create a column of " << nrows
@@ -79,7 +79,7 @@ void FwColumn<T>::init_xbuf(Py_buffer* pybuffer) {
 
 template <typename T>
 void FwColumn<T>::replace_buffer(MemoryBuffer* new_mbuf, MemoryBuffer*) {
-  assert(new_mbuf != nullptr);
+  xassert(new_mbuf != nullptr);
   if (new_mbuf->size() % sizeof(T)) {
     throw RuntimeError() << "New buffer has invalid size " << new_mbuf->size();
   }
@@ -145,7 +145,7 @@ void FwColumn<T>::reify() {
     // the new buffer (use memmove because the old and the new buffer can be
     // the same).
     size_t start = static_cast<size_t>(ri.slice_start());
-    assert(newsize + start * elemsize <= mbuf->size());
+    xassert(newsize + start * elemsize <= mbuf->size());
     memmove(new_mbuf->get(), elements() + start, newsize);
 
   } else {
@@ -221,7 +221,7 @@ void FwColumn<T>::rbind_impl(std::vector<const Column*>& columns,
   size_t old_alloc_size = alloc_size();
   size_t new_alloc_size = sizeof(T) * (size_t) new_nrows;
   mbuf = mbuf->safe_resize(new_alloc_size);
-  assert(!mbuf->is_readonly());
+  xassert(!mbuf->is_readonly());
   nrows = new_nrows;
 
   // Copy the data
@@ -250,7 +250,7 @@ void FwColumn<T>::rbind_impl(std::vector<const Column*>& columns,
     set_value(resptr, naptr, sizeof(T), rows_to_fill);
     resptr = add_ptr(resptr, rows_to_fill * sizeof(T));
   }
-  assert(resptr == mbuf->at(new_alloc_size));
+  xassert(resptr == mbuf->at(new_alloc_size));
 }
 
 

--- a/c/column_pyobj.cc
+++ b/c/column_pyobj.cc
@@ -6,6 +6,7 @@
 // © H2O.ai 2018
 //------------------------------------------------------------------------------
 #include "column.h"
+#include "utils/assert.h"
 
 
 
@@ -43,7 +44,7 @@ SType PyObjectColumn::stype() const {
 // "PyObj" columns cannot be properly saved. So if somehow they were, then when
 // opening, we'll just fill the column with NAs.
 void PyObjectColumn::open_mmap(const std::string&) {
-  assert(!ri && !mbuf);
+  xassert(!ri && !mbuf);
   mbuf = new MemoryMemBuf(static_cast<size_t>(nrows) * sizeof(PyObject*));
   fill_na();
 }

--- a/c/column_string.cc
+++ b/c/column_string.cc
@@ -40,10 +40,10 @@ StringColumn<T>::StringColumn(int64_t nrows_,
     if (sb == nullptr) {
       throw Error() << "String buffer cannot be null when offset buffer is defined";
     }
-    assert(mb->size() == exp_off_size);
-    assert(mb->get_elem<T>(0) == -1);
+    xassert(mb->size() == exp_off_size);
+    xassert(mb->get_elem<T>(0) == -1);
     size_t exp_str_size = static_cast<size_t>(abs(mb->get_elem<T>(nrows)) - 1);
-    assert(sb->size() == exp_str_size);
+    xassert(sb->size() == exp_str_size);
   }
 
   mbuf = mb;
@@ -57,7 +57,7 @@ StringColumn<T>::StringColumn(int64_t nrows_,
 
 template <typename T>
 void StringColumn<T>::init_data() {
-  assert(!ri && !mbuf && !strbuf);
+  xassert(!ri && !mbuf && !strbuf);
   strbuf = new MemoryMemBuf(0);
   mbuf = new MemoryMemBuf((static_cast<size_t>(nrows) + 1) * sizeof(T));
   mbuf->set_elem<T>(0, -1);
@@ -65,7 +65,7 @@ void StringColumn<T>::init_data() {
 
 template <typename T>
 void StringColumn<T>::init_mmap(const std::string& filename) {
-  assert(!ri && !mbuf && !strbuf);
+  xassert(!ri && !mbuf && !strbuf);
   strbuf = new MemmapMemBuf(path_str(filename), 0);
   mbuf = new MemmapMemBuf(filename, (static_cast<size_t>(nrows) + 1) * sizeof(T));
   mbuf->set_elem<T>(0, -1);
@@ -73,7 +73,7 @@ void StringColumn<T>::init_mmap(const std::string& filename) {
 
 template <typename T>
 void StringColumn<T>::open_mmap(const std::string& filename) {
-  assert(!ri && !mbuf && !strbuf);
+  xassert(!ri && !mbuf && !strbuf);
 
   mbuf = new MemmapMemBuf(filename);
   size_t exp_mbuf_size = sizeof(T) * (static_cast<size_t>(nrows) + 1);
@@ -116,8 +116,8 @@ void StringColumn<T>::init_xbuf(Py_buffer*) {
 template <typename T>
 void StringColumn<T>::save_to_disk(const std::string& filename,
                                    WritableBuffer::Strategy strategy) {
-  assert(mbuf != nullptr);
-  assert(strbuf != nullptr);
+  xassert(mbuf != nullptr);
+  xassert(strbuf != nullptr);
   mbuf->save_to_disk(filename, strategy);
   strbuf->save_to_disk(path_str(filename), strategy);
 }
@@ -142,8 +142,8 @@ template <typename T>
 void StringColumn<T>::replace_buffer(MemoryBuffer* new_offbuf,
                                      MemoryBuffer* new_strbuf)
 {
-  assert(new_offbuf != nullptr);
-  assert(new_strbuf != nullptr);
+  xassert(new_offbuf != nullptr);
+  xassert(new_strbuf != nullptr);
   int64_t new_nrows = new_offbuf->size()/sizeof(T) - 1;
   if (new_offbuf->size() % sizeof(T)) {
     throw ValueError() << "The size of `new_offbuf` is not a multiple of "
@@ -411,7 +411,7 @@ void StringColumn<T>::resize_and_fill(int64_t new_nrows)
       strbuf = new_strbuf;
     }
   } else {
-    if (old_nrows == 1) assert(old_strbuf_size == 0);
+    if (old_nrows == 1) xassert(old_strbuf_size == 0);
     T na = -static_cast<T>(old_strbuf_size + 1);
     set_value(offsets + nrows, &na, sizeof(T),
               static_cast<size_t>(diff_rows));
@@ -446,8 +446,8 @@ void StringColumn<T>::rbind_impl(std::vector<const Column*>& columns,
   // Reallocate the column
   mbuf = mbuf->safe_resize(new_mbuf_size);
   strbuf = strbuf->safe_resize(new_strbuf_size);
-  assert(!mbuf->is_readonly());
-  assert(!strbuf->is_readonly());
+  xassert(!mbuf->is_readonly());
+  xassert(!strbuf->is_readonly());
   nrows = new_nrows;
   T* offs = offsets();
 

--- a/c/csv/chunks.cc
+++ b/c/csv/chunks.cc
@@ -55,7 +55,7 @@ int ChunkOrganizer::get_nthreads() const {
 }
 
 void ChunkOrganizer::set_nthreads(int nth) {
-  assert(nth > 0);
+  xassert(nth > 0);
   nThreads = nth;
   determine_chunking_strategy();
 }
@@ -64,7 +64,7 @@ void ChunkOrganizer::set_nthreads(int nth) {
 ChunkCoordinates ChunkOrganizer::compute_chunk_boundaries(
   size_t i, LocalParseContext* ctx) const
 {
-  assert(i < chunkCount);
+  xassert(i < chunkCount);
   ChunkCoordinates c;
 
   bool isFirstChunk = (i == 0);
@@ -96,7 +96,7 @@ bool ChunkOrganizer::is_ordered(
   xcc.start = lastChunkEnd;
   xcc.true_start = true;
   if (ordered && acc.end) {
-    assert(acc.end >= lastChunkEnd);
+    xassert(acc.end >= lastChunkEnd);
     lastChunkEnd = acc.end;
   }
   return ordered;

--- a/c/csv/chunks.h
+++ b/c/csv/chunks.h
@@ -8,7 +8,6 @@
 #ifndef dt_CSV_CHUNKS_h
 #define dt_CSV_CHUNKS_h
 #include <memory>           // std::unique_ptr
-#include "utils/assert.h"
 
 
 //------------------------------------------------------------------------------

--- a/c/csv/fread.cc
+++ b/c/csv/fread.cc
@@ -18,6 +18,7 @@
 #include <cmath>       // std::sqrt, std::ceil
 #include <cstdio>      // std::snprintf
 #include <string>      // std::string
+#include "utils/assert.h"
 #include "utils/shared_mutex.h"
 
 
@@ -196,14 +197,14 @@ class FreadChunkedReader {
               // time.
               bool reparse_error = !acc.end && !xcc.true_start;
               if (!chunkster->is_ordered(acc, xcc) || reparse_error) {
-                assert(xcc.true_start);
+                xassert(xcc.true_start);
                 ctx->read_chunk(xcc, acc);
                 if (acc.end && !chunkster->is_ordered(acc, xcc)) {
                   throw RuntimeError() << "Unable to order chunks";
                 }
               }
               if (!acc.end) {
-                assert(stopErr[0]);
+                xassert(stopErr[0]);
                 stopTeam = true;
                 break;
               }
@@ -437,7 +438,7 @@ DataTablePtr FreadReader::read()
         }
       }
     }
-    ASSERT(firstJumpEnd);
+    xassert(firstJumpEnd);
     quoteRule = ctx.quoteRule = topQuoteRule;
     sep = ctx.sep = topSep;
     whiteChar = ctx.whiteChar = (sep==' ' ? '\t' : (sep=='\t' ? ' ' : 0));
@@ -469,7 +470,7 @@ DataTablePtr FreadReader::read()
         }
       }
     }
-    ASSERT(ncols >= 1 && line >= 1);
+    xassert(ncols >= 1 && line >= 1);
 
     // Create vector of Column objects
     columns.reserve(static_cast<size_t>(ncols));
@@ -481,7 +482,7 @@ DataTablePtr FreadReader::read()
     tch = sof;
     int tt = ctx.countfields();
     tch = sof;  // move back to start of line since countfields() moved to next
-    ASSERT(fill || tt == ncols);
+    xassert(fill || tt == ncols);
     if (verbose) {
       trace("  Detected %d columns on line %d. This line is either column "
             "names or first data row. Line starts as: \"%s\"",
@@ -494,8 +495,8 @@ DataTablePtr FreadReader::read()
     if (prevStart) {
       tch = prevStart;
       int ttt = ctx.countfields();
-      ASSERT(ttt != ncols);
-      ASSERT(tch==sof);
+      xassert(ttt != ncols);
+      xassert(tch==sof);
       if (ttt > 1) {
         warn("Starting data input on line %d <<%s>> with %d fields and discarding "
              "line %d <<%s>> before it because it has a different number of fields (%d).",
@@ -630,7 +631,7 @@ DataTablePtr FreadReader::read()
             } else {
               // the field could not be read with this quote rule, try again with next one
               // Trying the next rule will only be successful if the number of fields is consistent with it
-              ASSERT(quoteRule < 3);
+              xassert(quoteRule < 3);
               if (verbose)
                 trace("Bumping quote rule from %d to %d due to field %d on line %d of sampling jump %d starting \"%s\"",
                       quoteRule, quoteRule+1, field+1, jline, j, strlim(fieldStart,200));
@@ -654,7 +655,7 @@ DataTablePtr FreadReader::read()
         }
         bool eol_found = fctx.skip_eol();
         if (field < ncols-1 && !fill) {
-          ASSERT(tch==eof || eol_found);
+          xassert(tch==eof || eol_found);
           STOP("Line %d has too few fields when detecting types. Use fill=True to pad with NA. "
                "Expecting %d fields but found %d: \"%s\"", jline, ncols, field+1, strlim(jlineStart, 200));
         }
@@ -684,7 +685,7 @@ DataTablePtr FreadReader::read()
 
         lastRowEnd = tch;
         int thisLineLen = (int)(tch-jlineStart);  // tch is now on start of next line so this includes EOLLEN already
-        ASSERT(thisLineLen >= 0);
+        xassert(thisLineLen >= 0);
         sampleLines++;
         sumLen += thisLineLen;
         sumLenSq += thisLineLen*thisLineLen;
@@ -767,7 +768,7 @@ DataTablePtr FreadReader::read()
         estnrow = allocnrow = sampleLines;
         trace("All rows were sampled since file is small so we know nrow=%zd exactly", estnrow);
       } else {
-        ASSERT(sampleLines <= allocnrow);
+        xassert(sampleLines <= allocnrow);
       }
       if (max_nrows < allocnrow) {
         trace("Alloc limited to nrows=%zd according to the provided max_nrows argument.", max_nrows);
@@ -878,7 +879,7 @@ DataTablePtr FreadReader::read()
 
   read:  // we'll return here to reread any columns with out-of-sample type exceptions
   trace("[11] Read the data");
-  ASSERT(allocnrow <= max_nrows);
+  xassert(allocnrow <= max_nrows);
   if (sep == '\n') sep = '\xFF';
 
   {

--- a/c/csv/reader_fread.cc
+++ b/c/csv/reader_fread.cc
@@ -36,7 +36,7 @@ FreadReader::FreadReader(const GenericReader& g) : GenericReader(g)
   sof = dataptr();
   eof = sof + datasize();
   // TODO: Do not require the extra byte, and do not write into the input stream...
-  ASSERT(extra_byte_accessible() && eof > sof);
+  xassert(extra_byte_accessible() && eof > sof);
   *const_cast<char*>(eof) = '\0';
 
   whiteChar = '\0';
@@ -273,7 +273,7 @@ void FreadReader::parse_column_names(FreadTokenizer& ctx) {
           newlen = decode_win1252(usrc, ilen, unewsrc);
           newlen = decode_escaped_csv_string(unewsrc, newlen, unewsrc, echar);
         }
-        assert(newlen > 0);
+        xassert(newlen > 0);
         columns[i].name = std::string(newsrc, static_cast<size_t>(newlen));
         delete[] newsrc;
       }
@@ -515,7 +515,7 @@ void FreadLocalParseContext::read_chunk(
         // is only set to true on one thread at a time. Thus, there is no need
         // for "critical" section here.
         if (newType != oldType) {
-          assert(cc.true_start);
+          xassert(cc.true_start);
           if (verbose) {
             // Can't print because we're likely not master. So accumulate
             // message and print afterwards.
@@ -616,7 +616,7 @@ void FreadLocalParseContext::postprocess() {
           lo->str32.offset = off;
         } else {
           int newlen = decode_win1252(src, len, dest);
-          assert(newlen > 0);
+          xassert(newlen > 0);
           newlen = decode_escaped_csv_string(dest, newlen, dest, echar);
           off += static_cast<size_t>(newlen);
           lo->str32.offset = off;
@@ -624,7 +624,7 @@ void FreadLocalParseContext::postprocess() {
       } else if (len == 0) {
         lo->str32.offset = off;
       } else {
-        assert(lo->str32.isna());
+        xassert(lo->str32.isna());
         lo->str32.offset = -off;
       }
       lo += tbuf_ncols;

--- a/c/csv/reader_fread.h
+++ b/c/csv/reader_fread.h
@@ -163,11 +163,4 @@ class FreadLocalParseContext : public LocalParseContext
     } while(0)
 
 
-
-#define ASSERT(test) do { \
-  if (!(test)) \
-    STOP("Assertion violation at line %d, please report", __LINE__); \
-} while(0)
-
-
 #endif

--- a/c/csv/reader_parsers.cc
+++ b/c/csv/reader_parsers.cc
@@ -640,7 +640,7 @@ void ParserLibrary::init_parsers() {
   auto add = [&](PT pt, const char* name, char code, int8_t sz, SType st,
                  ParserFnPtr ptr) {
     size_t iid = static_cast<size_t>(pt);
-    assert(iid < ParserLibrary::num_parsers);
+    xassert(iid < ParserLibrary::num_parsers);
     parsers[iid] = ParserInfo(pt, name, code, sz, st, ptr);
     parser_fns[iid] = ptr;
   };

--- a/c/csv/reader_utils.cc
+++ b/c/csv/reader_utils.cc
@@ -231,7 +231,7 @@ void ChunkedDataReader::read_all()
   /*
   const char* const inputend = inputptr + inputsize;
   if (!inputptr || !inputend) return;
-  assert(alloc_nrows <= max_nrows);
+  xassert(alloc_nrows <= max_nrows);
   //
   // Thread-common state
   // -------------------
@@ -256,11 +256,11 @@ void ChunkedDataReader::read_all()
     {
       nthreads = omp_get_num_threads();
       compute_chunking_strategy();  // sets nchunks and possibly chunksize
-      assert(nchunks > 0);
+      xassert(nchunks > 0);
       if (chunks_contiguous) {
         chunksize = chunkdist = inputsize / nchunks;
       } else {
-        assert(chunksize > 0 && chunksize <= inputsize);
+        xassert(chunksize > 0 && chunksize <= inputsize);
         if (nchunks > 1) {
           chunkdist = (inputsize - chunksize) / (nchunks - 1);
         }
@@ -290,7 +290,7 @@ void ChunkedDataReader::read_all()
 
       // tend = tctx->read_chunk(chunkstart, chunkend);
       tnrows = tctx->get_nrows();
-      assert(tend >= chunkend);
+      xassert(tend >= chunkend);
 
       // Artificial loop makes it easy to quickly exit the "ordered" section.
       #pragma omp ordered
@@ -376,7 +376,7 @@ void ChunkedDataReader::read_all()
           new_alloc_nrows = static_cast<size_t>(1.2 * nrows_total *
                                                 nchunks / chunk0);
         }
-        assert(new_alloc_nrows >= nrows_total);
+        xassert(new_alloc_nrows >= nrows_total);
         realloc_columns(new_alloc_nrows);
         alloc_nrows = new_alloc_nrows;
         stop_team = false;
@@ -422,7 +422,7 @@ void LocalParseContext::allocate_tbuf(size_t ncols, size_t nrows) {
 
 
 LocalParseContext::~LocalParseContext() {
-  assert(used_nrows == 0);
+  xassert(used_nrows == 0);
   free(tbuf);
 }
 

--- a/c/datatable_cbind.cc
+++ b/c/datatable_cbind.cc
@@ -50,7 +50,7 @@ DataTable* DataTable::cbind(DataTable **dts, int ndts)
             columns[j++] = c;
         }
     }
-    assert(j == t_ncols);
+    xassert(j == t_ncols);
 
     // Done.
     ncols = t_ncols;

--- a/c/datatable_load.cc
+++ b/c/datatable_load.cc
@@ -8,7 +8,6 @@
 #include <stdlib.h>  // abs
 #include <string>  // memcpy
 #include "datatable.h"
-#include "utils/assert.h"
 #include "utils.h"
 
 

--- a/c/datatable_rbind.cc
+++ b/c/datatable_rbind.cc
@@ -27,7 +27,7 @@
  */
 void DataTable::rbind(DataTable** dts, int** cols, int ndts, int64_t new_ncols)
 {
-  assert(new_ncols >= ncols);
+  xassert(new_ncols >= ncols);
 
   // If this is a view datatable, then it must be materialized.
   this->reify();

--- a/c/datatablemodule.c
+++ b/c/datatablemodule.c
@@ -20,6 +20,7 @@
 #include "py_rowindex.h"
 #include "py_types.h"
 #include "py_utils.h"
+#include "utils/assert.h"
 
 
 PyMODINIT_FUNC PyInit__datatable(void);
@@ -104,7 +105,7 @@ PyObject* get_internal_function_ptrs(PyObject*, PyObject*) {
   ADD(datatable_unpack_slicerowindex);
   ADD(datatable_unpack_arrayrowindex);
 
-  assert(i == SIZE);
+  xassert(i == SIZE);
   return res;
 }
 
@@ -121,7 +122,7 @@ PyObject* get_integer_sizes(PyObject*, PyObject*) {
   ADD(sizeof(long long int));
   ADD(sizeof(size_t));
 
-  assert(i == SIZE);
+  xassert(i == SIZE);
   return res;
 }
 #undef ADD

--- a/c/memorybuf.cc
+++ b/c/memorybuf.cc
@@ -14,7 +14,6 @@
 #include <mutex>       // std::mutex, std::lock_guard
 #include "datatable_check.h"
 #include "utils/file.h"
-#include "utils/assert.h"
 #include "py_utils.h"
 #include "utils.h"
 

--- a/c/py_buffers.cc
+++ b/c/py_buffers.cc
@@ -17,6 +17,7 @@
 #include "py_datatable.h"
 #include "py_types.h"
 #include "py_utils.h"
+#include "utils/assert.h"
 #include "utils/exceptions.h"
 
 // Forward declarations
@@ -452,7 +453,7 @@ static int getbuffer_DataTable(
   }
 
   // Allocate the final buffer
-  assert(!stype_info[stype].varwidth);
+  xassert(!stype_info[stype].varwidth);
   size_t elemsize = stype_info[stype].elemsize;
   size_t colsize = nrows * elemsize;
   mbuf = new MemoryMemBuf(ncols * colsize);
@@ -464,7 +465,7 @@ static int getbuffer_DataTable(
     Column* col = dt->columns[i]->shallowcopy();
     col->reify();
     if (col->stype() == stype) {
-      assert(col->alloc_size() == colsize);
+      xassert(col->alloc_size() == colsize);
       memcpy(mbuf->at(i*colsize), col->data(), colsize);
     } else {
       // xmb becomes a "view" on a portion of the buffer `mbuf`. An
@@ -478,7 +479,7 @@ static int getbuffer_DataTable(
       // created having the converted data; but the side-effect of this is
       // that `mbuf` will have the same data, and in the right place.
       Column* newcol = col->cast(stype, xmb);
-      assert(newcol->alloc_size() == colsize);
+      xassert(newcol->alloc_size() == colsize);
       // We can now delete the new column: this will delete `xmb` as well,
       // however an ExternalMemBuf object does not attempt to free its
       // memory buffer. The converted data that was written to `mbuf` will

--- a/c/py_encodings.c
+++ b/c/py_encodings.c
@@ -57,9 +57,9 @@ int init_py_encodings(PyObject*)
   for (int k = 0; k < 3; k++) {
     uint32_t* map = (k == 0)? win1252_map : (k == 1)? win1251_map : iso8859_map;
     for (unsigned int i = 0; i < 256; i++) {
-      if (i < 0x80) assert(map[i] == i);  // check ASCII compatibility
+      if (i < 0x80) xassert(map[i] == i);  // check ASCII compatibility
       if (i && map[i] == 0) map[i] = 0x00BDBFEF;  // U+FFFD
-      assert((map[i] & 0xFF000000) == 0);
+      xassert((map[i] & 0xFF000000) == 0);
     }
   }
   return 1;

--- a/c/py_utils.c
+++ b/c/py_utils.c
@@ -102,16 +102,6 @@ void _dt_err_v(const char *format, ...)
 }
 
 
-__attribute__ ((format(printf, 1, 2)))
-void _dt_err_a(const char *format, ...)
-{
-    va_list vargs;
-    va_start(vargs, format);
-    PyErr_FormatV(PyExc_AssertionError, format, vargs);
-    va_end(vargs);
-}
-
-
 void log_call(const char* msg) {
   if (!config::logger) return;
   PyObject_CallMethod(config::logger, "info", "s", msg);

--- a/c/rowindex.cc
+++ b/c/rowindex.cc
@@ -9,7 +9,6 @@
 #include <cstring>     // std::memcpy
 #include "datatable_check.h"
 #include "utils.h"
-#include "utils/assert.h"
 #include "utils/omp.h"
 
 

--- a/c/rowindex_array.cc
+++ b/c/rowindex_array.cc
@@ -27,7 +27,7 @@ ArrayRowIndexImpl::ArrayRowIndexImpl(arr32_t&& array, bool sorted)
 {
   type = RowIndexType::RI_ARR32;
   length = static_cast<int64_t>(ind32.size());
-  assert(length <= std::numeric_limits<int32_t>::max());
+  xassert(length <= std::numeric_limits<int32_t>::max());
   set_min_max<int32_t>(ind32, sorted);
 }
 
@@ -46,7 +46,7 @@ ArrayRowIndexImpl::ArrayRowIndexImpl(
     const arr64_t& starts, const arr64_t& counts, const arr64_t& steps)
 {
   size_t n = starts.size();
-  assert(n == counts.size() && n == steps.size());
+  xassert(n == counts.size() && n == steps.size());
 
   // Compute the total number of elements, and the largest index that needs
   // to be stored. Also check for potential overflows / invalid values.
@@ -67,7 +67,7 @@ ArrayRowIndexImpl::ArrayRowIndexImpl(
     length += len;
   }
   if (max == 0) min = 0;
-  assert(min >= 0 && min <= max);
+  xassert(min >= 0 && min <= max);
   size_t zlen = static_cast<size_t>(length);
 
   if (zlen <= INT32_MAX && max <= INT32_MAX) {
@@ -83,7 +83,7 @@ ArrayRowIndexImpl::ArrayRowIndexImpl(
         j += istep;
       }
     }
-    assert(rowsptr == &ind32[zlen]);
+    xassert(rowsptr == &ind32[zlen]);
   } else {
     type = RowIndexType::RI_ARR64;
     ind64.resize(zlen);
@@ -97,7 +97,7 @@ ArrayRowIndexImpl::ArrayRowIndexImpl(
         j += istep;
       }
     }
-    assert(rowsptr == &ind64[zlen]);
+    xassert(rowsptr == &ind64[zlen]);
   }
 }
 
@@ -120,7 +120,7 @@ ArrayRowIndexImpl::ArrayRowIndexImpl(Column* col) {
 
 
 ArrayRowIndexImpl::ArrayRowIndexImpl(filterfn32* ff, int64_t n, bool sorted) {
-  assert(n <= std::numeric_limits<int32_t>::max());
+  xassert(n <= std::numeric_limits<int32_t>::max());
 
   // Output buffer, where we will write the indices of selected rows. This
   // buffer is preallocated to the length of the original dataset, and it will
@@ -414,7 +414,7 @@ void ArrayRowIndexImpl::compactify()
   if (type == RowIndexType::RI_ARR32) return;
   if (max > INT32_MAX || length > INT32_MAX) return;
   size_t zlen = static_cast<size_t>(length);
-  assert(zlen == ind64.size());
+  xassert(zlen == ind64.size());
 
   ind32.resize(zlen);
   for (size_t i = 0; i < zlen; ++i) {
@@ -454,7 +454,7 @@ RowIndexImpl* ArrayRowIndexImpl::inverse_impl(
 
 
 RowIndexImpl* ArrayRowIndexImpl::inverse(int64_t nrows) const {
-  assert(nrows >= length);
+  xassert(nrows >= length);
   if (type == RowIndexType::RI_ARR32) {
     if (nrows <= INT32_MAX)
       return inverse_impl<int32_t, int32_t>(ind32, nrows);

--- a/c/rowindex_slice.cc
+++ b/c/rowindex_slice.cc
@@ -8,6 +8,7 @@
 #include "rowindex.h"
 #include <algorithm>           // std::swap, std::move
 #include "datatable_check.h"   // IntegrityCheckContext
+#include "utils/assert.h"      // xassert
 #include "utils/exceptions.h"  // ValueError, RuntimeError
 
 
@@ -113,7 +114,7 @@ RowIndexImpl* SliceRowIndexImpl::uplift_from(RowIndexImpl* rii) {
 
 
 RowIndexImpl* SliceRowIndexImpl::inverse(int64_t nrows) const {
-  assert(nrows >= length);
+  xassert(nrows >= length);
   int64_t newcount = nrows - length;
   int64_t tstart = start;
   int64_t tcount = length;
@@ -161,7 +162,7 @@ RowIndexImpl* SliceRowIndexImpl::inverse(int64_t nrows) const {
         indices[j++] = i;
       }
     }
-    assert(j == znewcount);
+    xassert(j == znewcount);
     return new ArrayRowIndexImpl(std::move(indices), true);
   } else {
     arr64_t indices(znewcount);
@@ -176,7 +177,7 @@ RowIndexImpl* SliceRowIndexImpl::inverse(int64_t nrows) const {
         indices[j++] = i;
       }
     }
-    assert(j == znewcount);
+    xassert(j == znewcount);
     return new ArrayRowIndexImpl(std::move(indices), true);
   }
 }

--- a/c/sort.cc
+++ b/c/sort.cc
@@ -360,7 +360,7 @@ class SortContext {
   template <typename T, typename TU>
   void _initI(const Column* col) {
     auto icol = static_cast<const IntColumn<T>*>(col);
-    assert(sizeof(T) == sizeof(TU));
+    xassert(sizeof(T) == sizeof(TU));
     T min = icol->min();
     T max = icol->max();
     nsigbits = sizeof(T) * 8;
@@ -632,22 +632,22 @@ class SortContext {
     } else {
       switch (elemsize) {
         case 8:
-          assert(next_elemsize == 8 || next_elemsize == 4);
+          xassert(next_elemsize == 8 || next_elemsize == 4);
           if (next_elemsize == 8) _reorder_impl<uint64_t, uint64_t, true>();
           if (next_elemsize == 4) _reorder_impl<uint64_t, uint32_t, true>();
           break;
         case 4:
-          assert(next_elemsize == 4 || next_elemsize == 2);
+          xassert(next_elemsize == 4 || next_elemsize == 2);
           if (next_elemsize == 4) _reorder_impl<uint32_t, uint32_t, true>();
           if (next_elemsize == 2) _reorder_impl<uint32_t, uint16_t, true>();
           break;
         case 2:
-          assert(next_elemsize == 2 || next_elemsize == 0);
+          xassert(next_elemsize == 2 || next_elemsize == 0);
           if (next_elemsize == 2) _reorder_impl<uint16_t, uint16_t, true>();
           if (next_elemsize == 0) _reorder_impl<uint16_t, uint8_t, false>();
           break;
         case 1:
-          assert(next_elemsize == 0);
+          xassert(next_elemsize == 0);
           _reorder_impl<uint8_t, uint8_t, false>();
           break;
       }
@@ -673,14 +673,14 @@ class SortContext {
       size_t* tcounts = histogram + (nradixes * i);
       for (size_t j = j0; j < j1; ++j) {
         size_t k = tcounts[xi[j] >> shift]++;
-        assert(k < n);
+        xassert(k < n);
         next_o[k] = use_order? o[j] : static_cast<int32_t>(j);
         if (OUT) {
           xo[k] = static_cast<TO>(xi[j] & mask);
         }
       }
     }
-    assert(histogram[nchunks * nradixes - 1] == n);
+    xassert(histogram[nchunks * nradixes - 1] == n);
   }
 
   void _reorder_str() {
@@ -697,7 +697,7 @@ class SortContext {
       size_t* tcounts = histogram + (nradixes * i);
       for (size_t j = j0; j < j1; ++j) {
         size_t k = tcounts[xi[j]]++;
-        assert(k < n);
+        xassert(k < n);
         int32_t w = use_order? o[j] : static_cast<int32_t>(j);
         int32_t offend = stroffs[w];
         int32_t offstart = std::abs(stroffs[w - 1]) + ss;
@@ -708,7 +708,7 @@ class SortContext {
       }
     }
     next_elemsize = maxlen > 0;
-    assert(histogram[nchunks * nradixes - 1] == n);
+    xassert(histogram[nchunks * nradixes - 1] == n);
   }
 
 
@@ -806,7 +806,7 @@ class SortContext {
     for (size_t i = 0; i < nradixes; i++) {
       size_t start = i? rrendoffsets[i-1] : 0;
       size_t end = rrendoffsets[i];
-      assert(start <= end);
+      xassert(start <= end);
       rrmap[i].size   = end - start;
       rrmap[i].offset = start;
     }
@@ -833,7 +833,7 @@ class SortContext {
     size_t size0 = 0;
     size_t nsmallgroups = 0;
     size_t rrlarge = config::sort_insert_method_threshold;  // for now
-    assert(GROUPED > rrlarge);
+    xassert(GROUPED > rrlarge);
 
     strstart = _strstart + 1;
     nsigbits = strdata? 8 : shift;

--- a/c/sort_groups.cc
+++ b/c/sort_groups.cc
@@ -68,7 +68,7 @@ void GroupGatherer::from_data(
 
 
 void GroupGatherer::from_chunks(radix_range* rrmap, size_t nradixes) {
-  assert(count == 0);
+  xassert(count == 0);
   size_t dest_off = 0;
   for (size_t i = 0; i < nradixes; ++i) {
     size_t grp_size = rrmap[i].size;
@@ -88,7 +88,7 @@ void GroupGatherer::from_chunks(radix_range* rrmap, size_t nradixes) {
 void GroupGatherer::from_histogram(
   size_t* histogram, size_t nchunks, size_t nradixes)
 {
-  assert(count == 0);
+  xassert(count == 0);
   size_t* rrendoffsets = histogram + (nchunks - 1) * nradixes;
   int32_t off0 = 0;
   for (size_t i = 0; i < nradixes; ++i) {

--- a/c/types.c
+++ b/c/types.c
@@ -125,14 +125,12 @@ void init_types(void)
     //---- More static asserts -------------------------------------------------
     // This checks validity of a cast used in the fread.c
     for (int i = -128; i <= 127; i++) {
-        char ch = (char) i;
-        int test1 = (ch >= '0' && ch <= '9');
-        int test2 = ((uint_fast8_t)(ch - '0') < 10);
-        xassert(test1 == test2);
+      char ch = static_cast<char>(i);
+      xassert((ch >= '0' && ch <= '9') == ((uint_fast8_t)(ch - '0') < 10));
     }
 
     for (int i = 0; i < DT_STYPES_COUNT; i++) {
-        xassert((SType)i == stype_from_string(stype_info[i].code));
+      xassert((SType)i == stype_from_string(stype_info[i].code));
     }
 }
 

--- a/c/types.c
+++ b/c/types.c
@@ -120,7 +120,7 @@ void init_types(void)
     UPCAST(ST_REAL_F4,    ST_REAL_F8,     ST_REAL_F8)
     #undef UPCAST
     // In py_datatable.c we use 64-bit mask over stypes
-    assert(DT_STYPES_COUNT <= 64);
+    xassert(DT_STYPES_COUNT <= 64);
 
     //---- More static asserts -------------------------------------------------
     // This checks validity of a cast used in the fread.c
@@ -128,11 +128,11 @@ void init_types(void)
         char ch = (char) i;
         int test1 = (ch >= '0' && ch <= '9');
         int test2 = ((uint_fast8_t)(ch - '0') < 10);
-        assert(test1 == test2);
+        xassert(test1 == test2);
     }
 
     for (int i = 0; i < DT_STYPES_COUNT; i++) {
-        assert((SType)i == stype_from_string(stype_info[i].code));
+        xassert((SType)i == stype_from_string(stype_info[i].code));
     }
 }
 
@@ -144,7 +144,7 @@ void init_types(void)
  */
 SType stype_from_string(const std::string& str)
 {
-  assert(str.length() == 3 || str.length() == 2);
+  xassert(str.length() == 3 || str.length() == 2);
   char s0 = str[0], s1 = str[1], s2 = str[2];
   if (s0 == 'i') {
     if (s2 == 'i' || s2 == '\0') {

--- a/c/utils.h
+++ b/c/utils.h
@@ -239,17 +239,11 @@ void  _dt_free(void *ptr);
     return NULL;                                                               \
 } while (0)
 
-#define dterra0(message) do {                                                  \
-    _dt_err_a(message "\nat %s#L%d", __FILE__, __LINE__);                      \
-    return NULL;                                                               \
-} while (0)
-
 
 // External functions -- should be defined in py_utils.c
 // These functions merely set the error message, and nothing else.
 void _dt_err_r(const char *format, ...) __attribute__ ((format(printf, 1, 2)));
 void _dt_err_v(const char *format, ...) __attribute__ ((format(printf, 1, 2)));
-void _dt_err_a(const char *format, ...) __attribute__ ((format(printf, 1, 2)));
 
 
 

--- a/c/utils/assert.h
+++ b/c/utils/assert.h
@@ -5,18 +5,37 @@
 //
 // © H2O.ai 2018
 //------------------------------------------------------------------------------
-#ifndef dt_UTILS_ASSERT_H
-#define dt_UTILS_ASSERT_H
+#ifndef dt_UTILS_ASSERT_h
+#define dt_UTILS_ASSERT_h
+#include "utils/exceptions.h"
 
+// First, fix the NDEBUG macro.
+// This macro, if present, disables all assert statements. Unfortunately, python
+// may add it as a default compilation flag, so in order to combat this we have
+// defined a new `NONDEBUG` macro. This macro may be passed from the Makefile,
+// and if declared it means to ignore the NDEBUG macro even if it is present.
 #ifdef NDEBUG
-  // Macro NDEBUG, if present, disables all assert statements. Unfortunately,
-  // Python turns on this macro by default, so we need to turn it off
-  // explicitly.
   #ifdef NONDEBUG
     #undef NDEBUG
   #endif
 #endif
-#include <assert.h>  // assert, dt_static_assert
+
+// This will include the standard `assert` and `static_assert` macros.
+#include <assert.h>
+
+
+// Here we also define the `xassert` macro, which behaves similarly to `assert`,
+// however it throws exceptions instead of terminating the program
+#ifdef NDEBUG
+  #define xassert(EXPRESSION) ((void)0)
+#else
+  #define xassert(EXPRESSION) \
+    if (!(EXPRESSION)) { \
+      throw AssertionError() << "Assertion '" << #EXPRESSION << "' failed in " \
+          << __FILE__ << ", line " << __LINE__; \
+    }
+#endif
+
 
 #ifdef static_assert
   #define dt_static_assert static_assert

--- a/c/utils/assert.h
+++ b/c/utils/assert.h
@@ -12,10 +12,10 @@
 // First, fix the NDEBUG macro.
 // This macro, if present, disables all assert statements. Unfortunately, python
 // may add it as a default compilation flag, so in order to combat this we have
-// defined a new `NONDEBUG` macro. This macro may be passed from the Makefile,
+// defined a new `DTDEBUG` macro. This macro may be passed from the Makefile,
 // and if declared it means to ignore the NDEBUG macro even if it is present.
 #ifdef NDEBUG
-  #ifdef NONDEBUG
+  #ifdef DTDEBUG
     #undef NDEBUG
   #endif
 #endif

--- a/c/utils/exceptions.cc
+++ b/c/utils/exceptions.cc
@@ -143,13 +143,14 @@ bool PyError::is_keyboard_interrupt() const {
 
 //==============================================================================
 
-Error RuntimeError()  { return Error(PyExc_RuntimeError); }
-Error TypeError()     { return Error(type_error_class); }
-Error ValueError()    { return Error(value_error_class); }
-Error OverflowError() { return Error(PyExc_OverflowError); }
-Error MemoryError()   { return Error(PyExc_MemoryError); }
-Error NotImplError()  { return Error(PyExc_NotImplementedError); }
-Error IOError()       { return Error(PyExc_IOError); }
+Error RuntimeError()   { return Error(PyExc_RuntimeError); }
+Error TypeError()      { return Error(type_error_class); }
+Error ValueError()     { return Error(value_error_class); }
+Error OverflowError()  { return Error(PyExc_OverflowError); }
+Error MemoryError()    { return Error(PyExc_MemoryError); }
+Error NotImplError()   { return Error(PyExc_NotImplementedError); }
+Error IOError()        { return Error(PyExc_IOError); }
+Error AssertionError() { return Error(PyExc_AssertionError); }
 
 
 void replace_typeError(PyObject* obj) { type_error_class = obj; }

--- a/c/utils/exceptions.h
+++ b/c/utils/exceptions.h
@@ -82,6 +82,7 @@ Error OverflowError();
 Error MemoryError();
 Error NotImplError();
 Error IOError();
+Error AssertionError();
 
 void replace_typeError(PyObject* obj);
 void replace_valueError(PyObject* obj);

--- a/c/writebuf.cc
+++ b/c/writebuf.cc
@@ -165,7 +165,7 @@ size_t ThreadsafeWritableBuffer::prep_write(size_t n, const void*)
 
 void ThreadsafeWritableBuffer::write_at(size_t pos, size_t n, const void* src)
 {
-  assert(pos + n <= allocsize);
+  xassert(pos + n <= allocsize);
   bool done = false;
   while (!done) {
     int lockv;

--- a/setup.py
+++ b/setup.py
@@ -159,11 +159,6 @@ def get_extra_compile_flags():
               "-I" + get_llvm() + "/include",
               "-isystem " + get_llvm() + "/include/c++/v1"]
 
-    # This macro is needed to combat "-DNDEBUG" flag in default Python. This
-    # flag in turn enables all `assert` statements at the C level.
-    if "DTDEBUG" in os.environ:
-        flags += ["-DNONDEBUG"]
-
     # Enable/disable OpenMP support
     if "DTNOOPENMP" in os.environ:
         flags.append("-DDTNOOMP")

--- a/tests/fread/test_fread_large.py
+++ b/tests/fread/test_fread_large.py
@@ -60,6 +60,8 @@ def get_file_list(*path):
                 ext = ""
             if ext in bad_extensions:
                 continue
+            if f.endswith(".dat.gz"):
+                continue
             if ("readme" not in filename.lower() and
                     ".svm" not in filename and
                     ".json" not in filename and


### PR DESCRIPTION
The problem with regular `assert()` is that it terminates the testing framework, and we never see what the error was.