### PR TITLE
FreadObserver class

### DIFF
--- a/c/csv/chunks.cc
+++ b/c/csv/chunks.cc
@@ -34,7 +34,7 @@ void ChunkOrganizer::determine_chunking_strategy() {
   size_t inputSize = static_cast<size_t>(inputEnd - inputStart);
   size_t size1000 = static_cast<size_t>(1000 * lineLength);
   size_t zThreads = static_cast<size_t>(nThreads);
-  chunkSize = std::max<size_t>(size1000, 65536);
+  chunkSize = std::max<size_t>(size1000, 1 << 18);
   chunkCount = std::max<size_t>(inputSize / chunkSize, 1);
   if (chunkCount > zThreads) {
     chunkCount = zThreads * (1 + (chunkCount - 1)/zThreads);

--- a/c/csv/fread.cc
+++ b/c/csv/fread.cc
@@ -54,10 +54,9 @@ class FreadChunkedReader {
   private:
     FreadReader& f;
     ChunkOrganizerPtr chunkster;
-  public:
     // dt::shared_mutex shmutex;
-    size_t rowSize;
     int8_t* types;
+    size_t rowSize;
     size_t n_type_bumps;
     size_t chunk0;
     size_t row0;
@@ -65,7 +64,6 @@ class FreadChunkedReader {
     size_t max_nrows;
 
   public:
-    // The abominable constructor
     FreadChunkedReader(
         FreadReader& reader, size_t rowSize_, const char* lastRowEnd_,
         int8_t* types_
@@ -98,6 +96,7 @@ class FreadChunkedReader {
       );
     }
 
+    size_t get_n_type_bumps() const { return n_type_bumps; }
 
     //********************************//
     // Main function
@@ -276,8 +275,6 @@ class FreadChunkedReader {
       }
     }
 };
-
-
 
 
 
@@ -861,7 +858,7 @@ DataTablePtr FreadReader::read()
         typeCounts[columns[i].type]++;
       }
 
-      if (scr.n_type_bumps) {
+      if (scr.get_n_type_bumps()) {
         size_t n_type_bump_cols = 0;
         rowSize = 0;
         for (size_t j = 0; j < ncols; j++) {

--- a/c/csv/reader_fread.cc
+++ b/c/csv/reader_fread.cc
@@ -32,16 +32,18 @@
 
 FreadReader::FreadReader(const GenericReader& g) : GenericReader(g)
 {
+  size_t input_size = datasize();
   targetdir = nullptr;
   sof = dataptr();
-  eof = sof + datasize();
+  eof = sof + input_size;
   // TODO: Do not require the extra byte, and do not write into the input stream...
-  xassert(extra_byte_accessible() && eof > sof);
+  xassert(extra_byte_accessible() && input_size > 0);
   *const_cast<char*>(eof) = '\0';
 
   whiteChar = '\0';
   quoteRule = -1;
   LFpresent = false;
+  fo.input_size = input_size;
 }
 
 FreadReader::~FreadReader() {
@@ -365,26 +367,26 @@ DataTablePtr FreadReader::makeDatatable() {
 
 FreadLocalParseContext::FreadLocalParseContext(
     size_t bcols, size_t brows, FreadReader& f, int8_t* types_,
-    char*& tbm, size_t& tbmsize, char* se, size_t sesize
+    char* se, size_t sesize
   ) : LocalParseContext(bcols, brows),
       types(types_),
       freader(f),
       columns(f.columns),
       tokenizer(f.makeTokenizer(tbuf, NULL)),
       parsers(ParserLibrary::get_parser_fns()),
-      typeBumpMsg(tbm), typeBumpMsgSize(tbmsize),
       stopErr(se), stopErrSize(sesize)
 {
-  thPush = 0;
+  ttime_push = 0;
+  ttime_read = 0;
   anchor = nullptr;
   quote = f.quote;
   quoteRule = f.quoteRule;
   sep = f.sep;
   verbose = f.verbose;
   fill = f.fill;
-  nTypeBump = 0;
   skipEmptyLines = f.skip_blank_lines;
   numbersMayBeNAs = f.number_is_na;
+  n_type_bumps = 0;
   size_t ncols = columns.size();
   size_t bufsize = std::min(size_t(4096), f.datasize() / (ncols + 1));
   for (size_t i = 0, j = 0; i < ncols; ++i) {
@@ -404,6 +406,7 @@ FreadLocalParseContext::~FreadLocalParseContext() {}
 void FreadLocalParseContext::read_chunk(
   const ChunkCoordinates& cc, ChunkCoordinates& actual_cc)
 {
+  double t0 = verbose? wallclock() : 0;
   // If any error in the loop below occurs, we'll do `return;` and the output
   // variable `actual_cc` will contain `.end = nullptr;`.
   actual_cc.start = cc.start;
@@ -516,20 +519,11 @@ void FreadLocalParseContext::read_chunk(
         if (newType != oldType) {
           xassert(cc.true_start);
           if (verbose) {
-            // Can't print because we're likely not master. So accumulate
-            // message and print afterwards.
-            char temp[1001];
-            int len = snprintf(temp, 1000,
-              "Column %zu (\"%s\") bumped from '%s' to '%s' due to <<%.*s>> on row %llu\n",
-              j+1, columns[j].name.data(),
-              ParserLibrary::info(oldType).cname(),
-              ParserLibrary::info(newType).cname(),
-              (int)(tch-fieldStart), fieldStart, (llu)(row0+used_nrows));
-            typeBumpMsg = (char*) realloc(typeBumpMsg, typeBumpMsgSize + (size_t)len + 1);
-            strcpy(typeBumpMsg + typeBumpMsgSize, temp);
-            typeBumpMsgSize += (size_t)len;
+            freader.fo.type_bump_info(j + 1, columns[j], newType, fieldStart,
+                                      tch - fieldStart,
+                                      static_cast<int64_t>(row0 + used_nrows));
           }
-          nTypeBump++;
+          n_type_bumps++;
           types[j] = newType;
           columns[j].type = newType;
           columns[j].typeBumped = true;
@@ -580,6 +574,7 @@ void FreadLocalParseContext::read_chunk(
   // Tell the caller where we finished reading the chunk. This is why
   // the parameter `actual_cc` was passed to this function.
   actual_cc.end = tch;
+  if (verbose) ttime_read += wallclock() - t0;
 }
 
 
@@ -658,7 +653,7 @@ void FreadLocalParseContext::push_buffers() {
   // If the buffer is empty, then there's nothing to do...
   if (!used_nrows) return;
 
-  double now = verbose? wallclock() : 0;
+  double t0 = verbose? wallclock() : 0;
   size_t ncols = columns.size();
   for (size_t i = 0, j = 0, k = 0; i < ncols; i++) {
     const GReaderColumn& col = columns[i];
@@ -717,7 +712,7 @@ void FreadLocalParseContext::push_buffers() {
     j++;
   }
   used_nrows = 0;
-  if (verbose) thPush += wallclock() - now;
+  if (verbose) ttime_push += wallclock() - t0;
 }
 
 
@@ -877,4 +872,120 @@ int FreadTokenizer::countfields()
     return -1;  // -1 means this line not valid for this sep and quote rule
   }
   return ncol;
+}
+
+
+
+//==============================================================================
+// FreadObserver
+//==============================================================================
+
+FreadObserver::FreadObserver() {
+  t_start = wallclock();
+  t_initialized = 0;
+  t_parse_parameters_detected = 0;
+  t_column_types_detected = 0;
+  t_frame_allocated = 0;
+  t_data_read = 0;
+  t_data_reread = 0;
+  time_read_data = 0;
+  time_push_data = 0;
+  input_size = 0;
+  n_rows_read = 0;
+  n_cols_read = 0;
+  n_lines_sampled = 0;
+  n_rows_allocated = 0;
+  n_cols_allocated = 0;
+  n_cols_reread = 0;
+  allocation_size = 0;
+  read_data_nthreads = 0;
+}
+
+FreadObserver::~FreadObserver() {}
+
+
+void FreadObserver::report(const GenericReader& g) {
+  double t_end = wallclock();
+  xassert(t_start <= t_initialized &&
+          t_initialized <= t_parse_parameters_detected &&
+          t_parse_parameters_detected <= t_column_types_detected &&
+          t_column_types_detected <= t_frame_allocated &&
+          t_frame_allocated <= t_data_read &&
+          t_data_read <= t_data_reread &&
+          t_data_reread <= t_end &&
+          read_data_nthreads > 0);
+  double total_time = std::max(t_end - t_start, 1e-6);
+  int    total_minutes = static_cast<int>(total_time/60);
+  double total_seconds = total_time - total_minutes * 60;
+  double params_time = t_parse_parameters_detected - t_initialized;
+  double types_time = t_column_types_detected - t_parse_parameters_detected;
+  double alloc_time = t_frame_allocated - t_column_types_detected;
+  double read_time = t_data_read - t_frame_allocated;
+  double reread_time = t_data_reread - t_data_read;
+  double makedt_time = t_end - t_data_reread;
+  time_read_data /= read_data_nthreads;
+  time_push_data /= read_data_nthreads;
+  double time_wait_data = read_time + reread_time
+                          - time_read_data - time_push_data;
+  int p = total_time < 10 ? 5 :
+          total_time < 100 ? 6 :
+          total_time < 1000 ? 7 : 8;
+
+  g.trace("=============================");
+  g.trace("Read %s row%s x %s column%s from %s input in %02d:%06.3fs",
+          humanize_number(n_rows_read), (n_rows_read == 1 ? "" : "s"),
+          humanize_number(n_cols_read), (n_cols_read == 1 ? "" : "s"),
+          filesize_to_str(input_size),
+          total_minutes, total_seconds);
+  g.trace(" = %*.3fs (%2.0f%%) detecting parse parameters", p,
+          params_time, 100 * params_time / total_time);
+  g.trace(" + %*.3fs (%2.0f%%) detecting column types using %s sample rows", p,
+          types_time, 100 * types_time / total_time,
+          humanize_number(n_lines_sampled));
+  g.trace(" + %*.3fs (%2.0f%%) allocating [%s x %s] frame (%s) of which "
+          "%s (%.0f%%) rows used", p,
+          alloc_time, 100 * alloc_time / total_time,
+          humanize_number(n_rows_allocated),
+          humanize_number(n_cols_allocated),
+          filesize_to_str(allocation_size),
+          humanize_number(n_rows_read),
+          100.0 * n_rows_read / n_rows_allocated);  // may be > 100%
+  g.trace(" + %*.3fs (%2.0f%%) reading data using %zu thread%s", p,
+          read_time, 100 * read_time / total_time,
+          read_data_nthreads, (read_data_nthreads == 1? "" : "s"));
+  if (n_cols_reread) {
+    g.trace(" + %*.3fs (%2.0f%%) Rereading %d columns due to out-of-sample "
+            "type exceptions", p,
+            reread_time, 100 * reread_time / total_time,
+            n_cols_reread);
+  }
+  g.trace("    = %*.3fs (%2.0f%%) reading into row-major buffers", p,
+          time_read_data, 100 * time_read_data / total_time);
+  g.trace("    + %*.3fs (%2.0f%%) saving into the output frame", p,
+          time_push_data, 100 * time_push_data / total_time);
+  g.trace("    + %*.3fs (%2.0f%%) waiting", p,
+          time_wait_data, 100 * time_wait_data / total_time);
+  g.trace(" + %*.3fs (%2.0f%%) creating the final Frame", p,
+          makedt_time, 100 * makedt_time / total_time);
+  if (!type_bump_messages.empty()) {
+    g.trace("=============================");
+    for (std::string msg : type_bump_messages) {
+      g.trace("%s", msg.data());
+    }
+  }
+}
+
+
+void FreadObserver::type_bump_info(
+  size_t icol, const GReaderColumn& col, int8_t new_type,
+  const char* field, int64_t len, int64_t lineno)
+{
+  char temp[1001];
+  int n = snprintf(temp, sizeof(temp) - 1,
+    "Column %zu (%s) bumped from %s to %s due to <<%.*s>> on row %llu",
+    icol, col.name.data(),
+    ParserLibrary::info(col.type).cname(),
+    ParserLibrary::info(new_type).cname(),
+    static_cast<int>(len), field, lineno);
+  type_bump_messages.push_back(std::string(temp, static_cast<size_t>(n)));
 }

--- a/c/csv/reader_fread.h
+++ b/c/csv/reader_fread.h
@@ -167,12 +167,8 @@ class FreadLocalParseContext : public LocalParseContext
     FreadTokenizer tokenizer;
     const ParserFnPtr* parsers;
 
-    char*   stopErr;
-    size_t  stopErrSize;
-
   public:
-    FreadLocalParseContext(size_t bcols, size_t brows, FreadReader&, int8_t*,
-                           char* stopErr, size_t stopErrSize);
+    FreadLocalParseContext(size_t bcols, size_t brows, FreadReader&, int8_t*);
     FreadLocalParseContext(const FreadLocalParseContext&) = delete;
     FreadLocalParseContext& operator=(const FreadLocalParseContext&) = delete;
     virtual ~FreadLocalParseContext();

--- a/c/utils.c
+++ b/c/utils.c
@@ -129,17 +129,43 @@ const char* filesize_to_str(size_t fsize)
     }
     if (ndigits == 0 || (fsize == (fsize >> shift << shift))) {
       if (i < NSUFFIXES) {
-        snprintf(output, BUFFSIZE, "%llu%cB (%llu bytes)",
-                 lsize >> shift, suffixes[i], lsize);
+        snprintf(output, BUFFSIZE, "%llu%cB",
+                 lsize >> shift, suffixes[i]);
         return output;
       }
     } else {
-      snprintf(output, BUFFSIZE, "%.*f%cB (%llu bytes)",
-               ndigits, (double)fsize / (1 << shift), suffixes[i], lsize);
+      snprintf(output, BUFFSIZE, "%.*f%cB",
+               ndigits, (double)fsize / (1 << shift), suffixes[i]);
       return output;
     }
   }
   if (fsize == 1) return one_byte;
   snprintf(output, BUFFSIZE, "%llu bytes", lsize);
+  return output;
+}
+
+
+const char* humanize_number(size_t num) {
+  static char outputs[270];
+  static int curr_out = 0;
+  char* output = outputs + (curr_out++) * 27;
+  if (curr_out == 10) curr_out = 0;
+  int len = 0;
+  if (num) {
+    while (true) {
+      output[len++] = '0' + static_cast<char>(num % 10);
+      num /= 10;
+      if (!num) break;
+      if (len % 4 == 3) output[len++] = ',';
+    }
+    for (int i = 0; i < len/2; ++i) {
+      char c = output[i];
+      output[i] = output[len - 1 - i];
+      output[len - 1 - i] = c;
+    }
+  } else {
+    output[len++] = '0';
+  }
+  output[len] = '\0';
   return output;
 }

--- a/c/utils.h
+++ b/c/utils.h
@@ -35,6 +35,7 @@ int64_t max(int64_t a, int64_t b);
 float max_f4(float a, float b);
 double wallclock(void);
 const char* filesize_to_str(size_t filesize);
+const char* humanize_number(size_t num);
 
 inline std::string operator "" _s(const char* str, size_t len) {
   return std::string(str, len);

--- a/c/utils/exceptions.cc
+++ b/c/utils/exceptions.cc
@@ -105,12 +105,12 @@ Error& Error::operator<<(SType stype) {
 }
 
 Error& Error::operator<<(char c) {
-  if (c < ' ') {
-    uint8_t uc = static_cast<uint8_t>(c);
+  uint8_t uc = static_cast<uint8_t>(c);
+  if (uc < 0x20 || uc >= 0x80) {
     uint8_t d1 = uc >> 4;
     uint8_t d2 = uc & 15;
-    error << "\\x" << (d1 <= 9? '0' + d1 : 'a' + d1 - 10)
-                   << (d2 <= 9? '0' + d2 : 'a' + d2 - 10);
+    error << "\\x" << static_cast<char>((d1 <= 9? '0' : 'a' - 10) + d1)
+                   << static_cast<char>((d2 <= 9? '0' : 'a' - 10) + d2);
   } else {
     error << c;
   }

--- a/c/utils/exceptions.cc
+++ b/c/utils/exceptions.cc
@@ -104,6 +104,19 @@ Error& Error::operator<<(SType stype) {
   return *this;
 }
 
+Error& Error::operator<<(char c) {
+  if (c < ' ') {
+    uint8_t uc = static_cast<uint8_t>(c);
+    uint8_t d1 = uc >> 4;
+    uint8_t d2 = uc & 15;
+    error << "\\x" << (d1 <= 9? '0' + d1 : 'a' + d1 - 10)
+                   << (d2 <= 9? '0' + d2 : 'a' + d2 - 10);
+  } else {
+    error << c;
+  }
+  return *this;
+}
+
 
 void Error::topython() const {
   // The pointer returned by errstr.c_str() is valid until errstr gets out

--- a/c/utils/exceptions.h
+++ b/c/utils/exceptions.h
@@ -41,6 +41,7 @@ public:
   Error& operator<<(int64_t);
   Error& operator<<(int32_t);
   Error& operator<<(int8_t);
+  Error& operator<<(char);
   Error& operator<<(size_t);
   Error& operator<<(SType);
   Error& operator<<(const CErrno&);

--- a/tests/fread/test_fread_issues.py
+++ b/tests/fread/test_fread_issues.py
@@ -89,7 +89,8 @@ def test_issue_R2299():
            "3,4\n" * 5000)
     with pytest.raises(Exception) as e:
         dt.fread(src)
-    assert re.search("Expecting 2 cols but row .+ contains only 1 cols", str(e))
+    assert re.search("Too few fields on row .+: expected 2 but found only 1",
+                     str(e))
 
 
 def test_issue_R2351(tempfile):

--- a/tests/fread/test_fread_small.py
+++ b/tests/fread/test_fread_small.py
@@ -801,3 +801,23 @@ def test_typebumps(capsys):
             "row 105" in out)
     assert ("Column 4 (D) bumped from Int32 to Str32 due to <<\"1,000\">> on "
             "row 105" in out)
+
+
+def test_too_few_rows():
+    lines = ["1,2,3"] * 2500
+    lines[111] = "a"
+    src = "\n".join(lines)
+    with pytest.raises(RuntimeError) as e:
+        dt.fread(src, verbose=True)
+    assert ("Too few fields on row 111: expected 3 but found only 1"
+            in str(e.value))
+
+
+def test_too_many_rows():
+    lines = ["1,2,3"] * 2500
+    lines[111] = "0,0,0,0,0"
+    src = "\n".join(lines)
+    with pytest.raises(RuntimeError) as e:
+        dt.fread(src, verbose=True)
+    assert ("Too many fields on row 111: expected 3 but more are present"
+            in str(e.value))

--- a/tests/fread/test_fread_small.py
+++ b/tests/fread/test_fread_small.py
@@ -724,7 +724,8 @@ def test_almost_nodata(capsys):
     assert d0.shape == (n, 3)
     assert d0.ltypes == (ltype.int, ltype.str, ltype.str)
     assert d0.topython() == [[2017] * n, m, ["foo"] * n]
-    assert ("Column 2 (\"B\") bumped from 'Bool8/numeric' to 'Str32' "
+    print(out)
+    assert ("Column 2 (B) bumped from Bool8/numeric to Str32 "
             "due to <<gotcha>> on row 109" in out)
 
 
@@ -782,3 +783,21 @@ def test_maxnrows_on_large_dataset():
     assert d0.internal.check()
     assert d0.shape == (5, 3)
     assert d0.topython() == [[0, 1, 2, 3, 4], ["x"] * 5, [True] * 5]
+
+
+def test_typebumps(capsys):
+    lines = ["1,2,3,4"] * 2111
+    lines[105] = "Fals,3.5,boo,\"1,000\""
+    src = "A,B,C,D\n" + "\n".join(lines)
+    d0 = dt.fread(src, verbose=True)
+    out, err = capsys.readouterr()
+    assert ("4 columns need to be re-read because their types have changed"
+            in out)
+    assert ("Column 1 (A) bumped from Bool8/numeric to Str32 due to <<Fals>> "
+            "on row 105" in out)
+    assert ("Column 2 (B) bumped from Int32 to Float64 due to <<3.5>> on "
+            "row 105" in out)
+    assert ("Column 3 (C) bumped from Int32 to Str32 due to <<boo>> on "
+            "row 105" in out)
+    assert ("Column 4 (D) bumped from Int32 to Str32 due to <<\"1,000\">> on "
+            "row 105" in out)


### PR DESCRIPTION
* Created class `FreadObserver` to keep track of various timers / measures that will be reported in the end. This allows to greatly declutter the main class and many of its helper classes.
* Fixed bugs with reporting of timings in the final report.
* Better report: big numbers are humanized, correct plurals are used.
* Improve performance when reading small files by tweaking the `minChunkSize` constant
* Significantly simplified API of `FreadChunkReader` class.
* Eliminated `stopErr` logic: now an exception is raised instead.
* "[11] Read the data" message will now be displayed only once.
* Added 3 fread tests covering cases of too many / too few columns on an out-of-sample row; and also the case of type bumps in multiple columns.

WIP for #909