### PR TITLE
Clean-up of ChunkedDataReader

### DIFF
--- a/c/csv/chunks.cc
+++ b/c/csv/chunks.cc
@@ -81,20 +81,6 @@ ChunkCoordinates ChunkedDataReader::compute_chunk_boundaries(
 }
 
 
-bool ChunkedDataReader::is_ordered(
-  const ChunkCoordinates& acc, ChunkCoordinates& xcc)
-{
-  bool ordered = (acc.start == lastChunkEnd);
-  xcc.start = lastChunkEnd;
-  xcc.true_start = true;
-  if (ordered && acc.end) {
-    xassert(acc.end >= lastChunkEnd);
-    lastChunkEnd = acc.end;
-  }
-  return ordered;
-}
-
-
 double ChunkedDataReader::work_done_amount() const {
   double done = static_cast<double>(lastChunkEnd - inputStart);
   double total = static_cast<double>(inputEnd - inputStart);
@@ -243,6 +229,7 @@ void ChunkedDataReader::read_all()
 }
 
 
+
 void ChunkedDataReader::realloc_output_columns(size_t ichunk, size_t new_alloc)
 {
   if (ichunk == chunkCount - 1) {
@@ -264,19 +251,6 @@ void ChunkedDataReader::realloc_output_columns(size_t ichunk, size_t new_alloc)
 }
 
 
-          // The `is_ordered()` call checks whether the actual start of the
-          // chunk was correct (i.e. there are no gaps/overlaps in the
-          // input). If not, then we re-read the chunk using the correct
-          // coordinates (which `is_ordered()` saves in variable `xcc`).
-          // We also re-read if the first `read_chunk()` call returned an
-          // error: even if the chunk's start was determined correctly, we
-          // didn't know that up to this point, and so were not producing
-          // the correct error message.
-          // After re-reading, it is no longer possible to have `acc.end`
-          // being nullptr: if a genuine reading error occurs, it will be
-          // thrown as an exception. Thus, `acc.end` will have the correct
-          // end of the current chunk, which MUST be reported to `chunkster`
-          // by calling `is_ordered()` the second time.
 void ChunkedDataReader::order_chunk(
   ChunkCoordinates& acc, ChunkCoordinates& xcc, LocalParseContextPtr& ctx)
 {

--- a/c/csv/fread.cc
+++ b/c/csv/fread.cc
@@ -69,7 +69,7 @@ class FreadChunkedReader : public ChunkedDataReader {
 
   protected:
     virtual std::unique_ptr<LocalParseContext> init_thread_context() override {
-      size_t trows = std::max<size_t>(allocnrow / chunkCount, 4);
+      size_t trows = std::max<size_t>(nrows_allocated / chunkCount, 4);
       size_t tcols = f.columns.nColumnsInBuffer();
       return std::unique_ptr<LocalParseContext>(
                 new FreadLocalParseContext(tcols, trows, f, types, shmutex));

--- a/c/csv/fread.cc
+++ b/c/csv/fread.cc
@@ -69,8 +69,7 @@ class FreadChunkedReader : public ChunkedDataReader {
 
   protected:
     virtual std::unique_ptr<LocalParseContext> init_thread_context() override {
-      size_t nchunks = get_nchunks();
-      size_t trows = std::max<size_t>(allocnrow / nchunks, 4);
+      size_t trows = std::max<size_t>(allocnrow / chunkCount, 4);
       size_t tcols = f.columns.nColumnsInBuffer();
       return std::unique_ptr<LocalParseContext>(
                 new FreadLocalParseContext(tcols, trows, f, types, shmutex));

--- a/c/csv/reader.h
+++ b/c/csv/reader.h
@@ -401,15 +401,13 @@ typedef std::unique_ptr<LocalParseContext> LocalParseContextPtr;
  * ensuring that the data integrity is maintained.
  */
 class ChunkedDataReader {
-  private:
+  protected:
     size_t chunkSize;
     size_t chunkCount;
     const char* inputStart;
     const char* inputEnd;
     const char* lastChunkEnd;
     double lineLength;
-    int nThreads;
-    int : 32;
 
   protected:
     GenericReader& g;
@@ -427,12 +425,19 @@ class ChunkedDataReader {
     ChunkedDataReader& operator=(const ChunkedDataReader&) = delete;
     virtual ~ChunkedDataReader() {}
 
-    size_t get_nchunks() const;
-    int get_nthreads() const;
-    void set_nthreads(int n);
-
+    /**
+     * Main function that reads all data from the input.
+     */
     virtual void read_all();
 
+    /**
+     * Return the fraction of the input that was parsed, as a number between
+     * 0 and 1.0.
+     */
+    double work_done_amount() const;
+
+
+  protected:
     /**
      * Determine coordinates (start and end) of the `i`-th chunk. The index `i`
      * must be in the range [0..chunkCount).
@@ -458,16 +463,6 @@ class ChunkedDataReader {
      */
     bool is_ordered(const ChunkCoordinates& acc, ChunkCoordinates& xcc);
 
-    void unorder_chunk(const ChunkCoordinates& cc);
-
-    /**
-     * Return the fraction of the input that was parsed, as a number between
-     * 0 and 1.0.
-     */
-    double work_done_amount() const;
-
-
-  protected:
     /**
      * This method can be overridden in derived classes in order to implement
      * more advanced chunk boundaries detection. This method will be called from

--- a/c/csv/reader.h
+++ b/c/csv/reader.h
@@ -412,7 +412,6 @@ class ChunkedDataReader {
   protected:
     GenericReader& g;
     dt::shared_mutex shmutex;
-    size_t chunk0;
     size_t row0;
     size_t allocnrow;
     size_t max_nrows;
@@ -450,7 +449,7 @@ class ChunkedDataReader {
      * assuming that different invocation receive different `ctx` objects.
      */
     ChunkCoordinates compute_chunk_boundaries(
-      size_t i, LocalParseContext* ctx = nullptr) const;
+      size_t i, LocalParseContext* ctx) const;
 
     /**
      * Ensure that the chunks were placed properly. This method must be called
@@ -477,6 +476,8 @@ class ChunkedDataReader {
 
   private:
     void determine_chunking_strategy();
+
+    void realloc_output_columns(size_t i, size_t new_allocnrow);
 };
 
 

--- a/c/csv/reader.h
+++ b/c/csv/reader.h
@@ -412,9 +412,9 @@ class ChunkedDataReader {
   protected:
     GenericReader& g;
     dt::shared_mutex shmutex;
-    size_t row0;
-    size_t allocnrow;
-    size_t max_nrows;
+    size_t nrows_max;
+    size_t nrows_allocated;
+    size_t nrows_written;
     int nthreads;
     int : 32;
 

--- a/c/csv/reader.h
+++ b/c/csv/reader.h
@@ -478,6 +478,9 @@ class ChunkedDataReader {
     void determine_chunking_strategy();
 
     void realloc_output_columns(size_t i, size_t new_allocnrow);
+
+    void order_chunk(ChunkCoordinates& acc, ChunkCoordinates& xcc,
+                     LocalParseContextPtr& ctx);
 };
 
 

--- a/c/csv/reader_fread.cc
+++ b/c/csv/reader_fread.cc
@@ -76,6 +76,8 @@ FreadTokenizer FreadReader::makeTokenizer(
 
 //------------------------------------------------------------------------------
 // Detect the separator / quoting rule
+//
+// This entire section is WIP
 //------------------------------------------------------------------------------
 class HypothesisNoQC;
 class HypothesisQC;
@@ -221,6 +223,11 @@ class HypothesisNoQC : public Hypothesis {
 void FreadReader::detect_sep(FreadTokenizer&) {
 }
 
+
+
+//------------------------------------------------------------------------------
+// Misc
+//------------------------------------------------------------------------------
 
 /**
  * Parse a single line of input starting from location `ctx.ch` as strings,

--- a/c/csv/reader_fread.h
+++ b/c/csv/reader_fread.h
@@ -116,7 +116,6 @@ public:
   DataTablePtr read();
 
   // Simple getters
-  int get_nthreads() const { return nthreads; }
   double get_mean_line_len() const { return meanLineLen; }
   size_t get_ncols() const { return columns.size(); }
 

--- a/c/utils/exceptions.cc
+++ b/c/utils/exceptions.cc
@@ -192,3 +192,17 @@ void OmpExceptionManager::capture_exception() {
 void OmpExceptionManager::rethrow_exception_if_any() {
   if (ptr) std::rethrow_exception(ptr);
 }
+
+bool OmpExceptionManager::is_keyboard_interrupt() {
+  if (!ptr) return false;
+  bool ret = false;
+  try {
+    std::rethrow_exception(ptr);
+  } catch (PyError& e) {
+    ret = e.is_keyboard_interrupt();
+    capture_exception();
+  } catch (...) {
+    capture_exception();
+  }
+  return ret;
+}

--- a/c/utils/exceptions.h
+++ b/c/utils/exceptions.h
@@ -111,6 +111,8 @@ public:
   bool exception_caught();
   void capture_exception();
   void rethrow_exception_if_any();
+
+  bool is_keyboard_interrupt();
 };
 
 

--- a/tests/fread/test_fread_small.py
+++ b/tests/fread/test_fread_small.py
@@ -293,6 +293,13 @@ def test_float_many_zeros():
     assert d0.topython() == [[4.49548e-47]]
 
 
+def test_invalid_int_numbers():
+    d0 = dt.fread('A,B,C\n1,+,4\n2,-,5\n3,-,6\n')
+    assert d0.internal.check()
+    assert d0.names == ("A", "B", "C")
+    assert d0.topython() == [[1, 2, 3], ["+", "-", "-"], [4, 5, 6]]
+
+
 def test_invalid_float_numbers():
     d0 = dt.fread("A,B,C,D,E,F\n.,+.,.e,.e+,0e,e-3\n")
     assert d0.internal.check()
@@ -301,7 +308,7 @@ def test_invalid_float_numbers():
 
 
 #-------------------------------------------------------------------------------
-# Empty / tiny files
+# Tiny files
 #-------------------------------------------------------------------------------
 
 @pytest.mark.parametrize(
@@ -453,7 +460,7 @@ def test_fread2():
         """)
     assert f.shape == (3, 4)
     assert f.names == ("A", "B", "C", "D")
-    assert f.ltypes == (dt.ltype.int, dt.ltype.int, dt.ltype.int, dt.ltype.real)
+    assert f.ltypes == (ltype.int, ltype.int, ltype.int, ltype.real)
 
 
 def test_runaway_quote():


### PR DESCRIPTION
* "allocnrows" fault in ChunkedDataReader is now handled without switching to single-threaded context (and without discarding the data that was already read).
* progress bar for files >256MB will now appear immediately, w/o delay.
* Removed unnecessary / duplicate variables from ChunkedDataReader; renamed some of the existing variables for clarity.
* Simplified API of ChunkedDataReader
* Added descriptive comments
* Added few fread tests (unrelated to ChunkedDataReader though)