### PR TITLE
[BUILD] Parameterize the build and disable PPC64le by default

### DIFF
--- a/Jenkinsfile2
+++ b/Jenkinsfile2
@@ -7,6 +7,9 @@ import ai.h2o.ci.Utils
 def utilsLib = new Utils()
 
 properties([
+        parameters([
+            booleanParam(name: 'BUILD_PPC64LE', defaultValue: false, description: '[BUILD] Trigger build of PPC64le artifacts')
+        ]),
         buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '180', numToKeepStr: ''))
 ])
 
@@ -72,7 +75,7 @@ def BUILD_MATRIX = [
         ]
 ]
 
-if (!isPrJob()) {
+if (!isPrJob() && params.BUILD_PPC64LE) {
     BUILD_MATRIX[PPC64LE_PLATFORM] = PPC64LE_BUILD_CONF
 }
 


### PR DESCRIPTION
The change enables an option to trigger PPC64le build and disables default build of PPC64le.