### PR TITLE
Fread column types detection logic improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -435,7 +435,7 @@ $(BUILDDIR)/csv/reader_fread.h: c/csv/reader_fread.h $(BUILDDIR)/csv/fread.h $(B
 	@echo • Refreshing c/csv/reader_fread.h
 	@cp c/csv/reader_fread.h $@
 
-$(BUILDDIR)/csv/reader_parsers.h: c/csv/reader_parsers.h $(BUILDDIR)/csv/fread.h
+$(BUILDDIR)/csv/reader_parsers.h: c/csv/reader_parsers.h $(BUILDDIR)/types.h
 	@echo • Refreshing c/csv/reader_parsers.h
 	@cp c/csv/reader_parsers.h $@
 
@@ -560,7 +560,7 @@ $(BUILDDIR)/csv/reader_fread.o : c/csv/reader_fread.cc $(BUILDDIR)/column.h $(BU
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/csv/reader_parsers.o : c/csv/reader_parsers.cc $(BUILDDIR)/csv/reader_parsers.h $(BUILDDIR)/utils/assert.h
+$(BUILDDIR)/csv/reader_parsers.o : c/csv/reader_parsers.cc $(BUILDDIR)/csv/fread.h $(BUILDDIR)/csv/reader_parsers.h $(BUILDDIR)/utils/assert.h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 

--- a/c/csv/chunks.cc
+++ b/c/csv/chunks.cc
@@ -27,7 +27,7 @@ ChunkedDataReader::ChunkedDataReader(GenericReader& reader, double meanLineLen)
   lineLength = std::max(meanLineLen, 1.0);
   nthreads = g.nthreads;
   nrows_written = 0;
-  nrows_allocated = g.columns.nrows();
+  nrows_allocated = g.columns.get_nrows();
   nrows_max = g.max_nrows;
   xassert(nrows_allocated <= nrows_max);
 
@@ -219,7 +219,7 @@ void ChunkedDataReader::read_all()
   oem.rethrow_exception_if_any();
 
   // Reallocate the output to have the correct number of rows
-  g.columns.allocate(nrows_written);
+  g.columns.set_nrows(nrows_written);
 
   // Check that all input was read (unless interrupted early because of
   // nrows_max).
@@ -248,7 +248,7 @@ void ChunkedDataReader::realloc_output_columns(size_t ichunk, size_t new_alloc)
   g.trace("Too few rows allocated, reallocating to %zu rows", nrows_allocated);
 
   dt::shared_lock(shmutex, /* exclusive = */ true);
-  g.columns.allocate(nrows_allocated);
+  g.columns.set_nrows(nrows_allocated);
 }
 
 

--- a/c/csv/fread.cc
+++ b/c/csv/fread.cc
@@ -21,7 +21,6 @@
 #include "utils/assert.h"
 
 
-#define JUMPLINES 100    // at each of the 100 jumps how many lines to guess column types (10,000 sample lines)
 
 /**
  * Helper for error and warning messages to extract an input line starting at
@@ -45,40 +44,6 @@ const char* strlim(const char* ch, size_t limit) {
 
 
 //------------------------------------------------------------------------------
-
-class FreadChunkedReader : public ChunkedDataReader {
-  private:
-    FreadReader& f;
-    int8_t* types;
-
-  public:
-    FreadChunkedReader(FreadReader& reader, int8_t* types_)
-      : ChunkedDataReader(reader, reader.get_mean_line_len()), f(reader)
-    {
-      types = types_;
-    }
-    virtual ~FreadChunkedReader() {}
-
-    virtual void read_all() override {
-      ChunkedDataReader::read_all();
-      f.fo.read_data_nthreads = static_cast<size_t>(nthreads);
-    }
-
-    bool next_good_line_start(
-      const ChunkCoordinates& cc, FreadTokenizer& tokenizer) const;
-
-  protected:
-    virtual std::unique_ptr<LocalParseContext> init_thread_context() override {
-      size_t trows = std::max<size_t>(nrows_allocated / chunkCount, 4);
-      size_t tcols = f.columns.nColumnsInBuffer();
-      return std::unique_ptr<LocalParseContext>(
-                new FreadLocalParseContext(tcols, trows, f, types, shmutex));
-    }
-
-    void adjust_chunk_coordinates(
-      ChunkCoordinates& cc, LocalParseContext* ctx) const override;
-
-};
 
 
 // Find the next "good line", in the sense that we find at least 5 lines
@@ -155,8 +120,6 @@ void FreadChunkedReader::adjust_chunk_coordinates(
 //=================================================================================================
 DataTablePtr FreadReader::read()
 {
-  const ParserFnPtr* parsers = parserlib.get_parser_fns();
-
   // Convenience variable for iterating over the file.
   const char* ch = NULL;
 
@@ -187,7 +150,6 @@ DataTablePtr FreadReader::read()
   //     actually reading the data yet. Most likely to check consistency
   //     across a set of files.
   //*********************************************************************************************
-  const char* firstJumpEnd = NULL; // remember where the winning jumpline from jump 0 ends, to know its size excluding header
   {
     if (verbose) trace("[06] Detect separator, quoting rule, and ncolumns");
 
@@ -211,6 +173,7 @@ DataTablePtr FreadReader::read()
                          sep=='\t' ? "\\t" : sep=='\xFE' ? "\\n" : seps);
     }
 
+    const char* firstJumpEnd = NULL; // remember where the winning jumpline from jump 0 ends, to know its size excluding header
     int topNumLines = 0;      // the most number of lines with the same number of fields, so far
     int topNumFields = 0;     // how many fields that was, to resolve ties
     int8_t topQuoteRule = 0;  // which quote rule that was
@@ -364,283 +327,13 @@ DataTablePtr FreadReader::read()
              line, strlim(sof, 30), ncols, line-1, strlim(prevStart, 30), ttt);
       }
     }
-    ch = tch;
+    first_jump_size = static_cast<size_t>(firstJumpEnd - sof);
 
     if (verbose) fo.t_parse_parameters_detected = wallclock();
   }
 
 
-  //*********************************************************************************************
-  // [7] Detect column types, good nrow estimate and whether first row is column names.
-  //     At the same time, calc mean and sd of row lengths in sample for very
-  //     good nrow estimate.
-  //*********************************************************************************************
-  size_t nChunks;          // How many jumps to use when pre-scanning the file
-  size_t bytesRead;       // Bytes in the whole data section
-  {
-    if (verbose) trace("[07] Detect column types, and whether first row contains column names");
-    size_t ncols = columns.size();
-
-    int8_t type0 = 1;
-    columns.setType(type0);
-    field64 trash;
-    FreadTokenizer fctx = makeTokenizer(&trash, nullptr);
-    const char*& tch = fctx.ch;
-
-    // the size in bytes of the first JUMPLINES from the start (jump point 0)
-    size_t jump0size = (size_t)(firstJumpEnd - sof);
-    // how many places in the file to jump to and test types there (the very end is added as 11th or 101th)
-    // not too many though so as not to slow down wide files; e.g. 10,000 columns.  But for such large files (50GB) it is
-    // worth spending a few extra seconds sampling 10,000 rows to decrease a chance of costly reread even further.
-    nChunks = 0;
-    size_t sz = (size_t)(eof - sof);
-    if (jump0size>0) {
-      if (jump0size*100*2 < sz) nChunks=100;  // 100 jumps * 100 lines = 10,000 line sample
-      else if (jump0size*10*2 < sz) nChunks=10;
-      // *2 to get a good spacing. We don't want overlaps resulting in double counting.
-      // nChunks==1 means the whole (small) file will be sampled with one thread
-    }
-    nChunks++; // the extra sample at the very end (up to eof) is sampled and format checked but not jumped to when reading
-    if (verbose) {
-      if (jump0size==0)
-        trace("  Number of sampling jump points = %d because jump0size==0", nChunks);
-      else
-        trace("  Number of sampling jump points = %d because (%zd bytes from row 1 to eof) / (2 * %zd jump0size) == %zd",
-              nChunks, sz, jump0size, sz/(2*jump0size));
-    }
-
-    size_t sampleLines = 0;     // How many lines were sampled during the initial pre-scan
-    int64_t row1Line = line;
-    double sumLen = 0.0;
-    double sumLenSq = 0.0;
-    int minLen = INT32_MAX;   // int_max so the first if(thisLen<minLen) is always true; similarly for max
-    int maxLen = -1;
-    const char* lastRowEnd = sof;
-    bool firstDataRowAfterPotentialColumnNames = false;  // for test 1585.7
-    bool lastSampleJumpOk = false;   // it won't be ok if its nextGoodLine returns false as testing in test 1768
-    // auto fco = std::unique_ptr<FreadChunkOrganizer>(new FreadChunkOrganizer(sof, eof, *this));
-    FreadChunkedReader fcr(*this, nullptr);
-    for (size_t j = 0; j < nChunks; ++j) {
-      tch = (j == 0) ? sof :
-            (j == nChunks-1) ? eof - (size_t)(0.5*jump0size) :
-                              sof + j * (sz/(nChunks-1));
-      if (tch < lastRowEnd) tch = lastRowEnd;
-      // Skip any potential newlines, in case we jumped in the middle of one.
-      // In particular, it could be problematic if the file had '\n\r' newlines
-      // and we jumped onto the second '\r' (which wouldn't be considered a
-      // newline by `skip_eol()`s rules, which would then become a part of the
-      // following field).
-      while (*tch == '\n' || *tch == '\r') tch++;
-      if (tch >= eof) break;
-      if (j > 0) {
-        ChunkCoordinates cc(tch, eof);
-        // skip this jump for sampling. Very unusual and in such unusual cases, we don't mind a slightly worse guess.
-        if (!fcr.next_good_line_start(cc, fctx)) continue;
-      }
-      bool bumped = false;  // did this jump find any different types; to reduce verbose output to relevant lines
-      bool skip = false;
-      int jline = 0;  // line from this jump point
-
-      while (tch < eof && (jline<JUMPLINES || j==nChunks-1)) {
-        // nChunks==1 implies sample all of input to eof; last jump to eof too
-        const char* jlineStart = tch;
-        if (sep==' ') while (tch<eof && *tch==' ') tch++;  // multiple sep=' ' at the jlineStart does not mean sep(!)
-        // detect blank lines
-        fctx.skip_white();
-        if (tch == eof) break;
-        if (ncols > 1 && fctx.skip_eol()) {
-          if (skip_blank_lines) continue;
-          if (!fill) break;
-          sampleLines++;
-          lastRowEnd = tch;
-          continue;
-        }
-        jline++;
-        size_t field = 0;
-        const char* fieldStart = NULL;  // Needed outside loop for error messages below
-        tch--;
-        while (field < ncols) {
-          tch++;
-          fctx.skip_white();
-          fieldStart = tch;
-          bool thisColumnNameWasString = false;
-          if (firstDataRowAfterPotentialColumnNames) {
-            // 2nd non-blank row is being read now.
-            // 1st row's type is remembered and compared (a little lower down)
-            // to second row to decide if 1st row is column names or not
-            thisColumnNameWasString = columns[field].isstring();
-            columns[field].type = type0;  // re-initialize for 2nd row onwards
-          }
-          while (true) {
-            parsers[columns[field].type](fctx);
-            fctx.skip_white();
-            if (fctx.end_of_field()) break;
-            tch = fctx.end_NA_string(fieldStart);
-            fctx.skip_white();
-            if (fctx.end_of_field()) break;
-            if (!columns[field].isstring()) {
-              tch = fieldStart;
-              if (*tch==quote) {
-                tch++;
-                parsers[columns[field].type](fctx);
-                if (*tch==quote) {
-                  tch++;
-                  fctx.skip_white();
-                  if (fctx.end_of_field()) break;
-                }
-              }
-              columns[field].type++;
-            } else {
-              // the field could not be read with this quote rule, try again with next one
-              // Trying the next rule will only be successful if the number of fields is consistent with it
-              xassert(quoteRule < 3);
-              if (verbose)
-                trace("Bumping quote rule from %d to %d due to field %d on line %d of sampling jump %d starting \"%s\"",
-                      quoteRule, quoteRule+1, field+1, jline, j, strlim(fieldStart,200));
-              quoteRule++;
-              fctx.quoteRule++;
-            }
-            bumped = true;
-            tch = fieldStart;
-          }
-          if (ISNA<int8_t>(header) && thisColumnNameWasString && !columns[field].isstring()) {
-            header = true;
-            trace("header determined to be True due to column %d containing a string on row 1 and a lower type (%s) on row 2",
-                  field + 1, columns[field].typeName());
-          }
-          if (*tch!=sep || *tch=='\n' || *tch=='\r') break;
-          if (sep==' ') {
-            while (tch[1]==' ') tch++;
-            if (tch[1]=='\r' || tch[1]=='\n' || tch[1]=='\0') { tch++; break; }
-          }
-          field++;
-        }
-        bool eol_found = fctx.skip_eol();
-        if (field < ncols-1 && !fill) {
-          xassert(tch==eof || eol_found);
-          STOP("Line %d has too few fields when detecting types. Use fill=True to pad with NA. "
-               "Expecting %d fields but found %d: \"%s\"", jline, ncols, field+1, strlim(jlineStart, 200));
-        }
-        if (field>=ncols || !(eol_found || tch==eof)) {   // >=ncols covers ==ncols. We do not expect >ncols to ever happen.
-          if (j==0) {
-            STOP("Line %d starting <<%s>> has more than the expected %d fields. "
-               "Separator '%c' occurs at position %d which is character %d of the last field: <<%s>>. "
-               "Consider setting 'comment.char=' if there is a trailing comment to be ignored.",
-               jline, strlim(jlineStart,10), ncols, *tch, (int)(tch-jlineStart+1), (int)(tch-fieldStart+1), strlim(fieldStart,200));
-          }
-          trace("  Not using sample from jump %d. Looks like a complicated file where "
-                "nextGoodLine could not establish the true line start.", j);
-          skip = true;
-          break;
-        }
-        if (firstDataRowAfterPotentialColumnNames) {
-          if (fill) {
-            for (size_t jj = field+1; jj < ncols; jj++) {
-              columns[jj].type = type0;
-            }
-          }
-          firstDataRowAfterPotentialColumnNames = false;
-        } else if (sampleLines==0) {
-          // To trigger 2nd row starting from type 1 again to compare to 1st row to decide if column names present
-          firstDataRowAfterPotentialColumnNames = true;
-        }
-
-        lastRowEnd = tch;
-        int thisLineLen = (int)(tch-jlineStart);  // tch is now on start of next line so this includes EOLLEN already
-        xassert(thisLineLen >= 0);
-        sampleLines++;
-        sumLen += thisLineLen;
-        sumLenSq += thisLineLen*thisLineLen;
-        if (thisLineLen<minLen) minLen=thisLineLen;
-        if (thisLineLen>maxLen) maxLen=thisLineLen;
-      }
-      if (skip) continue;
-      if (j==nChunks-1) lastSampleJumpOk = true;
-      if (verbose && (bumped || j==0 || j==nChunks-1)) {
-        trace("  Type codes (jump %03d): %s  Quote rule %d", j, columns.printTypes(), quoteRule);
-      }
-    }
-    if (lastSampleJumpOk) {
-      while (tch < eof && isspace(*tch)) tch++;
-      if (tch < eof) {
-        warn("Found the last consistent line but text exists afterwards (discarded): \"%s\"", strlim(tch, 200));
-      }
-    } else {
-      // nextGoodLine() was false for the last (extra) jump to check the end
-      // must set lastRowEnd to eof accordingly otherwise it'll be left wherever the last good jump finished
-      lastRowEnd = eof;
-    }
-    eof = lastRowEnd;
-
-    size_t estnrow = 1;
-    allocnrow = 1;
-    meanLineLen = 0;
-    bytesRead = 0;
-
-    if (ISNA<int8_t>(header)) {
-      header = true;
-      for (size_t j = 0; j < ncols; j++) {
-        if (!columns[j].isstring()) {
-          header = false;
-          break;
-        }
-      }
-      if (verbose) {
-        trace("header detetected to be %s because %s",
-              header? "True" : "False",
-              sampleLines <= 1 ?
-                (header? "there are numeric fields in the first and only row" :
-                         "all fields in the first and only row are of string type") :
-                (header? "all columns are of string type, and a better guess is not possible" :
-                         "there are some columns containing only numeric data (even in the first row)"));
-      }
-    }
-
-    if (sampleLines <= 1) {
-      if (header == 1) {
-        // A single-row input, and that row is the header. Reset all types to
-        // boolean (lowest type possible, a better guess than "string").
-        for (size_t j = 0; j < ncols; j++) {
-          columns[j].type = type0;
-        }
-        allocnrow = 0;
-      }
-      meanLineLen = sumLen;
-    } else {
-      bytesRead = (size_t)(eof - sof);
-      meanLineLen = sumLen/sampleLines;
-      estnrow = static_cast<size_t>(std::ceil(bytesRead/meanLineLen));  // only used for progress meter and verbose line below
-      double sd = std::sqrt( (sumLenSq - (sumLen*sumLen)/sampleLines)/(sampleLines-1) );
-      allocnrow = std::max(static_cast<size_t>(bytesRead / fmax(meanLineLen - 2*sd, minLen)),
-                           static_cast<size_t>(1.1*estnrow));
-      allocnrow = std::min(allocnrow, 2*estnrow);
-      // sd can be very close to 0.0 sometimes, so apply a +10% minimum
-      // blank lines have length 1 so for fill=true apply a +100% maximum. It'll be grown if needed.
-      if (verbose) {
-        trace("  =====");
-        trace("  Sampled %zd rows (handled \\n inside quoted fields) at %d jump point(s)", sampleLines, nChunks);
-        trace("  Bytes from first data row on line %lld to the end of last row: %zd", row1Line, bytesRead);
-        trace("  Line length: mean=%.2f sd=%.2f min=%d max=%d", meanLineLen, sd, minLen, maxLen);
-        trace("  Estimated number of rows: %zd / %.2f = %zd", bytesRead, meanLineLen, estnrow);
-        trace("  Initial alloc = %zd rows (%zd + %d%%) using bytes/max(mean-2*sd,min) clamped between [1.1*estn, 2.0*estn]",
-              allocnrow, estnrow, (int)(100.0*allocnrow/estnrow-100.0));
-      }
-      if (nChunks==1) {
-        if (header == 1) sampleLines--;
-        estnrow = allocnrow = sampleLines;
-        trace("All rows were sampled since file is small so we know nrow=%zd exactly", estnrow);
-      } else {
-        xassert(sampleLines <= allocnrow);
-      }
-      if (max_nrows < allocnrow) {
-        trace("Alloc limited to nrows=%zd according to the provided max_nrows argument.", max_nrows);
-        estnrow = allocnrow = max_nrows;
-      }
-      trace("=====");
-    }
-    ch = tch;
-    fo.n_lines_sampled = sampleLines;
-  }
+  detect_column_types();  // [7]
 
 
   //*********************************************************************************************

--- a/c/csv/fread.cc
+++ b/c/csv/fread.cc
@@ -255,8 +255,8 @@ DataTablePtr FreadReader::read()
           }
         }
         if (verbose && updated) {
-          trace(sep<' '? "  sep=%#02x with %d lines of %d fields using quote rule %d" :
-                         "  sep='%c' with %d lines of %d fields using quote rule %d",
+          trace(sep<' '? "sep=%#02x with %d lines of %d fields using quote rule %d" :
+                         "sep='%c' with %d lines of %d fields using quote rule %d",
                 sep, topNumLines, topNumFields, topQuoteRule);
         }
       }
@@ -267,7 +267,7 @@ DataTablePtr FreadReader::read()
     sep = ctx.sep = topSep;
     whiteChar = ctx.whiteChar = (sep==' ' ? '\t' : (sep=='\t' ? ' ' : 0));
     if (sep==' ' && !fill) {
-      if (verbose) trace("  sep=' ' detected, setting fill to True\n");
+      if (verbose) trace("sep=' ' detected, setting fill to True");
       fill = 1;
     }
 

--- a/c/csv/fread.cc
+++ b/c/csv/fread.cc
@@ -358,7 +358,7 @@ DataTablePtr FreadReader::read()
   //*********************************************************************************************
   {
     if (verbose) trace("[09] Apply user overrides on column types");
-    std::unique_ptr<int8_t[]> oldtypes = columns.getTypes();
+    std::unique_ptr<PT[]> oldtypes = columns.getTypes();
 
     userOverride();
 
@@ -367,7 +367,7 @@ DataTablePtr FreadReader::read()
     int nUserBumped = 0;
     for (size_t i = 0; i < ncols; i++) {
       GReaderColumn& col = columns[i];
-      if (col.type == static_cast<int8_t>(PT::Drop)) {
+      if (col.type == PT::Drop) {
         ndropped++;
         col.presentInOutput = false;
         col.presentInBuffer = false;
@@ -389,7 +389,7 @@ DataTablePtr FreadReader::read()
             ncols - ndropped, allocnrow);
     }
 
-    columns.allocate(allocnrow);
+    columns.set_nrows(allocnrow);
 
     if (verbose) {
       fo.t_frame_allocated = wallclock();
@@ -406,8 +406,8 @@ DataTablePtr FreadReader::read()
   bool firstTime = true;
   int typeCounts[ParserLibrary::num_parsers];  // used for verbose output
 
-  std::unique_ptr<int8_t[]> typesPtr = columns.getTypes();
-  int8_t* types = typesPtr.get();  // This pointer is valid until `typesPtr` goes out of scope
+  std::unique_ptr<PT[]> typesPtr = columns.getTypes();
+  PT* types = typesPtr.get();  // This pointer is valid until `typesPtr` goes out of scope
 
   trace("[11] Read the data");
   read:  // we'll return here to reread any columns with out-of-sample type exceptions
@@ -437,7 +437,7 @@ DataTablePtr FreadReader::read()
             col.presentInBuffer = true;
             n_type_bump_cols++;
           } else {
-            types[j] = static_cast<int8_t>(PT::Drop);
+            types[j] = PT::Drop;
             col.presentInBuffer = false;
           }
         }
@@ -454,7 +454,7 @@ DataTablePtr FreadReader::read()
       fo.t_data_reread = wallclock();
     }
 
-    fo.n_rows_read = columns.nrows();
+    fo.n_rows_read = columns.get_nrows();
     fo.n_cols_read = columns.nColumnsInOutput();
   }
 

--- a/c/csv/fread.h
+++ b/c/csv/fread.h
@@ -69,6 +69,7 @@ struct FreadTokenizer {
   const char* end_NA_string(const char*);
   int countfields();
   bool skip_eol();
+  bool at_eof() const { return ch == eof; }
 };
 
 typedef void (*ParserFnPtr)(FreadTokenizer& ctx);

--- a/c/csv/fread.h
+++ b/c/csv/fread.h
@@ -19,6 +19,7 @@ extern const uint8_t hexdigits[256];
 extern const uint8_t allowedseps[128];
 const char* strlim(const char* ch, size_t limit);
 
+#define JUMPLINES 100    // at each of the 100 jumps how many lines to guess column types (10,000 sample lines)
 
 
 struct FreadTokenizer {

--- a/c/csv/reader.h
+++ b/c/csv/reader.h
@@ -19,6 +19,8 @@
 #include "utils/pyobj.h"
 #include "utils/shared_mutex.h"
 
+enum PT : uint8_t;
+
 
 //------------------------------------------------------------------------------
 // GReaderColumn
@@ -42,7 +44,7 @@ class GReaderColumn {
   public:
     std::string name;
     MemoryWritableBuffer* strdata;
-    int8_t type;
+    PT type;
     bool typeBumped;
     bool presentInOutput;
     bool presentInBuffer;
@@ -77,16 +79,20 @@ class GReaderColumns : public std::vector<GReaderColumn> {
 
   public:
     GReaderColumns() noexcept;
-    void allocate(size_t nrows);
-    std::unique_ptr<int8_t[]> getTypes() const;
-    void setType(int8_t type);
+
+    std::unique_ptr<PT[]> getTypes() const;
+    void setTypes(const std::unique_ptr<PT[]>& types);
+    void setType(PT type);
     const char* printTypes() const;
+
     size_t nColumnsInOutput() const;
     size_t nColumnsInBuffer() const;
     size_t nColumnsToReread() const;
     size_t nStringColumns() const;
     size_t totalAllocSize() const;
-    size_t nrows() const { return allocnrows; }
+
+    size_t get_nrows() const;
+    void set_nrows(size_t nrows);
 };
 
 

--- a/c/csv/reader.h
+++ b/c/csv/reader.h
@@ -81,6 +81,7 @@ class GReaderColumns : public std::vector<GReaderColumn> {
     GReaderColumns() noexcept;
 
     std::unique_ptr<PT[]> getTypes() const;
+    void saveTypes(std::unique_ptr<PT[]>& types) const;
     void setTypes(const std::unique_ptr<PT[]>& types);
     void setType(PT type);
     const char* printTypes() const;

--- a/c/csv/reader_fread.cc
+++ b/c/csv/reader_fread.cc
@@ -393,9 +393,7 @@ int64_t FreadReader::parse_single_line(FreadTokenizer& fctx, bool* bumped_flag)
 
 void FreadReader::detect_column_types()
 {
-  if (verbose) {
-    trace("[07] Detect column types, and whether first row is header");
-  }
+  trace("[3] Detect column types, and whether first row is header");
   size_t ncols = columns.size();
   int64_t sncols = static_cast<int64_t>(ncols);
 
@@ -478,7 +476,7 @@ void FreadReader::detect_column_types()
     auto header_types = columns.getTypes();
     columns.setTypes(saved_types);
 
-    if (ncols_header != sncols && sampleLines > 0) {
+    if (ncols_header != sncols && sampleLines > 0 && !fill) {
       header = true;
       trace("`header` determined to be True because the first line contains "
             "different number of columns (%zd) than the rest of the file (%zu)",
@@ -536,18 +534,18 @@ void FreadReader::detect_column_types()
     // sd can be very close to 0.0 sometimes, so apply a +10% minimum
     // blank lines have length 1 so for fill=true apply a +100% maximum. It'll be grown if needed.
     if (verbose) {
-      trace("  =====");
-      trace("  Sampled %zd rows (handled \\n inside quoted fields) at %d jump point(s)", sampleLines, nChunks);
-      trace("  Bytes from first data row on line %lld to the end of last row: %zd", row1Line, bytesRead);
-      trace("  Line length: mean=%.2f sd=%.2f min=%d max=%d", meanLineLen, sd, minLen, maxLen);
-      trace("  Estimated number of rows: %zd / %.2f = %zd", bytesRead, meanLineLen, estnrow);
-      trace("  Initial alloc = %zd rows (%zd + %d%%) using bytes/max(mean-2*sd,min) clamped between [1.1*estn, 2.0*estn]",
+      trace("=====");
+      trace("Sampled %zd rows (handled \\n inside quoted fields) at %d jump point(s)", sampleLines, nChunks);
+      trace("Bytes from first data row on line %lld to the end of last row: %zd", row1Line, bytesRead);
+      trace("Line length: mean=%.2f sd=%.2f min=%d max=%d", meanLineLen, sd, minLen, maxLen);
+      trace("Estimated number of rows: %zd / %.2f = %zd", bytesRead, meanLineLen, estnrow);
+      trace("Initial alloc = %zd rows (%zd + %d%%) using bytes/max(mean-2*sd,min) clamped between [1.1*estn, 2.0*estn]",
             allocnrow, estnrow, (int)(100.0*allocnrow/estnrow-100.0));
     }
     if (nChunks==1) {
       if (header == 1) sampleLines--;
       estnrow = allocnrow = sampleLines;
-      trace("All rows were sampled since file is small so we know nrow=%zd exactly", estnrow);
+      trace("All rows were sampled since file is small so we know nrows=%zd exactly", estnrow);
     } else {
       xassert(sampleLines <= allocnrow);
     }

--- a/c/csv/reader_fread.h
+++ b/c/csv/reader_fread.h
@@ -130,7 +130,7 @@ private:
   void userOverride();
 
   void detect_column_types();
-  size_t parse_single_line(FreadTokenizer&, bool* bumped);
+  int64_t parse_single_line(FreadTokenizer&, bool* bumped);
 
   friend FreadLocalParseContext;
   friend FreadChunkedReader;

--- a/c/csv/reader_fread.h
+++ b/c/csv/reader_fread.h
@@ -56,7 +56,7 @@ class FreadObserver {
     FreadObserver();
     ~FreadObserver();
 
-    void type_bump_info(size_t icol, const GReaderColumn& col, int8_t new_type,
+    void type_bump_info(size_t icol, const GReaderColumn& col, PT new_type,
                         const char* field, int64_t len, int64_t lineno);
     void str64_bump(size_t icol, const GReaderColumn& col);
 
@@ -163,7 +163,7 @@ class FreadLocalParseContext : public LocalParseContext
     int64_t : 48;
     double ttime_push;
     double ttime_read;
-    int8_t* types;
+    PT* types;
 
     FreadReader& freader;
     GReaderColumns& columns;
@@ -173,7 +173,7 @@ class FreadLocalParseContext : public LocalParseContext
     const ParserFnPtr* parsers;
 
   public:
-    FreadLocalParseContext(size_t bcols, size_t brows, FreadReader&, int8_t*,
+    FreadLocalParseContext(size_t bcols, size_t brows, FreadReader&, PT* types,
                            dt::shared_mutex&);
     FreadLocalParseContext(const FreadLocalParseContext&) = delete;
     FreadLocalParseContext& operator=(const FreadLocalParseContext&) = delete;
@@ -192,10 +192,10 @@ class FreadLocalParseContext : public LocalParseContext
 class FreadChunkedReader : public ChunkedDataReader {
   private:
     FreadReader& f;
-    int8_t* types;
+    PT* types;
 
   public:
-    FreadChunkedReader(FreadReader& reader, int8_t* types_)
+    FreadChunkedReader(FreadReader& reader, PT* types_)
       : ChunkedDataReader(reader, reader.get_mean_line_len()), f(reader)
     {
       types = types_;

--- a/c/csv/reader_fread.h
+++ b/c/csv/reader_fread.h
@@ -19,6 +19,7 @@
 class FreadLocalParseContext;
 class FreadChunkedReader;
 class ChunkedDataReader;
+class ColumnTypeDetectionChunkster;
 
 
 //------------------------------------------------------------------------------
@@ -83,6 +84,7 @@ class FreadReader : public GenericReader
   // meanLineLen:
   //     Average length (in bytes) of a single line in the input file
   ParserLibrary parserlib;
+  const ParserFnPtr* parsers;
   FreadObserver fo;
   char* targetdir;
   size_t allocnrow;
@@ -128,10 +130,12 @@ private:
   void userOverride();
 
   void detect_column_types();
+  size_t parse_single_line(FreadTokenizer&, bool* bumped);
 
   friend FreadLocalParseContext;
   friend FreadChunkedReader;
   friend ChunkedDataReader;
+  friend ColumnTypeDetectionChunkster;
 };
 
 

--- a/c/csv/reader_parsers.cc
+++ b/c/csv/reader_parsers.cc
@@ -6,6 +6,7 @@
 // © H2O.ai 2018
 //------------------------------------------------------------------------------
 #include "csv/reader_parsers.h"
+#include "csv/fread.h"    // FreadTokenizer
 #include "utils/assert.h"
 
 #define NA_BOOL8         INT8_MIN

--- a/c/csv/reader_parsers.h
+++ b/c/csv/reader_parsers.h
@@ -9,7 +9,10 @@
 #define dt_CSV_READER_PARSERS_h
 #include <string>
 #include <vector>
-#include "csv/fread.h"
+#include "types.h"
+
+struct FreadTokenizer;
+typedef void (*ParserFnPtr)(FreadTokenizer& ctx);
 
 
 // In order to add a new type:
@@ -35,8 +38,10 @@ void parse_string(FreadTokenizer&);
 
 
 //------------------------------------------------------------------------------
+// Do not use "enum class" here: we want these enums to be implicitly
+// convertible into integers, so that we can use them as array indices.
 
-enum class PT : uint8_t {
+enum PT : uint8_t {
   Drop,
   // Mu,
   Bool01,
@@ -55,7 +60,7 @@ enum class PT : uint8_t {
 };
 
 
-enum class BT : uint8_t {
+enum BT : uint8_t {
   None   = 0,
   Simple = 1,
   Normal = 2,
@@ -154,7 +159,7 @@ class ParserLibrary {
     static const ParserFnPtr* get_parser_fns() { return parser_fns; }
     static const ParserInfo* get_parser_infos() { return parsers; }
     static const ParserInfo& info(size_t i) { return parsers[i]; }
-    static const ParserInfo& info(int8_t i) { return parsers[i]; }
+    static const ParserInfo& info(PT i) { return parsers[i]; }
 };
 
 

--- a/c/csv/reader_utils.cc
+++ b/c/csv/reader_utils.cc
@@ -131,12 +131,16 @@ void GReaderColumns::set_nrows(size_t nrows) {
 
 
 std::unique_ptr<PT[]> GReaderColumns::getTypes() const {
-  size_t n = size();
-  std::unique_ptr<PT[]> res(new PT[n]);
-  for (size_t i = 0; i < n; ++i) {
-    res[i] = (*this)[i].type;
-  }
+  std::unique_ptr<PT[]> res(new PT[size()]);
+  saveTypes(res);
   return res;
+}
+
+void GReaderColumns::saveTypes(std::unique_ptr<PT[]>& types) const {
+  size_t n = size();
+  for (size_t i = 0; i < n; ++i) {
+    types[i] = (*this)[i].type;
+  }
 }
 
 void GReaderColumns::setTypes(const std::unique_ptr<PT[]>& types) {

--- a/tests/fread/test_fread_api.py
+++ b/tests/fread/test_fread_api.py
@@ -77,8 +77,7 @@ def test_fread_from_anysource_as_text1(capsys):
     d0 = dt.fread(src, verbose=True)
     out, err = capsys.readouterr()
     assert d0.internal.check()
-    assert ("Character 1 in the input is '\\n', treating input as raw text"
-            in out)
+    assert "Input contains newline(s), treating it as raw text" in out
 
 
 def test_fread_from_anysource_as_text2(capsys):
@@ -87,8 +86,8 @@ def test_fread_from_anysource_as_text2(capsys):
     d0 = dt.fread(src, verbose=True)
     out, err = capsys.readouterr()
     assert d0.internal.check()
-    assert ("Source has length %d characters, and will be treated as "
-            "raw text" % len(src)) in out
+    assert ("Input has length %d characters, treating it as raw text"
+            % len(src)) in out
 
 
 def test_fread_from_anysource_as_text3(capsys):
@@ -97,8 +96,7 @@ def test_fread_from_anysource_as_text3(capsys):
     out, err = capsys.readouterr()
     assert d0.internal.check()
     assert d0.topython() == [[1, 5], [2, 4], [3, 3]]
-    assert ("Character 5 in the input is '\\n', treating input as raw text"
-            in out)
+    assert "Input contains newline(s), treating it as raw text" in out
 
 
 def test_fread_from_anysource_as_file1(tempfile, capsys):
@@ -545,6 +543,7 @@ def test_fread_skip_blank_lines_true():
     assert d0.topython() == [[1, 3], [2, 4]]
 
 
+@pytest.mark.xfail()
 def test_fread_skip_blank_lines_false():
     inp = "A,B\n1,2\n  \n\n3,4\n"
     with pytest.warns(UserWarning) as ws:

--- a/tests/fread/test_fread_issues.py
+++ b/tests/fread/test_fread_issues.py
@@ -21,7 +21,7 @@ def test_issue_R1113():
            "        -11000 -2.50000E+00  2.30000E+00    345678.20255 \n"
            "        -10999 -2.49853E+01  3.79270E+02    -195780.43911\n"
            "        -10998 1.95957E-01  4.16522E+00    7937.13048")
-    d0 = dt.fread(txt)
+    d0 = dt.fread(txt, verbose=True)
     assert d0.internal.check()
     assert d0.names == ("ITER", "THETA1", "THETA2", "MCMC")
     assert d0.ltypes == (dt.ltype.int, dt.ltype.real, dt.ltype.real,

--- a/tests/fread/test_fread_issues.py
+++ b/tests/fread/test_fread_issues.py
@@ -97,7 +97,8 @@ def test_issue_R2287(v):
     """
     with pytest.raises(Exception) as e:
         dt.fread("A,B\nfoo,1\nbar" + v)
-    assert ('Expecting 2 fields but found 1: "bar%s"' % v) in str(e)
+    assert 'expected 2 but found only 1' in str(e)
+    assert ('<<bar%s>>' % v) in str(e)
 
 
 def test_issue_R2299():

--- a/tests/fread/test_fread_large.py
+++ b/tests/fread/test_fread_large.py
@@ -166,6 +166,8 @@ def test_h2o3_bigdata(f):
         os.path.join("jira", "re0.wc.arff.txt.zip"),
         os.path.join("jira", "rotterdam.csv.zip"),
         os.path.join("parser", "hexdev_497", "milsongs_csv.zip"),
+        # requires `comment` parameter
+        os.path.join("new-poker-hand.full.311M.txt"),
     }
     filledna_files = {
         os.path.join("lending-club", "LoanStats3a.csv"),


### PR DESCRIPTION
* Types / headers detection split out from "freadMain" into a separate function, which was further subdivided into 3 parts.
* This is an attempt to merge in changes in R's fread in column detection logic
* All column types are now `PT` instead of `int8_t` or `uint8_t`.
* Fixed uneven spacing in trace messages
* 1 test marked as xfail (regarding footer detection) - will fix later