### PR TITLE
Fread skip comments section

### DIFF
--- a/c/csv/chunks.cc
+++ b/c/csv/chunks.cc
@@ -168,6 +168,7 @@ void ChunkedDataReader::read_all()
       do {
         if (oem.exception_caught()) break;
         try {
+          tctx->row0 = nrows_written;
           order_chunk(tacc, txcc, tctx);
 
           size_t nrows_new = nrows_written + tctx->used_nrows;
@@ -181,7 +182,6 @@ void ChunkedDataReader::read_all()
               realloc_output_columns(i, nrows_new);
             }
           }
-          tctx->row0 = nrows_written;
           nrows_written = nrows_new;
 
           tctx->orderBuffer();

--- a/c/csv/fread.cc
+++ b/c/csv/fread.cc
@@ -120,24 +120,8 @@ void FreadChunkedReader::adjust_chunk_coordinates(
 //=================================================================================================
 DataTablePtr FreadReader::read()
 {
-  // Convenience variable for iterating over the file.
-  const char* ch = NULL;
+  detect_lf();
 
-  // Test whether '\n's are present in the file at all... If not, then standalone '\r's are valid
-  // line endings. However if '\n' exists in the file, then '\r' will be considered as regular
-  // characters instead of a line ending.
-  int cnt = 0;
-  ch = sof;
-  while (ch < eof && *ch != '\n' && cnt < 100) {
-    cnt += (*ch == '\r');
-    ch++;
-  }
-  LFpresent = (ch < eof && *ch == '\n');
-  if (LFpresent) {
-    trace("LF character (\\n) found in input, \\r-only line endings are prohibited");
-  } else {
-    trace("LF character (\\n) not found in input, CR (\\r) will be considered a line ending");
-  }
   if (verbose) fo.t_initialized = wallclock();
 
 

--- a/c/csv/reader.cc
+++ b/c/csv/reader.cc
@@ -121,8 +121,8 @@ void GenericReader::init_maxnrows() {
 
 void GenericReader::init_skiptoline() {
   int64_t n = freader.attr("skip_to_line").as_int64();
-  skip_to_line = (n < 0)? 0 : n;
-  if (n > 1) trace("skip_to_line = %lld", static_cast<long long>(n));
+  skip_to_line = (n < 0)? 0 : static_cast<size_t>(n);
+  if (n > 1) trace("skip_to_line = %zu", n);
 }
 
 void GenericReader::init_sep() {

--- a/c/csv/reader.h
+++ b/c/csv/reader.h
@@ -146,7 +146,7 @@ class GenericReader
     char    dec;
     char    quote;
     size_t  max_nrows;
-    int64_t skip_to_line;
+    size_t  skip_to_line;
     int8_t  header;
     bool    strip_whitespace;
     bool    skip_blank_lines;
@@ -166,7 +166,7 @@ class GenericReader
     MemoryBuffer* input_mbuf;
     const char* sof;
     const char* eof;
-    int64_t line;
+    size_t line;
     int32_t fileno;
     int : 32;
     GReaderColumns columns;

--- a/c/csv/reader_fread.cc
+++ b/c/csv/reader_fread.cc
@@ -565,6 +565,35 @@ void FreadReader::detect_column_types()
 //------------------------------------------------------------------------------
 
 /**
+ * This helper method tests whether '\n' characters are present in the file,
+ * and sets the `LFpresent` flag accordingly.
+ *
+ * If '\n' exists in the file, then `LFpresent` is set to true, and standalone
+ * '\r' will be treated as a regular character. However if there are no '\n's
+ * in the file (at least within the first 100 lines), then we will treat '\r'
+ * as a newline character.
+ */
+void FreadReader::detect_lf() {
+  int cnt = 0;
+  const char* ch = sof;
+  while (ch < eof && *ch != '\n' && cnt < 100) {
+    cnt += (*ch == '\r');
+    ch++;
+  }
+  LFpresent = (ch < eof && *ch == '\n');
+  if (LFpresent) {
+    trace("LF character (\\n) found in input, "
+          "\\r-only newlines will not be recognized");
+  } else {
+    trace("LF character (\\n) not found in input, "
+          "CR character (\\r) will be treated as a newline");
+  }
+
+}
+
+
+
+/**
  * Parse a single line of input starting from location `ctx.ch` as strings,
  * and interpret them as column names. At the end of this function the parsing
  * location `ctx.ch` will be moved to the beginning of the next line.

--- a/c/csv/reader_fread.h
+++ b/c/csv/reader_fread.h
@@ -130,6 +130,7 @@ private:
   void userOverride();
 
   void detect_lf();
+  void skip_preamble();
   void detect_column_types();
   int64_t parse_single_line(FreadTokenizer&, bool* bumped);
 

--- a/c/csv/reader_fread.h
+++ b/c/csv/reader_fread.h
@@ -129,6 +129,7 @@ private:
   void detect_sep(FreadTokenizer& ctx);
   void userOverride();
 
+  void detect_lf();
   void detect_column_types();
   int64_t parse_single_line(FreadTokenizer&, bool* bumped);
 

--- a/c/csv/reader_utils.cc
+++ b/c/csv/reader_utils.cc
@@ -21,7 +21,7 @@
 GReaderColumn::GReaderColumn() {
   mbuf = nullptr;
   strdata = nullptr;
-  type = PT::Drop;
+  type = PT::Bool01;  // should be PT::Mu
   typeBumped = false;
   presentInOutput = true;
   presentInBuffer = true;

--- a/tests/fread/test_fread_issues.py
+++ b/tests/fread/test_fread_issues.py
@@ -110,7 +110,7 @@ def test_issue_R2299():
            "3,4\n" * 5000)
     with pytest.raises(Exception) as e:
         dt.fread(src)
-    assert re.search("Too few fields on row .+: expected 2 but found only 1",
+    assert re.search("Too few fields on line 102: expected 2 but found only 1",
                      str(e))
 
 

--- a/tests/fread/test_fread_large.py
+++ b/tests/fread/test_fread_large.py
@@ -168,6 +168,9 @@ def test_h2o3_bigdata(f):
         os.path.join("parser", "hexdev_497", "milsongs_csv.zip"),
         # requires `comment` parameter
         os.path.join("new-poker-hand.full.311M.txt"),
+        # files with 36M columns
+        os.path.join("testng", "newsgroup_train1.csv"),
+        os.path.join("testng", "newsgroup_validation1.csv"),
     }
     filledna_files = {
         os.path.join("lending-club", "LoanStats3a.csv"),

--- a/tests/fread/test_fread_small.py
+++ b/tests/fread/test_fread_small.py
@@ -867,7 +867,7 @@ def test_too_few_rows():
     src = "\n".join(lines)
     with pytest.raises(RuntimeError) as e:
         dt.fread(src, verbose=True)
-    assert ("Too few fields on row 111: expected 3 but found only 1"
+    assert ("Too few fields on line 112: expected 3 but found only 1"
             in str(e.value))
 
 
@@ -877,5 +877,5 @@ def test_too_many_rows():
     src = "\n".join(lines)
     with pytest.raises(RuntimeError) as e:
         dt.fread(src, verbose=True)
-    assert ("Too many fields on row 111: expected 3 but more are present"
+    assert ("Too many fields on line 112: expected 3 but more are present"
             in str(e.value))


### PR DESCRIPTION
* Detect presence of a comment section on top of the file and automatically skip it.
* Better reporting of line numbers in error messages.
* Removed logic to skip "inconsistent number of rows at the beginning of the file". This logic was skipping arbitrary pieces of data, with giving much of an explanation to the user... It was also interfering with proper headers detection.
* File `../h2o-3/smalldata/jira/hexdev_325.csv` can now be parsed correctly.
* File `../h2o-3/smalldata/junit/is_NA.csv` is now parsed correctly.
* File `../h2o-3/smalldata/junit/mixcat_test.csv` no longer emits a warning.
* File `../h2o-3/smalldata/parser/orc/orc2csv/nulls-at-end-snappy.csv` is now parsed correctly.

Closes #937