### PR TITLE
Support strings with embedded NUL characters in fread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - fread can now read string columns that are larger than 2GB in size.
 - fread can now accept a list/tuple of stypes for its `columns` parameter.
 - improved logic for auto-assigning column names when they are missing.
+- fread now supports reading files that contain NUL characters.
 
 #### Changed
 - When creating a column of "object" type, we will now coerce float "nan"

--- a/c/csv/fread.cc
+++ b/c/csv/fread.cc
@@ -35,8 +35,23 @@ const char* strlim(const char* ch, size_t limit) {
   char* ptr = buf + 501 * flip;
   flip = 1 - flip;
   char* ch2 = ptr;
-  size_t width = 0;
-  while ((*ch>'\r' || (*ch!='\0' && *ch!='\r' && *ch!='\n')) && width++<limit) *ch2++ = *ch++;
+  char* ch2end = ptr + limit;
+  while (ch2 < ch2end) {
+    uint8_t c = static_cast<uint8_t>(*ch);
+    if (c < 0x0E && (c == 0 || c == 0x0D || c == 0x0A)) break;
+    if (c < 0x20 || c > 0x7F) {
+      int d0 = int(c & 0xF);
+      int d1 = int(c >> 4);
+      ch++;
+      *ch2++ = '\\';
+      *ch2++ = 'x';
+      *ch2++ = static_cast<char>((d1 < 10 ? '0' : 'A' - 10) + d1);
+      *ch2++ = static_cast<char>((d0 < 10 ? '0' : 'A' - 10) + d0);
+      if (ch2 > ch2end) { ch2 -= 4; break; }
+    } else {
+      *ch2++ = *ch++;
+    }
+  }
   *ch2 = '\0';
   return ptr;
 }

--- a/c/csv/reader_fread.cc
+++ b/c/csv/reader_fread.cc
@@ -446,11 +446,12 @@ void FreadReader::detect_column_types()
         // know that the start is correct).
         if (j == 0) {
           chunkster.last_row_end = eof;
+          sampleLines--;
         } else {
           columns.setTypes(saved_types);
           print_types = false;
+          break;
         }
-        break;
       }
       sampleLines++;
       chunkster.last_row_end = tch;
@@ -1249,7 +1250,7 @@ bool FreadTokenizer::end_of_field() {
   char c = *ch;
   if (c == sep) return true;
   if (static_cast<uint8_t>(c) > 13) return false;
-  if (c == '\n' || c == '\0') return true;
+  if (c == '\n' || (c == '\0' && ch == eof)) return true;
   if (c == '\r') {
     if (LFpresent) {
       const char* tch = ch + 1;

--- a/c/csv/reader_parsers.cc
+++ b/c/csv/reader_parsers.cc
@@ -520,7 +520,7 @@ void parse_string(FreadTokenizer& ctx) {
     while (1) {
       if (*ch == sep) break;
       if (static_cast<uint8_t>(*ch) <= 13) {
-        if (*ch == '\0' || *ch == '\n') break;
+        if (*ch == '\n' || ch == ctx.eof) break;
         if (*ch == '\r') {
           if (!ctx.LFpresent || ch[1] == '\n') break;
           const char *tch = ch + 1;
@@ -552,15 +552,20 @@ void parse_string(FreadTokenizer& ctx) {
   fieldStart++;  // step over opening quote
   switch(ctx.quoteRule) {
   case 0:  // quoted with embedded quotes doubled; the final unescaped " must be followed by sep|eol
-    while (*++ch) {
-      if (*ch==quote) {
-        if (ch[1]==quote) { ch++; continue; }
+    while (true) {
+      ch++;
+      if (*ch == '\0' && ch == ctx.eof) {
+        break;
+      } else if (*ch == quote) {
+        if (ch[1] == quote) { ch++; continue; }
         break;  // found undoubled closing quote
       }
     }
     break;
   case 1:  // quoted with embedded quotes escaped; the final unescaped " must be followed by sep|eol
-    while (*++ch) {
+    while (true) {
+      ch++;
+      if (*ch == '\0' && ch == ctx.eof) break;
       if (*ch=='\\' && (ch[1]==quote || ch[1]=='\\')) { ch++; continue; }
       if (*ch==quote) break;
     }

--- a/tests/fread/test_fread_small.py
+++ b/tests/fread/test_fread_small.py
@@ -670,6 +670,36 @@ def test_clashing_column_names2():
     assert d0.names == ("C1", "C0", "C2", "C3", "C4")
 
 
+def test_nuls1():
+    d0 = dt.fread("A,B\0\n1,2\n")
+    assert d0.internal.check()
+    # Special characters are replaced in column names
+    assert d0.names == ("A", "B.")
+    assert d0.shape == (1, 2)
+    assert d0.topython() == [[1], [2]]
+
+
+def test_nuls2():
+    d0 = dt.fread("A,B\nfoo,ba\0r\nalpha,beta\0\ngamma\0,delta\n")
+    assert d0.internal.check()
+    assert d0.names == ("A", "B")
+    assert d0.shape == (3, 2)
+    assert d0.topython() == [["foo", "alpha", "gamma\0"],
+                             ["ba\0r", "beta\0", "delta"]]
+
+def test_nuls3():
+    lines = ["%02d,%d,%d\0" % (i, i % 3, 20-i) for i in range(10)]
+    src = "\n".join(["a,b,c"] + lines + [""])
+    d0 = dt.fread(src, verbose=True)
+    assert d0.internal.check()
+    assert d0.shape == (10, 3)
+    assert d0.names == ("a", "b", "c")
+    assert d0.topython() == [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+                             [0, 1, 2, 0, 1, 2, 0, 1, 2, 0],
+                             ["%d\0" % i for i in range(20, 10, -1)]]
+
+
+
 
 #-------------------------------------------------------------------------------
 # Medium-size files (generated)


### PR DESCRIPTION
* `strlim()` function now escapes non-ascii and control characters when printing a line. This helps avoid display issues / encoding problems when throwing an error.
* Strings with NUL characters can now be safely read (as shown in tests)
* Fixes assertion violation when detecting sep/QR
* The example file from #947 no longer throws an assertion error -- instead it's a RuntimeError about too few fields on line 2

Closes #790 
Closes #947 