### PR TITLE
Fread: add Mu type to type hierarchy

### DIFF
--- a/c/csv/fread.h
+++ b/c/csv/fread.h
@@ -64,7 +64,8 @@ struct FreadTokenizer {
 
   bool LFpresent;
 
-  void skip_white();
+  void skip_whitespace();
+  void skip_whitespace_at_line_start();
   bool end_of_field();
   const char* end_NA_string(const char*);
   int countfields();

--- a/c/csv/reader.h
+++ b/c/csv/reader.h
@@ -82,6 +82,7 @@ class GReaderColumns : public std::vector<GReaderColumn> {
 
     std::unique_ptr<PT[]> getTypes() const;
     void saveTypes(std::unique_ptr<PT[]>& types) const;
+    bool sameTypes(std::unique_ptr<PT[]>& types) const;
     void setTypes(const std::unique_ptr<PT[]>& types);
     void setType(PT type);
     const char* printTypes() const;

--- a/c/csv/reader_fread.cc
+++ b/c/csv/reader_fread.cc
@@ -512,6 +512,9 @@ void FreadReader::detect_column_types()
 }
 
 
+/**
+ * Detect whether the first line in input is the header or not.
+ */
 void FreadReader::detect_header() {
   if (!ISNA<int8_t>(header)) return;
   size_t ncols = columns.size();
@@ -548,7 +551,8 @@ void FreadReader::detect_header() {
   if (n_sample_lines > 0) {
     for (size_t j = 0; j < ncols; ++j) {
       if (ParserLibrary::info(header_types[j]).isstring() &&
-          !ParserLibrary::info(saved_types[j]).isstring()) {
+          !ParserLibrary::info(saved_types[j]).isstring() &&
+          saved_types[j] != PT::Mu) {
         header = true;
         trace("`header` determined to be True due to column %d containing a "
               "string on row 1 and type %s in the rest of the sample.",

--- a/c/csv/reader_fread.cc
+++ b/c/csv/reader_fread.cc
@@ -43,6 +43,7 @@ FreadReader::FreadReader(const GenericReader& g)
   *const_cast<char*>(eof) = '\0';
 
   first_jump_size = 0;
+  n_sample_lines = 0;
   whiteChar = '\0';
   quoteRule = -1;
   LFpresent = false;
@@ -318,9 +319,8 @@ class ColumnTypeDetectionChunkster {
  * If the line cannot be parsed (because it contains a string that is not
  * parseable under the current quoting rule), then return -1.
  */
-int64_t FreadReader::parse_single_line(FreadTokenizer& fctx, bool* bumped_flag)
+int64_t FreadReader::parse_single_line(FreadTokenizer& fctx)
 {
-  bool bumped = false;
   const char*& tch = fctx.ch;
 
   // detect blank lines
@@ -366,8 +366,8 @@ int64_t FreadReader::parse_single_line(FreadTokenizer& fctx, bool* bumped_flag)
       }
 
       // Finally, bump the column's type and try again
+      // TODO: replace with proper PT iteration
       coltype = static_cast<PT>(coltype + 1);
-      bumped = true;
       if (j < ncols) columns[j].type = coltype;
     }
     j++;
@@ -387,7 +387,6 @@ int64_t FreadReader::parse_single_line(FreadTokenizer& fctx, bool* bumped_flag)
       xassert(0 && "Invalid state when parsing a line");
     }
   }
-  if (bumped_flag) *bumped_flag = bumped;
   return static_cast<int64_t>(j);
 }
 
@@ -405,15 +404,13 @@ void FreadReader::detect_column_types()
   ColumnTypeDetectionChunkster chunkster(*this, fctx);
   size_t nChunks = chunkster.nchunks;
 
-  size_t sampleLines = 0;     // How many lines were sampled during the initial pre-scan
   double sumLen = 0.0;
   double sumLenSq = 0.0;
   int minLen = INT32_MAX;   // int_max so the first if(thisLen<minLen) is always true; similarly for max
   int maxLen = -1;
 
   // Start with all columns having the smallest possible type
-  PT type0 = PT::Mu;  // TODO: replace with PT::Mu
-  columns.setType(type0);
+  columns.setType(PT::Mu);
 
   // This variable will store column types at the beginning of each jump
   // so that we can revert to them if the jump proves to be invalid.
@@ -424,15 +421,12 @@ void FreadReader::detect_column_types()
     tch = cc.start;
     if (tch >= eof) continue;
 
-    bool print_types = (j == 0 || j == nChunks - 1);
     columns.saveTypes(saved_types);
 
     for (int i = 0; i < JUMPLINES; ++i) {
       if (tch >= eof) break;
       const char* lineStart = tch;
-      bool bumped;
-      int64_t incols = parse_single_line(fctx, &bumped);
-      print_types |= bumped;
+      int64_t incols = parse_single_line(fctx);
       if (incols == 0 && (skip_blank_lines || ncols == 1)) {
         continue;
       }
@@ -447,14 +441,13 @@ void FreadReader::detect_column_types()
         // know that the start is correct).
         if (j == 0) {
           chunkster.last_row_end = eof;
-          sampleLines--;
+          n_sample_lines--;
         } else {
           columns.setTypes(saved_types);
-          print_types = false;
           break;
         }
       }
-      sampleLines++;
+      n_sample_lines++;
       chunkster.last_row_end = tch;
       int thisLineLen = (int)(tch - lineStart);
       xassert(thisLineLen >= 0);
@@ -463,89 +456,31 @@ void FreadReader::detect_column_types()
       if (thisLineLen<minLen) minLen = thisLineLen;
       if (thisLineLen>maxLen) maxLen = thisLineLen;
     }
-    if (verbose && print_types) {
+    if (verbose && (j == 0 || j == nChunks - 1 ||
+                    !columns.sameTypes(saved_types))) {
       trace("Type codes (jump %03d): %s", j, columns.printTypes());
     }
   }
+
+  detect_header();
 
   size_t estnrow = 1;
   allocnrow = 1;
   meanLineLen = 0;
 
-  if (ISNA<int8_t>(header)) {
-    columns.saveTypes(saved_types);
-
-    // Detect types in the header column
-    tch = sof;
-    columns.setType(type0);
-    int64_t ncols_header = parse_single_line(fctx, nullptr);
-    auto header_types = columns.getTypes();
-    columns.setTypes(saved_types);
-
-    if (ncols_header != sncols && sampleLines > 0 && !fill) {
-      header = true;
-      trace("`header` determined to be True because the first line contains "
-            "different number of columns (%zd) than the rest of the file (%zu)",
-            ncols_header, ncols);
-      if (ncols_header > sncols) {
-        fill = true;
-        trace("Setting `fill` to True because the header contains more columns "
-              "than the data.");
-        for (int64_t j = sncols; j < ncols_header; ++j) {
-          columns.push_back(GReaderColumn());
-        }
-      }
-    }
-
-    if (ISNA<int8_t>(header) && sampleLines > 0) {
-      for (size_t j = 0; j < ncols; ++j) {
-        if (ParserLibrary::info(header_types[j]).isstring() &&
-            !ParserLibrary::info(saved_types[j]).isstring()) {
-          header = true;
-          trace("`header` determined to be True due to column %d containing a "
-                "string on row 1 and type %s in the rest of the sample.",
-                j+1, ParserLibrary::info(saved_types[j]).cname());
-          break;
-        }
-      }
-    }
-
-    if (ISNA<int8_t>(header)) {
-      bool all_strings = true;
-      for (size_t j = 0; j < ncols; ++j) {
-        if (!ParserLibrary::info(header_types[j]).isstring())
-          all_strings = false;
-      }
-      if (all_strings) {
-        header = true;
-        trace("`header` determined to be True because all inputs columns are "
-              "strings and better guess is not possible");
-      } else {
-        header = false;
-        trace("`header` determined to be False because some of the fields on "
-              "the first row are not of the string type");
-        // If header is false, then the first row also belongs to the sample.
-        // Accurate count of sample lines is needed so that we can allocate
-        // the correct amount of rows for the output Frame.
-        sampleLines++;
-      }
-    }
-
-  }
-
-  if (sampleLines <= 1) {
+  if (n_sample_lines <= 1) {
     if (header == 1) {
       // A single-row input, and that row is the header. Reset all types to
       // boolean (lowest type possible, a better guess than "string").
-      columns.setType(type0);
+      columns.setType(PT::Mu);
       allocnrow = 0;
     }
     meanLineLen = sumLen;
   } else {
     size_t bytesRead = static_cast<size_t>(eof - sof);
-    meanLineLen = sumLen/sampleLines;
+    meanLineLen = sumLen/n_sample_lines;
     estnrow = static_cast<size_t>(std::ceil(bytesRead/meanLineLen));  // only used for progress meter and verbose line below
-    double sd = std::sqrt( (sumLenSq - (sumLen*sumLen)/sampleLines)/(sampleLines-1) );
+    double sd = std::sqrt( (sumLenSq - (sumLen*sumLen)/n_sample_lines)/(n_sample_lines-1) );
     allocnrow = std::max(static_cast<size_t>(bytesRead / fmax(meanLineLen - 2*sd, minLen)),
                          static_cast<size_t>(1.1*estnrow));
     allocnrow = std::min(allocnrow, 2*estnrow);
@@ -553,7 +488,7 @@ void FreadReader::detect_column_types()
     // blank lines have length 1 so for fill=true apply a +100% maximum. It'll be grown if needed.
     if (verbose) {
       trace("=====");
-      trace("Sampled %zd rows (handled \\n inside quoted fields) at %d jump point(s)", sampleLines, nChunks);
+      trace("Sampled %zd rows (handled \\n inside quoted fields) at %d jump point(s)", n_sample_lines, nChunks);
       trace("Bytes from first data row to the end of last row: %zd", bytesRead);
       trace("Line length: mean=%.2f sd=%.2f min=%d max=%d", meanLineLen, sd, minLen, maxLen);
       trace("Estimated number of rows: %zd / %.2f = %zd", bytesRead, meanLineLen, estnrow);
@@ -561,11 +496,11 @@ void FreadReader::detect_column_types()
             allocnrow, estnrow, (int)(100.0*allocnrow/estnrow-100.0));
     }
     if (nChunks==1) {
-      if (header == 1) sampleLines--;
-      estnrow = allocnrow = sampleLines;
+      if (header == 1) n_sample_lines--;
+      estnrow = allocnrow = n_sample_lines;
       trace("All rows were sampled since file is small so we know nrows=%zd exactly", estnrow);
     } else {
-      xassert(sampleLines <= allocnrow);
+      xassert(n_sample_lines <= allocnrow);
     }
     if (max_nrows < allocnrow) {
       trace("Alloc limited to nrows=%zd according to the provided max_nrows argument.", max_nrows);
@@ -573,7 +508,74 @@ void FreadReader::detect_column_types()
     }
     trace("=====");
   }
-  fo.n_lines_sampled = sampleLines;
+  fo.n_lines_sampled = n_sample_lines;
+}
+
+
+void FreadReader::detect_header() {
+  if (!ISNA<int8_t>(header)) return;
+  size_t ncols = columns.size();
+  int64_t sncols = static_cast<int64_t>(ncols);
+
+  field64 tmp;
+  FreadTokenizer fctx = makeTokenizer(&tmp, nullptr);
+  const char*& tch = fctx.ch;
+
+  // Detect types in the header column
+  auto saved_types = columns.getTypes();
+  tch = sof;
+  columns.setType(PT::Mu);
+  int64_t ncols_header = parse_single_line(fctx);
+  auto header_types = columns.getTypes();
+  columns.setTypes(saved_types);
+
+  if (ncols_header != sncols && n_sample_lines > 0 && !fill) {
+    header = true;
+    trace("`header` determined to be True because the first line contains "
+          "different number of columns (%zd) than the rest of the file (%zu)",
+          ncols_header, ncols);
+    if (ncols_header > sncols) {
+      fill = true;
+      trace("Setting `fill` to True because the header contains more columns "
+            "than the data.");
+      for (int64_t j = sncols; j < ncols_header; ++j) {
+        columns.push_back(GReaderColumn());
+      }
+    }
+    return;
+  }
+
+  if (n_sample_lines > 0) {
+    for (size_t j = 0; j < ncols; ++j) {
+      if (ParserLibrary::info(header_types[j]).isstring() &&
+          !ParserLibrary::info(saved_types[j]).isstring()) {
+        header = true;
+        trace("`header` determined to be True due to column %d containing a "
+              "string on row 1 and type %s in the rest of the sample.",
+              j+1, ParserLibrary::info(saved_types[j]).cname());
+        return;
+      }
+    }
+  }
+
+  bool all_strings = true;
+  for (size_t j = 0; j < ncols; ++j) {
+    if (!ParserLibrary::info(header_types[j]).isstring())
+      all_strings = false;
+  }
+  if (all_strings) {
+    header = true;
+    trace("`header` determined to be True because all inputs columns are "
+          "strings and better guess is not possible");
+  } else {
+    header = false;
+    trace("`header` determined to be False because some of the fields on "
+          "the first row are not of the string type");
+    // If header is false, then the first row also belongs to the sample.
+    // Accurate count of sample lines is needed so that we can allocate
+    // the correct amount of rows for the output Frame.
+    n_sample_lines++;
+  }
 }
 
 

--- a/c/csv/reader_fread.h
+++ b/c/csv/reader_fread.h
@@ -90,6 +90,7 @@ class FreadReader : public GenericReader
   size_t allocnrow;
   double meanLineLen;
   size_t first_jump_size;
+  size_t n_sample_lines;
 
   //----- Parse parameters -----------------------------------------------------
   // quoteRule:
@@ -132,7 +133,8 @@ private:
   void detect_lf();
   void skip_preamble();
   void detect_column_types();
-  int64_t parse_single_line(FreadTokenizer&, bool* bumped);
+  void detect_header();
+  int64_t parse_single_line(FreadTokenizer&);
 
   friend FreadLocalParseContext;
   friend FreadChunkedReader;

--- a/c/csv/reader_parsers.cc
+++ b/c/csv/reader_parsers.cc
@@ -509,7 +509,7 @@ void parse_string(FreadTokenizer& ctx) {
   const char quote = ctx.quote;
   const char sep = ctx.sep;
 
-  // need to skip_white first for the reason that a quoted field might have space before the
+  // need to skip_whitespace first for the reason that a quoted field might have space before the
   // quote; e.g. test 1609. We need to skip the space(s) to then switch on quote or not.
   if (*ch==' ' && ctx.strip_whitespace) while(*++ch==' ');  // if sep==' ' the space would have been skipped already and we wouldn't be on space now.
   const char* fieldStart = ch;
@@ -610,7 +610,7 @@ void parse_string(FreadTokenizer& ctx) {
   ctx.target->str32.offset = (int32_t)(fieldStart - ctx.anchor);
   if (*ch==quote) {
     ctx.ch = ch + 1;
-    ctx.skip_white();
+    ctx.skip_whitespace();
   } else {
     ctx.ch = ch;
     if (*ch=='\0') {
@@ -652,7 +652,7 @@ void ParserLibrary::init_parsers() {
   };
 
   add(PT::Drop,         "Dropped",         '-', 0, ST_VOID, parse_string);
-  // add(PT::Mu,           "Unknown",         '?', 0, parse_mu);
+  add(PT::Mu,           "Unknown",         '?', 1, ST_BOOLEAN_I1, parse_mu);
   add(PT::BoolL,        "Bool8/lowercase", 'b', 1, ST_BOOLEAN_I1, parse_bool8_lowercase);
   add(PT::BoolU,        "Bool8/uppercase", 'b', 1, ST_BOOLEAN_I1, parse_bool8_uppercase);
   add(PT::BoolT,        "Bool8/titlecase", 'b', 1, ST_BOOLEAN_I1, parse_bool8_titlecase);

--- a/c/csv/reader_parsers.cc
+++ b/c/csv/reader_parsers.cc
@@ -651,18 +651,18 @@ void ParserLibrary::init_parsers() {
     parser_fns[iid] = ptr;
   };
 
-  add(PT::Drop,         "Dropped",         '-', 0, ST_VOID, parse_string);
-  add(PT::Mu,           "Unknown",         '?', 1, ST_BOOLEAN_I1, parse_mu);
-  add(PT::BoolL,        "Bool8/lowercase", 'b', 1, ST_BOOLEAN_I1, parse_bool8_lowercase);
-  add(PT::BoolU,        "Bool8/uppercase", 'b', 1, ST_BOOLEAN_I1, parse_bool8_uppercase);
-  add(PT::BoolT,        "Bool8/titlecase", 'b', 1, ST_BOOLEAN_I1, parse_bool8_titlecase);
-  add(PT::Bool01,       "Bool8/numeric",   'b', 1, ST_BOOLEAN_I1, parse_bool8_numeric);
-  add(PT::Int32,        "Int32",           'i', 4, ST_INTEGER_I4, parse_int32_simple);
-  add(PT::Int64,        "Int64",           'I', 8, ST_INTEGER_I8, parse_int64_simple);
-  add(PT::Float32Hex,   "Float32/hex",     'f', 4, ST_REAL_F4, parse_float32_hex);
-  add(PT::Float64Plain, "Float64",         'F', 8, ST_REAL_F8, parse_float64_simple);
-  add(PT::Float64Ext,   "Float64/ext",     'F', 8, ST_REAL_F8, parse_float64_extended);
-  add(PT::Float64Hex,   "Float64/hex",     'F', 8, ST_REAL_F8, parse_float64_hex);
+  add(PT::Drop,         "Dropped",         '-', 0, ST_VOID,            parse_string);
+  add(PT::Mu,           "Unknown",         '?', 1, ST_BOOLEAN_I1,      parse_mu);
+  add(PT::Bool01,       "Bool8/numeric",   'b', 1, ST_BOOLEAN_I1,      parse_bool8_numeric);
+  add(PT::BoolU,        "Bool8/uppercase", 'b', 1, ST_BOOLEAN_I1,      parse_bool8_uppercase);
+  add(PT::BoolT,        "Bool8/titlecase", 'b', 1, ST_BOOLEAN_I1,      parse_bool8_titlecase);
+  add(PT::BoolL,        "Bool8/lowercase", 'b', 1, ST_BOOLEAN_I1,      parse_bool8_lowercase);
+  add(PT::Int32,        "Int32",           'i', 4, ST_INTEGER_I4,      parse_int32_simple);
+  add(PT::Int64,        "Int64",           'I', 8, ST_INTEGER_I8,      parse_int64_simple);
+  add(PT::Float32Hex,   "Float32/hex",     'f', 4, ST_REAL_F4,         parse_float32_hex);
+  add(PT::Float64Plain, "Float64",         'F', 8, ST_REAL_F8,         parse_float64_simple);
+  add(PT::Float64Ext,   "Float64/ext",     'F', 8, ST_REAL_F8,         parse_float64_extended);
+  add(PT::Float64Hex,   "Float64/hex",     'F', 8, ST_REAL_F8,         parse_float64_hex);
   add(PT::Str32,        "Str32",           's', 4, ST_STRING_I4_VCHAR, parse_string);
   add(PT::Str64,        "Str64",           'S', 8, ST_STRING_I8_VCHAR, parse_string);
 }

--- a/c/csv/reader_parsers.h
+++ b/c/csv/reader_parsers.h
@@ -43,7 +43,7 @@ void parse_string(FreadTokenizer&);
 
 enum PT : uint8_t {
   Drop,
-  // Mu,
+  Mu,
   Bool01,
   BoolU,
   BoolT,

--- a/c/csv/reader_utils.cc
+++ b/c/csv/reader_utils.cc
@@ -21,7 +21,7 @@
 GReaderColumn::GReaderColumn() {
   mbuf = nullptr;
   strdata = nullptr;
-  type = PT::Bool01;  // should be PT::Mu
+  type = PT::Mu;
   typeBumped = false;
   presentInOutput = true;
   presentInBuffer = true;

--- a/c/csv/reader_utils.cc
+++ b/c/csv/reader_utils.cc
@@ -143,6 +143,14 @@ void GReaderColumns::saveTypes(std::unique_ptr<PT[]>& types) const {
   }
 }
 
+bool GReaderColumns::sameTypes(std::unique_ptr<PT[]>& types) const {
+  size_t n = size();
+  for (size_t i = 0; i < n; ++i) {
+    if (types[i] != (*this)[i].type) return false;
+  }
+  return true;
+}
+
 void GReaderColumns::setTypes(const std::unique_ptr<PT[]>& types) {
   size_t n = size();
   for (size_t i = 0; i < n; ++i) {

--- a/datatable/fread.py
+++ b/datatable/fread.py
@@ -970,17 +970,18 @@ _pathlike = (str, bytes, os.PathLike) if hasattr(os, "PathLike") else \
 # Directly corresponds to `PT` enum in "reader_parsers.h"
 _coltypes_strs = [
     "drop",      # 0
-    "bool8n",    # 1
-    "bool8u",    # 2
-    "bool8t",    # 3
-    "bool8l",    # 4
-    "int32",     # 5
-    "int64",     # 6
-    "float32x",  # 7
-    "float64",   # 8
-    "float64e",  # 9
-    "float64x",  # 10
-    "str",       # 11
+    "mu",        # 1
+    "bool8n",    # 2
+    "bool8u",    # 3
+    "bool8t",    # 4
+    "bool8l",    # 5
+    "int32",     # 6
+    "int64",     # 7
+    "float32x",  # 8
+    "float64",   # 9
+    "float64e",  # 10
+    "float64x",  # 11
+    "str",       # 12
 ]
 
 _coltypes = {k: _coltypes_strs.index(v) for (k, v) in [

--- a/tests/fread/test_fread_detect.py
+++ b/tests/fread/test_fread_detect.py
@@ -29,3 +29,14 @@ def test_fread_headers_less2():
     assert f0.internal.check()
     assert f0.names == ("A", "B", "C0", "C1")
     assert f0.topython() == [[10, 11], [5, -3], ["foo", "bar"], [1, 2]]
+
+
+def test_fread_headers_against_mu():
+    # See issue #656
+    # First row contains "A" in first column, while in the rest of the file
+    # first column is empty. "Empty" type should be considered equivalent to
+    # string (or any other) for the purpose of headers detection.
+    f0 = dt.fread("A,100,2\n,300,4\n,500,6\n")
+    assert f0.internal.check()
+    assert f0.names == ("C0", "C1", "C2")
+    assert f0.topython() == [["A", "", ""], [100, 300, 500], [2, 4, 6]]

--- a/tests/fread/test_fread_small.py
+++ b/tests/fread/test_fread_small.py
@@ -832,7 +832,7 @@ def test_almost_nodata(capsys):
     assert d0.ltypes == (ltype.int, ltype.str, ltype.str)
     assert d0.topython() == [[2017] * n, m, ["foo"] * n]
     print(out)
-    assert ("Column 2 (B) bumped from Bool8/numeric to Str32 "
+    assert ("Column 2 (B) bumped from Unknown to Str32 "
             "due to <<gotcha>> on row 109" in out)
 
 


### PR DESCRIPTION
* Add "Mu" (unknown) parser type, which matches only empty columns. 
* This type is used as a root of type hierarchy, which is a much better choice than Bool01
* Improve column name detection in cases when some of the columns are of Mu type.

WIP for #657
Closes #656
Closes #515