### PR TITLE
Fread improvements to `columns` parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   exception throws.
 - Default column names, if none given by the user, are "C0", "C1", "C2", ...
   for both `fread` and `Frame` constructor.
+- function-valued `columns` parameter in fread has been changed: if previously
+  the function was invoked for every column, now it receives the list of all
+  columns at once, and is expected to return a modified list (or dict / set /
+  etc). Each column description in the list that the function receives carries
+  the columns name and stype, in the future `format` field will also be added.
 
 #### Fixed
 - fread will no longer consume excessive amounts of memory when reading a file

--- a/Makefile
+++ b/Makefile
@@ -733,7 +733,7 @@ $(BUILDDIR)/utils/file.o : c/utils/file.cc $(BUILDDIR)/utils.h $(BUILDDIR)/utils
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/utils/pyobj.o : c/utils/pyobj.cc $(BUILDDIR)/py_column.h $(BUILDDIR)/py_datatable.h $(BUILDDIR)/py_rowindex.h $(BUILDDIR)/py_types.h $(BUILDDIR)/python/float.h $(BUILDDIR)/python/list.h $(BUILDDIR)/python/long.h $(BUILDDIR)/utils/exceptions.h $(BUILDDIR)/utils/pyobj.h
+$(BUILDDIR)/utils/pyobj.o : c/utils/pyobj.cc $(BUILDDIR)/py_column.h $(BUILDDIR)/py_datatable.h $(BUILDDIR)/py_rowindex.h $(BUILDDIR)/py_types.h $(BUILDDIR)/python/float.h $(BUILDDIR)/python/list.h $(BUILDDIR)/python/long.h $(BUILDDIR)/utils/assert.h $(BUILDDIR)/utils/exceptions.h $(BUILDDIR)/utils/pyobj.h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 

--- a/Makefile
+++ b/Makefile
@@ -548,7 +548,7 @@ $(BUILDDIR)/csv/py_csv.o : c/csv/py_csv.cc $(BUILDDIR)/options.h $(BUILDDIR)/csv
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/csv/reader.o : c/csv/reader.cc $(BUILDDIR)/csv/reader.h $(BUILDDIR)/csv/reader_arff.h $(BUILDDIR)/csv/reader_fread.h $(BUILDDIR)/options.h $(BUILDDIR)/utils/exceptions.h $(BUILDDIR)/utils/omp.h
+$(BUILDDIR)/csv/reader.o : c/csv/reader.cc $(BUILDDIR)/csv/reader.h $(BUILDDIR)/csv/reader_arff.h $(BUILDDIR)/csv/reader_fread.h $(BUILDDIR)/options.h $(BUILDDIR)/python/long.h $(BUILDDIR)/utils/exceptions.h $(BUILDDIR)/utils/omp.h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
@@ -672,7 +672,7 @@ $(BUILDDIR)/python/float.o : c/python/float.cc $(BUILDDIR)/python/float.h $(BUIL
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/python/list.o : c/python/list.cc $(BUILDDIR)/python/float.h $(BUILDDIR)/python/list.h $(BUILDDIR)/python/long.h $(BUILDDIR)/utils/exceptions.h
+$(BUILDDIR)/python/list.o : c/python/list.cc $(BUILDDIR)/python/float.h $(BUILDDIR)/python/list.h $(BUILDDIR)/python/long.h $(BUILDDIR)/utils/exceptions.h $(BUILDDIR)/utils/assert.h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 

--- a/Makefile
+++ b/Makefile
@@ -569,7 +569,7 @@ $(BUILDDIR)/csv/reader_parsers.o : c/csv/reader_parsers.cc $(BUILDDIR)/csv/fread
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/csv/reader_utils.o : c/csv/reader_utils.cc $(BUILDDIR)/csv/fread.h $(BUILDDIR)/csv/reader.h $(BUILDDIR)/csv/reader_parsers.h $(BUILDDIR)/utils/assert.h $(BUILDDIR)/utils/exceptions.h $(BUILDDIR)/utils/omp.h
+$(BUILDDIR)/csv/reader_utils.o : c/csv/reader_utils.cc $(BUILDDIR)/csv/fread.h $(BUILDDIR)/csv/reader.h $(BUILDDIR)/csv/reader_parsers.h $(BUILDDIR)/python/long.h $(BUILDDIR)/python/string.h $(BUILDDIR)/utils/assert.h $(BUILDDIR)/utils/exceptions.h $(BUILDDIR)/utils/omp.h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 

--- a/Makefile
+++ b/Makefile
@@ -263,6 +263,7 @@ fast_objects = $(addprefix $(BUILDDIR)/, \
 	python/float.o            \
 	python/list.o             \
 	python/long.o             \
+	python/string.o           \
 	rowindex.o                \
 	rowindex_array.o          \
 	rowindex_slice.o          \
@@ -461,6 +462,10 @@ $(BUILDDIR)/python/long.h: c/python/long.h $(BUILDDIR)/utils/pyobj.h
 	@echo • Refreshing c/python/long.h
 	@cp c/python/long.h $@
 
+$(BUILDDIR)/python/string.h: c/python/string.h $(BUILDDIR)/utils/pyobj.h
+	@echo • Refreshing c/python/string.h
+	@cp c/python/string.h $@
+
 
 $(BUILDDIR)/utils/array.h: c/utils/array.h $(BUILDDIR)/utils/exceptions.h
 	@echo • Refreshing c/utils/array.h
@@ -548,7 +553,7 @@ $(BUILDDIR)/csv/py_csv.o : c/csv/py_csv.cc $(BUILDDIR)/options.h $(BUILDDIR)/csv
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/csv/reader.o : c/csv/reader.cc $(BUILDDIR)/csv/reader.h $(BUILDDIR)/csv/reader_arff.h $(BUILDDIR)/csv/reader_fread.h $(BUILDDIR)/options.h $(BUILDDIR)/python/long.h $(BUILDDIR)/utils/exceptions.h $(BUILDDIR)/utils/omp.h
+$(BUILDDIR)/csv/reader.o : c/csv/reader.cc $(BUILDDIR)/csv/reader.h $(BUILDDIR)/csv/reader_arff.h $(BUILDDIR)/csv/reader_fread.h $(BUILDDIR)/options.h $(BUILDDIR)/python/long.h $(BUILDDIR)/python/string.h $(BUILDDIR)/utils/exceptions.h $(BUILDDIR)/utils/omp.h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
@@ -677,6 +682,10 @@ $(BUILDDIR)/python/list.o : c/python/list.cc $(BUILDDIR)/python/float.h $(BUILDD
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
 $(BUILDDIR)/python/long.o : c/python/long.cc $(BUILDDIR)/python/long.h $(BUILDDIR)/utils/exceptions.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+$(BUILDDIR)/python/string.o : c/python/string.cc $(BUILDDIR)/python/string.h $(BUILDDIR)/utils/exceptions.h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 

--- a/c/column_from_pylist.cc
+++ b/c/column_from_pylist.cc
@@ -156,7 +156,7 @@ static void force_as_int(PyyList& list, MemoryBuffer* membuf)
       outdata[i] = GETNA<T>();
       continue;
     }
-    PyyLong litem = item.is_long()? item : item.__int__();
+    PyyLong litem = item.is_long()? (PyyLong)item : item.__int__();
     outdata[i] = litem.masked_value<T>();
   }
 }

--- a/c/column_string.cc
+++ b/c/column_string.cc
@@ -42,8 +42,7 @@ StringColumn<T>::StringColumn(int64_t nrows_,
     }
     xassert(mb->size() == exp_off_size);
     xassert(mb->get_elem<T>(0) == -1);
-    size_t exp_str_size = static_cast<size_t>(abs(mb->get_elem<T>(nrows)) - 1);
-    xassert(sb->size() == exp_str_size);
+    xassert(sb->size() == static_cast<size_t>(abs(mb->get_elem<T>(nrows)) - 1));
   }
 
   mbuf = mb;

--- a/c/csv/fread.cc
+++ b/c/csv/fread.cc
@@ -327,7 +327,7 @@ DataTablePtr FreadReader::read()
     if (verbose) trace("[5] Apply user overrides on column types");
     std::unique_ptr<PT[]> oldtypes = columns.getTypes();
 
-    userOverride();
+    report_columns_to_python();
 
     size_t ncols = columns.size();
     size_t ndropped = 0;

--- a/c/csv/fread.cc
+++ b/c/csv/fread.cc
@@ -334,7 +334,7 @@ DataTablePtr FreadReader::read()
     int nUserBumped = 0;
     for (size_t i = 0; i < ncols; i++) {
       GReaderColumn& col = columns[i];
-      if (col.type == PT::Drop) {
+      if (col.rtype == RT::RDrop) {
         ndropped++;
         col.presentInOutput = false;
         col.presentInBuffer = false;
@@ -404,7 +404,6 @@ DataTablePtr FreadReader::read()
             col.presentInBuffer = true;
             n_type_bump_cols++;
           } else {
-            types[j] = PT::Drop;
             col.presentInBuffer = false;
           }
         }

--- a/c/csv/reader.cc
+++ b/c/csv/reader.cc
@@ -600,7 +600,7 @@ void GenericReader::report_columns_to_python() {
         columns[i].rtype = static_cast<RT>(elem.as_int64());  // unsafe?
         // Temporary
         switch (columns[i].rtype) {
-          case RDrop:    columns[i].type = PT::Drop; break;
+          case RDrop:    columns[i].type = PT::Str32; break;
           case RAuto:    break;
           case RBool:    columns[i].type = PT::Bool01; break;
           case RInt:     columns[i].type = PT::Int32; break;

--- a/c/csv/reader.cc
+++ b/c/csv/reader.cc
@@ -587,14 +587,17 @@ void GenericReader::report_columns_to_python() {
   if (override_column_types) {
     PyyList colNamesList(ncols);
     PyyList colTypesList(ncols);
+    PyyList colDescriptorList(ncols);
     for (size_t i = 0; i < ncols; i++) {
       colNamesList[i] = PyyString(columns[i].name);
       colTypesList[i] = PyyLong(columns[i].type);
+      colDescriptorList[i] = columns[i].py_descriptor();
     }
 
     PyyList newTypesList =
-      freader.invoke("_override_columns", "(OO)",
-                     colNamesList.release(), colTypesList.release());
+      freader.invoke("_override_columns", "(O)",
+                     // colNamesList.release(), colTypesList.release(),
+                     colDescriptorList.release());
 
     if (newTypesList) {
       for (size_t i = 0; i < ncols; i++) {

--- a/c/csv/reader.cc
+++ b/c/csv/reader.cc
@@ -585,24 +585,34 @@ void GenericReader::report_columns_to_python() {
   size_t ncols = columns.size();
 
   if (override_column_types) {
-    PyyList colNamesList(ncols);
-    PyyList colTypesList(ncols);
     PyyList colDescriptorList(ncols);
     for (size_t i = 0; i < ncols; i++) {
-      colNamesList[i] = PyyString(columns[i].name);
-      colTypesList[i] = PyyLong(columns[i].type);
       colDescriptorList[i] = columns[i].py_descriptor();
     }
 
     PyyList newTypesList =
       freader.invoke("_override_columns0", "(O)",
-                     // colNamesList.release(), colTypesList.release(),
                      colDescriptorList.release());
 
     if (newTypesList) {
       for (size_t i = 0; i < ncols; i++) {
         PyObj elem = newTypesList[i];
-        columns[i].type = static_cast<PT>(elem.as_int64());  // unsafe?
+        columns[i].rtype = static_cast<RT>(elem.as_int64());  // unsafe?
+        // Temporary
+        switch (columns[i].rtype) {
+          case RDrop:    columns[i].type = PT::Drop; break;
+          case RAuto:    break;
+          case RBool:    columns[i].type = PT::Bool01; break;
+          case RInt:     columns[i].type = PT::Int32; break;
+          case RInt32:   columns[i].type = PT::Int32; break;
+          case RInt64:   columns[i].type = PT::Int64; break;
+          case RFloat:   columns[i].type = PT::Float32Hex; break;
+          case RFloat32: columns[i].type = PT::Float32Hex; break;
+          case RFloat64: columns[i].type = PT::Float64Plain; break;
+          case RStr:     columns[i].type = PT::Str32; break;
+          case RStr32:   columns[i].type = PT::Str32; break;
+          case RStr64:   columns[i].type = PT::Str64; break;
+        }
       }
     }
 

--- a/c/csv/reader.cc
+++ b/c/csv/reader.cc
@@ -567,9 +567,7 @@ void GenericReader::decode_utf16() {
 
   Py_ssize_t ssize = static_cast<Py_ssize_t>(size);
   int byteorder = 0;
-  tempstr = PyObj::fromPyObjectNewRef(
-    PyUnicode_DecodeUTF16(ch, ssize, "replace", &byteorder)
-  );
+  tempstr = PyObj(PyUnicode_DecodeUTF16(ch, ssize, "replace", &byteorder));
   PyObject* t = tempstr.as_pyobject();  // new ref
   // borrowed ref, belongs to PyObject `t`
   const char* buf = PyUnicode_AsUTF8AndSize(t, &ssize);

--- a/c/csv/reader.cc
+++ b/c/csv/reader.cc
@@ -595,7 +595,7 @@ void GenericReader::report_columns_to_python() {
     }
 
     PyyList newTypesList =
-      freader.invoke("_override_columns", "(O)",
+      freader.invoke("_override_columns0", "(O)",
                      // colNamesList.release(), colTypesList.release(),
                      colDescriptorList.release());
 

--- a/c/csv/reader.h
+++ b/c/csv/reader.h
@@ -155,7 +155,7 @@ class GenericReader
     bool    fill;
     bool    blank_is_na;
     bool    number_is_na;
-    int : 8;
+    bool    override_column_types;
     const char* skip_to_string;
     const char* const* na_strings;
 
@@ -234,6 +234,7 @@ class GenericReader
     void init_skipstring();
     void init_stripwhite();
     void init_skipblanklines();
+    void init_overridecolumntypes();
 
   protected:
     void open_input();
@@ -243,6 +244,7 @@ class GenericReader
     void skip_to_line_number();
     void skip_to_line_with_string();
     void decode_utf16();
+    void report_columns_to_python();
 
     void _message(const char* method, const char* format, va_list args) const;
 

--- a/c/csv/reader.h
+++ b/c/csv/reader.h
@@ -40,6 +40,7 @@ enum PT : uint8_t;
 class GReaderColumn {
   private:
     MemoryBuffer* mbuf;
+    static PyTypeObject* NameTypePyTuple;
 
   public:
     std::string name;
@@ -64,6 +65,8 @@ class GReaderColumn {
     MemoryBuffer* extract_databuf();
     MemoryBuffer* extract_strbuf();
     void convert_to_str64();
+    PyObj py_descriptor() const;
+    static void init_nametypepytuple();
 };
 
 

--- a/c/csv/reader.h
+++ b/c/csv/reader.h
@@ -20,6 +20,7 @@
 #include "utils/shared_mutex.h"
 
 enum PT : uint8_t;
+enum RT : uint8_t;
 
 
 //------------------------------------------------------------------------------
@@ -33,7 +34,7 @@ enum PT : uint8_t;
  *
  * An input column usually translates into an output column in a DataTable
  * returned to the user. The exception to this are "dropped" columns. They are
- * marked with `presentInOutput = false` flag (and have type PT::Drop).
+ * marked with `presentInOutput = false` flag (and have rtype RT::RDrop).
  *
  * Implemented in "csv/reader_utils.cc".
  */
@@ -46,10 +47,11 @@ class GReaderColumn {
     std::string name;
     MemoryWritableBuffer* strdata;
     PT type;
+    RT rtype;
     bool typeBumped;
     bool presentInOutput;
     bool presentInBuffer;
-    int32_t : 32;
+    int32_t : 24;
 
   public:
     GReaderColumn();

--- a/c/csv/reader_fread.cc
+++ b/c/csv/reader_fread.cc
@@ -333,7 +333,7 @@ int64_t FreadReader::parse_single_line(FreadTokenizer& fctx)
     fctx.skip_whitespace();
 
     const char* fieldStart = tch;
-    PT coltype = j < ncols ? columns[j].type : PT::Drop;
+    PT coltype = j < ncols ? columns[j].type : PT::Str32;
     while (true) {
       // Try to parse using the regular field parser
       tch = fieldStart;
@@ -874,7 +874,7 @@ void FreadLocalParseContext::read_chunk(
         while (true) {
           tch = fieldStart;
           bool quoted = false;
-          if (!ParserLibrary::info(newType).isstring() && newType != PT::Drop) {
+          if (!ParserLibrary::info(newType).isstring()) {
             tokenizer.skip_whitespace();
             const char* afterSpace = tch;
             tch = tokenizer.end_NA_string(tch);

--- a/c/csv/reader_fread.cc
+++ b/c/csv/reader_fread.cc
@@ -754,34 +754,6 @@ void FreadReader::parse_column_names(FreadTokenizer& ctx) {
 }
 
 
-void FreadReader::userOverride()
-{
-  size_t ncols = columns.size();
-  Py_ssize_t sncols = static_cast<Py_ssize_t>(ncols);
-  PyObject* colNamesList = PyList_New(sncols);
-  PyObject* colTypesList = PyList_New(sncols);
-  for (size_t i = 0; i < ncols; i++) {
-    const char* src = columns[i].name.data();
-    size_t len = columns[i].name.size();
-    Py_ssize_t slen = static_cast<Py_ssize_t>(len);
-    PyObject* pycol = slen > 0? PyUnicode_FromStringAndSize(src, slen)
-                              : none();
-    PyObject* pytype = PyLong_FromLong(columns[i].type);
-    PyList_SET_ITEM(colNamesList, i, pycol);
-    PyList_SET_ITEM(colTypesList, i, pytype);
-  }
-
-  pyreader().invoke("_override_columns", "(OO)", colNamesList, colTypesList);
-
-  for (size_t i = 0; i < ncols; i++) {
-    PyObject* t = PyList_GET_ITEM(colTypesList, i);
-    columns[i].type = static_cast<PT>(PyLong_AsUnsignedLongMask(t));
-  }
-  pyfree(colTypesList);
-  pyfree(colNamesList);
-}
-
-
 
 //------------------------------------------------------------------------------
 // FreadLocalParseContext

--- a/c/csv/reader_fread.h
+++ b/c/csv/reader_fread.h
@@ -128,7 +128,6 @@ public:
 private:
   void parse_column_names(FreadTokenizer& ctx);
   void detect_sep(FreadTokenizer& ctx);
-  void userOverride();
 
   void detect_lf();
   void skip_preamble();

--- a/c/csv/reader_parsers.cc
+++ b/c/csv/reader_parsers.cc
@@ -651,7 +651,6 @@ void ParserLibrary::init_parsers() {
     parser_fns[iid] = ptr;
   };
 
-  add(PT::Drop,         "Dropped",         '-', 0, ST_VOID,            parse_string);
   add(PT::Mu,           "Unknown",         '?', 1, ST_BOOLEAN_I1,      parse_mu);
   add(PT::Bool01,       "Bool8/numeric",   'b', 1, ST_BOOLEAN_I1,      parse_bool8_numeric);
   add(PT::BoolU,        "Bool8/uppercase", 'b', 1, ST_BOOLEAN_I1,      parse_bool8_uppercase);

--- a/c/csv/reader_parsers.h
+++ b/c/csv/reader_parsers.h
@@ -49,7 +49,6 @@ void parse_string(FreadTokenizer&);
  * listed above.
  */
 enum PT : uint8_t {
-  Drop,
   Mu,
   Bool01,
   BoolU,
@@ -123,7 +122,7 @@ class ParserInfo {
     PT          id;
     int : 32;
 
-    ParserInfo() : fn(nullptr), code(0), id(PT::Drop) {}
+    ParserInfo() : fn(nullptr), code(0) {}
     ParserInfo(PT id_, const char* name_, char code_, int8_t sz_, SType st_,
                ParserFnPtr ptr)
       : fn(ptr), name(name_), code(code_), elemsize(sz_), stype(st_), id(id_) {}

--- a/c/csv/reader_parsers.h
+++ b/c/csv/reader_parsers.h
@@ -91,18 +91,18 @@ enum BT : uint8_t {
  * to one or more parse types.
  */
 enum RT : uint8_t {
-  RAuto,
-  RDrop,
-  RBool,
-  RInt,
-  RInt32,
-  RInt64,
-  RFloat,
-  RFloat32,
-  RFloat64,
-  RStr,
-  RStr32,
-  RStr64,
+  RDrop    = 0,
+  RAuto    = 1,
+  RBool    = 2,
+  RInt     = 3,
+  RInt32   = 4,
+  RInt64   = 5,
+  RFloat   = 6,
+  RFloat32 = 7,
+  RFloat64 = 8,
+  RStr     = 9,
+  RStr32   = 10,
+  RStr64   = 11,
 };
 
 

--- a/c/csv/reader_utils.cc
+++ b/c/csv/reader_utils.cc
@@ -32,8 +32,8 @@ GReaderColumn::GReaderColumn() {
 
 GReaderColumn::GReaderColumn(GReaderColumn&& o)
   : mbuf(o.mbuf), name(std::move(o.name)), strdata(o.strdata), type(o.type),
-    typeBumped(o.typeBumped), presentInOutput(o.presentInOutput),
-    presentInBuffer(o.presentInBuffer) {
+    rtype(o.rtype), typeBumped(o.typeBumped),
+    presentInOutput(o.presentInOutput), presentInBuffer(o.presentInBuffer) {
   o.mbuf = nullptr;
   o.strdata = nullptr;
 }

--- a/c/csv/reader_utils.cc
+++ b/c/csv/reader_utils.cc
@@ -24,6 +24,7 @@ GReaderColumn::GReaderColumn() {
   mbuf = nullptr;
   strdata = nullptr;
   type = PT::Mu;
+  rtype = RT::RAuto;
   typeBumped = false;
   presentInOutput = true;
   presentInBuffer = true;

--- a/c/python/list.cc
+++ b/c/python/list.cc
@@ -109,7 +109,12 @@ PyObject* PyyListEntry::get() const {
 }
 
 
-PyyListEntry::operator PyObj() const { return PyObj(get()); }
+PyyListEntry::operator PyObj() const {
+  // Variable `entry` cannot be inlined, otherwise PyObj constructor will
+  // assume that the reference to PyObject* can be stolen.
+  PyObject* entry = get();  // borrowed ref
+  return PyObj(entry);
+}
 PyyListEntry::operator PyyList() const { return PyyList(get()); }
 PyyListEntry::operator PyyLong() const { return PyyLong(get()); }
 PyyListEntry::operator PyyFloat() const { return PyyFloat(get()); }

--- a/c/python/list.cc
+++ b/c/python/list.cc
@@ -8,6 +8,7 @@
 #include "python/list.h"
 #include "python/long.h"
 #include "python/float.h"
+#include "utils/assert.h"
 #include "utils/exceptions.h"
 
 
@@ -89,6 +90,7 @@ PyyListEntry::PyyListEntry(PyObject* pylist, Py_ssize_t index)
 
 
 PyyListEntry& PyyListEntry::operator=(PyObject* s) {
+  xassert(list);
   PyList_SET_ITEM(list, i, s);
   return *this;
 }
@@ -102,6 +104,7 @@ PyyListEntry& PyyListEntry::operator=(const PyObj& o) {
 
 
 PyObject* PyyListEntry::get() const {
+  xassert(list);
   return PyList_GET_ITEM(list, i);
 }
 

--- a/c/python/list.h
+++ b/c/python/list.h
@@ -33,7 +33,7 @@ class PyyListEntry {
     PyObject* as_new_ref() const;
 
   private:
-    PyObject* get() const;
+    PyObject* get() const;  // returns a borrowed ref
 };
 
 

--- a/c/python/long.cc
+++ b/c/python/long.cc
@@ -91,6 +91,13 @@ PyyLong::operator PyObj() && {
   return PyObj(std::move(t));
 }
 
+PyObject* PyyLong::release() {
+  PyObject* t = obj;
+  obj = nullptr;
+  return t;
+}
+
+
 
 template<> long PyyLong::value<long>(int* overflow) const {
   long value = PyLong_AsLongAndOverflow(obj, overflow);

--- a/c/python/long.cc
+++ b/c/python/long.cc
@@ -88,7 +88,7 @@ PyyLong::operator PyObj() const & {
 PyyLong::operator PyObj() && {
   PyObject* t = obj;
   obj = nullptr;
-  return PyObj::fromPyObjectNewRef(t);
+  return PyObj(std::move(t));
 }
 
 

--- a/c/python/long.cc
+++ b/c/python/long.cc
@@ -16,6 +16,21 @@
 
 PyyLong::PyyLong() : obj(nullptr) {}
 
+PyyLong::PyyLong(int32_t n) {
+  obj = PyLong_FromLong(n);
+}
+
+PyyLong::PyyLong(int64_t n) {
+  obj = PyLong_FromLongLong(n);
+}
+
+PyyLong::PyyLong(size_t n) {
+  obj = PyLong_FromSize_t(n);
+}
+
+PyyLong::PyyLong(double x) {
+  obj = PyLong_FromDouble(x);
+}
 
 PyyLong::PyyLong(PyObject* src) {
   if (!src) throw PyError();
@@ -65,6 +80,16 @@ PyyLong PyyLong::fromAnyObject(PyObject* obj) {
 //------------------------------------------------------------------------------
 // Public API
 //------------------------------------------------------------------------------
+
+PyyLong::operator PyObj() const & {
+  return PyObj(obj);
+}
+
+PyyLong::operator PyObj() && {
+  PyObject* t = obj;
+  obj = nullptr;
+  return PyObj::fromPyObjectNewRef(t);
+}
 
 
 template<> long PyyLong::value<long>(int* overflow) const {

--- a/c/python/long.h
+++ b/c/python/long.h
@@ -52,6 +52,7 @@ class PyyLong {
 
     operator PyObj() const &;
     operator PyObj() &&;
+    PyObject* release();
 
     static PyyLong fromAnyObject(PyObject*);
     friend void swap(PyyLong& first, PyyLong& second) noexcept;

--- a/c/python/long.h
+++ b/c/python/long.h
@@ -37,6 +37,10 @@ class PyyLong {
 
   public:
     PyyLong();
+    PyyLong(int32_t n);
+    PyyLong(int64_t n);
+    PyyLong(size_t n);
+    PyyLong(double x);
     PyyLong(PyObject*);
     PyyLong(const PyyLong&);
     PyyLong(PyyLong&&);
@@ -45,6 +49,9 @@ class PyyLong {
     template<typename T> T value() const;
     template<typename T> T value(int* overflow) const;
     template<typename T> T masked_value() const;
+
+    operator PyObj() const &;
+    operator PyObj() &&;
 
     static PyyLong fromAnyObject(PyObject*);
     friend void swap(PyyLong& first, PyyLong& second) noexcept;

--- a/c/python/string.cc
+++ b/c/python/string.cc
@@ -76,5 +76,5 @@ PyyString::operator PyObj() const & {
 PyyString::operator PyObj() && {
   PyObject* t = obj;
   obj = nullptr;
-  return PyObj::fromPyObjectNewRef(t);
+  return PyObj(std::move(t));
 }

--- a/c/python/string.cc
+++ b/c/python/string.cc
@@ -1,0 +1,80 @@
+//------------------------------------------------------------------------------
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// © H2O.ai 2018
+//------------------------------------------------------------------------------
+#include "python/string.h"
+#include "utils/exceptions.h"
+
+
+
+//------------------------------------------------------------------------------
+// Constructors
+//------------------------------------------------------------------------------
+
+PyyString::PyyString() : obj(nullptr) {}
+
+PyyString::PyyString(const std::string& s) {
+  Py_ssize_t slen = static_cast<Py_ssize_t>(s.size());
+  obj = PyUnicode_FromStringAndSize(s.data(), slen);
+}
+
+PyyString::PyyString(const char* str, size_t len) {
+  Py_ssize_t slen = static_cast<Py_ssize_t>(len);
+  obj = PyUnicode_FromStringAndSize(str, slen);
+}
+
+PyyString::PyyString(const char* str) {
+  Py_ssize_t slen = static_cast<Py_ssize_t>(std::strlen(str));
+  obj = PyUnicode_FromStringAndSize(str, slen);
+}
+
+
+PyyString::PyyString(PyObject* src) {
+  if (!src) throw PyError();
+  if (src == Py_None) {
+    obj = nullptr;
+  } else {
+    obj = src;
+    if (!PyUnicode_Check(src)) {
+      throw TypeError() << "Object " << src << " is not a string";
+    }
+    Py_INCREF(src);
+  }
+}
+
+PyyString::PyyString(const PyyString& other) {
+  obj = other.obj;
+  Py_INCREF(obj);
+}
+
+PyyString::PyyString(PyyString&& other) : PyyString() {
+  swap(*this, other);
+}
+
+PyyString::~PyyString() {
+  Py_XDECREF(obj);
+}
+
+
+void swap(PyyString& first, PyyString& second) noexcept {
+  std::swap(first.obj, second.obj);
+}
+
+
+
+//------------------------------------------------------------------------------
+// Public API
+//------------------------------------------------------------------------------
+
+PyyString::operator PyObj() const & {
+  return PyObj(obj);
+}
+
+PyyString::operator PyObj() && {
+  PyObject* t = obj;
+  obj = nullptr;
+  return PyObj::fromPyObjectNewRef(t);
+}

--- a/c/python/string.cc
+++ b/c/python/string.cc
@@ -78,3 +78,9 @@ PyyString::operator PyObj() && {
   obj = nullptr;
   return PyObj(std::move(t));
 }
+
+PyObject* PyyString::release() {
+  PyObject* t = obj;
+  obj = nullptr;
+  return t;
+}

--- a/c/python/string.h
+++ b/c/python/string.h
@@ -1,0 +1,41 @@
+//------------------------------------------------------------------------------
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// © H2O.ai 2018
+//------------------------------------------------------------------------------
+#ifndef dt_PYTHON_STRING_h
+#define dt_PYTHON_STRING_h
+#include <Python.h>
+#include <string>
+#include "utils/pyobj.h"
+
+
+
+/**
+ * C++ wrapper around PyUnicode_Object (python `str` object).
+ */
+class PyyString {
+  private:
+    PyObject* obj;
+
+  public:
+    PyyString();
+    PyyString(const std::string& s);
+    PyyString(const char* str);
+    PyyString(const char* str, size_t len);
+    PyyString(PyObject*);
+    PyyString(const PyyString&);
+    PyyString(PyyString&&);
+    ~PyyString();
+
+    operator PyObj() const &;
+    operator PyObj() &&;
+
+    friend void swap(PyyString& first, PyyString& second) noexcept;
+};
+
+
+
+#endif

--- a/c/python/string.h
+++ b/c/python/string.h
@@ -32,6 +32,7 @@ class PyyString {
 
     operator PyObj() const &;
     operator PyObj() &&;
+    PyObject* release();
 
     friend void swap(PyyString& first, PyyString& second) noexcept;
 };

--- a/c/types.c
+++ b/c/types.c
@@ -123,15 +123,19 @@ void init_types(void)
     xassert(DT_STYPES_COUNT <= 64);
 
     //---- More static asserts -------------------------------------------------
-    // This checks validity of a cast used in the fread.c
-    for (int i = -128; i <= 127; i++) {
-      char ch = static_cast<char>(i);
-      xassert((ch >= '0' && ch <= '9') == ((uint_fast8_t)(ch - '0') < 10));
-    }
+    #ifndef NDEBUG
+      // This checks validity of a cast used in reader_parsers.cc
+      // Cannot use `char ch` as a loop variable here because `127 + 1 == -128`.
+      for (int i = -128; i <= 127; i++) {
+        char ch = static_cast<char>(i);
+        xassert((ch >= '0' && ch <= '9') ==
+                (static_cast<uint_fast8_t>(ch - '0') < 10));
+      }
 
-    for (int i = 0; i < DT_STYPES_COUNT; i++) {
-      xassert((SType)i == stype_from_string(stype_info[i].code));
-    }
+      for (int i = 0; i < DT_STYPES_COUNT; i++) {
+        xassert(static_cast<SType>(i) == stype_from_string(stype_info[i].code));
+      }
+    #endif
 }
 
 

--- a/c/utils/pyobj.h
+++ b/c/utils/pyobj.h
@@ -33,16 +33,17 @@ class PyObj
 {
   PyObject* obj;
   mutable PyObject* tmp;
+  static PyObject* None;
 
 public:
   PyObj();
-  PyObj(PyObject*);
+  PyObj(PyObject* const&);
+  PyObj(PyObject*&&);
   PyObj(PyObject*, const char* attr);
   PyObj(const PyObj&);
   PyObj(PyObj&&);
   PyObj& operator=(PyObj other);
   ~PyObj();
-  static PyObj fromPyObjectNewRef(PyObject*);
   static PyObj none();
 
   friend void swap(PyObj& first, PyObj& second) noexcept {

--- a/c/utils/pyobj.h
+++ b/c/utils/pyobj.h
@@ -18,6 +18,7 @@ class RowIndex;
 class PyyList;
 class PyyLong;
 class PyyFloat;
+class PyyString;
 extern PyObject* Py_One;
 extern PyObject* Py_Zero;
 
@@ -172,6 +173,7 @@ public:
   operator PyyList() const;
   operator PyyLong() const;
   operator PyyFloat() const;
+  operator PyyString() const;
 };
 
 

--- a/datatable/fread.py
+++ b/datatable/fread.py
@@ -768,15 +768,11 @@ class GenericReader(object):
         self._colnames = colnames
 
 
-    def _override_columns(self, colnames, coltypes):
-        assert len(colnames) == len(coltypes)
+    def _override_columns(self, coldescs):
+        colnames, coltypes = zip(*coldescs)
         n = len(colnames)
         colspec = self._columns
         self._colnames = []
-
-        if colspec is None:
-            self._colnames = colnames
-            return coltypes
 
         if isinstance(colspec, (slice, range)):
             if isinstance(colspec, slice):
@@ -903,8 +899,7 @@ class GenericReader(object):
 
             if nargs == 3:
                 for i in range(n):
-                    typ = _coltypes_strs[coltypes[i]]
-                    ret = colspec(i, colnames[i], typ)
+                    ret = colspec(i, colnames[i], coltypes[i])
                     if ret is None or ret is False:
                         coltypes[i] = 0
                     elif ret is True:

--- a/datatable/fread.py
+++ b/datatable/fread.py
@@ -766,7 +766,7 @@ class GenericReader(object):
 
         if colspec is None:
             self._colnames = colnames
-            return
+            return coltypes
 
         if isinstance(colspec, (slice, range)):
             if isinstance(colspec, slice):
@@ -785,7 +785,7 @@ class GenericReader(object):
                     self._colnames.append(colnames[i])
                 else:
                     coltypes[i] = 0
-            return
+            return coltypes
 
         if isinstance(colspec, set):
             # Make a copy of the `colspec`, in order to check whether all the
@@ -802,7 +802,7 @@ class GenericReader(object):
             if colsfound:
                 self.logger.warning("Column(s) %r not found in the input file"
                                     % list(colsfound))
-            return
+            return coltypes
 
         if isinstance(colspec, (list, tuple)):
             nn = len(colspec)
@@ -829,7 +829,7 @@ class GenericReader(object):
                 else:
                     raise TTypeError("Entry `columns[%d]` has invalid type %r"
                                      % (i, entry.__class__.__name__))
-            return
+            return coltypes
 
         if isinstance(colspec, dict):
             for i in range(n):
@@ -854,6 +854,7 @@ class GenericReader(object):
                     if not coltypes[i]:
                         raise TValueError("Unknown type %r used as an override "
                                           "for column %r" % (newtype, newname))
+            return coltypes
 
         if callable(colspec) and hasattr(colspec, "__code__"):
             nargs = colspec.__code__.co_argcount
@@ -872,7 +873,7 @@ class GenericReader(object):
                                           "argument was expected to return a "
                                           "`Union[None, bool, str]` but "
                                           "instead returned value %r" % (ret,))
-                return
+                return coltypes
 
             if nargs == 2:
                 for i in range(n):
@@ -888,7 +889,7 @@ class GenericReader(object):
                                           "argument was expected to return a "
                                           "`Union[None, bool, str]` but "
                                           "instead returned value %r" % (ret,))
-                return
+                return coltypes
 
             if nargs == 3:
                 for i in range(n):
@@ -910,10 +911,10 @@ class GenericReader(object):
                                           "`Union[None, bool, str, Tuple[str, "
                                           "Union[str, type]]]` but "
                                           "instead returned value %r" % ret)
-                return
+                return coltypes
 
-            raise RuntimeError("Unknown colspec: %r"  # pragma: no cover
-                               % colspec)
+        raise RuntimeError("Unknown colspec: %r"  # pragma: no cover
+                           % colspec)
 
 
     def _process_excel_file(self, filename):

--- a/datatable/fread.py
+++ b/datatable/fread.py
@@ -758,6 +758,16 @@ class GenericReader(object):
                 print("Warning: unknown encoding %s" % tty_encoding)
 
 
+    def _set_column_names(self, colnames):
+        """
+        Invoked by `gread` from C++ to inform the class about the detected
+        column names. This method is a simplified version of
+        `_override_columns`, and will only be invoked if `self._columns` is
+        None.
+        """
+        self._colnames = colnames
+
+
     def _override_columns(self, colnames, coltypes):
         assert len(colnames) == len(coltypes)
         n = len(colnames)

--- a/datatable/fread.py
+++ b/datatable/fread.py
@@ -893,14 +893,14 @@ class GenericReader(object):
                 coltypes[i] = rtype.rauto.value
             elif isinstance(entry, (stype, ltype, type)):
                 colnames.append(colsdesc[i].name)
-                coltypes[i] = _coltypes.get(entry)
+                coltypes[i] = _rtypes_map[entry].value
             elif isinstance(entry, tuple):
                 newname, newtype = entry
-                colnames.append(newname)
-                coltypes[i] = _coltypes.get(newtype)
-                if not coltypes[i]:
+                if newtype not in _rtypes_map:
                     raise TValueError("Unknown type %r used as an override "
                                       "for column %r" % (newtype, newname))
+                colnames.append(newname)
+                coltypes[i] = _rtypes_map[newtype].value
             else:
                 raise TTypeError("Entry `columns[%d]` has invalid type %r"
                                  % (i, entry.__class__.__name__))
@@ -925,11 +925,11 @@ class GenericReader(object):
                 coltypes[i] = rtype.rauto.value
             elif isinstance(entry, (stype, ltype, type)):
                 colnames.append(name)
-                coltypes[i] = _coltypes.get(entry)
+                coltypes[i] = _rtypes_map[entry].value
             elif isinstance(entry, tuple):
                 newname, newtype = entry
                 colnames.append(newname)
-                coltypes[i] = _coltypes.get(newtype)
+                coltypes[i] = _rtypes_map[newtype].value
                 assert isinstance(newname, str)
                 if not coltypes[i]:
                     raise TValueError("Unknown type %r used as an override "
@@ -969,52 +969,6 @@ _pathlike = (str, bytes, os.PathLike) if hasattr(os, "PathLike") else \
 
 
 #-------------------------------------------------------------------------------
-# Directly corresponds to `PT` enum in "reader_parsers.h"
-_coltypes_strs = [
-    "drop",      # 0
-    "mu",        # 1
-    "bool8n",    # 2
-    "bool8u",    # 3
-    "bool8t",    # 4
-    "bool8l",    # 5
-    "int32",     # 6
-    "int64",     # 7
-    "float32x",  # 8
-    "float64",   # 9
-    "float64e",  # 10
-    "float64x",  # 11
-    "str",       # 12
-]
-
-_coltypes = {k: _coltypes_strs.index(v) for (k, v) in [
-    (bool,       "bool8n"),
-    (int,        "int32"),
-    (float,      "float64"),
-    (str,        "str"),
-    ("bool",     "bool8n"),
-    ("bool8",    "bool8n"),
-    ("bool8n",   "bool8n"),
-    ("bool8u",   "bool8u"),
-    ("bool8t",   "bool8t"),
-    ("bool8l",   "bool8l"),
-    ("int",      "int32"),
-    ("int32",    "int32"),
-    ("int64",    "int64"),
-    ("float32x", "float32x"),
-    ("float",    "float64"),
-    ("float64",  "float64"),
-    ("float64e", "float64e"),
-    ("float64x", "float64x"),
-    ("str",      "str"),
-    ("drop",     "drop"),
-    (stype.bool8, "bool8n"),
-    (stype.int32, "int32"),
-    (stype.int64, "int64"),
-    (stype.float32, "float32x"),  # should be float32
-    (stype.float64, "float64"),
-    (stype.str32, "str"),  # should be str32
-    (stype.str64, "str"),  # should be str32
-]}
 
 # Corresponds to RT enum in "reader_parsers.h"
 class rtype(enum.Enum):
@@ -1032,3 +986,36 @@ class rtype(enum.Enum):
     rstr64   = 11
 
 
+_rtypes_map = {
+    None:          rtype.rdrop,
+    bool:          rtype.rbool,
+    int:           rtype.rint,
+    float:         rtype.rfloat,
+    str:           rtype.rstr,
+    "drop":        rtype.rdrop,
+    "bool":        rtype.rbool,
+    "auto":        rtype.rauto,
+    "bool8":       rtype.rbool,
+    "logical":     rtype.rbool,
+    "int":         rtype.rint,
+    "integer":     rtype.rint,
+    "int32":       rtype.rint32,
+    "int64":       rtype.rint64,
+    "float":       rtype.rfloat,
+    "float32":     rtype.rfloat32,
+    "float64":     rtype.rfloat64,
+    "str":         rtype.rstr,
+    "str32":       rtype.rstr32,
+    "str64":       rtype.rstr64,
+    stype.bool8:   rtype.rbool,
+    stype.int32:   rtype.rint32,
+    stype.int64:   rtype.rint64,
+    stype.float32: rtype.rfloat32,
+    stype.float64: rtype.rfloat64,
+    stype.str32:   rtype.rstr32,
+    stype.str64:   rtype.rstr64,
+    ltype.bool:    rtype.rbool,
+    ltype.int:     rtype.rint,
+    ltype.real:    rtype.rfloat,
+    ltype.str:     rtype.rstr,
+}

--- a/datatable/fread.py
+++ b/datatable/fread.py
@@ -4,6 +4,7 @@
 #   License, v. 2.0. If a copy of the MPL was not distributed with this
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #-------------------------------------------------------------------------------
+import enum
 import os
 import pathlib
 import psutil
@@ -21,7 +22,7 @@ from datatable.utils.terminal import term
 from datatable.utils.misc import (normalize_slice, normalize_range,
                                   humanize_bytes)
 from datatable.utils.misc import plural_form as plural
-from datatable.types import stype
+from datatable.types import stype, ltype
 
 _log_color = term.bright_black
 
@@ -148,7 +149,7 @@ class GenericReader(object):
 
 
     #---------------------------------------------------------------------------
-    # Parameter helpers
+    # Resolve from various sources
     #---------------------------------------------------------------------------
 
     def _resolve_source(self, anysource, file, text, cmd, url):
@@ -371,6 +372,34 @@ class GenericReader(object):
 
         else:
             self._file = filename
+
+
+    def _process_excel_file(self, filename):
+        try:
+            import xlrd
+        except ImportError:
+            raise TValueError("Module `xlrd` is required in order to read "
+                              "Excel file '%s'. You can install this module "
+                              "by running `pip install xlrd` in the command "
+                              "line." % filename)
+        self._result = []
+        wb = xlrd.open_workbook(filename)
+        for ws in wb.sheets():
+            # If the worksheet is empty, skip it
+            if ws.ncols == 0:
+                continue
+            # Assume first row contains headers
+            colnames = ws.row_values(0)
+            cols0 = [core.column_from_list(ws.col_values(i, start_rowx=1),
+                                           -stype.str32.value)
+                     for i in range(ws.ncols)]
+            colset = core.columns_from_columns(cols0)
+            res = Frame(colset.to_datatable(), names=colnames)
+            self._result.append(res)
+        if len(self._result) == 0:
+            self._result = 0
+        if len(self._result) == 1:
+            self._result = self._result[0]
 
 
     #---------------------------------------------------------------------------
@@ -758,6 +787,11 @@ class GenericReader(object):
                 print("Warning: unknown encoding %s" % tty_encoding)
 
 
+
+    #---------------------------------------------------------------------------
+    # Process `columns` argument
+    #---------------------------------------------------------------------------
+
     def _set_column_names(self, colnames):
         """
         Invoked by `gread` from C++ to inform the class about the detected
@@ -768,186 +802,148 @@ class GenericReader(object):
         self._colnames = colnames
 
 
-    def _override_columns(self, coldescs):
-        colnames, coltypes = zip(*coldescs)
-        n = len(colnames)
-        colspec = self._columns
-        self._colnames = []
+    def _override_columns0(self, coldescs):
+        return self._override_columns1(self._columns, coldescs)
 
+
+    def _override_columns1(self, colspec, coldescs):
         if isinstance(colspec, (slice, range)):
-            if isinstance(colspec, slice):
-                start, count, step = normalize_slice(colspec, n)
-            else:
-                t = normalize_range(colspec, n)
-                if t is None:
-                    raise TValueError("Invalid range iterator for a file with "
-                                      "%d columns: %r" % (n, colspec))
-                start, count, step = t
-            if step <= 0:
-                raise TValueError("Cannot use slice/range with negative step "
-                                  "for column filter: %r" % colspec)
-            for i in range(n):
-                if (i - start) % step == 0 and i < start + count * step:
-                    self._colnames.append(colnames[i])
-                else:
-                    coltypes[i] = 0
-            return coltypes
+            return self._apply_columns_slice(colspec, coldescs)
 
         if isinstance(colspec, set):
-            # Make a copy of the `colspec`, in order to check whether all the
-            # columns requested by the user were found, and issue a warning
-            # otherwise.
-            colsfound = set(colspec)
-            for i in range(n):
-                if colnames[i] in colspec:
-                    if colnames[i] in colsfound:
-                        colsfound.remove(colnames[i])
-                    self._colnames.append(colnames[i])
-                else:
-                    coltypes[i] = 0
-            if colsfound:
-                self.logger.warning("Column(s) %r not found in the input file"
-                                    % list(colsfound))
-            return coltypes
+            return self._apply_columns_set(colspec, coldescs)
 
         if isinstance(colspec, (list, tuple)):
-            nn = len(colspec)
-            if n != nn:
-                raise TValueError("Input file contains %s, whereas `columns` "
-                                  "parameter specifies only %s"
-                                  % (plural(n, "column"), plural(nn, "column")))
-            for i in range(n):
-                entry = colspec[i]
-                if entry is None:
-                    coltypes[i] = 0
-                elif isinstance(entry, str):
-                    self._colnames.append(entry)
-                elif isinstance(entry, stype):
-                    self._colnames.append(colnames[i])
-                    coltypes[i] = _coltypes.get(entry)
-                elif isinstance(entry, tuple):
-                    newname, newtype = entry
-                    self._colnames.append(newname)
-                    coltypes[i] = _coltypes.get(newtype)
-                    if not coltypes[i]:
-                        raise TValueError("Unknown type %r used as an override "
-                                          "for column %r" % (newtype, newname))
-                else:
-                    raise TTypeError("Entry `columns[%d]` has invalid type %r"
-                                     % (i, entry.__class__.__name__))
-            return coltypes
+            return self._apply_columns_list(colspec, coldescs)
 
         if isinstance(colspec, dict):
-            for i in range(n):
-                name = colnames[i]
-                if name in colspec:
-                    entry = colspec[name]
-                else:
-                    entry = colspec.get(..., ...)
-                if entry is None:
-                    coltypes[i] = 0
-                elif entry is Ellipsis:
-                    self._colnames.append(name)
-                elif isinstance(entry, str):
-                    self._colnames.append(entry)
-                else:
-                    assert isinstance(entry, tuple)
-                    newname, newtype = entry
-                    if newname is Ellipsis:
-                        newname = name
-                    self._colnames.append(newname)
-                    coltypes[i] = _coltypes.get(newtype)
-                    if not coltypes[i]:
-                        raise TValueError("Unknown type %r used as an override "
-                                          "for column %r" % (newtype, newname))
-            return coltypes
+            return self._apply_columns_dict(colspec, coldescs)
 
-        if callable(colspec) and hasattr(colspec, "__code__"):
-            nargs = colspec.__code__.co_argcount
-
-            if nargs == 1:
-                for i in range(n):
-                    ret = colspec(colnames[i])
-                    if ret is None or ret is False:
-                        coltypes[i] = 0
-                    elif ret is True:
-                        self._colnames.append(colnames[i])
-                    elif isinstance(ret, str):
-                        self._colnames.append(ret)
-                    else:
-                        raise TValueError("Function passed as the `columns` "
-                                          "argument was expected to return a "
-                                          "`Union[None, bool, str]` but "
-                                          "instead returned value %r" % (ret,))
-                return coltypes
-
-            if nargs == 2:
-                for i in range(n):
-                    ret = colspec(i, colnames[i])
-                    if ret is None or ret is False:
-                        coltypes[i] = 0
-                    elif ret is True:
-                        self._colnames.append(colnames[i])
-                    elif isinstance(ret, str):
-                        self._colnames.append(ret)
-                    else:
-                        raise TValueError("Function passed as the `columns` "
-                                          "argument was expected to return a "
-                                          "`Union[None, bool, str]` but "
-                                          "instead returned value %r" % (ret,))
-                return coltypes
-
-            if nargs == 3:
-                for i in range(n):
-                    ret = colspec(i, colnames[i], coltypes[i])
-                    if ret is None or ret is False:
-                        coltypes[i] = 0
-                    elif ret is True:
-                        self._colnames.append(colnames[i])
-                    elif isinstance(ret, str):
-                        self._colnames.append(ret)
-                    elif isinstance(ret, tuple) and len(ret) == 2:
-                        newname, newtype = ret
-                        self._colnames.append(newname)
-                        coltypes[i] = _coltypes.get(newtype)
-                    else:
-                        raise TValueError("Function passed as the `columns` "
-                                          "argument was expected to return a "
-                                          "`Union[None, bool, str, Tuple[str, "
-                                          "Union[str, type]]]` but "
-                                          "instead returned value %r" % ret)
-                return coltypes
+        if callable(colspec):
+            return self._apply_columns_function(colspec, coldescs)
 
         raise RuntimeError("Unknown colspec: %r"  # pragma: no cover
                            % colspec)
 
 
-    def _process_excel_file(self, filename):
-        try:
-            import xlrd
-        except ImportError:
-            raise TValueError("Module `xlrd` is required in order to read "
-                              "Excel file '%s'. You can install this module "
-                              "by running `pip install xlrd` in the command "
-                              "line." % filename)
-        self._result = []
-        wb = xlrd.open_workbook(filename)
-        for ws in wb.sheets():
-            # If the worksheet is empty, skip it
-            if ws.ncols == 0:
-                continue
-            # Assume first row contains headers
-            colnames = ws.row_values(0)
-            cols0 = [core.column_from_list(ws.col_values(i, start_rowx=1),
-                                           -stype.str32.value)
-                     for i in range(ws.ncols)]
-            colset = core.columns_from_columns(cols0)
-            res = Frame(colset.to_datatable(), names=colnames)
-            self._result.append(res)
-        if len(self._result) == 0:
-            self._result = 0
-        if len(self._result) == 1:
-            self._result = self._result[0]
+    def _apply_columns_slice(self, colslice, colsdesc):
+        n = len(colsdesc)
+
+        if isinstance(colslice, slice):
+            start, count, step = normalize_slice(colslice, n)
+        else:
+            t = normalize_range(colslice, n)
+            if t is None:
+                raise TValueError("Invalid range iterator for a file with "
+                                  "%d columns: %r" % (n, colslice))
+            start, count, step = t
+        if step <= 0:
+            raise TValueError("Cannot use slice/range with negative step "
+                              "for column filter: %r" % colslice)
+
+        colnames = [None] * count
+        coltypes = [rtype.rdrop.value] * n
+        for j in range(count):
+            i = start + j * step
+            colnames[j] = colsdesc[i].name
+            coltypes[i] = rtype.rauto.value
+        self._colnames = colnames
+        return coltypes
+
+
+    def _apply_columns_set(self, colset, colsdesc):
+        n = len(colsdesc)
+        # Make a copy of the `colset` in order to check whether all the
+        # columns requested by the user were found, and issue a warning
+        # otherwise.
+        requested_cols = colset.copy()
+        colnames = []
+        coltypes = [rtype.rdrop.value] * n
+        for i in range(n):
+            colname = colsdesc[i][0]
+            if colname in colset:
+                requested_cols.discard(colname)
+                colnames.append(colname)
+                coltypes[i] = rtype.rauto.value
+        if requested_cols:
+            self.logger.warning("Column(s) %r not found in the input file"
+                                % list(requested_cols))
+        self._colnames = colnames
+        return coltypes
+
+
+    def _apply_columns_list(self, collist, colsdesc):
+        n = len(colsdesc)
+        nn = len(collist)
+        if n != nn:
+            raise TValueError("Input file contains %s, whereas `columns` "
+                              "parameter specifies only %s"
+                              % (plural(n, "column"), plural(nn, "column")))
+        colnames = []
+        coltypes = [rtype.rdrop.value] * n
+        for i in range(n):
+            entry = collist[i]
+            if entry is None or entry is False:
+                pass
+            elif entry is True or entry is Ellipsis:
+                colnames.append(colsdesc[i].name)
+                coltypes[i] = rtype.rauto.value
+            elif isinstance(entry, str):
+                colnames.append(entry)
+                coltypes[i] = rtype.rauto.value
+            elif isinstance(entry, (stype, ltype, type)):
+                colnames.append(colsdesc[i].name)
+                coltypes[i] = _coltypes.get(entry)
+            elif isinstance(entry, tuple):
+                newname, newtype = entry
+                colnames.append(newname)
+                coltypes[i] = _coltypes.get(newtype)
+                if not coltypes[i]:
+                    raise TValueError("Unknown type %r used as an override "
+                                      "for column %r" % (newtype, newname))
+            else:
+                raise TTypeError("Entry `columns[%d]` has invalid type %r"
+                                 % (i, entry.__class__.__name__))
+        self._colnames = colnames
+        return coltypes
+
+
+    def _apply_columns_dict(self, colsdict, colsdesc):
+        default_entry = colsdict.get(..., ...)
+        colnames = []
+        coltypes = [rtype.rdrop.value] * len(colsdesc)
+        for i in range(len(colsdesc)):
+            name = colsdesc[i].name
+            entry = colsdict.get(name, default_entry)
+            if entry is None:
+                pass  # coltype is already "drop"
+            elif entry is Ellipsis:
+                colnames.append(name)
+                coltypes[i] = rtype.rauto.value
+            elif isinstance(entry, str):
+                colnames.append(entry)
+                coltypes[i] = rtype.rauto.value
+            elif isinstance(entry, (stype, ltype, type)):
+                colnames.append(name)
+                coltypes[i] = _coltypes.get(entry)
+            elif isinstance(entry, tuple):
+                newname, newtype = entry
+                colnames.append(newname)
+                coltypes[i] = _coltypes.get(newtype)
+                assert isinstance(newname, str)
+                if not coltypes[i]:
+                    raise TValueError("Unknown type %r used as an override "
+                                      "for column %r" % (newtype, newname))
+            else:
+                raise TTypeError("Unknown value %r for column '%s' in "
+                                 "columns descriptor" % (entry, name))
+        self._colnames = colnames
+        return coltypes
+
+
+    def _apply_columns_function(self, colsfn, colsdesc):
+        res = colsfn(colsdesc)
+        return self._override_columns1(res, colsdesc)
 
 
 
@@ -1019,3 +1015,20 @@ _coltypes = {k: _coltypes_strs.index(v) for (k, v) in [
     (stype.str32, "str"),  # should be str32
     (stype.str64, "str"),  # should be str32
 ]}
+
+# Corresponds to RT enum in "reader_parsers.h"
+class rtype(enum.Enum):
+    rdrop    = 0
+    rauto    = 1
+    rbool    = 2
+    rint     = 3
+    rint32   = 4
+    rint64   = 5
+    rfloat   = 6
+    rfloat32 = 7
+    rfloat64 = 8
+    rstr     = 9
+    rstr32   = 10
+    rstr64   = 11
+
+

--- a/datatable/nff.py
+++ b/datatable/nff.py
@@ -93,8 +93,7 @@ def open(path):
             else:
                 raise ValueError("Unknown NFF format: %s" % info[0])
 
-        f0 = dt.fread(metafile, sep=",",
-                      columns=lambda i, name, type: (name, str))
+        f0 = dt.fread(metafile, sep=",", columns=[dt.stype.str32] * 4)
         f1 = f0(select=["filename", "stype", "meta"])
         colnames = f0["colname"].topython()[0]
         _dt = core.datatable_load(f1.internal, nrows, path)

--- a/tests/fread/test_fread_api.py
+++ b/tests/fread/test_fread_api.py
@@ -437,7 +437,7 @@ def test_fread_columns_dict2():
 
 def test_fread_columns_dict3():
     d0 = dt.fread(text="A,B,C\n1,2,3",
-                  columns={"A": ("foo", float), "B": (..., str), "C": None})
+                  columns={"A": ("foo", float), "B": str, "C": None})
     assert d0.names == ("foo", "B")
     assert d0.ltypes == (ltype.real, ltype.str)
     assert d0.topython() == [[1.0], ["2"]]
@@ -446,16 +446,17 @@ def test_fread_columns_dict3():
 def test_fread_columns_fn1():
     text = ("A1,A2,A3,A4,A5,x16,b333\n"
             "5,4,3,2,1,0,0\n")
-    d0 = dt.fread(text=text, columns=lambda col: int(col[1:]) % 2 == 0)
+    d0 = dt.fread(text=text, columns=lambda cols: [int(col.name[1:]) % 2 == 0
+                                                   for col in cols])
     assert d0.internal.check()
     assert d0.names == ("A2", "A4", "x16")
     assert d0.topython() == [[4], [2], [0]]
 
 
 def test_fread_columns_fn3():
-    d0 = dt.fread('A,B\n"1","2"', columns=lambda i, name, type: (name, int))
-    d1 = dt.fread('A,B\n"1","2"', columns=lambda i, name, type: (name, float))
-    d2 = dt.fread('A,B\n"1","2"', columns=lambda i, name, type: (name, str))
+    d0 = dt.fread('A,B\n"1","2"', columns=lambda cols: [int] * len(cols))
+    d1 = dt.fread('A,B\n"1","2"', columns=lambda cols: [float] * len(cols))
+    d2 = dt.fread('A,B\n"1","2"', columns=lambda cols: [str] * len(cols))
     assert d0.internal.check()
     assert d1.internal.check()
     assert d2.internal.check()


### PR DESCRIPTION
* API change: when `columns` parameter is a function, then up to now this function was called multiple times, once for each column in the input dataset. However from now on, the function will receive the list of all column descriptions at once, allowing the user to apply more elaborate logic in deciding which columns to keep / modify.
* Column descriptors passed to the function are named tuples containing fields `(name, type)`. In the future `format` will also be added. The `type` field here is the `stype` of the column (previously they were integer constants corresponding directly to the internal `PT` enum).
* At C++ level, parser type `PT::Drop` was removed (it is now a "requested type" `RT::RDrop`).
* Each `GReaderColumn` now has field `rtype` containing the "user-requested type" of the column (however currently it is not widely used).
* Fixed few warnings in unrelated files.
* Added `PyyString` helper class and replaced `PyObj::fromPyObjectNewRef` with a move-constructor.

Closes #954 