### PR TITLE
Exclude binary files from source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,3 +6,6 @@ include setup.cfg
 recursive-include c         *.c *.cc *.h
 recursive-include datatable *.py
 recursive-include tests     *.py
+
+exclude datatable/lib/*.*
+include datatable/lib/__init__.py


### PR DESCRIPTION
The problem was that `sdist` command tries to automatically include files it thinks are needed; and at the same time the option `--no-defaults` does not work.

Closes #974 