### PR TITLE
Fread can now anonymize user input from verbose log / error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### [Unreleased](https://github.com/h2oai/datatable/compare/HEAD...v0.3.2)
 #### Added
 - Fread can now parse integers with thousands separator (e.g. "1,000").
-
+- Added option `fread.anonymize` to force fread anonymize all user input in the
+  verbose logs / error messages.
 
 ### [v0.3.2](https://github.com/h2oai/datatable/compare/0.3.2...v0.3.1) — 2018-04-25
 #### Added

--- a/Makefile
+++ b/Makefile
@@ -556,7 +556,7 @@ $(BUILDDIR)/csv/py_csv.o : c/csv/py_csv.cc $(BUILDDIR)/options.h $(BUILDDIR)/csv
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/csv/reader.o : c/csv/reader.cc $(BUILDDIR)/csv/reader.h $(BUILDDIR)/csv/reader_arff.h $(BUILDDIR)/csv/reader_fread.h $(BUILDDIR)/options.h $(BUILDDIR)/python/long.h $(BUILDDIR)/python/string.h $(BUILDDIR)/utils/exceptions.h $(BUILDDIR)/utils/omp.h
+$(BUILDDIR)/csv/reader.o : c/csv/reader.cc $(BUILDDIR)/csv/reader.h $(BUILDDIR)/csv/reader_arff.h $(BUILDDIR)/csv/reader_fread.h $(BUILDDIR)/encodings.h $(BUILDDIR)/options.h $(BUILDDIR)/python/long.h $(BUILDDIR)/python/string.h $(BUILDDIR)/utils/exceptions.h $(BUILDDIR)/utils/omp.h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 

--- a/c/csv/fread.cc
+++ b/c/csv/fread.cc
@@ -22,42 +22,6 @@
 
 
 
-/**
- * Helper for error and warning messages to extract an input line starting at
- * `*ch` and until an end of line, but no longer than `limit` characters.
- * This function returns the string copied into an internal static buffer. Cannot
- * be called more than twice per single printf() invocation.
- * Parameter `limit` cannot exceed 500.
- */
-const char* strlim(const char* ch, size_t limit) {
-  static char buf[1002];
-  static int flip = 0;
-  char* ptr = buf + 501 * flip;
-  flip = 1 - flip;
-  char* ch2 = ptr;
-  char* ch2end = ptr + limit;
-  while (ch2 < ch2end) {
-    uint8_t c = static_cast<uint8_t>(*ch);
-    if (c < 0x0E && (c == 0 || c == 0x0D || c == 0x0A)) break;
-    if (c < 0x20 || c > 0x7F) {
-      int d0 = int(c & 0xF);
-      int d1 = int(c >> 4);
-      ch++;
-      *ch2++ = '\\';
-      *ch2++ = 'x';
-      *ch2++ = static_cast<char>((d1 < 10 ? '0' : 'A' - 10) + d1);
-      *ch2++ = static_cast<char>((d0 < 10 ? '0' : 'A' - 10) + d0);
-      if (ch2 > ch2end) { ch2 -= 4; break; }
-    } else {
-      *ch2++ = *ch++;
-    }
-  }
-  *ch2 = '\0';
-  return ptr;
-}
-
-
-
 //------------------------------------------------------------------------------
 
 

--- a/c/csv/fread.h
+++ b/c/csv/fread.h
@@ -17,7 +17,6 @@
 extern const long double pow10lookup[701];
 extern const uint8_t hexdigits[256];
 extern const uint8_t allowedseps[128];
-const char* strlim(const char* ch, size_t limit);
 
 #define JUMPLINES 100    // at each of the 100 jumps how many lines to guess column types (10,000 sample lines)
 

--- a/c/csv/reader.h
+++ b/c/csv/reader.h
@@ -161,6 +161,9 @@ class GenericReader
     bool    blank_is_na;
     bool    number_is_na;
     bool    override_column_types;
+    bool    printout_anonymize;
+    bool    printout_escape_unicode;
+    size_t : 48;
     const char* skip_to_string;
     const char* const* na_strings;
 
@@ -174,7 +177,8 @@ class GenericReader
     const char* eof;
     size_t line;
     int32_t fileno;
-    int : 32;
+    bool cr_is_newline;
+    int : 24;
     GReaderColumns columns;
 
   private:
@@ -251,6 +255,7 @@ class GenericReader
     void decode_utf16();
     void report_columns_to_python();
 
+    const char* repr_source(const char* ch, size_t limit);
     void _message(const char* method, const char* format, va_list args) const;
 
     DataTablePtr read_empty_input();

--- a/c/csv/reader_fread.cc
+++ b/c/csv/reader_fread.cc
@@ -605,6 +605,7 @@ void FreadReader::detect_lf() {
     ch++;
   }
   LFpresent = (ch < eof && *ch == '\n');
+  cr_is_newline = !LFpresent;
   if (LFpresent) {
     trace("LF character (\\n) found in input, "
           "\\r-only newlines will not be recognized");
@@ -964,7 +965,7 @@ void FreadLocalParseContext::read_chunk(
           << row0 + used_nrows + freader.line
           << ": expected " << ncols << " but found only " << j
           << " (with sep='" << sep << "'). Set fill=True to ignore this error. "
-          << " <<" << strlim(tlineStart, 500) << ">>";
+          << " <<" << freader.repr_source(tlineStart, 500) << ">>";
       } else {
         return;
       }
@@ -974,7 +975,7 @@ void FreadLocalParseContext::read_chunk(
         throw RuntimeError() << "Too many fields on line "
           << row0 + used_nrows + freader.line
           << ": expected " << ncols << " but more are present. <<"
-          << strlim(tlineStart, 500) << ">>";
+          << freader.repr_source(tlineStart, 500) << ">>";
       } else {
         return;
       }

--- a/c/csv/reader_utils.cc
+++ b/c/csv/reader_utils.cc
@@ -396,3 +396,4 @@ void StrBuf2::resize(size_t newsize) {
   }
 }
 
+

--- a/c/options.cc
+++ b/c/options.cc
@@ -23,6 +23,7 @@ size_t sort_max_chunk_length = 1 << 20;
 int8_t sort_max_radix_bits = 16;
 int8_t sort_over_radix_bits = 16;
 int32_t sort_nthreads = 1;
+bool fread_anonymize = false;
 
 
 static int32_t normalize_nthreads(int32_t nth) {
@@ -88,6 +89,10 @@ void set_sort_nthreads(int32_t n) {
   sort_nthreads = normalize_nthreads(n);
 }
 
+void set_fread_anonymize(int8_t v) {
+  fread_anonymize = v;
+}
+
 
 
 PyObject* set_option(PyObject*, PyObject* args) {
@@ -121,6 +126,9 @@ PyObject* set_option(PyObject*, PyObject* args) {
 
   } else if (name == "core_logger") {
     set_core_logger(value.as_pyobject());
+
+  } else if (name == "fread.anonymize") {
+    set_fread_anonymize(value.as_bool());
 
   } else {
     throw ValueError() << "Unknown option `" << name << "`";

--- a/c/options.h
+++ b/c/options.h
@@ -20,6 +20,7 @@ extern size_t sort_max_chunk_length;
 extern int8_t sort_max_radix_bits;
 extern int8_t sort_over_radix_bits;
 extern int32_t sort_nthreads;
+extern bool fread_anonymize;
 
 void set_nthreads(int32_t n);
 void set_core_logger(PyObject*);
@@ -29,6 +30,7 @@ void set_sort_max_chunk_length(int64_t n);
 void set_sort_max_radix_bits(int64_t n);
 void set_sort_over_radix_bits(int64_t n);
 void set_sort_nthreads(int32_t n);
+void set_fread_anonymize(int8_t v);
 
 
 DECLARE_FUNCTION(

--- a/datatable/fread.py
+++ b/datatable/fread.py
@@ -18,6 +18,7 @@ from typing import List, Union, Callable, Optional, Tuple, Dict, Set
 
 from datatable.lib import core
 from datatable.frame import Frame
+from datatable.options import options
 from datatable.utils.typechecks import (typed, U, TValueError, TTypeError,
                                         DatatableWarning)
 from datatable.utils.terminal import term
@@ -1018,6 +1019,8 @@ class _DefaultLogger:
 _pathlike = (str, bytes, os.PathLike) if hasattr(os, "PathLike") else \
             (str, bytes)
 
+options.register_option(
+    "fread.anonymize", xtype=bool, default=False, core=True)
 
 
 

--- a/tests/fread/test_fread_api.py
+++ b/tests/fread/test_fread_api.py
@@ -834,3 +834,27 @@ def test_nastrings_invalid(na):
     with pytest.raises(Exception) as e:
         dt.fread("A\n1", na_strings=[na])
     assert "has whitespace or control characters" in str(e)
+
+
+
+#-------------------------------------------------------------------------------
+# `anonymize`
+#-------------------------------------------------------------------------------
+
+def test_anonymize1(capsys):
+    try:
+        src = ("Якби ви знали, паничі,\n"
+               "Де люде плачуть живучи,\n"
+               "То ви б елегій не творили\n"
+               "Та марне бога б не хвалили,\n"
+               "На наші сльози сміючись.\n")
+        d0 = dt.fread(src, sep="", verbose=True)
+        out, err = capsys.readouterr()
+        assert "На наші сльози сміючись." in out
+        dt.options.fread.anonymize = True
+        d1 = dt.fread(src, sep="", verbose=True)
+        out, err = capsys.readouterr()
+        assert "На наші сльози сміючись." not in out
+        assert "UU UUUU UUUUUU UUUUUUUU." in out
+    finally:
+        dt.options.fread.anonymize = False

--- a/tests/test_dt_options.py
+++ b/tests/test_dt_options.py
@@ -13,13 +13,14 @@ def test_options_all():
     # Update this test every time a new option is added
     assert repr(dt.options).startswith("<datatable.options.DtConfig:")
     assert set(dir(dt.options)) == {
-        "nthreads", "core_logger", "sort", "display", "frame"}
+        "nthreads", "core_logger", "sort", "display", "frame", "fread"}
     assert set(dir(dt.options.sort)) == {
         "insert_method_threshold", "thread_multiplier", "max_chunk_length",
         "max_radix_bits", "over_radix_bits", "nthreads"}
     assert set(dir(dt.options.display)) == {"interactive_hint"}
     assert set(dir(dt.options.frame)) == {
         "names_auto_index", "names_auto_prefix"}
+    assert set(dir(dt.options.fread)) == {"anonymize"}
 
 
 @pytest.mark.run(order=1002)


### PR DESCRIPTION
* More robust input printout in verbose logs / error messages
* Anonymization is controlled by an option `dt.options.fread.anonymize`
* An example of input is now printed in verbose mode after the file is opened