### PR TITLE
Anonymize column names in fread's error messages as well

### DIFF
--- a/c/csv/fread.cc
+++ b/c/csv/fread.cc
@@ -308,7 +308,7 @@ DataTablePtr FreadReader::read()
           // FIXME: if the user wants to override the type, let them
           STOP("Attempt to override column %d \"%s\" of inherent type '%s' down to '%s' which will lose accuracy. " \
                "If this was intended, please coerce to the lower type afterwards. Only overrides to a higher type are permitted.",
-               i+1, col.name.data(), ParserLibrary::info(oldtypes[i]).cname(), col.typeName());
+               i+1, col.repr_name(*this), ParserLibrary::info(oldtypes[i]).cname(), col.typeName());
         }
         nUserBumped += (col.type != oldtypes[i]);
       }
@@ -391,6 +391,6 @@ DataTablePtr FreadReader::read()
 
   trace("[7] Finalize the datatable");
   DataTablePtr res = makeDatatable();
-  if (verbose) fo.report(*this);
+  if (verbose) fo.report();
   return res;
 }

--- a/c/csv/reader.cc
+++ b/c/csv/reader.cc
@@ -385,7 +385,13 @@ static void print_byte(uint8_t c, char*& out) {
  * The function will attempt to escape all non-printable characters. It can
  * optionally escape all unicode characters too; or anonymize all text content.
  */
-const char* GenericReader::repr_source(const char* ch, size_t limit)
+const char* GenericReader::repr_source(const char* ch, size_t limit) const {
+  return repr_binary(ch, eof, limit);
+}
+
+
+const char* GenericReader::repr_binary(
+  const char* ch, const char* endch, size_t limit) const
 {
   static constexpr size_t BUFSIZE = 1002;
   static char buf[BUFSIZE + 10];
@@ -400,15 +406,15 @@ const char* GenericReader::repr_source(const char* ch, size_t limit)
   while (out < end) {
     stopped_at_newline = true;
     saved = out;
-    if (ch == eof) break;
+    if (ch == endch) break;
     uint8_t c = static_cast<uint8_t>(*ch++);
 
     // Stop at a newline
     if (c == '\n') break;
     if (c == '\r') {
       if (cr_is_newline) break;
-      if (ch < eof     && ch[0] == '\n') break;  // \r\n
-      if (ch + 1 < eof && ch[0] == '\r' && ch[1] == '\n') break;  // \r\r\n
+      if (ch < endch     && ch[0] == '\n') break;  // \r\n
+      if (ch + 1 < endch && ch[0] == '\r' && ch[1] == '\n') break;  // \r\r\n
     }
     stopped_at_newline = false;
 
@@ -429,7 +435,7 @@ const char* GenericReader::repr_source(const char* ch, size_t limit)
     else if (c < 0xF8) {
       auto usrc = reinterpret_cast<const uint8_t*>(ch - 1);
       size_t cp_bytes = (c < 0xE0)? 2 : (c < 0xF0)? 3 : 4;
-      bool cp_valid = (ch + cp_bytes - 2 < eof) &&
+      bool cp_valid = (ch + cp_bytes - 2 < endch) &&
                       is_valid_utf8(usrc, cp_bytes);
       if (!cp_valid || printout_escape_unicode) {
         print_byte(c, out);
@@ -745,7 +751,7 @@ void GenericReader::report_columns_to_python() {
   } else {
     PyyList colNamesList(ncols);
     for (size_t i = 0; i < ncols; ++i) {
-      colNamesList[i] = PyyString(columns[i].name);
+      colNamesList[i] = PyyString(columns[i].get_name());
     }
     freader.invoke("_set_column_names", "(O)", colNamesList.release());
   }

--- a/c/csv/reader.h
+++ b/c/csv/reader.h
@@ -21,6 +21,7 @@
 
 enum PT : uint8_t;
 enum RT : uint8_t;
+class GenericReader;
 
 
 //------------------------------------------------------------------------------
@@ -59,6 +60,8 @@ class GReaderColumn {
     GReaderColumn(GReaderColumn&&);
     virtual ~GReaderColumn();
     const char* typeName() const;
+    const std::string& get_name() const;
+    const char* repr_name(const GenericReader& g) const;
     size_t elemsize() const;
     size_t getAllocSize() const;
     bool isstring() const;
@@ -227,6 +230,9 @@ class GenericReader
     void warn(const char* format, ...) const;
     void progress(double progress, int status = 0);
 
+    const char* repr_source(const char* ch, size_t limit) const;
+    const char* repr_binary(const char* ch, const char* end, size_t limit) const;
+
   // Helper functions
   private:
     void init_verbose();
@@ -255,7 +261,6 @@ class GenericReader
     void decode_utf16();
     void report_columns_to_python();
 
-    const char* repr_source(const char* ch, size_t limit);
     void _message(const char* method, const char* format, va_list args) const;
 
     DataTablePtr read_empty_input();

--- a/c/csv/reader_fread.h
+++ b/c/csv/reader_fread.h
@@ -32,6 +32,7 @@ class ColumnTypeDetectionChunkster;
  */
 class FreadObserver {
   public:
+    const GenericReader& g;
     double t_start;
     double t_initialized;
     double t_parse_parameters_detected;
@@ -53,14 +54,14 @@ class FreadObserver {
     std::vector<std::string> messages;
 
   public:
-    FreadObserver();
+    FreadObserver(const GenericReader&);
     ~FreadObserver();
 
     void type_bump_info(size_t icol, const GReaderColumn& col, PT new_type,
                         const char* field, int64_t len, int64_t lineno);
     void str64_bump(size_t icol, const GReaderColumn& col);
 
-    void report(const GenericReader&);
+    void report();
 };
 
 

--- a/c/csv/reader_utils.cc
+++ b/c/csv/reader_utils.cc
@@ -68,6 +68,17 @@ const char* GReaderColumn::typeName() const {
   return ParserLibrary::info(type).name.data();
 }
 
+const std::string& GReaderColumn::get_name() const {
+  return name;
+}
+
+const char* GReaderColumn::repr_name(const GenericReader& g) const {
+  const char* start = name.c_str();
+  const char* end = start + name.size();
+  return g.repr_binary(start, end, 25);
+}
+
+
 size_t GReaderColumn::elemsize() const {
   return static_cast<size_t>(ParserLibrary::info(type).elemsize);
 }

--- a/tests/fread/test_fread_api.py
+++ b/tests/fread/test_fread_api.py
@@ -858,3 +858,21 @@ def test_anonymize1(capsys):
         assert "UU UUUU UUUUUU UUUUUUUU." in out
     finally:
         dt.options.fread.anonymize = False
+
+
+def test_anonymize2(capsys):
+    try:
+        lines = ["secret code"] + [str(j) for j in range(10000)]
+        lines[111] = "boo"
+        src = "\n".join(lines)
+        d0 = dt.fread(src, verbose=True)
+        out, err = capsys.readouterr()
+        assert "secret code" in out
+        assert "Column 1 (secret code)" in out
+        dt.options.fread.anonymize = True
+        d0 = dt.fread(src, verbose=True)
+        out, err = capsys.readouterr()
+        assert "Column 1 (secret code)" not in out
+        assert "Column 1 (aaaaaa aaaa)" in out
+    finally:
+        dt.options.fread.anonymize = False


### PR DESCRIPTION
Before now only input samples were anonymized. Now column names are anonymized too (if option `dt.options.fread.anonymize` is turned on).