### PR TITLE
Rbind various improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### [Unreleased](https://github.com/h2oai/datatable/compare/HEAD...v0.4.0)
 #### Added
+- rbind()-ing now works on columns of all types (including between any types).
+- Added `dt.rbind()` function to perform out-of-place row binding.
 
 
 ### [v0.4.0](https://github.com/h2oai/datatable/compare/0.4.0...v0.3.2) — 2018-05-07

--- a/Makefile
+++ b/Makefile
@@ -541,7 +541,7 @@ $(BUILDDIR)/column_int.o : c/column_int.cc $(BUILDDIR)/column.h $(BUILDDIR)/csv/
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/column_pyobj.o : c/column_pyobj.cc $(BUILDDIR)/column.h $(BUILDDIR)/utils/assert.h
+$(BUILDDIR)/column_pyobj.o : c/column_pyobj.cc $(BUILDDIR)/column.h $(BUILDDIR)/utils/assert.h $(BUILDDIR)/utils.h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 

--- a/c/column.h
+++ b/c/column.h
@@ -620,7 +620,7 @@ protected:
   // void cast_into(RealColumn<double>*) const override;
   void cast_into(PyObjectColumn*) const override;
   // void cast_into(StringColumn<int32_t>*) const;
-  // void cast_into(StringColumn<int64_t>*) const;
+  void cast_into(StringColumn<int64_t>*) const override;
   void fill_na() override;
 
   //int verify_meta_integrity(std::vector<char>*, int, const char* = "Column") const override;
@@ -630,6 +630,8 @@ protected:
 };
 
 
+template <> void StringColumn<int32_t>::cast_into(StringColumn<int64_t>*) const;
+template <> void StringColumn<int64_t>::cast_into(StringColumn<int64_t>*) const;
 extern template class StringColumn<int32_t>;
 extern template class StringColumn<int64_t>;
 

--- a/c/column.h
+++ b/c/column.h
@@ -552,6 +552,9 @@ protected:
   // void cast_into(StringColumn<int32_t>*) const;
   // void cast_into(StringColumn<int64_t>*) const;
 
+  void rbind_impl(std::vector<const Column*>& columns, int64_t nrows,
+                  bool isempty) override;
+
   void fill_na() override;
   void reify() override;
   friend Column;

--- a/c/column_fw.cc
+++ b/c/column_fw.cc
@@ -214,22 +214,22 @@ void FwColumn<T>::rbind_impl(std::vector<const Column*>& columns,
                              int64_t new_nrows, bool col_empty)
 {
   const T na = na_elem;
-  const void *naptr = static_cast<const void*>(&na);
+  const void* naptr = static_cast<const void*>(&na);
 
   // Reallocate the column's data buffer
-  size_t old_nrows = (size_t) nrows;
+  size_t old_nrows = static_cast<size_t>(nrows);
   size_t old_alloc_size = alloc_size();
-  size_t new_alloc_size = sizeof(T) * (size_t) new_nrows;
+  size_t new_alloc_size = sizeof(T) * static_cast<size_t>(new_nrows);
   mbuf = mbuf->safe_resize(new_alloc_size);
   xassert(!mbuf->is_readonly());
   nrows = new_nrows;
 
   // Copy the data
-  void *resptr = mbuf->at(col_empty ? 0 : old_alloc_size);
+  void* resptr = mbuf->at(col_empty ? 0 : old_alloc_size);
   size_t rows_to_fill = col_empty ? old_nrows : 0;
   for (const Column* col : columns) {
-    if (col->stype() == 0) {
-      rows_to_fill += (size_t) col->nrows;
+    if (col->stype() == ST_VOID) {
+      rows_to_fill += static_cast<size_t>(col->nrows);
     } else {
       if (rows_to_fill) {
         set_value(resptr, naptr, sizeof(T), rows_to_fill);
@@ -237,7 +237,7 @@ void FwColumn<T>::rbind_impl(std::vector<const Column*>& columns,
         rows_to_fill = 0;
       }
       if (col->stype() != stype()) {
-        Column *newcol = col->cast(stype());
+        Column* newcol = col->cast(stype());
         delete col;
         col = newcol;
       }

--- a/c/types.h
+++ b/c/types.h
@@ -7,11 +7,10 @@
 //------------------------------------------------------------------------------
 #ifndef dt_TYPES_H
 #define dt_TYPES_H
-#include <stddef.h>  // size_t
-#include <stdint.h>  // int*_t
 #include <string>
 #include <cmath>     // isnan
 #include <limits>    // std::numeric_limits
+#include <Python.h>
 
 
 // intXX(32)  =>  int32_t
@@ -462,6 +461,7 @@ template<> constexpr uint16_t GETNA() { return NA_U2; }
 template<> constexpr uint32_t GETNA() { return NA_U4; }
 template<> constexpr float    GETNA() { return NA_F4; }
 template<> constexpr double   GETNA() { return NA_F8; }
+template<> constexpr PyObject* GETNA() { return Py_None; }
 
 /**
  * ISNA function
@@ -479,6 +479,7 @@ template<> inline bool ISNA(uint16_t x) { return ISNA_U2(x); }
 template<> inline bool ISNA(uint32_t x) { return ISNA_U4(x); }
 template<> inline bool ISNA(float x)    { return isnan(x); }
 template<> inline bool ISNA(double x)   { return isnan(x); }
+template<> inline bool ISNA(PyObject* x) { return x == Py_None; }
 
 /**
  * Similar to ISNA<T>(x) template, except it returns true only for integer-

--- a/datatable/__init__.py
+++ b/datatable/__init__.py
@@ -7,6 +7,7 @@
 
 from datatable.graph.dtproxy import f
 from .__version__ import version as __version__
+from .dt_append import rbind, cbind
 from .frame import Frame
 from .expr import mean, min, max, sd, isna
 from .fread import fread, GenericReader
@@ -20,7 +21,8 @@ __all__ = ("__version__", "Frame", "max", "mean", "min", "open", "sd",
            "isna", "fread", "GenericReader", "save", "stype", "ltype", "f",
            "TypeError", "ValueError", "DataTable", "options",
            "bool8", "int8", "int16", "int32", "int64",
-           "float32", "float64", "str32", "str64", "obj64")
+           "float32", "float64", "str32", "str64", "obj64",
+           "cbind", "rbind")
 
 bool8 = stype.bool8
 int8 = stype.int8

--- a/datatable/dt_append.py
+++ b/datatable/dt_append.py
@@ -8,10 +8,15 @@ import datatable as dt
 from datatable.utils.misc import plural_form as plural
 from datatable.utils.typechecks import typed, Frame_t, TValueError
 
+def rbind(*frames, force=False, bynames=True):
+    return _rbind(dt.Frame(), *frames, force=force, bynames=bynames)
+
+def cbind(self, *frames, force=False):
+    return _cbind(dt.Frame(), *frames, force=force)
 
 
 @typed(frames=Frame_t, force=bool, bynames=bool)
-def rbind(self, *frames, force=False, bynames=True):
+def _rbind(self, *frames, force=False, bynames=True):
     """
     Append rows of `frames` to the current Frame.
 
@@ -137,7 +142,7 @@ def rbind(self, *frames, force=False, bynames=True):
 
 
 @typed(frames=Frame_t, force=bool, inplace=bool)
-def cbind(self, *frames, force=False, inplace=True):
+def _cbind(self, *frames, force=False, inplace=True):
     """
     Append columns of Frames `frames` to the current Frame.
 

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -14,7 +14,7 @@ from datatable.lib import core
 import datatable
 from .widget import DataFrameWidget
 
-from datatable.dt_append import rbind as dt_rbind, cbind as dt_cbind
+from datatable.dt_append import _rbind, _cbind
 from datatable.nff import save as dt_save
 from datatable.utils.misc import plural_form as plural
 from datatable.utils.misc import load_module
@@ -570,9 +570,9 @@ class Frame(object):
 
 
     # Methods defined externally
-    append = dt_rbind
-    rbind = dt_rbind
-    cbind = dt_cbind
+    append = _rbind
+    rbind = _rbind
+    cbind = _cbind
     to_csv = write_csv
     save = dt_save
 

--- a/tests/munging/test_dt_append.py
+++ b/tests/munging/test_dt_append.py
@@ -4,6 +4,7 @@
 #   License, v. 2.0. If a copy of the MPL was not distributed with this
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #-------------------------------------------------------------------------------
+import math
 import tempfile
 import shutil
 import pytest
@@ -183,12 +184,10 @@ def test_rbind_strings4():
 
 
 def test_rbind_strings5():
-    # TODO: fix this test once rbinding strings with non-strings properly
-    #       implemented.
     f0 = dt.Frame([1, 2, 3])
     f1 = dt.Frame(["foo", "bra"])
-    with pytest.raises(NotImplementedError):
-        f1.rbind(f0)
+    f1.rbind(f0)
+    assert f1.topython() == [["foo", "bra", "1", "2", "3"]]
 
 
 
@@ -326,4 +325,28 @@ def test_rbind_different_stypes4():
     ]
 
 
-# TODO: add tests for appending categorical columns (requires merging levelsets)
+def test_rbind_all_stypes():
+    sources = {
+        dt.bool8: [True, False, True, None, False, None],
+        dt.int8: [3, -5, None, 17, None, 99, -99],
+        dt.int16: [None, 245, 872, -333, None],
+        dt.int32: [10000, None, 1, 0, None, 34, -2222222],
+        dt.int64: [None, 9348571093841, -394, 3053867, 111334],
+        dt.float32: [None, 3.3, math.inf, -7.123e20, 34098.79],
+        dt.float64: [math.inf, math.nan, 341.0, -34985.94872, 1e310],
+        dt.str32: ["first", None, "third", "asblkhblierb", ""],
+        dt.str64: ["red", "orange", "blue", "purple", "magenta", None],
+        # dt.obj64: [1, False, "yey", math.nan, (3, "foo"), None, 2.33],
+    }
+    all_stypes = list(sources.keys())
+    for st1 in all_stypes:
+        for st2 in all_stypes:
+            f1 = dt.Frame(sources[st1], stype=st1)
+            f2 = dt.Frame(sources[st2], stype=st2)
+            try:
+                f1.rbind(f2)
+            except Exception as e:
+                raise Exception("Cannot rbind %s to %s (%s)"
+                                % (st1.name, st2.name, e))
+            assert f1.internal.check()
+            assert f1.nrows == len(sources[st1]) + len(sources[st2])

--- a/tests/munging/test_dt_append.py
+++ b/tests/munging/test_dt_append.py
@@ -336,17 +336,26 @@ def test_rbind_all_stypes():
         dt.float64: [math.inf, math.nan, 341.0, -34985.94872, 1e310],
         dt.str32: ["first", None, "third", "asblkhblierb", ""],
         dt.str64: ["red", "orange", "blue", "purple", "magenta", None],
-        # dt.obj64: [1, False, "yey", math.nan, (3, "foo"), None, 2.33],
+        dt.obj64: [1, False, "yey", math.nan, (3, "foo"), None, 2.33],
     }
     all_stypes = list(sources.keys())
     for st1 in all_stypes:
         for st2 in all_stypes:
             f1 = dt.Frame(sources[st1], stype=st1)
             f2 = dt.Frame(sources[st2], stype=st2)
-            try:
-                f1.rbind(f2)
-            except Exception as e:
-                raise Exception("Cannot rbind %s to %s (%s)"
-                                % (st1.name, st2.name, e))
+            f3 = dt.Frame().rbind(f1, f2)
+            f1.rbind(f2)
             assert f1.internal.check()
+            assert f2.internal.check()
+            assert f3.internal.check()
             assert f1.nrows == len(sources[st1]) + len(sources[st2])
+            assert f3.shape == f1.shape
+            assert f1.topython() == f3.topython()
+
+
+def test_rbind_modulefn():
+    f0 = dt.Frame([1, 5409, 204])
+    f1 = dt.Frame([109813, None, 9385])
+    f3 = dt.rbind(f0, f1)
+    assert f3.internal.check()
+    assert f3.topython()[0] == f0.topython()[0] + f1.topython()[0]


### PR DESCRIPTION
* New module-level `dt.rbind()` function to rbind several frames without modifying any of them (this is a convenient shortcut for `dt.Frame().rbind(...)`). Similarly, `dt.cbind()` was also added.
* It is now possible to rbind columns of any types, including cross-type rbinds.
* Added type cast str32->str64
* Additional tests for rbinding

Closes #1018