### PR TITLE
Ensure that fread only emits messages to Python from the master thread.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - rbind()-ing now works on columns of all types (including between any types).
 - Added `dt.rbind()` function to perform out-of-place row binding.
 
+#### Fixed
+- Ensure that fread only emits messages to Python from the master thread.
+
 
 ### [v0.4.0](https://github.com/h2oai/datatable/compare/0.4.0...v0.3.2) — 2018-05-07
 #### Added

--- a/c/csv/chunks.cc
+++ b/c/csv/chunks.cc
@@ -154,6 +154,7 @@ void ChunkedDataReader::read_all()
     for (size_t i = 0; i < chunkCount; ++i) {
       if (oem.exception_caught()) continue;
       try {
+        if (tMaster) g.emit_delayed_messages();
         if (tShowAlways || (tShowProgress && wallclock() >= tShowWhen)) {
           g.progress(work_done_amount());
           tShowAlways = true;
@@ -212,6 +213,7 @@ void ChunkedDataReader::read_all()
     }
 
     // Report progress one last time
+    if (tMaster) g.emit_delayed_messages();
     if (tShowAlways) {
       int status = 1 + oem.exception_caught() + oem.is_keyboard_interrupt();
       g.progress(work_done_amount(), status);

--- a/c/csv/reader.h
+++ b/c/csv/reader.h
@@ -193,6 +193,13 @@ class GenericReader
     PyObj skipstring_arg;
     PyObj tempstr;
 
+    // If `trace()` cannot display a message immediately (because it was not
+    // sent from the main thread), it will be temporarily stored in this
+    // variable. Call `emit_delayed_messages()` from the master thread to send
+    // these messages to the frontend.
+    mutable std::string delayed_message;
+    // std::string delayed_warning;
+
   //---- Public API ----
   public:
     GenericReader(const PyObj& pyreader);
@@ -229,6 +236,7 @@ class GenericReader
     void trace(const char* format, ...) const;
     void warn(const char* format, ...) const;
     void progress(double progress, int status = 0);
+    void emit_delayed_messages();
 
     const char* repr_source(const char* ch, size_t limit) const;
     const char* repr_binary(const char* ch, const char* end, size_t limit) const;

--- a/tests/fread/test_fread_random.py
+++ b/tests/fread/test_fread_random.py
@@ -33,7 +33,7 @@ def make_seeds():
     n = 25
     if (os.environ.get(root_env_name, "") != "" and
             os.environ.get(env_coverage, "") == ""):
-        n = 500
+        n = 100
     return [random.randint(0, 2**31) for _ in range(n)]
 
 


### PR DESCRIPTION
Identified 1 instance where a debug message was generated from a non-master thread. Put checks in place that such messages are delayed for the master thread. Hopefully this should resolve the GIL_Check problem (although hard to know for sure, since the problem was not reproducible).

Closes #1013 