### PR TITLE
[BUILD] GitHub Release

### DIFF
--- a/ci/Jenkinsfile2
+++ b/ci/Jenkinsfile2
@@ -17,7 +17,7 @@ properties([
 
 RELEASE_BRANCH_PREFIX = 'rel-'
 
-H2O_OPS_TOKEN_CREDS_ID = 'h2o-ops-personal-auth-token'
+CREDS_ID = 'h2o-ops-personal-auth-token'
 
 def DOCKER_IMAGE_TAG = '0.3.2-PR-996.3'
 
@@ -108,7 +108,11 @@ def needsLargerTest
 SOURCE_DIR = "/home/0xdiag"
 TARGET_DIR = "/tmp/pydatatable_large_data"
 
-S3_FOLDER_STABLE = 'stable'
+
+BUCKET = 'h2o-release'
+STABLE_FOLDER = 'datatable/stale'
+S3_URL_STABLE = "s3://${BUCKET}/${STABLE_FOLDER}"
+HTTPS_URL_STABLE = "https://${BUCKET}.s3.amazonaws.com/${STABLE_FOLDER}"
 
 // Data map for linking into container
 def linkMap = [
@@ -131,7 +135,7 @@ BUILD_MATRIX.each { platform, config ->
 
             cleanWs()
             def buildStageName = "Build ${platform}"
-            withCustomCommitStates(scm, H2O_OPS_TOKEN_CREDS_ID, buildStageName) {
+            withCustomCommitStates(scm, CREDS_ID, buildStageName) {
                 stage(buildStageName) {
                     dir(buildDir) {
                         unstash 'datatable-sources'
@@ -152,7 +156,7 @@ BUILD_MATRIX.each { platform, config ->
                 }
                 def coverageStageName = "Coverage ${platform}"
                 coverageStageName = appendLargeTestsSuffixIfRequired(coverageStageName, needsLargerTest)
-                withCustomCommitStates(scm, H2O_OPS_TOKEN_CREDS_ID, coverageStageName) {
+                withCustomCommitStates(scm, CREDS_ID, coverageStageName) {
                     stage(coverageStageName) {
                         def coverageClosure = {
                             project.coverage(coverageDir, platform, getVenvActivationCmd(platform, DEFAULT_PY36_ENV), BUILD_MATRIX[platform]['env'], false, TARGET_DIR)
@@ -173,7 +177,7 @@ BUILD_MATRIX.each { platform, config ->
                     def testStageName = "Test ${platform} with ${testEnv}"
                     if (config.test && !params.DISABLE_TESTS) {
                         testStageName = appendLargeTestsSuffixIfRequired(testStageName, needsLargerTest)
-                        withCustomCommitStates(scm, H2O_OPS_TOKEN_CREDS_ID, testStageName) {
+                        withCustomCommitStates(scm, CREDS_ID, testStageName) {
                             stage(testStageName) {
                                 dir(testDir) {
                                     unstash 'datatable-sources'
@@ -314,8 +318,8 @@ ansiColor('xterm') {
                             withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: "awsArtifactsUploader"]]) {
                                 docker.image("docker.h2o.ai/s3cmd").inside {
                                     sh """
-                                        s3cmd put -P ${publishS3Dir}/dist/*.whl s3://h2o-release/datatable/${S3_FOLDER_STABLE}/datatable-${versionText}/
-                                        s3cmd put -P ${publishS3Dir}/dist/*.tar.gz s3://h2o-release/datatable/${S3_FOLDER_STABLE}/datatable-${versionText}/
+                                        s3cmd put -P ${publishS3Dir}/dist/*.whl ${getS3TargetUrl(versionText)}
+                                        s3cmd put -P ${publishS3Dir}/dist/*.tar.gz ${getS3TargetUrl(versionText)}
                                     """
                                 }
                             }
@@ -326,13 +330,13 @@ ansiColor('xterm') {
                         dumpInfo()
                         docker.withRegistry("https://docker.h2o.ai", "docker.h2o.ai") {
                             docker.image('docker.h2o.ai/opsh2oai/hub').inside("--init -v /home/jenkins/.ssh:/home/jenkins/.ssh:ro -v /home/jenkins/.gitconfig:/home/jenkins/.gitconfig:ro") {
-                                withCredentials([string(credentialsId: 'h2o-ops-personal-auth-token', variable: 'GITHUB_TOKEN')]) {
+                                withCredentials([string(credentialsId: CREDS_ID, variable: 'GITHUB_TOKEN')]) {
                                     final def releaseMsgFile = "release-msg.md"
                                     def releaseMsg = """v${versionText}
 
 ${project.getChangelogPartForVersion(versionText, "${publishS3Dir}/CHANGELOG.md")}
 ---
-${project.getReleaseDownloadLinksText("${publishS3Dir}/dist", "https://h2o-release.s3.amazonaws.com/datatable/${S3_FOLDER_STABLE}/datatable-${versionText}")}
+${project.getReleaseDownloadLinksText("${publishS3Dir}/dist", "${getHTTPSTargetUrl(versionText)}")}
 """
                                     writeFile(file: "${publishS3Dir}/${releaseMsgFile}", text: releaseMsg)
                                     sh """
@@ -361,6 +365,14 @@ def uploadToS3(artifact, versionText, platformDir) {
         platform = platformDir
         isRelease = true
     }
+}
+
+def getS3TargetUrl(final versionText) {
+    return "${S3_URL_STABLE}/datatable-${versionText}/"
+}
+
+def getHTTPSTargetUrl(final versionText) {
+    return "${HTTPS_URL_STABLE}/datatable-${versionText}/"
 }
 
 def getVenvActivationCmd(final platform, final venvName) {

--- a/ci/Jenkinsfile2
+++ b/ci/Jenkinsfile2
@@ -121,6 +121,9 @@ def linkMap = [
 
 def dockerArgs = createDockerArgs(linkMap, SOURCE_DIR, TARGET_DIR)
 
+/////////////////////////////////////
+// Build, Coverage and Test stages //
+/////////////////////////////////////
 def stages = [:]
 BUILD_MATRIX.each { platform, config ->
     stages[platform] = {
@@ -201,11 +204,16 @@ BUILD_MATRIX.each { platform, config ->
     }
 }
 
+////////////////////////
+// Main pipeline code //
+////////////////////////
 ansiColor('xterm') {
     timestamps {
         if (isPrJob()) {
             cancelPreviousBuilds()
         }
+
+        // Checkout, apply patch and stash sources
         node('linux') {
             stage('Init') {
                 checkout scm
@@ -243,111 +251,105 @@ ansiColor('xterm') {
             }
         }
 
+        // Build, Coverage and Test stages for all platforms
         parallel stages
 
-        // Publish into S3 all snapshots versions
+        def versionText = null
+        def publishS3Dir = 'publish-s3'
+        // If building master or rel-* branch, publish to S3
         if (doPublish()) {
+            // Build and archive sdist wheel and read information required for following stages.
             node('docker && !mr-0xc8') {
-
                 final def buildDir = 'build-sdist'
                 stage('Build sdist') {
                     dir(buildDir) {
                         unstash 'datatable-sources'
                     }
-                    // Specify build Closure
+                    // read additional information for following stages
+                    unstash 'VERSION'
+                    versionText = readFile("build/dist/VERSION.txt").trim()
+
                     def buildClosure = {
                         project.buildSDist(buildDir, CI_VERSION_SUFFIX, getVenvActivationCmd(LINUX_PLATFORM, DEFAULT_PY36_ENV))
                     }
                     callInEnv(X86_64_LINUX_DOCKER_IMAGE, dockerArgs, buildClosure)
                 }
+            }
 
-                def publishS3Dir = 'publish-s3'
+            if (versionText == null || versionText.trim() == '') {
+                error 'Version cannot be read'
+            }
 
+            // Always publish to artifacts.h2o.ai
+            node('master') {
                 stage('Publish snapshot to S3') {
                     cleanWs()
                     dumpInfo()
-
                     project.pullFilesFromArch('build/dist/**/*.whl, build-sdist/dist/**/*.tar.gz', "${publishS3Dir}/dist")
-                    unstash 'VERSION'
-                    sh "echo 'Stashed files:' && cd ${publishS3Dir} && find dist"
-
-                    def versionText = utilsLib.getCommandOutput("cat build/dist/VERSION.txt")
-
                     BUILD_MATRIX.each { platform, config ->
-//                        FIXME
-//                        uploadToS3("${publishS3Dir}/dist/*${project.getWheelPlatformName(platform)}*", versionText, project.getS3PlatformName(platform))
-//                        uploadToS3("${publishS3Dir}/dist/*.tar.gz", versionText, project.getS3PlatformName(platform))
+                        uploadToS3("${publishS3Dir}/dist/*${project.getWheelPlatformName(platform)}*", versionText, project.getS3PlatformName(platform))
+                        uploadToS3("${publishS3Dir}/dist/*.tar.gz", versionText, project.getS3PlatformName(platform))
                     }
                 }
+            }
 
-//                FIXME
-                if (true) { //params.PROMOTE) {
-                    cleanWs()
+            // We want to publish master builds automatically. For other branches (because doPublish() is true those
+            // might be only rel-* branches) we want user confirmation.
+            if (env.BRANCH_NAME != 'master') {
+                timeout(unit: 'HOURS', time: 24) {
+                    input('Promote build?')
+                }
+            }
+            node('master') {
+                cleanWs()
+                project.pullFilesFromArch('build/dist/**/*.whl, build-sdist/dist/**/*.tar.gz', "${publishS3Dir}/dist")
 
-                    project.pullFilesFromArch('build/dist/**/*.whl, build-sdist/dist/**/*.tar.gz', "${publishS3Dir}/dist")
-                    unstash 'VERSION'
-                    sh "echo 'Stashed files:' && cd ${publishS3Dir} && find dist"
-
-                    def versionText = utilsLib.getCommandOutput("cat build/dist/VERSION.txt")
-
-                    final def publishPublicS3StageName = 'Publish to public S3'
-                    stage(publishPublicS3StageName) {
-                        dumpInfo()
-
-                        def targetFolder = S3_FOLDER_NIGHTLY
-                        if (isRelease()) {
-                            targetFolder = S3_FOLDER_STABLE
-                        }
-
-                        docker.withRegistry("https://docker.h2o.ai", "docker.h2o.ai") {
-                            withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: "awsArtifactsUploader"]]) {
-                                docker.image("docker.h2o.ai/s3cmd").inside {
-//                                    FIXME
-//                                    sh """
-//                                        ls
-//                                        s3cmd put -P ${publishS3Dir}/dist/*.whl s3://h2o-release/datatable/${targetFolder}/datatable-${versionText}/
-//                                        s3cmd put -P ${publishS3Dir}/dist/*.tar.gz s3://h2o-release/datatable/${targetFolder}/datatable-${versionText}/
-//                                    """
-                                }
+                // Building either master (nightly) or user has apporved the promotion, so upload to h2o-releases.
+                final def publishPublicS3StageName = 'Publish to public S3'
+                stage(publishPublicS3StageName) {
+                    dumpInfo()
+                    def targetFolder = S3_FOLDER_NIGHTLY
+                    if (isRelease()) {
+                        targetFolder = S3_FOLDER_STABLE
+                    }
+                    docker.withRegistry("https://docker.h2o.ai", "docker.h2o.ai") {
+                        withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: "awsArtifactsUploader"]]) {
+                            docker.image("docker.h2o.ai/s3cmd").inside {
+                                sh """
+                                    s3cmd put -P ${publishS3Dir}/dist/*.whl s3://h2o-release/datatable/${targetFolder}/datatable-${versionText}/
+                                    s3cmd put -P ${publishS3Dir}/dist/*.tar.gz s3://h2o-release/datatable/${targetFolder}/datatable-${versionText}/
+                                """
                             }
                         }
                     }
+                }
 
-//                    FIXME
-                    if (true) { //isRelease()) {
-                        node('master') {
-                            stage('GitHub Release') {
-                                cleanWs()
-                                dumpInfo()
-                                docker.withRegistry("https://docker.h2o.ai", "docker.h2o.ai") {
-                                    docker.image('docker.h2o.ai/opsh2oai/hub').inside("--init -v /home/jenkins/.ssh:/home/jenkins/.ssh:ro -v /home/jenkins/.gitconfig:/home/jenkins/.gitconfig:ro") {
-                                        withCredentials([string(credentialsId: 'h2o-ops-personal-auth-token', variable: 'GITHUB_TOKEN')]) {
-                                            project.pullFilesFromArch('build/dist/**/*.whl, build-sdist/dist/**/*.tar.gz', "${publishS3Dir}/dist")
-                                            final def releaseMsgFile = "${publishS3Dir}/release-msg.md"
-                                            dir (publishS3Dir) {
-                                                unstash 'CHANGELOG'
-                                            }
-                                            def currentChangelog = """${versionText}
+                // GitHub release should be created for rel-* biulds only (not for master build)
+                if (isRelease()) {
+                    stage('GitHub Release') {
+                        dumpInfo()
+                        dir(publishS3Dir) {
+                            checkout scm
+                            unstash 'CHANGELOG'
+                        }
+                        docker.withRegistry("https://docker.h2o.ai", "docker.h2o.ai") {
+                            docker.image('docker.h2o.ai/opsh2oai/hub').inside("--init -v /home/jenkins/.ssh:/home/jenkins/.ssh:ro -v /home/jenkins/.gitconfig:/home/jenkins/.gitconfig:ro") {
+                                withCredentials([string(credentialsId: 'h2o-ops-personal-auth-token', variable: 'GITHUB_TOKEN')]) {
+                                    final def releaseMsgFile = "release-msg.md"
+                                    def currentChangelog = """${versionText}
 
 ${project.getChangelogPartForVersion('0.4.0', "${publishS3Dir}/CHANGELOG.md")}
 ---
 ${project.getReleaseDownloadLinksText("${publishS3Dir}/dist", "https://h2o-release.s3.amazonaws.com/datatable/${S3_FOLDER_STABLE}/datatable-${versionText}")}
 """
-                                            writeFile(file: releaseMsgFile, text: currentChangelog)
-//                                            FIXME
-                                            sh "cat ${releaseMsgFile}"
-                                            sh "find ${publishS3Dir}/dist \\( -name '*.whl' -o -name '*.tar.gz' \\) -exec echo -a {} \\;"
-//                                            sh "hub release create -d \"v${versionText}\" -f ${releaseMsgFile} \$(find ${publishS3Dir}/dist \\( -name '*.whl' -o -name '*.tar.gz' \\) -exec echo -a {} \\;)"
-                                        }
-                                    }
+                                    writeFile(file: "${publishS3Dir}/${releaseMsgFile}", text: currentChangelog)
+                                    sh """
+                                        cd ${publishS3Dir}
+                                        hub release create -d -f ${releaseMsgFile} \$(find dist/ \\( -name '*.whl' -o -name '*.tar.gz' \\) -exec echo -a {} \\;) "v${versionText}" 
+                                    """
                                 }
                             }
                         }
-                    }
-                } else {
-                    final def publishPublicS3StageNameSkipped = "${publishPublicS3StageName} - SKIPPED"
-                    stage(publishPublicS3StageNameSkipped) {
-                        echo publishPublicS3StageNameSkipped
                     }
                 }
             }
@@ -355,6 +357,9 @@ ${project.getReleaseDownloadLinksText("${publishS3Dir}/dist", "https://h2o-relea
     }
 }
 
+//////////////////////
+// Helper functions //
+//////////////////////
 def uploadToS3(artifact, versionText, platformDir) {
     s3upDocker {
         localArtifact = artifact
@@ -455,9 +460,7 @@ def appendLargeTestsSuffixIfRequired(stageName, needsLargerTest) {
 }
 
 def doPublish() {
-//    FIXME
-//    return env.BRANCH_NAME == 'master' || isRelease()
-    return true
+    return env.BRANCH_NAME == 'master' || isRelease()
 }
 
 def isRelease() {

--- a/ci/Jenkinsfile2
+++ b/ci/Jenkinsfile2
@@ -108,6 +108,9 @@ def needsLargerTest
 SOURCE_DIR = "/home/0xdiag"
 TARGET_DIR = "/tmp/pydatatable_large_data"
 
+S3_FOLDER_NIGHTLY = 'nightly'
+S3_FOLDER_STABLE = 'stable'
+
 // Data map for linking into container
 def linkMap = [
         "Data"     : "h2oai-benchmarks/Data",
@@ -217,6 +220,8 @@ ansiColor('xterm') {
                     manager.addBadge("warning.gif", "Large tests required")
                 }
                 stash 'datatable-sources'
+                stash includes: "CHANGELOG.md", name: 'CHANGELOG'
+
                 docker.image(X86_64_LINUX_DOCKER_IMAGE).inside {
                     def dockerfileSHAsString = ""
                     EXPECTED_SHAS.files.each { filename, sha ->
@@ -269,34 +274,72 @@ ansiColor('xterm') {
                     def versionText = utilsLib.getCommandOutput("cat build/dist/VERSION.txt")
 
                     BUILD_MATRIX.each { platform, config ->
-                        uploadToS3("${publishS3Dir}/dist/*${project.getWheelPlatformName(platform)}*", versionText, project.getS3PlatformName(platform))
-                        uploadToS3("${publishS3Dir}/dist/*.tar.gz", versionText, project.getS3PlatformName(platform))
+//                        FIXME
+//                        uploadToS3("${publishS3Dir}/dist/*${project.getWheelPlatformName(platform)}*", versionText, project.getS3PlatformName(platform))
+//                        uploadToS3("${publishS3Dir}/dist/*.tar.gz", versionText, project.getS3PlatformName(platform))
                     }
                 }
 
-                if (params.PROMOTE) {
+//                FIXME
+                if (true) { //params.PROMOTE) {
+                    cleanWs()
+
+                    project.pullFilesFromArch('build/dist/**/*.whl, build-sdist/dist/**/*.tar.gz', "${publishS3Dir}/dist")
+                    unstash 'VERSION'
+                    sh "echo 'Stashed files:' && cd ${publishS3Dir} && find dist"
+
+                    def versionText = utilsLib.getCommandOutput("cat build/dist/VERSION.txt")
+
                     final def publishPublicS3StageName = 'Publish to public S3'
                     stage(publishPublicS3StageName) {
-                        cleanWs()
                         dumpInfo()
 
-                        def targetFolder = 'nightly'
+                        def targetFolder = S3_FOLDER_NIGHTLY
                         if (isRelease()) {
-                            targetFolder = 'stable'
+                            targetFolder = S3_FOLDER_STABLE
                         }
 
                         docker.withRegistry("https://docker.h2o.ai", "docker.h2o.ai") {
                             withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: "awsArtifactsUploader"]]) {
                                 docker.image("docker.h2o.ai/s3cmd").inside {
-                                    project.pullFilesFromArch('build/dist/**/*.whl, build-sdist/dist/**/*.tar.gz', "${publishS3Dir}/dist")
-                                    unstash 'VERSION'
-                                    sh "echo 'Stashed files:' && cd ${publishS3Dir} && find dist"
-                                    def versionText = utilsLib.getCommandOutput("cat build/dist/VERSION.txt")
-                                    sh """
-                                        ls
-                                        s3cmd put -P ${publishS3Dir}/dist/*.whl s3://h2o-release/datatable/${targetFolder}/datatable-${versionText}/
-                                        s3cmd put -P ${publishS3Dir}/dist/*.tar.gz s3://h2o-release/datatable/${targetFolder}/datatable-${versionText}/
-                                    """
+//                                    FIXME
+//                                    sh """
+//                                        ls
+//                                        s3cmd put -P ${publishS3Dir}/dist/*.whl s3://h2o-release/datatable/${targetFolder}/datatable-${versionText}/
+//                                        s3cmd put -P ${publishS3Dir}/dist/*.tar.gz s3://h2o-release/datatable/${targetFolder}/datatable-${versionText}/
+//                                    """
+                                }
+                            }
+                        }
+                    }
+
+//                    FIXME
+                    if (true) { //isRelease()) {
+                        node('master') {
+                            stage('GitHub Release') {
+                                cleanWs()
+                                dumpInfo()
+                                docker.withRegistry("https://docker.h2o.ai", "docker.h2o.ai") {
+                                    docker.image('docker.h2o.ai/opsh2oai/hub').inside("--init -v /home/jenkins/.ssh:/home/jenkins/.ssh:ro -v /home/jenkins/.gitconfig:/home/jenkins/.gitconfig:ro") {
+                                        withCredentials([string(credentialsId: 'h2o-ops-personal-auth-token', variable: 'GITHUB_TOKEN')]) {
+                                            project.pullFilesFromArch('build/dist/**/*.whl, build-sdist/dist/**/*.tar.gz', "${publishS3Dir}/dist")
+                                            final def releaseMsgFile = "${publishS3Dir}/release-msg.md"
+                                            dir (publishS3Dir) {
+                                                unstash 'CHANGELOG'
+                                            }
+                                            def currentChangelog = """${versionText}
+
+${project.getChangelogPartForVersion('0.4.0', "${publishS3Dir}/CHANGELOG.md")}
+---
+${project.getReleaseDownloadLinksText("${publishS3Dir}/dist", "https://h2o-release.s3.amazonaws.com/datatable/${S3_FOLDER_STABLE}/datatable-${versionText}")}
+"""
+                                            writeFile(file: releaseMsgFile, text: currentChangelog)
+//                                            FIXME
+                                            sh "cat ${releaseMsgFile}"
+                                            sh "find ${publishS3Dir}/dist \\( -name '*.whl' -o -name '*.tar.gz' \\) -exec echo -a {} \\;"
+//                                            sh "hub release create -d \"v${versionText}\" -f ${releaseMsgFile} \$(find ${publishS3Dir}/dist \\( -name '*.whl' -o -name '*.tar.gz' \\) -exec echo -a {} \\;)"
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -412,7 +455,9 @@ def appendLargeTestsSuffixIfRequired(stageName, needsLargerTest) {
 }
 
 def doPublish() {
-    return env.BRANCH_NAME == 'master' || isRelease()
+//    FIXME
+//    return env.BRANCH_NAME == 'master' || isRelease()
+    return true
 }
 
 def isRelease() {

--- a/ci/Jenkinsfile2
+++ b/ci/Jenkinsfile2
@@ -18,6 +18,8 @@ properties([
 RELEASE_BRANCH_PREFIX = 'rel-'
 
 CREDS_ID = 'h2o-ops-personal-auth-token'
+GITCONFIG_CRED_ID = 'master-gitconfig'
+RSA_CRED_ID = 'master-id-rsa'
 
 def DOCKER_IMAGE_TAG = '0.3.2-PR-996.3'
 
@@ -329,8 +331,8 @@ ansiColor('xterm') {
                     stage('GitHub Release') {
                         dumpInfo()
                         docker.withRegistry("https://docker.h2o.ai", "docker.h2o.ai") {
-                            docker.image('docker.h2o.ai/opsh2oai/hub').inside("--init -v /home/jenkins/.ssh:/home/jenkins/.ssh:ro -v /home/jenkins/.gitconfig:/home/jenkins/.gitconfig:ro") {
-                                withCredentials([string(credentialsId: CREDS_ID, variable: 'GITHUB_TOKEN')]) {
+                            docker.image('docker.h2o.ai/opsh2oai/hub').inside("--init") {
+                                withCredentials([file(credentialsId: RSA_CRED_ID, variable: 'ID_RSA_PATH'), file(credentialsId: GITCONFIG_CRED_ID, variable: 'GITCONFIG_PATH'), string(credentialsId: CREDS_ID, variable: 'GITHUB_TOKEN')]) {
                                     final def releaseMsgFile = "release-msg.md"
                                     def releaseMsg = """v${versionText}
 
@@ -340,9 +342,13 @@ ${project.getReleaseDownloadLinksText("${publishS3Dir}/dist", "${getHTTPSTargetU
 """
                                     writeFile(file: "${publishS3Dir}/${releaseMsgFile}", text: releaseMsg)
                                     sh """
+                                        mkdir -p ~/.ssh
+                                        cp \${ID_RSA_PATH} ~/.ssh/id_rsa
+                                        cp \${GITCONFIG_PATH} ~/.gitconfig
                                         cd ${publishS3Dir}
-                                        hub release create -d -f ${releaseMsgFile} \$(find dist/ \\( -name '*.whl' -o -name '*.tar.gz' \\) -exec echo -a {} \\;) "v${versionText}" 
+                                        hub release create -f ${releaseMsgFile} \$(find dist/ \\( -name '*.whl' -o -name '*.tar.gz' \\) -exec echo -a {} \\;) "v${versionText}"
                                     """
+                                    echo readFile("${publishS3Dir}/${releaseMsgFile}")
                                 }
                             }
                         }

--- a/ci/Jenkinsfile2
+++ b/ci/Jenkinsfile2
@@ -274,29 +274,37 @@ ansiColor('xterm') {
                     }
                 }
 
-                stage('Publish to public S3') {
-                    cleanWs()
-                    dumpInfo()
+                if (params.PROMOTE) {
+                    final def publishPublicS3StageName = 'Publish to public S3'
+                    stage(publishPublicS3StageName) {
+                        cleanWs()
+                        dumpInfo()
 
-                    def targetFolder = 'nightly'
-                    if (isRelease()) {
-                        targetFolder = 'stable'
-                    }
+                        def targetFolder = 'nightly'
+                        if (isRelease()) {
+                            targetFolder = 'stable'
+                        }
 
-                    docker.withRegistry("https://docker.h2o.ai", "docker.h2o.ai") {
-                        withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: "awsArtifactsUploader"]]) {
-                            docker.image("docker.h2o.ai/s3cmd").inside {
-                                project.pullFilesFromArch('build/dist/**/*.whl, build-sdist/dist/**/*.tar.gz', "${publishS3Dir}/dist")
-                                unstash 'VERSION'
-                                sh "echo 'Stashed files:' && cd ${publishS3Dir} && find dist"
-                                def versionText = utilsLib.getCommandOutput("cat build/dist/VERSION.txt")
-                                sh """
-                                   ls
-                                   s3cmd put -P ${publishS3Dir}/dist/*.whl s3://h2o-release/datatable/${targetFolder}/datatable-${versionText}/
-                                   s3cmd put -P ${publishS3Dir}/dist/*.tar.gz s3://h2o-release/datatable/${targetFolder}/datatable-${versionText}/
-                               """
+                        docker.withRegistry("https://docker.h2o.ai", "docker.h2o.ai") {
+                            withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: "awsArtifactsUploader"]]) {
+                                docker.image("docker.h2o.ai/s3cmd").inside {
+                                    project.pullFilesFromArch('build/dist/**/*.whl, build-sdist/dist/**/*.tar.gz', "${publishS3Dir}/dist")
+                                    unstash 'VERSION'
+                                    sh "echo 'Stashed files:' && cd ${publishS3Dir} && find dist"
+                                    def versionText = utilsLib.getCommandOutput("cat build/dist/VERSION.txt")
+                                    sh """
+                                        ls
+                                        s3cmd put -P ${publishS3Dir}/dist/*.whl s3://h2o-release/datatable/${targetFolder}/datatable-${versionText}/
+                                        s3cmd put -P ${publishS3Dir}/dist/*.tar.gz s3://h2o-release/datatable/${targetFolder}/datatable-${versionText}/
+                                    """
+                                }
                             }
                         }
+                    }
+                } else {
+                    final def publishPublicS3StageNameSkipped = "${publishPublicS3StageName} - SKIPPED"
+                    stage(publishPublicS3StageNameSkipped) {
+                        echo publishPublicS3StageNameSkipped
                     }
                 }
             }

--- a/ci/Jenkinsfile2
+++ b/ci/Jenkinsfile2
@@ -112,7 +112,7 @@ TARGET_DIR = "/tmp/pydatatable_large_data"
 
 
 BUCKET = 'h2o-release'
-STABLE_FOLDER = 'datatable/stale'
+STABLE_FOLDER = 'datatable/stable'
 S3_URL_STABLE = "s3://${BUCKET}/${STABLE_FOLDER}"
 HTTPS_URL_STABLE = "https://${BUCKET}.s3.amazonaws.com/${STABLE_FOLDER}"
 

--- a/ci/Jenkinsfile2
+++ b/ci/Jenkinsfile2
@@ -328,7 +328,7 @@ ansiColor('xterm') {
                             docker.image('docker.h2o.ai/opsh2oai/hub').inside("--init -v /home/jenkins/.ssh:/home/jenkins/.ssh:ro -v /home/jenkins/.gitconfig:/home/jenkins/.gitconfig:ro") {
                                 withCredentials([string(credentialsId: 'h2o-ops-personal-auth-token', variable: 'GITHUB_TOKEN')]) {
                                     final def releaseMsgFile = "release-msg.md"
-                                    def releaseMsg = """${versionText}
+                                    def releaseMsg = """v${versionText}
 
 ${project.getChangelogPartForVersion(versionText, "${publishS3Dir}/CHANGELOG.md")}
 ---

--- a/ci/Jenkinsfile2
+++ b/ci/Jenkinsfile2
@@ -108,7 +108,6 @@ def needsLargerTest
 SOURCE_DIR = "/home/0xdiag"
 TARGET_DIR = "/tmp/pydatatable_large_data"
 
-S3_FOLDER_NIGHTLY = 'nightly'
 S3_FOLDER_STABLE = 'stable'
 
 // Data map for linking into container
@@ -293,56 +292,49 @@ ansiColor('xterm') {
                 }
             }
 
-            // We want to publish master builds automatically. For other branches (because doPublish() is true those
-            // might be only rel-* branches) we want user confirmation.
-            if (env.BRANCH_NAME != 'master') {
+            // If we are building rel-* branch, ask for user confirmation in order to promote this build. Given approval,
+            // artifacts will be copied to h2o-release and a GitHub release will be created.
+            if (isRelease()) {
                 timeout(unit: 'HOURS', time: 24) {
                     input('Promote build?')
                 }
-            }
-            node('master') {
-                cleanWs()
-                project.pullFilesFromArch('build/dist/**/*.whl, build-sdist/dist/**/*.tar.gz', "${publishS3Dir}/dist")
-
-                // Building either master (nightly) or user has apporved the promotion, so upload to h2o-releases.
-                final def publishPublicS3StageName = 'Publish to public S3'
-                stage(publishPublicS3StageName) {
-                    dumpInfo()
-                    def targetFolder = S3_FOLDER_NIGHTLY
-                    if (isRelease()) {
-                        targetFolder = S3_FOLDER_STABLE
+                node('master') {
+                    cleanWs()
+                    // git repository and CHANGELOG.md must be present in order to create GitHub Release
+                    dir(publishS3Dir) {
+                        checkout scm
+                        unstash 'CHANGELOG'
                     }
-                    docker.withRegistry("https://docker.h2o.ai", "docker.h2o.ai") {
-                        withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: "awsArtifactsUploader"]]) {
-                            docker.image("docker.h2o.ai/s3cmd").inside {
-                                sh """
-                                    s3cmd put -P ${publishS3Dir}/dist/*.whl s3://h2o-release/datatable/${targetFolder}/datatable-${versionText}/
-                                    s3cmd put -P ${publishS3Dir}/dist/*.tar.gz s3://h2o-release/datatable/${targetFolder}/datatable-${versionText}/
-                                """
+                    project.pullFilesFromArch('build/dist/**/*.whl, build-sdist/dist/**/*.tar.gz', "${publishS3Dir}/dist")
+
+                    final def publishPublicS3StageName = 'Publish to public S3'
+                    stage(publishPublicS3StageName) {
+                        dumpInfo()
+                        docker.withRegistry("https://docker.h2o.ai", "docker.h2o.ai") {
+                            withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: "awsArtifactsUploader"]]) {
+                                docker.image("docker.h2o.ai/s3cmd").inside {
+                                    sh """
+                                        s3cmd put -P ${publishS3Dir}/dist/*.whl s3://h2o-release/datatable/${S3_FOLDER_STABLE}/datatable-${versionText}/
+                                        s3cmd put -P ${publishS3Dir}/dist/*.tar.gz s3://h2o-release/datatable/${S3_FOLDER_STABLE}/datatable-${versionText}/
+                                    """
+                                }
                             }
                         }
                     }
-                }
 
-                // GitHub release should be created for rel-* biulds only (not for master build)
-                if (isRelease()) {
                     stage('GitHub Release') {
                         dumpInfo()
-                        dir(publishS3Dir) {
-                            checkout scm
-                            unstash 'CHANGELOG'
-                        }
                         docker.withRegistry("https://docker.h2o.ai", "docker.h2o.ai") {
                             docker.image('docker.h2o.ai/opsh2oai/hub').inside("--init -v /home/jenkins/.ssh:/home/jenkins/.ssh:ro -v /home/jenkins/.gitconfig:/home/jenkins/.gitconfig:ro") {
                                 withCredentials([string(credentialsId: 'h2o-ops-personal-auth-token', variable: 'GITHUB_TOKEN')]) {
                                     final def releaseMsgFile = "release-msg.md"
-                                    def currentChangelog = """${versionText}
+                                    def releaseMsg = """${versionText}
 
-${project.getChangelogPartForVersion('0.4.0', "${publishS3Dir}/CHANGELOG.md")}
+${project.getChangelogPartForVersion(versionText, "${publishS3Dir}/CHANGELOG.md")}
 ---
 ${project.getReleaseDownloadLinksText("${publishS3Dir}/dist", "https://h2o-release.s3.amazonaws.com/datatable/${S3_FOLDER_STABLE}/datatable-${versionText}")}
 """
-                                    writeFile(file: "${publishS3Dir}/${releaseMsgFile}", text: currentChangelog)
+                                    writeFile(file: "${publishS3Dir}/${releaseMsgFile}", text: releaseMsg)
                                     sh """
                                         cd ${publishS3Dir}
                                         hub release create -d -f ${releaseMsgFile} \$(find dist/ \\( -name '*.whl' -o -name '*.tar.gz' \\) -exec echo -a {} \\;) "v${versionText}" 

--- a/ci/default.groovy
+++ b/ci/default.groovy
@@ -174,9 +174,5 @@ def getReleaseDownloadLinksText(final folder, final s3PathPrefix) {
 
 }
 
-def getReleaseBucket(final targetFolder, final versionText) {
-    return "s3://h2o-release/datatable/${targetFolder}/datatable-${versionText}/"
-}
-
 return this
 


### PR DESCRIPTION
Closes #1016.

Flow of the pipeline is now following (nothing is changed for PRs):

1. Initialization
2. Build, Coverage and Test all platforms
3. If we are building `master` or `rel-*` branch then publish to `artifacts.h2o.ai`
    1. ~If building `master`, publish to `h2o-release` under `nightly`~. Nightly builds are uploaded to `artifacts.h2o.ai` only.
    2. If building other branch, ask for user approval, if granted, then publish to `h2o-release` under `stable` and create a GitHub release.
