### PR TITLE
Fread now recognizes quoted NA strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 #### Fixed
 - Ensure that fread only emits messages to Python from the master thread.
+- Fread can now properly recognize quoted NA strings.
 
 
 ### [v0.4.0](https://github.com/h2oai/datatable/compare/0.4.0...v0.3.2) — 2018-05-07

--- a/c/csv/reader.cc
+++ b/c/csv/reader.cc
@@ -107,11 +107,8 @@ void GenericReader::init_nthreads() {
       nthreads = config::nthreads;
       trace("Using default %d thread%s", nthreads, (nthreads==1? "" : "s"));
     } else {
-      nthreads = nth;
-      int32_t maxth = omp_get_max_threads();
-      if (nthreads > maxth) nthreads = maxth;
-      if (nthreads <= 0) nthreads += maxth;
-      if (nthreads <= 0) nthreads = 1;
+      nthreads = config::normalize_nthreads(nth);
+      int maxth = config::normalize_nthreads(0);
       trace("Using %d thread%s (requested=%d, max.available=%d)",
             nthreads, (nthreads==1? "" : "s"), nth, maxth);
     }

--- a/c/csv/reader_parsers.cc
+++ b/c/csv/reader_parsers.cc
@@ -680,8 +680,14 @@ void parse_string(FreadTokenizer& ctx) {
   default:
     return;  // Internal error: undefined quote rule
   }
-  ctx.target->str32.length = (int32_t)(ch - fieldStart);
-  ctx.target->str32.offset = (int32_t)(fieldStart - ctx.anchor);
+  int32_t fieldLen = static_cast<int32_t>(ch - fieldStart);
+  if (fieldLen ? ctx.end_NA_string(fieldStart)==ch : ctx.blank_is_na) {
+    // TODO - speed up by avoiding end_NA_string when there are none
+    ctx.target->str32.setna();
+  } else {
+    ctx.target->str32.length = fieldLen;
+    ctx.target->str32.offset = static_cast<int32_t>(fieldStart - ctx.anchor);
+  }
   if (*ch==quote) {
     ctx.ch = ch + 1;
     ctx.skip_whitespace();

--- a/c/options.cc
+++ b/c/options.cc
@@ -26,7 +26,7 @@ int32_t sort_nthreads = 1;
 bool fread_anonymize = false;
 
 
-static int32_t normalize_nthreads(int32_t nth) {
+int32_t normalize_nthreads(int32_t nth) {
   // Initialize `max_threads` only once, on the first run. This is because we
   // use `omp_set_num_threads` below, and once it was used,
   // `omp_get_max_threads` will return that number, and we won't be able to

--- a/c/options.h
+++ b/c/options.h
@@ -22,6 +22,7 @@ extern int8_t sort_over_radix_bits;
 extern int32_t sort_nthreads;
 extern bool fread_anonymize;
 
+int32_t normalize_nthreads(int32_t nth);
 void set_nthreads(int32_t n);
 void set_core_logger(PyObject*);
 void set_sort_insert_method_threshold(int64_t n);

--- a/tests/fread/test_fread_random.py
+++ b/tests/fread/test_fread_random.py
@@ -72,6 +72,9 @@ def test_fread_omnibus(seed):
         assert len(coldata) == nrows
         if coltype != dt.ltype.int and all(is_intlike(x) for x in coldata):
             coltype = dt.ltype.int
+        if (coltype not in [dt.ltype.real, dt.ltype.int] and
+                all(is_reallike(x) for x in coldata)):
+            coltype = dt.ltype.real
         # Check 'bool' last, since ['0', '1'] is both int-like and bool-like
         if coltype != dt.ltype.bool and all_boollike(coldata):
             coltype = dt.ltype.bool
@@ -145,13 +148,21 @@ def all_boollike(coldata):
 
 
 def is_intlike(x):
-    x = x.strip()
+    x = x.strip().strip('"\'')
     return (x.isdigit() or
             (len(x) > 2 and x[0] == x[-1] and x[0] in "'\"" and
                                x[1:-1].isdigit()) or
             x == "" or
             x == '""' or
             x == "''")
+
+def is_reallike(x):
+    x = x.strip().strip('"\'')
+    try:
+        float(x)
+        return True
+    except:
+        return False
 
 
 def generate_int_column(allparams):

--- a/tests/fread/test_fread_small.py
+++ b/tests/fread/test_fread_small.py
@@ -698,6 +698,18 @@ def test_whitespace_nas():
                              [2.3, 1, None, 0]]
 
 
+def test_quoted_na_strings():
+    # Check that na strings are recognized regardless from whether they
+    # were quoted or not. See issue #1014
+    d0 = dt.fread('A,   B,   C\n'
+                  'foo, bar, caw\n'
+                  'nan, inf, "inf"\n', na_strings=["nan", "inf"])
+    assert d0.internal.check()
+    assert d0.names == ("A", "B", "C")
+    assert d0.ltypes == (dt.ltype.str,) * 3
+    assert d0.topython() == [["foo", None], ["bar", None], ["caw", None]]
+
+
 def test_clashing_column_names():
     # there should be no warning; and first column should be C2
     d0 = dt.fread("""C2\n1,2,3,4,5,6,7\n""")
@@ -736,7 +748,7 @@ def test_nuls2():
                              ["ba\0r", "beta\0", "delta"]]
 
 def test_nuls3():
-    lines = ["%02d,%d,%d\0" % (i, i % 3, 20-i) for i in range(10)]
+    lines = ["%02d,%d,%d\0" % (i, i % 3, 20 - i) for i in range(10)]
     src = "\n".join(["a,b,c"] + lines + [""])
     d0 = dt.fread(src, verbose=True)
     assert d0.internal.check()


### PR DESCRIPTION
Note that this change also makes it unnecessary to supply quoted the na strings
```
>>> dt.fread("c1,c2,c3\n"
             "a,b,c\n"
             'nan,inf,"inf"', na_strings=['inf', 'nan'])
     c1  c2  c3
---  --  --  --
 0   a   b   c 
 1             

[2 rows x 3 columns]
```

Closes #1014