### PR TITLE
MemoryMapManager fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Ensure that fread only emits messages to Python from the master thread.
 - Fread can now properly recognize quoted NA strings.
 - Fixed error when unbounded f-expressions were printed to console.
+- Fixed problems when operating with too many memory-mapped Frames at once.
 
 
 ### [v0.4.0](https://github.com/h2oai/datatable/compare/0.4.0...v0.3.2) — 2018-05-07

--- a/Makefile
+++ b/Makefile
@@ -641,7 +641,7 @@ $(BUILDDIR)/memrange.o : c/memrange.cc $(BUILDDIR)/datatable_check.h $(BUILDDIR)
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/mmm.o : c/mmm.cc $(BUILDDIR)/mmm.h
+$(BUILDDIR)/mmm.o : c/mmm.cc $(BUILDDIR)/mmm.h $(BUILDDIR)/utils/assert.h $(BUILDDIR)/utils/exceptions.h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 

--- a/c/memrange.cc
+++ b/c/memrange.cc
@@ -898,6 +898,7 @@
   }
 
   void MmapMRI::evict() {
+    mmm_index = 0;  // prevent from sending del_entry() signal back
     memunmap();
     xassert(!mapped && !mmm_index);
   }

--- a/c/mmm.cc
+++ b/c/mmm.cc
@@ -48,15 +48,23 @@ void MemoryMapManager::del_entry(size_t i, MemoryMapWorker* obj) {
 
 
 void MemoryMapManager::freeup_memory() {
+  size_t size0 = entries.size();
+  xassert(size0 > 0);
   // Sort the entries by size in descending order
   sort_entries();
+  size_t size1 = entries.size();
+  xassert(size1 == size0);
   // Evict the entries at the top of the array
   for (size_t j = 0; j < n_entries_to_purge; ++j) {
     if (entries.size() <= 1) break;
     entries.back().obj->evict();
+    size_t s = entries.size();
+    xassert(s == size0 - j);
     entries.pop_back();
   }
-  xassert(!entries.empty());
+  size_t size2 = entries.size();
+  xassert(size2 > 0);
+  xassert(size2 < size1 || (size2 == 1 && size1 == 1));
 }
 
 

--- a/c/mmm.h
+++ b/c/mmm.h
@@ -22,19 +22,23 @@ class MmmEntry {
 public:
   size_t size;
   MemoryMapWorker* obj;
+
+  MmmEntry() : size(0), obj(nullptr) {}
+  MmmEntry(size_t s , MemoryMapWorker* o) : size(s), obj(o) {}
+  ~MmmEntry() { size = 0; obj = nullptr; }
+  bool operator<(const MmmEntry& rhs) const { return size > rhs.size; }
 };
 
 
 class MemoryMapManager {
   std::vector<MmmEntry> entries;  // 0th entry always remains empty.
-  size_t count;  // Number of items currently in the `entries` array.
-                 // The entries are at indices 1 .. count
 
 public:
   static MemoryMapManager* get();
   void add_entry(MemoryMapWorker* obj, size_t size);
-  void del_entry(size_t i);
+  void del_entry(size_t i, MemoryMapWorker* obj);
   void freeup_memory();
+  bool check(size_t i, MemoryMapWorker* obj) { return entries[i].obj == obj; }
 
 private:
   static const size_t n_entries_to_purge = 128;

--- a/c/mmm.h
+++ b/c/mmm.h
@@ -5,8 +5,8 @@
 //
 // © H2O.ai 2018
 //------------------------------------------------------------------------------
-#ifndef dt_MMM_H
-#define dt_MMM_H
+#ifndef dt_MMM_h
+#define dt_MMM_h
 #include <vector>
 
 
@@ -36,9 +36,9 @@ class MemoryMapManager {
 public:
   static MemoryMapManager* get();
   void add_entry(MemoryMapWorker* obj, size_t size);
-  void del_entry(size_t i, MemoryMapWorker* obj);
+  void del_entry(size_t i);
   void freeup_memory();
-  bool check(size_t i, MemoryMapWorker* obj) { return entries[i].obj == obj; }
+  bool check_entry(size_t i, const MemoryMapWorker* obj);
 
 private:
   static const size_t n_entries_to_purge = 128;


### PR DESCRIPTION
It appears there were multiple problems with memory-mapped objects, which all decided to manifest in this test case. How convenient. Here's the list of fixes:
- If `errno 12` was raised 3 times in a row even after we attempt to free up the resources, the code was not raising any error but instead proceeded as if memory map was done successfully. Later on an attempt to read/write to such data pointer was causing a crash.
- `MmapMRI::memunmap` was not working properly for 0-size files.
- The eviction logic in `MemoryMapManager` was accidentally removing two last entries from the list of memory maps instead of one, which means that (a) later on evictions were performed on wrong objects; (b) some of the tracked memory maps were "lost" by the MemoryMapManager and could not be properly evicted when the system ran into "too many open memory maps" error.
- In `MemoryMapManager::sort_entries()` the comparator function used `>=` instead of `>`, which caused `std::sort` go into infinite loop when having equal elements.
- In `MemoryMapManager::sort_entries()` the indices of the objects were not updated properly on the worker objects after sorting, which resulted in wrong objects being evicted, and possibly memory corruption.

In addition,
- Simplified API of `MemoryMapManager`, now it uses more idiomatic C++.
- Added integrity checks for `MmapMRI` class.

Closes #1052 
Closes https://github.com/h2oai/h2oai/issues/3449