### PR TITLE
Implement proper compilation with AddressSanitizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ microbench/fread/fread
 
 # Auto-generated files
 datatable/__git__.py
+.asan/

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ all:
 
 
 clean::
+	rm -rf .asan
 	rm -rf .cache
 	rm -rf .eggs
 	rm -rf build
@@ -58,7 +59,6 @@ test_install:
 
 
 test:
-	$(MAKE) test_install
 	rm -rf build/test-reports 2>/dev/null
 	mkdir -p build/test-reports/
 	$(PYTHON) -m pytest -ra --maxfail=10 $(PYTEST_FLAGS) \
@@ -77,11 +77,23 @@ debug:
 	$(MAKE) build
 	$(MAKE) install
 
-asan:
+
+# In order to run with Address Sanitizer:
+#	$ make clean
+#   $ make asan_env
+#   $ source .asan/bin/activate
+#   $ make asan
+#   $ make install
+#   $ make test
+# (note that `make test_install` doesn't work due to py-cpuinfo crashing
+# in Asan).
+
+asan_env:
 	$(MAKE) clean
-	DTASAN=1 \
-	$(MAKE) fast
-	$(MAKE) install
+	bash -x ci/asan-env.sh
+
+asan:
+	DTASAN=1 $(MAKE) fast
 
 bi:
 	$(MAKE) build

--- a/c/csv/reader.cc
+++ b/c/csv/reader.cc
@@ -704,7 +704,7 @@ DataTablePtr GenericReader::read_empty_input() {
 void GenericReader::detect_improper_files() {
   const char* ch = sof;  // dataptr();
   while (ch < eof && (*ch==' ' || *ch=='\t')) ch++;
-  if (std::memcmp(ch, "<!DOCTYPE html>", 15) == 0) {
+  if (ch + 15 < eof && std::memcmp(ch, "<!DOCTYPE html>", 15) == 0) {
     throw RuntimeError() << src_arg.as_cstring() << " is an HTML file. Please "
         << "open it in a browser and then save in a plain text format.";
   }

--- a/ci/asan-env.sh
+++ b/ci/asan-env.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+if [ ! -d ".asan" ]; then
+    PYVER=`python -c "import sys; print(sys.version[:3])"`
+    TARGET=".asan/lib/python$PYVER/site-packages"
+
+    virtualenv .asan --python=python$PYVER
+    echo -e "\nexport DT_ASAN_TARGETDIR=\"$TARGET\"\n" >> .asan/bin/activate
+
+    DT_ASAN_TARGETDIR=$TARGET \
+        python ci/asan-pip.py
+
+    LLVM="$LLVM4$LLVM5$LLVM6"
+    CC="$LLVM/bin/clang"
+    PYCONF="python$PYVER-config"
+    LDFLAGS="$LDFLAGS `$PYCONF --ldflags`"
+    CFLAGS="$CFLAGS `$PYCONF --cflags` -fsanitize=address"
+
+    DT_ASAN_TARGETDIR=$TARGET \
+        $CC $CFLAGS $LDFLAGS -o .asan/bin/mypython ci/asan-python.c
+
+    chmod +x .asan/bin/mypython
+    cp .asan/bin/mypython .asan/bin/python
+
+    source .asan/bin/activate
+    pip install colorama
+    pip install typesentry
+    pip install blessed
+    pip install llvmlite
+    pip install pytest
+    pip install pandas
+fi
+

--- a/ci/asan-pip.py
+++ b/ci/asan-pip.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+import os
+
+target = os.environ.get("DT_ASAN_TARGETDIR")
+
+text = """#!/usr/bin/env python
+import sys
+try:
+    from pip._internal import main
+except ImportError:
+    from pip import main
+
+if __name__ == "__main__":
+    sys.argv.append("--target=%s")
+    ret = main()
+    sys.exit(ret)
+""" % (target,)
+
+for root, dirs, files in os.walk(os.path.join(target, "..", "..", "..", "bin")):
+    for f in files:
+        if f.startswith("pip"):
+            with open(os.path.join(root, f), "w") as out:
+                out.write(text)

--- a/ci/asan-python.c
+++ b/ci/asan-python.c
@@ -1,0 +1,38 @@
+/*
+See: https://docs.python.org/3/extending/embedding.html
+
+$LLVM6/bin/clang \
+  -I/Library/Frameworks/Python.framework/Versions/3.6/include/python3.6m
+  -L/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/config-3.6m-darwin -lpython3.6m -ldl -framework CoreFoundation \
+  -fsanitize=address -o asan-python asan-python.c
+*/
+#include <Python.h>
+#include <dirent.h>
+
+int main(int argc, char** argv)
+{
+  wchar_t** wargv = malloc(sizeof(wchar_t*) * (argc + 1));
+  for (int i = 0; i < argc; ++i) {
+    wargv[i] = Py_DecodeLocale(argv[i], NULL);
+  }
+  wargv[argc] = NULL;
+
+  char* venv0 = getenv("DT_ASAN_TARGETDIR");
+  if (!venv0) {
+    fprintf(stderr, "Environment variable DT_ASAN_TARGETDIR is missing\n");
+    exit(1);
+  }
+  char* venv1 = realpath(venv0, NULL);
+
+  wchar_t* wpath0 = Py_GetPath();
+  char* pypath0 = malloc(wcslen(wpath0) + 1);
+  sprintf(pypath0, "%S", wpath0);
+
+  char* path = malloc(strlen(venv1) + strlen(pypath0) + 2);
+  sprintf(path, "%s:%s", venv1, pypath0);
+  wchar_t* wpath = Py_DecodeLocale(path, NULL);
+  Py_SetPath(wpath);
+
+  if (argc == 1) printf("[my-python: PATH=%s]\n", path);
+  return Py_Main(argc, wargv);
+}

--- a/ci/default.groovy
+++ b/ci/default.groovy
@@ -90,7 +90,8 @@ def test(stageDir, platform, venvCmd, extraEnv, invokeLargeTests, targetDataDir)
                 ${venvCmd}
                 pyVersion=\$(python --version 2>&1 | egrep -o '[0-9]\\.[0-9]' | tr -d '.')
                 pip install --no-cache-dir --upgrade `find dist -name "datatable-*cp\${pyVersion}*${getWheelPlatformName(platform)}*"`
-                make test MODULE=datatable
+                make test_install MODULE=datatable
+                make test
             """
         }
     } finally {

--- a/datatable/__init__.py
+++ b/datatable/__init__.py
@@ -10,12 +10,13 @@ from .__version__ import version as __version__
 from .dt_append import rbind, cbind
 from .frame import Frame
 from .expr import mean, min, max, sd, isna
-from .fread import fread, GenericReader
+from .fread import fread, GenericReader, FreadWarning
 from .nff import save, open
 from .options import options
 from .types import stype, ltype
 from .utils.typechecks import TTypeError as TypeError
 from .utils.typechecks import TValueError as ValueError
+from .utils.typechecks import DatatableWarning
 try:
     from .__git__ import __git_revision__
 except:
@@ -25,7 +26,8 @@ except:
 __all__ = ("__version__", "__git_revision__",
            "Frame", "max", "mean", "min", "open", "sd",
            "isna", "fread", "GenericReader", "save", "stype", "ltype", "f",
-           "TypeError", "ValueError", "DataTable", "options",
+           "TypeError", "ValueError", "DatatableWarning", "FreadWarning",
+           "DataTable", "options",
            "bool8", "int8", "int16", "int32", "int64",
            "float32", "float64", "str32", "str64", "obj64",
            "cbind", "rbind")

--- a/tests/fread/test_fread_api.py
+++ b/tests/fread/test_fread_api.py
@@ -11,7 +11,7 @@
 import pytest
 import datatable as dt
 import os
-from datatable import ltype, stype
+from datatable import ltype, stype, DatatableWarning, FreadWarning
 
 
 
@@ -246,7 +246,7 @@ def test_fread_zip_file_multi(tempfile):
         zf.writestr("data1.csv", "a,b,c\nfoo,bar,baz\ngee,jou,sha\n")
         zf.writestr("data2.csv", "A,B,C\n3,4,5\n6,7,8\n")
         zf.writestr("data3.csv", "Aa,Bb,Cc\ntrue,1.5,\nfalse,1e+20,yay\n")
-    with pytest.warns(UserWarning) as ws:
+    with pytest.warns(FreadWarning) as ws:
         d0 = dt.fread(zfname)
         d1 = dt.fread(zfname + "/data2.csv")
         d2 = dt.fread(zfname + "/data3.csv")
@@ -456,7 +456,7 @@ def test_fread_columns_set1():
 
 
 def test_fread_columns_set2():
-    with pytest.warns(UserWarning) as ws:
+    with pytest.warns(DatatableWarning) as ws:
         d0 = dt.fread(text="A,B,A\n1,2,3\n", columns={"A"})
     assert d0.names == ("A", "A.1")
     assert d0.topython() == [[1], [3]]
@@ -465,7 +465,7 @@ def test_fread_columns_set2():
 
 
 def test_fread_columns_set_bad():
-    with pytest.warns(UserWarning) as ws:
+    with pytest.warns(FreadWarning) as ws:
         dt.fread(text="A,B,C\n1,2,3", columns={"A", "foo"})
     assert len(ws) == 1
     assert "Column(s) ['foo'] not found in the input" in ws[0].message.args[0]
@@ -595,7 +595,7 @@ def test_fread_skip_blank_lines_true():
 @pytest.mark.xfail()
 def test_fread_skip_blank_lines_false():
     inp = "A,B\n1,2\n  \n\n3,4\n"
-    with pytest.warns(UserWarning) as ws:
+    with pytest.warns(DatatableWarning) as ws:
         d1 = dt.fread(text=inp, skip_blank_lines=False)
         assert d1.internal.check()
         assert d1.shape == (1, 2)

--- a/tests/munging/test_dt_append.py
+++ b/tests/munging/test_dt_append.py
@@ -11,7 +11,7 @@ import pytest
 import types
 import datatable as dt
 from tests import assert_equals
-from datatable import stype
+from datatable import stype, DatatableWarning
 
 
 #-------------------------------------------------------------------------------
@@ -123,7 +123,7 @@ def test_not_inplace():
 
 def test_repeating_names():
     # Warnings about repeated names -- ignore
-    with pytest.warns(UserWarning):
+    with pytest.warns(DatatableWarning):
         dt0 = dt.Frame([[5], [6], [7], [4]], names=["x", "y", "x", "x"])
         dt1 = dt.Frame([[4], [3], [2]], names=["y", "x", "x"])
         dtr = dt.Frame([[5, 3], [6, 4], [7, 2], [4, None]],

--- a/tests/munging/test_dt_cbind.py
+++ b/tests/munging/test_dt_cbind.py
@@ -8,7 +8,7 @@ import pytest
 import types
 import datatable as dt
 from tests import assert_equals
-from datatable import stype
+from datatable import stype, DatatableWarning
 
 
 def dt_compute_stats(*dts):
@@ -36,7 +36,7 @@ def test_cbind_simple():
     d0 = dt.Frame([1, 2, 3])
     d1 = dt.Frame([4, 5, 6])
     dt_compute_stats(d0, d1)
-    with pytest.warns(UserWarning):
+    with pytest.warns(DatatableWarning):
         d0.cbind(d1)
     dr = dt.Frame([[1, 2, 3], [4, 5, 6]], names=["C0", "C1"])
     assert_equals(d0, dr)
@@ -59,7 +59,7 @@ def test_cbind_empty2():
 def test_cbind_self():
     d0 = dt.Frame({"fun": [1, 2, 3]})
     dt_compute_stats(d0)
-    with pytest.warns(UserWarning):
+    with pytest.warns(DatatableWarning):
         d0.cbind(d0).cbind(d0).cbind(d0)
     dr = dt.Frame([[1, 2, 3]] * 8,
                   names=["fun"] + ["fun.%d" % i for i in range(1, 8)])
@@ -90,7 +90,7 @@ def test_cbind_forced1():
     d0 = dt.Frame([1, 2, 3])
     d1 = dt.Frame([4, 5])
     dt_compute_stats(d0, d1)
-    with pytest.warns(UserWarning):
+    with pytest.warns(DatatableWarning):
         d0.cbind(d1, force=True)
     dr = dt.Frame([[1, 2, 3], [4, 5, None]], names=["C0", "C1"])
     assert_equals(d0, dr)

--- a/tests/test_dt_create.py
+++ b/tests/test_dt_create.py
@@ -11,7 +11,7 @@
 import math
 import pytest
 import datatable as dt
-from datatable import ltype, stype
+from datatable import ltype, stype, DatatableWarning
 from tests import same_iterables, list_equals, assert_equals
 
 
@@ -410,7 +410,7 @@ def test_issue_409():
 
 
 def test_duplicate_names1():
-    with pytest.warns(UserWarning) as ws:
+    with pytest.warns(DatatableWarning) as ws:
         d = dt.Frame([[1], [2], [3]], names=["A", "A", "A"])
         assert d.names == ("A", "A.1", "A.2")
     assert len(ws) == 1
@@ -418,7 +418,7 @@ def test_duplicate_names1():
 
 
 def test_duplicate_names2():
-    with pytest.warns(UserWarning):
+    with pytest.warns(DatatableWarning):
         d = dt.Frame([[1], [2], [3], [4]], names=("A", "A.1", "A", "A.2"))
         assert d.names == ("A", "A.1", "A.2", "A.3")
 

--- a/tests/test_nff.py
+++ b/tests/test_nff.py
@@ -8,6 +8,7 @@ import shutil
 import pytest
 import tempfile
 import datatable as dt
+from datatable import DatatableWarning
 from tests import assert_equals
 
 
@@ -59,7 +60,7 @@ def test_obj_columns(tempdir):
     assert d0.internal.check()
     assert d0.ltypes == (dt.ltype.int, dt.ltype.obj)
     assert d0.shape == (4, 2)
-    with pytest.warns(UserWarning) as ws:
+    with pytest.warns(DatatableWarning) as ws:
         d0.save(tempdir)
     assert len(ws) == 1
     assert "Column 'B' of type obj64 was not saved" in ws[0].message.args[0]


### PR DESCRIPTION
Running Asan on a Python extension module is challenging. In theory it should be possible, but [the documentation](https://github.com/google/sanitizers/wiki/AddressSanitizerAsDso) states "Use at your own risk". In practice, I wasn't successful at running Asan via `LD_PRELOAD` or `DYLD_INSERT_LIBRARIES` as suggested.

This PR uses a different approach: create a new executable that *embeds* Python (as described [in python docs](https://docs.python.org/3/extending/embedding.html)). This executable however will be compiled with static Asan support. Then I can use that executable as if it was "real" python, by installing it into a fresh virtual environment. 

Running `datatable` with Asan revealed a single instance of unsafe memory read, which this PR also fixes.
