### PR TITLE
Fread fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### [Unreleased](https://github.com/h2oai/datatable/compare/HEAD...v0.5.0)
+#### Added
+- fread will detect feather file and issue an appropriate error message.
+- when fread extracts data from archives into memory, it will now display
+  the size of the extracted data in verbose mode.
+
+#### Fixed
+- fread will no longer emit an error if there is an NA string in the header.
+- if the input contains excessively long lines, fread will no longer waste time
+  printing a sample of first 5 lines in verbose mode.
+- fixed wrong calculation of mean / standard deviation of line length in fread
+  if the sample contained broken lines.
 
 
 ### [v0.5.0](https://github.com/h2oai/datatable/compare/v0.5.0...v0.4.0) — 2018-05-25

--- a/c/csv/reader_fread.cc
+++ b/c/csv/reader_fread.cc
@@ -441,11 +441,10 @@ void FreadReader::detect_column_types()
         // know that the start is correct).
         if (j == 0) {
           chunkster.last_row_end = eof;
-          n_sample_lines--;
         } else {
           columns.setTypes(saved_types);
-          break;
         }
+        break;
       }
       n_sample_lines++;
       chunkster.last_row_end = tch;
@@ -708,7 +707,7 @@ void FreadReader::parse_column_names(FreadTokenizer& ctx) {
     if (i >= ncols) {
       columns.push_back(GReaderColumn());
     }
-    if (zlen > 0) {
+    if (ilen > 0) {
       const uint8_t* usrc = reinterpret_cast<const uint8_t*>(start);
       int res = check_escaped_string(usrc, zlen, echar);
       if (res == 0) {

--- a/datatable/fread.py
+++ b/datatable/fread.py
@@ -373,6 +373,8 @@ class GenericReader(object):
             if self._verbose:
                 self.logger.debug("Extracting %s into memory" % filename)
             self._text = zf.read()
+            if self._verbose:
+                self.logger.debug("Extracted: size = %d" % len(self._text))
 
         elif ext == ".bz2":
             import bz2
@@ -380,6 +382,8 @@ class GenericReader(object):
             if self._verbose:
                 self.logger.debug("Extracting %s into memory" % filename)
             self._text = zf.read()
+            if self._verbose:
+                self.logger.debug("Extracted: size = %d" % len(self._text))
 
         elif ext == ".xz":
             import lzma
@@ -387,6 +391,8 @@ class GenericReader(object):
             if self._verbose:
                 self.logger.debug("Extracting %s into memory" % filename)
             self._text = zf.read()
+            if self._verbose:
+                self.logger.debug("Extracted: size = %d" % len(self._text))
 
         elif ext == ".xlsx" or ext == ".xls":
             self._process_excel_file(filename)

--- a/tests/fread/test_fread_small.py
+++ b/tests/fread/test_fread_small.py
@@ -759,6 +759,15 @@ def test_nuls3():
                              ["%d\0" % i for i in range(20, 10, -1)]]
 
 
+def test_headers_with_na():
+    # Conceivably, this file can also be recognized as `header=False`, owing
+    # to the fact that there is an NA value in the first line.
+    d = dt.fread("A,B,NA\n"
+                 "1,2,3\n")
+    assert d.internal.check()
+    assert d.names == ("A", "B", "C0")
+    assert d.topython() == [[1], [2], [3]]
+
 
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
* fread will detect feather file and issue an appropriate error message.
* when fread extracts data from archives into memory, it will now display the size of the extracted data in verbose mode.
* fread will no longer emit an error if there is an NA string in the header.
* if the input contains excessively long lines, fread will no longer waste time printing a sample of first 5 lines in verbose mode.
* fixed wrong calculation of mean / standard deviation of line length in fread if the sample contained broken lines.

-----
Note that the core of the problem is that fread is not well-suited for ill-formed input files that contain hardly any newlines. Because fread needs to scan the first several lines multiple times, it may take very long time to finish. This PR sidesteps the issue by learning to recognize feather format files; however ultimately if another large binary file with almost no newlines is given, it would take a very long time to parse it.

Closes #1067