### PR TITLE
Work-around for python bug with PyStructSequence_InitType

### DIFF
--- a/c/csv/reader_utils.cc
+++ b/c/csv/reader_utils.cc
@@ -134,8 +134,9 @@ void GReaderColumn::init_nametypepytuple() {
   desc->n_in_sequence = 2;
   // Do not use PyStructSequence_NewType, because it is buggy
   // (see https://lists.gt.net/python/bugs/1320383)
-  NameTypePyTuple = new PyTypeObject;
-  PyStructSequence_InitType2(NameTypePyTuple, desc);
+  // The memory must also be cleared because https://bugs.python.org/issue33742
+  NameTypePyTuple = new PyTypeObject();
+  PyStructSequence_InitType(NameTypePyTuple, desc);
 
   // clean up
   delete[] fields;


### PR DESCRIPTION
This is a problem with the core Python, submitted an issue at python mailing list: https://bugs.python.org/issue33742
Luckily, it's easy to work around, so I'm implementing a local fix too.

Closes #1085