### PR TITLE
Memory handling code cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -299,6 +299,7 @@ fast_objects = $(addprefix $(BUILDDIR)/, \
 	stats.o                   \
 	types.o                   \
 	utils.o                   \
+	utils/alloc.o             \
 	utils/exceptions.o        \
 	utils/file.o              \
 	utils/pyobj.o             \
@@ -505,7 +506,11 @@ $(BUILDDIR)/python/string.h: c/python/string.h $(BUILDDIR)/utils/pyobj.h
 	@cp c/python/string.h $@
 
 
-$(BUILDDIR)/utils/array.h: c/utils/array.h $(BUILDDIR)/memrange.h $(BUILDDIR)/utils/exceptions.h
+$(BUILDDIR)/utils/alloc.h: c/utils/alloc.h
+	@echo • Refreshing c/utils/alloc.h
+	@cp c/utils/alloc.h $@
+
+$(BUILDDIR)/utils/array.h: c/utils/array.h $(BUILDDIR)/memrange.h $(BUILDDIR)/utils/alloc.h $(BUILDDIR)/utils/exceptions.h
 	@echo • Refreshing c/utils/array.h
 	@cp c/utils/array.h $@
 
@@ -563,7 +568,7 @@ $(BUILDDIR)/column_int.o : c/column_int.cc $(BUILDDIR)/column.h $(BUILDDIR)/csv/
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/column_pyobj.o : c/column_pyobj.cc $(BUILDDIR)/column.h $(BUILDDIR)/utils/assert.h $(BUILDDIR)/utils.h
+$(BUILDDIR)/column_pyobj.o : c/column_pyobj.cc $(BUILDDIR)/column.h $(BUILDDIR)/utils/assert.h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
@@ -575,7 +580,7 @@ $(BUILDDIR)/column_string.o : c/column_string.cc $(BUILDDIR)/column.h $(BUILDDIR
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/columnset.o : c/columnset.cc $(BUILDDIR)/columnset.h $(BUILDDIR)/utils.h $(BUILDDIR)/utils/exceptions.h
+$(BUILDDIR)/columnset.o : c/columnset.cc $(BUILDDIR)/columnset.h $(BUILDDIR)/utils.h $(BUILDDIR)/utils/alloc.h $(BUILDDIR)/utils/exceptions.h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
@@ -663,7 +668,7 @@ $(BUILDDIR)/groupby.o : c/groupby.cc $(BUILDDIR)/utils/exceptions.h $(BUILDDIR)/
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/memrange.o : c/memrange.cc $(BUILDDIR)/datatable_check.h $(BUILDDIR)/memrange.h $(BUILDDIR)/mmm.h $(BUILDDIR)/utils/exceptions.h
+$(BUILDDIR)/memrange.o : c/memrange.cc $(BUILDDIR)/datatable_check.h $(BUILDDIR)/memrange.h $(BUILDDIR)/mmm.h $(BUILDDIR)/utils/alloc.h $(BUILDDIR)/utils/exceptions.h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
@@ -747,7 +752,7 @@ $(BUILDDIR)/rowindex_slice.o : c/rowindex_slice.cc $(BUILDDIR)/datatable_check.h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/sort.o : c/sort.cc $(BUILDDIR)/column.h $(BUILDDIR)/datatable.h $(BUILDDIR)/options.h $(BUILDDIR)/rowindex.h $(BUILDDIR)/sort.h $(BUILDDIR)/types.h $(BUILDDIR)/utils.h $(BUILDDIR)/utils/array.h $(BUILDDIR)/utils/assert.h $(BUILDDIR)/utils/omp.h
+$(BUILDDIR)/sort.o : c/sort.cc $(BUILDDIR)/column.h $(BUILDDIR)/datatable.h $(BUILDDIR)/options.h $(BUILDDIR)/rowindex.h $(BUILDDIR)/sort.h $(BUILDDIR)/types.h $(BUILDDIR)/utils.h $(BUILDDIR)/utils/alloc.h $(BUILDDIR)/utils/array.h $(BUILDDIR)/utils/assert.h $(BUILDDIR)/utils/omp.h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
@@ -771,6 +776,10 @@ $(BUILDDIR)/utils.o : c/utils.c $(BUILDDIR)/utils.h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
+$(BUILDDIR)/utils/alloc.o : c/utils/alloc.cc $(BUILDDIR)/utils/alloc.h $(BUILDDIR)/mmm.h $(BUILDDIR)/utils/exceptions.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
 $(BUILDDIR)/utils/exceptions.o : c/utils/exceptions.cc $(BUILDDIR)/utils/exceptions.h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
@@ -783,6 +792,6 @@ $(BUILDDIR)/utils/pyobj.o : c/utils/pyobj.cc $(BUILDDIR)/py_column.h $(BUILDDIR)
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/writebuf.o : c/writebuf.cc $(BUILDDIR)/memrange.h $(BUILDDIR)/utils.h $(BUILDDIR)/utils/assert.h $(BUILDDIR)/utils/omp.h $(BUILDDIR)/writebuf.h
+$(BUILDDIR)/writebuf.o : c/writebuf.cc $(BUILDDIR)/memrange.h $(BUILDDIR)/utils.h $(BUILDDIR)/utils/alloc.h $(BUILDDIR)/utils/assert.h $(BUILDDIR)/utils/omp.h $(BUILDDIR)/writebuf.h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@

--- a/Makefile
+++ b/Makefile
@@ -435,7 +435,7 @@ $(BUILDDIR)/utils.h: c/utils.h $(BUILDDIR)/utils/exceptions.h
 	@echo • Refreshing c/utils.h
 	@cp c/utils.h $@
 
-$(BUILDDIR)/writebuf.h: c/writebuf.h $(BUILDDIR)/utils/file.h
+$(BUILDDIR)/writebuf.h: c/writebuf.h $(BUILDDIR)/utils/file.h $(BUILDDIR)/utils/shared_mutex.h
 	@echo • Refreshing c/writebuf.h
 	@cp c/writebuf.h $@
 

--- a/c/column_pyobj.cc
+++ b/c/column_pyobj.cc
@@ -6,7 +6,6 @@
 // © H2O.ai 2018
 //------------------------------------------------------------------------------
 #include "column.h"
-#include "utils.h"          // set_value, add_ptr
 #include "utils/assert.h"
 
 

--- a/c/columnset.cc
+++ b/c/columnset.cc
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include "utils.h"
+#include "utils/alloc.h"
 #include "utils/exceptions.h"
 
 
@@ -28,8 +29,7 @@ Column** columns_from_slice(DataTable* dt, const RowIndex& rowindex,
   }
 
   Column** srccols = dt->columns;
-  Column** columns = nullptr;
-  dtmalloc(columns, Column*, count + 1);
+  Column** columns = dt::amalloc<Column*>(count + 1);
   columns[count] = nullptr;
 
   for (int64_t i = 0, j = start; i < count; i++, j += step) {
@@ -50,8 +50,7 @@ Column** columns_from_array(DataTable* dt, const RowIndex& rowindex,
   if (!dt) return nullptr;
   if (!indices && ncols) return nullptr;
   Column** srccols = dt->columns;
-  Column** columns = nullptr;
-  dtmalloc(columns, Column*, ncols + 1);
+  Column** columns = dt::amalloc<Column*>(ncols + 1);
   columns[ncols] = nullptr;
 
   for (int64_t i = 0; i < ncols; i++) {
@@ -99,13 +98,15 @@ Column** columns_from_mixed(
   for (int64_t i = 0; i < ncols; i++) {
     ncomputedcols += (spec[i] < 0);
   }
-  if (dt == nullptr && ncomputedcols < ncols) dterrr0("Missing DataTable");
-  if (ncomputedcols == 0) dterrr0("Num computed columns = 0");
+  if (dt == nullptr && ncomputedcols < ncols) {
+    throw RuntimeError() << "Missing DataTable";
+  }
+  if (ncomputedcols == 0) {
+    throw ValueError() << "Num computed columns = 0";
+  }
 
-  void** out = nullptr;
-  Column** columns = nullptr;
-  dtmalloc(out, void*, ncomputedcols);
-  dtmalloc(columns, Column*, ncols + 1);
+  void** out = dt::amalloc<void*>(ncomputedcols);
+  Column** columns = dt::amalloc<Column*>(ncols + 1);
   columns[ncols] = nullptr;
 
   int64_t j = 0;

--- a/c/datatable.cc
+++ b/c/datatable.cc
@@ -43,13 +43,13 @@ DataTable::DataTable(Column** cols)
 
 
 
-DataTable* DataTable::delete_columns(int *cols_to_remove, int n)
+DataTable* DataTable::delete_columns(int *cols_to_remove, int64_t n)
 {
   if (n == 0) return this;
   qsort(cols_to_remove, (size_t)n, sizeof(int), _compare_ints);
   int j = 0;
   int next_col_to_remove = cols_to_remove[0];
-  int k = 0;
+  int64_t k = 0;
   for (int i = 0; i < ncols; ++i) {
     if (i == next_col_to_remove) {
       delete columns[i];

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -61,14 +61,14 @@ class DataTable {
   public:
     DataTable(Column**);
     ~DataTable();
-    DataTable* delete_columns(int*, int);
+    DataTable* delete_columns(int*, int64_t);
     void resize_rows(int64_t n);
     void apply_na_mask(DataTable* mask);
     void replace_rowindex(const RowIndex& newri);
     void replace_groupby(const Groupby& newgb);
     void reify();
-    void rbind(DataTable**, int**, int, int64_t);
-    DataTable* cbind(DataTable**, int);
+    void rbind(DataTable**, int**, int64_t, int64_t);
+    DataTable* cbind(DataTable**, int64_t);
     size_t memory_footprint();
 
     /**

--- a/c/datatable_cbind.cc
+++ b/c/datatable_cbind.cc
@@ -16,11 +16,11 @@
  * it will be filled with NAs; with the exception of 1-row datatables which will
  * be expanded to the desired height by duplicating that row.
  */
-DataTable* DataTable::cbind(DataTable **dts, int ndts)
+DataTable* DataTable::cbind(DataTable **dts, int64_t ndts)
 {
     int64_t t_ncols = ncols;
     int64_t t_nrows = nrows;
-    for (int i = 0; i < ndts; ++i) {
+    for (int64_t i = 0; i < ndts; ++i) {
         t_ncols += dts[i]->ncols;
         if (t_nrows < dts[i]->nrows) t_nrows = dts[i]->nrows;
     }
@@ -37,10 +37,10 @@ DataTable* DataTable::cbind(DataTable **dts, int ndts)
     }
 
     // Append columns from `dts` into the "main" datatable
-    dtrealloc(columns, Column*, t_ncols + 1);
+    columns = dt::arealloc(columns, t_ncols + 1);
     columns[t_ncols] = nullptr;
     int64_t j = ncols;
-    for (int i = 0; i < ndts; ++i) {
+    for (int64_t i = 0; i < ndts; ++i) {
         int64_t ncolsi = dts[i]->ncols;
         int64_t nrowsi = dts[i]->nrows;
         for (int64_t ii = 0; ii < ncolsi; ++ii) {

--- a/c/datatable_load.cc
+++ b/c/datatable_load.cc
@@ -27,8 +27,7 @@
 DataTable* DataTable::load(DataTable* colspec, int64_t nrows, const std::string& path)
 {
     int64_t ncols = colspec->nrows;
-    Column** columns = nullptr;
-    dtmalloc(columns, Column*, ncols + 1);
+    Column** columns = dt::amalloc<Column*>(ncols + 1);
     columns[ncols] = nullptr;
 
     if (colspec->ncols != 3 && colspec->ncols != 5) {

--- a/c/datatable_rbind.cc
+++ b/c/datatable_rbind.cc
@@ -25,21 +25,22 @@
  * number `cols[i][j]` in datatable `dts[j]` (if `cols[i][j] >= 0`, otherwise
  * NAs).
  */
-void DataTable::rbind(DataTable** dts, int** cols, int ndts, int64_t new_ncols)
+void DataTable::rbind(
+    DataTable** dts, int** cols, int64_t ndts, int64_t new_ncols)
 {
   xassert(new_ncols >= ncols);
 
   // If this is a view datatable, then it must be materialized.
   this->reify();
 
-  dtrealloc_x(columns, Column*, new_ncols + 1);
+  columns = dt::arealloc<Column*>(columns, new_ncols + 1);
   for (int64_t i = ncols; i < new_ncols; ++i) {
     columns[i] = new VoidColumn(nrows);
   }
   columns[new_ncols] = nullptr;
 
   int64_t new_nrows = nrows;
-  for (int i = 0; i < ndts; ++i) {
+  for (int64_t i = 0; i < ndts; ++i) {
     new_nrows += dts[i]->nrows;
   }
 

--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -106,9 +106,9 @@ PyObject* get_internal_function_ptrs(PyObject*, PyObject*) {
   PyObject *res = PyTuple_New(SIZE);
   if (!res) return nullptr;
 
-  ADD(_dt_malloc);
-  ADD(_dt_realloc);
-  ADD(_dt_free);
+  ADD(dt::malloc<void>);
+  ADD(dt::realloc<void>);
+  ADD(dt::free);
   ADD(datatable_get_column_data);
   ADD(datatable_unpack_slicerowindex);
   ADD(datatable_unpack_arrayrowindex);

--- a/c/memrange.h
+++ b/c/memrange.h
@@ -91,7 +91,7 @@ class MemoryRange
     //   when it is no longer needed, but not before the MemoryRange object is
     //   deleted. However, if `own` is true, then the MemoryRange object will
     //   take ownership of that pointer. In this case the `ptr` should have had
-    //   been allocated using `std::malloc`.
+    //   been allocated using `dt::malloc`.
     //
     // MemoryRange(n, ptr, pybuf)
     //   Create MemoryRange from a pointer `ptr` to a memory buffer of size `n`

--- a/c/py_columnset.cc
+++ b/c/py_columnset.cc
@@ -80,8 +80,7 @@ PyObject* columns_from_array(PyObject*, PyObject *args)
   RowIndex rowindex = PyObj(arg2).as_rowindex();
 
   int64_t ncols = PyList_Size(elems);
-  int64_t* indices = nullptr;
-  dtmalloc(indices, int64_t, ncols);
+  int64_t* indices = dt::amalloc<int64_t>(ncols);
   for (int64_t i = 0; i < ncols; i++) {
     PyObject* elem = PyList_GET_ITEM(elems, i);
     indices[i] = (int64_t) PyLong_AsSize_t(elem);
@@ -106,9 +105,7 @@ PyObject* columns_from_mixed(PyObject*, PyObject *args)
 
   columnset_mapfn* fnptr = (columnset_mapfn*) rawptr;
   int64_t ncols = PyList_Size(pyspec);
-  int64_t* spec = nullptr;
-
-  dtmalloc(spec, int64_t, ncols);
+  int64_t* spec = dt::amalloc<int64_t>(ncols);
   for (int64_t i = 0; i < ncols; i++) {
     PyObject* elem = PyList_GET_ITEM(pyspec, i);
     if (PyLong_CheckExact(elem)) {
@@ -129,14 +126,13 @@ PyObject* columns_from_columns(PyObject*, PyObject* args)
     return nullptr;
 
   int64_t ncols = PyList_Size(col_list);
-  Column** columns;
-  dtmalloc(columns, Column*, ncols + 1);
+  Column** columns = dt::amalloc<Column*>(ncols + 1);
   for (int64_t i = 0; i < ncols; ++i) {
     PyObject* elem = PyList_GET_ITEM(col_list, i);
     int ret = pycolumn::unwrap(elem, columns + i);
     if (!ret) {
       for (int64_t j = 0; j < i; ++j) delete columns[j];
-      dtfree(columns);
+      dt::free(columns);
       return nullptr;
     }
     reinterpret_cast<pycolumn::obj*>(elem)->ref = nullptr;

--- a/c/py_datatable_fromlist.c
+++ b/c/py_datatable_fromlist.c
@@ -40,8 +40,8 @@ PyObject* pydatatable::datatable_from_list(PyObject*, PyObject* args)
   }
 
   size_t ncols = srcs.size();
-  Column** cols = nullptr;
-  dtcalloc(cols, Column*, ncols + 1);
+  Column** cols = static_cast<Column**>(std::calloc(ncols + 1, sizeof(Column*)));
+  if (!cols) throw MemoryError();
 
   // Check validity of the data and construct the output columnset.
   size_t nrows = 0;

--- a/c/py_types.c
+++ b/c/py_types.c
@@ -134,11 +134,11 @@ static PyObject* stype_object_pyptr_tostring(Column* col, int64_t row)
   return x;
 }
 
-static PyObject* stype_notimpl(Column* col, UNUSED(int64_t row))
+static PyObject* stype_notimpl(Column* col, int64_t)
 {
-    PyErr_Format(PyExc_NotImplementedError,
-                 "Cannot stringify column of type %d", col->stype());
-    return nullptr;
+  PyErr_Format(PyExc_NotImplementedError,
+               "Cannot stringify column of type %d", col->stype());
+  return nullptr;
 }
 
 

--- a/c/py_utils.c
+++ b/c/py_utils.c
@@ -44,65 +44,6 @@ PyObject* decref(PyObject *x) {
 }
 
 
-void* _dt_malloc(size_t n)
-{
-    if (!n) return nullptr;
-    void *res = malloc(n);
-    if (res == nullptr) {
-        PyErr_Format(PyExc_MemoryError, "Failed to allocate %zd bytes", n);
-    }
-    return res;
-}
-
-
-void* _dt_realloc(void *ptr, size_t n)
-{
-    if (!n) return nullptr;
-    void *res = realloc(ptr, n);
-    if (res == nullptr) {
-        PyErr_Format(PyExc_MemoryError, "Failed to allocate %zd bytes", n);
-    }
-    return res;
-}
-
-
-void* _dt_calloc(size_t n, size_t size)
-{
-    if (!n) return nullptr;
-    void *res = calloc(n, size);
-    if (res == nullptr) {
-        PyErr_Format(PyExc_MemoryError, "Failed to allocate %zd bytes",
-                     n * size);
-    }
-    return res;
-}
-
-
-void _dt_free(void *ptr)
-{
-    free(ptr);
-}
-
-
-__attribute__ ((format(printf, 1, 2)))
-void _dt_err_r(const char *format, ...)
-{
-    va_list vargs;
-    va_start(vargs, format);
-    PyErr_FormatV(PyExc_RuntimeError, format, vargs);
-    va_end(vargs);
-}
-
-
-__attribute__ ((format(printf, 1, 2)))
-void _dt_err_v(const char *format, ...)
-{
-    va_list vargs;
-    va_start(vargs, format);
-    PyErr_FormatV(PyExc_ValueError, format, vargs);
-    va_end(vargs);
-}
-
 
 void log_call(const char* msg) {
   if (!config::logger) return;

--- a/c/sort.cc
+++ b/c/sort.cc
@@ -119,6 +119,7 @@
 #include "rowindex.h"
 #include "types.h"
 #include "utils.h"
+#include "utils/alloc.h"
 #include "utils/array.h"
 #include "utils/assert.h"
 #include "utils/omp.h"
@@ -566,8 +567,7 @@ class SortContext {
   void build_histogram() {
     size_t counts_size = nchunks * nradixes;
     if (histogram_size < counts_size) {
-      histogram = static_cast<size_t*>(
-        std::realloc(histogram, counts_size * sizeof(size_t)));
+      histogram = dt::arealloc<size_t>(histogram, counts_size);
       histogram_size = counts_size;
     }
     std::memset(histogram, 0, counts_size * sizeof(size_t));
@@ -854,9 +854,10 @@ class SortContext {
       if (sz > rrlarge) {
         size_t off = rrmap[rri].offset;
         n = sz;
-        x = add_ptr(_x, off * zelemsize);
+        x = static_cast<void*>(static_cast<char*>(_x) + off * zelemsize);
         o = _o + off;
-        next_x = add_ptr(_next_x, off * zelemsize);
+        next_x = static_cast<void*>(
+                    static_cast<char*>(_next_x) + off * zelemsize);
         next_o = _next_o + off;
         elemsize = _elemsize;
         if (make_groups) {

--- a/c/types.c
+++ b/c/types.c
@@ -23,12 +23,6 @@ dt_static_assert(sizeof(void*) == sizeof(size_t),
 dt_static_assert(sizeof(void*) == sizeof(int64_t),
                  "size(int64_t) != size(void*)");
 
-dt_static_assert(SIZEOF(int) == sizeof(int), "Wrong SIZEOF(int) expansion");
-dt_static_assert(SIZEOF(void) == 1, "Wrong SIZEOF(void) expansion");
-dt_static_assert(SIZEOF(void*) == sizeof(void*),
-                 "Wrong SIZEOF(void*) expansion");
-dt_static_assert(SIZEOF(int64_t) == sizeof(int64_t),
-                 "Wrong SIZEOF(int64_t) expansion");
 dt_static_assert(sizeof(int8_t) == 1, "int8_t should be 1-byte");
 dt_static_assert(sizeof(int16_t) == 2, "int16_t should be 2-byte");
 dt_static_assert(sizeof(int32_t) == 4, "int32_t should be 4-byte");

--- a/c/utils.c
+++ b/c/utils.c
@@ -9,11 +9,6 @@
 #include <stdint.h>
 
 
-int64_t min(int64_t a, int64_t b) { return a < b? a : b; }
-int64_t max(int64_t a, int64_t b) { return a > b? a : b; }
-float max_f4(float a, float b) { return a < b? b : a; }
-
-
 namespace dt {
 
 /**
@@ -71,7 +66,8 @@ void set_value(void * __restrict__ ptr, const void * __restrict__ value,
   size_t final_sz = sz * count;
   for (size_t i = sz; i < final_sz; i <<= 1) {
     size_t writesz = i < final_sz - i ? i : final_sz - i;
-    memcpy(add_ptr(ptr, i), ptr, writesz);
+    void* dest = static_cast<void*>(static_cast<char*>(ptr) + i);
+    memcpy(dest, ptr, writesz);
   }
 }
 

--- a/c/utils.h
+++ b/c/utils.h
@@ -5,13 +5,8 @@
 //
 // © H2O.ai 2018
 //------------------------------------------------------------------------------
-
-
-//==============================================================================
-//  Collection of macros / helper functions
-//==============================================================================
-#ifndef dt_UTILS_H
-#define dt_UTILS_H
+#ifndef dt_UTILS_h
+#define dt_UTILS_h
 #include <Python.h>
 #include <stddef.h>
 #include <stdio.h>     // vsnprintf
@@ -30,9 +25,6 @@
 #define llu   unsigned long long int
 
 
-int64_t min(int64_t a, int64_t b);
-int64_t max(int64_t a, int64_t b);
-float max_f4(float a, float b);
 double wallclock(void);
 const char* filesize_to_str(size_t filesize);
 const char* humanize_number(size_t num);
@@ -56,195 +48,16 @@ inline std::string operator "" _s(const char* str, size_t len) {
 #define zCHECK_N(x, n, ...) n
 #define zCHECK(...) zCHECK_N(__VA_ARGS__, 0,)
 #define zIIF(c) zPRIMITIVE_CAT(zIIF_, c)
-#define zTEST1_void x,1,
-#define zTEST2_void char
 #define zTEST3_ ~,1,
-// This expands into `x,1,` if T is void, into `x,1,*` if T is void*, or into
-// `zTEST1_<T>` otherwise.
-#define zEXPANDT1(T) zCAT(zTEST1_, T)
-// Similarly, this expands into `char` if T is void, into `char*` if T is void*,
-// or into `zTEST2_<T>` otherwise
-#define zEXPANDT2(T) zCAT(zTEST2_, T)
-// Expands to `1` if T is void or void*, or to `0` otherwise
-#define zIS_T_VOID(T) zCHECK(zEXPANDT1(T))
-// Finally, this expands into `sizeof(char)` if T is void, into `sizeof(char*)`
-// if T is void*, and into `sizeof(<T>)` in all other cases.
-#define SIZEOF(T) zIIF(zIS_T_VOID(T))(sizeof(zEXPANDT2(T)), sizeof(T))
 
 // This macro expands to `t` if symbol `x` is defined and equal to 1, and to
 // `f` otherwise.
 #define IFDEF(x, t, f) zIIF(zCHECK(zPRIMITIVE_CAT(zTEST3_, x)))(t, f)
 #define WHEN(x, t) IFDEF(x, t, )
 
-
-
 #define APPLY(macro, arg) macro(arg)
 #define STRINGIFY_(L) #L
 #define STRINGIFY(x) APPLY(STRINGIFY_, x)
-
-/**
- * Use this macro to malloc a memory region and assign it to a variable. For
- * example, to malloc an array of 1000 integers:
- *
- *     int32_t *arr;
- *     dtmalloc(arr, int32_t, 1000);
- *
- * This will also work correctly for allocating a `void*` pointer:
- *
- *     void *buf;
- *     dtmalloc(buf, void, 1024 * 1024);
- *
- * The macro checks that the allocation was successful, and if not it executes
- * `return NULL`. Thus, it can only be used within a function that returns a
- * pointer. The `_g` version of this macro instead executes `goto fail`, where
- * any special cleanup may be performed.
- **/
-#define dtmalloc(ptr, T, n) do {                                               \
-    ptr = (T*) _dt_malloc((size_t)(n) * SIZEOF(T));                            \
-    if (ptr == null && n) return null;                                         \
-} while(0)
-
-#define dtmalloc_g(ptr, T, n) do {                                             \
-    ptr = (T*) _dt_malloc((size_t)(n) * SIZEOF(T));                            \
-    if (ptr == null && n) goto fail;                                           \
-} while(0)
-
-
-
-/**
- * Similar to `dtmalloc(ptr, T, n)`, except that it declares the variable `ptr`
- * in addition to malloc-ing it.
- */
-#define dtdeclmalloc(ptr, T, n)                                                \
-    T* ptr = (T*) _dt_malloc((size_t)(n) * SIZEOF(T));                         \
-    if (ptr == null && n) return null;
-
-
-
-/**
- * This macro is a replacement for standard `realloc` in much the same way as
- * `dtmalloc` is a replacement for system `malloc`:
- *
- *     float *data = NULL;
- *     dtrealloc(data, float, 100);
- *
- * The macro checks that the allocation was successful, and if not it executes
- * `return NULL`. Thus, it can only be used within a function that returns a
- * pointer. The `_g` version of this macro instead executes `goto fail`, where
- * any special cleanup may be performed.
- */
-#define dtrealloc(ptr, T, n) do {                                              \
-    ptr = (T*) _dt_realloc(ptr, (size_t)(n) * SIZEOF(T));                      \
-    if (ptr == null && n) return null;                                         \
-} while(0)
-
-#define dtrealloc_g(ptr, T, n) do {                                            \
-    ptr = (T*) _dt_realloc(ptr, (size_t)(n) * SIZEOF(T));                      \
-    if (ptr == null && n) goto fail;                                           \
-} while(0)
-
-#define dtrealloc_x(ptr, T, n) do {                                            \
-    ptr = (T*) _dt_realloc(ptr, (size_t)(n) * SIZEOF(T));                      \
-    if (ptr == null && n) throw MemoryError();                                 \
-} while(0)
-
-
-
-/**
- * Replacement for `calloc`.
- */
-#define dtcalloc(ptr, T, n) do {                                               \
-    ptr = (T*) _dt_calloc((size_t)(n), SIZEOF(T));                             \
-    if (ptr == null && n) return null;                                         \
-} while(0)
-
-#define dtcalloc_g(ptr, T, n) do {                                             \
-    ptr = (T*) _dt_calloc((size_t)(n), SIZEOF(T));                             \
-    if (ptr == null && n) goto fail;                                           \
-} while(0)
-
-
-
-/**
- * Macro to free the memory previously allocated with `dtmalloc` / `dtrealloc`.
- * This frees the memory and sets the pointer to NULL, for safety.
- **/
-#define dtfree(ptr) while (ptr) {                                              \
-    /*printf("  dtfree(%p) at %s line %d\n", (void*)ptr, __FILE__, __LINE__);*/\
-    _dt_free(ptr);                                                             \
-    ptr = null;                                                                \
-}
-
-
-
-/**
- * Macro for safe pointer arithmetic on `void*` pointers. Normally we'd want to
- * say simply `ptr + n`, but this is not in standard C, and produces a warning
- * on Clang compiler (and in C++ such operation is straight prohibited...).
- */
-#define add_ptr(ptr, n)       ((void*)((char*)(ptr) + (n)))
-#define add_constptr(ptr, n)  ((const void*)((const char*)(ptr) + (n)))
-
-
-//---- Private -------------------------
-// The _dt_xxx functions are external and should be defined in py_utils.c
-void* _dt_calloc(size_t n, size_t size);
-void* _dt_malloc(size_t n);
-void* _dt_realloc(void *ptr, size_t n);
-void  _dt_free(void *ptr);
-#ifdef __cplusplus
-    #define null NULL
-#else
-    #define null NULL
-    #define bool _Bool
-#endif
-
-
-//==============================================================================
-// Error handling
-//==============================================================================
-
-/**
- * Raise a RuntimeError with the provided message
- */
-#define dterrr(format, ...) do {                                               \
-    _dt_err_r(format "\nat %s#L%d", __VA_ARGS__, __FILE__, __LINE__);          \
-    return NULL;                                                               \
-} while (0)
-
-#define dterrr0(message) do {                                                  \
-    _dt_err_r(message "\nat %s#L%d", __FILE__, __LINE__);                      \
-    return NULL;                                                               \
-} while (0)
-
-/**
- * Raise a ValueError with the provided message
- */
-#define dterrv(format, ...) do {                                               \
-    _dt_err_v(format "\nat %s#L%d", __VA_ARGS__, __FILE__, __LINE__);          \
-    return NULL;                                                               \
-} while (0)
-
-/**
- * Raise a RuntimeError, but also include in the message current `errno`.
- */
-#define dterre(format, ...) do {                                               \
-    _dt_err_r(format ": Error %d %s\nat %s#L%d",                               \
-              __VA_ARGS__, errno, strerror(errno), __FILE__, __LINE__);        \
-    return NULL;                                                               \
-} while (0)
-
-#define dterre0(message) do {                                                  \
-    _dt_err_r(message ": Error %d %s\nat %s#L%d",                              \
-              errno, strerror(errno), __FILE__, __LINE__);                     \
-    return NULL;                                                               \
-} while (0)
-
-
-// External functions -- should be defined in py_utils.c
-// These functions merely set the error message, and nothing else.
-void _dt_err_r(const char *format, ...) __attribute__ ((format(printf, 1, 2)));
-void _dt_err_v(const char *format, ...) __attribute__ ((format(printf, 1, 2)));
 
 
 
@@ -265,11 +78,6 @@ extern template int nlz(uint8_t);
 //==============================================================================
 // Other
 //==============================================================================
-
-/**
- * Mark a function parameter as deliberately unused.
- **/
-#define UNUSED(x)  __attribute__((unused)) x
 
 #define zMAKE_PRAGMA(x) _Pragma(#x);
 

--- a/c/utils/alloc.cc
+++ b/c/utils/alloc.cc
@@ -1,0 +1,57 @@
+//------------------------------------------------------------------------------
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// © H2O.ai 2018
+//------------------------------------------------------------------------------
+#include "utils/alloc.h"
+#include <cerrno>              // errno
+#include <cstdlib>             // std::realloc, std::free
+#include "utils/exceptions.h"  // MemoryError
+#include "mmm.h"               // MemoryMapManager
+
+namespace dt
+{
+
+
+void* _realloc(void* ptr, size_t n) {
+  if (!n) {
+    std::free(ptr);
+    return nullptr;
+  }
+  int attempts = 3;
+  while (true) {
+    // The documentation for `void* realloc(void* ptr, size_t new_size);` says
+    // the following:
+    // | If there is not enough memory, the old memory block is not freed and
+    // | null pointer is returned.
+    // | If new_size is zero, the behavior is implementation defined (null
+    // | pointer may be returned (in which case the old memory block may or may
+    // | not be freed), or some non-null pointer may be returned that may not be
+    // | used to access storage). Support for zero size is deprecated as of
+    // | C11 DR 400.
+    void* newptr = std::realloc(ptr, n);
+    if (newptr) {
+      return newptr;
+    }
+    if (errno == 12 && attempts--) {
+      // Occasionally, `std::realloc()` may fail if the system ran out of
+      // memmap resources. It's unclear why, but freeing up some of memmap
+      // handles sometime allows `std::realloc()` to succeed.
+      MemoryMapManager::get()->freeup_memory();
+      errno = 0;
+    } else {
+      throw MemoryError()
+        << "Unable to allocate memory of size " << n << Errno;
+    }
+  }
+}
+
+
+void free(void* ptr) {
+  std::free(ptr);
+}
+
+
+}; // namespace dt

--- a/c/utils/alloc.h
+++ b/c/utils/alloc.h
@@ -1,0 +1,45 @@
+//------------------------------------------------------------------------------
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// © H2O.ai 2018
+//------------------------------------------------------------------------------
+#ifndef dt_UTILS_ALLLOC_h
+#define dt_UTILS_ALLLOC_h
+#include <cstdlib>
+
+namespace dt
+{
+void free(void*);
+void* _realloc(void*, size_t);
+
+
+
+template <typename T> inline T* malloc(size_t n) {
+  return static_cast<T*>(_realloc(nullptr, n));
+}
+
+template <typename T> inline T* amalloc(size_t n) {
+  return static_cast<T*>(_realloc(nullptr, n * sizeof(T)));
+}
+
+template <typename T> inline T* amalloc(int64_t n) {
+  return static_cast<T*>(_realloc(nullptr, static_cast<size_t>(n) * sizeof(T)));
+}
+
+
+template <typename T> inline T* realloc(T* ptr, size_t n) {
+  return static_cast<T*>(_realloc(ptr, n));
+}
+
+template <typename T> inline T* arealloc(T* ptr, size_t n) {
+  return static_cast<T*>(_realloc(ptr, n * sizeof(T)));
+}
+
+template <typename T> inline T* arealloc(T* ptr, int64_t n) {
+  return static_cast<T*>(_realloc(ptr, static_cast<size_t>(n) * sizeof(T)));
+}
+
+}; // namespace dt
+#endif

--- a/c/utils/array.h
+++ b/c/utils/array.h
@@ -7,9 +7,9 @@
 //------------------------------------------------------------------------------
 #ifndef dt_UTILS_ARRAY_h
 #define dt_UTILS_ARRAY_h
-#include <algorithm>   // std::swap
-#include <cstdlib>     // std::realloc, std::free
+#include <algorithm>      // std::swap
 #include "memrange.h"
+#include "utils/alloc.h"  // dt::realloc
 #include "utils/exceptions.h"
 
 namespace dt
@@ -55,7 +55,7 @@ template <typename T> class array
     array(size_t len = 0) : x(nullptr), n(0), owned(true) { resize(len); }
     array(size_t len, const T* ptr)
       : x(const_cast<T*>(ptr)), n(len), owned(false) {}
-    ~array() { if (owned) std::free(x); }
+    ~array() { if (owned) dt::free(x); }
     // copy-constructor and assignment are forbidden
     array(const array<T>&) = delete;
     array<T>& operator=(const array<T>&) = delete;
@@ -104,18 +104,7 @@ template <typename T> class array
       if (!owned) {
         throw MemoryError() << "Cannot resize array: not owned";
       }
-      if (newn == 0) {
-        std::free(x);
-        x = nullptr;
-        n = 0;
-        return;
-      }
-      T* newx = static_cast<T*>(std::realloc(x, sizeof(T) * newn));
-      if (!newx) {
-        throw MemoryError() << "Unable to allocate " << sizeof(T) * newn
-                            << " bytes";
-      }
-      x = newx;
+      x = dt::arealloc<T>(x, newn);
       n = newn;
     }
 };

--- a/c/writebuf.cc
+++ b/c/writebuf.cc
@@ -119,90 +119,43 @@ void FileWritableBuffer::finalize()
 //==============================================================================
 
 ThreadsafeWritableBuffer::ThreadsafeWritableBuffer()
-  : buffer(nullptr), allocsize(0), nlocks(0) {}
+  : buffer(nullptr), allocsize(0) {}
 
 
 ThreadsafeWritableBuffer::~ThreadsafeWritableBuffer() {}
 
 
-size_t ThreadsafeWritableBuffer::prep_write(size_t n, const void*)
-{
+size_t ThreadsafeWritableBuffer::prep_write(size_t n, const void*) {
   size_t pos = bytes_written;
-  bytes_written += n;
+  size_t nbw = pos + n;
 
-  // In the rare case when we need to reallocate the underlying buffer (because
-  // more space is needed than originally anticipated), this will block until
-  // all other threads finish writing their chunks, and only then proceed with
-  // the reallocation. Otherwise, reallocating the memory when some other thread
-  // is writing into it leads to very-hard-to-debug crashes...
-  while (bytes_written > allocsize) {
-    size_t newsize = bytes_written * 2;
-    int lockv = 1;
-    // (1) wait until no other process is writing into the buffer
-    while (lockv) {
-      #pragma omp atomic read
-      lockv = nlocks;
-    }
-    // (2) make `numuses` negative, indicating that no other thread may
-    //     initiate a memcopy operation for now.
-    #pragma omp atomic capture
-    { lockv = nlocks; nlocks -= 1000000; }
-    // (3) The only case when `lockv != 0` is if another thread started memcopy
-    //     operation in-between steps (1) and (2) above. In that case we restore
-    //     the previous value of `numuses` and repeat the loop.
-    //     Otherwise (and it is the most common case) we reallocate the buffer
-    //     and only then restore the `numuses` variable.
-    if (lockv == 0) {
-      this->realloc(newsize);
-    }
-    #pragma omp atomic update
-    nlocks += 1000000;
+  if (nbw > allocsize) {
+    dt::shared_lock lock(shmutex, /* exclusive = */ true);
+    size_t newsize = nbw * 2;
+    this->realloc(newsize);
+    xassert(allocsize >= newsize);
   }
 
+  bytes_written = nbw;
   return pos;
 }
 
 
-void ThreadsafeWritableBuffer::write_at(size_t pos, size_t n, const void* src)
-{
-  xassert(pos + n <= allocsize);
-  bool done = false;
-  while (!done) {
-    int lockv;
-    #pragma omp atomic capture
-    lockv = nlocks++;
-    if (lockv >= 0) {
-      void* target = static_cast<void*>(static_cast<char*>(buffer) + pos);
-      std::memcpy(target, src, n);
-      done = true;
-    }
-    #pragma omp atomic update
-    nlocks--;
+void ThreadsafeWritableBuffer::write_at(size_t pos, size_t n, const void* src) {
+  if (pos + n > allocsize) {
+    throw RuntimeError() << "Attempt to write at pos=" << pos << " chunk of "
+      "length " << n << ", however the buffer is allocated for " << allocsize
+      << " bytes only";
   }
+  dt::shared_lock lock(shmutex, /* exclusive = */ false);
+  char* target = static_cast<char*>(buffer) + pos;
+  std::memcpy(target, src, n);
 }
 
 
-void ThreadsafeWritableBuffer::finalize()
-{
-  int lockv = 1;
-  while (lockv) {
-    #pragma omp atomic read
-    lockv = nlocks;
-  }
-  while (allocsize > bytes_written) {
-    lockv = 1;
-    while (lockv) {
-      #pragma omp atomic read
-      lockv = nlocks;
-    }
-    #pragma omp atomic capture
-    { lockv = nlocks; nlocks -= 1000000; }
-    if (lockv == 0) {
-      this->realloc(bytes_written);
-    }
-    #pragma omp atomic update
-    nlocks += 1000000;
-  }
+void ThreadsafeWritableBuffer::finalize() {
+  dt::shared_lock lock(shmutex, /* exclusive = */ true);
+  this->realloc(bytes_written);
 }
 
 
@@ -218,9 +171,8 @@ MemoryWritableBuffer::MemoryWritableBuffer(size_t size)
 }
 
 
-MemoryWritableBuffer::~MemoryWritableBuffer()
-{
-  std::free(buffer);
+MemoryWritableBuffer::~MemoryWritableBuffer() {
+  dt::free(buffer);
 }
 
 

--- a/c/writebuf.cc
+++ b/c/writebuf.cc
@@ -6,12 +6,12 @@
 // © H2O.ai 2018
 //------------------------------------------------------------------------------
 #include "writebuf.h"
-#include <cstdlib>     // std::realloc
 #include <cstring>     // std::memcpy
 #include <errno.h>     // errno
 #include <sys/mman.h>  // mmap
 #include <unistd.h>    // write
 #include "memrange.h"
+#include "utils/alloc.h"   // dt::realloc
 #include "utils/assert.h"
 #include "utils/omp.h"
 #include "utils.h"
@@ -214,13 +214,7 @@ void ThreadsafeWritableBuffer::finalize()
 MemoryWritableBuffer::MemoryWritableBuffer(size_t size)
   : ThreadsafeWritableBuffer()
 {
-  if (size) {
-    buffer = std::malloc(size);
-    allocsize = size;
-    if (!buffer) {
-      throw MemoryError() << "Unable to allocate memory of size " << size;
-    }
-  }
+  this->realloc(size);
 }
 
 
@@ -232,17 +226,8 @@ MemoryWritableBuffer::~MemoryWritableBuffer()
 
 void MemoryWritableBuffer::realloc(size_t newsize)
 {
-  if (newsize) {
-    buffer = std::realloc(buffer, newsize);
-    allocsize = newsize;
-    if (!buffer) {
-      throw MemoryError() << "Unable to allocate memory of size " << newsize;
-    }
-  } else {
-    std::free(buffer);
-    buffer = nullptr;
-    allocsize = 0;
-  }
+  buffer = dt::realloc(buffer, newsize);
+  allocsize = newsize;
 }
 
 

--- a/c/writebuf.h
+++ b/c/writebuf.h
@@ -10,6 +10,7 @@
 #include <stdio.h>     // size_t
 #include <string>      // std::string
 #include "utils/file.h"
+#include "utils/shared_mutex.h"
 
 class MemoryRange;
 
@@ -127,8 +128,7 @@ class ThreadsafeWritableBuffer : public WritableBuffer
 protected:
   void*  buffer;
   size_t allocsize;
-  volatile int nlocks;
-  int    _unused;
+  dt::shared_mutex shmutex;
 
   virtual void realloc(size_t newsize) = 0;
 


### PR DESCRIPTION
* Many old macros such as `dtmalloc`, `dtrealloc`, `dtfree`, `dterrr` etc. that were used only in few places, were eliminated.
* Added utility functions `dt::malloc` and `dt::realloc` that are somewhat smarter than standard `malloc` and `free`: they will attempt to free up memory if the first attempt at allocating fails with errno=12 (ENOMEM).
* `ThreadsafeWritableBuffer` now uses `dt::shared_mutex` for read/write access control (this replaces the old mechanism which was based on atomically incrementing /decrementing a counter). Now it is no longer possible for this object to become deadlocked if `resize()` call throws an exception.
