### PR TITLE
Fread bug (assertion error / memory error)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed a bug in dt.cbind() where the first Frame in the list was ignored.
 - Fix bug with applying a cast expression to a view column.
 - Fix occasional memory errors caused by a lack of available mmap handles.
+- Fix a bug in fread with QR bump occurring out-of-sample.
 
 
 ### [v0.6.0](https://github.com/h2oai/datatable/compare/v0.6.0...v0.5.0) — 2018-06-05

--- a/Makefile
+++ b/Makefile
@@ -463,7 +463,7 @@ $(BUILDDIR)/csv/py_csv.h: c/csv/py_csv.h $(BUILDDIR)/py_utils.h
 	@echo • Refreshing c/csv/py_csv.h
 	@cp c/csv/py_csv.h $@
 
-$(BUILDDIR)/csv/reader.h: c/csv/reader.h $(BUILDDIR)/column.h $(BUILDDIR)/datatable.h $(BUILDDIR)/memrange.h $(BUILDDIR)/utils/pyobj.h $(BUILDDIR)/utils/shared_mutex.h $(BUILDDIR)/writebuf.h
+$(BUILDDIR)/csv/reader.h: c/csv/reader.h $(BUILDDIR)/column.h $(BUILDDIR)/datatable.h $(BUILDDIR)/memrange.h $(BUILDDIR)/utils/array.h $(BUILDDIR)/utils/pyobj.h $(BUILDDIR)/utils/shared_mutex.h $(BUILDDIR)/writebuf.h
 	@echo • Refreshing c/csv/reader.h
 	@cp c/csv/reader.h $@
 

--- a/c/csv/chunks.cc
+++ b/c/csv/chunks.cc
@@ -208,6 +208,7 @@ void ChunkedDataReader::read_all()
       try {
         tctx->push_buffers();
       } catch (...) {
+        tctx->used_nrows = 0;
         oem.capture_exception();
       }
     }

--- a/c/csv/reader.h
+++ b/c/csv/reader.h
@@ -16,6 +16,7 @@
 #include "datatable.h"    // DataTable
 #include "memrange.h"     // MemoryRange
 #include "writebuf.h"     // WritableBuffer
+#include "utils/array.h"
 #include "utils/pyobj.h"
 #include "utils/shared_mutex.h"
 
@@ -372,7 +373,7 @@ struct ChunkCoordinates {
  */
 class LocalParseContext {
   public:
-    field64* tbuf;
+    dt::array<field64> tbuf;
     size_t tbuf_ncols;
     size_t tbuf_nrows;
     size_t used_nrows;

--- a/c/csv/reader.h
+++ b/c/csv/reader.h
@@ -356,6 +356,10 @@ struct ChunkCoordinates {
 //------------------------------------------------------------------------------
 
 /**
+ * This is a helper class for ChunkedDataReader (see below). It carries
+ * variables that will be local to each thread during the parallel reading of
+ * the input.
+ *
  * tbuf
  *   Output buffer. Within the buffer the data is stored in row-major order,
  *   i.e. in the same order as in the original CSV file. We view the buffer as
@@ -373,7 +377,11 @@ struct ChunkCoordinates {
  */
 class LocalParseContext {
   public:
+    struct SInfo { size_t start, size, write_at; };
+
     dt::array<field64> tbuf;
+    dt::array<uint8_t> sbuf;
+    dt::array<SInfo> strinfo;
     size_t tbuf_ncols;
     size_t tbuf_nrows;
     size_t used_nrows;

--- a/c/csv/reader_fread.cc
+++ b/c/csv/reader_fread.cc
@@ -1094,7 +1094,7 @@ void FreadLocalParseContext::push_buffers() {
 
       if (elemsize == 4) {
         int32_t* dest = static_cast<int32_t*>(data) + row0 + 1;
-        int32_t delta = static_cast<int32_t>(si.write_at) + 1 - si.start;
+        int32_t delta = static_cast<int32_t>(si.write_at + 1 - si.start);
         for (size_t n = 0; n < used_nrows; ++n) {
           int32_t soff = lo->str32.offset;
           *dest++ = (soff < 0)? soff - delta : soff + delta;
@@ -1102,7 +1102,7 @@ void FreadLocalParseContext::push_buffers() {
         }
       } else {
         int64_t* dest = static_cast<int64_t*>(data) + row0 + 1;
-        int64_t delta = static_cast<int64_t>(si.write_at) + 1 - si.start;
+        int64_t delta = static_cast<int64_t>(si.write_at + 1 - si.start);
         for (size_t n = 0; n < used_nrows; ++n) {
           int64_t soff = lo->str32.offset;
           *dest++ = (soff < 0)? soff - delta : soff + delta;

--- a/c/csv/reader_fread.cc
+++ b/c/csv/reader_fread.cc
@@ -768,7 +768,7 @@ FreadLocalParseContext::FreadLocalParseContext(
       freader(f),
       columns(f.columns),
       shmutex(mut),
-      tokenizer(f.makeTokenizer(tbuf, nullptr)),
+      tokenizer(f.makeTokenizer(tbuf.data(), nullptr)),
       parsers(ParserLibrary::get_parser_fns())
 {
   ttime_push = 0;
@@ -818,13 +818,13 @@ void FreadLocalParseContext::read_chunk(
   const char*& tch = tokenizer.ch;
   tch = cc.start;
   used_nrows = 0;
-  tokenizer.target = tbuf;
+  tokenizer.target = tbuf.data();
   tokenizer.anchor = anchor = cc.start;
 
   while (tch < cc.end) {
     if (used_nrows == tbuf_nrows) {
       allocate_tbuf(tbuf_ncols, tbuf_nrows * 3 / 2);
-      tokenizer.target = tbuf + used_nrows * tbuf_ncols;
+      tokenizer.target = tbuf.data() + used_nrows * tbuf_ncols;
     }
     const char* tlineStart = tch;  // for error message
     const char* fieldStart = tch;
@@ -999,7 +999,7 @@ void FreadLocalParseContext::postprocess() {
   size_t nstrcols = strbufs.size();
   for (size_t k = 0; k < nstrcols; ++k) {
     MemoryRange& strdest = strbufs[k].mbuf;
-    field64* lo = tbuf + strbufs[k].idx8;
+    field64* lo = tbuf.data() + strbufs[k].idx8;
     int32_t off = 1;
     size_t bufsize = strdest.size();
     for (size_t n = 0; n < used_nrows; n++) {
@@ -1093,7 +1093,7 @@ void FreadLocalParseContext::push_buffers() {
       StrBuf& sb = strbufs[k];
       size_t ptr = sb.ptr;
       size_t sz = sb.sz;
-      field64* lo = tbuf + sb.idx8;
+      field64* lo = tbuf.data() + sb.idx8;
 
       wb->write_at(ptr, sz, sb.mbuf.rptr());
 
@@ -1117,7 +1117,7 @@ void FreadLocalParseContext::push_buffers() {
       k++;
 
     } else {
-      const field64* src = tbuf + j;
+      const field64* src = tbuf.data() + j;
       if (elemsize == 8) {
         uint64_t* dest = static_cast<uint64_t*>(data) + row0;
         for (size_t r = 0; r < used_nrows; r++) {

--- a/c/csv/reader_fread.h
+++ b/c/csv/reader_fread.h
@@ -116,7 +116,6 @@ class FreadReader : public GenericReader
 
 public:
   explicit FreadReader(const GenericReader&);
-  ~FreadReader();
 
   DataTablePtr read();
 
@@ -172,7 +171,6 @@ class FreadLocalParseContext : public LocalParseContext
     FreadReader& freader;
     GReaderColumns& columns;
     dt::shared_mutex& shmutex;
-    std::vector<StrBuf> strbufs;
     FreadTokenizer tokenizer;
     const ParserFnPtr* parsers;
 

--- a/c/csv/reader_utils.cc
+++ b/c/csv/reader_utils.cc
@@ -283,13 +283,13 @@ size_t GReaderColumns::totalAllocSize() const {
 // LocalParseContext
 //------------------------------------------------------------------------------
 
-LocalParseContext::LocalParseContext(size_t ncols, size_t nrows) {
-  tbuf = nullptr;
-  tbuf_ncols = 0;
-  tbuf_nrows = 0;
+LocalParseContext::LocalParseContext(size_t ncols, size_t nrows)
+  : tbuf(ncols * nrows + 1)
+{
+  tbuf_ncols = ncols;
+  tbuf_nrows = nrows;
   used_nrows = 0;
   row0 = 0;
-  allocate_tbuf(ncols, nrows);
 }
 
 
@@ -297,21 +297,11 @@ LocalParseContext::~LocalParseContext() {
   if (used_nrows != 0) {
     printf("Assertion error in ~LocalParseContext(): used_nrows != 0\n");
   }
-  dt::free(tbuf);
 }
 
 
 void LocalParseContext::allocate_tbuf(size_t ncols, size_t nrows) {
-  size_t old_size = tbuf? (tbuf_ncols * tbuf_nrows + 1) * sizeof(field64) : 0;
-  size_t new_size = (ncols * nrows + 1) * sizeof(field64);
-  if (new_size > old_size) {
-    void* tbuf_raw = realloc(tbuf, new_size);
-    if (!tbuf_raw) {
-      throw MemoryError() << "Cannot allocate " << new_size
-                          << " bytes for a temporary buffer";
-    }
-    tbuf = static_cast<field64*>(tbuf_raw);
-  }
+  tbuf.resize(ncols * nrows + 1);
   tbuf_ncols = ncols;
   tbuf_nrows = nrows;
 }

--- a/c/csv/reader_utils.cc
+++ b/c/csv/reader_utils.cc
@@ -284,7 +284,7 @@ size_t GReaderColumns::totalAllocSize() const {
 //------------------------------------------------------------------------------
 
 LocalParseContext::LocalParseContext(size_t ncols, size_t nrows)
-  : tbuf(ncols * nrows + 1)
+  : tbuf(ncols * nrows + 1), sbuf(0), strinfo(ncols)
 {
   tbuf_ncols = ncols;
   tbuf_nrows = nrows;

--- a/c/csv/reader_utils.cc
+++ b/c/csv/reader_utils.cc
@@ -310,7 +310,9 @@ void LocalParseContext::allocate_tbuf(size_t ncols, size_t nrows) {
 
 
 LocalParseContext::~LocalParseContext() {
-  if (used_nrows != 0) printf("used_nrows!=0 in ~LocalParseContext()\n");
+  if (used_nrows != 0) {
+    printf("Assertion error in ~LocalParseContext(): used_nrows != 0\n");
+  }
   free(tbuf);
 }
 

--- a/datatable/fread.py
+++ b/datatable/fread.py
@@ -193,7 +193,7 @@ class GenericReader(object):
             # text of `src`, then its type is "text".
             if len(src) >= 4096:
                 if self.verbose:
-                    self.logger.debug("Input has length %d characters, "
+                    self.logger.debug("Input is a string of length %d, "
                                       "treating it as raw text" % len(src))
                 self._resolve_source_text(src)
             else:

--- a/tests/fread/test_fread_api.py
+++ b/tests/fread/test_fread_api.py
@@ -86,7 +86,7 @@ def test_fread_from_anysource_as_text2(capsys):
     d0 = dt.fread(src, verbose=True)
     out, err = capsys.readouterr()
     assert d0.internal.check()
-    assert ("Input has length %d characters, treating it as raw text"
+    assert ("Input is a string of length %d, treating it as raw text"
             % len(src)) in out
 
 

--- a/tests/fread/test_fread_small.py
+++ b/tests/fread/test_fread_small.py
@@ -1043,3 +1043,18 @@ def test_too_many_rows():
         dt.fread(src, verbose=True)
     assert ("Too many fields on line 112: expected 3 but more are present"
             in str(e.value))
+
+
+def test_qr_bump_out_of_sample(capsys):
+    lines = ["123,abcd\n"] * 3000
+    lines[137] = '-1,"This" is not funny\n'
+    src = "".join(lines)
+    d0 = dt.fread(src, verbose=True)
+    out, err = capsys.readouterr()
+    assert "sep = ','" in out
+    assert "Quote rule = 0" in out
+    assert d0.shape == (3000, 2)
+    pysrc = [[123] * 3000, ["abcd"] * 3000]
+    pysrc[0][137] = -1
+    pysrc[1][137] = '"This" is not funny'
+    assert d0.topython() == pysrc


### PR DESCRIPTION
* Fix bug in fread that sometimes resulted in memory corruption when reading a file and a QR bump occurred in the middle of the file.
* Eliminate some dead code in fread's LocalParseContext
* Eliminate `StrBuf`s array, replacing it with a single string buffer per `LocalParseContext` + an array of auxiliary information `dt::array<SInfo>`. This reduces the code complexity, the number of memory allocations, and the chance that `strbufs` will become desynchronized with `columns`.
* Added a test

Closes #1117 