### PR TITLE
Reduce startup time of datatable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed memory leak in groupby operations.
 - `names` parameter in Frame constructor is now checked for correctness.
 - Fix a bug in fread with QR bump occurring out-of-sample.
+- `import datatable` now takes only 0.13s, down from 0.6s.
 
 
 ### [v0.6.0](https://github.com/h2oai/datatable/compare/v0.6.0...v0.5.0) — 2018-06-05

--- a/datatable/fread.py
+++ b/datatable/fread.py
@@ -11,7 +11,6 @@ import pathlib
 import re
 import shutil
 import tempfile
-import urllib.request
 import warnings
 from typing import List, Union, Callable, Optional, Tuple, Dict, Set
 
@@ -326,13 +325,13 @@ class GenericReader(object):
 
 
     def _resolve_source_url(self, url):
-        if url is None:
-            return
-        targetfile = tempfile.mktemp(dir=self.tempdir)
-        urllib.request.urlretrieve(url, filename=targetfile)
-        self._tempfiles.append(targetfile)
-        self._file = targetfile
-        self._src = url
+        if url is not None:
+            import urllib.request
+            targetfile = tempfile.mktemp(dir=self.tempdir)
+            urllib.request.urlretrieve(url, filename=targetfile)
+            self._tempfiles.append(targetfile)
+            self._file = targetfile
+            self._src = url
 
 
     def _resolve_archive(self, filename, subpath=None):

--- a/datatable/types.py
+++ b/datatable/types.py
@@ -104,8 +104,8 @@ class stype(enum.Enum):
 
     @property
     def dtype(self):
-        if not _stype_2_dtype:
-            raise RuntimeError("numpy module is not installed")
+        if not _numpy_init_attempted:
+            _init_numpy_transforms()
         return _stype_2_dtype[self]
 
 
@@ -177,6 +177,10 @@ def ___new___(cls, value):
     try:
         if value in cls._value2member_map_ and type(value) is not bool:
             return cls._value2member_map_[value]
+        if not isinstance(value, int) and not _numpy_init_attempted:
+            _init_numpy_transforms()
+            if value in cls._value2member_map_:
+                return cls._value2member_map_[value]
     except TypeError:
         # `value` is not hasheable -- not valid for our enum. Pass-through
         # and raise the TValueError below.
@@ -227,22 +231,42 @@ _stype_2_ctype = {
     stype.obj64: ctypes.py_object,
 }
 
-try:
-    import numpy
-    _stype_2_dtype = {
-        stype.bool8: numpy.dtype("bool"),
-        stype.int8: numpy.dtype("int8"),
-        stype.int16: numpy.dtype("int16"),
-        stype.int32: numpy.dtype("int32"),
-        stype.int64: numpy.dtype("int64"),
-        stype.float32: numpy.dtype("float32"),
-        stype.float64: numpy.dtype("float64"),
-        stype.str32: numpy.dtype("object"),
-        stype.str64: numpy.dtype("object"),
-        stype.obj64: numpy.dtype("object"),
-    }
-except ImportError:
-    _stype_2_dtype = {}
+_numpy_init_attempted = False
+_stype_2_dtype = {}
+
+def _init_numpy_transforms():
+    global _numpy_init_attempted
+    global _stype_2_dtype
+    _numpy_init_attempted = True
+    print("Importing numpy...")
+    try:
+        import numpy as np
+        _stype_2_dtype = {
+            stype.bool8: np.dtype("bool"),
+            stype.int8: np.dtype("int8"),
+            stype.int16: np.dtype("int16"),
+            stype.int32: np.dtype("int32"),
+            stype.int64: np.dtype("int64"),
+            stype.float32: np.dtype("float32"),
+            stype.float64: np.dtype("float64"),
+            stype.str32: np.dtype("object"),
+            stype.str64: np.dtype("object"),
+            stype.obj64: np.dtype("object"),
+        }
+        _init_value2members_from([
+            (np.dtype("bool"), stype.bool8),
+            (np.dtype("int8"), stype.int8),
+            (np.dtype("int16"), stype.int16),
+            (np.dtype("int32"), stype.int32),
+            (np.dtype("int64"), stype.int64),
+            (np.dtype("float32"), stype.float32),
+            (np.dtype("float64"), stype.float64),
+            (np.dtype("str"), stype.str64),
+            (np.dtype("object"), stype.obj64),
+        ])
+    except ImportError:
+        raise RuntimeError("numpy module is not installed")
+
 
 _stype_2_struct = {
     stype.bool8: "b",
@@ -279,19 +303,7 @@ def _additional_stype_members():
     yield ("obj", stype.obj64)
     yield ("object", stype.obj64)
     yield ("object64", stype.obj64)
-    try:
-        import numpy as np
-        yield (np.dtype("bool"), stype.bool8)
-        yield (np.dtype("int8"), stype.int8)
-        yield (np.dtype("int16"), stype.int16)
-        yield (np.dtype("int32"), stype.int32)
-        yield (np.dtype("int64"), stype.int64)
-        yield (np.dtype("float32"), stype.float32)
-        yield (np.dtype("float64"), stype.float64)
-        yield (np.dtype("str"), stype.str64)
-        yield (np.dtype("object"), stype.obj64)
-    except ImportError:  # pragma: no cover
-        pass
+
     # "old"-style stypes
     yield ("i1b", stype.bool8)
     yield ("i1i", stype.int8)
@@ -305,10 +317,14 @@ def _additional_stype_members():
     yield ("p8p", stype.obj64)
 
 
-for k, st in _additional_stype_members():
-    assert type(st) is stype
-    stype._value2member_map_[k] = st
-    ltype._value2member_map_[k] = st.ltype
+
+def _init_value2members_from(iterator):
+    for k, st in iterator:
+        assert type(st) is stype
+        stype._value2member_map_[k] = st
+        ltype._value2member_map_[k] = st.ltype
+
+_init_value2members_from(_additional_stype_members())
 
 core.register_function(2, stype)
 core.register_function(3, ltype)

--- a/datatable/utils/terminal.py
+++ b/datatable/utils/terminal.py
@@ -36,15 +36,16 @@ class MyTerminal(blessed.Terminal):
         self.__dict__, tt.__dict__ = tt.__dict__, self.__dict__
 
     def _check_ipython(self):
-        try:
-            import IPython
-            import ipykernel
+        # When running inside a Jupyter notebook, IPython and ipykernel will
+        # already be preloaded (in sys.modules). We don't want to try to
+        # import them, because it adds unnecessary startup delays.
+        if "IPython" in sys.modules and "ipykernel" in sys.modules:
+            IPython = sys.modules["IPython"]
+            ipykernel = sys.modules["ipykernel"]
             ipy = IPython.get_ipython()
             if ipy and isinstance(ipy, ipykernel.zmqshell.ZMQInteractiveShell):
                 self._encoding = "UTF8"
                 self.jupyter = ipy
-        except:
-            pass
 
 
 

--- a/datatable/utils/typechecks.py
+++ b/datatable/utils/typechecks.py
@@ -7,9 +7,9 @@
 """
 Utility for checking types at runtime.
 """
-import importlib
 import typesentry
 import warnings
+import sys
 from typesentry import U
 from datatable.utils.terminal import term
 
@@ -47,17 +47,11 @@ class _LazyClass(typesentry.MagicType):
             return self._module + "." + self._symbol
 
     def check(self, var):
-        if not self._checker:
-            self._load_symbol()
-        return self._checker(var)
-
-    def _load_symbol(self):
-        try:
-            mod = importlib.import_module(self._module)
-            cls = getattr(mod, self._symbol, False)
-            self._checker = lambda x: isinstance(x, cls)
-        except ImportError:
-            self._checker = lambda x: False
+        if self._module in sys.modules:
+            mod = sys.modules[self._module]
+            cls = getattr(mod, self._symbol, tuple())
+            return isinstance(var, cls)
+        return False
 
 
 Frame_t = _LazyClass("datatable", "Frame")


### PR DESCRIPTION
Import datatable time reduced from 0.580s to 0.133s (x4.4 improvement).
For comparison, importing pandas takes 0.387s, and numpy 0.106s.

This also helps with #1077, reducing the time it takes to launch a new python process with `datatable` module.

Closes #1122 