### PR TITLE
String repr

### DIFF
--- a/c/column.cc
+++ b/c/column.cc
@@ -31,8 +31,8 @@ Column* Column::new_column(SType stype) {
     case ST_INTEGER_I8:      return new IntColumn<int64_t>();
     case ST_REAL_F4:         return new RealColumn<float>();
     case ST_REAL_F8:         return new RealColumn<double>();
-    case ST_STRING_I4_VCHAR: return new StringColumn<int32_t>();
-    case ST_STRING_I8_VCHAR: return new StringColumn<int64_t>();
+    case ST_STRING_I4_VCHAR: return new StringColumn<uint32_t>();
+    case ST_STRING_I8_VCHAR: return new StringColumn<uint64_t>();
     case ST_OBJECT_PYPTR:    return new PyObjectColumn();
     default:
       throw ValueError() << "Unable to create a column of SType = " << stype;
@@ -326,8 +326,8 @@ Column* Column::cast(SType new_stype, MemoryRange&& mr) const {
     case ST_INTEGER_I8:      cast_into(static_cast<IntColumn<int64_t>*>(res)); break;
     case ST_REAL_F4:         cast_into(static_cast<RealColumn<float>*>(res)); break;
     case ST_REAL_F8:         cast_into(static_cast<RealColumn<double>*>(res)); break;
-    case ST_STRING_I4_VCHAR: cast_into(static_cast<StringColumn<int32_t>*>(res)); break;
-    case ST_STRING_I8_VCHAR: cast_into(static_cast<StringColumn<int64_t>*>(res)); break;
+    case ST_STRING_I4_VCHAR: cast_into(static_cast<StringColumn<uint32_t>*>(res)); break;
+    case ST_STRING_I8_VCHAR: cast_into(static_cast<StringColumn<uint64_t>*>(res)); break;
     case ST_OBJECT_PYPTR:    cast_into(static_cast<PyObjectColumn*>(res)); break;
     default:
       throw ValueError() << "Unable to cast into stype = " << new_stype;
@@ -356,10 +356,10 @@ void Column::cast_into(RealColumn<float>*) const {
 void Column::cast_into(RealColumn<double>*) const {
   throw ValueError() << "Cannot cast " << stype() << " into double";
 }
-void Column::cast_into(StringColumn<int32_t>*) const {
+void Column::cast_into(StringColumn<uint32_t>*) const {
   throw ValueError() << "Cannot cast " << stype() << " into str32";
 }
-void Column::cast_into(StringColumn<int64_t>*) const {
+void Column::cast_into(StringColumn<uint64_t>*) const {
   throw ValueError() << "Cannot cast " << stype() << " into str64";
 }
 void Column::cast_into(PyObjectColumn*) const {

--- a/c/column.h
+++ b/c/column.h
@@ -600,9 +600,6 @@ template <typename T> class StringColumn : public Column
   MemoryRange strbuf;
 
 public:
-  static constexpr T NAMASK = T(1) << (sizeof(T)*8 - 1);
-  static constexpr T NONA   = ~NAMASK;
-
   StringColumn(int64_t nrows);
   StringColumn(int64_t nrows, MemoryRange&& offbuf, MemoryRange&& strbuf);
   void save_to_disk(const std::string& filename,

--- a/c/column.h
+++ b/c/column.h
@@ -282,8 +282,8 @@ protected:
   virtual void cast_into(IntColumn<int64_t>*) const;
   virtual void cast_into(RealColumn<float>*) const;
   virtual void cast_into(RealColumn<double>*) const;
-  virtual void cast_into(StringColumn<int32_t>*) const;
-  virtual void cast_into(StringColumn<int64_t>*) const;
+  virtual void cast_into(StringColumn<uint32_t>*) const;
+  virtual void cast_into(StringColumn<uint64_t>*) const;
   virtual void cast_into(PyObjectColumn*) const;
 
 
@@ -398,8 +398,8 @@ public:
   void cast_into(RealColumn<float>*) const override;
   void cast_into(RealColumn<double>*) const override;
   void cast_into(PyObjectColumn*) const override;
-  void cast_into(StringColumn<int32_t>*) const override;
-  void cast_into(StringColumn<int64_t>*) const override;
+  void cast_into(StringColumn<uint32_t>*) const override;
+  void cast_into(StringColumn<uint64_t>*) const override;
 
   bool verify_integrity(IntegrityCheckContext&,
                         const std::string& name = "Column") const override;
@@ -457,8 +457,8 @@ protected:
   void cast_into(RealColumn<float>*) const override;
   void cast_into(RealColumn<double>*) const override;
   void cast_into(PyObjectColumn*) const override;
-  void cast_into(StringColumn<int32_t>*) const override;
-  void cast_into(StringColumn<int64_t>*) const override;
+  void cast_into(StringColumn<uint32_t>*) const override;
+  void cast_into(StringColumn<uint64_t>*) const override;
 
   using Column::stats;
   using Column::mbuf;
@@ -521,8 +521,8 @@ protected:
   void cast_into(RealColumn<float>*) const override;
   void cast_into(RealColumn<double>*) const override;
   void cast_into(PyObjectColumn*) const override;
-  void cast_into(StringColumn<int32_t>*) const override;
-  void cast_into(StringColumn<int64_t>*) const override;
+  void cast_into(StringColumn<uint32_t>*) const override;
+  void cast_into(StringColumn<uint64_t>*) const override;
 
   using Column::stats;
   using Column::new_data_column;
@@ -576,8 +576,8 @@ protected:
   // void cast_into(RealColumn<float>*) const override;
   // void cast_into(RealColumn<double>*) const override;
   void cast_into(PyObjectColumn*) const override;
-  // void cast_into(StringColumn<int32_t>*) const;
-  // void cast_into(StringColumn<int64_t>*) const;
+  // void cast_into(StringColumn<uint32_t>*) const;
+  // void cast_into(StringColumn<uint64_t>*) const;
 
   void replace_buffer(MemoryRange&&) override;
   void rbind_impl(std::vector<const Column*>& columns, int64_t nrows,
@@ -600,6 +600,9 @@ template <typename T> class StringColumn : public Column
   MemoryRange strbuf;
 
 public:
+  static constexpr T NAMASK = T(1) << (sizeof(T)*8 - 1);
+  static constexpr T NONA   = ~NAMASK;
+
   StringColumn(int64_t nrows);
   StringColumn(int64_t nrows, MemoryRange&& offbuf, MemoryRange&& strbuf);
   void save_to_disk(const std::string& filename,
@@ -650,8 +653,8 @@ protected:
   // void cast_into(RealColumn<float>*) const override;
   // void cast_into(RealColumn<double>*) const override;
   void cast_into(PyObjectColumn*) const override;
-  // void cast_into(StringColumn<int32_t>*) const;
-  void cast_into(StringColumn<int64_t>*) const override;
+  // void cast_into(StringColumn<uint32_t>*) const;
+  void cast_into(StringColumn<uint64_t>*) const override;
   void fill_na() override;
 
   //int verify_meta_integrity(std::vector<char>*, int, const char* = "Column") const override;
@@ -661,10 +664,10 @@ protected:
 };
 
 
-template <> void StringColumn<int32_t>::cast_into(StringColumn<int64_t>*) const;
-template <> void StringColumn<int64_t>::cast_into(StringColumn<int64_t>*) const;
-extern template class StringColumn<int32_t>;
-extern template class StringColumn<int64_t>;
+template <> void StringColumn<uint32_t>::cast_into(StringColumn<uint64_t>*) const;
+template <> void StringColumn<uint64_t>::cast_into(StringColumn<uint64_t>*) const;
+extern template class StringColumn<uint32_t>;
+extern template class StringColumn<uint64_t>;
 
 
 

--- a/c/column_bool.cc
+++ b/c/column_bool.cc
@@ -96,19 +96,21 @@ inline static void cast_helper(int64_t nrows, const int8_t* src, T* trg) {
 
 template <typename T>
 inline static MemoryRange cast_str_helper(
-  int64_t nrows, const int8_t* src, T* toffsets)
+  const BoolColumn* src, StringColumn<T>* target)
 {
-  size_t exp_size = static_cast<size_t>(nrows);
+  const int8_t* src_data = src->elements_r();
+  T* toffsets = target->offsets_w();
+  size_t exp_size = static_cast<size_t>(src->nrows);
   auto wb = MWBPtr(new MemoryWritableBuffer(exp_size));
   char* tmpbuf = new char[1024];
   char* tmpend = tmpbuf + 1000;  // Leave at least 24 spare chars in buffer
   char* ch = tmpbuf;
   T offset = 0;
-  toffsets[0] = 0;
-  for (int64_t i = 0; i < nrows; ++i) {
-    int8_t x = src[i];
+  toffsets[-1] = 0;
+  for (int64_t i = 0; i < src->nrows; ++i) {
+    int8_t x = src_data[i];
     if (ISNA<int8_t>(x)) {
-      toffsets[i] = offset | StringColumn<T>::NAMASK;
+      toffsets[i] = offset | GETNA<T>();
     } else {
       *ch++ = '0' + x;
       offset++;
@@ -163,17 +165,13 @@ void BoolColumn::cast_into(PyObjectColumn* target) const {
 }
 
 void BoolColumn::cast_into(StringColumn<uint32_t>* target) const {
-  MemoryRange data = target->data_buf();
-  uint32_t* offsets = static_cast<uint32_t*>(data.wptr());
-  MemoryRange strbuf = cast_str_helper<uint32_t>(nrows, elements_r(), offsets);
-  target->replace_buffer(std::move(data), std::move(strbuf));
+  MemoryRange strbuf = cast_str_helper<uint32_t>(this, target);
+  target->replace_buffer(target->data_buf(), std::move(strbuf));
 }
 
 void BoolColumn::cast_into(StringColumn<uint64_t>* target) const {
-  MemoryRange data = target->data_buf();
-  uint64_t* offsets = static_cast<uint64_t*>(data.wptr());
-  MemoryRange strbuf = cast_str_helper<uint64_t>(nrows, elements_r(), offsets);
-  target->replace_buffer(std::move(data), std::move(strbuf));
+  MemoryRange strbuf = cast_str_helper<uint64_t>(this, target);
+  target->replace_buffer(target->data_buf(), std::move(strbuf));
 }
 
 

--- a/c/column_bool.cc
+++ b/c/column_bool.cc
@@ -103,12 +103,12 @@ inline static MemoryRange cast_str_helper(
   char* tmpbuf = new char[1024];
   char* tmpend = tmpbuf + 1000;  // Leave at least 24 spare chars in buffer
   char* ch = tmpbuf;
-  T offset = 1;
-  toffsets[-1] = -1;
+  T offset = 0;
+  toffsets[0] = 0;
   for (int64_t i = 0; i < nrows; ++i) {
     int8_t x = src[i];
     if (ISNA<int8_t>(x)) {
-      toffsets[i] = -offset;
+      toffsets[i] = offset | StringColumn<T>::NAMASK;
     } else {
       *ch++ = '0' + x;
       offset++;
@@ -162,17 +162,17 @@ void BoolColumn::cast_into(PyObjectColumn* target) const {
   }
 }
 
-void BoolColumn::cast_into(StringColumn<int32_t>* target) const {
+void BoolColumn::cast_into(StringColumn<uint32_t>* target) const {
   MemoryRange data = target->data_buf();
-  int32_t* offsets = static_cast<int32_t*>(data.wptr()) + 1;
-  MemoryRange strbuf = cast_str_helper<int32_t>(nrows, elements_r(), offsets);
+  uint32_t* offsets = static_cast<uint32_t*>(data.wptr());
+  MemoryRange strbuf = cast_str_helper<uint32_t>(nrows, elements_r(), offsets);
   target->replace_buffer(std::move(data), std::move(strbuf));
 }
 
-void BoolColumn::cast_into(StringColumn<int64_t>* target) const {
+void BoolColumn::cast_into(StringColumn<uint64_t>* target) const {
   MemoryRange data = target->data_buf();
-  int64_t* offsets = static_cast<int64_t*>(data.wptr()) + 1;
-  MemoryRange strbuf = cast_str_helper<int64_t>(nrows, elements_r(), offsets);
+  uint64_t* offsets = static_cast<uint64_t*>(data.wptr());
+  MemoryRange strbuf = cast_str_helper<uint64_t>(nrows, elements_r(), offsets);
   target->replace_buffer(std::move(data), std::move(strbuf));
 }
 

--- a/c/column_int.cc
+++ b/c/column_int.cc
@@ -212,18 +212,18 @@ void IntColumn<T>::cast_into(RealColumn<double>* target) const {
 }
 
 template <typename T>
-void IntColumn<T>::cast_into(StringColumn<int32_t>* target) const {
-  int32_t* offsets = target->offsets_w();
-  MemoryRange strbuf = cast_str_helper<T, int32_t>(
+void IntColumn<T>::cast_into(StringColumn<uint32_t>* target) const {
+  uint32_t* offsets = target->offsets_w();
+  MemoryRange strbuf = cast_str_helper<T, uint32_t>(
       this->nrows, this->elements_r(), offsets
   );
   target->replace_buffer(target->data_buf(), std::move(strbuf));
 }
 
 template <typename T>
-void IntColumn<T>::cast_into(StringColumn<int64_t>* target) const {
-  int64_t* offsets = target->offsets_w();
-  MemoryRange strbuf = cast_str_helper<T, int64_t>(
+void IntColumn<T>::cast_into(StringColumn<uint64_t>* target) const {
+  uint64_t* offsets = target->offsets_w();
+  MemoryRange strbuf = cast_str_helper<T, uint64_t>(
       this->nrows, this->elements_r(), offsets
   );
   target->replace_buffer(target->data_buf(), std::move(strbuf));

--- a/c/column_int.cc
+++ b/c/column_int.cc
@@ -144,16 +144,16 @@ inline static MemoryRange cast_str_helper(
   char* tmpbuf = new char[1024];
   char* tmpend = tmpbuf + 1000;  // Leave at least 24 spare chars in buffer
   char* ch = tmpbuf;
-  OT offset = 1;
-  toffsets[-1] = -1;
+  OT offset = 0;
+  toffsets[-1] = 0;
   for (int64_t i = 0; i < nrows; ++i) {
     IT x = src[i];
     if (ISNA<IT>(x)) {
-      toffsets[i] = -offset;
+      toffsets[i] = offset | GETNA<OT>();
     } else {
       char* ch0 = ch;
       toa<IT>(&ch, x);
-      offset += ch - ch0;
+      offset += static_cast<OT>(ch - ch0);
       toffsets[i] = offset;
       if (ch > tmpend) {
         wb->write(static_cast<size_t>(ch - tmpbuf), tmpbuf);

--- a/c/column_real.cc
+++ b/c/column_real.cc
@@ -130,16 +130,16 @@ inline static MemoryRange cast_str_helper(
   char* tmpbuf = new char[1024];
   char* tmpend = tmpbuf + 1000;  // Leave at least 24 spare chars in buffer
   char* ch = tmpbuf;
-  OT offset = 1;
-  toffsets[-1] = -1;
+  OT offset = 0;
+  toffsets[-1] = 0;
   for (int64_t i = 0; i < src->nrows; ++i) {
     IT x = src_data[i];
     if (ISNA<IT>(x)) {
-      toffsets[i] = -offset;
+      toffsets[i] = offset | GETNA<OT>();
     } else {
       char* ch0 = ch;
       toa<IT>(&ch, x);
-      offset += ch - ch0;
+      offset += static_cast<OT>(ch - ch0);
       toffsets[i] = offset;
       if (ch > tmpend) {
         wb->write(static_cast<size_t>(ch - tmpbuf), tmpbuf);

--- a/c/column_real.cc
+++ b/c/column_real.cc
@@ -187,14 +187,14 @@ void RealColumn<T>::cast_into(IntColumn<int64_t>* target) const {
 }
 
 template <typename T>
-void RealColumn<T>::cast_into(StringColumn<int32_t>* target) const {
-  MemoryRange strbuf = cast_str_helper<T, int32_t>(this, target);
+void RealColumn<T>::cast_into(StringColumn<uint32_t>* target) const {
+  MemoryRange strbuf = cast_str_helper<T, uint32_t>(this, target);
   target->replace_buffer(target->data_buf(), std::move(strbuf));
 }
 
 template <typename T>
-void RealColumn<T>::cast_into(StringColumn<int64_t>* target) const {
-  MemoryRange strbuf = cast_str_helper<T, int64_t>(this, target);
+void RealColumn<T>::cast_into(StringColumn<uint64_t>* target) const {
+  MemoryRange strbuf = cast_str_helper<T, uint64_t>(this, target);
   target->replace_buffer(target->data_buf(), std::move(strbuf));
 }
 

--- a/c/column_string.cc
+++ b/c/column_string.cc
@@ -585,7 +585,7 @@ bool StringColumn<T>::verify_integrity(
   }
 
   int64_t mbuf_nrows = data_nrows();
-  strdata_size = static_cast<size_t>(str_offsets[mbuf_nrows - 1] & NONA);
+  strdata_size = str_offsets[mbuf_nrows - 1] & ~GETNA<T>();
 
   if (strbuf.size() != strdata_size) {
     icc << "Size of string data section in " << name << " does not correspond"

--- a/c/column_string.cc
+++ b/c/column_string.cc
@@ -79,6 +79,15 @@ void StringColumn<T>::open_mmap(const std::string& filename) {
         " rows. Expected file size of " << exp_mbuf_size <<
         " bytes, actual size is " << mbuf.size() << " bytes";
   }
+  if (mbuf.get_element<T>(0) != 0) {
+    // Recode old format of string storage
+    T* offsets = static_cast<T*>(mbuf.wptr()) + 1;
+    offsets[-1] = 0;
+    for (int64_t i = 0; i < nrows; ++i) {
+      T x = offsets[i];
+      offsets[i] = ISNA<T>(x)? GETNA<T>() - x - 1 : x - 1;
+    }
+  }
 
   std::string filename_str = path_str(filename);
 

--- a/c/csv/reader.h
+++ b/c/csv/reader.h
@@ -294,7 +294,7 @@ class GenericReader
  * structure for reading strings from a file.
  */
 struct RelStr {
-  int32_t offset;
+  uint32_t offset;
   int32_t length;
 
   bool isna() { return length == std::numeric_limits<int32_t>::min(); }

--- a/c/csv/reader_fread.cc
+++ b/c/csv/reader_fread.cc
@@ -1046,7 +1046,7 @@ void FreadLocalParseContext::orderBuffer() {
       // offset of the last element. This quantity cannot be calculated in the
       // postprocess() step, since `used_nrows` may some times change affecting
       // this size after the post-processing.
-      uint32_t offset0 = static_cast<int32_t>(strinfo[j].start);
+      uint32_t offset0 = static_cast<uint32_t>(strinfo[j].start);
       uint32_t offsetL = tbuf[j + tbuf_ncols * (used_nrows - 1)].str32.offset;
       size_t sz = (offsetL - offset0) & ~GETNA<uint32_t>();
       strinfo[j].size = sz;

--- a/c/csv/reader_parsers.cc
+++ b/c/csv/reader_parsers.cc
@@ -614,7 +614,7 @@ void parse_string(FreadTokenizer& ctx) {
       // TODO - speed up by avoiding end_NA_string when there are none
       ctx.target->str32.setna();
     } else {
-      ctx.target->str32.offset = (int32_t)(fieldStart - ctx.anchor);
+      ctx.target->str32.offset = static_cast<uint32_t>(fieldStart - ctx.anchor);
       ctx.target->str32.length = fieldLen;
     }
     return;
@@ -686,7 +686,7 @@ void parse_string(FreadTokenizer& ctx) {
     ctx.target->str32.setna();
   } else {
     ctx.target->str32.length = fieldLen;
-    ctx.target->str32.offset = static_cast<int32_t>(fieldStart - ctx.anchor);
+    ctx.target->str32.offset = static_cast<uint32_t>(fieldStart - ctx.anchor);
   }
   if (*ch==quote) {
     ctx.ch = ch + 1;

--- a/c/csv/reader_utils.cc
+++ b/c/csv/reader_utils.cc
@@ -49,9 +49,9 @@ void GReaderColumn::allocate(size_t nrows) {
   mbuf.resize(allocsize);
   if (col_is_string) {
     if (elemsize() == 4)
-      mbuf.set_element<int32_t>(0, -1);
+      mbuf.set_element<int32_t>(0, 0);
     else
-      mbuf.set_element<int64_t>(0, -1);
+      mbuf.set_element<int64_t>(0, 0);
     if (!strdata) {
       strdata = new MemoryWritableBuffer(allocsize);
     }

--- a/c/datatable_check.cc
+++ b/c/datatable_check.cc
@@ -96,6 +96,18 @@ IntegrityCheckContext& IntegrityCheckContext::operator<<(size_t num) {
   return *this;
 }
 
+IntegrityCheckContext& IntegrityCheckContext::operator<<(uint32_t num) {
+  if (num_errors < max_errors)
+    error_stream << num;
+  return *this;
+}
+
+IntegrityCheckContext& IntegrityCheckContext::operator<<(uint64_t num) {
+  if (num_errors < max_errors)
+    error_stream << num;
+  return *this;
+}
+
 void IntegrityCheckContext::operator<<(const EndOfError&) {
   if (num_errors < max_errors)
     error_stream << "\n";

--- a/c/datatable_check.cc
+++ b/c/datatable_check.cc
@@ -102,11 +102,13 @@ IntegrityCheckContext& IntegrityCheckContext::operator<<(uint32_t num) {
   return *this;
 }
 
-IntegrityCheckContext& IntegrityCheckContext::operator<<(uint64_t num) {
-  if (num_errors < max_errors)
-    error_stream << num;
-  return *this;
-}
+#ifdef __APPLE__
+  IntegrityCheckContext& IntegrityCheckContext::operator<<(uint64_t num) {
+    if (num_errors < max_errors)
+      error_stream << num;
+    return *this;
+  }
+#endif
 
 void IntegrityCheckContext::operator<<(const EndOfError&) {
   if (num_errors < max_errors)

--- a/c/datatable_check.h
+++ b/c/datatable_check.h
@@ -38,8 +38,10 @@ public:
   IntegrityCheckContext& operator<<(int32_t);
   IntegrityCheckContext& operator<<(int8_t);
   IntegrityCheckContext& operator<<(size_t);
-  IntegrityCheckContext& operator<<(uint64_t);
   IntegrityCheckContext& operator<<(uint32_t);
+  #ifdef __APPLE__
+    IntegrityCheckContext& operator<<(uint64_t);
+  #endif
   void operator<<(const EndOfError&);
 };
 

--- a/c/datatable_check.h
+++ b/c/datatable_check.h
@@ -38,6 +38,8 @@ public:
   IntegrityCheckContext& operator<<(int32_t);
   IntegrityCheckContext& operator<<(int8_t);
   IntegrityCheckContext& operator<<(size_t);
+  IntegrityCheckContext& operator<<(uint64_t);
+  IntegrityCheckContext& operator<<(uint32_t);
   void operator<<(const EndOfError&);
 };
 

--- a/c/datatable_load.cc
+++ b/c/datatable_load.cc
@@ -43,13 +43,12 @@ DataTable* DataTable::load(DataTable* colspec, int64_t nrows, const std::string&
                            << stypes;
     }
 
-    StringColumn<int32_t>* colf =
-        static_cast<StringColumn<int32_t>*>(colspec->columns[0]);
-    StringColumn<int32_t>* cols =
-        static_cast<StringColumn<int32_t>*>(colspec->columns[1]);
+    auto colf = static_cast<StringColumn<uint32_t>*>(colspec->columns[0]);
+    auto cols = static_cast<StringColumn<uint32_t>*>(colspec->columns[1]);
 
-    const int32_t* offf = colf->offsets();
-    const int32_t* offs = cols->offsets();
+    const uint32_t* offf = colf->offsets();
+    const uint32_t* offs = cols->offsets();
+    constexpr uint32_t NONA = StringColumn<uint32_t>::NONA;
 
     std::string rootdir(path);
     if (!(rootdir.empty() || rootdir.back() == '/'))
@@ -58,16 +57,16 @@ DataTable* DataTable::load(DataTable* colspec, int64_t nrows, const std::string&
     for (int64_t i = 0; i < ncols; ++i)
     {
         // Extract filename
-        size_t fsta = static_cast<size_t>(abs(offf[i - 1]));
-        size_t fend = static_cast<size_t>(abs(offf[i]));
+        size_t fsta = static_cast<size_t>(offf[i]);
+        size_t fend = static_cast<size_t>(offf[i + 1] & NONA);
         size_t flen = static_cast<size_t>(fend - fsta);
 
         std::string filename = rootdir;
         filename.append(colf->strdata() + fsta, flen);
 
         // Extract stype
-        size_t ssta = static_cast<size_t>(abs(offs[i - 1]));
-        size_t send = static_cast<size_t>(abs(offs[i]));
+        size_t ssta = static_cast<size_t>(offs[i]);
+        size_t send = static_cast<size_t>(offs[i + 1] & NONA);
         size_t slen = static_cast<size_t>(send - ssta);
         if (!(slen == 3 || slen==2)) {
             throw ValueError() << "Incorrect stype's length: " << slen;

--- a/c/datatable_load.cc
+++ b/c/datatable_load.cc
@@ -48,25 +48,25 @@ DataTable* DataTable::load(DataTable* colspec, int64_t nrows, const std::string&
 
     const uint32_t* offf = colf->offsets();
     const uint32_t* offs = cols->offsets();
-    constexpr uint32_t NONA = StringColumn<uint32_t>::NONA;
+    constexpr uint32_t NONA = ~GETNA<uint32_t>();
 
     std::string rootdir(path);
     if (!(rootdir.empty() || rootdir.back() == '/'))
       rootdir += "/";
 
-    for (int64_t i = 0; i < ncols; ++i)
-    {
+    for (int64_t i = 0; i < ncols; ++i) {
+
         // Extract filename
-        size_t fsta = static_cast<size_t>(offf[i]);
-        size_t fend = static_cast<size_t>(offf[i + 1] & NONA);
+        size_t fsta = static_cast<size_t>(offf[i - 1] & NONA);
+        size_t fend = static_cast<size_t>(offf[i] & NONA);
         size_t flen = static_cast<size_t>(fend - fsta);
 
         std::string filename = rootdir;
         filename.append(colf->strdata() + fsta, flen);
 
         // Extract stype
-        size_t ssta = static_cast<size_t>(offs[i]);
-        size_t send = static_cast<size_t>(offs[i + 1] & NONA);
+        size_t ssta = static_cast<size_t>(offs[i - 1] & NONA);
+        size_t send = static_cast<size_t>(offs[i] & NONA);
         size_t slen = static_cast<size_t>(send - ssta);
         if (!(slen == 3 || slen==2)) {
             throw ValueError() << "Incorrect stype's length: " << slen;

--- a/c/expr/binaryop.cc
+++ b/c/expr/binaryop.cc
@@ -117,18 +117,16 @@ static void strmap_n_to_n(int64_t row0, int64_t row1, void** params) {
   const T1* offsets1 = col1->offsets();
   const char* strdata0 = col0->strdata();
   const char* strdata1 = col1->strdata();
-  constexpr T0 NONA0 = StringColumn<T0>::NONA;
-  constexpr T1 NONA1 = StringColumn<T1>::NONA;
   T2* res_data = static_cast<T2*>(col2->data_w());
-  T0 str0start = offsets0[row0] & NONA0;
-  T1 str1start = offsets1[row0] & NONA1;
-  for (int64_t i = row0 + 1; i <= row1; ++i) {
+  T0 str0start = offsets0[row0 - 1] & ~GETNA<T0>();
+  T1 str1start = offsets1[row0 - 1] & ~GETNA<T1>();
+  for (int64_t i = row0; i < row1; ++i) {
     T0 str0end = offsets0[i];
     T1 str1end = offsets1[i];
     res_data[i] = OP(str0start, str0end, strdata0,
                      str1start, str1end, strdata1);
-    str0start = str0end & NONA0;
-    str1start = str1end & NONA1;
+    str0start = str0end & ~GETNA<T0>();
+    str1start = str1end & ~GETNA<T1>();
   }
 }
 
@@ -143,16 +141,15 @@ static void strmap_n_to_1(int64_t row0, int64_t row1, void** params) {
   const T1* offsets1 = col1->offsets();
   const char* strdata0 = col0->strdata();
   const char* strdata1 = col1->strdata();
-  constexpr T0 NONA0 = ~GETNA<T0>();
-  T0 str0start = offsets0[row0] & NONA0;
+  T0 str0start = offsets0[row0 - 1] & ~GETNA<T0>();
   T1 str1start = 0;
-  T1 str1end = offsets1[1];
+  T1 str1end = offsets1[0];
   T2* res_data = static_cast<T2*>(col2->data_w());
   for (int64_t i = row0; i < row1; ++i) {
     T0 str0end = offsets0[i];
     res_data[i] = OP(str0start, str0end, strdata0,
                      str1start, str1end, strdata1);
-    str0start = str0end & NONA0;
+    str0start = str0end & ~GETNA<T0>();
   }
 }
 
@@ -258,9 +255,7 @@ inline static int8_t op_le(LT x, RT y) {  // x <= y
 template<typename T1, typename T2>
 inline static int8_t strop_eq(T1 start1, T1 end1, const char* strdata1,
                               T2 start2, T2 end2, const char* strdata2) {
-  constexpr T1 NAMASK1 = StringColumn<T1>::NAMASK;
-  constexpr T2 NAMASK2 = StringColumn<T2>::NAMASK;
-  if ((end1 & NAMASK1) == 0 && (end2 & NAMASK2) == 0) {
+  if (!ISNA<T1>(end1) && !ISNA<T2>(end2)) {
     if (end1 - start1 == end2 - start2) {
       const char* ch1 = strdata1 + start1;
       const char* ch2 = strdata2 + start2;
@@ -273,16 +268,14 @@ inline static int8_t strop_eq(T1 start1, T1 end1, const char* strdata1,
       return 0;
     }
   } else {
-    return (end1 & NAMASK1) && (end2 & NAMASK2);
+    return ISNA<T1>(end1) && ISNA<T2>(end2);
   }
 }
 
 template<typename T1, typename T2>
 inline static int8_t strop_ne(T1 start1, T1 end1, const char* strdata1,
                               T2 start2, T2 end2, const char* strdata2) {
-  constexpr T1 NAMASK1 = StringColumn<T1>::NAMASK;
-  constexpr T2 NAMASK2 = StringColumn<T2>::NAMASK;
-  if ((end1 & NAMASK1) == 0 && (end2 & NAMASK2) == 0) {
+  if (!ISNA<T1>(end1) && !ISNA<T2>(end2)) {
     if (end1 - start1 == end2 - start2) {
       const char* ch1 = strdata1 + start1;
       const char* ch2 = strdata2 + start2;
@@ -295,7 +288,7 @@ inline static int8_t strop_ne(T1 start1, T1 end1, const char* strdata1,
       return 1;
     }
   } else {
-    return (end1 & NAMASK1) == 0 || (end2 & NAMASK2) == 0;
+    return !(ISNA<T1>(end1) && ISNA<T2>(end2));
   }
 }
 

--- a/c/expr/unaryop.cc
+++ b/c/expr/unaryop.cc
@@ -124,8 +124,8 @@ static mapperfn resolve0(SType stype, int opcode) {
     case ST_INTEGER_I8: return resolve1<int64_t>(opcode);
     case ST_REAL_F4:    return resolve1<float>(opcode);
     case ST_REAL_F8:    return resolve1<double>(opcode);
-    case ST_STRING_I4_VCHAR: return resolve_str<int32_t>(opcode);
-    case ST_STRING_I8_VCHAR: return resolve_str<int64_t>(opcode);
+    case ST_STRING_I4_VCHAR: return resolve_str<uint32_t>(opcode);
+    case ST_STRING_I8_VCHAR: return resolve_str<uint64_t>(opcode);
     default: break;
   }
   return nullptr;

--- a/c/expr/unaryop.cc
+++ b/c/expr/unaryop.cc
@@ -61,11 +61,6 @@ inline static int8_t op_isna(T x) {
 }
 
 template<typename T>
-inline static int8_t strop_isna(T x) {
-  return (x < 0);
-}
-
-template<typename T>
 struct Inverse {
   inline static T impl(T x) {
     return ISNA<T>(x) ? x : ~x;
@@ -107,7 +102,7 @@ static mapperfn resolve1(int opcode) {
 template<typename T>
 static mapperfn resolve_str(int opcode) {
   if (opcode == OpCode::IsNa) {
-    return strmap_n<T, int8_t, strop_isna<T>>;
+    return strmap_n<T, int8_t, op_isna<T>>;
   }
   return nullptr;
 }

--- a/c/memrange.cc
+++ b/c/memrange.cc
@@ -997,6 +997,10 @@
 
   template int32_t MemoryRange::get_element(int64_t) const;
   template int64_t MemoryRange::get_element(int64_t) const;
+  template uint32_t MemoryRange::get_element(int64_t) const;
+  template uint64_t MemoryRange::get_element(int64_t) const;
   template void MemoryRange::set_element(int64_t, char);
   template void MemoryRange::set_element(int64_t, int32_t);
   template void MemoryRange::set_element(int64_t, int64_t);
+  template void MemoryRange::set_element(int64_t, uint32_t);
+  template void MemoryRange::set_element(int64_t, uint64_t);

--- a/c/memrange.h
+++ b/c/memrange.h
@@ -276,10 +276,14 @@ class MemoryRange
 template <> void MemoryRange::set_element(int64_t, PyObject*);
 extern template int32_t MemoryRange::get_element(int64_t) const;
 extern template int64_t MemoryRange::get_element(int64_t) const;
+extern template uint32_t MemoryRange::get_element(int64_t) const;
+extern template uint64_t MemoryRange::get_element(int64_t) const;
 extern template void MemoryRange::set_element(int64_t, PyObject*);
 extern template void MemoryRange::set_element(int64_t, char);
 extern template void MemoryRange::set_element(int64_t, int32_t);
 extern template void MemoryRange::set_element(int64_t, int64_t);
+extern template void MemoryRange::set_element(int64_t, uint32_t);
+extern template void MemoryRange::set_element(int64_t, uint64_t);
 
 
 #endif

--- a/c/py_buffers.cc
+++ b/c/py_buffers.cc
@@ -147,7 +147,7 @@ static Column* convert_fwchararray_to_column(Py_buffer* view)
   }
 
   strbuf.resize(static_cast<size_t>(offset - 1));
-  return new StringColumn<int32_t>(nrows, std::move(offbuf), std::move(strbuf));
+  return new StringColumn<uint32_t>(nrows, std::move(offbuf), std::move(strbuf));
 }
 
 
@@ -214,7 +214,7 @@ static Column* try_to_resolve_object_column(Column* col)
 
   strbuf.resize(offset);
   delete col;
-  return new StringColumn<int32_t>(nrows, std::move(offbuf), std::move(strbuf));
+  return new StringColumn<uint32_t>(nrows, std::move(offbuf), std::move(strbuf));
 }
 
 

--- a/c/py_types.cc
+++ b/c/py_types.cc
@@ -93,12 +93,11 @@ template <typename T>
 static PyObject* stype_vchar_T_tostring(Column* col, int64_t row) {
   StringColumn<T>* str_col = static_cast<StringColumn<T>*>(col);
   const T* offsets = str_col->offsets();
-  if (ISNA<T>(offsets[row]))
-      return none();
-  T start = offsets[row];
-  T len = (offsets[row + 1] & StringColumn<T>::NONA) - start;
-  return PyUnicode_FromStringAndSize(str_col->strdata() +
-      static_cast<size_t>(start), len);
+  T end = offsets[row];
+  if (ISNA<T>(end)) return none();
+  T start = offsets[row - 1] & ~GETNA<T>();
+  T len = end - start;
+  return PyUnicode_FromStringAndSize(str_col->strdata() + start, len);
 }
 
 static PyObject* stype_object_pyptr_tostring(Column* col, int64_t row)

--- a/c/py_types.cc
+++ b/c/py_types.cc
@@ -93,10 +93,10 @@ template <typename T>
 static PyObject* stype_vchar_T_tostring(Column* col, int64_t row) {
   StringColumn<T>* str_col = static_cast<StringColumn<T>*>(col);
   const T* offsets = str_col->offsets();
-  if (offsets[row] < 0)
+  if (ISNA<T>(offsets[row]))
       return none();
-  T start = abs(offsets[row - 1]);
-  T len = offsets[row] - start;
+  T start = offsets[row];
+  T len = (offsets[row + 1] & StringColumn<T>::NONA) - start;
   return PyUnicode_FromStringAndSize(str_col->strdata() +
       static_cast<size_t>(start), len);
 }
@@ -150,8 +150,8 @@ int init_py_types(PyObject*)
   py_stype_formatters[ST_REAL_I2]            = stype_notimpl;
   py_stype_formatters[ST_REAL_I4]            = stype_notimpl;
   py_stype_formatters[ST_REAL_I8]            = stype_notimpl;
-  py_stype_formatters[ST_STRING_I4_VCHAR]    = stype_vchar_T_tostring<int32_t>;
-  py_stype_formatters[ST_STRING_I8_VCHAR]    = stype_vchar_T_tostring<int64_t>;
+  py_stype_formatters[ST_STRING_I4_VCHAR]    = stype_vchar_T_tostring<uint32_t>;
+  py_stype_formatters[ST_STRING_I8_VCHAR]    = stype_vchar_T_tostring<uint64_t>;
   py_stype_formatters[ST_STRING_FCHAR]       = stype_notimpl;
   py_stype_formatters[ST_STRING_U1_ENUM]     = stype_notimpl;
   py_stype_formatters[ST_STRING_U2_ENUM]     = stype_notimpl;

--- a/c/py_types.cc
+++ b/c/py_types.cc
@@ -96,7 +96,7 @@ static PyObject* stype_vchar_T_tostring(Column* col, int64_t row) {
   T end = offsets[row];
   if (ISNA<T>(end)) return none();
   T start = offsets[row - 1] & ~GETNA<T>();
-  T len = end - start;
+  auto len = static_cast<Py_ssize_t>(end - start);
   return PyUnicode_FromStringAndSize(str_col->strdata() + start, len);
 }
 

--- a/c/sort.cc
+++ b/c/sort.cc
@@ -495,11 +495,11 @@ class SortContext {
             reduction(max:maxlen)
     for (size_t j = 0; j < n; ++j) {
       int32_t k = use_order? o[j] : static_cast<int32_t>(j);
-      T offstart = offs[k];
-      if (ISNA<T>(offstart)) {
+      T offend = offs[k];
+      if (ISNA<T>(offend)) {
         xo[j] = 0;
       } else {
-        T offend = offs[k + 1] & ~GETNA<T>();
+        T offstart = offs[k - 1] & ~GETNA<T>();
         T len = offend - offstart;
         xo[j] = len > 0? strdata[offstart] + 2 : 1;
         if (len > maxlen) maxlen = len;
@@ -710,8 +710,8 @@ class SortContext {
         size_t k = tcounts[xi[j]]++;
         xassert(k < n);
         int32_t w = use_order? o[j] : static_cast<int32_t>(j);
-        T offstart = soffs[w];
-        T offend = (soffs[w + 1] & ~GETNA<T>()) + sstart;
+        T offend = soffs[w];
+        T offstart = (soffs[w - 1] & ~GETNA<T>()) + sstart;
         T len = offend - offstart;
         xo[k] = len > 0? strdata[offstart] + 2 : 1;
         next_o[k] = w;

--- a/c/sort.cc
+++ b/c/sort.cc
@@ -497,12 +497,16 @@ class SortContext {
       int32_t k = use_order? o[j] : static_cast<int32_t>(j);
       T offend = offs[k];
       if (ISNA<T>(offend)) {
-        xo[j] = 0;
+        xo[j] = 0;    // NA string
       } else {
         T offstart = offs[k - 1] & ~GETNA<T>();
-        T len = offend - offstart;
-        xo[j] = len > 0? strdata[offstart] + 2 : 1;
-        if (len > maxlen) maxlen = len;
+        if (offend > offstart) {
+          xo[j] = strdata[offstart] + 2;
+          T len = offend - offstart;
+          if (len > maxlen) maxlen = len;
+        } else {
+          xo[j] = 1;  // empty string
+        }
       }
     }
     next_elemsize = (maxlen > 1);
@@ -712,10 +716,15 @@ class SortContext {
         int32_t w = use_order? o[j] : static_cast<int32_t>(j);
         T offend = soffs[w];
         T offstart = (soffs[w - 1] & ~GETNA<T>()) + sstart;
-        T len = offend - offstart;
-        xo[k] = len > 0? strdata[offstart] + 2 : 1;
+        xassert(!ISNA<T>(offend));
+        if (offend > offstart) {
+          xo[k] = strdata[offstart] + 2;
+          T len = offend - offstart;
+          if (len > maxlen) maxlen = len;
+        } else {
+          xo[k] = 1;  // string is shorter than sstart
+        }
         next_o[k] = w;
-        if (len > maxlen) maxlen = len;
       }
     }
     next_elemsize = maxlen > 0;

--- a/c/sort.h
+++ b/c/sort.h
@@ -125,20 +125,20 @@ extern template void insert_sort_values(const uint16_t*, int32_t*, int, GroupGat
 extern template void insert_sort_values(const uint32_t*, int32_t*, int, GroupGatherer&);
 extern template void insert_sort_values(const uint64_t*, int32_t*, int, GroupGatherer&);
 
-extern template void insert_sort_keys_str(const uint8_t*, const int32_t*, int32_t, int32_t*, int32_t*, int, GroupGatherer&);
-extern template void insert_sort_values_str(const uint8_t*, const int32_t*, int32_t, int32_t*, int, GroupGatherer&);
-extern template void insert_sort_keys_str(const uint8_t*, const int64_t*, int64_t, int32_t*, int32_t*, int, GroupGatherer&);
-extern template void insert_sort_values_str(const uint8_t*, const int64_t*, int64_t, int32_t*, int, GroupGatherer&);
+extern template void insert_sort_keys_str(  const uint8_t*, const uint32_t*, uint32_t, int32_t*, int32_t*, int, GroupGatherer&);
+extern template void insert_sort_values_str(const uint8_t*, const uint32_t*, uint32_t, int32_t*, int, GroupGatherer&);
+extern template void insert_sort_keys_str(  const uint8_t*, const uint64_t*, uint64_t, int32_t*, int32_t*, int, GroupGatherer&);
+extern template void insert_sort_values_str(const uint8_t*, const uint64_t*, uint64_t, int32_t*, int, GroupGatherer&);
 
-extern template int compare_offstrings(const uint8_t*, int32_t, int32_t, int32_t, int32_t);
-extern template int compare_offstrings(const uint8_t*, int64_t, int64_t, int64_t, int64_t);
+extern template int compare_offstrings(const uint8_t*, uint32_t, uint32_t, uint32_t, uint32_t);
+extern template int compare_offstrings(const uint8_t*, uint64_t, uint64_t, uint64_t, uint64_t);
 
 extern template void GroupGatherer::from_data(const uint8_t*,  int32_t*, size_t);
 extern template void GroupGatherer::from_data(const uint16_t*, int32_t*, size_t);
 extern template void GroupGatherer::from_data(const uint32_t*, int32_t*, size_t);
 extern template void GroupGatherer::from_data(const uint64_t*, int32_t*, size_t);
-extern template void GroupGatherer::from_data(const uint8_t*, const int32_t*, int32_t, int32_t*, size_t);
-extern template void GroupGatherer::from_data(const uint8_t*, const int64_t*, int64_t, int32_t*, size_t);
+extern template void GroupGatherer::from_data(const uint8_t*, const uint32_t*, uint32_t, int32_t*, size_t);
+extern template void GroupGatherer::from_data(const uint8_t*, const uint64_t*, uint64_t, int32_t*, size_t);
 
 
 #endif

--- a/c/sort_groups.cc
+++ b/c/sort_groups.cc
@@ -50,12 +50,12 @@ void GroupGatherer::from_data(
   const uint8_t* strdata, const T* stroffs, T start, V* o, size_t n)
 {
   if (n == 0) return;
-  T olast0 = stroffs[o[0]] + start;
-  T olast1 = stroffs[o[0] + 1];
+  T olast0 = (stroffs[o[0] - 1] + start) & ~GETNA<T>();
+  T olast1 = stroffs[o[0]];
   size_t lasti = 0;
   for (size_t i = 1; i < n; ++i) {
-    T ocurr0 = stroffs[o[i]] + start;
-    T ocurr1 = stroffs[o[i] + 1];
+    T ocurr0 = (stroffs[o[i] - 1] + start) & ~GETNA<T>();
+    T ocurr1 = stroffs[o[i]];
     if (compare_offstrings(strdata, olast0, olast1, ocurr0, ocurr1)) {
       push(i - lasti);
       olast0 = ocurr0;

--- a/c/sort_groups.cc
+++ b/c/sort_groups.cc
@@ -50,12 +50,12 @@ void GroupGatherer::from_data(
   const uint8_t* strdata, const T* stroffs, T start, V* o, size_t n)
 {
   if (n == 0) return;
-  T olast0 = std::abs(stroffs[o[0] - 1]) + start;
-  T olast1 = stroffs[o[0]];
+  T olast0 = stroffs[o[0]] + start;
+  T olast1 = stroffs[o[0] + 1];
   size_t lasti = 0;
   for (size_t i = 1; i < n; ++i) {
-    T ocurr0 = std::abs(stroffs[o[i] - 1]) + start;
-    T ocurr1 = stroffs[o[i]];
+    T ocurr0 = stroffs[o[i]] + start;
+    T ocurr1 = stroffs[o[i] + 1];
     if (compare_offstrings(strdata, olast0, olast1, ocurr0, ocurr1)) {
       push(i - lasti);
       olast0 = ocurr0;
@@ -107,5 +107,5 @@ template void GroupGatherer::from_data(const uint8_t*,  int32_t*, size_t);
 template void GroupGatherer::from_data(const uint16_t*, int32_t*, size_t);
 template void GroupGatherer::from_data(const uint32_t*, int32_t*, size_t);
 template void GroupGatherer::from_data(const uint64_t*, int32_t*, size_t);
-template void GroupGatherer::from_data(const uint8_t*, const int32_t*, int32_t, int32_t*, size_t);
-template void GroupGatherer::from_data(const uint8_t*, const int64_t*, int64_t, int32_t*, size_t);
+template void GroupGatherer::from_data(const uint8_t*, const uint32_t*, uint32_t, int32_t*, size_t);
+template void GroupGatherer::from_data(const uint8_t*, const uint64_t*, uint64_t, int32_t*, size_t);

--- a/c/sort_groups.cc
+++ b/c/sort_groups.cc
@@ -50,11 +50,11 @@ void GroupGatherer::from_data(
   const uint8_t* strdata, const T* stroffs, T start, V* o, size_t n)
 {
   if (n == 0) return;
-  T olast0 = (stroffs[o[0] - 1] + start) & ~GETNA<T>();
+  T olast0 = (stroffs[o[0] - 1] & ~GETNA<T>()) + start;
   T olast1 = stroffs[o[0]];
   size_t lasti = 0;
   for (size_t i = 1; i < n; ++i) {
-    T ocurr0 = (stroffs[o[i] - 1] + start) & ~GETNA<T>();
+    T ocurr0 = (stroffs[o[i] - 1] & ~GETNA<T>()) + start;
     T ocurr1 = stroffs[o[i]];
     if (compare_offstrings(strdata, olast0, olast1, ocurr0, ocurr1)) {
       push(i - lasti);

--- a/c/sort_insert.cc
+++ b/c/sort_insert.cc
@@ -40,8 +40,8 @@ int compare_offstrings(
     const uint8_t* strdata, T aoff0, T aoff1, T boff0, T boff1)
 {
   // Handle NAs and empty strings
-  if (boff1 < 0) return aoff1 < 0? 0 : -1;
-  if (aoff1 < 0) return 1;
+  if (ISNA<T>(boff1)) return ISNA<T>(aoff1)? 0 : -1;
+  if (ISNA<T>(aoff1)) return 1;
   T lena = aoff1 - aoff0;
   T lenb = boff1 - boff0;
   if (lenb <= 0) return lena <= 0? 0 : -1;
@@ -146,12 +146,12 @@ void insert_sort_keys_str(
   int j;
   tmp[0] = 0;
   for (int i = 1; i < n; ++i) {
-    T off0i = std::abs(stroffs[o[i]-1]) + strstart;
-    T off1i = stroffs[o[i]];
+    T off0i = stroffs[o[i]] + strstart;
+    T off1i = stroffs[o[i] + 1];
     for (j = i; j > 0; --j) {
       V k = tmp[j - 1];
-      T off0k = std::abs(stroffs[o[k]-1]) + strstart;
-      T off1k = stroffs[o[k]];
+      T off0k = stroffs[o[k]] + strstart;
+      T off1k = stroffs[o[k] + 1];
       int cmp = compare_offstrings(strdata, off0i, off1i, off0k, off1k);
       if (cmp != 1) break;
       tmp[j] = tmp[j-1];
@@ -176,12 +176,12 @@ void insert_sort_values_str(
   int j;
   o[0] = 0;
   for (int i = 1; i < n; ++i) {
-    T off0i = std::abs(stroffs[i-1]) + strstart;
-    T off1i = stroffs[i];
+    T off0i = stroffs[i] + strstart;
+    T off1i = stroffs[i + 1];
     for (j = i; j > 0; j--) {
       V k = o[j - 1];
-      T off0k = std::abs(stroffs[k-1]) + strstart;
-      T off1k = stroffs[k];
+      T off0k = stroffs[k] + strstart;
+      T off1k = stroffs[k + 1];
       int cmp = compare_offstrings(strdata, off0i, off1i, off0k, off1k);
       if (cmp != 1) break;
       o[j] = o[j-1];
@@ -209,9 +209,9 @@ template void insert_sort_values(const uint16_t*, int32_t*, int, GroupGatherer&)
 template void insert_sort_values(const uint32_t*, int32_t*, int, GroupGatherer&);
 template void insert_sort_values(const uint64_t*, int32_t*, int, GroupGatherer&);
 
-template void insert_sort_keys_str(const uint8_t*, const int32_t*, int32_t, int32_t*, int32_t*, int, GroupGatherer&);
-template void insert_sort_values_str(const uint8_t*, const int32_t*, int32_t, int32_t*, int, GroupGatherer&);
-template void insert_sort_keys_str(const uint8_t*, const int64_t*, int64_t, int32_t*, int32_t*, int, GroupGatherer&);
-template void insert_sort_values_str(const uint8_t*, const int64_t*, int64_t, int32_t*, int, GroupGatherer&);
-template int compare_offstrings(const uint8_t*, int32_t, int32_t, int32_t, int32_t);
-template int compare_offstrings(const uint8_t*, int64_t, int64_t, int64_t, int64_t);
+template void insert_sort_keys_str(  const uint8_t*, const uint32_t*, uint32_t, int32_t*, int32_t*, int, GroupGatherer&);
+template void insert_sort_values_str(const uint8_t*, const uint32_t*, uint32_t, int32_t*, int, GroupGatherer&);
+template void insert_sort_keys_str(  const uint8_t*, const uint64_t*, uint64_t, int32_t*, int32_t*, int, GroupGatherer&);
+template void insert_sort_values_str(const uint8_t*, const uint64_t*, uint64_t, int32_t*, int, GroupGatherer&);
+template int compare_offstrings(const uint8_t*, uint32_t, uint32_t, uint32_t, uint32_t);
+template int compare_offstrings(const uint8_t*, uint64_t, uint64_t, uint64_t, uint64_t);

--- a/c/sort_insert.cc
+++ b/c/sort_insert.cc
@@ -42,11 +42,11 @@ int compare_offstrings(
   // Handle NAs and empty strings
   if (ISNA<T>(boff1)) return ISNA<T>(aoff1)? 0 : -1;
   if (ISNA<T>(aoff1)) return 1;
+  if (boff1 <= boff0) return aoff1 <= aoff0? 0 : -1;
+  if (aoff1 <= aoff0) return 1;
+
   T lena = aoff1 - aoff0;
   T lenb = boff1 - boff0;
-  if (lenb <= 0) return lena <= 0? 0 : -1;
-  if (lena <= 0) return 1;
-
   for (T t = 0; t < lena; ++t) {
     if (t == lenb) return -1;  // b is shorter than a
     uint8_t ca = strdata[aoff0 + t];
@@ -180,7 +180,7 @@ void insert_sort_values_str(
     T off1i = stroffs[i];
     for (j = i; j > 0; j--) {
       V k = o[j - 1];
-      T off0k = (stroffs[k] + strstart) & ~GETNA<T>();
+      T off0k = (stroffs[k - 1] + strstart) & ~GETNA<T>();
       T off1k = stroffs[k];
       int cmp = compare_offstrings(strdata, off0i, off1i, off0k, off1k);
       if (cmp != 1) break;

--- a/c/sort_insert.cc
+++ b/c/sort_insert.cc
@@ -146,12 +146,12 @@ void insert_sort_keys_str(
   int j;
   tmp[0] = 0;
   for (int i = 1; i < n; ++i) {
-    T off0i = stroffs[o[i]] + strstart;
-    T off1i = stroffs[o[i] + 1];
+    T off0i = (stroffs[o[i] - 1] + strstart) & ~GETNA<T>();
+    T off1i = stroffs[o[i]];
     for (j = i; j > 0; --j) {
       V k = tmp[j - 1];
-      T off0k = stroffs[o[k]] + strstart;
-      T off1k = stroffs[o[k] + 1];
+      T off0k = (stroffs[o[k] - 1] + strstart) & ~GETNA<T>();
+      T off1k = stroffs[o[k]];
       int cmp = compare_offstrings(strdata, off0i, off1i, off0k, off1k);
       if (cmp != 1) break;
       tmp[j] = tmp[j-1];
@@ -176,12 +176,12 @@ void insert_sort_values_str(
   int j;
   o[0] = 0;
   for (int i = 1; i < n; ++i) {
-    T off0i = stroffs[i] + strstart;
-    T off1i = stroffs[i + 1];
+    T off0i = (stroffs[i - 1] + strstart) & ~GETNA<T>();
+    T off1i = stroffs[i];
     for (j = i; j > 0; j--) {
       V k = o[j - 1];
-      T off0k = stroffs[k] + strstart;
-      T off1k = stroffs[k + 1];
+      T off0k = (stroffs[k] + strstart) & ~GETNA<T>();
+      T off1k = stroffs[k];
       int cmp = compare_offstrings(strdata, off0i, off1i, off0k, off1k);
       if (cmp != 1) break;
       o[j] = o[j-1];

--- a/c/stats.cc
+++ b/c/stats.cc
@@ -468,10 +468,10 @@ void StringStats<T>::compute_sorted_stats(const Column* col) {
 
   if (max_grpsize) {
     int64_t i = ri.nth(groups[best_igrp]);
-    T o0 = offsets[i] & ~GETNA<T>();
+    T o0 = offsets[i - 1] & ~GETNA<T>();
     _nmodal = max_grpsize;
     _mode.ch = scol->strdata() + o0;
-    _mode.size = (offsets[i + 1] & ~GETNA<T>()) - o0;
+    _mode.size = offsets[i] - o0;
   } else {
     _nmodal = 0;
     _mode.ch = nullptr;

--- a/c/stats.h
+++ b/c/stats.h
@@ -237,8 +237,8 @@ class StringStats : public Stats {
     virtual void compute_sorted_stats(const Column*) override;
 };
 
-extern template class StringStats<int32_t>;
-extern template class StringStats<int64_t>;
+extern template class StringStats<uint32_t>;
+extern template class StringStats<uint64_t>;
 
 
 

--- a/c/types.h
+++ b/c/types.h
@@ -412,13 +412,7 @@ typedef struct EnumMeta {     // ST_STRING_UX_ENUM
 
 /**
  * NA constants
- *
- * Integer-based NAs can be compared by value (e.g. `x == NA_I4`), whereas
- * floating-point NAs require special functions `ISNA_F4(x)` and `ISNA_F8(x)`.
  */
-
-#define NA_F4_BITS 0x7F8007A2u
-#define NA_F8_BITS 0x7FF00000000007A2ull
 
 constexpr int8_t   NA_I1 = INT8_MIN;
 constexpr int16_t  NA_I2 = INT16_MIN;
@@ -428,22 +422,10 @@ constexpr uint8_t  NA_U1 = UINT8_MAX;
 constexpr uint16_t NA_U2 = UINT16_MAX;
 constexpr uint32_t NA_U4 = UINT32_MAX;
 constexpr uint64_t NA_U8 = UINT64_MAX;
+constexpr uint32_t NA_S4 = uint32_t(1) << 31;
+constexpr uint64_t NA_S8 = uint64_t(1) << 63;
 constexpr float    NA_F4 = std::numeric_limits<float>::quiet_NaN();
 constexpr double   NA_F8 = std::numeric_limits<double>::quiet_NaN();
-
-int ISNA_F4(float x);
-int ISNA_F8(double x);
-
-#define ISNA_I1(x)  ((int8_t)(x)   == NA_I1)
-#define ISNA_I2(x)  ((int16_t)(x)  == NA_I2)
-#define ISNA_I4(x)  ((int32_t)(x)  == NA_I4)
-#define ISNA_I8(x)  ((int64_t)(x)  == NA_I8)
-#define ISNA_U1(x)  ((uint8_t)(x)  == NA_U1)
-#define ISNA_U2(x)  ((uint16_t)(x) == NA_U2)
-#define ISNA_U4(x)  ((uint32_t)(x) == NA_U4)
-#define ISNA_F4(x)  (isnan(x))
-#define ISNA_F8(x)  (isnan(x))
-
 
 /**
  * GETNA function
@@ -456,9 +438,8 @@ template<> constexpr int8_t   GETNA() { return NA_I1; }
 template<> constexpr int16_t  GETNA() { return NA_I2; }
 template<> constexpr int32_t  GETNA() { return NA_I4; }
 template<> constexpr int64_t  GETNA() { return NA_I8; }
-template<> constexpr uint8_t  GETNA() { return NA_U1; }
-template<> constexpr uint16_t GETNA() { return NA_U2; }
-template<> constexpr uint32_t GETNA() { return NA_U4; }
+template<> constexpr uint32_t GETNA() { return NA_S4; }
+template<> constexpr uint64_t GETNA() { return NA_S8; }
 template<> constexpr float    GETNA() { return NA_F4; }
 template<> constexpr double   GETNA() { return NA_F8; }
 template<> constexpr PyObject* GETNA() { return Py_None; }
@@ -470,13 +451,12 @@ template<> constexpr PyObject* GETNA() { return Py_None; }
  */
 template <typename T>
            inline bool ISNA(T)          { return true;       }
-template<> inline bool ISNA(int8_t x)   { return ISNA_I1(x); }
-template<> inline bool ISNA(int16_t x)  { return ISNA_I2(x); }
-template<> inline bool ISNA(int32_t x)  { return ISNA_I4(x); }
-template<> inline bool ISNA(int64_t x)  { return ISNA_I8(x); }
-template<> inline bool ISNA(uint8_t x)  { return ISNA_U1(x); }
-template<> inline bool ISNA(uint16_t x) { return ISNA_U2(x); }
-template<> inline bool ISNA(uint32_t x) { return ISNA_U4(x); }
+template<> inline bool ISNA(int8_t x)   { return x == NA_I1; }
+template<> inline bool ISNA(int16_t x)  { return x == NA_I2; }
+template<> inline bool ISNA(int32_t x)  { return x == NA_I4; }
+template<> inline bool ISNA(int64_t x)  { return x == NA_I8; }
+template<> inline bool ISNA(uint32_t x) { return (x & NA_S4); }
+template<> inline bool ISNA(uint64_t x) { return (x & NA_S8); }
 template<> inline bool ISNA(float x)    { return isnan(x); }
 template<> inline bool ISNA(double x)   { return isnan(x); }
 template<> inline bool ISNA(PyObject* x) { return x == Py_None; }

--- a/c/utils/exceptions.cc
+++ b/c/utils/exceptions.cc
@@ -76,6 +76,8 @@ Error& Error::operator<<(int64_t v)            { error << v; return *this; }
 Error& Error::operator<<(int32_t v)            { error << v; return *this; }
 Error& Error::operator<<(int8_t v)             { error << v; return *this; }
 Error& Error::operator<<(size_t v)             { error << v; return *this; }
+Error& Error::operator<<(uint64_t v)           { error << v; return *this; }
+Error& Error::operator<<(uint32_t v)           { error << v; return *this; }
 #ifdef __APPLE__
   Error& Error::operator<<(ssize_t v)          { error << v; return *this; }
 #endif

--- a/c/utils/exceptions.cc
+++ b/c/utils/exceptions.cc
@@ -76,9 +76,9 @@ Error& Error::operator<<(int64_t v)            { error << v; return *this; }
 Error& Error::operator<<(int32_t v)            { error << v; return *this; }
 Error& Error::operator<<(int8_t v)             { error << v; return *this; }
 Error& Error::operator<<(size_t v)             { error << v; return *this; }
-Error& Error::operator<<(uint64_t v)           { error << v; return *this; }
 Error& Error::operator<<(uint32_t v)           { error << v; return *this; }
 #ifdef __APPLE__
+  Error& Error::operator<<(uint64_t v)         { error << v; return *this; }
   Error& Error::operator<<(ssize_t v)          { error << v; return *this; }
 #endif
 

--- a/c/utils/exceptions.h
+++ b/c/utils/exceptions.h
@@ -43,12 +43,12 @@ public:
   Error& operator<<(int8_t);
   Error& operator<<(char);
   Error& operator<<(size_t);
-  Error& operator<<(uint64_t);
   Error& operator<<(uint32_t);
   Error& operator<<(SType);
   Error& operator<<(const CErrno&);
   Error& operator<<(PyObject*);
   #ifdef __APPLE__
+    Error& operator<<(uint64_t);
     Error& operator<<(ssize_t);
   #endif
 

--- a/c/utils/exceptions.h
+++ b/c/utils/exceptions.h
@@ -43,6 +43,8 @@ public:
   Error& operator<<(int8_t);
   Error& operator<<(char);
   Error& operator<<(size_t);
+  Error& operator<<(uint64_t);
+  Error& operator<<(uint32_t);
   Error& operator<<(SType);
   Error& operator<<(const CErrno&);
   Error& operator<<(PyObject*);

--- a/datatable/nff.py
+++ b/datatable/nff.py
@@ -47,7 +47,7 @@ def save(self, dest, _strategy="auto"):
 
     metafile = os.path.join(dest, "_meta.nff")
     with _builtin_open(metafile, "w", encoding="utf-8") as out:
-        out.write("# NFF1+\n")
+        out.write("# NFF2\n")
         out.write("# nrows = %d\n" % self.nrows)
         out.write('filename,stype,meta,colname,min,max\n')
         l = len(str(self.ncols))
@@ -98,6 +98,8 @@ def open(path):
             nff_version = 1
         elif info[0] == "NFF1+":
             nff_version = 1.5
+        elif info[0] == "NFF2":
+            nff_version = 2
         if nff_version:
             assert len(info) == 2
             mm = re.match("nrows\s*=\s*(\d+)", info[1])

--- a/tests/munging/test_dt_append.py
+++ b/tests/munging/test_dt_append.py
@@ -351,6 +351,9 @@ def test_rbind_all_stypes():
             assert f1.nrows == len(sources[st1]) + len(sources[st2])
             assert f3.shape == f1.shape
             assert f1.topython() == f3.topython()
+            del f1
+            del f2
+            del f3
 
 
 def test_rbind_modulefn():


### PR DESCRIPTION
Change internal representation of NA strings: now string offsets are assumed to be `uint32_t` / `uint64_t`, and NA strings are marked with the highest bit set in the end offset of the string. The first element in the offsets array is now always 0, and the offsets are assumed to be from the beginning of the string buffer (not from the -1 byte as before).

This change affects how the string data is stored internally, and therefore also how it is saved in the NFF files. However, the change is backward-compatible in the sense that if an old NFF file is opened with `dt.open()`, the old format of strings will be automatically converted into the new one. This may cause a small amount of slowdown, as the data for all string columns needs to be loaded into memory and then processed. When saving, such data will be saved in the new format (there is no option to save in the old format).

Closes #958 
