### PR TITLE
Remove basic integrity checks when opening mmap columns

### DIFF
--- a/c/column.cc
+++ b/c/column.cc
@@ -86,11 +86,11 @@ void Column::save_to_disk(const std::string& filename,
  * valid values, and that the extra parameters match the buffer's contents).
  */
 Column* Column::open_mmap_column(SType stype, int64_t nrows,
-                                 const std::string& filename)
+                                 const std::string& filename, bool recode)
 {
   Column* col = new_column(stype);
   col->nrows = nrows;
-  col->open_mmap(filename);
+  col->open_mmap(filename, recode);
   return col;
 }
 

--- a/c/column.h
+++ b/c/column.h
@@ -82,7 +82,8 @@ public:
   static Column* new_data_column(SType, int64_t nrows);
   static Column* new_na_column(SType, int64_t nrows);
   static Column* new_mmap_column(SType, int64_t nrows, const std::string& filename);
-  static Column* open_mmap_column(SType, int64_t nrows, const std::string& filename);
+  static Column* open_mmap_column(SType, int64_t nrows, const std::string& filename,
+                                  bool recode = false);
   static Column* new_xbuf_column(SType, int64_t nrows, Py_buffer* pybuffer);
   static Column* new_mbuf_column(SType, MemoryRange&&);
   static Column* new_mbuf_column(SType, MemoryRange&&, MemoryRange&&);
@@ -259,7 +260,7 @@ protected:
   Column(int64_t nrows = 0);
   virtual void init_data() = 0;
   virtual void init_mmap(const std::string& filename) = 0;
-  virtual void open_mmap(const std::string& filename) = 0;
+  virtual void open_mmap(const std::string& filename, bool recode) = 0;
   virtual void init_xbuf(Py_buffer* pybuffer) = 0;
   virtual void rbind_impl(std::vector<const Column*>& columns,
                           int64_t nrows, bool isempty) = 0;
@@ -336,7 +337,7 @@ public:
 protected:
   void init_data() override;
   void init_mmap(const std::string& filename) override;
-  void open_mmap(const std::string& filename) override;
+  void open_mmap(const std::string& filename, bool) override;
   void init_xbuf(Py_buffer* pybuffer) override;
   static constexpr T na_elem = GETNA<T>();
   void rbind_impl(std::vector<const Column*>& columns, int64_t nrows,
@@ -566,7 +567,7 @@ protected:
   PyObjectColumn();
   // TODO: This should be corrected when PyObjectStats is implemented
   PyObjectStats* get_stats() const override;
-  void open_mmap(const std::string& filename) override;
+  void open_mmap(const std::string& filename, bool) override;
 
   // void cast_into(BoolColumn*) const override;
   // void cast_into(IntColumn<int8_t>*) const override;
@@ -634,7 +635,7 @@ protected:
   StringColumn();
   void init_data() override;
   void init_mmap(const std::string& filename) override;
-  void open_mmap(const std::string& filename) override;
+  void open_mmap(const std::string& filename, bool recode) override;
   void init_xbuf(Py_buffer* pybuffer) override;
 
   void rbind_impl(std::vector<const Column*>& columns, int64_t nrows,
@@ -689,7 +690,7 @@ protected:
   VoidColumn() {}
   void init_data() override {}
   void init_mmap(const std::string&) override {}
-  void open_mmap(const std::string&) override {}
+  void open_mmap(const std::string&, bool) override {}
   void init_xbuf(Py_buffer*) override {}
 
   Stats* get_stats() const override { return nullptr; }

--- a/c/column_fw.cc
+++ b/c/column_fw.cc
@@ -54,16 +54,16 @@ void FwColumn<T>::init_mmap(const std::string& filename) {
 }
 
 template <typename T>
-void FwColumn<T>::open_mmap(const std::string& filename) {
+void FwColumn<T>::open_mmap(const std::string& filename, bool) {
   xassert(!ri);
   mbuf = MemoryRange::mmap(filename);
-  size_t exp_size = static_cast<size_t>(nrows) * sizeof(T);
-  if (mbuf.size() != exp_size) {
-    throw Error() << "File \"" << filename <<
-        "\" cannot be used to create a column with " << nrows <<
-        " rows. Expected file size of " << exp_size <<
-        " bytes, actual size is " << mbuf.size() << " bytes";
-  }
+  // size_t exp_size = static_cast<size_t>(nrows) * sizeof(T);
+  // if (mbuf.size() != exp_size) {
+  //   throw Error() << "File \"" << filename <<
+  //       "\" cannot be used to create a column with " << nrows <<
+  //       " rows. Expected file size of " << exp_size <<
+  //       " bytes, actual size is " << mbuf.size() << " bytes";
+  // }
 }
 
 template <typename T>

--- a/c/column_pyobj.cc
+++ b/c/column_pyobj.cc
@@ -33,7 +33,7 @@ SType PyObjectColumn::stype() const {
 
 // "PyObj" columns cannot be properly saved. So if somehow they were, then when
 // opening, we'll just fill the column with NAs.
-void PyObjectColumn::open_mmap(const std::string&) {
+void PyObjectColumn::open_mmap(const std::string&, bool) {
   xassert(!ri);
   mbuf = MemoryRange::mem(static_cast<size_t>(nrows) * sizeof(PyObject*))
          .set_pyobjects(/*clear_data = */ true);

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -97,7 +97,7 @@ class DataTable {
     bool verify_integrity(IntegrityCheckContext& icc) const;
 
     static DataTable* load(DataTable* schema, int64_t nrows,
-                           const std::string& path);
+                           const std::string& path, bool recode);
 
   private:
     DataTable* _statdt(colmakerfn f) const;

--- a/c/datatable_load.cc
+++ b/c/datatable_load.cc
@@ -24,7 +24,8 @@
  * nrows
  *     Number of rows in the stored datatable.
  */
-DataTable* DataTable::load(DataTable* colspec, int64_t nrows, const std::string& path)
+DataTable* DataTable::load(DataTable* colspec, int64_t nrows, const std::string& path,
+                           bool recode)
 {
     int64_t ncols = colspec->nrows;
     Column** columns = dt::amalloc<Column*>(ncols + 1);
@@ -55,7 +56,6 @@ DataTable* DataTable::load(DataTable* colspec, int64_t nrows, const std::string&
       rootdir += "/";
 
     for (int64_t i = 0; i < ncols; ++i) {
-
         // Extract filename
         size_t fsta = static_cast<size_t>(offf[i - 1] & NONA);
         size_t fend = static_cast<size_t>(offf[i] & NONA);
@@ -78,7 +78,7 @@ DataTable* DataTable::load(DataTable* colspec, int64_t nrows, const std::string&
         }
 
         // Load the column
-        columns[i] = Column::open_mmap_column(stype, nrows, filename);
+        columns[i] = Column::open_mmap_column(stype, nrows, filename, recode);
     }
 
     return new DataTable(columns);

--- a/c/py_datatable.cc
+++ b/c/py_datatable.cc
@@ -73,10 +73,11 @@ PyObject* datatable_load(PyObject*, PyObject* args) {
   DataTable* colspec;
   int64_t nrows;
   const char* path;
-  if (!PyArg_ParseTuple(args, "O&ns:datatable_load",
-                        &unwrap, &colspec, &nrows, &path))
+  int recode;
+  if (!PyArg_ParseTuple(args, "O&nsi:datatable_load",
+                        &unwrap, &colspec, &nrows, &path, &recode))
     return nullptr;
-  return wrap(DataTable::load(colspec, nrows, path));
+  return wrap(DataTable::load(colspec, nrows, path, recode));
 }
 
 

--- a/datatable/nff.py
+++ b/datatable/nff.py
@@ -117,7 +117,7 @@ def open(path):
     f0 = dt.fread(metafile, sep=",", columns=coltypes)
     f1 = f0(select=["filename", "stype", "meta"])
     colnames = f0["colname"].topython()[0]
-    _dt = core.datatable_load(f1.internal, nrows, path)
+    _dt = core.datatable_load(f1.internal, nrows, path, nff_version < 2)
     df = dt.Frame(_dt, names=colnames)
     assert df.nrows == nrows, "Wrong number of rows read: %d" % df.nrows
     return df


### PR DESCRIPTION
These checks are causing unnecessary delays with many-column frames.
If a frame was saved into NFF correctly, and the NFF was not manually modified by the user, these checks are not needed. However in the unlikely event that one of these assumptions fail, the system will now crash instead of throwing a graceful exception.

There seems to be no easy way of postponing the checks until the time the column(s) are actually read, which is why I had to remove the checks altogether.

We will be able to restore those checks after switching to Jay binary format (#1109).

Closes #1130