### PR TITLE
Fread fixes: lock and initial rows estimate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - fix bug where max_nrows parameter was sometimes causing a seg.fault
 - fix fread performance bug caused by memory-mapped file being accidentally
   copied into RAM.
+- fix rare crash in fread when resizing the number of rows.
 
 
 ### [v0.6.0](https://github.com/h2oai/datatable/compare/v0.6.0...v0.5.0) — 2018-06-05

--- a/c/csv/chunks.cc
+++ b/c/csv/chunks.cc
@@ -277,7 +277,7 @@ void ChunkedDataReader::realloc_output_columns(size_t ichunk, size_t new_alloc)
   nrows_allocated = new_alloc;
   g.trace("Too few rows allocated, reallocating to %zu rows", nrows_allocated);
 
-  dt::shared_lock(shmutex, /* exclusive = */ true);
+  dt::shared_lock lock(shmutex, /* exclusive = */ true);
   g.columns.set_nrows(nrows_allocated);
 }
 

--- a/c/csv/reader_fread.cc
+++ b/c/csv/reader_fread.cc
@@ -650,7 +650,7 @@ void FreadReader::detect_column_types()
       trace("Initial alloc = %zd rows (%zd + %d%%) using bytes/max(mean-2*sd,min) clamped between [1.1*estn, 2.0*estn]",
             allocnrow, estnrow, static_cast<int>(100.0*allocnrow/estnrow-100.0));
     }
-    if (tch == eof) {
+    if (nChunks == 1 && tch == eof) {
       if (header == 1) n_sample_lines--;
       estnrow = allocnrow = n_sample_lines;
       trace("All rows were sampled since file is small so we know nrows=%zd exactly", estnrow);


### PR DESCRIPTION
- Fix incorrect initial estimate of the number of rows needed (this bug was introduced very recently);
- Fix incorrect usage of a shared mutex lock when resizing the output columns. Because of this bug, it was possible to get a crash (or malformed output) in rare cases.

Closes #1149