### PR TITLE
View frames can now be saved to csv properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - fix fread performance bug caused by memory-mapped file being accidentally
   copied into RAM.
 - fix rare crash in fread when resizing the number of rows.
+- fix saving view frames to csv.
 
 
 ### [v0.6.0](https://github.com/h2oai/datatable/compare/v0.6.0...v0.5.0) — 2018-06-05

--- a/c/csv/writer.cc
+++ b/c/csv/writer.cc
@@ -377,14 +377,17 @@ void CsvWriter::write()
         }
 
         // Write the data in rows row0..row1 and in all columns
-        char *thch = thbuf;
-        for (int64_t row = row0; row < row1; row++) {
-          for (size_t col = 0; col < ncols; col++) {
-            columns[col]->write(&thch, row);
-            *thch++ = ',';
-          }
-          thch[-1] = '\n';
-        }
+        char* thch = thbuf;
+        dt->rowindex.strided_loop(row0, row1, 1,
+          [&](int64_t row) {
+            for (size_t col = 0; col < ncols; col++) {
+              columns[col]->write(&thch, row);
+              *thch++ = ',';
+            }
+            thch[-1] = '\n';
+          });
+        // for (int64_t row = row0; row < row1; row++) {
+        // }
         th_write_size = static_cast<size_t>(thch - thbuf);
       } catch (...) {
         oem.capture_exception();

--- a/c/csv/writer.h
+++ b/c/csv/writer.h
@@ -28,7 +28,7 @@ class CsvWriter {
   WritableBuffer::Strategy strategy;
   bool usehex;
   bool verbose;
-  __attribute__((unused)) char _padding[1];
+  int : 8;
 
   // Intermediate values used while writing the file
   std::unique_ptr<WritableBuffer> wb;

--- a/tests/test_tocsv.py
+++ b/tests/test_tocsv.py
@@ -102,6 +102,16 @@ def test_issue507(tempfile, col, scol):
     assert open(tempfile, "rb").read() == exp_text.encode()
 
 
+def test_view_to_csv():
+    df0 = dt.Frame([range(10), range(0, 20, 2)], names=["A", "B"])
+    df1 = df0[::2, :]
+    txt1 = df1.to_csv()
+    df1.materialize()
+    txt2 = df1.to_csv()
+    assert txt1 == txt2
+
+
+
 
 #-------------------------------------------------------------------------------
 # Test writing different data types
@@ -321,4 +331,3 @@ def test_save_str64():
         "baar,q\n"
         "ba,\n"
         ",bvqpoeqnperoin;dj\n")
-


### PR DESCRIPTION
Fixed bug where "view" aspect of a Frame was not taken into account when saving it into csv.

Closes #932 