### PR TITLE
Prevent warnings coming from omp.h include on some platforms

### DIFF
--- a/c/utils/omp.h
+++ b/c/utils/omp.h
@@ -14,7 +14,10 @@
   #define omp_set_num_threads(n)
   #define omp_get_thread_num() 0
 #else
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wreserved-id-macro"
   #include <omp.h>
+  #pragma clang diagnostic pop
 #endif
 
 


### PR DESCRIPTION
Warnings usually appear on `x86_64_centos` platform:
```
In file included from c/utils/omp.h:17:
/opt/h2oai/dai/include/omp.h:17:12: warning: macro name is a reserved identifier [-Wreserved-id-macro]
#   define __OMP_H
           ^
/opt/h2oai/dai/include/omp.h:31:16: warning: macro name is a reserved identifier [-Wreserved-id-macro]
#       define __KAI_KMPC_CONVENTION
               ^
/opt/h2oai/dai/include/omp.h:185:11: warning: macro name is a reserved identifier [-Wreserved-id-macro]
#   undef __KAI_KMPC_CONVENTION
          ^
3 warnings generated.
```