### PR TITLE
Stype/Ltype refactoring

### DIFF
--- a/c/column_bool.cc
+++ b/c/column_bool.cc
@@ -13,7 +13,7 @@
 
 
 SType BoolColumn::stype() const {
-  return ST_BOOLEAN_I1;
+  return SType::BOOL;
 }
 
 

--- a/c/column_from_pylist.cc
+++ b/c/column_from_pylist.cc
@@ -410,7 +410,7 @@ static int find_next_stype(int curr_stype, int stype0, int ltype0) {
   if (ltype0 > 0) {
     for (int i = curr_stype + 1; i < int(DT_STYPES_COUNT); i++) {
       if (i >= int(SType::FSTR) && i <= int(SType::DATE16)) continue;
-      if (info(static_cast<SType>(i)).ltype() == ltype0) return i;
+      if (int(info(static_cast<SType>(i)).ltype()) == ltype0) return i;
     }
     return curr_stype;
   }
@@ -418,7 +418,7 @@ static int find_next_stype(int curr_stype, int stype0, int ltype0) {
     for (int i = curr_stype + 1; i < int(DT_STYPES_COUNT); i++) {
       if (i >= int(SType::FSTR) &&
           i <= int(SType::DATE16)) continue;
-      if (info(static_cast<SType>(i)).ltype() <= -ltype0) return i;
+      if (int(info(static_cast<SType>(i)).ltype()) <= -ltype0) return i;
     }
     return curr_stype;
   }

--- a/c/column_from_pylist.cc
+++ b/c/column_from_pylist.cc
@@ -410,7 +410,7 @@ static int find_next_stype(int curr_stype, int stype0, int ltype0) {
   if (ltype0 > 0) {
     for (int i = curr_stype + 1; i < int(DT_STYPES_COUNT); i++) {
       if (i >= int(SType::FSTR) && i <= int(SType::DATE16)) continue;
-      if (stype_info[i].ltype == ltype0) return i;
+      if (info(static_cast<SType>(i)).ltype() == ltype0) return i;
     }
     return curr_stype;
   }
@@ -418,7 +418,7 @@ static int find_next_stype(int curr_stype, int stype0, int ltype0) {
     for (int i = curr_stype + 1; i < int(DT_STYPES_COUNT); i++) {
       if (i >= int(SType::FSTR) &&
           i <= int(SType::DATE16)) continue;
-      if (stype_info[i].ltype <= -ltype0) return i;
+      if (info(static_cast<SType>(i)).ltype() <= -ltype0) return i;
     }
     return curr_stype;
   }

--- a/c/column_fw.cc
+++ b/c/column_fw.cc
@@ -235,7 +235,7 @@ void FwColumn<T>::rbind_impl(std::vector<const Column*>& columns,
     resptr += old_alloc_size;
   }
   for (const Column* col : columns) {
-    if (col->stype() == ST_VOID) {
+    if (col->stype() == SType::VOID) {
       rows_to_fill += static_cast<size_t>(col->nrows);
     } else {
       if (rows_to_fill) {

--- a/c/column_int.cc
+++ b/c/column_int.cc
@@ -15,7 +15,10 @@
 
 template <typename T>
 SType IntColumn<T>::stype() const {
-  return stype_integer(sizeof(T));
+  return sizeof(T) == 1? SType::INT8 :
+         sizeof(T) == 2? SType::INT16 :
+         sizeof(T) == 4? SType::INT32 :
+         sizeof(T) == 8? SType::INT64 : SType::VOID;
 }
 
 

--- a/c/column_pyobj.cc
+++ b/c/column_pyobj.cc
@@ -27,7 +27,7 @@ PyObjectColumn::PyObjectColumn(int64_t nrows_, MemoryRange&& mb)
 
 
 SType PyObjectColumn::stype() const {
-  return ST_OBJECT_PYPTR;
+  return SType::OBJ;
 }
 
 
@@ -111,10 +111,10 @@ void PyObjectColumn::rbind_impl(
     dest_data += old_nrows;
   }
   for (const Column* col : columns) {
-    if (col->stype() == ST_VOID) {
+    if (col->stype() == SType::VOID) {
       dest_data += static_cast<size_t>(col->nrows);
     } else {
-      if (col->stype() != ST_OBJECT_PYPTR) {
+      if (col->stype() != SType::OBJ) {
         Column* newcol = col->cast(stype());
         delete col;
         col = newcol;

--- a/c/column_real.cc
+++ b/c/column_real.cc
@@ -14,7 +14,8 @@
 
 template <typename T>
 SType RealColumn<T>::stype() const {
-  return stype_real(sizeof(T));
+  return sizeof(T) == 4? SType::FLOAT32 :
+         sizeof(T) == 8? SType::FLOAT64 : SType::VOID;
 }
 
 

--- a/c/column_string.cc
+++ b/c/column_string.cc
@@ -379,7 +379,7 @@ void StringColumn<T>::rbind_impl(std::vector<const Column*>& columns,
   }
   for (size_t i = 0; i < columns.size(); ++i) {
     const Column* col = columns[i];
-    if (col->stype() == ST_VOID) continue;
+    if (col->stype() == SType::VOID) continue;
     if (col->stype() != stype()) {
       columns[i] = col->cast(stype());
       delete col;
@@ -408,7 +408,7 @@ void StringColumn<T>::rbind_impl(std::vector<const Column*>& columns,
     offs += old_nrows;
   }
   for (const Column* col : columns) {
-    if (col->stype() == ST_VOID) {
+    if (col->stype() == SType::VOID) {
       rows_to_fill += col->nrows;
     } else {
       if (rows_to_fill) {

--- a/c/column_string.cc
+++ b/c/column_string.cc
@@ -157,7 +157,8 @@ void StringColumn<T>::replace_buffer(MemoryRange&& new_offbuf,
 
 template <typename T>
 SType StringColumn<T>::stype() const {
-  return stype_string(sizeof(T));
+  return sizeof(T) == 4? SType::STR32 :
+         sizeof(T) == 8? SType::STR64 : SType::VOID;
 }
 
 template <typename T>

--- a/c/csv/reader_parsers.cc
+++ b/c/csv/reader_parsers.cc
@@ -733,21 +733,21 @@ void ParserLibrary::init_parsers() {
     parser_fns[iid] = ptr;
   };
 
-  add(PT::Mu,           "Unknown",         '?', 1, ST_BOOLEAN_I1,      parse_mu);
-  add(PT::Bool01,       "Bool8/numeric",   'b', 1, ST_BOOLEAN_I1,      parse_bool8_numeric);
-  add(PT::BoolU,        "Bool8/uppercase", 'b', 1, ST_BOOLEAN_I1,      parse_bool8_uppercase);
-  add(PT::BoolT,        "Bool8/titlecase", 'b', 1, ST_BOOLEAN_I1,      parse_bool8_titlecase);
-  add(PT::BoolL,        "Bool8/lowercase", 'b', 1, ST_BOOLEAN_I1,      parse_bool8_lowercase);
-  add(PT::Int32,        "Int32",           'i', 4, ST_INTEGER_I4,      parse_int32_simple);
-  add(PT::Int32Sep,     "Int32/separated", 'i', 4, ST_INTEGER_I4,      parse_intNN_separated<int32_t>);
-  add(PT::Int64,        "Int64",           'I', 8, ST_INTEGER_I8,      parse_int64_simple);
-  add(PT::Int64Sep,     "Int64/separated", 'I', 8, ST_INTEGER_I8,      parse_intNN_separated<int64_t>);
-  add(PT::Float32Hex,   "Float32/hex",     'f', 4, ST_REAL_F4,         parse_float32_hex);
-  add(PT::Float64Plain, "Float64",         'F', 8, ST_REAL_F8,         parse_float64_simple);
-  add(PT::Float64Ext,   "Float64/ext",     'F', 8, ST_REAL_F8,         parse_float64_extended);
-  add(PT::Float64Hex,   "Float64/hex",     'F', 8, ST_REAL_F8,         parse_float64_hex);
-  add(PT::Str32,        "Str32",           's', 4, ST_STRING_I4_VCHAR, parse_string);
-  add(PT::Str64,        "Str64",           'S', 8, ST_STRING_I8_VCHAR, parse_string);
+  add(PT::Mu,           "Unknown",         '?', 1, SType::BOOL,    parse_mu);
+  add(PT::Bool01,       "Bool8/numeric",   'b', 1, SType::BOOL,    parse_bool8_numeric);
+  add(PT::BoolU,        "Bool8/uppercase", 'b', 1, SType::BOOL,    parse_bool8_uppercase);
+  add(PT::BoolT,        "Bool8/titlecase", 'b', 1, SType::BOOL,    parse_bool8_titlecase);
+  add(PT::BoolL,        "Bool8/lowercase", 'b', 1, SType::BOOL,    parse_bool8_lowercase);
+  add(PT::Int32,        "Int32",           'i', 4, SType::INT32,   parse_int32_simple);
+  add(PT::Int32Sep,     "Int32/separated", 'i', 4, SType::INT32,   parse_intNN_separated<int32_t>);
+  add(PT::Int64,        "Int64",           'I', 8, SType::INT64,   parse_int64_simple);
+  add(PT::Int64Sep,     "Int64/separated", 'I', 8, SType::INT64,   parse_intNN_separated<int64_t>);
+  add(PT::Float32Hex,   "Float32/hex",     'f', 4, SType::FLOAT32, parse_float32_hex);
+  add(PT::Float64Plain, "Float64",         'F', 8, SType::FLOAT64, parse_float64_simple);
+  add(PT::Float64Ext,   "Float64/ext",     'F', 8, SType::FLOAT64, parse_float64_extended);
+  add(PT::Float64Hex,   "Float64/hex",     'F', 8, SType::FLOAT64, parse_float64_hex);
+  add(PT::Str32,        "Str32",           's', 4, SType::STR32,   parse_string);
+  add(PT::Str64,        "Str64",           'S', 8, SType::STR64,   parse_string);
 }
 
 

--- a/c/csv/reader_utils.cc
+++ b/c/csv/reader_utils.cc
@@ -233,7 +233,7 @@ PyObj GReaderColumn::py_descriptor() const {
   static PyTypeObject* name_type_pytuple = init_nametypepytuple();
   PyObject* nt_tuple = PyStructSequence_New(name_type_pytuple);  // new ref
   if (!nt_tuple) throw PyError();
-  PyObject* stype = py_stype_objs[ParserLibrary::info(ptype).stype];
+  PyObject* stype = py_stype_objs[int(ParserLibrary::info(ptype).stype)];
   Py_INCREF(stype);
   PyStructSequence_SetItem(nt_tuple, 0, PyyString(name).release());
   PyStructSequence_SetItem(nt_tuple, 1, stype);

--- a/c/csv/reader_utils.cc
+++ b/c/csv/reader_utils.cc
@@ -233,8 +233,7 @@ PyObj GReaderColumn::py_descriptor() const {
   static PyTypeObject* name_type_pytuple = init_nametypepytuple();
   PyObject* nt_tuple = PyStructSequence_New(name_type_pytuple);  // new ref
   if (!nt_tuple) throw PyError();
-  PyObject* stype = py_stype_objs[int(ParserLibrary::info(ptype).stype)];
-  Py_INCREF(stype);
+  PyObject* stype = info(ParserLibrary::info(ptype).stype).py_stype();
   PyStructSequence_SetItem(nt_tuple, 0, PyyString(name).release());
   PyStructSequence_SetItem(nt_tuple, 1, stype);
   return PyObj(std::move(nt_tuple));

--- a/c/datatable_load.cc
+++ b/c/datatable_load.cc
@@ -37,8 +37,7 @@ DataTable* DataTable::load(DataTable* colspec, int64_t nrows, const std::string&
     }
     SType stypef = colspec->columns[0]->stype();
     SType stypes = colspec->columns[1]->stype();
-    if (stypef != ST_STRING_I4_VCHAR ||
-        stypes != ST_STRING_I4_VCHAR) {
+    if (stypef != SType::STR32 || stypes != SType::STR32) {
         throw ValueError() << "String columns are expected in colspec table, "
                            << "instead got " << stypef << " and "
                            << stypes;
@@ -73,7 +72,7 @@ DataTable* DataTable::load(DataTable* colspec, int64_t nrows, const std::string&
         }
         std::string stype_str(cols->strdata() + ssta, slen);
         SType stype = stype_from_string(stype_str);
-        if (stype == ST_VOID) {
+        if (stype == SType::VOID) {
             throw ValueError() << "Unrecognized stype: " << stype_str;
         }
 

--- a/c/expr/binaryop.cc
+++ b/c/expr/binaryop.cc
@@ -326,9 +326,9 @@ template<typename LT, typename RT, typename VT>
 static mapperfn resolve1(int opcode, SType stype, void** params, int64_t nrows, OpMode mode) {
   if (opcode >= OpCode::Equal) {
     // override stype for relational operators
-    stype = ST_BOOLEAN_I1;
+    stype = SType::BOOL;
   } else if (opcode == OpCode::Divide && std::is_integral<VT>::value) {
-    stype = ST_REAL_F8;
+    stype = SType::FLOAT64;
   }
   params[2] = Column::new_data_column(stype, nrows);
   switch (opcode) {
@@ -362,7 +362,7 @@ static mapperfn resolve1str(int opcode, void** params, int64_t nrows, OpMode mod
     mode = OpMode::N_to_One;
     std::swap(params[0], params[1]);
   }
-  params[2] = Column::new_data_column(ST_BOOLEAN_I1, nrows);
+  params[2] = Column::new_data_column(SType::BOOL, nrows);
   switch (opcode) {
     case OpCode::Equal:    return resolve2str<T0, T1, int8_t, strop_eq<T0, T1>>(mode);
     case OpCode::NotEqual: return resolve2str<T0, T1, int8_t, strop_ne<T0, T1>>(mode);
@@ -375,89 +375,89 @@ static mapperfn resolve1str(int opcode, void** params, int64_t nrows, OpMode mod
 static mapperfn resolve0(SType lhs_type, SType rhs_type, int opcode, void** params, int64_t nrows, OpMode mode) {
   if (mode == OpMode::Error) return nullptr;
   switch (lhs_type) {
-    case ST_BOOLEAN_I1:
-    case ST_INTEGER_I1:
+    case SType::BOOL:
+    case SType::INT8:
       switch (rhs_type) {
-        case ST_BOOLEAN_I1:
-        case ST_INTEGER_I1: return resolve1<int8_t, int8_t, int8_t>(opcode, ST_INTEGER_I1, params, nrows, mode);
-        case ST_INTEGER_I2: return resolve1<int8_t, int16_t, int16_t>(opcode, ST_INTEGER_I2, params, nrows, mode);
-        case ST_INTEGER_I4: return resolve1<int8_t, int32_t, int32_t>(opcode, ST_INTEGER_I4, params, nrows, mode);
-        case ST_INTEGER_I8: return resolve1<int8_t, int64_t, int64_t>(opcode, ST_INTEGER_I8, params, nrows, mode);
-        case ST_REAL_F4:    return resolve1<int8_t, float, float>(opcode, ST_REAL_F4, params, nrows, mode);
-        case ST_REAL_F8:    return resolve1<int8_t, double, double>(opcode, ST_REAL_F8, params, nrows, mode);
+        case SType::BOOL:
+        case SType::INT8:    return resolve1<int8_t, int8_t, int8_t>(opcode, SType::INT8, params, nrows, mode);
+        case SType::INT16:   return resolve1<int8_t, int16_t, int16_t>(opcode, SType::INT16, params, nrows, mode);
+        case SType::INT32:   return resolve1<int8_t, int32_t, int32_t>(opcode, SType::INT32, params, nrows, mode);
+        case SType::INT64:   return resolve1<int8_t, int64_t, int64_t>(opcode, SType::INT64, params, nrows, mode);
+        case SType::FLOAT32: return resolve1<int8_t, float, float>(opcode, SType::FLOAT32, params, nrows, mode);
+        case SType::FLOAT64: return resolve1<int8_t, double, double>(opcode, SType::FLOAT64, params, nrows, mode);
         default: break;
       }
       break;
 
-    case ST_INTEGER_I2:
+    case SType::INT16:
       switch (rhs_type) {
-        case ST_BOOLEAN_I1:
-        case ST_INTEGER_I1: return resolve1<int16_t, int8_t, int16_t>(opcode, ST_INTEGER_I2, params, nrows, mode);
-        case ST_INTEGER_I2: return resolve1<int16_t, int16_t, int16_t>(opcode, ST_INTEGER_I2, params, nrows, mode);
-        case ST_INTEGER_I4: return resolve1<int16_t, int32_t, int32_t>(opcode, ST_INTEGER_I4, params, nrows, mode);
-        case ST_INTEGER_I8: return resolve1<int16_t, int64_t, int64_t>(opcode, ST_INTEGER_I8, params, nrows, mode);
-        case ST_REAL_F4:    return resolve1<int16_t, float, float>(opcode, ST_REAL_F4, params, nrows, mode);
-        case ST_REAL_F8:    return resolve1<int16_t, double, double>(opcode, ST_REAL_F8, params, nrows, mode);
+        case SType::BOOL:
+        case SType::INT8:    return resolve1<int16_t, int8_t, int16_t>(opcode, SType::INT16, params, nrows, mode);
+        case SType::INT16:   return resolve1<int16_t, int16_t, int16_t>(opcode, SType::INT16, params, nrows, mode);
+        case SType::INT32:   return resolve1<int16_t, int32_t, int32_t>(opcode, SType::INT32, params, nrows, mode);
+        case SType::INT64:   return resolve1<int16_t, int64_t, int64_t>(opcode, SType::INT64, params, nrows, mode);
+        case SType::FLOAT32: return resolve1<int16_t, float, float>(opcode, SType::FLOAT32, params, nrows, mode);
+        case SType::FLOAT64: return resolve1<int16_t, double, double>(opcode, SType::FLOAT64, params, nrows, mode);
         default: break;
       }
       break;
 
-    case ST_INTEGER_I4:
+    case SType::INT32:
       switch (rhs_type) {
-        case ST_BOOLEAN_I1:
-        case ST_INTEGER_I1: return resolve1<int32_t, int8_t, int32_t>(opcode, ST_INTEGER_I4, params, nrows, mode);
-        case ST_INTEGER_I2: return resolve1<int32_t, int16_t, int32_t>(opcode, ST_INTEGER_I4, params, nrows, mode);
-        case ST_INTEGER_I4: return resolve1<int32_t, int32_t, int32_t>(opcode, ST_INTEGER_I4, params, nrows, mode);
-        case ST_INTEGER_I8: return resolve1<int32_t, int64_t, int64_t>(opcode, ST_INTEGER_I8, params, nrows, mode);
-        case ST_REAL_F4:    return resolve1<int32_t, float, float>(opcode, ST_REAL_F4, params, nrows, mode);
-        case ST_REAL_F8:    return resolve1<int32_t, double, double>(opcode, ST_REAL_F8, params, nrows, mode);
+        case SType::BOOL:
+        case SType::INT8:    return resolve1<int32_t, int8_t, int32_t>(opcode, SType::INT32, params, nrows, mode);
+        case SType::INT16:   return resolve1<int32_t, int16_t, int32_t>(opcode, SType::INT32, params, nrows, mode);
+        case SType::INT32:   return resolve1<int32_t, int32_t, int32_t>(opcode, SType::INT32, params, nrows, mode);
+        case SType::INT64:   return resolve1<int32_t, int64_t, int64_t>(opcode, SType::INT64, params, nrows, mode);
+        case SType::FLOAT32: return resolve1<int32_t, float, float>(opcode, SType::FLOAT32, params, nrows, mode);
+        case SType::FLOAT64: return resolve1<int32_t, double, double>(opcode, SType::FLOAT64, params, nrows, mode);
         default: break;
       }
       break;
 
-    case ST_INTEGER_I8:
+    case SType::INT64:
       switch (rhs_type) {
-        case ST_BOOLEAN_I1:
-        case ST_INTEGER_I1: return resolve1<int64_t, int8_t, int64_t>(opcode, ST_INTEGER_I8, params, nrows, mode);
-        case ST_INTEGER_I2: return resolve1<int64_t, int16_t, int64_t>(opcode, ST_INTEGER_I8, params, nrows, mode);
-        case ST_INTEGER_I4: return resolve1<int64_t, int32_t, int64_t>(opcode, ST_INTEGER_I8, params, nrows, mode);
-        case ST_INTEGER_I8: return resolve1<int64_t, int64_t, int64_t>(opcode, ST_INTEGER_I8, params, nrows, mode);
-        case ST_REAL_F4:    return resolve1<int64_t, float, float>(opcode, ST_REAL_F4, params, nrows, mode);
-        case ST_REAL_F8:    return resolve1<int64_t, double, double>(opcode, ST_REAL_F8, params, nrows, mode);
+        case SType::BOOL:
+        case SType::INT8:    return resolve1<int64_t, int8_t, int64_t>(opcode, SType::INT64, params, nrows, mode);
+        case SType::INT16:   return resolve1<int64_t, int16_t, int64_t>(opcode, SType::INT64, params, nrows, mode);
+        case SType::INT32:   return resolve1<int64_t, int32_t, int64_t>(opcode, SType::INT64, params, nrows, mode);
+        case SType::INT64:   return resolve1<int64_t, int64_t, int64_t>(opcode, SType::INT64, params, nrows, mode);
+        case SType::FLOAT32: return resolve1<int64_t, float, float>(opcode, SType::FLOAT32, params, nrows, mode);
+        case SType::FLOAT64: return resolve1<int64_t, double, double>(opcode, SType::FLOAT64, params, nrows, mode);
         default: break;
       }
       break;
 
-    case ST_REAL_F4:
+    case SType::FLOAT32:
       switch (rhs_type) {
-        case ST_BOOLEAN_I1:
-        case ST_INTEGER_I1: return resolve1<float, int8_t, float>(opcode, ST_REAL_F4, params, nrows, mode);
-        case ST_INTEGER_I2: return resolve1<float, int16_t, float>(opcode, ST_REAL_F4, params, nrows, mode);
-        case ST_INTEGER_I4: return resolve1<float, int32_t, float>(opcode, ST_REAL_F4, params, nrows, mode);
-        case ST_INTEGER_I8: return resolve1<float, int64_t, float>(opcode, ST_REAL_F4, params, nrows, mode);
-        case ST_REAL_F4:    return resolve1<float, float, float>(opcode, ST_REAL_F4, params, nrows, mode);
-        case ST_REAL_F8:    return resolve1<float, double, double>(opcode, ST_REAL_F8, params, nrows, mode);
+        case SType::BOOL:
+        case SType::INT8:    return resolve1<float, int8_t, float>(opcode, SType::FLOAT32, params, nrows, mode);
+        case SType::INT16:   return resolve1<float, int16_t, float>(opcode, SType::FLOAT32, params, nrows, mode);
+        case SType::INT32:   return resolve1<float, int32_t, float>(opcode, SType::FLOAT32, params, nrows, mode);
+        case SType::INT64:   return resolve1<float, int64_t, float>(opcode, SType::FLOAT32, params, nrows, mode);
+        case SType::FLOAT32: return resolve1<float, float, float>(opcode, SType::FLOAT32, params, nrows, mode);
+        case SType::FLOAT64: return resolve1<float, double, double>(opcode, SType::FLOAT64, params, nrows, mode);
         default: break;
       }
       break;
 
-    case ST_REAL_F8:
+    case SType::FLOAT64:
       switch (rhs_type) {
-        case ST_BOOLEAN_I1:
-        case ST_INTEGER_I1: return resolve1<double, int8_t, double>(opcode, ST_REAL_F8, params, nrows, mode);
-        case ST_INTEGER_I2: return resolve1<double, int16_t, double>(opcode, ST_REAL_F8, params, nrows, mode);
-        case ST_INTEGER_I4: return resolve1<double, int32_t, double>(opcode, ST_REAL_F8, params, nrows, mode);
-        case ST_INTEGER_I8: return resolve1<double, int64_t, double>(opcode, ST_REAL_F8, params, nrows, mode);
-        case ST_REAL_F4:    return resolve1<double, float, double>(opcode, ST_REAL_F8, params, nrows, mode);
-        case ST_REAL_F8:    return resolve1<double, double, double>(opcode, ST_REAL_F8, params, nrows, mode);
+        case SType::BOOL:
+        case SType::INT8:    return resolve1<double, int8_t, double>(opcode, SType::FLOAT64, params, nrows, mode);
+        case SType::INT16:   return resolve1<double, int16_t, double>(opcode, SType::FLOAT64, params, nrows, mode);
+        case SType::INT32:   return resolve1<double, int32_t, double>(opcode, SType::FLOAT64, params, nrows, mode);
+        case SType::INT64:   return resolve1<double, int64_t, double>(opcode, SType::FLOAT64, params, nrows, mode);
+        case SType::FLOAT32: return resolve1<double, float, double>(opcode, SType::FLOAT64, params, nrows, mode);
+        case SType::FLOAT64: return resolve1<double, double, double>(opcode, SType::FLOAT64, params, nrows, mode);
         default: break;
       }
       break;
 
-    case ST_STRING_I4_VCHAR:
+    case SType::STR32:
       switch (rhs_type) {
-        case ST_STRING_I4_VCHAR: return resolve1str<uint32_t, uint32_t>(opcode, params, nrows, mode);
-        case ST_STRING_I8_VCHAR: return resolve1str<uint32_t, uint64_t>(opcode, params, nrows, mode);
+        case SType::STR32: return resolve1str<uint32_t, uint32_t>(opcode, params, nrows, mode);
+        case SType::STR64: return resolve1str<uint32_t, uint64_t>(opcode, params, nrows, mode);
         default: break;
       }
       break;

--- a/c/expr/reduceop.cc
+++ b/c/expr/reduceop.cc
@@ -208,24 +208,24 @@ static gmapperfn resolve1(int opcode) {
 static gmapperfn resolve0(int opcode, SType stype) {
   if (opcode == OpCode::Sum) {
     switch (stype) {
-      case ST_BOOLEAN_I1:
-      case ST_INTEGER_I1:  return sum_skipna<int8_t, int64_t>;
-      case ST_INTEGER_I2:  return sum_skipna<int16_t, int64_t>;
-      case ST_INTEGER_I4:  return sum_skipna<int32_t, int64_t>;
-      case ST_INTEGER_I8:  return sum_skipna<int64_t, int64_t>;
-      case ST_REAL_F4:     return sum_skipna<float, double>;
-      case ST_REAL_F8:     return sum_skipna<double, double>;
+      case SType::BOOL:
+      case SType::INT8:    return sum_skipna<int8_t, int64_t>;
+      case SType::INT16:   return sum_skipna<int16_t, int64_t>;
+      case SType::INT32:   return sum_skipna<int32_t, int64_t>;
+      case SType::INT64:   return sum_skipna<int64_t, int64_t>;
+      case SType::FLOAT32: return sum_skipna<float, double>;
+      case SType::FLOAT64: return sum_skipna<double, double>;
       default:             return nullptr;
     }
   }
   switch (stype) {
-    case ST_BOOLEAN_I1:
-    case ST_INTEGER_I1:  return resolve1<int8_t, double>(opcode);
-    case ST_INTEGER_I2:  return resolve1<int16_t, double>(opcode);
-    case ST_INTEGER_I4:  return resolve1<int32_t, double>(opcode);
-    case ST_INTEGER_I8:  return resolve1<int64_t, double>(opcode);
-    case ST_REAL_F4:     return resolve1<float, float>(opcode);
-    case ST_REAL_F8:     return resolve1<double, double>(opcode);
+    case SType::BOOL:
+    case SType::INT8:    return resolve1<int8_t, double>(opcode);
+    case SType::INT16:   return resolve1<int16_t, double>(opcode);
+    case SType::INT32:   return resolve1<int32_t, double>(opcode);
+    case SType::INT64:   return resolve1<int64_t, double>(opcode);
+    case SType::FLOAT32: return resolve1<float, float>(opcode);
+    case SType::FLOAT64: return resolve1<double, double>(opcode);
     default:             return nullptr;
   }
 }
@@ -243,12 +243,12 @@ Column* reduceop(int opcode, Column* arg, const Groupby& groupby)
   }
   SType arg_type = arg->stype();
   SType res_type = opcode == OpCode::Min || opcode == OpCode::Max ||
-                   arg_type == ST_REAL_F4 ? arg_type : ST_REAL_F8;
+                   arg_type == SType::FLOAT32 ? arg_type : SType::FLOAT64;
   if (opcode == OpCode::Sum) {
-    if (arg_type == ST_REAL_F4 || arg_type == ST_REAL_F8) {
-      res_type = ST_REAL_F8;
+    if (arg_type == SType::FLOAT32 || arg_type == SType::FLOAT64) {
+      res_type = SType::FLOAT64;
     } else {
-      res_type = ST_INTEGER_I8;
+      res_type = SType::INT64;
     }
   }
   int32_t ngrps = static_cast<int32_t>(groupby.ngroups());

--- a/c/expr/unaryop.cc
+++ b/c/expr/unaryop.cc
@@ -110,17 +110,17 @@ static mapperfn resolve_str(int opcode) {
 
 static mapperfn resolve0(SType stype, int opcode) {
   switch (stype) {
-    case ST_BOOLEAN_I1:
+    case SType::BOOL:
       if (opcode == OpCode::Invert) return map_n<int8_t, int8_t, bool_inverse>;
       return resolve1<int8_t>(opcode);
-    case ST_INTEGER_I1: return resolve1<int8_t>(opcode);
-    case ST_INTEGER_I2: return resolve1<int16_t>(opcode);
-    case ST_INTEGER_I4: return resolve1<int32_t>(opcode);
-    case ST_INTEGER_I8: return resolve1<int64_t>(opcode);
-    case ST_REAL_F4:    return resolve1<float>(opcode);
-    case ST_REAL_F8:    return resolve1<double>(opcode);
-    case ST_STRING_I4_VCHAR: return resolve_str<uint32_t>(opcode);
-    case ST_STRING_I8_VCHAR: return resolve_str<uint64_t>(opcode);
+    case SType::INT8:    return resolve1<int8_t>(opcode);
+    case SType::INT16:   return resolve1<int16_t>(opcode);
+    case SType::INT32:   return resolve1<int32_t>(opcode);
+    case SType::INT64:   return resolve1<int64_t>(opcode);
+    case SType::FLOAT32: return resolve1<float>(opcode);
+    case SType::FLOAT64: return resolve1<double>(opcode);
+    case SType::STR32:   return resolve_str<uint32_t>(opcode);
+    case SType::STR64:   return resolve_str<uint64_t>(opcode);
     default: break;
   }
   return nullptr;
@@ -135,9 +135,9 @@ Column* unaryop(int opcode, Column* arg)
   SType arg_type = arg->stype();
   SType res_type = arg_type;
   if (opcode == OpCode::IsNa) {
-    res_type = ST_BOOLEAN_I1;
-  } else if (arg_type == ST_BOOLEAN_I1 && opcode == OpCode::Minus) {
-    res_type = ST_INTEGER_I1;
+    res_type = SType::BOOL;
+  } else if (arg_type == SType::BOOL && opcode == OpCode::Minus) {
+    res_type = SType::INT8;
   }
   void* params[2];
   params[0] = arg;

--- a/c/py_buffers.cc
+++ b/c/py_buffers.cc
@@ -282,7 +282,7 @@ static int getbuffer_Column(pycolumn::obj* self, Py_buffer* view, int flags) {
     // time for a read-only buffer.
     throw ValueError() << "Cannot create a writable buffer for a Column";
   }
-  if (stype_info[int(col->stype())].varwidth) {
+  if (info(col->stype()).is_varwidth()) {
     throw ValueError() << "Column's data has variable width";
   }
 
@@ -423,8 +423,8 @@ static int getbuffer_DataTable(
   }
 
   // Allocate the final buffer
-  xassert(!stype_info[int(stype)].varwidth);
-  size_t elemsize = stype_info[int(stype)].elemsize;
+  xassert(!info(stype).is_varwidth());
+  size_t elemsize = info(stype).elemsize();
   size_t colsize = nrows * elemsize;
   MemoryRange memr = MemoryRange::mem(ncols * colsize);
   const char* fmt = format_from_stype(stype);
@@ -492,7 +492,7 @@ static int getbuffer_DataTable(
     https://github.com/numpy/numpy/issues/9456
 
     if (REQ_INDIRECT(flags)) {
-        size_t elemsize = stype_info[stype].elemsize;
+        size_t elemsize = info(stype).elemsize();
         Py_ssize_t *info = dt::amalloc<Py_ssize_t>(6);
         void** buf = dt::amalloc<void*>(ncols);
         for (int i = 0; i < ncols; i++) {

--- a/c/py_buffers.cc
+++ b/c/py_buffers.cc
@@ -87,7 +87,7 @@ Column* Column::from_buffer(PyObject* buffer)
   int64_t nrows = view->len / view->itemsize;
 
   Column* res = nullptr;
-  if (stype == ST_STRING_I4_VCHAR) {
+  if (stype == SType::STR32) {
     res = convert_fwchararray_to_column(view);
   } else if (view->strides == nullptr) {
     res = Column::new_xbuf_column(stype, nrows, view);
@@ -116,7 +116,7 @@ Column* Column::from_buffer(PyObject* buffer)
         out[j] = inp[j * stride];
     }
   }
-  if (res->stype() == ST_OBJECT_PYPTR) {
+  if (res->stype() == SType::OBJ) {
     res = try_to_resolve_object_column(res);
   }
   return res;
@@ -245,12 +245,12 @@ struct XInfo {
   XInfo() {
     shape[0] = shape[1] = 0;
     strides[0] = strides[1] = 0;
-    stype = ST_VOID;
+    stype = SType::VOID;
   }
 
   ~XInfo() {
     // if (mbuf.is_nonempty()) {
-      // if (mbuf->get_refcount() == 1 && stype == ST_OBJECT_PYPTR) {
+      // if (mbuf->get_refcount() == 1 && stype == SType::OBJ) {
       //   PyObject** elems = static_cast<PyObject**>(mbuf->get());
       //   size_t nelems = mbuf->size() / sizeof(PyObject*);
       //   for (size_t i = 0; i < nelems; ++i) {
@@ -282,7 +282,7 @@ static int getbuffer_Column(pycolumn::obj* self, Py_buffer* view, int flags) {
     // time for a read-only buffer.
     throw ValueError() << "Cannot create a writable buffer for a Column";
   }
-  if (stype_info[col->stype()].varwidth) {
+  if (stype_info[int(col->stype())].varwidth) {
     throw ValueError() << "Column's data has variable width";
   }
 
@@ -410,20 +410,21 @@ static int getbuffer_DataTable(
 
   // First, find the common stype for all columns in the DataTable.
   SType stype = self->use_stype_for_buffers;
-  if (stype == ST_VOID) {
+  if (stype == SType::VOID) {
     // Auto-detect common stype
     uint64_t stypes_mask = 0;
     for (size_t i = 0; i < ncols; ++i) {
       SType next_stype = dt->columns[i]->stype();
-      if (stypes_mask & (1 << next_stype)) continue;
-      stypes_mask |= 1 << next_stype;
+      uint64_t unstype = static_cast<uint64_t>(next_stype);
+      if (stypes_mask & (1 << unstype)) continue;
+      stypes_mask |= 1 << unstype;
       stype = common_stype_for_buffer(stype, next_stype);
     }
   }
 
   // Allocate the final buffer
-  xassert(!stype_info[stype].varwidth);
-  size_t elemsize = stype_info[stype].elemsize;
+  xassert(!stype_info[int(stype)].varwidth);
+  size_t elemsize = stype_info[int(stype)].elemsize;
   size_t colsize = nrows * elemsize;
   MemoryRange memr = MemoryRange::mem(ncols * colsize);
   const char* fmt = format_from_stype(stype);
@@ -592,36 +593,36 @@ PyObject* pydatatable::install_buffer_hooks(PyObject*, PyObject* args)
 
 static SType stype_from_format(const char* format, int64_t itemsize)
 {
-  SType stype = ST_VOID;
+  SType stype = SType::VOID;
   char c = format[0];
   if (c == '@' || c == '=') c = format[1];
 
   if (c == 'b' || c == 'h' || c == 'i' || c == 'l' || c == 'q' || c == 'n') {
     // These are all various integer types
-    stype = itemsize == 1 ? ST_INTEGER_I1 :
-            itemsize == 2 ? ST_INTEGER_I2 :
-            itemsize == 4 ? ST_INTEGER_I4 :
-            itemsize == 8 ? ST_INTEGER_I8 : ST_VOID;
+    stype = itemsize == 1 ? SType::INT8 :
+            itemsize == 2 ? SType::INT16 :
+            itemsize == 4 ? SType::INT32 :
+            itemsize == 8 ? SType::INT64 : SType::VOID;
   }
   else if (c == 'd' || c == 'f') {
-    stype = itemsize == 4 ? ST_REAL_F4 :
-            itemsize == 8 ? ST_REAL_F8 : ST_VOID;
+    stype = itemsize == 4 ? SType::FLOAT32 :
+            itemsize == 8 ? SType::FLOAT64 : SType::VOID;
   }
   else if (c == '?') {
-    stype = itemsize == 1 ? ST_BOOLEAN_I1 : ST_VOID;
+    stype = itemsize == 1 ? SType::BOOL : SType::VOID;
   }
   else if (c == 'O') {
-    stype = ST_OBJECT_PYPTR;
+    stype = SType::OBJ;
   }
   else if (c >= '1' && c <= '9') {
     if (format[strlen(format) - 1] == 'w') {
       int numeral = atoi(format);
       if (itemsize == numeral * 4) {
-        stype = ST_STRING_I4_VCHAR;
+        stype = SType::STR32;
       }
     }
   }
-  if (stype == ST_VOID) {
+  if (stype == SType::VOID) {
     throw ValueError()
         << "Unknown format '" << format << "' with itemsize " << itemsize;
   }
@@ -630,12 +631,12 @@ static SType stype_from_format(const char* format, int64_t itemsize)
 
 static const char* format_from_stype(SType stype)
 {
-  return stype == ST_BOOLEAN_I1? "?" :
-         stype == ST_INTEGER_I1? "b" :
-         stype == ST_INTEGER_I2? "h" :
-         stype == ST_INTEGER_I4? "i" :
-         stype == ST_INTEGER_I8? "q" :
-         stype == ST_REAL_F4? "f" :
-         stype == ST_REAL_F8? "d" :
-         stype == ST_OBJECT_PYPTR? "O" : "x";
+  return stype == SType::BOOL? "?" :
+         stype == SType::INT8? "b" :
+         stype == SType::INT16? "h" :
+         stype == SType::INT32? "i" :
+         stype == SType::INT64? "q" :
+         stype == SType::FLOAT32? "f" :
+         stype == SType::FLOAT64? "d" :
+         stype == SType::OBJ? "O" : "x";
 }

--- a/c/py_column.cc
+++ b/c/py_column.cc
@@ -63,13 +63,13 @@ PyObject* get_mtype(pycolumn::obj* self) {
 
 PyObject* get_stype(pycolumn::obj* self) {
   SType stype = self->ref->stype();
-  return incref(py_stype_objs[stype]);
+  return incref(py_stype_objs[static_cast<int>(stype)]);
 }
 
 
 PyObject* get_ltype(pycolumn::obj* self) {
   SType stype = self->ref->stype();
-  return incref(py_ltype_objs[stype_info[stype].ltype]);
+  return incref(py_ltype_objs[stype_info[static_cast<int>(stype)].ltype]);
 }
 
 

--- a/c/py_column.cc
+++ b/c/py_column.cc
@@ -63,13 +63,13 @@ PyObject* get_mtype(pycolumn::obj* self) {
 
 PyObject* get_stype(pycolumn::obj* self) {
   SType stype = self->ref->stype();
-  return incref(py_stype_objs[static_cast<int>(stype)]);
+  return info(stype).py_stype();
 }
 
 
 PyObject* get_ltype(pycolumn::obj* self) {
   SType stype = self->ref->stype();
-  return incref(py_ltype_objs[stype_info[static_cast<int>(stype)].ltype]);
+  return info(stype).py_ltype();
 }
 
 

--- a/c/py_datatable.cc
+++ b/c/py_datatable.cc
@@ -42,7 +42,7 @@ PyObject* wrap(DataTable* dt)
   if (pydt) {
     auto pypydt = reinterpret_cast<pydatatable::obj*>(pydt);
     pypydt->ref = dt;
-    pypydt->use_stype_for_buffers = ST_VOID;
+    pypydt->use_stype_for_buffers = SType::VOID;
   }
   return pydt;
 }
@@ -127,7 +127,7 @@ PyObject* get_ltypes(obj* self) {
   if (list == nullptr) return nullptr;
   while (--i >= 0) {
     SType st = self->ref->columns[i]->stype();
-    LType lt = stype_info[st].ltype;
+    LType lt = stype_info[static_cast<int>(st)].ltype;
     PyTuple_SET_ITEM(list, i, incref(py_ltype_objs[lt]));
   }
   return list;
@@ -141,7 +141,7 @@ PyObject* get_stypes(obj* self) {
   if (list == nullptr) return nullptr;
   while (--i >= 0) {
     SType st = dt->columns[i]->stype();
-    PyTuple_SET_ITEM(list, i, incref(py_stype_objs[st]));
+    PyTuple_SET_ITEM(list, i, incref(py_stype_objs[static_cast<int>(st)]));
   }
   return list;
 }
@@ -214,7 +214,7 @@ PyObject* to_scalar(obj* self, PyObject*) {
   if (dt->ncols == 1 && dt->nrows == 1) {
     Column* col = dt->columns[0];
     int64_t i = col->rowindex().nth(0);
-    auto f = py_stype_formatters[col->stype()];
+    auto f = py_stype_formatters[static_cast<int>(col->stype())];
     return f(col, i);
   } else {
     throw ValueError() << ".scalar() method cannot be applied to a Frame with "

--- a/c/py_datatable.cc
+++ b/c/py_datatable.cc
@@ -127,8 +127,7 @@ PyObject* get_ltypes(obj* self) {
   if (list == nullptr) return nullptr;
   while (--i >= 0) {
     SType st = self->ref->columns[i]->stype();
-    LType lt = stype_info[static_cast<int>(st)].ltype;
-    PyTuple_SET_ITEM(list, i, incref(py_ltype_objs[lt]));
+    PyTuple_SET_ITEM(list, i, info(st).py_ltype());
   }
   return list;
 }
@@ -141,7 +140,7 @@ PyObject* get_stypes(obj* self) {
   if (list == nullptr) return nullptr;
   while (--i >= 0) {
     SType st = dt->columns[i]->stype();
-    PyTuple_SET_ITEM(list, i, incref(py_stype_objs[static_cast<int>(st)]));
+    PyTuple_SET_ITEM(list, i, info(st).py_stype());
   }
   return list;
 }

--- a/c/py_datawindow.cc
+++ b/c/py_datawindow.cc
@@ -112,7 +112,8 @@ static int _init_(obj* self, PyObject* args, PyObject* kwds)
                rindex_is_arr32? rindexarr32[j] :
                rindex_is_arr64? rindexarr64[j] :
                       rindexstart + rindexstep * j;
-      PyObject *value = py_stype_formatters[col->stype()](col, irow);
+      int itype = static_cast<int>(col->stype());
+      PyObject *value = py_stype_formatters[itype](col, irow);
       if (value == nullptr) goto fail;
       PyList_SET_ITEM(py_coldata, n_init_rows++, value);
     }
@@ -124,10 +125,10 @@ static int _init_(obj* self, PyObject* args, PyObject* kwds)
   if (stypes == nullptr || ltypes == nullptr) goto fail;
   for (int64_t i = col0; i < col1; i++) {
     Column *col = dt->columns[i];
-    SType stype = col->stype();
-    LType ltype = stype_info[stype].ltype;
+    int itype = static_cast<int>(col->stype());
+    LType ltype = stype_info[itype].ltype;
     PyList_SET_ITEM(ltypes, i - col0, incref(py_ltype_names[ltype]));
-    PyList_SET_ITEM(stypes, i - col0, incref(py_stype_names[stype]));
+    PyList_SET_ITEM(stypes, i - col0, incref(py_stype_names[itype]));
   }
 
   self->row0 = row0;
@@ -217,9 +218,11 @@ static int _init_hexview(
   stypes = PyList_New(ncols);
   ltypes = PyList_New(ncols);
   if (!stypes || !ltypes) goto fail;
+  PyObject* ltype0 = py_ltype_names[LT_STRING];
+  PyObject* stype0 = py_stype_names[int(SType::FSTR)];
   for (int64_t i = 0; i < ncols; i++) {
-    PyList_SET_ITEM(ltypes, i, incref(py_ltype_names[LT_STRING]));
-    PyList_SET_ITEM(stypes, i, incref(py_stype_names[ST_STRING_FCHAR]));
+    PyList_SET_ITEM(ltypes, i, incref(ltype0));
+    PyList_SET_ITEM(stypes, i, incref(stype0));
   }
 
   self->row0 = row0;

--- a/c/py_datawindow.cc
+++ b/c/py_datawindow.cc
@@ -125,10 +125,9 @@ static int _init_(obj* self, PyObject* args, PyObject* kwds)
   if (stypes == nullptr || ltypes == nullptr) goto fail;
   for (int64_t i = col0; i < col1; i++) {
     Column *col = dt->columns[i];
-    int itype = static_cast<int>(col->stype());
-    LType ltype = stype_info[itype].ltype;
-    PyList_SET_ITEM(ltypes, i - col0, incref(py_ltype_names[ltype]));
-    PyList_SET_ITEM(stypes, i - col0, incref(py_stype_names[itype]));
+    info info_stype(col->stype());
+    PyList_SET_ITEM(ltypes, i - col0, info_stype.py_ltype());
+    PyList_SET_ITEM(stypes, i - col0, info_stype.py_stype());
   }
 
   self->row0 = row0;
@@ -218,11 +217,10 @@ static int _init_hexview(
   stypes = PyList_New(ncols);
   ltypes = PyList_New(ncols);
   if (!stypes || !ltypes) goto fail;
-  PyObject* ltype0 = py_ltype_names[LT_STRING];
-  PyObject* stype0 = py_stype_names[int(SType::FSTR)];
+  info itype(SType::STR32);
   for (int64_t i = 0; i < ncols; i++) {
-    PyList_SET_ITEM(ltypes, i, incref(ltype0));
-    PyList_SET_ITEM(stypes, i, incref(stype0));
+    PyList_SET_ITEM(ltypes, i, itype.py_ltype());
+    PyList_SET_ITEM(stypes, i, itype.py_stype());
   }
 
   self->row0 = row0;

--- a/c/py_types.cc
+++ b/c/py_types.cc
@@ -133,40 +133,39 @@ int init_py_types(PyObject*)
     if (py_ltype_names[i] == nullptr) return 0;
   }
 
-  for (int i = 0; i < DT_STYPES_COUNT; i++) {
+  for (size_t i = 0; i < DT_STYPES_COUNT; i++) {
     py_stype_names[i] = PyUnicode_FromString(stype_info[i].code);
     if (py_stype_names[i] == nullptr) return 0;
   }
 
-  py_stype_formatters[ST_VOID]               = stype_notimpl;
-  py_stype_formatters[ST_BOOLEAN_I1]         = stype_boolean_i8_tostring;
-  py_stype_formatters[ST_INTEGER_I1]         = stype_integer_i8_tostring;
-  py_stype_formatters[ST_INTEGER_I2]         = stype_integer_i16_tostring;
-  py_stype_formatters[ST_INTEGER_I4]         = stype_integer_i32_tostring;
-  py_stype_formatters[ST_INTEGER_I8]         = stype_integer_i64_tostring;
-  py_stype_formatters[ST_REAL_F4]            = stype_real_f32_tostring;
-  py_stype_formatters[ST_REAL_F8]            = stype_real_f64_tostring;
-  py_stype_formatters[ST_REAL_I2]            = stype_notimpl;
-  py_stype_formatters[ST_REAL_I4]            = stype_notimpl;
-  py_stype_formatters[ST_REAL_I8]            = stype_notimpl;
-  py_stype_formatters[ST_STRING_I4_VCHAR]    = stype_vchar_T_tostring<uint32_t>;
-  py_stype_formatters[ST_STRING_I8_VCHAR]    = stype_vchar_T_tostring<uint64_t>;
-  py_stype_formatters[ST_STRING_FCHAR]       = stype_notimpl;
-  py_stype_formatters[ST_STRING_U1_ENUM]     = stype_notimpl;
-  py_stype_formatters[ST_STRING_U2_ENUM]     = stype_notimpl;
-  py_stype_formatters[ST_STRING_U4_ENUM]     = stype_notimpl;
-  py_stype_formatters[ST_DATETIME_I8_EPOCH]  = stype_notimpl;
-  py_stype_formatters[ST_DATETIME_I4_TIME]   = stype_notimpl;
-  py_stype_formatters[ST_DATETIME_I4_DATE]   = stype_notimpl;
-  py_stype_formatters[ST_DATETIME_I2_MONTH]  = stype_notimpl;
-  py_stype_formatters[ST_OBJECT_PYPTR]       = stype_object_pyptr_tostring;
+  py_stype_formatters[int(SType::VOID)]    = stype_notimpl;
+  py_stype_formatters[int(SType::BOOL)]    = stype_boolean_i8_tostring;
+  py_stype_formatters[int(SType::INT8)]    = stype_integer_i8_tostring;
+  py_stype_formatters[int(SType::INT16)]   = stype_integer_i16_tostring;
+  py_stype_formatters[int(SType::INT32)]   = stype_integer_i32_tostring;
+  py_stype_formatters[int(SType::INT64)]   = stype_integer_i64_tostring;
+  py_stype_formatters[int(SType::FLOAT32)] = stype_real_f32_tostring;
+  py_stype_formatters[int(SType::FLOAT64)] = stype_real_f64_tostring;
+  py_stype_formatters[int(SType::DEC16)]   = stype_notimpl;
+  py_stype_formatters[int(SType::DEC32)]   = stype_notimpl;
+  py_stype_formatters[int(SType::DEC64)]   = stype_notimpl;
+  py_stype_formatters[int(SType::STR32)]   = stype_vchar_T_tostring<uint32_t>;
+  py_stype_formatters[int(SType::STR64)]   = stype_vchar_T_tostring<uint64_t>;
+  py_stype_formatters[int(SType::FSTR)]    = stype_notimpl;
+  py_stype_formatters[int(SType::CAT8)]    = stype_notimpl;
+  py_stype_formatters[int(SType::CAT16)]   = stype_notimpl;
+  py_stype_formatters[int(SType::CAT32)]   = stype_notimpl;
+  py_stype_formatters[int(SType::DATE64)]  = stype_notimpl;
+  py_stype_formatters[int(SType::TIME32)]  = stype_notimpl;
+  py_stype_formatters[int(SType::DATE32)]  = stype_notimpl;
+  py_stype_formatters[int(SType::DATE16)]  = stype_notimpl;
+  py_stype_formatters[int(SType::OBJ)]     = stype_object_pyptr_tostring;
 
   return 1;
 }
 
-void init_py_stype_objs(PyObject* stype_enum)
-{
-  for (int i = 0; i < DT_STYPES_COUNT; i++) {
+void init_py_stype_objs(PyObject* stype_enum) {
+  for (size_t i = 0; i < DT_STYPES_COUNT; i++) {
     // The call may raise an exception -- that's ok
     py_stype_objs[i] = PyObject_CallFunction(stype_enum, "i", i);
     if (py_stype_objs[i] == nullptr) {

--- a/c/py_types.cc
+++ b/c/py_types.cc
@@ -9,10 +9,8 @@
 #include "py_utils.h"
 #include "column.h"
 
-PyObject* py_ltype_names[DT_LTYPES_COUNT];
-PyObject* py_stype_names[DT_STYPES_COUNT];
-PyObject* py_ltype_objs[DT_LTYPES_COUNT];
-PyObject* py_stype_objs[DT_STYPES_COUNT];
+// TODO: merge with types.h / types.cc
+
 
 stype_formatter* py_stype_formatters[DT_STYPES_COUNT];
 size_t py_buffers_size;
@@ -120,24 +118,6 @@ int init_py_types(PyObject*)
   init_types();
   py_buffers_size = sizeof(Py_buffer);
 
-  py_ltype_names[LT_MU]       = PyUnicode_FromString("mu");
-  py_ltype_names[LT_BOOLEAN]  = PyUnicode_FromString("bool");
-  py_ltype_names[LT_INTEGER]  = PyUnicode_FromString("int");
-  py_ltype_names[LT_REAL]     = PyUnicode_FromString("real");
-  py_ltype_names[LT_STRING]   = PyUnicode_FromString("str");
-  py_ltype_names[LT_DATETIME] = PyUnicode_FromString("time");
-  py_ltype_names[LT_DURATION] = PyUnicode_FromString("duration");
-  py_ltype_names[LT_OBJECT]   = PyUnicode_FromString("obj");
-
-  for (int i = 0; i < DT_LTYPES_COUNT; i++) {
-    if (py_ltype_names[i] == nullptr) return 0;
-  }
-
-  for (size_t i = 0; i < DT_STYPES_COUNT; i++) {
-    py_stype_names[i] = PyUnicode_FromString(stype_info[i].code);
-    if (py_stype_names[i] == nullptr) return 0;
-  }
-
   py_stype_formatters[int(SType::VOID)]    = stype_notimpl;
   py_stype_formatters[int(SType::BOOL)]    = stype_boolean_i8_tostring;
   py_stype_formatters[int(SType::INT8)]    = stype_integer_i8_tostring;
@@ -162,27 +142,4 @@ int init_py_types(PyObject*)
   py_stype_formatters[int(SType::OBJ)]     = stype_object_pyptr_tostring;
 
   return 1;
-}
-
-void init_py_stype_objs(PyObject* stype_enum) {
-  for (size_t i = 0; i < DT_STYPES_COUNT; i++) {
-    // The call may raise an exception -- that's ok
-    py_stype_objs[i] = PyObject_CallFunction(stype_enum, "i", i);
-    if (py_stype_objs[i] == nullptr) {
-      PyErr_Clear();
-      py_stype_objs[i] = none();
-    }
-  }
-}
-
-void init_py_ltype_objs(PyObject* ltype_enum)
-{
-  for (int i = 0; i < DT_LTYPES_COUNT; i++) {
-    // The call may raise an exception -- that's ok
-    py_ltype_objs[i] = PyObject_CallFunction(ltype_enum, "i", i);
-    if (py_ltype_objs[i] == nullptr) {
-      PyErr_Clear();
-      py_ltype_objs[i] = none();
-    }
-  }
 }

--- a/c/py_types.h
+++ b/c/py_types.h
@@ -38,17 +38,11 @@ class Column;
 
 typedef PyObject* (stype_formatter)(Column *col, int64_t row);
 
-extern PyObject* py_ltype_names[DT_LTYPES_COUNT];
-extern PyObject* py_stype_names[DT_STYPES_COUNT];
-extern PyObject* py_ltype_objs[DT_LTYPES_COUNT];
-extern PyObject* py_stype_objs[DT_STYPES_COUNT];
 extern stype_formatter* py_stype_formatters[DT_STYPES_COUNT];
 extern size_t py_buffers_size;
 
 
 int init_py_types(PyObject *module);
-void init_py_stype_objs(PyObject* stype_enum);
-void init_py_ltype_objs(PyObject* ltype_enum);
 
 
 PyObject* bool_to_py(int8_t x);

--- a/c/rowindex_array.cc
+++ b/c/rowindex_array.cc
@@ -103,13 +103,13 @@ ArrayRowIndexImpl::ArrayRowIndexImpl(
 
 ArrayRowIndexImpl::ArrayRowIndexImpl(Column* col) {
   switch (col->stype()) {
-    case ST_BOOLEAN_I1:
+    case SType::BOOL:
       init_from_boolean_column(static_cast<BoolColumn*>(col));
       break;
-    case ST_INTEGER_I1:
-    case ST_INTEGER_I2:
-    case ST_INTEGER_I4:
-    case ST_INTEGER_I8:
+    case SType::INT8:
+    case SType::INT16:
+    case SType::INT32:
+    case SType::INT64:
       init_from_integer_column(col);
       break;
     default:
@@ -328,13 +328,13 @@ void ArrayRowIndexImpl::init_from_integer_column(Column* col) {
     // the column is destructed.
     MemoryRange xbuf = MemoryRange::external(ind32.data(), zn * sizeof(int32_t));
     xassert(xbuf.is_writable());
-    col3 = col2->cast(ST_INTEGER_I4, std::move(xbuf));
+    col3 = col2->cast(SType::INT32, std::move(xbuf));
   } else {
     type = RowIndexType::RI_ARR64;
     ind64.resize(zn);
     MemoryRange xbuf = MemoryRange::external(ind64.data(), zn * sizeof(int64_t));
     xassert(xbuf.is_writable());
-    col3 = col2->cast(ST_INTEGER_I8, std::move(xbuf));
+    col3 = col2->cast(SType::INT64, std::move(xbuf));
   }
 
   delete col2;

--- a/c/sort.cc
+++ b/c/sort.cc
@@ -275,15 +275,15 @@ class SortContext {
     // `strdata`, `stroffs`, `strstart` for string columns
     SType stype = col->stype();
     switch (stype) {
-      case ST_BOOLEAN_I1: _initB(col); break;
-      case ST_INTEGER_I1: _initI<int8_t,  uint8_t>(col); break;
-      case ST_INTEGER_I2: _initI<int16_t, uint16_t>(col); break;
-      case ST_INTEGER_I4: _initI<int32_t, uint32_t>(col); break;
-      case ST_INTEGER_I8: _initI<int64_t, uint64_t>(col); break;
-      case ST_REAL_F4:    _initF<uint32_t>(col); break;
-      case ST_REAL_F8:    _initF<uint64_t>(col); break;
-      case ST_STRING_I4_VCHAR: _initS<uint32_t>(col); break;
-      case ST_STRING_I8_VCHAR: _initS<uint64_t>(col); break;
+      case SType::BOOL:    _initB(col); break;
+      case SType::INT8:    _initI<int8_t,  uint8_t>(col); break;
+      case SType::INT16:   _initI<int16_t, uint16_t>(col); break;
+      case SType::INT32:   _initI<int32_t, uint32_t>(col); break;
+      case SType::INT64:   _initI<int64_t, uint64_t>(col); break;
+      case SType::FLOAT32: _initF<uint32_t>(col); break;
+      case SType::FLOAT64: _initF<uint64_t>(col); break;
+      case SType::STR32:   _initS<uint32_t>(col); break;
+      case SType::STR64:   _initS<uint64_t>(col); break;
       default:
         throw NotImplError() << "Unable to sort Column of stype " << stype;
     }

--- a/c/types.cc
+++ b/c/types.cc
@@ -93,28 +93,28 @@ void init_types(void)
 {
   #define STI(T, code, code2, csize, vw, ltype, na) \
       stype_info[int(T)] = STypeInfo{csize, na, code, code2, ltype, vw}
-  STI(SType::VOID,    "---", "--", 0, 0, LT_MU,       NULL);
-  STI(SType::BOOL,    "i1b", "b1", 1, 0, LT_BOOLEAN,  &NA_I1);
-  STI(SType::INT8,    "i1i", "i1", 1, 0, LT_INTEGER,  &NA_I1);
-  STI(SType::INT16,   "i2i", "i2", 2, 0, LT_INTEGER,  &NA_I2);
-  STI(SType::INT32,   "i4i", "i4", 4, 0, LT_INTEGER,  &NA_I4);
-  STI(SType::INT64,   "i8i", "i8", 8, 0, LT_INTEGER,  &NA_I8);
-  STI(SType::FLOAT32, "f4r", "r4", 4, 0, LT_REAL,     &NA_F4);
-  STI(SType::FLOAT64, "f8r", "r8", 8, 0, LT_REAL,     &NA_F8);
-  STI(SType::DEC16,   "i2r", "d2", 2, 0, LT_REAL,     &NA_I2);
-  STI(SType::DEC32,   "i4r", "d4", 4, 0, LT_REAL,     &NA_I4);
-  STI(SType::DEC64,   "i8r", "d8", 8, 0, LT_REAL,     &NA_I8);
-  STI(SType::STR32,   "i4s", "s4", 4, 1, LT_STRING,   NULL);
-  STI(SType::STR64,   "i8s", "s8", 8, 1, LT_STRING,   NULL);
-  STI(SType::FSTR,    "c#s", "sx", 0, 0, LT_STRING,   NULL);
-  STI(SType::CAT8,    "u1e", "e1", 1, 1, LT_STRING,   &NA_U1);
-  STI(SType::CAT16,   "u2e", "e2", 2, 1, LT_STRING,   &NA_U2);
-  STI(SType::CAT32,   "u4e", "e4", 4, 1, LT_STRING,   &NA_U4);
-  STI(SType::DATE64,  "i8d", "t8", 8, 0, LT_DATETIME, &NA_I8);
-  STI(SType::TIME32,  "i4t", "T4", 4, 0, LT_DATETIME, &NA_I4);
-  STI(SType::DATE32,  "i4d", "t4", 4, 0, LT_DATETIME, &NA_I4);
-  STI(SType::DATE16,  "i2d", "t2", 2, 0, LT_DATETIME, &NA_I2);
-  STI(SType::OBJ,     "p8p", "o8", 8, 0, LT_OBJECT,   NULL);
+  STI(SType::VOID,    "---", "--", 0, 0, LType::MU,       nullptr);
+  STI(SType::BOOL,    "i1b", "b1", 1, 0, LType::BOOL,     &NA_I1);
+  STI(SType::INT8,    "i1i", "i1", 1, 0, LType::INT,      &NA_I1);
+  STI(SType::INT16,   "i2i", "i2", 2, 0, LType::INT,      &NA_I2);
+  STI(SType::INT32,   "i4i", "i4", 4, 0, LType::INT,      &NA_I4);
+  STI(SType::INT64,   "i8i", "i8", 8, 0, LType::INT,      &NA_I8);
+  STI(SType::FLOAT32, "f4r", "r4", 4, 0, LType::REAL,     &NA_F4);
+  STI(SType::FLOAT64, "f8r", "r8", 8, 0, LType::REAL,     &NA_F8);
+  STI(SType::DEC16,   "i2r", "d2", 2, 0, LType::REAL,     &NA_I2);
+  STI(SType::DEC32,   "i4r", "d4", 4, 0, LType::REAL,     &NA_I4);
+  STI(SType::DEC64,   "i8r", "d8", 8, 0, LType::REAL,     &NA_I8);
+  STI(SType::STR32,   "i4s", "s4", 4, 1, LType::STRING,   nullptr);
+  STI(SType::STR64,   "i8s", "s8", 8, 1, LType::STRING,   nullptr);
+  STI(SType::FSTR,    "c#s", "sx", 0, 0, LType::STRING,   nullptr);
+  STI(SType::CAT8,    "u1e", "e1", 1, 1, LType::STRING,   &NA_U1);
+  STI(SType::CAT16,   "u2e", "e2", 2, 1, LType::STRING,   &NA_U2);
+  STI(SType::CAT32,   "u4e", "e4", 4, 1, LType::STRING,   &NA_U4);
+  STI(SType::DATE64,  "i8d", "t8", 8, 0, LType::DATETIME, &NA_I8);
+  STI(SType::TIME32,  "i4t", "T4", 4, 0, LType::DATETIME, &NA_I4);
+  STI(SType::DATE32,  "i4d", "t4", 4, 0, LType::DATETIME, &NA_I4);
+  STI(SType::DATE16,  "i2d", "t2", 2, 0, LType::DATETIME, &NA_I2);
+  STI(SType::OBJ,     "p8p", "o8", 8, 0, LType::OBJECT,   nullptr);
   #undef STI
 
   #define UPCAST(stype1, stype2, stypeR)         \
@@ -241,7 +241,7 @@ SType common_stype_for_buffer(SType stype1, SType stype2) {
 
 
 void init_py_stype_objs(PyObject* stype_enum) {
-  for (size_t i = 0; i < DT_STYPES_COUNT; i++) {
+  for (size_t i = 0; i < DT_STYPES_COUNT; ++i) {
     // The call may raise an exception -- that's ok
     py_stype_objs[i] = PyObject_CallFunction(stype_enum, "i", i);
     if (py_stype_objs[i] == nullptr) {
@@ -253,7 +253,7 @@ void init_py_stype_objs(PyObject* stype_enum) {
 
 void init_py_ltype_objs(PyObject* ltype_enum)
 {
-  for (int i = 0; i < DT_LTYPES_COUNT; i++) {
+  for (size_t i = 0; i < DT_LTYPES_COUNT; ++i) {
     // The call may raise an exception -- that's ok
     py_ltype_objs[i] = PyObject_CallFunction(ltype_enum, "i", i);
     if (py_ltype_objs[i] == nullptr) {
@@ -287,7 +287,7 @@ LType info::ltype() const {
 }
 
 PyObject* info::py_ltype() const {
-  PyObject* res = py_ltype_objs[ltype()];
+  PyObject* res = py_ltype_objs[static_cast<uint8_t>(ltype())];
   Py_INCREF(res);
   return res;
 }

--- a/c/types.cc
+++ b/c/types.cc
@@ -53,66 +53,66 @@ static SType stype_upcast_map[DT_STYPES_COUNT][DT_STYPES_COUNT];
 
 void init_types(void)
 {
-  #define STI(T, code, code2, csize, msize, vw, ltype, na) \
-      stype_info[T] = (STypeInfo){csize, msize, na, code, code2, ltype, vw}
-  STI(ST_VOID,              "---", "--", 0, 0,                   0, LT_MU,       NULL);
-  STI(ST_BOOLEAN_I1,        "i1b", "b1", 1, 0,                   0, LT_BOOLEAN,  &NA_I1);
-  STI(ST_INTEGER_I1,        "i1i", "i1", 1, 0,                   0, LT_INTEGER,  &NA_I1);
-  STI(ST_INTEGER_I2,        "i2i", "i2", 2, 0,                   0, LT_INTEGER,  &NA_I2);
-  STI(ST_INTEGER_I4,        "i4i", "i4", 4, 0,                   0, LT_INTEGER,  &NA_I4);
-  STI(ST_INTEGER_I8,        "i8i", "i8", 8, 0,                   0, LT_INTEGER,  &NA_I8);
-  STI(ST_REAL_F4,           "f4r", "r4", 4, 0,                   0, LT_REAL,     &NA_F4);
-  STI(ST_REAL_F8,           "f8r", "r8", 8, 0,                   0, LT_REAL,     &NA_F8);
-  STI(ST_REAL_I2,           "i2r", "d2", 2, sizeof(DecimalMeta), 0, LT_REAL,     &NA_I2);
-  STI(ST_REAL_I4,           "i4r", "d4", 4, sizeof(DecimalMeta), 0, LT_REAL,     &NA_I4);
-  STI(ST_REAL_I8,           "i8r", "d8", 8, sizeof(DecimalMeta), 0, LT_REAL,     &NA_I8);
-  STI(ST_STRING_I4_VCHAR,   "i4s", "s4", 4, sizeof(VarcharMeta), 1, LT_STRING,   NULL);
-  STI(ST_STRING_I8_VCHAR,   "i8s", "s8", 8, sizeof(VarcharMeta), 1, LT_STRING,   NULL);
-  STI(ST_STRING_FCHAR,      "c#s", "sx", 0, sizeof(FixcharMeta), 0, LT_STRING,   NULL);
-  STI(ST_STRING_U1_ENUM,    "u1e", "e1", 1, sizeof(EnumMeta),    1, LT_STRING,   &NA_U1);
-  STI(ST_STRING_U2_ENUM,    "u2e", "e2", 2, sizeof(EnumMeta),    1, LT_STRING,   &NA_U2);
-  STI(ST_STRING_U4_ENUM,    "u4e", "e4", 4, sizeof(EnumMeta),    1, LT_STRING,   &NA_U4);
-  STI(ST_DATETIME_I8_EPOCH, "i8d", "t8", 8, 0,                   0, LT_DATETIME, &NA_I8);
-  STI(ST_DATETIME_I4_TIME,  "i4t", "T4", 4, 0,                   0, LT_DATETIME, &NA_I4);
-  STI(ST_DATETIME_I4_DATE,  "i4d", "t4", 4, 0,                   0, LT_DATETIME, &NA_I4);
-  STI(ST_DATETIME_I2_MONTH, "i2d", "t2", 2, 0,                   0, LT_DATETIME, &NA_I2);
-  STI(ST_OBJECT_PYPTR,      "p8p", "o8", 8, 0,                   0, LT_OBJECT,   NULL);
+  #define STI(T, code, code2, csize, vw, ltype, na) \
+      stype_info[int(T)] = (STypeInfo){csize, 0, na, code, code2, ltype, vw}
+  STI(SType::VOID,    "---", "--", 0, 0, LT_MU,       NULL);
+  STI(SType::BOOL,    "i1b", "b1", 1, 0, LT_BOOLEAN,  &NA_I1);
+  STI(SType::INT8,    "i1i", "i1", 1, 0, LT_INTEGER,  &NA_I1);
+  STI(SType::INT16,   "i2i", "i2", 2, 0, LT_INTEGER,  &NA_I2);
+  STI(SType::INT32,   "i4i", "i4", 4, 0, LT_INTEGER,  &NA_I4);
+  STI(SType::INT64,   "i8i", "i8", 8, 0, LT_INTEGER,  &NA_I8);
+  STI(SType::FLOAT32, "f4r", "r4", 4, 0, LT_REAL,     &NA_F4);
+  STI(SType::FLOAT64, "f8r", "r8", 8, 0, LT_REAL,     &NA_F8);
+  STI(SType::DEC16,   "i2r", "d2", 2, 0, LT_REAL,     &NA_I2);
+  STI(SType::DEC32,   "i4r", "d4", 4, 0, LT_REAL,     &NA_I4);
+  STI(SType::DEC64,   "i8r", "d8", 8, 0, LT_REAL,     &NA_I8);
+  STI(SType::STR32,   "i4s", "s4", 4, 1, LT_STRING,   NULL);
+  STI(SType::STR64,   "i8s", "s8", 8, 1, LT_STRING,   NULL);
+  STI(SType::FSTR,    "c#s", "sx", 0, 0, LT_STRING,   NULL);
+  STI(SType::CAT8,    "u1e", "e1", 1, 1, LT_STRING,   &NA_U1);
+  STI(SType::CAT16,   "u2e", "e2", 2, 1, LT_STRING,   &NA_U2);
+  STI(SType::CAT32,   "u4e", "e4", 4, 1, LT_STRING,   &NA_U4);
+  STI(SType::DATE64,  "i8d", "t8", 8, 0, LT_DATETIME, &NA_I8);
+  STI(SType::TIME32,  "i4t", "T4", 4, 0, LT_DATETIME, &NA_I4);
+  STI(SType::DATE32,  "i4d", "t4", 4, 0, LT_DATETIME, &NA_I4);
+  STI(SType::DATE16,  "i2d", "t2", 2, 0, LT_DATETIME, &NA_I2);
+  STI(SType::OBJ,     "p8p", "o8", 8, 0, LT_OBJECT,   NULL);
   #undef STI
 
   #define UPCAST(stype1, stype2, stypeR)         \
-      stype_upcast_map[stype1][stype2] = stypeR; \
-      stype_upcast_map[stype2][stype1] = stypeR;
+      stype_upcast_map[int(stype1)][int(stype2)] = stypeR; \
+      stype_upcast_map[int(stype2)][int(stype1)] = stypeR;
 
-  for (int i = 1; i < DT_STYPES_COUNT; i++) {
+  for (size_t i = 1; i < DT_STYPES_COUNT; i++) {
     SType i_stype = static_cast<SType>(i);
-    stype_upcast_map[i][0] = stype_info[i].varwidth? ST_OBJECT_PYPTR : i_stype;
-    stype_upcast_map[0][i] = stype_info[i].varwidth? ST_OBJECT_PYPTR : i_stype;
-    for (int j = 1; j < DT_STYPES_COUNT; j++) {
+    stype_upcast_map[i][0] = stype_info[i].varwidth? SType::OBJ : i_stype;
+    stype_upcast_map[0][i] = stype_info[i].varwidth? SType::OBJ : i_stype;
+    for (size_t j = 1; j < DT_STYPES_COUNT; j++) {
       stype_upcast_map[i][j] =
-        stype_info[i].varwidth || i != j ? ST_OBJECT_PYPTR : i_stype;
+        stype_info[i].varwidth || i != j ? SType::OBJ : i_stype;
     }
   }
-  UPCAST(ST_BOOLEAN_I1, ST_INTEGER_I1,  ST_INTEGER_I1)
-  UPCAST(ST_BOOLEAN_I1, ST_INTEGER_I2,  ST_INTEGER_I2)
-  UPCAST(ST_BOOLEAN_I1, ST_INTEGER_I4,  ST_INTEGER_I4)
-  UPCAST(ST_BOOLEAN_I1, ST_INTEGER_I8,  ST_INTEGER_I8)
-  UPCAST(ST_BOOLEAN_I1, ST_REAL_F4,     ST_REAL_F4)
-  UPCAST(ST_BOOLEAN_I1, ST_REAL_F8,     ST_REAL_F8)
-  UPCAST(ST_INTEGER_I1, ST_INTEGER_I2,  ST_INTEGER_I2)
-  UPCAST(ST_INTEGER_I1, ST_INTEGER_I4,  ST_INTEGER_I4)
-  UPCAST(ST_INTEGER_I1, ST_INTEGER_I8,  ST_INTEGER_I8)
-  UPCAST(ST_INTEGER_I1, ST_REAL_F4,     ST_REAL_F4)
-  UPCAST(ST_INTEGER_I1, ST_REAL_F8,     ST_REAL_F8)
-  UPCAST(ST_INTEGER_I2, ST_INTEGER_I4,  ST_INTEGER_I4)
-  UPCAST(ST_INTEGER_I2, ST_INTEGER_I8,  ST_INTEGER_I8)
-  UPCAST(ST_INTEGER_I2, ST_REAL_F4,     ST_REAL_F4)
-  UPCAST(ST_INTEGER_I2, ST_REAL_F8,     ST_REAL_F8)
-  UPCAST(ST_INTEGER_I4, ST_INTEGER_I8,  ST_INTEGER_I8)
-  UPCAST(ST_INTEGER_I4, ST_REAL_F4,     ST_REAL_F4)
-  UPCAST(ST_INTEGER_I4, ST_REAL_F8,     ST_REAL_F8)
-  UPCAST(ST_INTEGER_I8, ST_REAL_F4,     ST_REAL_F4)
-  UPCAST(ST_INTEGER_I8, ST_REAL_F8,     ST_REAL_F8)
-  UPCAST(ST_REAL_F4,    ST_REAL_F8,     ST_REAL_F8)
+  UPCAST(SType::BOOL,  SType::INT8,    SType::INT8)
+  UPCAST(SType::BOOL,  SType::INT16,   SType::INT16)
+  UPCAST(SType::BOOL,  SType::INT32,   SType::INT32)
+  UPCAST(SType::BOOL,  SType::INT64,   SType::INT64)
+  UPCAST(SType::BOOL,  SType::FLOAT32, SType::FLOAT32)
+  UPCAST(SType::BOOL,  SType::FLOAT64, SType::FLOAT64)
+  UPCAST(SType::INT8,  SType::INT16,   SType::INT16)
+  UPCAST(SType::INT8,  SType::INT32,   SType::INT32)
+  UPCAST(SType::INT8,  SType::INT64,   SType::INT64)
+  UPCAST(SType::INT8,  SType::FLOAT32, SType::FLOAT32)
+  UPCAST(SType::INT8,  SType::FLOAT64, SType::FLOAT64)
+  UPCAST(SType::INT16, SType::INT32,   SType::INT32)
+  UPCAST(SType::INT16, SType::INT64,   SType::INT64)
+  UPCAST(SType::INT16, SType::FLOAT32, SType::FLOAT32)
+  UPCAST(SType::INT16, SType::FLOAT64, SType::FLOAT64)
+  UPCAST(SType::INT32, SType::INT64,   SType::INT64)
+  UPCAST(SType::INT32, SType::FLOAT32, SType::FLOAT32)
+  UPCAST(SType::INT32, SType::FLOAT64, SType::FLOAT64)
+  UPCAST(SType::INT64, SType::FLOAT32, SType::FLOAT32)
+  UPCAST(SType::INT64, SType::FLOAT64, SType::FLOAT64)
+  UPCAST(SType::FLOAT32, SType::FLOAT64, SType::FLOAT64)
   #undef UPCAST
   // In py_datatable.c we use 64-bit mask over stypes
   xassert(DT_STYPES_COUNT <= 64);
@@ -127,7 +127,7 @@ void init_types(void)
               (static_cast<uint_fast8_t>(ch - '0') < 10));
     }
 
-    for (int i = 0; i < DT_STYPES_COUNT; i++) {
+    for (size_t i = 0; i < DT_STYPES_COUNT; i++) {
       xassert(static_cast<SType>(i) == stype_from_string(stype_info[i].code));
     }
   #endif
@@ -137,7 +137,7 @@ void init_types(void)
 /**
  * Helper function to convert SType from string representation into the numeric
  * constant. The string `s` must have length 3. If the stype is invalid, this
- * function will return ST_VOID.
+ * function will return SType::VOID.
  */
 SType stype_from_string(const std::string& str)
 {
@@ -145,58 +145,58 @@ SType stype_from_string(const std::string& str)
   char s0 = str[0], s1 = str[1], s2 = str[2];
   if (s0 == 'i') {
     if (s2 == 'i' || s2 == '\0') {
-      if (s1 == '1') return ST_INTEGER_I1;
-      if (s1 == '2') return ST_INTEGER_I2;
-      if (s1 == '4') return ST_INTEGER_I4;
-      if (s1 == '8') return ST_INTEGER_I8;
+      if (s1 == '1') return SType::INT8;
+      if (s1 == '2') return SType::INT16;
+      if (s1 == '4') return SType::INT32;
+      if (s1 == '8') return SType::INT64;
     } else if (s2 == 'b') {
-      if (s1 == '1') return ST_BOOLEAN_I1;
+      if (s1 == '1') return SType::BOOL;
     } else if (s2 == 'r') {
-      if (s1 == '2') return ST_REAL_I2;
-      if (s1 == '4') return ST_REAL_I4;
-      if (s1 == '8') return ST_REAL_I8;
+      if (s1 == '2') return SType::DEC16;
+      if (s1 == '4') return SType::DEC32;
+      if (s1 == '8') return SType::DEC64;
     } else if (s2 == 's') {
-      if (s1 == '4') return ST_STRING_I4_VCHAR;
-      if (s1 == '8') return ST_STRING_I8_VCHAR;
+      if (s1 == '4') return SType::STR32;
+      if (s1 == '8') return SType::STR64;
     } else if (s2 == 'd') {
-      if (s1 == '2') return ST_DATETIME_I2_MONTH;
-      if (s1 == '4') return ST_DATETIME_I4_DATE;
-      if (s1 == '8') return ST_DATETIME_I8_EPOCH;
+      if (s1 == '2') return SType::DATE16;
+      if (s1 == '4') return SType::DATE32;
+      if (s1 == '8') return SType::DATE64;
     } else if (s2 == 't') {
-      if (s1 == '4') return ST_DATETIME_I4_TIME;
+      if (s1 == '4') return SType::TIME32;
     }
   } else if (s0 == 'r' && s2 == '\0') {
-    if (s1 == '4') return ST_REAL_F4;
-    if (s1 == '8') return ST_REAL_F8;
+    if (s1 == '4') return SType::FLOAT32;
+    if (s1 == '8') return SType::FLOAT64;
   } else if (s0 == 'b' && s2 == '\0') {
-    if (s1 == '1' && s2 == '\0') return ST_BOOLEAN_I1;
+    if (s1 == '1' && s2 == '\0') return SType::BOOL;
   } else if (s0 == 'o') {
-    if (s1 == '8' && s2 == '\0') return ST_OBJECT_PYPTR;
+    if (s1 == '8' && s2 == '\0') return SType::OBJ;
   } else if (s0 == 's') {
     if (s2 == '\0') {
-      if (s1 == '4') return ST_STRING_I4_VCHAR;
-      if (s1 == '8') return ST_STRING_I8_VCHAR;
+      if (s1 == '4') return SType::STR32;
+      if (s1 == '8') return SType::STR64;
     }
   } else if (s0 == 'f') {
     if (s2 == 'r') {
-      if (s1 == '4') return ST_REAL_F4;
-      if (s1 == '8') return ST_REAL_F8;
+      if (s1 == '4') return SType::FLOAT32;
+      if (s1 == '8') return SType::FLOAT64;
     }
   } else if (s0 == 'u') {
     if (s2 == 'e') {
-      if (s1 == '1') return ST_STRING_U1_ENUM;
-      if (s1 == '2') return ST_STRING_U2_ENUM;
-      if (s1 == '4') return ST_STRING_U4_ENUM;
+      if (s1 == '1') return SType::CAT8;
+      if (s1 == '2') return SType::CAT16;
+      if (s1 == '4') return SType::CAT32;
     }
   } else if (s0 == 'c') {
-    if (s1 == '#' && s2 == 's') return ST_STRING_FCHAR;
+    if (s1 == '#' && s2 == 's') return SType::FSTR;
   } else if (s0 == 'p') {
-    if (s1 == '8' && s2 == 'p') return ST_OBJECT_PYPTR;
+    if (s1 == '8' && s2 == 'p') return SType::OBJ;
   }
-  return ST_VOID;
+  return SType::VOID;
 }
 
 
 SType common_stype_for_buffer(SType stype1, SType stype2) {
-  return stype_upcast_map[stype1][stype2];
+  return stype_upcast_map[int(stype1)][int(stype2)];
 }

--- a/c/types.h
+++ b/c/types.h
@@ -102,42 +102,42 @@ typedef enum LType {
  * That is, a single logical type may have multiple storage types, but not the
  * other way around.
  *
- * ST_VOID
+ * SType::VOID
  *     "Fake" type, column with this stype is in an invalid state. This type may
  *     be used internally to indicate that a column is being constructed.
  *
  * -----------------------------------------------------------------------------
  *
- * ST_BOOLEAN_I1
+ * SType::BOOL
  *     elem: int8_t (1 byte)
  *     NA:   -128
  *     A boolean with True = 1, False = 0. All other values are invalid.
  *
  * -----------------------------------------------------------------------------
  *
- * ST_INTEGER_I1
+ * SType::INT8
  *     elem: int8_t (1 byte)
  *     NA:   -2**7 = -128
  *     An integer in the range -127 .. 127.
  *
- * ST_INTEGER_I2
+ * SType::INT16
  *     elem: int16_t (2 bytes)
  *     NA:   -2**15 = -32768
  *     An integer in the range -32767 .. 32767.
  *
- * ST_INTEGER_I4
+ * SType::INT32
  *     elem: int32_t (4 bytes)
  *     NA:   -2**31 = -2147483648
  *     An integer in the range -2147483647 .. 2147483647.
  *
- * ST_INTEGER_I8
+ * SType::INT64
  *     elem: int64_t (8 bytes)
  *     NA:   -2**63 = -9223372036854775808
  *     An integer in the range -9223372036854775807 .. 9223372036854775807.
  *
  * -----------------------------------------------------------------------------
  *
- * ST_REAL_F4
+ * SType::FLOAT32
  *     elem: float (4 bytes)
  *     NA:   0x7F8007A2
  *     Floating-point real number, corresponding to C's `float` (IEEE 754). We
@@ -145,12 +145,12 @@ typedef enum LType {
  *     numbers starting with 0x7F8 or 0xFF8 should be treated as actual NANs (or
  *     infinities).
  *
- * ST_REAL_F8
+ * SType::FLOAT64
  *     elem: double (8 bytes)
  *     NA:   0x7FF00000000007A2
  *     Floating-point real number, corresponding to C's `double` (IEEE 754).
  *
- * ST_REAL_I2
+ * SType::DEC16
  *     elem: int16_t (2 bytes)
  *     NA:   -2**15 = -32768
  *     meta: `scale` (int)
@@ -162,13 +162,13 @@ typedef enum LType {
  *     each value. Thus, all values will have common scale, which greatly
  *     simplifies their use.
  *
- * ST_REAL_I4
+ * SType::DEC32
  *     elem: int32_t (4 bytes)
  *     NA:   -2**31
  *     meta: `scale` (int)
  *     Fixed-point real number stored as a 32-bit integer.
  *
- * ST_REAL_I8
+ * SType::DEC64
  *     elem: int64_t (8 bytes)
  *     NA:   -2**63
  *     meta: `scale` (int)
@@ -176,7 +176,7 @@ typedef enum LType {
  *
  * -----------------------------------------------------------------------------
  *
- * ST_STRING_I4_VCHAR
+ * SType::STR32
  *     elem: uint32_t (4 bytes) + unsigned char[]
  *     NA:   (1 << 31) mask
  *     Variable-width strings. The data consists of 2 buffers:
@@ -198,13 +198,13 @@ typedef enum LType {
  *         strbuf  = [h e l l o]
  *         offsets = [0, 1<<31, 5, 5, 5|(1<<31)]
  *
- * ST_STRING_I8_VCHAR
+ * SType::STR64
  *     elem: uint64_t (8 bytes) + unsigned char[]
  *     NA:   (1 << 63) mask
- *     Variable-width strings: same as ST_STRING_I4_VCHAR but use 64-bit
+ *     Variable-width strings: same as SType::STR32 but use 64-bit
  *     offsets.
  *
- * ST_STRING_FCHAR
+ * SType::FSTR
  *     elem: unsigned char[] (n bytes)
  *     NA:   0xFF 0xFF ... 0xFF
  *     meta: `n` (int)
@@ -215,7 +215,7 @@ typedef enum LType {
  *     data is encoded in UTF-8. The NA value is encoded as a sequence of 0xFF
  *     bytes, which is not a valid UTF-8 string.
  *
- * ST_STRING_U1_ENUM
+ * SType::CAT8
  *     elem: uint8_t (1 byte)
  *     NA:   255
  *     meta: `offoff` (long int), `dataoff` (long int), `nlevels` (int)
@@ -229,42 +229,42 @@ typedef enum LType {
  *     to a multiple of 8 bytes); finally comes the array of categorical
  *     indices. Meta information contains offsets of the second and the third
  *     sections. The layout of the first 2 sections is exactly the same as
- *     that of the ST_STRING_I4_VCHAR type.
+ *     that of the SType::STR32 type.
  *
- * ST_STRING_U2_ENUM
+ * SType::CAT16
  *     elem: uint16_t (2 bytes)
  *     NA:   65535
  *     meta: `offoff` (long int), `dataoff` (long int), `nlevels` (int)
  *     Strings stored as a categorical variable with no more than 65535 distinct
- *     levels. The layout is exactly the same as that of ST_STRING_U1_ENUM, only
+ *     levels. The layout is exactly the same as that of CAT8, only
  *     the last section uses 2 bytes per element instead of just 1 byte.
  *
- * ST_STRING_U4_ENUM
+ * SType::CAT32
  *     elem: uint32_t (4 bytes)
  *     NA:   2**32-1
  *     meta: `offoff` (long int), `dataoff` (long int), `nlevels` (int)
  *     Strings stored as a categorical variable with no more than 2**32-1
  *     distinct levels. (The combined size of all categorical strings may not
- *     exceed 2**32 too). The layout is same as that of ST_STRING_U1_ENUM, only
+ *     exceed 2**32 too). The layout is same as that of CAT8, only
  *     the last section uses 4 bytes per element instead of just 1 byte.
  *
  *
  * -----------------------------------------------------------------------------
  *
- * ST_DATETIME_I8_EPOCH
+ * SType::DATE64
  *     elem: int64_t (8 bytes)
  *     NA:   -2**63
  *     Timestamp, stored as the number of microseconds since 0000-03-01. The
  *     allowed time range is ≈290,000 years around the epoch. The time is
  *     assumed to be in UTC, and does not allow specifying a time zone.
  *
- * ST_DATETIME_I4_DATE
+ * SType::DATE32
  *     elem: int32_t (4 bytes)
  *     NA:   -2**31
  *     Date only: the number of days since 0000-03-01. The allowed time range
  *     is ≈245,000 years.
  *
- * ST_DATETIME_I2_MONTH
+ * SType::DATE16
  *     elem: int16_t (2 bytes)
  *     NA:   -2**15
  *     Year+month only: the number of months since 0000-03-01. The allowed time
@@ -273,7 +273,7 @@ typedef enum LType {
  *     adding/subtraction in monthly/yearly intervals (other datetime types do
  *     not allow that since months/years have uneven lengths).
  *
- * ST_DATETIME_I4_TIME
+ * SType::TIME32
  *     elem: int32_t (4 bytes)
  *     NA:   -2**31
  *     Time only: the number of milliseconds since midnight. The allowed time
@@ -282,37 +282,38 @@ typedef enum LType {
  *
  * -----------------------------------------------------------------------------
  *
- * ST_OBJECT_PTR
+ * SType::OBJ
  *     elem: PyObject*
  *     NA:   Py_None
  *
  */
-typedef enum SType {
-    ST_VOID              = 0,
-    ST_BOOLEAN_I1        = 1,
-    ST_INTEGER_I1        = 2,
-    ST_INTEGER_I2        = 3,
-    ST_INTEGER_I4        = 4,
-    ST_INTEGER_I8        = 5,
-    ST_REAL_F4           = 6,
-    ST_REAL_F8           = 7,
-    ST_REAL_I2           = 8,
-    ST_REAL_I4           = 9,
-    ST_REAL_I8           = 10,
-    ST_STRING_I4_VCHAR   = 11,
-    ST_STRING_I8_VCHAR   = 12,
-    ST_STRING_FCHAR      = 13,
-    ST_STRING_U1_ENUM    = 14,
-    ST_STRING_U2_ENUM    = 15,
-    ST_STRING_U4_ENUM    = 16,
-    ST_DATETIME_I8_EPOCH = 17,
-    ST_DATETIME_I4_TIME  = 18,
-    ST_DATETIME_I4_DATE  = 19,
-    ST_DATETIME_I2_MONTH = 20,
-    ST_OBJECT_PYPTR      = 21,
-} __attribute__ ((__packed__)) SType;
+enum class SType : uint8_t {
+  VOID    = 0,
+  BOOL    = 1,
+  INT8    = 2,
+  INT16   = 3,
+  INT32   = 4,
+  INT64   = 5,
+  FLOAT32 = 6,
+  FLOAT64 = 7,
+  DEC16   = 8,
+  DEC32   = 9,
+  DEC64   = 10,
+  STR32   = 11,
+  STR64   = 12,
+  FSTR    = 13,
+  CAT8    = 14,
+  CAT16   = 15,
+  CAT32   = 16,
+  DATE64  = 17,
+  TIME32  = 18,
+  DATE32  = 19,
+  DATE16  = 20,
+  OBJ     = 21,
+};
 
-#define DT_STYPES_COUNT  (ST_OBJECT_PYPTR + 1)
+constexpr size_t DT_STYPES_COUNT =
+    static_cast<size_t>(SType::OBJ) + 1;
 
 
 
@@ -338,7 +339,7 @@ typedef enum SType {
  * varwidth:
  *     flag indicating whether the field is variable-width. If this is false,
  *     then the column is a plain array of elements, each of `elemsize` bytes
- *     (except for ST_STRING_FCHAR, where each element's size is `meta->n`).
+ *     (except for FSTR, where each element's size is `meta->n`).
  *     If this flag is true, then the field has more complex layout and
  *     specialized logic to handle that layout.
  *
@@ -366,18 +367,18 @@ extern STypeInfo stype_info[DT_STYPES_COUNT];
 /**
  * Structs for meta information associated with particular types.
  *
- * DecimalMeta (ST_REAL_I2, ST_REAL_I4, ST_REAL_I8)
+ * DecimalMeta (DEC16, DEC32, DEC64)
  *     scale: the number of digits after the decimal point. For example stored
  *            value 123 represents actual value 1.23 when `scale = 2`, or
  *            actual value 123000 when `scale = -3`.
  *
- * VarcharMeta (ST_STRING_I4_VCHAR, ST_STRING_I8_VCHAR)
+ * VarcharMeta (SType::STR32, SType::STR64)
  *     offoff: location within the data buffer of the section with offsets.
  *
- * FixcharMeta (ST_STRING_FCHAR)
+ * FixcharMeta (FSTR)
  *     n: number of characters in the fixed-width string.
  *
- * EnumMeta (ST_STRING_U1_ENUM, ST_STRING_U2_ENUM, ST_STRING_U4_ENUM)
+ * EnumMeta (CAT8, CAT16, CAT32)
  *     offoff: location within the data buffer of the section with offsets.
  *     dataoff: location of the section with categorical levels (one per row).
  *     nlevels: total number of categorical levels.
@@ -391,7 +392,7 @@ typedef struct VarcharMeta {  // ST_STRING_IX_VCHAR
     int64_t offoff;
 } VarcharMeta;
 
-typedef struct FixcharMeta {  // ST_STRING_FCHAR
+typedef struct FixcharMeta {  // FSTR
     int32_t n;
 } FixcharMeta;
 
@@ -480,20 +481,20 @@ SType common_stype_for_buffer(SType stype1, SType stype2);
 
 
 constexpr SType stype_integer(size_t s) {
-    return s == 1? ST_INTEGER_I1 :
-           s == 2? ST_INTEGER_I2 :
-           s == 4? ST_INTEGER_I4 :
-           s == 8? ST_INTEGER_I8 : ST_VOID;
+    return s == 1? SType::INT8 :
+           s == 2? SType::INT16 :
+           s == 4? SType::INT32 :
+           s == 8? SType::INT64 : SType::VOID;
 }
 
 constexpr SType stype_real(size_t s) {
-    return s == 4? ST_REAL_F4 :
-           s == 8? ST_REAL_F8 : ST_VOID;
+    return s == 4? SType::FLOAT32 :
+           s == 8? SType::FLOAT64 : SType::VOID;
 }
 
 constexpr SType stype_string(size_t s) {
-    return s == 4? ST_STRING_I4_VCHAR :
-           s == 8? ST_STRING_I8_VCHAR : ST_VOID;
+    return s == 4? SType::STR32 :
+           s == 8? SType::STR64 : SType::VOID;
 }
 
 

--- a/c/types.h
+++ b/c/types.h
@@ -25,11 +25,11 @@ struct CString {
  * "Logical" type of a data column.
  *
  * Logical type is supposed to match the user's notion of a column type. For
- * example logical "LT_INTEGER" type corresponds to the mathematical set of
+ * example logical "LType::INT" type corresponds to the mathematical set of
  * integers, and thus reflects the usual notion of what the "integer" *is*.
  *
  * Each logical type has multiple underlying "storage" types, that describe
- * how the type is actually stored in memory. For example, LT_INTEGER can be
+ * how the type is actually stored in memory. For example, LType::INT can be
  * stored as an 8-, 16-, 32- or a 64-bit integer. All "storage" types within
  * a single logical type should be freely interchangeable: operators or
  * functions that accept certain logical type should be able to work with any
@@ -41,50 +41,50 @@ struct CString {
  * bit shift operators require integer (or boolean) arguments.
  *
  *
- * LT_MU
+ * LType::MU
  *     special "marker" type for a column that has unknown type. For example,
  *     this can be used to indicate that the system should autodetect the
  *     column's type from the data. This type has no storage types.
  *
- * LT_BOOLEAN
+ * LType::BOOL
  *     column for storing boolean (0/1) values. Right now we only allow to
  *     store booleans as 1-byte signed chars. In most arithmetic expressions
  *     booleans are automatically promoted to integers (or reals) if needed.
  *
- * LT_INTEGER
+ * LType::INT
  *     integer values, equivalent of ℤ in mathematics. We support multiple
  *     storage sizes for integers: from 8 bits to 64 bits, but do not allow
  *     arbitrary-length integers. In most expressions integers will be
  *     automatically promoted to reals if needed.
  *
- * LT_REAL
+ * LType::REAL
  *     real values, equivalent of ℝ in mathematics. We store these in either
  *     fixed- or floating-point formats.
  *
- * LT_STRING
+ * LType::STRING
  *     all strings are encoded in UTF-8. We allow either variable-width strings
  *     or fixed-width.
  *
- * LT_DATETIME
- * LT_DURATION
+ * LType::DATETIME
+ * LType::DURATION
  *
- * LT_OBJECT
+ * LType::OBJECT
  *     column for storing all other values of arbitrary (possibly heterogeneous)
  *     types. Each element is a `PyObject*`. Missing values are `Py_None`s.
  *
  */
-typedef enum LType {
-    LT_MU       = 0,
-    LT_BOOLEAN  = 1,
-    LT_INTEGER  = 2,
-    LT_REAL     = 3,
-    LT_STRING   = 4,
-    LT_DATETIME = 5,
-    LT_DURATION = 6,
-    LT_OBJECT   = 7,
-} __attribute__ ((__packed__)) LType;
+enum class LType : uint8_t {
+  MU       = 0,
+  BOOL     = 1,
+  INT      = 2,
+  REAL     = 3,
+  STRING   = 4,
+  DATETIME = 5,
+  DURATION = 6,
+  OBJECT   = 7,
+};
 
-#define DT_LTYPES_COUNT  (LT_OBJECT + 1)  // 1 + the largest LT_* type
+constexpr size_t DT_LTYPES_COUNT = static_cast<size_t>(LType::OBJECT) + 1;
 
 
 
@@ -307,8 +307,7 @@ enum class SType : uint8_t {
   OBJ     = 21,
 };
 
-constexpr size_t DT_STYPES_COUNT =
-    static_cast<size_t>(SType::OBJ) + 1;
+constexpr size_t DT_STYPES_COUNT = static_cast<size_t>(SType::OBJ) + 1;
 
 
 

--- a/c/types.h
+++ b/c/types.h
@@ -408,22 +408,4 @@ SType stype_from_string(const std::string&);
 SType common_stype_for_buffer(SType stype1, SType stype2);
 
 
-constexpr SType stype_integer(size_t s) {
-    return s == 1? SType::INT8 :
-           s == 2? SType::INT16 :
-           s == 4? SType::INT32 :
-           s == 8? SType::INT64 : SType::VOID;
-}
-
-constexpr SType stype_real(size_t s) {
-    return s == 4? SType::FLOAT32 :
-           s == 8? SType::FLOAT64 : SType::VOID;
-}
-
-constexpr SType stype_string(size_t s) {
-    return s == 4? SType::STR32 :
-           s == 8? SType::STR64 : SType::VOID;
-}
-
-
 #endif

--- a/c/utils/exceptions.cc
+++ b/c/utils/exceptions.cc
@@ -102,7 +102,7 @@ Error& Error::operator<<(const CErrno&) {
 }
 
 Error& Error::operator<<(SType stype) {
-  error << stype_info[int(stype)].code2;
+  error << info(stype).name();
   return *this;
 }
 

--- a/c/utils/exceptions.cc
+++ b/c/utils/exceptions.cc
@@ -102,7 +102,7 @@ Error& Error::operator<<(const CErrno&) {
 }
 
 Error& Error::operator<<(SType stype) {
-  error << stype_info[stype].code2;
+  error << stype_info[int(stype)].code2;
   return *this;
 }
 

--- a/tests/fread/test_fread_small.py
+++ b/tests/fread/test_fread_small.py
@@ -1001,7 +1001,7 @@ def test_round_filesize(tempfile, mul, eol):
 
 
 def test_maxnrows_on_large_dataset():
-    src = "A,B,C\n" + "\n".join("%06d,x,1" % i for i in range(1000000))
+    src = "A,B,C\n" + "\n".join("%06d,x,1" % i for i in range(2000000))
     t0 = time.time()
     d0 = dt.fread(src, max_nrows=5, verbose=True)
     t0 = time.time() - t0
@@ -1011,6 +1011,7 @@ def test_maxnrows_on_large_dataset():
     t1 = time.time()
     d1 = dt.fread(src)
     t1 = time.time() - t1
+    assert d1.shape == (2000000, 3)
     assert t0 < t1 / 2, ("Reading with max_nrows=5 should be faster than "
                          "reading the whole dataset")
 
@@ -1020,6 +1021,7 @@ def test_typebumps(capsys):
     lines[105] = "Fals,3.5,boo,\"1,000\""
     src = "A,B,C,D\n" + "\n".join(lines)
     d0 = dt.fread(src, verbose=True)
+    d0.internal.check()
     out, err = capsys.readouterr()
     assert ("4 columns need to be re-read because their types have changed"
             in out)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -58,7 +58,7 @@ def c_stypes():
                     r'"(..)",\s*'
                     r"(\d+),\s*"
                     r"(\d),\s*"
-                    r"(?:0|(\w+)),\s*"
+                    r"LType::(\w+),\s*"
                     r"&?(\w+)\)",
                     txt2)
     for name, code3, code2, elemsize, varwidth, ltype, na in mm:
@@ -281,7 +281,7 @@ def test_ltype_repr():
 def test_stype_ltypes(c_stypes2):
     from datatable import stype, ltype
     for st in stype:
-        assert st.ltype is ltype(c_stypes2[st.code]["ltype"][3:].lower())
+        assert st.ltype is ltype(c_stypes2[st.code]["ltype"].lower())
 
 
 def test_ltype_stypes():

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -42,7 +42,8 @@ def c_stypes():
     file1 = os.path.join(os.path.dirname(__file__), "..", "c", "types.h")
     with open(file1, "r", encoding="utf-8") as f:
         txt1 = f.read()
-    mm = re.search(r"typedef enum SType {\s*(.*?),?\s*}", txt1, re.DOTALL)
+    mm = re.search(r"enum class SType : uint8_t {\s*(.*?),?\s*}",
+                   txt1, re.DOTALL)
     assert mm
     txt2 = mm.group(1)
     for name, i in re.findall(r"(\w+)\s*=\s*(\d+)", txt2):
@@ -52,20 +53,18 @@ def c_stypes():
     file2 = os.path.join(os.path.dirname(__file__), "..", "c", "types.cc")
     with open(file2, "r", encoding="utf-8") as f:
         txt2 = f.read()
-    mm = re.findall(r"STI\((\w+),\s*"
+    mm = re.findall(r"STI\(SType::(\w+),\s*"
                     r'"(...)",\s*'
                     r'"(..)",\s*'
                     r"(\d+),\s*"
-                    r"(?:0|sizeof\((\w+)\)),\s*"
                     r"(\d),\s*"
                     r"(?:0|(\w+)),\s*"
                     r"&?(\w+)\)",
                     txt2)
-    for name, code3, code2, elemsize, meta, varwidth, ltype, na in mm:
+    for name, code3, code2, elemsize, varwidth, ltype, na in mm:
         stypes[name]["stype"] = code3
         stypes[name]["code2"] = code2
         stypes[name]["elemsize"] = int(elemsize)
-        stypes[name]["meta"] = meta
         stypes[name]["varwidth"] = bool(int(varwidth))
         stypes[name]["ltype"] = ltype
         stypes[name]["na"] = na


### PR DESCRIPTION
* Convert `SType` / `LType` into enum classes (before they were plain-C enums)
* Replaced `stype_info[...]` with `info(stype)` class which provides same information, and even some more
* Names of SType constants were shortened and simplified. For example, we now have `SType::STR32` instead of `ST_STRING_I4_VCHAR`.
* The `.window()` method of a DataTable now returns a list of stype constants, previously it returned a list of stype "short names". This was a leftover from the era when stypes were strings.
* Eliminated some obsolete code

Closes #1152