### PR TITLE
Enable construction of Frame from kwd args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Filters can now be used together with groupby expressions.
 - fread's verbose output now includes time for opening the input file.
 - Added ability to read/write Jay files.
+- Frames can now be constructed via the keyword-args list of columns
+  (i.e. `Frame(A=..., B=...)`).
 
 #### Fixed
 - Fixed a bug in dt.cbind() where the first Frame in the list was ignored.

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -47,14 +47,17 @@ class Frame(object):
                  "_inames", "_dt")
 
     def __init__(self, src=None, names=None, stypes=None, **kwargs):
-        if "colnames" in kwargs and names is None:
-            names = kwargs.pop("colnames")
-            dtwarn("Parameter `colnames` in Frame constructor is "
-                   "deprecated. Use `names` instead.")
-        if "stype" in kwargs:
-            stypes = [kwargs.pop("stype")]
-        if kwargs:
-            dtwarn("Unknown options %r to Frame()" % kwargs)
+        if src is None and kwargs:
+            src = kwargs
+            if names is not None:
+                src["names"] = names
+            if stypes is not None:
+                src["stypes"] = stypes
+        else:
+            if "stype" in kwargs:
+                stypes = [kwargs.pop("stype")]
+            if kwargs:
+                dtwarn("Unknown options %r to Frame()" % kwargs)
         Frame._id_counter_ += 1
         self._id = Frame._id_counter_  # type: int
         self._ncols = 0      # type: int

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -47,16 +47,12 @@ class Frame(object):
                  "_inames", "_dt")
 
     def __init__(self, src=None, names=None, stypes=None, **kwargs):
-        if src is None and kwargs:
-            src = kwargs
-            if names is not None:
-                src["names"] = names
-            if stypes is not None:
-                src["stypes"] = stypes
-        else:
-            if "stype" in kwargs:
-                stypes = [kwargs.pop("stype")]
-            if kwargs:
+        if "stype" in kwargs:
+            stypes = [kwargs.pop("stype")]
+        if kwargs:
+            if src is None:
+                src = kwargs
+            else:
                 dtwarn("Unknown options %r to Frame()" % kwargs)
         Frame._id_counter_ += 1
         self._id = Frame._id_counter_  # type: int

--- a/tests/test_dt_create.py
+++ b/tests/test_dt_create.py
@@ -101,12 +101,21 @@ def test_create_from_dict():
 
 
 def test_create_from_kwargs():
-    d0 = dt.Frame(A=[1, 2, 3], B=[True, None, False], names=["a", "b", "c"])
+    d0 = dt.Frame(A=[1, 2, 3], B=[True, None, False], C=["a", "b", "c"])
     d0.internal.check()
-    assert same_iterables(d0.names, ("A", "B", "names"))
+    assert same_iterables(d0.names, ("A", "B", "C"))
     assert same_iterables(d0.topython(), [[1, 2, 3],
                                           [True, None, False],
                                           ["a", "b", "c"]])
+
+
+def test_create_from_kwargs2():
+    d0 = dt.Frame(x=range(4), y=[1, 3, 8, 0], stypes=[dt.int64, dt.float32])
+    d0.internal.check()
+    assert d0.shape == (4, 2)
+    assert same_iterables(d0.names, ("x", "y"))
+    assert same_iterables(d0.stypes, (dt.int64, dt.float32))
+    assert same_iterables(d0.topython(), [[0, 1, 2, 3], [1, 3, 8, 0]])
 
 
 def test_create_from_datatable():

--- a/tests/test_dt_create.py
+++ b/tests/test_dt_create.py
@@ -100,6 +100,15 @@ def test_create_from_dict():
     d7.internal.check()
 
 
+def test_create_from_kwargs():
+    d0 = dt.Frame(A=[1, 2, 3], B=[True, None, False], names=["a", "b", "c"])
+    d0.internal.check()
+    assert same_iterables(d0.names, ("A", "B", "names"))
+    assert same_iterables(d0.topython(), [[1, 2, 3],
+                                          [True, None, False],
+                                          ["a", "b", "c"]])
+
+
 def test_create_from_datatable():
     d8_0 = dt.Frame({"A": [1, 4, 3],
                      "B": [False, True, False],


### PR DESCRIPTION
It is now possible to construct a Frame by giving the source columns as a list of kwd args:
```
dt.Frame(col1=..., col2=..., col3=...)
```

Closes #1105