### PR TITLE
Keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   (i.e. `Frame(A=..., B=...)`).
 - Implemented logical operators "and" `&` and "or" `|` for eager evaluator.
 - Implemented integer division `//` and modulo `%` operators.
+- Now a key column can be set on a Frame.
 
 #### Fixed
 - bug in dt.cbind() where the first Frame in the list was ignored.

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -53,6 +53,7 @@ class DataTable {
   public:
     int64_t  nrows;
     int64_t  ncols;
+    int64_t  nkeys;
     RowIndex rowindex;
     Groupby  groupby;
     Column** columns;
@@ -80,6 +81,8 @@ class DataTable {
      * information will be computed and stored with the RowIndex.
      */
     RowIndex sortby(const arr32_t& colindices, Groupby* out_grps) const;
+
+    void set_nkeys(int64_t nk);
 
     DataTable* min_datatable() const;
     DataTable* max_datatable() const;

--- a/c/py_datatable.cc
+++ b/c/py_datatable.cc
@@ -166,10 +166,20 @@ PyObject* get_groupby(obj* self) {
   return gb.ngroups()? pygroupby::wrap(gb) : none();
 }
 
-
 int set_groupby(obj* self, PyObject* value) {
   Groupby* gb = pygroupby::unwrap(value);
   self->ref->replace_groupby(gb? *gb : Groupby());
+  return 0;
+}
+
+
+PyObject* get_nkeys(obj* self) {
+  return PyLong_FromLongLong(self->ref->nkeys);
+}
+
+int set_nkeys(obj* self, PyObject* value) {
+  int64_t nk = PyObj(value).as_int64();
+  self->ref->set_nkeys(nk);
   return 0;
 }
 
@@ -636,6 +646,7 @@ static PyGetSetDef datatable_getseters[] = {
   GETTER(isview),
   GETTER(rowindex),
   GETSET(groupby),
+  GETSET(nkeys),
   GETTER(rowindex_type),
   GETTER(datatable_ptr),
   GETTER(alloc_size),

--- a/c/py_datatable.h
+++ b/c/py_datatable.h
@@ -93,6 +93,10 @@ DECLARE_GETSET(
   groupby,
   "Groupby applied to the Frame, or None if no groupby was applied")
 
+DECLARE_GETSET(
+  nkeys,
+  "Number of key columns in the Frame")
+
 DECLARE_GETTER(
   datatable_ptr,
   "Get pointer (converted to an int) to the wrapped DataTable object")
@@ -195,7 +199,6 @@ DECLARE_METHOD(
   save_jay,
   "save_jay(file, colnames)\n\n"
   "Save DataTable into a .jay file.\n")
-
 
 
 DECLARE_METHOD(

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -179,17 +179,18 @@ class Frame(object):
     def _data_viewer(self, row0, row1, col0, col1):
         view = self._dt.window(row0, row1, col0, col1)
         length = max(2, len(str(row1)))
+        nk = self._nkeys
         return {
-            "names": self._names[col0:col1],
+            "names": self._names[:nk] + self._names[col0 + nk:col1 + nk],
             "types": view.types,
             "stypes": view.stypes,
             "columns": view.data,
-            "indices": ["%*d" % (length, x) for x in range(row0, row1)],
+            "rownumbers": ["%*d" % (length, x) for x in range(row0, row1)],
         }
 
     def view(self, interactive=True):
-        widget = DataFrameWidget(self._nrows, self._ncols, self._data_viewer,
-                                 interactive)
+        widget = DataFrameWidget(self._nrows, self._ncols, self._nkeys,
+                                 self._data_viewer, interactive)
         widget.render()
 
 
@@ -978,7 +979,7 @@ def column_hexview(col, dt, colidx):
             "types": view.types,
             "stypes": view.stypes,
             "columns": view.data,
-            "indices": ["%0*X" % (l, 16 * r) for r in range(row0, row1)],
+            "rownumbers": ["%0*X" % (l, 16 * r) for r in range(row0, row1)],
         }
 
     print("Column %d" % colidx)

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -44,7 +44,7 @@ class Frame(object):
     _id_counter_ = 0
 
     __slots__ = ("_id", "_ncols", "_nrows", "_ltypes", "_stypes", "_names",
-                 "_inames", "_dt")
+                 "_inames", "_dt", "_nkeys")
 
     def __init__(self, src=None, names=None, stypes=None, **kwargs):
         if "stype" in kwargs:
@@ -58,6 +58,7 @@ class Frame(object):
         self._id = Frame._id_counter_  # type: int
         self._ncols = 0      # type: int
         self._nrows = 0      # type: int
+        self._nkeys = 0      # type: int
         self._ltypes = None  # type: Tuple[ltype]
         self._stypes = None  # type: Tuple[stype]
         self._names = None   # type: Tuple[str]
@@ -73,13 +74,19 @@ class Frame(object):
 
     @property
     def nrows(self):
-        """Number of rows in the datatable."""
+        """Number of rows in the frame."""
         return self._nrows
 
     @property
     def ncols(self):
-        """Number of columns in the datatable."""
+        """Number of columns in the frame."""
         return self._ncols
+
+    @property
+    def key(self):
+        """Tuple of column names that comprise the Frame's key. If the Frame
+        is not keyed, this will return an empty tuple."""
+        return self._names[:self._nkeys]
 
     @property
     def shape(self):
@@ -107,7 +114,7 @@ class Frame(object):
 
     @property
     def internal(self):
-        """Access to the underlying C Frame object."""
+        """Access to the internal C DataTable object."""
         return self._dt
 
 
@@ -118,6 +125,30 @@ class Frame(object):
     @nrows.setter
     def nrows(self, n):
         self.resize(n)
+
+    @key.setter
+    def key(self, colnames):
+        if colnames is None:
+            self._nkeys = 0
+            self._dt.nkeys = 0
+            return
+        if isinstance(colnames, (int, str)):
+            colnames = [colnames]
+        nk = len(colnames)
+        colindices = [self.colindex(n) for n in colnames]
+        if colindices == list(range(nk)):
+            # The key columns are already in the right order: no need to
+            # rearrange the columns
+            pass
+        elif len(set(colindices)) == nk:
+            allindices = colindices + [i for i in range(self._ncols)
+                                       if i not in colindices]
+            self.__init__(self[:, allindices])
+        else:
+            raise ValueError("Duplicate columns requested for the key: %r"
+                             % [self._names[i] for i in colindices])
+        self._nkeys = nk
+        self._dt.nkeys = nk
 
     @names.setter
     @typed()

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -831,6 +831,38 @@ def test_scalar_on_view(dt0):
 
 
 #-------------------------------------------------------------------------------
+# Keys
+#-------------------------------------------------------------------------------
+
+def test_keys_simple():
+    dt0 = dt.Frame([["Joe", "Mary", "Leslie", "Adam", "Alice"],
+                    [1, 5, 15, 12, 8],
+                    [3.6, 9.78, 2.01, -4.23, 5.3819]],
+                   names=["name", "sex", "avg"])
+    assert dt0.key == tuple()
+    dt0.key = "name"
+    dt0.internal.check()
+    assert dt0.key == ("name",)
+    assert dt0.shape == (5, 3)
+    assert dt0.names == ("name", "sex", "avg")
+    assert dt0.topython() == [["Adam", "Alice", "Joe", "Leslie", "Mary"],
+                              [12, 8, 1, 15, 5],
+                              [-4.23, 5.3819, 3.6, 2.01, 9.78]]
+    dt0.key = "sex"
+    dt0.internal.check()
+    assert not dt0.internal.isview
+    assert dt0.key == ("sex",)
+    assert dt0.shape == (5, 3)
+    assert dt0.names == ("sex", "name", "avg")
+    assert dt0.topython() == [[1, 5, 8, 12, 15],
+                              ["Joe", "Mary", "Alice", "Adam", "Leslie"],
+                              [3.6, 9.78, 5.3819, -4.23, 2.01]]
+    dt0.key = None
+    assert dt0.key == tuple()
+
+
+
+#-------------------------------------------------------------------------------
 # Misc
 #-------------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR introduces the notion of a **key** in a Frame:
```
frame.key = "colA"  # set to a name or an index of a column
assert frame.key == ("colA", )
```
* Currently, only a single column can be used as a key. Support for multiple key columns will be added later, after #791 is implemented.
* Key column is automatically moved to the front of the frame.
* The values in the key column are sorted and unique.
* When displaying a frame, the widget shows key column in place of the row numbers.

WIP for #1167 