### PR TITLE
Fix minor fread issues

### DIFF
--- a/c/csv/fread.cc
+++ b/c/csv/fread.cc
@@ -90,8 +90,10 @@ std::unique_ptr<DataTable> FreadReader::read()
       }
     }
     if (verbose) {
-      trace("After %d type and %d drop user overrides : %s",
-            nUserBumped, ndropped, columns.printTypes());
+      if (nUserBumped || ndropped) {
+        trace("After %d type and %d drop user overrides : %s",
+              nUserBumped, ndropped, columns.printTypes());
+      }
       trace("Allocating %d column slots with %zd rows",
             ncols - ndropped, allocnrow);
     }

--- a/c/csv/fread.h
+++ b/c/csv/fread.h
@@ -18,6 +18,10 @@
 extern const long double pow10lookup[701];
 extern const uint8_t hexdigits[256];
 extern const uint8_t allowedseps[128];
+namespace dt {
+namespace read {
+  struct ChunkCoordinates;
+}}
 
 
 struct FreadTokenizer {
@@ -69,6 +73,11 @@ struct FreadTokenizer {
   int countfields();
   bool skip_eol();
   bool at_eof() const { return ch == eof; }
+
+  bool next_good_line_start(
+    const dt::read::ChunkCoordinates& cc, int ncols, bool fill, bool skipEmptyLines);
+
+
 };
 
 

--- a/c/csv/reader.cc
+++ b/c/csv/reader.cc
@@ -514,6 +514,7 @@ void GenericReader::open_input() {
   } else if ((text = text_arg.as_cstring(&size))) {
     input_mbuf = MemoryRange::external(text, size + 1);
     extra_byte = 1;
+    input_is_string = true;
 
   } else if ((filename = file_arg.as_cstring())) {
     input_mbuf = MemoryRange::overmap(filename, /* extra = */ 1);

--- a/c/csv/reader.h
+++ b/c/csv/reader.h
@@ -86,7 +86,8 @@ class GenericReader
     size_t line;
     int32_t fileno;
     bool cr_is_newline;
-    int : 24;
+    bool input_is_string{ false };
+    int : 16;
     dt::read::Columns columns;
     double t_open_input{ 0 };
 

--- a/c/read/fread/fread_parallel_reader.h
+++ b/c/read/fread/fread_parallel_reader.h
@@ -32,9 +32,6 @@ class FreadParallelReader : public ParallelReader {
 
     virtual void read_all() override;
 
-    bool next_good_line_start(
-      const ChunkCoordinates& cc, FreadTokenizer& tokenizer) const;
-
   protected:
     virtual std::unique_ptr<ThreadContext> init_thread_context() override;
 

--- a/c/read/parallel_reader.cc
+++ b/c/read/parallel_reader.cc
@@ -57,7 +57,7 @@ void ParallelReader::determine_chunking_strategy() {
     if (inputSize_reduced) {
       // If chunkCount is 1 then we'll attempt to read the whole input
       // with the first chunk, which is not what we want...
-      chunkCount++;
+      chunkCount += 2;
       g.trace("Number of threads reduced to %d because due to max_nrows=%zu "
               "we estimate the amount of data to be read will be small",
               nthreads, nrows_max);
@@ -263,6 +263,9 @@ void ParallelReader::read_all()
 
 void ParallelReader::realloc_output_columns(size_t ichunk, size_t new_alloc)
 {
+  if (new_alloc == nrows_allocated) {
+    return;
+  }
   if (ichunk == chunkCount - 1) {
     // If we're on the last jump, then `new_alloc` is exactly how many rows
     // will be needed.

--- a/tests/fread/test_fread_small.py
+++ b/tests/fread/test_fread_small.py
@@ -907,7 +907,7 @@ def test_int64s_and_typebumps(capsys):
            ]
     src[2][111] = 4568034971487098  # i64-2s
     src[3][111] += 0.11  # f64-1
-    src[4][111] = 11111111111111.11  #  f64-2
+    src[4][111] = 11111111111111.11  # f64-2
     src[6][111] = "111e"  # s32-2
     src[7][111] = "1111111111111111111111"  # s32-3
     src[8][111] = "1.23e"
@@ -1004,7 +1004,7 @@ def test_maxnrows_on_large_dataset():
     # Limit number of threads during reading, otherwise the test may fail on a
     # machine with many cores (all chunks read at once, in the same amount of
     # time as the single chunk containing the first 5 rows).
-    src = "A,B,C\n" + "\n".join("%06d,x,1" % i for i in range(2000000))
+    src = b"A,B,C\n" + b"\n".join(b"%06d,x,1" % i for i in range(2000000))
     t0 = time.time()
     d0 = dt.fread(src, nthreads=4, max_nrows=5, verbose=True)
     t0 = time.time() - t0
@@ -1012,7 +1012,7 @@ def test_maxnrows_on_large_dataset():
     assert d0.shape == (5, 3)
     assert d0.topython() == [[0, 1, 2, 3, 4], ["x"] * 5, [True] * 5]
     t1 = time.time()
-    d1 = dt.fread(src, nthreads=4)
+    d1 = dt.fread(src, nthreads=4, verbose=True)
     t1 = time.time() - t1
     assert d1.shape == (2000000, 3)
     assert t0 < t1 / 2, ("Reading with max_nrows=5 should be faster than "


### PR DESCRIPTION
- `next_good_line_start()` method was moved into `FreadTokenizer`, so that `ColumnTypeDetectionChunkster` doesn't need to instantiate a `ParallelReader`.
- Do not attempt to reallocate output columns if the size is already correct.
- If the input is a string, do not say in verbose message "memory-mapping file"
- Use bytes object instead of string for `test_maxnrows_on_large_dataset` so that fread doesn't waste time converting it into bytes (for the case max_nrows=5 the majority of time is spent there).

Closes #1179