### PR TITLE
Preserve the original column types in the aggregated frame

### DIFF
--- a/c/extras/aggregator.h
+++ b/c/extras/aggregator.h
@@ -17,7 +17,7 @@
 class Aggregator {
   public:
     Aggregator(int32_t, int32_t, int32_t, int32_t, unsigned int);
-    void aggregate(DataTable*, DataTable*);
+    DataTable* aggregate(DataTable*);
     static constexpr double epsilon = 1.0e-15;
 
   private:

--- a/datatable/extras/aggregate.py
+++ b/datatable/extras/aggregate.py
@@ -9,7 +9,8 @@ from datatable import Frame
 from datatable.lib import core
 
 def aggregate(self, n_bins=500, nx_bins=50, ny_bins=50, max_dimensions=50, seed=0):
-  dt_exemplars, dt_members = core.aggregate(self._dt, n_bins, nx_bins, ny_bins, max_dimensions, seed)
+  dt_members = core.aggregate(self._dt, n_bins, nx_bins, ny_bins, max_dimensions, seed)
   names_exemplars = self.names + ("count",)
   names_members = ("exemplar_id")
-  return Frame(dt_exemplars, names_exemplars), Frame(dt_members, names_members)
+  self.__init__(self.internal, names_exemplars)
+  return Frame(dt_members, names_members)

--- a/tests/extras/test_aggregate.py
+++ b/tests/extras/test_aggregate.py
@@ -22,61 +22,61 @@ from datatable import stype
 
 def test_aggregate_1d_continuous_integer_sorted():
     n_bins = 3
-    d0 = dt.Frame([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
-    d_exemplars, d_members = aggregate(d0, n_bins)
+    d_in = dt.Frame([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    d_members = aggregate(d_in, n_bins)
     d_members.internal.check()
     assert d_members.shape == (10, 1)
     assert d_members.ltypes == (ltype.int,)
     assert d_members.topython() == [[0, 0, 0, 0, 1, 1, 1, 2, 2, 2]]
-    d_exemplars.internal.check()
-    assert d_exemplars.shape == (3, 2)
-    assert d_exemplars.ltypes == (ltype.real, ltype.int)
-    assert d_exemplars.topython() == [[0, 4, 7], 
+    d_in.internal.check()
+    assert d_in.shape == (3, 2)
+    assert d_in.ltypes == (ltype.int, ltype.int)
+    assert d_in.topython() == [[0, 4, 7], 
                                       [4, 3, 3]]
 
 
 def test_aggregate_1d_continuous_integer_random():
     n_bins = 3
-    d0 = dt.Frame([9, 8, 2, 3, 3, 0, 5, 5, 8, 1])
-    d_exemplars, d_members = aggregate(d0, n_bins)
+    d_in = dt.Frame([9, 8, 2, 3, 3, 0, 5, 5, 8, 1])
+    d_members = aggregate(d_in, n_bins)
     d_members.internal.check()
     assert d_members.shape == (10, 1)
     assert d_members.ltypes == (ltype.int,)
     assert d_members.topython() == [[2, 2, 0, 0, 0, 0, 1, 1, 2, 0]]
-    d_exemplars.internal.check()
-    assert d_exemplars.shape == (3, 2)
-    assert d_exemplars.ltypes == (ltype.real, ltype.int)
-    assert d_exemplars.topython() == [[2, 5, 9], 
+    d_in.internal.check()
+    assert d_in.shape == (3, 2)
+    assert d_in.ltypes == (ltype.int, ltype.int)
+    assert d_in.topython() == [[2, 5, 9], 
                                       [5, 2, 3]]
 
 
 def test_aggregate_1d_continuous_real_sorted():
     n_bins = 3
-    d0 = dt.Frame([0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9])
-    d_exemplars, d_members = aggregate(d0, n_bins)
+    d_in = dt.Frame([0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9])
+    d_members = aggregate(d_in, n_bins)
     d_members.internal.check()
     assert d_members.shape == (10, 1)
     assert d_members.ltypes == (ltype.int,)
     assert d_members.topython() == [[0, 0, 0, 0, 1, 1, 1, 2, 2, 2]]
-    d_exemplars.internal.check()
-    assert d_exemplars.shape == (3, 2)
-    assert d_exemplars.ltypes == (ltype.real, ltype.int)
-    assert d_exemplars.topython() == [[0.0, 0.4, 0.7], 
+    d_in.internal.check()
+    assert d_in.shape == (3, 2)
+    assert d_in.ltypes == (ltype.real, ltype.int)
+    assert d_in.topython() == [[0.0, 0.4, 0.7], 
                                       [4, 3, 3]]
     
      
 def test_aggregate_1d_continuous_real_random():
     n_bins = 3
-    d0 = dt.Frame([0.7, 0.7, 0.5, 0.1, 0.0, 0.9, 0.1, 0.3, 0.4, 0.2])
-    d_exemplars, d_members = aggregate(d0, n_bins)
+    d_in = dt.Frame([0.7, 0.7, 0.5, 0.1, 0.0, 0.9, 0.1, 0.3, 0.4, 0.2])
+    d_members = aggregate(d_in, n_bins)
     d_members.internal.check()
     assert d_members.shape == (10, 1)
     assert d_members.ltypes == (ltype.int,)
     assert d_members.topython() == [[2, 2, 1, 0, 0, 2, 0, 0, 1, 0]]
-    d_exemplars.internal.check()
-    assert d_exemplars.shape == (3, 2)
-    assert d_exemplars.ltypes == (ltype.real, ltype.int)
-    assert d_exemplars.topython() == [[0.1, 0.5, 0.7], 
+    d_in.internal.check()
+    assert d_in.shape == (3, 2)
+    assert d_in.ltypes == (ltype.real, ltype.int)
+    assert d_in.topython() == [[0.1, 0.5, 0.7], 
                                       [5, 2, 3]]
 
 
@@ -87,17 +87,17 @@ def test_aggregate_1d_continuous_real_random():
 def test_aggregate_2d_continuous_integer_sorted():
     nx_bins = 3
     ny_bins = 3
-    d0 = dt.Frame([[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], 
+    d_in = dt.Frame([[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], 
                    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]])
-    d_exemplars, d_members = aggregate(d0, 0, nx_bins, ny_bins)
+    d_members = aggregate(d_in, 0, nx_bins, ny_bins)
     d_members.internal.check()
     assert d_members.shape == (10, 1)
     assert d_members.ltypes == (ltype.int,)
     assert d_members.topython() == [[0, 0, 0, 0, 4, 4, 4, 8, 8, 8]]
-    d_exemplars.internal.check()
-    assert d_exemplars.shape == (3, 3)
-    assert d_exemplars.ltypes == (ltype.real, ltype.real, ltype.int)
-    assert d_exemplars.topython() == [[0, 4, 7], 
+    d_in.internal.check()
+    assert d_in.shape == (3, 3)
+    assert d_in.ltypes == (ltype.int, ltype.int, ltype.int)
+    assert d_in.topython() == [[0, 4, 7], 
                                       [0, 4, 7],
                                       [4, 3, 3]]
 
@@ -105,17 +105,17 @@ def test_aggregate_2d_continuous_integer_sorted():
 def test_aggregate_2d_continuous_integer_random():
     nx_bins = 3
     ny_bins = 3
-    d0 = dt.Frame([[9, 8, 2, 3, 3, 0, 5, 5, 8, 1], 
+    d_in = dt.Frame([[9, 8, 2, 3, 3, 0, 5, 5, 8, 1], 
                    [3, 5, 8, 1, 4, 4, 8, 7, 6, 1]])
-    d_exemplars, d_members = aggregate(d0, 0, nx_bins, ny_bins)
+    d_members = aggregate(d_in, 0, nx_bins, ny_bins)
     d_members.internal.check()
     assert d_members.shape == (10, 1)
     assert d_members.ltypes == (ltype.int,)
     assert d_members.topython() == [[2, 5, 6, 0, 3, 3, 7, 7, 8, 0]]
-    d_exemplars.internal.check()
-    assert d_exemplars.shape == (7, 3)
-    assert d_exemplars.ltypes == (ltype.real, ltype.real, ltype.int)
-    assert d_exemplars.topython() == [[3, 9, 3, 8, 2, 5, 8], 
+    d_in.internal.check()
+    assert d_in.shape == (7, 3)
+    assert d_in.ltypes == (ltype.int, ltype.int, ltype.int)
+    assert d_in.topython() == [[3, 9, 3, 8, 2, 5, 8], 
                                       [1, 3, 4, 5, 8, 8, 6],
                                       [2, 1, 2, 1, 1, 2, 1]]
 
@@ -123,17 +123,17 @@ def test_aggregate_2d_continuous_integer_random():
 def test_aggregate_2d_continuous_real_sorted():
     nx_bins = 3
     ny_bins = 3
-    d0 = dt.Frame([[0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9], 
+    d_in = dt.Frame([[0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9], 
                    [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]])
-    d_exemplars, d_members = aggregate(d0, 0, nx_bins, ny_bins)
+    d_members = aggregate(d_in, 0, nx_bins, ny_bins)
     d_members.internal.check()
     assert d_members.shape == (10, 1)
     assert d_members.ltypes == (ltype.int,)
     assert d_members.topython() == [[0, 0, 0, 0, 4, 4, 4, 8, 8, 8]]
-    d_exemplars.internal.check()
-    assert d_exemplars.shape == (3, 3)
-    assert d_exemplars.ltypes == (ltype.real, ltype.real, ltype.int)
-    assert d_exemplars.topython() == [[0.0, 0.4, 0.7], 
+    d_in.internal.check()
+    assert d_in.shape == (3, 3)
+    assert d_in.ltypes == (ltype.real, ltype.real, ltype.int)
+    assert d_in.topython() == [[0.0, 0.4, 0.7], 
                                       [0.0, 0.4, 0.7],
                                       [4, 3, 3]]
 
@@ -141,110 +141,110 @@ def test_aggregate_2d_continuous_real_sorted():
 def test_aggregate_2d_continuous_real_random():
     nx_bins = 3
     ny_bins = 3
-    d0 = dt.Frame([[0.9, 0.8, 0.2, 0.3, 0.3, 0.0, 0.5, 0.5, 0.8, 0.1], 
+    d_in = dt.Frame([[0.9, 0.8, 0.2, 0.3, 0.3, 0.0, 0.5, 0.5, 0.8, 0.1], 
                    [0.3, 0.5, 0.8, 0.1, 0.4, 0.4, 0.8, 0.7, 0.6, 0.1]])
-    d_exemplars, d_members = aggregate(d0, 0, nx_bins, ny_bins)
+    d_members = aggregate(d_in, 0, nx_bins, ny_bins)
     d_members.internal.check()
     assert d_members.shape == (10, 1)
     assert d_members.ltypes == (ltype.int,)
     assert d_members.topython() == [[2, 5, 6, 0, 3, 3, 7, 7, 8, 0]]
-    d_exemplars.internal.check()
-    assert d_exemplars.shape == (7, 3)
-    assert d_exemplars.ltypes == (ltype.real, ltype.real, ltype.int)
-    assert d_exemplars.topython() == [[0.3, 0.9, 0.3, 0.8, 0.2, 0.5, 0.8], 
+    d_in.internal.check()
+    assert d_in.shape == (7, 3)
+    assert d_in.ltypes == (ltype.real, ltype.real, ltype.int)
+    assert d_in.topython() == [[0.3, 0.9, 0.3, 0.8, 0.2, 0.5, 0.8], 
                                       [0.1, 0.3, 0.4, 0.5, 0.8, 0.8, 0.6],
                                       [2, 1, 2, 1, 1, 2, 1]]
 
 
 def test_aggregate_1d_categorical_sorted():
-    d0 = dt.Frame(["blue", "green", "indigo", "orange", "red", "violet", "yellow"])
-    d_exemplars, d_members = aggregate(d0)
+    d_in = dt.Frame(["blue", "green", "indigo", "orange", "red", "violet", "yellow"])
+    d_members = aggregate(d_in)
     assert d_members.shape == (7, 1)
     assert d_members.ltypes == (ltype.int,)
     assert d_members.topython() == [[0, 1, 2, 3, 4, 5, 6]]
-    d_exemplars.internal.check()
-    assert d_exemplars.shape == (7, 2)
-    assert d_exemplars.ltypes == (ltype.str, ltype.int)
-    assert d_exemplars.topython() == [["blue", "green", "indigo", "orange", "red", "violet", "yellow"], 
+    d_in.internal.check()
+    assert d_in.shape == (7, 2)
+    assert d_in.ltypes == (ltype.str, ltype.int)
+    assert d_in.topython() == [["blue", "green", "indigo", "orange", "red", "violet", "yellow"], 
                                       [1, 1, 1, 1, 1, 1, 1]]
 
 
 def test_aggregate_1d_categorical_random():
-    d0 = dt.Frame(["blue", "orange", "yellow", "green", "blue", "indigo", "violet"])
-    d_exemplars, d_members = aggregate(d0)
+    d_in = dt.Frame(["blue", "orange", "yellow", "green", "blue", "indigo", "violet"])
+    d_members = aggregate(d_in)
     assert d_members.shape == (7, 1)
     assert d_members.ltypes == (ltype.int,)
     assert d_members.topython() == [[0, 3, 5, 1, 0, 2, 4]]
-    d_exemplars.internal.check()
-    assert d_exemplars.shape == (6, 2)
-    assert d_exemplars.ltypes == (ltype.str, ltype.int)
-    assert d_exemplars.topython() == [["blue", "green", "indigo", "orange", "violet", "yellow"], 
+    d_in.internal.check()
+    assert d_in.shape == (6, 2)
+    assert d_in.ltypes == (ltype.str, ltype.int)
+    assert d_in.topython() == [["blue", "green", "indigo", "orange", "violet", "yellow"], 
                                       [2, 1, 1, 1, 1, 1]]
 
 
 def test_aggregate_2d_categorical_sorted():
-    d0 = dt.Frame([["blue", "green", "indigo", "orange", "red", "violet", "yellow"], 
+    d_in = dt.Frame([["blue", "green", "indigo", "orange", "red", "violet", "yellow"], 
                   ["Friday", "Monday", "Saturday", "Sunday", "Thursday", "Tuesday", "Wednesday"]])
-    d_exemplars, d_members = aggregate(d0)
+    d_members = aggregate(d_in)
     d_members.internal.check()
     assert d_members.shape == (7, 1)
     assert d_members.ltypes == (ltype.int,)
     assert d_members.topython() == [[0, 8, 16, 24, 32, 40, 48]]
-    d_exemplars.internal.check()
-    assert d_exemplars.shape == (7, 3)
-    assert d_exemplars.ltypes == (ltype.str, ltype.str, ltype.int)
-    assert d_exemplars.topython() == [["blue", "green", "indigo", "orange", "red", "violet", "yellow"], 
+    d_in.internal.check()
+    assert d_in.shape == (7, 3)
+    assert d_in.ltypes == (ltype.str, ltype.str, ltype.int)
+    assert d_in.topython() == [["blue", "green", "indigo", "orange", "red", "violet", "yellow"], 
                                       ["Friday", "Monday", "Saturday", "Sunday", "Thursday", "Tuesday", "Wednesday"],
                                       [1, 1, 1, 1, 1, 1, 1]]
 
 
 def test_aggregate_2d_categorical_random():
-    d0 = dt.Frame([["blue", "indigo", "red", "violet", "yellow", "violet", "red"], 
+    d_in = dt.Frame([["blue", "indigo", "red", "violet", "yellow", "violet", "red"], 
                    ["Monday", "Monday", "Wednesday", "Saturday", "Thursday", "Friday", "Wednesday"]])
 
-    d_exemplars, d_members = aggregate(d0)
+    d_members = aggregate(d_in)
     d_members.internal.check()
     assert d_members.shape == (7, 1)
     assert d_members.ltypes == (ltype.int,)
     assert d_members.topython() == [[5, 6, 22, 13, 19, 3, 22]]
-    d_exemplars.internal.check()
-    assert d_exemplars.shape == (6, 3)
-    assert d_exemplars.ltypes == (ltype.str, ltype.str, ltype.int)
-    assert d_exemplars.topython() == [['violet', 'blue', 'indigo', 'violet', 'yellow', 'red'], 
+    d_in.internal.check()
+    assert d_in.shape == (6, 3)
+    assert d_in.ltypes == (ltype.str, ltype.str, ltype.int)
+    assert d_in.topython() == [['violet', 'blue', 'indigo', 'violet', 'yellow', 'red'], 
                                       ['Friday', 'Monday', 'Monday', 'Saturday', 'Thursday', 'Wednesday'],
                                       [1, 1, 1, 1, 1, 2]]
 
 
 def test_aggregate_2d_mixed_sorted():
     nx_bins = 7
-    d0 = dt.Frame([[0, 1, 2, 3, 4, 5, 6], 
+    d_in = dt.Frame([[0, 1, 2, 3, 4, 5, 6], 
                    ["blue", "green", "indigo", "orange", "red", "violet", "yellow"]])
-    d_exemplars, d_members = aggregate(d0, 0, nx_bins)
+    d_members = aggregate(d_in, 0, nx_bins)
     d_members.internal.check()
     assert d_members.shape == (7, 1)
     assert d_members.ltypes == (ltype.int,)
     assert d_members.topython() == [[0, 8, 16, 24, 32, 40, 48]]
-    d_exemplars.internal.check()
-    assert d_exemplars.shape == (7, 3)
-    assert d_exemplars.ltypes == (ltype.real, ltype.str, ltype.int)
-    assert d_exemplars.topython() == [[0, 1, 2, 3, 4, 5, 6], 
+    d_in.internal.check()
+    assert d_in.shape == (7, 3)
+    assert d_in.ltypes == (ltype.int, ltype.str, ltype.int)
+    assert d_in.topython() == [[0, 1, 2, 3, 4, 5, 6], 
                                       ["blue", "green", "indigo", "orange", "red", "violet", "yellow"],
                                       [1, 1, 1, 1, 1, 1, 1]]
 
 
 def test_aggregate_2d_mixed_random():
     nx_bins = 6
-    d0 = dt.Frame([[3, 0, 6, 6, 1, 2, 4], 
+    d_in = dt.Frame([[3, 0, 6, 6, 1, 2, 4], 
                    ["blue", "indigo", "red", "violet", "yellow", "violet", "red"]])
-    d_exemplars, d_members = aggregate(d0, 0, nx_bins)
+    d_members = aggregate(d_in, 0, nx_bins)
     d_members.internal.check()
     assert d_members.shape == (7, 1)
     assert d_members.ltypes == (ltype.int,)
     assert d_members.topython() == [[2, 6, 17, 23, 24, 19, 15]]
-    d_exemplars.internal.check()
-    assert d_exemplars.shape == (7, 3)
-    assert d_exemplars.ltypes == (ltype.real, ltype.str, ltype.int)
-    assert d_exemplars.topython() == [[3, 0, 4, 6, 2, 6, 1], 
+    d_in.internal.check()
+    assert d_in.shape == (7, 3)
+    assert d_in.ltypes == (ltype.int, ltype.str, ltype.int)
+    assert d_in.topython() == [[3, 0, 4, 6, 2, 6, 1], 
                                       ['blue', 'indigo', 'red', 'red', 'violet', 'violet', 'yellow'],
                                       [1, 1, 1, 1, 1, 1, 1]]
 


### PR DESCRIPTION
The input frame is now aggregated in-place preserving the original
column types. Based on the input, the members frame is created by the
aggregator and returned to Python.

Closes #1183