### PR TITLE
Properly skip categorical columns during the ND aggregation

### DIFF
--- a/c/extras/aggregator.cc
+++ b/c/extras/aggregator.cc
@@ -325,8 +325,10 @@ void Aggregator::group_nd(DataTablePtr& dt_exemplars, DataTablePtr& dt_members) 
 void Aggregator::adjust_radius(DataTablePtr& dt_exemplars, double& radius) {
   double diff = 0;
   for (int i = 0; i < dt_exemplars->ncols; ++i) {
-    RealColumn<double>* ci = static_cast<RealColumn<double>*>(dt_exemplars->columns[i]);
-    diff += (ci->max() - ci->min()) * (ci->max() - ci->min());
+    if (dt_exemplars->columns[i]->stype() == SType::FLOAT64) {
+      RealColumn<double>* ci = static_cast<RealColumn<double>*>(dt_exemplars->columns[i]);
+      diff += (ci->max() - ci->min()) * (ci->max() - ci->min());
+    }
   }
 
   diff /= dt_exemplars->ncols;
@@ -352,10 +354,13 @@ double Aggregator::calculate_distance(double* e1, double* e2, int64_t ndims, dou
 
 void Aggregator::normalize_row(DataTablePtr& dt, double* r, int32_t row_id) {
   for (int32_t i = 0; i < dt->ncols; ++i) {
-    RealColumn<double>* c = static_cast<RealColumn<double>*>(dt->columns[i]);
-    const double* d_c = static_cast<const double*>(dt->columns[i]->data());
-
-    r[i] =  (d_c[row_id] - c->min()) / (c->max() - c->min());
+    if (dt->columns[i]->stype() == SType::FLOAT64) {
+      RealColumn<double>* c = static_cast<RealColumn<double>*>(dt->columns[i]);
+      const double* d_c = static_cast<const double*>(dt->columns[i]->data());
+      r[i] =  (d_c[row_id] - c->min()) / (c->max() - c->min());
+    } else {
+      r[i] = 0;
+    }
   }
 }
 
@@ -385,12 +390,15 @@ void Aggregator::project_row(DataTablePtr& dt_exemplars, double* r, int32_t row_
   std::memset(r, 0, static_cast<size_t>(max_dimensions) * sizeof(double));
 
   for (int32_t i = 0; i < (dt_exemplars->ncols) * max_dimensions; ++i) {
-    RealColumn<double>* c = static_cast<RealColumn<double>*> (dt_exemplars->columns[i / max_dimensions]);
-    const double* d_c = static_cast<const double*>(dt_exemplars->columns[i / max_dimensions]->data());
+    int col_id = i / max_dimensions;
+    if (dt_exemplars->columns[col_id]->stype() == SType::FLOAT64) {
+      RealColumn<double>* c = static_cast<RealColumn<double>*> (dt_exemplars->columns[col_id]);
+      const double* d_c = static_cast<const double*>(dt_exemplars->columns[col_id]->data());
 
-    if (!ISNA<double>(d_c[row_id])) {
-      // TODO: handle missing values and do r[j] /= n normalization at the end
-      r[i % max_dimensions] +=  pmatrix[i] * (d_c[row_id] - c->min()) / (c->max() - c->min());
+      if (!ISNA<double>(d_c[row_id])) {
+        // TODO: handle missing values and do r[j] /= n normalization at the end
+        r[i % max_dimensions] +=  pmatrix[i] * (d_c[row_id] - c->min()) / (c->max() - c->min());
+      }
     }
   }
 }

--- a/c/extras/aggregator.cc
+++ b/c/extras/aggregator.cc
@@ -389,15 +389,17 @@ double* Aggregator::generate_pmatrix(DataTablePtr& dt_exemplars) {
 void Aggregator::project_row(DataTablePtr& dt_exemplars, double* r, int32_t row_id, double* pmatrix) {
   std::memset(r, 0, static_cast<size_t>(max_dimensions) * sizeof(double));
 
-  for (int32_t i = 0; i < (dt_exemplars->ncols) * max_dimensions; ++i) {
-    int col_id = i / max_dimensions;
-    if (dt_exemplars->columns[col_id]->stype() == SType::FLOAT64) {
-      RealColumn<double>* c = static_cast<RealColumn<double>*> (dt_exemplars->columns[col_id]);
-      const double* d_c = static_cast<const double*>(dt_exemplars->columns[col_id]->data());
-
+  for (int32_t i = 0; i < dt_exemplars->ncols; ++i) {
+    if (dt_exemplars->columns[i]->stype() == SType::FLOAT64) {
+      const double* d_c = static_cast<const double*>(dt_exemplars->columns[i]->data());
       if (!ISNA<double>(d_c[row_id])) {
-        // TODO: handle missing values and do r[j] /= n normalization at the end
-        r[i % max_dimensions] +=  pmatrix[i] * (d_c[row_id] - c->min()) / (c->max() - c->min());
+
+        RealColumn<double>* c = static_cast<RealColumn<double>*> (dt_exemplars->columns[i]);
+        for (int32_t j = 0; j < max_dimensions; ++j) {
+          //TODO: handle missing values and do r[j] /= n normalization at the end
+          r[j] +=  pmatrix[i * max_dimensions + j] * (d_c[row_id] - c->min()) / (c->max() - c->min());
+        }
+
       }
     }
   }


### PR DESCRIPTION
Minor change, but prevents the `aggregator` from crashing.
Until we find a good way to treat categorical columns in the ND
aggregation algo, we skip those in the both cases: `ncols` <=`max_dimensions` and 
`ncols` > `max_dimensions`. 

Closes #1185