### PR TITLE
Tweak fread chunking strategy to better handle wide datasets

### DIFF
--- a/c/csv/reader_fread.cc
+++ b/c/csv/reader_fread.cc
@@ -607,7 +607,7 @@ void FreadReader::detect_column_types()
       int thisLineLen = static_cast<int>(tch - lineStart);
       xassert(thisLineLen >= 0);
       sumLen += thisLineLen;
-      sumLenSq += thisLineLen*thisLineLen;
+      sumLenSq += 1.0 * thisLineLen * thisLineLen;
       if (thisLineLen<minLen) minLen = thisLineLen;
       if (thisLineLen>maxLen) maxLen = thisLineLen;
     }

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -191,7 +191,7 @@ def test_groups_large1():
                                     for x in (100, 200, 300, 500, 1000, 0)])
 def test_groups_large2_str(n, seed):
     random.seed(seed)
-    if n == 0:
+    while n == 0:
         n = int(random.expovariate(0.0005))
     src = ["%x" % random.getrandbits(6) for _ in range(n)]
     f0 = dt.Frame({"A": src})


### PR DESCRIPTION
* Fix `sd` calculation formula in case the lines are long (previously the formula produced wrong results for line lengths > 46340)
* Improve the algorithm for chunk size selection: if the lines are long we are better-off reducing the number of lines per chunk below 1000.