### PR TITLE
Fix rare failure in test_join_random

### DIFF
--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -83,7 +83,11 @@ def test_join_random(seed, lt):
                  24)
         keys = list(set(random.getrandbits(nbits) for _ in range(nkeys)))
     elif lt == ltype.real:
-        keys = list(set(random.random() for _ in range(nkeys)))
+        keys = [random.random() for _ in range(nkeys)]
+        if st == stype.float32:
+            keys = list(set(dt.Frame(keys, stype=st).topython()[0]))
+        else:
+            keys = list(set(keys))
     else:
         l = int(random.expovariate(0.05)) + 1
         keys = list(set(random_string(l) for _ in range(nkeys)))


### PR DESCRIPTION
The issue was that some float64 values were mapped into the same float32 values, which causes the values in the column to be non-unique.

Closes #1208