### PR TITLE
[BUILD] Set LD_LIBRARY_PATH for CentOS 7 image.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ ubuntu_docker_publish: Dockerfile-ubuntu.$(PLATFORM).tag
 	docker push $(CONTAINER_NAME_TAG)
 
 ARCH_NAME ?= $(shell uname -m)
-DOCKER_IMAGE_TAG ?= 0.6.0-PR-1010.4
+DOCKER_IMAGE_TAG ?= 0.6.0-PR-1210.1
 CENTOS_DOCKER_IMAGE_NAME ?= docker.h2o.ai/opsh2oai/datatable-build-$(ARCH_NAME)_centos7:$(DOCKER_IMAGE_TAG)
 UBUNTU_DOCKER_IMAGE_NAME ?= docker.h2o.ai/opsh2oai/datatable-build-$(ARCH_NAME)_ubuntu:$(DOCKER_IMAGE_TAG)
 

--- a/ci/Dockerfile-centos7.in
+++ b/ci/Dockerfile-centos7.in
@@ -24,6 +24,7 @@ ENV PATH=/opt/h2oai/dai/python/bin:$PATH
 ENV PATH=/usr/local/bin:$PATH
 ENV PATH=$LLVM6/bin:$PATH
 ENV PANDAS_VERSION=0.20.0
+ENV LD_LIBRARY_PATH=/opt/h2oai/dai/lib/:${LD_LIBRARY_PATH}
 
 RUN pip install llvmlite==0.23.0 wheel virtualenv && \
     \

--- a/ci/Jenkinsfile2
+++ b/ci/Jenkinsfile2
@@ -34,12 +34,12 @@ RELEASE_BRANCH_PREFIX = 'rel-'
 CREDS_ID = 'h2o-ops-personal-auth-token'
 GITCONFIG_CRED_ID = 'master-gitconfig'
 RSA_CRED_ID = 'master-id-rsa'
-DOCKER_IMAGE_TAG = '0.6.0-PR-1010.4'
+DOCKER_IMAGE_TAG = '0.6.0-PR-1210.1'
 X86_64_CENTOS_DOCKER_IMAGE = "docker.h2o.ai/opsh2oai/datatable-build-x86_64_centos7:${DOCKER_IMAGE_TAG}"
 EXPECTED_SHAS = [
         files : [
                 'ci/Dockerfile-ubuntu.in' : 'd5b19e748c079d65964e6c1e458f525854aee0f3',
-                'ci/Dockerfile-centos7.in': 'd9ef4a7f981719e05fff49487c6176b7ba445817',
+                'ci/Dockerfile-centos7.in': '5d7dc9fc0033e00b00df8c81f1fd2371aa88cc74',
         ]
 ]
 

--- a/tests/fread/test_fread_small.py
+++ b/tests/fread/test_fread_small.py
@@ -140,8 +140,8 @@ def test_float_hex_invalid():
 
 
 def test_float_decimal0():
-    assert dt.fread("1.3485701e-303\n").scalar() == 1.3485701e-303
     if "powerpc64" not in str(sys.implementation):
+        assert dt.fread("1.3485701e-303\n").scalar() == 1.3485701e-303
         assert dt.fread("1.46761e-313\n").scalar() == 1.46761e-313
     assert (dt.fread("A\n1.23456789123456789123456999\n").scalar() ==
             1.23456789123456789123456999)


### PR DESCRIPTION
This PR adds env var LD_LIBRARY_PATH for CentOS 7 docker images. The env var is required, otherwise it results in `ImportError: libc++.so.1: cannot open shared object file: No such file or directory`