### PR TITLE
[BUILD] Add option to pass git revision via variable.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,6 +195,7 @@ centos7_in_docker: Dockerfile-centos7.$(PLATFORM).tag
 		-w /dot \
 		--entrypoint /bin/bash \
 		-e "CI_VERSION_SUFFIX=$(CI_VERSION_SUFFIX)" \
+		-e "DTBL_GIT_HASH=$(DTBL_GIT_HASH)" \
 		$(CONTAINER_NAME_TAG) \
 		-c 'make dist'
 	mkdir -p $(DIST_DIR)/$(PLATFORM)
@@ -233,6 +234,7 @@ centos7_build_in_docker_impl:
 		-w /dot \
 		--entrypoint /bin/bash \
 		-e "CI_VERSION_SUFFIX=$(CI_VERSION_SUFFIX)" \
+		-e "DTBL_GIT_HASH=$(DTBL_GIT_HASH)" \
 		$(CUSTOM_ARGS) \
 		$(CENTOS_DOCKER_IMAGE_NAME) \
 		-c ". activate $(BUILD_VENV) && \
@@ -253,6 +255,7 @@ centos7_version_in_docker:
 		-w /dot \
 		--entrypoint /bin/bash \
 		-e "CI_VERSION_SUFFIX=$(CI_VERSION_SUFFIX)" \
+		-e "DTBL_GIT_HASH=$(DTBL_GIT_HASH)" \
 		$(CUSTOM_ARGS) \
 		$(CENTOS_DOCKER_IMAGE_NAME) \
 		-c ". activate datatable-py36-with-pandas && \
@@ -270,6 +273,7 @@ centos7_test_in_docker_impl:
 		-w /dot \
 		--entrypoint /bin/bash \
 		-e "DT_LARGE_TESTS_ROOT=$(DT_LARGE_TESTS_ROOT)" \
+		-e "DTBL_GIT_HASH=$(DTBL_GIT_HASH)" \
 		$(CUSTOM_ARGS) \
 		$(CENTOS_DOCKER_IMAGE_NAME) \
 		-c ". activate $(TEST_VENV) && \
@@ -300,6 +304,7 @@ ubuntu_build_in_docker_impl:
 		--entrypoint /bin/bash \
 		-e "CI_VERSION_SUFFIX=$(CI_VERSION_SUFFIX)" \
 		-e "DT_LARGE_TESTS_ROOT=$(DT_LARGE_TESTS_ROOT)" \
+		-e "DTBL_GIT_HASH=$(DTBL_GIT_HASH)" \
 		$(CUSTOM_ARGS) \
 		$(UBUNTU_DOCKER_IMAGE_NAME) \
 		-c ". /envs/$(BUILD_VENV)/bin/activate && \
@@ -316,6 +321,7 @@ ubuntu_build_sdist_in_docker:
 		--entrypoint /bin/bash \
 		-e "CI_VERSION_SUFFIX=$(CI_VERSION_SUFFIX)" \
 		-e "DT_LARGE_TESTS_ROOT=$(DT_LARGE_TESTS_ROOT)" \
+		-e "DTBL_GIT_HASH=$(DTBL_GIT_HASH)" \
 		$(CUSTOM_ARGS) \
 		$(UBUNTU_DOCKER_IMAGE_NAME) \
 		-c ". /envs/datatable-py36-with-pandas/bin/activate && \
@@ -337,6 +343,7 @@ ubuntu_coverage_py36_with_pandas_in_docker:
 		-w /dot \
 		--entrypoint /bin/bash \
 		-e "DT_LARGE_TESTS_ROOT=$(DT_LARGE_TESTS_ROOT)" \
+		-e "DTBL_GIT_HASH=$(DTBL_GIT_HASH)" \
 		$(CUSTOM_ARGS) \
 		$(UBUNTU_DOCKER_IMAGE_NAME) \
 		-c ". /envs/datatable-py36-with-pandas/bin/activate && \
@@ -352,6 +359,7 @@ ubuntu_test_in_docker_impl:
 		-w /dot \
 		--entrypoint /bin/bash \
 		-e "DT_LARGE_TESTS_ROOT=$(DT_LARGE_TESTS_ROOT)" \
+		-e "DTBL_GIT_HASH=$(DTBL_GIT_HASH)" \
 		$(CUSTOM_ARGS) \
 		$(UBUNTU_DOCKER_IMAGE_NAME) \
 		-c ". /envs/$(TEST_VENV)/bin/activate && \

--- a/ci/Jenkinsfile2
+++ b/ci/Jenkinsfile2
@@ -485,26 +485,22 @@ ansiColor('xterm') {
                 parallel(testStages)
             }
             // Build sdist
-
-            // FIXME
-            // if (doPublish()) {
-                node(X86_64_BUILD_NODE_LABEL) {
-                    def stageDir = 'build-sdist'
-                    buildSummary.stageWithSummary ('Build sdist', stageDir) {
-                        cleanWs()
-                        dumpInfo()
-                        withEnv(["CI_VERSION_SUFFIX=${CI_VERSION_SUFFIX}", "DTBL_GIT_HASH=${gitHash}"]) {
-                            dir (stageDir) {
-                                unstash 'datatable-sources'
-                                unstash 'VERSION'
-                                sh "make ${MAKE_OPTS} ubuntu_build_sdist_in_docker"
-                                stash includes: 'dist/*.tar.gz', name: 'sdist-tar'
-                                arch "dist/*.tar.gz"
-                            }
+            node(X86_64_BUILD_NODE_LABEL) {
+                def stageDir = 'build-sdist'
+                buildSummary.stageWithSummary ('Build sdist', stageDir) {
+                    cleanWs()
+                    dumpInfo()
+                    withEnv(["CI_VERSION_SUFFIX=${CI_VERSION_SUFFIX}", "DTBL_GIT_HASH=${gitHash}"]) {
+                        dir (stageDir) {
+                            unstash 'datatable-sources'
+                            unstash 'VERSION'
+                            sh "make ${MAKE_OPTS} ubuntu_build_sdist_in_docker"
+                            stash includes: 'dist/*.tar.gz', name: 'sdist-tar'
+                            arch "dist/*.tar.gz"
                         }
                     }
                 }
-            // }
+            }
             // Publish snapshot to S3
             if (doPublish()) {
                 node(RELEASE_NODE_LABEL) {

--- a/ci/Jenkinsfile2
+++ b/ci/Jenkinsfile2
@@ -69,6 +69,8 @@ def needsLargerTest
 def dockerArgs = createDockerArgs()
 // String with current version
 def versionText
+// String with current git revision
+def gitHash
 
 MAKE_OPTS = "CI=1"
 
@@ -98,7 +100,8 @@ ansiColor('xterm') {
                 dir (stageDir) {
                     buildSummary.stageWithSummary('Checkout', stageDir) {
                         def scmEnv = checkout scm
-                        env.BRANCH_NAME = scmEnv['GIT_BRANCH'].replaceAll('origin/', '').replaceAll('/', '_')
+                        gitHash = scmEnv.GIT_COMMIT
+                        env.BRANCH_NAME = scmEnv.GIT_BRANCH.replaceAll('origin/', '').replaceAll('/', '_')
                         if (doPPC()) {
                             manager.addBadge("success.gif", "PPC64LE build triggered!")
                         }
@@ -482,13 +485,15 @@ ansiColor('xterm') {
                 parallel(testStages)
             }
             // Build sdist
-            if (doPublish()) {
+
+            // FIXME
+            // if (doPublish()) {
                 node(X86_64_BUILD_NODE_LABEL) {
                     def stageDir = 'build-sdist'
                     buildSummary.stageWithSummary ('Build sdist', stageDir) {
                         cleanWs()
                         dumpInfo()
-                        withEnv(["CI_VERSION_SUFFIX=${CI_VERSION_SUFFIX}"]) {
+                        withEnv(["CI_VERSION_SUFFIX=${CI_VERSION_SUFFIX}", "DTBL_GIT_HASH=${gitHash}"]) {
                             dir (stageDir) {
                                 unstash 'datatable-sources'
                                 unstash 'VERSION'
@@ -499,7 +504,7 @@ ansiColor('xterm') {
                         }
                     }
                 }
-            }
+            // }
             // Publish snapshot to S3
             if (doPublish()) {
                 node(RELEASE_NODE_LABEL) {


### PR DESCRIPTION
I've added an option to pass the git revision as env var. I think it's a bit safer than stashing the `.git` folder in jenkins (there might be something host dependent in this folder I think).

If `DTBL_GIT_HASH` is `None` or empty string, then it reads the revision from git, if `.git` is not accessible it fails.

Also sdist is now built for PRs as well. The stage is matter of seconds, so I think it's reasonable to build it as a part of PRs as well, WDYT?

Closes #1212