### PR TITLE
Add .groovy extension to Jenkins files

### DIFF
--- a/ci/Jenkinsfile-build-docker-images.groovy
+++ b/ci/Jenkinsfile-build-docker-images.groovy
@@ -1,4 +1,9 @@
 #!/usr/bin/groovy
+//------------------------------------------------------------------------------
+//  This Source Code Form is subject to the terms of the Mozilla Public
+//  License, v. 2.0. If a copy of the MPL was not distributed with this
+//  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//------------------------------------------------------------------------------
 
 @Library('test-shared-library@mr/ita/190-build-summary-emailer') _
 

--- a/ci/Jenkinsfile.groovy
+++ b/ci/Jenkinsfile.groovy
@@ -1,4 +1,9 @@
-#! /usr/bin/groovy
+#!/usr/bin/groovy
+//------------------------------------------------------------------------------
+//  This Source Code Form is subject to the terms of the Mozilla Public
+//  License, v. 2.0. If a copy of the MPL was not distributed with this
+//  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//------------------------------------------------------------------------------
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //                                                                                                        //

--- a/ci/default.groovy
+++ b/ci/default.groovy
@@ -1,5 +1,4 @@
 #!/usr/bin/groovy
-
 //------------------------------------------------------------------------------
 //  This Source Code Form is subject to the terms of the Mozilla Public
 //  License, v. 2.0. If a copy of the MPL was not distributed with this


### PR DESCRIPTION
With the `.groovy` extension, the files can now be properly syntax-highlighted in a code editor.

Closes #1215