### PR TITLE
Py framework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -689,7 +689,7 @@ $(BUILDDIR)/python/args.h: c/python/args.h $(BUILDDIR)/python/arg.h
 	@echo • Refreshing c/python/args.h
 	@cp c/python/args.h $@
 
-$(BUILDDIR)/python/ext_type.h: c/python/ext_type.h $(BUILDDIR)/python/args.h $(BUILDDIR)/utils/exceptions.h
+$(BUILDDIR)/python/ext_type.h: c/python/ext_type.h $(BUILDDIR)/python/args.h $(BUILDDIR)/utils/exceptions.h $(BUILDDIR)/utils/pyobj.h
 	@echo • Refreshing c/python/ext_type.h
 	@cp c/python/ext_type.h $@
 
@@ -894,7 +894,7 @@ $(BUILDDIR)/extras/aggregator.o : c/extras/aggregator.cc $(BUILDDIR)/extras/aggr
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
 
-$(BUILDDIR)/frame/py_frame.o : c/frame/py_frame.cc $(BUILDDIR)/frame/py_frame.h
+$(BUILDDIR)/frame/py_frame.o : c/frame/py_frame.cc $(BUILDDIR)/frame/py_frame.h $(BUILDDIR)/python/long.h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 

--- a/Makefile
+++ b/Makefile
@@ -429,6 +429,7 @@ fast_objects = $(addprefix $(BUILDDIR)/, \
 	expr/reduceop.o           \
 	expr/unaryop.o            \
 	extras/aggregator.o       \
+	frame/py_frame.o          \
 	groupby.o                 \
 	jay/open_jay.o            \
 	jay/save_jay.o            \
@@ -446,6 +447,7 @@ fast_objects = $(addprefix $(BUILDDIR)/, \
 	py_rowindex.o             \
 	py_types.o                \
 	py_utils.o                \
+	python/args.o             \
 	python/float.o            \
 	python/list.o             \
 	python/long.o             \
@@ -528,6 +530,7 @@ $(BUILDDIR)/encodings.h: c/encodings.h
 $(BUILDDIR)/groupby.h: c/groupby.h $(BUILDDIR)/memrange.h $(BUILDDIR)/rowindex.h
 	@echo • Refreshing c/groupby.h
 	@cp c/groupby.h $@
+
 
 $(BUILDDIR)/jay/jay_generated.h: c/jay/jay_generated.h $(BUILDDIR)/lib/flatbuffers/flatbuffers.h
 	@echo • Refreshing c/jay/jay_generated.h
@@ -671,6 +674,24 @@ $(BUILDDIR)/expr/py_expr.h: c/expr/py_expr.h $(BUILDDIR)/column.h $(BUILDDIR)/gr
 $(BUILDDIR)/extras/aggregator.h: c/extras/aggregator.h $(BUILDDIR)/datatable.h $(BUILDDIR)/py_datatable.h $(BUILDDIR)/rowindex.h $(BUILDDIR)/types.h
 	@echo • Refreshing c/extras/aggregator.h
 	@cp c/extras/aggregator.h $@
+
+
+$(BUILDDIR)/frame/py_frame.h: c/frame/py_frame.h $(BUILDDIR)/python/ext_type.h $(BUILDDIR)/datatable.h
+	@echo • Refreshing c/frame/py_frame.h
+	@cp c/frame/py_frame.h $@
+
+
+$(BUILDDIR)/python/arg.h: c/python/arg.h
+	@echo • Refreshing c/python/arg.h
+	@cp c/python/arg.h $@
+
+$(BUILDDIR)/python/args.h: c/python/args.h $(BUILDDIR)/python/arg.h
+	@echo • Refreshing c/python/args.h
+	@cp c/python/args.h $@
+
+$(BUILDDIR)/python/ext_type.h: c/python/ext_type.h $(BUILDDIR)/python/args.h $(BUILDDIR)/utils/exceptions.h
+	@echo • Refreshing c/python/ext_type.h
+	@cp c/python/ext_type.h $@
 
 $(BUILDDIR)/python/float.h: c/python/float.h $(BUILDDIR)/utils/pyobj.h
 	@echo • Refreshing c/python/float.h
@@ -842,13 +863,14 @@ $(BUILDDIR)/datatable_rbind.o : c/datatable_rbind.cc $(BUILDDIR)/column.h $(BUIL
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
-$(BUILDDIR)/datatablemodule.o : c/datatablemodule.cc $(BUILDDIR)/capi.h $(BUILDDIR)/csv/py_csv.h $(BUILDDIR)/csv/writer.h $(BUILDDIR)/expr/py_expr.h $(BUILDDIR)/extras/aggregator.h $(BUILDDIR)/options.h $(BUILDDIR)/py_column.h $(BUILDDIR)/py_columnset.h $(BUILDDIR)/py_datatable.h $(BUILDDIR)/py_datawindow.h $(BUILDDIR)/py_encodings.h $(BUILDDIR)/py_groupby.h $(BUILDDIR)/py_rowindex.h $(BUILDDIR)/py_types.h $(BUILDDIR)/py_utils.h $(BUILDDIR)/utils/assert.h
+$(BUILDDIR)/datatablemodule.o : c/datatablemodule.cc $(BUILDDIR)/capi.h $(BUILDDIR)/csv/py_csv.h $(BUILDDIR)/csv/writer.h $(BUILDDIR)/expr/py_expr.h $(BUILDDIR)/extras/aggregator.h $(BUILDDIR)/options.h $(BUILDDIR)/py_column.h $(BUILDDIR)/py_columnset.h $(BUILDDIR)/py_datatable.h $(BUILDDIR)/py_datawindow.h $(BUILDDIR)/py_encodings.h $(BUILDDIR)/py_groupby.h $(BUILDDIR)/py_rowindex.h $(BUILDDIR)/py_types.h $(BUILDDIR)/py_utils.h $(BUILDDIR)/utils/assert.h $(BUILDDIR)/frame/py_frame.h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
 $(BUILDDIR)/encodings.o : c/encodings.cc $(BUILDDIR)/encodings.h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
+
 
 $(BUILDDIR)/expr/binaryop.o : c/expr/binaryop.cc $(BUILDDIR)/expr/py_expr.h $(BUILDDIR)/types.h $(BUILDDIR)/utils/exceptions.h
 	@echo • Compiling $<
@@ -866,9 +888,16 @@ $(BUILDDIR)/expr/unaryop.o : c/expr/unaryop.cc $(BUILDDIR)/expr/py_expr.h $(BUIL
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
+
 $(BUILDDIR)/extras/aggregator.o : c/extras/aggregator.cc $(BUILDDIR)/extras/aggregator.h $(BUILDDIR)/py_utils.h $(BUILDDIR)/rowindex.h $(BUILDDIR)/types.h $(BUILDDIR)/utils/omp.h $(BUILDDIR)/utils/pyobj.h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
+
+
+$(BUILDDIR)/frame/py_frame.o : c/frame/py_frame.cc $(BUILDDIR)/frame/py_frame.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
 
 $(BUILDDIR)/groupby.o : c/groupby.cc $(BUILDDIR)/utils/exceptions.h $(BUILDDIR)/groupby.h
 	@echo • Compiling $<
@@ -937,6 +966,11 @@ $(BUILDDIR)/py_types.o : c/py_types.cc $(BUILDDIR)/py_types.h $(BUILDDIR)/py_uti
 	@$(CC) -c $< $(CCFLAGS) -o $@
 
 $(BUILDDIR)/py_utils.o : c/py_utils.cc $(BUILDDIR)/py_datatable.h $(BUILDDIR)/py_utils.h
+	@echo • Compiling $<
+	@$(CC) -c $< $(CCFLAGS) -o $@
+
+
+$(BUILDDIR)/python/args.o : c/python/args.cc $(BUILDDIR)/python/args.h $(BUILDDIR)/utils/exceptions.h
 	@echo • Compiling $<
 	@$(CC) -c $< $(CCFLAGS) -o $@
 

--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -11,6 +11,7 @@
 #include "csv/py_csv.h"
 #include "csv/writer.h"
 #include "expr/py_expr.h"
+#include "frame/py_frame.h"
 #include "options.h"
 #include "py_column.h"
 #include "py_columnset.h"
@@ -235,6 +236,13 @@ PyInit__datatable(void) {
     if (!pyrowindex::static_init(m)) return nullptr;
     if (!init_py_encodings(m)) return nullptr;
     init_jay();
+
+    try {
+      dt::Frame::Type::init(m);
+
+    } catch (const std::exception& e) {
+      exception_to_python(e);
+    }
 
     return m;
 }

--- a/c/frame/py_frame.cc
+++ b/c/frame/py_frame.cc
@@ -7,9 +7,11 @@
 //------------------------------------------------------------------------------
 #include "frame/py_frame.h"
 #include <iostream>
+#include "python/long.h"
 
 namespace dt {
 
+py::NoArgs Frame::Type::args__init__("__init__");
 
 
 const char* Frame::Type::classname() {
@@ -28,6 +30,16 @@ const char* Frame::Type::classdoc() {
     "This is a primary data structure for datatable module.\n";
 }
 
+void Frame::Type::init_getsetters(GetSetters& gs) {
+  gs.add<&Frame::get_ncols>("ncols");
+  gs.add<&Frame::get_nrows>("nrows");
+}
+
+
+void Frame::m__init__(py::Args&) {
+  std::cout << "In Frame.__init__()\n";
+}
+
 void Frame::m__dealloc__() {
   std::cout << "In Frame::dealloc (dt=" << dt << ")\n";
 }
@@ -38,6 +50,13 @@ void Frame::m__get_buffer__(Py_buffer* , int ) const {
 void Frame::m__release_buffer__(Py_buffer*) const {
 }
 
+PyObj Frame::get_ncols() const {
+  return PyObj(PyyLong(11));
+}
+
+PyObj Frame::get_nrows() const {
+  return PyObj(PyyLong(47));
+}
 
 
 }  // namespace dt

--- a/c/frame/py_frame.cc
+++ b/c/frame/py_frame.cc
@@ -1,0 +1,43 @@
+//------------------------------------------------------------------------------
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// © H2O.ai 2018
+//------------------------------------------------------------------------------
+#include "frame/py_frame.h"
+#include <iostream>
+
+namespace dt {
+
+
+
+const char* Frame::Type::classname() {
+  return "datatable.Frame";
+}
+
+const char* Frame::Type::classdoc() {
+  return
+    "Two-dimensional column-oriented table of data. Each column has its own\n"
+    "name and type. Types may vary across columns but cannot vary within\n"
+    "each column.\n"
+    "\n"
+    "Internally the data is stored as C primitives, and processed using\n"
+    "multithreaded native C++ code.\n"
+    "\n"
+    "This is a primary data structure for datatable module.\n";
+}
+
+void Frame::m__dealloc__() {
+  std::cout << "In Frame::dealloc (dt=" << dt << ")\n";
+}
+
+void Frame::m__get_buffer__(Py_buffer* , int ) const {
+}
+
+void Frame::m__release_buffer__(Py_buffer*) const {
+}
+
+
+
+}  // namespace dt

--- a/c/frame/py_frame.cc
+++ b/c/frame/py_frame.cc
@@ -11,7 +11,14 @@
 
 namespace dt {
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wexit-time-destructors"
+#pragma clang diagnostic ignored "-Wglobal-constructors"
+
 py::NoArgs Frame::Type::args__init__("__init__");
+py::NoArgs Frame::Type::args_bang("bang");
+
+#pragma clang diagnostic pop
 
 
 const char* Frame::Type::classname() {
@@ -33,6 +40,10 @@ const char* Frame::Type::classdoc() {
 void Frame::Type::init_getsetters(GetSetters& gs) {
   gs.add<&Frame::get_ncols>("ncols");
   gs.add<&Frame::get_nrows>("nrows");
+}
+
+void Frame::Type::init_methods(Methods& mm) {
+  mm.add<&Frame::bang, args_bang>("bang");
 }
 
 
@@ -58,5 +69,9 @@ PyObj Frame::get_nrows() const {
   return PyObj(PyyLong(47));
 }
 
+PyObj Frame::bang(py::NoArgs&) {
+  std::cout << "Yay, Frame::bang()!\n";
+  return PyObj::none();
+}
 
 }  // namespace dt

--- a/c/frame/py_frame.cc
+++ b/c/frame/py_frame.cc
@@ -15,8 +15,8 @@ namespace dt {
 #pragma clang diagnostic ignored "-Wexit-time-destructors"
 #pragma clang diagnostic ignored "-Wglobal-constructors"
 
-py::NoArgs Frame::Type::args__init__("__init__");
-py::NoArgs Frame::Type::args_bang("bang");
+py::NoArgs Frame::Type::args___init__;
+py::NoArgs Frame::Type::args_bang;
 
 #pragma clang diagnostic pop
 

--- a/c/frame/py_frame.h
+++ b/c/frame/py_frame.h
@@ -1,0 +1,41 @@
+//------------------------------------------------------------------------------
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// © H2O.ai 2018
+//------------------------------------------------------------------------------
+#ifndef dt_FRAME_PYFRAME_h
+#define dt_FRAME_PYFRAME_h
+#include "python/ext_type.h"
+#include "datatable.h"
+
+namespace dt {
+
+
+/**
+ * [WIP]
+ * This class is exposed to python via `datatable.lib.core.Frame`, but it is
+ * not directly usable yet.
+ */
+class Frame : public PyObject {
+  private:
+    DataTable* dt;
+
+  public:
+    class Type : public py::ExtType<Frame> {
+      public:
+        static const char* classname();
+        static const char* classdoc();
+    };
+
+    void m__dealloc__();
+    void m__get_buffer__(Py_buffer* buf, int flags) const;
+    void m__release_buffer__(Py_buffer* buf) const;
+};
+
+
+
+}  // namespace dt
+
+#endif

--- a/c/frame/py_frame.h
+++ b/c/frame/py_frame.h
@@ -26,10 +26,12 @@ class Frame : public PyObject {
     class Type : public py::ExtType<Frame> {
       public:
         static py::NoArgs args__init__;
+        static py::NoArgs args_bang;
         static const char* classname();
         static const char* classdoc();
 
         static void init_getsetters(GetSetters& gs);
+        static void init_methods(Methods& gs);
     };
 
     void m__init__(py::Args&);
@@ -39,6 +41,8 @@ class Frame : public PyObject {
 
     PyObj get_ncols() const;
     PyObj get_nrows() const;
+
+    PyObj bang(py::NoArgs&);
 };
 
 

--- a/c/frame/py_frame.h
+++ b/c/frame/py_frame.h
@@ -25,13 +25,20 @@ class Frame : public PyObject {
   public:
     class Type : public py::ExtType<Frame> {
       public:
+        static py::NoArgs args__init__;
         static const char* classname();
         static const char* classdoc();
+
+        static void init_getsetters(GetSetters& gs);
     };
 
+    void m__init__(py::Args&);
     void m__dealloc__();
     void m__get_buffer__(Py_buffer* buf, int flags) const;
     void m__release_buffer__(Py_buffer* buf) const;
+
+    PyObj get_ncols() const;
+    PyObj get_nrows() const;
 };
 
 

--- a/c/frame/py_frame.h
+++ b/c/frame/py_frame.h
@@ -25,7 +25,7 @@ class Frame : public PyObject {
   public:
     class Type : public py::ExtType<Frame> {
       public:
-        static py::NoArgs args__init__;
+        static py::NoArgs args___init__;
         static py::NoArgs args_bang;
         static const char* classname();
         static const char* classdoc();

--- a/c/py_datatable.cc
+++ b/c/py_datatable.cc
@@ -698,7 +698,7 @@ PyTypeObject type = {
   nullptr,                            /* tp_print */
   nullptr,                            /* tp_getattr */
   nullptr,                            /* tp_setattr */
-  nullptr,                            /* tp_compare */
+  nullptr,                            /* tp_as_sync */
   nullptr,                            /* tp_repr */
   nullptr,                            /* tp_as_number */
   nullptr,                            /* tp_as_sequence */

--- a/c/python/arg.h
+++ b/c/python/arg.h
@@ -1,0 +1,21 @@
+//------------------------------------------------------------------------------
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// © H2O.ai 2018
+//------------------------------------------------------------------------------
+#ifndef dt_PYTHON_ARG_h
+#define dt_PYTHON_ARG_h
+#include <Python.h>
+
+namespace py {
+
+
+class Arg {
+
+};
+
+
+}  // namespace py
+#endif

--- a/c/python/args.cc
+++ b/c/python/args.cc
@@ -21,6 +21,8 @@ Args::Args(const char* name) : fn_name(name) {}
 
 Args::~Args() {}
 
+void Args::set_name(const char* name) { fn_name = name; }
+
 bool Args::has(size_t) const { return false; }
 
 bool Args::has(const char*) const { return false; }

--- a/c/python/args.cc
+++ b/c/python/args.cc
@@ -36,7 +36,7 @@ Arg Args::get(const char*) const { throw AssertionError(); }
 //------------------------------------------------------------------------------
 
 void NoArgs::bind(PyObject* _args, PyObject* _kwds) {
-  if (Py_SIZE(_args) || PyDict_Size(_kwds)) {
+  if ((_args && Py_SIZE(_args)) || (_kwds && PyDict_Size(_kwds))) {
     throw TypeError() << fn_name << "() accepts no arguments";
   }
 }

--- a/c/python/args.cc
+++ b/c/python/args.cc
@@ -1,0 +1,71 @@
+//------------------------------------------------------------------------------
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// © H2O.ai 2018
+//------------------------------------------------------------------------------
+#include "python/args.h"
+#include "utils/exceptions.h"
+
+namespace py {
+
+
+//------------------------------------------------------------------------------
+// Args
+//------------------------------------------------------------------------------
+
+Args::Args() : fn_name(nullptr) {}
+
+Args::Args(const char* name) : fn_name(name) {}
+
+Args::~Args() {}
+
+bool Args::has(size_t) const { return false; }
+
+bool Args::has(const char*) const { return false; }
+
+Arg Args::get(size_t) const { throw AssertionError(); }
+
+Arg Args::get(const char*) const { throw AssertionError(); }
+
+
+
+//------------------------------------------------------------------------------
+// NoArgs
+//------------------------------------------------------------------------------
+
+void NoArgs::bind(PyObject* _args, PyObject* _kwds) {
+  if (Py_SIZE(_args) || PyDict_Size(_kwds)) {
+    throw TypeError() << fn_name << "() accepts no arguments";
+  }
+}
+
+
+
+//------------------------------------------------------------------------------
+// PosAndKwdArgs
+//------------------------------------------------------------------------------
+
+PosAndKwdArgs::PosAndKwdArgs(
+    const char* name, size_t np, std::initializer_list<const char*> ki)
+    : Args(name), n_posonly_args(np), n_kwdonly_args(0), kwd_names(ki),
+      args(nullptr), kwds(nullptr) {}
+
+
+void PosAndKwdArgs::bind(PyObject* _args, PyObject* _kws) {
+  args = _args;
+  kwds = _kws;
+
+  size_t nargs = static_cast<size_t>(Py_SIZE(args));
+
+  if (nargs < n_posonly_args) {
+    size_t nmiss = n_posonly_args - nargs;
+    throw TypeError() << fn_name << "() is missing " << nmiss
+        << " required positional argument" << (nmiss > 1 ? "s" : "");
+  }
+
+}
+
+
+}  // namespace py

--- a/c/python/args.h
+++ b/c/python/args.h
@@ -34,6 +34,7 @@ class Args {
     Args(const char* name);
     virtual ~Args();
 
+    void set_name(const char* name);
     virtual void bind(PyObject* _args, PyObject* _kwds) = 0;
 
     virtual bool has(size_t i) const;

--- a/c/python/args.h
+++ b/c/python/args.h
@@ -1,0 +1,83 @@
+//------------------------------------------------------------------------------
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// © H2O.ai 2018
+//------------------------------------------------------------------------------
+#ifndef dt_PYTHON_ARGS_h
+#define dt_PYTHON_ARGS_h
+#include <vector>
+#include <Python.h>
+#include "python/arg.h"
+
+namespace py {
+
+
+
+//------------------------------------------------------------------------------
+// Args
+//------------------------------------------------------------------------------
+
+/**
+ * Helper class for ExtType: it encapsulates arguments passed to a function
+ * and helps to verify / parse them. This is the base class for a family of
+ * args-related functions, each designed to handle different calling
+ * convention.
+ */
+class Args {
+  protected:
+    const char* fn_name;
+
+  public:
+    Args();
+    Args(const char* name);
+    virtual ~Args();
+
+    virtual void bind(PyObject* _args, PyObject* _kwds) = 0;
+
+    virtual bool has(size_t i) const;
+    virtual bool has(const char* name) const;
+    virtual Arg get(size_t i) const;
+    virtual Arg get(const char* name) const;
+};
+
+
+
+//------------------------------------------------------------------------------
+// NoArgs
+//------------------------------------------------------------------------------
+
+class NoArgs : public Args {
+  public:
+    using Args::Args;
+
+    void bind(PyObject* _args, PyObject* _kwds) override;
+};
+
+
+
+//------------------------------------------------------------------------------
+// PosAndKwdArgs
+//------------------------------------------------------------------------------
+
+class PosAndKwdArgs : public Args {
+  private:
+    // All references are borrowed
+    size_t n_posonly_args;
+    size_t n_kwdonly_args;
+    std::vector<const char*> kwd_names;
+    std::vector<PyObject*> defaults;
+    PyObject* args;
+    PyObject* kwds;
+
+  public:
+    PosAndKwdArgs(const char*, size_t, std::initializer_list<const char*>);
+
+    void bind(PyObject* _args, PyObject* _kws) override;
+};
+
+
+}  // namespace py
+
+#endif

--- a/c/python/ext_type.h
+++ b/c/python/ext_type.h
@@ -1,0 +1,199 @@
+//------------------------------------------------------------------------------
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// © H2O.ai 2018
+//------------------------------------------------------------------------------
+#ifndef dt_PYTHON_EXT_TYPE_h
+#define dt_PYTHON_EXT_TYPE_h
+#include <vector>
+#include <Python.h>
+#include "python/args.h"
+#include "utils/exceptions.h"
+
+namespace py {
+
+/**
+ * Usage:
+ *   class MyObj : public PyObject {
+ *     public:
+ *       class Type : public py::ExtType<MyObj> {
+ *         static const char* classname();  // required
+ *         static const char* classdoc();
+ *         static PyTypeObject* baseclass();
+ *       };
+ *
+ *       MyObj();
+ *       void m__init__(Args);
+ *       void m__dealloc__();
+ *
+ *       void init_methods();
+ *       void init_getsetters();
+ *   };
+ *
+ * Then, in datatablemodule.c:
+ *   MyObj::Type::init(module);
+ */
+
+template <class T>
+struct ExtType {
+  static PyTypeObject type;
+
+  static void init(PyObject* module);
+
+  static const char* classdoc() { return nullptr; }
+  static PyTypeObject* baseclass() { return nullptr; }
+  static bool is_subclassable() { return false; }
+};
+
+
+
+//------------------------------------------------------------------------------
+// Implementation internals
+//------------------------------------------------------------------------------
+namespace _impl {
+
+  template <typename T>
+  int _safe_init(PyObject* self, PyObject* args, PyObject* kwds) {
+    try {
+      T::args__init__.bind(args, kwds);
+      static_cast<T*>(self)->m__init__(T::args__init__);
+      return 0;
+    } catch (const std::exception& e) {
+      exception_to_python(e);
+      return -1;
+    }
+  }
+
+  template <typename T>
+  void _safe_dealloc(PyObject* self) {
+    try {
+      T* tself = static_cast<T*>(self);
+      tself->m__dealloc__();
+    } catch (const std::exception& e) {
+      exception_to_python(e);
+    }
+  }
+
+  template <typename T>
+  int _safe_getbuffer(PyObject* self, Py_buffer* buf, int flags) {
+    try {
+      T* tself = static_cast<T*>(self);
+      tself->m__get_buffer__(buf, flags);
+      return 0;
+    } catch (const std::exception& e) {
+      exception_to_python(e);
+      return -1;
+    }
+  }
+
+  template <typename T>
+  void _safe_releasebuffer(PyObject* self, Py_buffer* buf) {
+    try {
+      T* tself = static_cast<T*>(self);
+      tself->m__release_buffer__(buf);
+    } catch (const std::exception& e) {
+      exception_to_python(e);
+    }
+  }
+
+  /**
+   * SFINAE checker for the presence of various methods:
+   *   has<T>::buffers  will return true if T has method `m__get_buffer__`
+   *                    (signature is not verified)
+   *   has<T>::init returns true if T has method `m__init__`
+   */
+  template <typename T>
+  class has {
+    template <class C> static char test_init(decltype(&C::m__init__));
+    template <class C> static long test_init(...);
+    template <class C> static char test_buf(decltype(&C::m__get_buffer__));
+    template <class C> static long test_buf(...);
+
+  public:
+    static constexpr bool _init_ = (sizeof(test_init<T>(nullptr)) == 1);
+    static constexpr bool buffers = (sizeof(test_buf<T>(nullptr)) == 1);
+  };
+
+  /**
+   * Conditional initialization of additional `type` parameters. Use this
+   * class as follows:
+   *
+   *   init<T, has<T>::feature>::feature()
+   *
+   * This will initialize `<feature>`, but only if that feature actuall exists
+   * in class `T`.
+   */
+  template <typename, bool>
+  struct init {
+    static void _init_(PyTypeObject&) {}
+    static void buffers(PyTypeObject&) {}
+  };
+
+  template <typename T>
+  struct init<T, true> {
+    static void _init_(PyTypeObject& type) {
+      type.tp_init = _safe_init<T>;
+    }
+
+    static void buffers(PyTypeObject& type) {
+      PyBufferProcs* bufs = new PyBufferProcs();
+      bufs->bf_getbuffer = _safe_getbuffer<T>;
+      bufs->bf_releasebuffer = _safe_releasebuffer<T>;
+      type.tp_as_buffer = bufs;
+    }
+  };
+
+}  // namespace _impl
+
+
+
+//------------------------------------------------------------------------------
+// Implementation
+//------------------------------------------------------------------------------
+
+template <class T>
+PyTypeObject ExtType<T>::type;
+
+
+/**
+ * Main method for initializing the `PyTypeObject type` variable.
+ * See: https://docs.python.org/3/c-api/typeobj.html
+ */
+template <class T>
+void ExtType<T>::init(PyObject* module) {
+  std::memset(&type, 0, sizeof(PyTypeObject));
+  Py_INCREF(&type);
+
+  type.tp_name      = T::Type::classname();
+  type.tp_doc       = T::Type::classdoc();
+  type.tp_base      = T::Type::baseclass();
+  type.tp_basicsize = static_cast<Py_ssize_t>(sizeof(T));
+  type.tp_itemsize  = 0;
+  type.tp_flags     = Py_TPFLAGS_DEFAULT;
+  if (T::Type::is_subclassable()) type.tp_flags |= Py_TPFLAGS_BASETYPE;
+
+  type.tp_alloc     = &PyType_GenericAlloc;
+  type.tp_new       = &PyType_GenericNew;
+  type.tp_dealloc   = _impl::_safe_dealloc<T>;
+
+  _impl::init<T, _impl::has<T>::_init_>::_init_(type);
+  _impl::init<T, _impl::has<T>::buffers>::buffers(type);
+
+  // Finish type initialization
+  int r = PyType_Ready(&type);
+  if (r < 0) throw PyError();
+
+  PyObject* pyobj_type = reinterpret_cast<PyObject*>(&type);
+  const char* name = std::strrchr(type.tp_name, '.');
+  if (name) name++; else name = type.tp_name;
+
+  r = PyModule_AddObject(module, name, pyobj_type);
+  if (r < 0) throw PyError();
+}
+
+
+}  // namespace py
+
+#endif

--- a/c/utils/pyobj.cc
+++ b/c/utils/pyobj.cc
@@ -202,6 +202,12 @@ PyObject* PyObj::as_pyobject() const {
   return obj;
 }
 
+PyObject* PyObj::release() {
+  PyObject* t = obj;
+  obj = nullptr;
+  return t;
+}
+
 
 DataTable* PyObj::as_datatable() const {
   DataTable* dt = nullptr;

--- a/c/utils/pyobj.h
+++ b/c/utils/pyobj.h
@@ -115,6 +115,7 @@ public:
    */
   PyObject* as_pyobject() const;
   PyObject* data() const { return obj; }
+  PyObject* release();
 
   DataTable* as_datatable() const;
   Column* as_column() const;


### PR DESCRIPTION
This is a new framework for defining Python objects from C++. It intends to supplement the existing methodology (see py_utils.h), which is largely based on an assortment of macros.

The framework is not yet complete. The following is currently possible:
* Define a new python extension type by deriving from `py::ExtType`;
* Specify constructor/destructor/repr functions by defining methods with predefined names, such as `void m__dealloc__()`;
* Define any number of getters/setters, and then declare them via `static void init_getsetters(GetSetters&)`;
* Define any number of methods, and then declare them via `static void init_methods(Methods&)`;
* All methods are automatically wrapped into exception-catching blocks;
* Methods can receive an arbitrary number of parameters and keyword arguments, as controlled by the `Args` parameter for each method. The API to work with these args is still WIP.

-----
This new framework, besides being more convenient to work with, offers several advantages compared to the current technology:
* Easier and faster parsing of function arguments;
* Better error messages for parameters that have incorrect types;
* Less boilerplate code.

WIP for #1220