### PR TITLE
Remove unnecessary properties from Frame

### DIFF
--- a/c/py_datatable.h
+++ b/c/py_datatable.h
@@ -35,6 +35,8 @@ namespace pydatatable
  */
 struct obj : public PyObject {
   DataTable* ref;
+  PyObject* ltypes;  // memoized tuples of ltypes / stypes
+  PyObject* stypes;
   SType use_stype_for_buffers;
   int64_t : 56;
 };

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -41,8 +41,7 @@ class Frame(object):
 
     This is a primary data structure for datatable module.
     """
-    __slots__ = ("_ltypes", "_stypes", "_names",
-                 "_inames", "_dt", "_nkeys")
+    __slots__ = ("_ltypes", "_stypes", "_names", "_inames", "_dt")
 
     def __init__(self, src=None, names=None, stypes=None, **kwargs):
         if "stype" in kwargs:
@@ -52,7 +51,6 @@ class Frame(object):
                 src = kwargs
             else:
                 dtwarn("Unknown options %r to Frame()" % kwargs)
-        self._nkeys = 0      # type: int
         self._ltypes = None  # type: Tuple[ltype]
         self._stypes = None  # type: Tuple[stype]
         self._names = None   # type: Tuple[str]
@@ -80,7 +78,7 @@ class Frame(object):
     def key(self):
         """Tuple of column names that comprise the Frame's key. If the Frame
         is not keyed, this will return an empty tuple."""
-        return self._names[:self._nkeys]
+        return self._names[:self._dt.nkeys]
 
     @property
     def shape(self):
@@ -123,7 +121,6 @@ class Frame(object):
     @key.setter
     def key(self, colnames):
         if colnames is None:
-            self._nkeys = 0
             self._dt.nkeys = 0
             return
         if isinstance(colnames, (int, str)):
@@ -141,7 +138,6 @@ class Frame(object):
         else:
             raise ValueError("Duplicate columns requested for the key: %r"
                              % [self._names[i] for i in colindices])
-        self._nkeys = nk
         self._dt.nkeys = nk
 
     @names.setter
@@ -173,7 +169,7 @@ class Frame(object):
     def _data_viewer(self, row0, row1, col0, col1):
         view = self._dt.window(row0, row1, col0, col1)
         length = max(2, len(str(row1)))
-        nk = self._nkeys
+        nk = self._dt.nkeys
         return {
             "names": self._names[:nk] + self._names[col0 + nk:col1 + nk],
             "types": view.types,
@@ -183,7 +179,7 @@ class Frame(object):
         }
 
     def view(self, interactive=True):
-        widget = DataFrameWidget(self.nrows, self.ncols, self._nkeys,
+        widget = DataFrameWidget(self.nrows, self.ncols, self._dt.nkeys,
                                  self._data_viewer, interactive)
         widget.render()
 
@@ -257,7 +253,6 @@ class Frame(object):
 
     def _fill_from_dt(self, _dt, names=None):
         self._dt = _dt
-        self._nkeys = _dt.nkeys
         # Clear the memorized values, in case they were already computed.
         self._stypes = None
         self._ltypes = None

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -41,9 +41,7 @@ class Frame(object):
 
     This is a primary data structure for datatable module.
     """
-    _id_counter_ = 0
-
-    __slots__ = ("_id", "_ncols", "_nrows", "_ltypes", "_stypes", "_names",
+    __slots__ = ("_ncols", "_nrows", "_ltypes", "_stypes", "_names",
                  "_inames", "_dt", "_nkeys")
 
     def __init__(self, src=None, names=None, stypes=None, **kwargs):
@@ -54,8 +52,6 @@ class Frame(object):
                 src = kwargs
             else:
                 dtwarn("Unknown options %r to Frame()" % kwargs)
-        Frame._id_counter_ += 1
-        self._id = Frame._id_counter_  # type: int
         self._ncols = 0      # type: int
         self._nrows = 0      # type: int
         self._nkeys = 0      # type: int
@@ -166,7 +162,7 @@ class Frame(object):
     def __repr__(self):
         srows = plural(self._nrows, "row")
         scols = plural(self._ncols, "col")
-        return "<Frame #%d (%s x %s)>" % (self._id, srows, scols)
+        return "<Frame [%s x %s]>" % (srows, scols)
 
     def _display_in_terminal_(self):  # pragma: no cover
         # This method is called from the display hook set from .utils.terminal

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -41,7 +41,7 @@ class Frame(object):
 
     This is a primary data structure for datatable module.
     """
-    __slots__ = ("_ncols", "_nrows", "_ltypes", "_stypes", "_names",
+    __slots__ = ("_ltypes", "_stypes", "_names",
                  "_inames", "_dt", "_nkeys")
 
     def __init__(self, src=None, names=None, stypes=None, **kwargs):
@@ -52,8 +52,6 @@ class Frame(object):
                 src = kwargs
             else:
                 dtwarn("Unknown options %r to Frame()" % kwargs)
-        self._ncols = 0      # type: int
-        self._nrows = 0      # type: int
         self._nkeys = 0      # type: int
         self._ltypes = None  # type: Tuple[ltype]
         self._stypes = None  # type: Tuple[stype]
@@ -71,12 +69,12 @@ class Frame(object):
     @property
     def nrows(self):
         """Number of rows in the frame."""
-        return self._nrows
+        return self._dt.nrows
 
     @property
     def ncols(self):
         """Number of columns in the frame."""
-        return self._ncols
+        return self._dt.ncols
 
     @property
     def key(self):
@@ -87,7 +85,7 @@ class Frame(object):
     @property
     def shape(self):
         """Tuple (number of rows, number of columns)."""
-        return (self._nrows, self._ncols)
+        return (self._dt.nrows, self._dt.ncols)
 
     @property
     def names(self):
@@ -137,7 +135,7 @@ class Frame(object):
             # rearrange the columns
             pass
         elif len(set(colindices)) == nk:
-            allindices = colindices + [i for i in range(self._ncols)
+            allindices = colindices + [i for i in range(self.ncols)
                                        if i not in colindices]
             self.__init__(self[:, allindices])
         else:
@@ -160,8 +158,8 @@ class Frame(object):
     #---------------------------------------------------------------------------
 
     def __repr__(self):
-        srows = plural(self._nrows, "row")
-        scols = plural(self._ncols, "col")
+        srows = plural(self.nrows, "row")
+        scols = plural(self.ncols, "col")
         return "<Frame [%s x %s]>" % (srows, scols)
 
     def _display_in_terminal_(self):  # pragma: no cover
@@ -185,7 +183,7 @@ class Frame(object):
         }
 
     def view(self, interactive=True):
-        widget = DataFrameWidget(self._nrows, self._ncols, self._nkeys,
+        widget = DataFrameWidget(self.nrows, self.ncols, self._nkeys,
                                  self._data_viewer, interactive)
         widget.render()
 
@@ -259,8 +257,6 @@ class Frame(object):
 
     def _fill_from_dt(self, _dt, names=None):
         self._dt = _dt
-        self._ncols = _dt.ncols
-        self._nrows = _dt.nrows
         self._nkeys = _dt.nkeys
         # Clear the memorized values, in case they were already computed.
         self._stypes = None
@@ -271,12 +267,12 @@ class Frame(object):
             if not isinstance(names, (tuple, list)):
                 raise TTypeError("The `names` parameter should be either a "
                                  "tuple or a list, not %r" % type(names))
-            if len(names) != self._ncols:
+            if len(names) != self.ncols:
                 raise TValueError("The length of the `names` parameter (%d) "
                                   "does not match the number of columns in the "
-                                  "Frame (%d)" % (len(names), self._ncols))
+                                  "Frame (%d)" % (len(names), self.ncols))
         else:
-            names = [None] * self._ncols
+            names = [None] * self.ncols
         self._names, self._inames = Frame._dedup_names(names)
 
 
@@ -587,8 +583,9 @@ class Frame(object):
         # `cols` must be a sorted list of positive integer indices
         if not cols:
             return
+        old_ncols = self.ncols
         self._dt.delete_columns(cols)
-        assert self._ncols - len(cols) == self._dt.ncols
+        assert self.ncols == old_ncols - len(cols)
         newnames = self.names[:cols[0]]
         for i in range(1, len(cols)):
             newnames += self.names[(cols[i - 1] + 1):cols[i]]
@@ -614,7 +611,7 @@ class Frame(object):
                 raise TValueError("Column `%s` does not exist in %r"
                                   % (name, self))
         else:
-            n = self._ncols
+            n = self.ncols
             if 0 <= name < n:
                 return name
             elif -n <= name < 0:
@@ -650,7 +647,7 @@ class Frame(object):
         """
         idx = self.colindex(by)
         ri = self._dt.sort(idx)[0]
-        cs = core.columns_from_slice(self._dt, ri, 0, self._ncols, 1)
+        cs = core.columns_from_slice(self._dt, ri, 0, self.ncols, 1)
         _dt = cs.to_datatable()
         return Frame(_dt, names=self.names)
 
@@ -661,7 +658,6 @@ class Frame(object):
         #   - tile existing values
         if nrows < 0:
             raise TValueError("Cannot resize to %d rows" % nrows)
-        self._nrows = nrows
         self._dt.resize_rows(nrows)
 
 
@@ -808,9 +804,9 @@ class Frame(object):
         """
         if isinstance(columns, (list, tuple)):
             names = columns
-            if len(names) != self._ncols:
+            if len(names) != self.ncols:
                 raise TValueError("Cannot rename columns to %r: expected %s"
-                                  % (names, plural(self._ncols, "name")))
+                                  % (names, plural(self.ncols, "name")))
         else:
             names = list(self._names)
             for oldname, newname in columns.items():
@@ -840,7 +836,7 @@ class Frame(object):
         if srcdt.isview:
             srcdt = srcdt.materialize()
         srccols = collections.OrderedDict()
-        for i in range(self._ncols):
+        for i in range(self.ncols):
             name = self._names[i]
             column = srcdt.column(i)
             dtype = self.stypes[i].dtype

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -41,7 +41,7 @@ class Frame(object):
 
     This is a primary data structure for datatable module.
     """
-    __slots__ = ("_ltypes", "_stypes", "_names", "_inames", "_dt")
+    __slots__ = ("_names", "_inames", "_dt")
 
     def __init__(self, src=None, names=None, stypes=None, **kwargs):
         if "stype" in kwargs:
@@ -51,8 +51,6 @@ class Frame(object):
                 src = kwargs
             else:
                 dtwarn("Unknown options %r to Frame()" % kwargs)
-        self._ltypes = None  # type: Tuple[ltype]
-        self._stypes = None  # type: Tuple[stype]
         self._names = None   # type: Tuple[str]
         # Mapping of column names to their indices
         self._inames = None  # type: Dict[str, int]
@@ -93,16 +91,12 @@ class Frame(object):
     @property
     def ltypes(self):
         """Tuple of column types."""
-        if self._ltypes is None:
-            self._ltypes = self._dt.ltypes
-        return self._ltypes
+        return self._dt.ltypes
 
     @property
     def stypes(self):
         """Tuple of column storage types."""
-        if self._stypes is None:
-            self._stypes = self._dt.stypes
-        return self._stypes
+        return self._dt.stypes
 
     @property
     def internal(self):
@@ -253,9 +247,6 @@ class Frame(object):
 
     def _fill_from_dt(self, _dt, names=None):
         self._dt = _dt
-        # Clear the memorized values, in case they were already computed.
-        self._stypes = None
-        self._ltypes = None
         if names:
             if isinstance(names, str):
                 names = [names]

--- a/datatable/graph/__init__.py
+++ b/datatable/graph/__init__.py
@@ -69,7 +69,6 @@ def make_datatable(dt, rows, select, groupby=None, join=None, sort=None,
                     rowsnode.negate()
                     rowsnode.execute()
                     dt.internal.replace_rowindex(ee.rowindex)
-                    dt._nrows = dt.internal.nrows
                     return
                 else:
                     update_mode = True

--- a/datatable/graph/cols_node.py
+++ b/datatable/graph/cols_node.py
@@ -90,9 +90,6 @@ class AllCSNode(ColumnSetNode):
         ri = self._engine.rowindex
         dt.internal.replace_column_slice(0, self.dt.ncols, 1,
                                          ri, replacement.internal)
-        # Clear cached stypes/ltypes; No need to update names
-        dt._stypes = None
-        dt._ltypes = None
 
 
     def get_list(self):
@@ -155,9 +152,6 @@ class SliceCSNode(ColumnSetNode):
         ri = self._engine.rowindex
         dt.internal.replace_column_slice(self._start, self._count, self._step,
                                          ri, replacement.internal)
-        # Clear cached stypes/ltypes; No need to update names
-        dt._stypes = None
-        dt._ltypes = None
 
 
     def get_list(self):

--- a/datatable/graph/context.py
+++ b/datatable/graph/context.py
@@ -184,7 +184,7 @@ class LlvmEvaluationEngine(EvaluationEngine):
         return prefix + str(self._var_counter)
 
     def get_dtvar(self, dt):
-        varname = "dt" + str(getattr(dt, "_id"))
+        varname = "dt" + str(id(dt))
         if varname not in self._global_names:
             ptr = dt.internal.datatable_ptr
             self.add_global(varname, "void*", "(void*) %dL" % ptr)

--- a/datatable/graph/dtproxy.py
+++ b/datatable/graph/dtproxy.py
@@ -57,7 +57,7 @@ class DatatableProxy(object):
     >>> d3 = d0[:, expr]
     >>> d4 = d0[expr > 0, expr]
     """
-    __slots__ = ["_datatable", "_rowindex"]
+    __slots__ = ["_datatable", "_rowindex", "_name"]
 
     # Developer notes:
     # This class uses dynamic name resolution to convert arbitrary attribute
@@ -65,9 +65,10 @@ class DatatableProxy(object):
     # internal attributes or method names that have a chance of clashing with
     # user's column names.
 
-    def __init__(self):
+    def __init__(self, name):
         self._datatable = None
         self._rowindex = None
+        self._name = name
 
 
     def get_datatable(self):
@@ -106,17 +107,11 @@ class DatatableProxy(object):
 
 
     def __repr__(self):
-        if self._datatable:
-            return "DatatableProxy(%s)" % str(self)
-        else:
-            return "DatatableProxy(unbound)"
+        return "FrameProxy('%s', %s)" % (self._name, repr(self._datatable))
 
 
     def __str__(self):
-        if self._datatable:
-            return "f" + str(getattr(self._datatable, "_id"))
-        else:
-            return "f"
+        return self._name
 
 
     def __dir__(self):
@@ -161,5 +156,5 @@ class DatatableProxy(object):
             return self._datatable.stypes
 
 
-f = DatatableProxy()
-g = DatatableProxy()
+f = DatatableProxy("f")
+g = DatatableProxy("g")

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -149,8 +149,7 @@ def test_dt_properties(dt0):
     assert (sys.getsizeof(dt0) > dt0.internal.alloc_size +
             sys.getsizeof(dt0.names) +
             sum(sys.getsizeof(colname) for colname in dt0.names) +
-            sys.getsizeof(dt0._inames) + sys.getsizeof(dt0._ltypes) +
-            sys.getsizeof(dt0._stypes))
+            sys.getsizeof(dt0._inames))
 
 
 @pytest.mark.run(order=2)

--- a/tests/test_dt_options.py
+++ b/tests/test_dt_options.py
@@ -132,6 +132,7 @@ def test_core_logger():
     dt.options.core_logger = ml
     assert dt.options.core_logger == ml
     f0 = dt.Frame([1, 2, 3])
+    assert f0.shape == (3, 1)
     f0.internal.check()
     assert "call DataTable.datatable_from_list(...)" in ml.messages
     assert "call DataTable.ncols" in ml.messages


### PR DESCRIPTION
Removed `_id`, `_ncols`, `_nrows`, `_stypes`, `_ltypes` -- all of these can be retrieved from the internal `_dt` object.

Closes #1238