### PR TITLE
Fix bug with ltypes being left in incorrect state after deleting columns

### DIFF
--- a/c/py_datatable.cc
+++ b/c/py_datatable.cc
@@ -250,6 +250,14 @@ PyObject* get_alloc_size(obj* self) {
 // PyDatatable methods
 //==============================================================================
 
+static void _clear_types(obj* self) {
+  Py_XDECREF(self->stypes);
+  Py_XDECREF(self->ltypes);
+  self->stypes = nullptr;
+  self->ltypes = nullptr;
+}
+
+
 PyObject* window(obj* self, PyObject* args) {
   int64_t row0, row1, col0, col1;
   if (!PyArg_ParseTuple(args, "llll", &row0, &row1, &col0, &col1))
@@ -316,6 +324,7 @@ PyObject* delete_columns(obj* self, PyObject* args) {
   }
   dt->delete_columns(cols_to_remove, ncols);
 
+  _clear_types(self);
   dt::free(cols_to_remove);
   Py_RETURN_NONE;
 }
@@ -383,11 +392,7 @@ PyObject* replace_column_slice(obj* self, PyObject* args) {
       dt->columns[j] = replcol->shallowcopy();
     }
   }
-  // Clear cached stypes/ltypes; No need to update names
-  Py_XDECREF(self->stypes);
-  Py_XDECREF(self->ltypes);
-  self->stypes = nullptr;
-  self->ltypes = nullptr;
+  _clear_types(self);
   Py_RETURN_NONE;
 }
 
@@ -451,10 +456,7 @@ PyObject* replace_column_array(obj* self, PyObject* args) {
   dt->columns[dt->ncols] = nullptr;
 
   // Clear cached stypes/ltypes; No need to update names
-  Py_XDECREF(self->stypes);
-  Py_XDECREF(self->ltypes);
-  self->stypes = nullptr;
-  self->ltypes = nullptr;
+  _clear_types(self);
   Py_RETURN_NONE;
 }
 

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -220,7 +220,9 @@ def test_dt_getitem(dt0):
 
 # Not a fixture: create a new datatable each time this function is called
 def smalldt():
-    return dt.Frame([[i] for i in range(16)], names=list("ABCDEFGHIJKLMNOP"))
+    res = dt.Frame([[i] for i in range(16)], names=list("ABCDEFGHIJKLMNOP"))
+    assert res.ltypes == (ltype.bool, ltype.bool) + (ltype.int,) * 14
+    return res
 
 def test_del_0cols():
     d0 = smalldt()
@@ -236,6 +238,7 @@ def test_del_1col_str_1():
     assert d0.shape == (1, 15)
     assert d0.topython() == [[i] for i in range(1, 16)]
     assert d0.names == tuple("BCDEFGHIJKLMNOP")
+    assert len(d0.ltypes) == d0.ncols
 
 def test_del_1col_str_2():
     d0 = smalldt()


### PR DESCRIPTION
The actual bug fix is 1 line of code -- to clear the stypes+ltypes when deleting columns.

However, this PR also adds integrity checks for internal properties `.stypes`, `.ltypes`, `.names` and `.inames`, so that this kind of errors could be caught more easily in the future.

Closes #1248