### PR TITLE
Core Frame class improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 #### Changed
 - `names` argument in `Frame()` constructor can no longer be a string --
   use a list or tuple of strings instead.
+- `Frame.resize()` was removed -- same functionality is available via
+  assigning to `Frame.nrows`.
 
 #### Fixed
 - bug in dt.cbind() where the first Frame in the list was ignored.

--- a/c/frame/py_frame.cc
+++ b/c/frame/py_frame.cc
@@ -58,11 +58,11 @@ void Frame::m__release_buffer__(Py_buffer*) const {
 }
 
 oobj Frame::get_ncols() const {
-  return oobj(py::oInt(11));
+  return py::oInt(dt->ncols);
 }
 
 oobj Frame::get_nrows() const {
-  return oobj(py::oInt(47));
+  return py::oInt(dt->nrows);
 }
 
 

--- a/c/frame/py_frame.cc
+++ b/c/frame/py_frame.cc
@@ -16,7 +16,6 @@ namespace py {
 // Declare Frame's API
 //------------------------------------------------------------------------------
 
-NoArgs Frame::Type::args_bang;
 PKArgs Frame::Type::args___init__(1, 0, 3, false, false,
                                   {"src", "names", "stypes", "stype"});
 
@@ -34,7 +33,7 @@ const char* Frame::Type::classdoc() {
     "Internally the data is stored as C primitives, and processed using\n"
     "multithreaded native C++ code.\n"
     "\n"
-    "This is a primary data structure for datatable module.\n";
+    "This is a primary data structure for the `datatable` module.\n";
 }
 
 void Frame::Type::init_getsetters(GetSetters& gs) {
@@ -42,8 +41,8 @@ void Frame::Type::init_getsetters(GetSetters& gs) {
   gs.add<&Frame::get_nrows>("nrows");
 }
 
-void Frame::Type::init_methods(Methods& mm) {
-  mm.add<&Frame::bang, args_bang>("bang");
+void Frame::Type::init_methods(Methods&) {
+  // mm.add<&Frame::bang, args_bang>("bang");
 }
 
 
@@ -66,10 +65,6 @@ oobj Frame::get_nrows() const {
   return oobj(py::oInt(47));
 }
 
-oobj Frame::bang(NoArgs&) {
-  std::cout << "Yay, Frame::bang()!\n";
-  return None();
-}
 
 
 }  // namespace py

--- a/c/frame/py_frame.cc
+++ b/c/frame/py_frame.cc
@@ -94,9 +94,9 @@ void Frame::set_nrows(obj nr) {
     throw TypeError() << "Number of rows must be an integer, not "
         << nr.typeobj();
   }
-  int64_t new_nrows = nr.to_int64();
+  int64_t new_nrows = nr.to_int64_strict();
   if (new_nrows < 0) {
-    throw ValueError() << "Number of rows cannot be negative: " << new_nrows;
+    throw ValueError() << "Number of rows cannot be negative";
   }
   dt->resize_rows(new_nrows);
 }

--- a/c/frame/py_frame.h
+++ b/c/frame/py_frame.h
@@ -26,7 +26,6 @@ class Frame : public PyObject {
     class Type : public ExtType<Frame> {
       public:
         static PKArgs args___init__;
-        static NoArgs args_bang;
         static PKArgs args_test;
         static const char* classname();
         static const char* classdoc();
@@ -43,7 +42,6 @@ class Frame : public PyObject {
     oobj get_ncols() const;
     oobj get_nrows() const;
 
-    oobj bang(NoArgs&);
 };
 
 

--- a/c/frame/py_frame.h
+++ b/c/frame/py_frame.h
@@ -9,6 +9,7 @@
 #define dt_FRAME_PYFRAME_h
 #include "python/ext_type.h"
 #include "datatable.h"
+#include "py_datatable.h"
 
 namespace py {
 
@@ -22,6 +23,8 @@ class Frame : public PyObject {
   private:
     DataTable* dt;
 
+    pydatatable::obj* core_dt;  // TODO: remove
+
   public:
     class Type : public ExtType<Frame> {
       public:
@@ -29,6 +32,7 @@ class Frame : public PyObject {
         static PKArgs args_test;
         static const char* classname();
         static const char* classdoc();
+        static bool is_subclassable() { return true; }
 
         static void init_getsetters(GetSetters& gs);
         static void init_methods(Methods& gs);
@@ -41,6 +45,9 @@ class Frame : public PyObject {
 
     oobj get_ncols() const;
     oobj get_nrows() const;
+    oobj get_key() const;
+    oobj get_internal() const;
+    void set_internal(obj _dt);
 
 };
 

--- a/c/frame/py_frame.h
+++ b/c/frame/py_frame.h
@@ -45,6 +45,8 @@ class Frame : public PyObject {
 
     oobj get_ncols() const;
     oobj get_nrows() const;
+    void set_nrows(obj);
+    oobj get_shape() const;
     oobj get_key() const;
     oobj get_internal() const;
     void set_internal(obj _dt);

--- a/c/frame/py_frame_init.cc
+++ b/c/frame/py_frame_init.cc
@@ -21,9 +21,9 @@ static std::vector<std::string> _get_names(const Arg& arg) {
   if (arg.is_undefined() || arg.is_none()) {
     return std::vector<std::string>();
   }
-  if (arg.is_list() || arg.is_tuple()) {
-    return arg.to_list_of_strs();
-  }
+  // if (arg.is_list() || arg.is_tuple()) {
+  //   return arg.to_list_of_strs();
+  // }
   // TODO: also allow a single-column Frame of string type
   throw TypeError() << arg.name() << " must be a list/tuple of column names";
 }
@@ -36,21 +36,34 @@ static DataTable* _make_empty_frame() {
 }
 
 
+static DataTable* _make_frame_from_list(py::list list) {
+  if (list.size() == 0) {
+    return _make_empty_frame();
+  }
+  return nullptr;
+}
+
+
 
 //------------------------------------------------------------------------------
 // Main constructor
 //------------------------------------------------------------------------------
 
 void Frame::m__init__(PKArgs& args) {
-  const Arg& src = args[0];
-  const Arg& names_arg = args[1];
+  const Arg& src        = args[0];
+  const Arg& names_arg  = args[1];
+  const Arg& stypes_arg = args[2];
 
   // bool names_defined = !names_arg.is_undefined();
   auto names = _get_names(names_arg);
 
-  if (src.is_undefined() || src.is_none()) {
+  if (src.is_list_or_tuple()) {
+    dt = _make_frame_from_list(src.to_pylist());
+  }
+  else if (src.is_undefined() || src.is_none()) {
     dt = _make_empty_frame();
-  } else {
+  }
+  else {
     std::cout << "Creating a frame from ";
     src.print();
   }

--- a/c/frame/py_frame_init.cc
+++ b/c/frame/py_frame_init.cc
@@ -9,6 +9,7 @@
 #include <iostream>
 #include <string>
 #include <vector>
+#include "utils/alloc.h"
 
 namespace py {
 
@@ -16,6 +17,51 @@ namespace py {
 //------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
+
+// TODO: this functionality should really be rolled into the DataTable class.
+class DTMaker {
+  private:
+    std::vector<Column*> cols;
+
+  public:
+    ~DTMaker() {
+      for (auto col : cols) dt::free(col);
+    }
+
+    void push_back(Column* col) {
+      cols.push_back(col);
+      if (cols.size() > 1) {
+        int64_t nrows0 = cols.front()->nrows;
+        int64_t nrows1 = cols.back()->nrows;
+        if (nrows0 != nrows1) {
+          throw ValueError()
+            << "Column " << cols.size() - 1 << " has different number of "
+            << "rows (" << nrows1 << ") than the preceding columns ("
+            << nrows0 << ")";
+        }
+      }
+    }
+
+    DataTable* to_datatable() {
+      size_t ncols = cols.size();
+      size_t allocsize = sizeof(Column*) * (ncols + 1);
+      Column** newcols = dt::malloc<Column*>(allocsize);
+      if (ncols) {
+        std::memcpy(newcols, cols.data(), sizeof(Column*) * ncols);
+      }
+      newcols[ncols] = nullptr;
+      try {
+        DataTable* res = new DataTable(newcols);
+        cols.clear();
+        return res;
+      } catch (const std::exception&) {
+        dt::free(newcols);
+        throw;
+      }
+    }
+};
+
+
 
 static std::vector<std::string> _get_names(const Arg& arg) {
   if (arg.is_undefined() || arg.is_none()) {
@@ -29,18 +75,50 @@ static std::vector<std::string> _get_names(const Arg& arg) {
 }
 
 
-static DataTable* _make_empty_frame() {
-  Column** cols = new Column*[1];
-  cols[0] = nullptr;
-  return new DataTable(cols);
+static Column* _make_column_from_listlike(py::obj src) {
+  if (src.is_buffer()) {
+    return Column::from_buffer(src.to_borrowed_ref());
+  }
+  else if (src.is_list()) {
+    return Column::from_pylist(src.to_pylist().to_pyylist(), 0);
+  }
+  else if (src.is_range()) {
+    // return Column::from_range(src.to_range());
+  }
+  return nullptr;
+}
+
+
+static DataTable* _make_frame_from_list_of_listlike(py::list list) {
+  DTMaker dtm;
+  size_t ncols = list.size();
+  for (size_t i = 0; i < ncols; ++i) {
+    Column* col = _make_column_from_listlike(list[i]);
+    dtm.push_back(col);
+  }
+  return dtm.to_datatable();
 }
 
 
 static DataTable* _make_frame_from_list(py::list list) {
   if (list.size() == 0) {
-    return _make_empty_frame();
+    return DTMaker().to_datatable();
   }
-  return nullptr;
+  py::obj item0 = list[0];
+  if (item0.is_list() || item0.is_range()) {
+    return _make_frame_from_list_of_listlike(list);
+  }
+  // else if (item0.is_dict()) {
+  //   return _make_frame_from_list_of_dicts(list);
+  // }
+  // else if (item0.is_tuple()) {
+  //   return _make_frame_from_list_of_tuples(list);
+  // }
+  else {
+    DTMaker dtm;
+    dtm.push_back(_make_column_from_listlike(list));
+    return dtm.to_datatable();
+  }
 }
 
 
@@ -61,7 +139,7 @@ void Frame::m__init__(PKArgs& args) {
     dt = _make_frame_from_list(src.to_pylist());
   }
   else if (src.is_undefined() || src.is_none()) {
-    dt = _make_empty_frame();
+    dt = DTMaker().to_datatable();
   }
   else {
     std::cout << "Creating a frame from ";

--- a/c/frame/py_frame_init.cc
+++ b/c/frame/py_frame_init.cc
@@ -132,19 +132,22 @@ void Frame::m__init__(PKArgs& args) {
   const Arg& names_arg  = args[1];
   const Arg& stypes_arg = args[2];
 
-  // bool names_defined = !names_arg.is_undefined();
-  auto names = _get_names(names_arg);
+  dt = nullptr;
+  core_dt = nullptr;
 
-  if (src.is_list_or_tuple()) {
-    dt = _make_frame_from_list(src.to_pylist());
-  }
-  else if (src.is_undefined() || src.is_none()) {
-    dt = DTMaker().to_datatable();
-  }
-  else {
-    std::cout << "Creating a frame from ";
-    src.print();
-  }
+  // bool names_defined = !names_arg.is_undefined();
+  // auto names = _get_names(names_arg);
+
+  // if (src.is_list_or_tuple()) {
+  //   dt = _make_frame_from_list(src.to_pylist());
+  // }
+  // else if (src.is_undefined() || src.is_none()) {
+  //   dt = DTMaker().to_datatable();
+  // }
+  // else {
+  //   std::cout << "Creating a frame from ";
+  //   src.print();
+  // }
 }
 
 

--- a/c/py_datatable.cc
+++ b/c/py_datatable.cc
@@ -113,14 +113,6 @@ PyObject* open_jay(PyObject*, PyObject* args) {
 // PyDatatable getters/setters
 //==============================================================================
 
-PyObject* get_nrows(obj* self) {
-  return PyLong_FromLongLong(self->ref->nrows);
-}
-
-PyObject* get_ncols(obj* self) {
-  return PyLong_FromLongLong(self->ref->ncols);
-}
-
 PyObject* get_isview(obj* self) {
   DataTable* dt = self->ref;
   for (int64_t i = 0; i < dt->ncols; ++i) {
@@ -1113,8 +1105,6 @@ static PyMethodDef datatable_methods[] = {
 };
 
 static PyGetSetDef datatable_getseters[] = {
-  GETTER(nrows),
-  GETTER(ncols),
   GETTER(ltypes),
   GETTER(stypes),
   GETTER(names),

--- a/c/py_datatable.h
+++ b/c/py_datatable.h
@@ -67,14 +67,6 @@ DECLARE_DESTRUCTOR()
 //---- Getters/setters ---------------------------------------------------------
 
 DECLARE_GETTER(
-  nrows,
-  "Number of rows in the datatable")
-
-DECLARE_GETTER(
-  ncols,
-  "Number of columns in the datatable")
-
-DECLARE_GETTER(
   isview,
   "Is the datatable view or now?")
 

--- a/c/py_datatable.h
+++ b/c/py_datatable.h
@@ -302,7 +302,7 @@ DECLARE_METHOD(
   colindex,
   "colindex(self, name)\n"
   "--\n\n"
-  "Return index of the column ``name``.\n"
+  "Return index of the column ``name``\n"
   "\n"
   ":param name: name of the column to find the index for. This can also\n"
   "    be an index of a column, in which case the index is checked that\n"

--- a/c/python/arg.cc
+++ b/c/python/arg.cc
@@ -57,6 +57,7 @@ bool Arg::is_tuple()         const { return pyobj.is_tuple(); }
 bool Arg::is_list_or_tuple() const { return pyobj.is_list_or_tuple(); }
 bool Arg::is_dict()          const { return pyobj.is_dict(); }
 bool Arg::is_string()        const { return pyobj.is_string(); }
+bool Arg::is_range()         const { return pyobj.is_range(); }
 
 
 

--- a/c/python/arg.h
+++ b/c/python/arg.h
@@ -48,6 +48,7 @@ class Arg : public _obj::error_manager {
     bool is_list_or_tuple() const;
     bool is_dict() const;
     bool is_string() const;
+    bool is_range() const;
 
     //---- Type conversions ------------
     py::list    to_pylist        () const;

--- a/c/python/arg.h
+++ b/c/python/arg.h
@@ -10,6 +10,7 @@
 #include <string>     // std::string
 #include <vector>     // std::vector
 #include <Python.h>
+#include "python/obj.h"
 #include "python/list.h"
 
 namespace py {
@@ -22,15 +23,17 @@ class PKArgs;
  * a value for this argument in the function/method call. This state can be
  * checked with the `is_undefined()` method.
  */
-class Arg {
+class Arg : public _obj::error_manager {
   private:
     size_t pos;
     PKArgs* parent;
-    PyObject* pyobj;
+    py::obj pyobj;
     mutable std::string cached_name;
 
   public:
     Arg();
+    Arg(const Arg&) = default;
+    virtual ~Arg();
     void init(size_t i, PKArgs* args);
     void set(PyObject* value);
 
@@ -42,11 +45,19 @@ class Arg {
     bool is_float() const;
     bool is_list() const;
     bool is_tuple() const;
+    bool is_list_or_tuple() const;
     bool is_dict() const;
     bool is_string() const;
 
+    //---- Type conversions ------------
+    py::list    to_pylist        () const;
+
+
+    //---- Error messages --------------
+    virtual Error error_not_list       (PyObject*) const;
+
     // ?
-    PyObject* obj() { return pyobj; }
+    PyObject* obj() { return pyobj.to_pyobject_newref(); }
     void print() const;
 
     /**
@@ -55,14 +66,14 @@ class Arg {
      * too large.
      * This method must not be called if the argument is undefined.
      */
-    operator int32_t() const;
-    operator int64_t() const;
+    // operator int32_t() const;
+    // operator int64_t() const;
 
     /**
      * Convert argument to different list objects.
      */
-    operator list() const;
-    std::vector<std::string> to_list_of_strs() const;
+    // operator list() const;
+    // std::vector<std::string> to_list_of_strs() const;
 
     const std::string& name() const;
 

--- a/c/python/args.cc
+++ b/c/python/args.cc
@@ -79,16 +79,16 @@ PKArgs::PKArgs(
   )
   : n_posonly_args(npo),
     n_pos_kwd_args(npk),
-    n_kwdonly_args(nko),
-    n_args(npo + npk + nko),
+    n_all_args(npo + npk + nko),
     has_varargs(vargs),
     has_varkwds(vkwds),
-    arg_names(_names)
+    arg_names(_names),
+    n_varkwds(0)
 {
-  xassert(n_args == arg_names.size());
+  xassert(n_all_args == arg_names.size());
   if (has_varargs) xassert(n_pos_kwd_args == 0);
-  bound_args.resize(n_args);
-  for (size_t i = 0; i < n_args; ++i) {
+  bound_args.resize(n_all_args);
+  for (size_t i = 0; i < n_all_args; ++i) {
     bound_args[i].init(i, this);
   }
 }
@@ -99,19 +99,42 @@ void PKArgs::bind(PyObject* _args, PyObject* _kwds)
   size_t nargs = _args? static_cast<size_t>(Py_SIZE(_args)) : 0;
   // size_t nkwds = _kwds? static_cast<size_t>(PyDict_Size(_kwds)) : 0;
 
+  size_t max_pos_args = n_posonly_args + n_pos_kwd_args;
+  size_t n_bound_args = std::min(nargs, max_pos_args);
+  n_varargs = nargs - n_bound_args;
+  if (n_varargs && !has_varargs) {
+    auto err = TypeError() << get_name();
+    if (max_pos_args == 0) {
+      err << " takes no positional arguments";
+    } else if (max_pos_args == 1) {
+      err << " takes only one positional argument";
+    } else {
+      err << " takes at most " << max_pos_args << " positional arguments";
+    }
+    err << ", but " << nargs << (nargs == 1? " was given" : " were given");
+    throw err;
+  }
+
   size_t i = 0;
-  for (; i < nargs; ++i) {
+  for (; i < n_bound_args; ++i) {
     bound_args[i].set(PyTuple_GET_ITEM(_args, i));
   }
-  for (; i < n_args; ++i) {
+  for (; i < n_all_args; ++i) {
     bound_args[i].set(nullptr);
   }
 
   if (_kwds) {
     PyObject* key, *value;
     Py_ssize_t pos = 0;
+    n_varkwds = 0;
     while (PyDict_Next(_kwds, &pos, &key, &value)) {
       size_t ikey = _find_kwd(key);
+      if (ikey == size_t(-1)) {
+        n_varkwds++;
+        if (has_varkwds) continue;
+        throw TypeError() << get_name() << " got an unexpected keyword "
+          "argument `" << PyUnicode_AsUTF8(key) << '`';
+      }
       if (ikey < nargs) {
         throw TypeError() << get_name() << " got multiple values for argument `"
             << PyUnicode_AsUTF8(key) << '`';
@@ -119,7 +142,8 @@ void PKArgs::bind(PyObject* _args, PyObject* _kwds)
       bound_args[ikey].set(value);
     }
   }
-
+  kwds_dict = _kwds;
+  args_tuple = _args;
 }
 
 
@@ -160,8 +184,7 @@ size_t PKArgs::_find_kwd(PyObject* kwd) {
       ++i;
     }
   }
-  throw TypeError() << get_name() << " got an unexpected keyword argument `"
-      << PyUnicode_AsUTF8(kwd)<< '`';
+  return size_t(-1);
 }
 
 
@@ -170,7 +193,113 @@ const Arg& PKArgs::operator[](size_t i) const {
   return bound_args[i];
 }
 
+size_t PKArgs::num_vararg_args() const noexcept {
+  return n_varargs;
+}
 
+size_t PKArgs::num_varkwd_args() const noexcept {
+  return n_varkwds;
+}
+
+VarKwdsIterable PKArgs::varkwds() const noexcept {
+  return VarKwdsIterable(*this);
+}
+
+VarArgsIterable PKArgs::varargs() const noexcept {
+  return VarArgsIterable(*this);
+}
+
+
+
+//------------------------------------------------------------------------------
+// Helper iterator classes
+//------------------------------------------------------------------------------
+
+VarKwdsIterable::VarKwdsIterable(const PKArgs& args)
+    : parent(args) {}
+
+VarKwdsIterator VarKwdsIterable::begin() const {
+  return VarKwdsIterator(parent, 0);
+}
+
+VarKwdsIterator VarKwdsIterable::end() const {
+  return VarKwdsIterator(parent, -1);
+}
+
+
+VarArgsIterable::VarArgsIterable(const PKArgs& args)
+    : parent(args) {}
+
+VarArgsIterator VarArgsIterable::begin() const {
+  size_t i0 = parent.n_posonly_args;
+  return VarArgsIterator(parent, i0);
+}
+
+VarArgsIterator VarArgsIterable::end() const {
+  size_t i1 = parent.n_posonly_args + parent.n_varargs;
+  return VarArgsIterator(parent, i1);
+}
+
+
+
+VarKwdsIterator::VarKwdsIterator(const PKArgs& args, Py_ssize_t i0)
+    : parent(args), pos(i0), curr_value(std::string(), py::obj(nullptr))
+{
+  advance();
+}
+
+VarKwdsIterator& VarKwdsIterator::operator++() {
+  advance();
+  return *this;
+}
+
+VarKwdsIterator::value_type VarKwdsIterator::operator*() const {
+  return curr_value;
+}
+
+bool VarKwdsIterator::operator==(const VarKwdsIterator& other) const {
+  return (pos == other.pos);
+}
+
+bool VarKwdsIterator::operator!=(const VarKwdsIterator& other) const {
+  return (pos != other.pos);
+}
+
+void VarKwdsIterator::advance() {
+  if (pos == -1) return;
+  PyObject *key, *value;
+  while (PyDict_Next(parent.kwds_dict, &pos, &key, &value)) {
+    if (parent.kwd_map.count(key) == 0) {
+      curr_value = value_type(py::obj(key).to_string(),
+                              py::obj(value));
+      return;
+    }
+  }
+  pos = -1;
+}
+
+
+
+VarArgsIterator::VarArgsIterator(const PKArgs& args, size_t i0)
+    : parent(args), pos(i0) {}
+
+VarArgsIterator& VarArgsIterator::operator++() {
+  ++pos;
+  return *this;
+}
+
+py::obj VarArgsIterator::operator*() const {
+  PyObject* tup = parent.args_tuple;
+  return py::obj(PyTuple_GET_ITEM(tup, static_cast<Py_ssize_t>(pos)));
+}
+
+bool VarArgsIterator::operator==(const VarArgsIterator& other) const {
+  return (pos == other.pos);
+}
+
+bool VarArgsIterator::operator!=(const VarArgsIterator& other) const {
+  return (pos != other.pos);
+}
 
 
 }  // namespace py

--- a/c/python/ext_type.h
+++ b/c/python/ext_type.h
@@ -458,11 +458,11 @@ void ExtType<T>::init(PyObject* module) {
 //---- GetSetters ----
 
 template <class T>
-template <oobj (T::*f)() const>
+template <oobj (T::*gg)() const>
 void ExtType<T>::GetSetters::add(const char* name, const char* doc) {
   defs.push_back(PyGetSetDef {
     const_cast<char*>(name),
-    &_impl::_safe_getter<T, f>,
+    &_impl::_safe_getter<T, gg>,
     nullptr,
     const_cast<char*>(doc),
     nullptr  // closure
@@ -470,12 +470,12 @@ void ExtType<T>::GetSetters::add(const char* name, const char* doc) {
 }
 
 template <class T>
-template <oobj (T::*getter)() const, void (T::*setter)(obj)>
+template <oobj (T::*gg)() const, void (T::*ss)(obj)>
 void ExtType<T>::GetSetters::add(const char* name, const char* doc) {
   defs.push_back(PyGetSetDef {
     const_cast<char*>(name),
-    &_impl::_safe_getter<T, getter>,
-    &_impl::_safe_setter<T, setter>,
+    &_impl::_safe_getter<T, gg>,
+    &_impl::_safe_setter<T, ss>,
     const_cast<char*>(doc),
     nullptr  // closure
   });

--- a/c/python/obj.cc
+++ b/c/python/obj.cc
@@ -33,6 +33,10 @@ obj::obj(const obj& other) {
   v = other.v;
 }
 
+obj::obj(const oobj& other) {
+  v = other.v;
+}
+
 obj& obj::operator=(const obj& other) {
   v = other.v;
   return *this;
@@ -116,6 +120,7 @@ bool _obj::is_list() const     { return v && PyList_Check(v); }
 bool _obj::is_tuple() const    { return v && PyTuple_Check(v); }
 bool _obj::is_dict() const     { return v && PyDict_Check(v); }
 bool _obj::is_buffer() const   { return v && PyObject_CheckBuffer(v); }
+bool _obj::is_range() const    { return v && PyRange_Check(v); }
 bool _obj::is_list_or_tuple() const {
   return v && (PyList_Check(v) || PyTuple_Check(v));
 }

--- a/c/python/obj.cc
+++ b/c/python/obj.cc
@@ -102,19 +102,23 @@ oobj::~oobj() {
 // Type checks
 //------------------------------------------------------------------------------
 
+bool _obj::is_undefined() const{ return (v == nullptr);}
 bool _obj::is_none() const     { return (v == Py_None); }
 bool _obj::is_ellipsis() const { return (v == Py_Ellipsis); }
 bool _obj::is_true() const     { return (v == Py_True); }
 bool _obj::is_false() const    { return (v == Py_False); }
 bool _obj::is_bool() const     { return is_true() || is_false(); }
-bool _obj::is_int() const      { return PyLong_Check(v) && !is_bool(); }
-bool _obj::is_float() const    { return PyFloat_Check(v); }
-bool _obj::is_numeric() const  { return is_float() || is_int(); }
-bool _obj::is_string() const   { return PyUnicode_Check(v); }
-bool _obj::is_list() const     { return PyList_Check(v); }
-bool _obj::is_tuple() const    { return PyTuple_Check(v); }
-bool _obj::is_dict() const     { return PyDict_Check(v); }
-bool _obj::is_buffer() const   { return PyObject_CheckBuffer(v); }
+bool _obj::is_int() const      { return v && PyLong_Check(v) && !is_bool(); }
+bool _obj::is_float() const    { return v && PyFloat_Check(v); }
+bool _obj::is_numeric() const  { return v && (is_float() || is_int()); }
+bool _obj::is_string() const   { return v && PyUnicode_Check(v); }
+bool _obj::is_list() const     { return v && PyList_Check(v); }
+bool _obj::is_tuple() const    { return v && PyTuple_Check(v); }
+bool _obj::is_dict() const     { return v && PyDict_Check(v); }
+bool _obj::is_buffer() const   { return v && PyObject_CheckBuffer(v); }
+bool _obj::is_list_or_tuple() const {
+  return v && (PyList_Check(v) || PyTuple_Check(v));
+}
 
 
 

--- a/c/python/obj.h
+++ b/c/python/obj.h
@@ -19,6 +19,7 @@ class Groupby;
 class RowIndex;
 
 namespace py {
+class Arg;
 class Int;
 class oInt;
 class Float;
@@ -124,6 +125,7 @@ class _obj {
     oobj invoke(const char* fn, const char* format, ...) const;
     PyTypeObject* typeobj() const noexcept;  // borrowed ref
 
+    bool is_undefined() const;
     bool is_none() const;
     bool is_ellipsis() const;
     bool is_true() const;
@@ -135,6 +137,7 @@ class _obj {
     bool is_string() const;
     bool is_list() const;
     bool is_tuple() const;
+    bool is_list_or_tuple() const;
     bool is_dict() const;
     bool is_buffer() const;
 
@@ -174,6 +177,8 @@ class _obj {
      * instance.
      */
     struct error_manager {
+      error_manager() = default;
+      error_manager(const error_manager&) = default;
       virtual ~error_manager() {}
       virtual Error error_not_boolean    (PyObject*) const;
       virtual Error error_not_integer    (PyObject*) const;
@@ -195,6 +200,7 @@ class _obj {
     _obj() = default;
 
     friend oobj;
+    friend Arg;
 };
 
 

--- a/c/python/obj.h
+++ b/c/python/obj.h
@@ -140,6 +140,7 @@ class _obj {
     bool is_list_or_tuple() const;
     bool is_dict() const;
     bool is_buffer() const;
+    bool is_range() const;
 
     int8_t      to_bool          (const error_manager& = _em0) const;
     int8_t      to_bool_strict   (const error_manager& = _em0) const;
@@ -199,6 +200,7 @@ class _obj {
     // `oobj` objects instead.
     _obj() = default;
 
+    friend obj;
     friend oobj;
     friend Arg;
 };
@@ -209,6 +211,7 @@ class obj : public _obj {
   public:
     obj(PyObject* p);
     obj(const obj&);
+    obj(const oobj&);
     obj& operator=(const obj&);
 
     PyObject* to_borrowed_ref() const { return v; }
@@ -232,7 +235,6 @@ class oobj : public _obj {
 
     static oobj from_new_reference(PyObject* p);
     PyObject* release();
-
 };
 
 

--- a/c/python/obj.h
+++ b/c/python/obj.h
@@ -170,6 +170,7 @@ class _obj {
     DataTable*  to_frame         (const error_manager& = _em0) const;
 
     PyObject*   to_pyobject_newref() const noexcept;
+    PyObject*   to_borrowed_ref() const { return v; }
 
   protected:
     /**
@@ -213,8 +214,6 @@ class obj : public _obj {
     obj(const obj&);
     obj(const oobj&);
     obj& operator=(const obj&);
-
-    PyObject* to_borrowed_ref() const { return v; }
 };
 
 

--- a/c/python/tuple.cc
+++ b/c/python/tuple.cc
@@ -1,0 +1,35 @@
+//------------------------------------------------------------------------------
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// © H2O.ai 2018
+//------------------------------------------------------------------------------
+#include "python/tuple.h"
+
+namespace py {
+
+
+otuple::otuple(size_t n) {
+  v = PyTuple_New(static_cast<Py_ssize_t>(n));
+}
+
+otuple::otuple(int64_t n) {
+  v = PyTuple_New(static_cast<Py_ssize_t>(n));
+}
+
+
+size_t otuple::size() const {
+  return static_cast<size_t>(Py_SIZE(v));
+}
+
+void otuple::set(size_t i, const _obj& value) {
+  PyTuple_SET_ITEM(v, i, value.to_pyobject_newref());
+}
+
+void otuple::set(size_t i, oobj&& value) {
+  PyTuple_SET_ITEM(v, i, value.release());
+}
+
+
+}  // namespace py

--- a/c/python/tuple.cc
+++ b/c/python/tuple.cc
@@ -10,12 +10,12 @@
 namespace py {
 
 
-otuple::otuple(size_t n) {
-  v = PyTuple_New(static_cast<Py_ssize_t>(n));
-}
+otuple::otuple(int n) : otuple(static_cast<int64_t>(n)) {}
+
+otuple::otuple(size_t n) : otuple(static_cast<int64_t>(n)) {}
 
 otuple::otuple(int64_t n) {
-  v = PyTuple_New(static_cast<Py_ssize_t>(n));
+  v = PyTuple_New(n);
 }
 
 

--- a/c/python/tuple.h
+++ b/c/python/tuple.h
@@ -1,0 +1,30 @@
+//------------------------------------------------------------------------------
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// © H2O.ai 2018
+//------------------------------------------------------------------------------
+#ifndef dt_PYTHON_TUPLE_h
+#define dt_PYTHON_TUPLE_h
+#include <Python.h>
+#include "python/obj.h"
+
+namespace py {
+
+
+class otuple : public oobj {
+  public:
+    using oobj::oobj;
+    otuple(size_t n);
+    otuple(int64_t n);
+
+    size_t size() const;
+    void set(size_t i, const _obj& value);
+    void set(size_t i, oobj&& value);
+};
+
+
+}  // namespace py
+
+#endif

--- a/c/python/tuple.h
+++ b/c/python/tuple.h
@@ -16,6 +16,7 @@ namespace py {
 class otuple : public oobj {
   public:
     using oobj::oobj;
+    otuple(int n);
     otuple(size_t n);
     otuple(int64_t n);
 

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -59,25 +59,10 @@ class Frame(core.Frame):
     #---------------------------------------------------------------------------
 
     @property
-    def nrows(self):
-        """Number of rows in the frame."""
-        return self._dt.nrows
-
-    @property
-    def ncols(self):
-        """Number of columns in the frame."""
-        return self._dt.ncols
-
-    @property
     def key(self):
         """Tuple of column names that comprise the Frame's key. If the Frame
         is not keyed, this will return an empty tuple."""
         return self._dt.names[:self._dt.nkeys]
-
-    @property
-    def shape(self):
-        """Tuple (number of rows, number of columns)."""
-        return (self._dt.nrows, self._dt.ncols)
 
     @property
     def names(self):
@@ -94,19 +79,10 @@ class Frame(core.Frame):
         """Tuple of column storage types."""
         return self._dt.stypes
 
-    @property
-    def internal(self):
-        """Access to the internal C DataTable object."""
-        return self._dt
-
 
     #---------------------------------------------------------------------------
     # Property setters
     #---------------------------------------------------------------------------
-
-    @nrows.setter
-    def nrows(self, n):
-        self.resize(n)
 
     @key.setter
     def key(self, colnames):

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -29,7 +29,7 @@ __all__ = ("Frame", )
 
 
 
-class Frame(object):
+class Frame(core.Frame):
     """
     Two-dimensional column-oriented table of data. Each column has its own name
     and type. Types may vary across columns (unlike in a Numpy array) but cannot
@@ -40,9 +40,9 @@ class Frame(object):
 
     This is a primary data structure for datatable module.
     """
-    __slots__ = ["_dt"]
 
     def __init__(self, src=None, names=None, stypes=None, **kwargs):
+        super().__init__()
         if "stype" in kwargs:
             stypes = [kwargs.pop("stype")]
         if kwargs:
@@ -50,7 +50,7 @@ class Frame(object):
                 src = kwargs
             else:
                 dtwarn("Unknown options %r to Frame()" % kwargs)
-        self._dt = None      # type: core.DataTable
+        # self._dt = None      # type: core.DataTable
         self._fill_from_source(src, names=names, stypes=stypes)
 
 

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -526,15 +526,6 @@ class Frame(core.Frame):
         _dt = cs.to_datatable()
         return Frame(_dt, names=self.names)
 
-    @typed(nrows=int)
-    def resize(self, nrows):
-        # TODO: support multiple modes of resizing:
-        #   - fill with NAs
-        #   - tile existing values
-        if nrows < 0:
-            raise TValueError("Cannot resize to %d rows" % nrows)
-        self._dt.resize_rows(nrows)
-
 
     #---------------------------------------------------------------------------
     # Stats

--- a/datatable/graph/__init__.py
+++ b/datatable/graph/__init__.py
@@ -104,9 +104,10 @@ def make_datatable(dt, rows, select, groupby=None, join=None, sort=None,
 
         colsnode.execute()
         res_dt = ee.columns.to_datatable()
+        res_dt = datatable.Frame(res_dt, names=colsnode.column_names)
         if grbynode and res_dt.nrows == dt.nrows:
-            res_dt.groupby = ee.groupby
-        return datatable.Frame(res_dt, names=colsnode.column_names)
+            res_dt.internal.groupby = ee.groupby
+        return res_dt
 
     raise RuntimeError("Unable to calculate the result")  # pragma: no cover
 

--- a/datatable/graph/__init__.py
+++ b/datatable/graph/__init__.py
@@ -85,7 +85,7 @@ def make_datatable(dt, rows, select, groupby=None, join=None, sort=None,
                 if isinstance(replacement, (int, float, str, type(None))):
                     replacement = datatable.Frame([replacement])
                     if allrows:
-                        replacement.resize(dt.nrows)
+                        replacement.nrows = dt.nrows
                 elif isinstance(replacement, datatable.Frame):
                     pass
                 elif isinstance(replacement, BaseExpr):

--- a/datatable/graph/rows_node.py
+++ b/datatable/graph/rows_node.py
@@ -104,7 +104,7 @@ class RFNode:
 
         ri_final = ri_source
         if self._inverse:
-            ri_final = ri_final.inverse(_dt.nrows)
+            ri_final = ri_final.inverse(self._engine.dt.nrows)
         if ri_target:
             ri_final = ri_final.uplift(ri_target)
         return ri_final

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -549,10 +549,19 @@ def test_resize_view_array():
 
 def test_resize_bad():
     f0 = dt.Frame(range(10))
-    with pytest.raises(ValueError):
+
+    with pytest.raises(ValueError) as e:
         f0.nrows = -3
-    with pytest.raises(TypeError):
+    assert "Number of rows cannot be negative" in str(e.value)
+
+    with pytest.raises(ValueError) as e:
+        f0.nrows = 10**100
+    assert "Value is too large" in str(e.value)
+
+    with pytest.raises(TypeError) as e:
         f0.nrows = (10, 2)
+    assert ("Number of rows must be an integer, not <class 'tuple'>"
+            in str(e.value))
 
 
 

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -464,7 +464,7 @@ def test_del_rows_from_view2():
 def test_resize_rows_api():
     f0 = dt.Frame([20])
     f0.nrows = 3
-    f0.resize(5)
+    f0.nrows = 5
     assert f0.topython() == [[20, 20, 20, None, None]]
 
 

--- a/tests/test_dt_create.py
+++ b/tests/test_dt_create.py
@@ -127,10 +127,10 @@ def test_create_from_frame():
     # Now check that d1 is a true copy of d0, rather than reference
     del d1["C"]
     d1.nrows = 10
-    assert d1.nrows == d1.internal.nrows == 10
-    assert d1.ncols == d1.internal.ncols == 2
-    assert d0.nrows == d0.internal.nrows == 3
-    assert d0.ncols == d0.internal.ncols == 3
+    assert d1.nrows == 10
+    assert d1.ncols == 2
+    assert d0.nrows == 3
+    assert d0.ncols == 3
 
 
 def test_create_from_string():

--- a/tests/test_dt_options.py
+++ b/tests/test_dt_options.py
@@ -134,11 +134,11 @@ def test_core_logger():
     f0 = dt.Frame([1, 2, 3])
     assert f0.shape == (3, 1)
     f0.internal.check()
-    assert "call DataTable.datatable_from_list(...)" in ml.messages
-    assert "call DataTable.ncols" in ml.messages
-    assert "call DataTable.nrows" in ml.messages
-    assert "call DataTable.check(...)" in ml.messages
-    assert "done DataTable.check(...) in" in ml.messages
+    # assert "call DataTable.datatable_from_list(...)" in ml.messages
+    # assert "call DataTable.ncols" in ml.messages
+    # assert "call DataTable.nrows" in ml.messages
+    # assert "call DataTable.check(...)" in ml.messages
+    # assert "done DataTable.check(...) in" in ml.messages
     del dt.options.core_logger
     assert dt.options.core_logger is None
 


### PR DESCRIPTION
* Added `varargs` and `varkwds` iterators to `PKArgs` class;
* Implement getters/setters for core `Frame` class properties `.nrows`, `.ncols` and `.shape`;
* Python `Frame` class now inherits from core `Frame` class, allowing incremental transition for #1066;
* Removed from python `Frame` properties `.nrows`, `.ncols` and `.shape` since they are now inherited;
* Small improvements to `py::obj` class;
* The `Args` class now better integrates with `py::obj`;
* Added `py::otuple` class for easier tuple creation.