### PR TITLE
core.Frame name-related functionality improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   use a list or tuple of strings instead.
 - `Frame.resize()` was removed -- same functionality is available via
   assigning to `Frame.nrows`.
+- `Frame.rename()` was removed -- .name setter can be used instead.
 
 #### Fixed
 - bug in dt.cbind() where the first Frame in the list was ignored.

--- a/c/frame/py_frame.cc
+++ b/c/frame/py_frame.cc
@@ -52,7 +52,9 @@ void Frame::Type::init_getsetters(GetSetters& gs)
   gs.add<&Frame::get_shape>("shape",
     "Tuple with (nrows, ncols) dimensions of the Frame\n");
   gs.add<&Frame::get_stypes>("stypes",
-    "The tuple of stypes (\"storage type\") for each column\n");
+    "The tuple of each column's stypes (\"storage types\")\n");
+  gs.add<&Frame::get_ltypes>("ltypes",
+    "The tuple of each column's ltypes (\"logical types\")\n");
   gs.add<&Frame::get_key>("key");
   gs.add<&Frame::get_internal>("internal", "[DEPRECATED]");
   gs.add<&Frame::get_internal, &Frame::set_internal>("_dt");
@@ -67,6 +69,7 @@ void Frame::Type::init_methods(Methods&) {
 void Frame::m__dealloc__() {
   Py_XDECREF(core_dt);
   Py_XDECREF(stypes);
+  Py_XDECREF(ltypes);
   // `dt` is already managed by `core_dt`.
   // delete dt;
   dt = nullptr;
@@ -123,6 +126,19 @@ oobj Frame::get_stypes() const {
     stypes = ostypes.release();
   }
   return oobj(stypes);
+}
+
+
+oobj Frame::get_ltypes() const {
+  if (ltypes == nullptr) {
+    py::otuple oltypes(dt->ncols);
+    for (size_t i = 0; i < oltypes.size(); ++i) {
+      SType st = dt->columns[i]->stype();
+      oltypes.set(i, info(st).py_ltype());
+    }
+    ltypes = oltypes.release();
+  }
+  return oobj(ltypes);
 }
 
 

--- a/c/frame/py_frame.cc
+++ b/c/frame/py_frame.cc
@@ -63,7 +63,28 @@ void Frame::Type::init_getsetters(GetSetters& gs)
     "The tuple of each column's ltypes (\"logical types\")\n");
 
   gs.add<&Frame::get_names, &Frame::set_names>("names",
-    "Tuple of column names\n");
+    "Tuple of column names.\n"
+    "\n"
+    "You can rename the Frame's columns by assigning a new list/tuple of\n"
+    "names to this property. The length of the new list of names must be\n"
+    "the same as the number of columns in the Frame.\n"
+    "\n"
+    "It is also possible to rename just a few columns by assigning a\n"
+    "dictionary ``{oldname: newname, ...}``. Any column not listed in the\n"
+    "dictionary will retain its name.\n"
+    "\n"
+    "Examples\n"
+    "--------\n"
+    ">>> d0 = dt.Frame([[1], [2], [3]])\n"
+    ">>> d0.names = ['A', 'B', 'C']\n"
+    ">>> d0.names\n"
+    "('A', 'B', 'C')\n"
+    ">>> d0.names = {'B': 'middle'}\n"
+    ">>> d0.names\n"
+    "('A', 'middle', 'C')\n"
+    ">>> del d0.names\n"
+    ">>> d0.names\n"
+    "('C0', 'C1', 'C2')");
 
   gs.add<&Frame::get_key>("key");
   gs.add<&Frame::get_internal>("internal", "[DEPRECATED]");

--- a/c/frame/py_frame.h
+++ b/c/frame/py_frame.h
@@ -29,6 +29,7 @@ class Frame : public PyObject {
   private:
     DataTable* dt;
     mutable PyObject* stypes;  // memoized tuple of stypes
+    mutable PyObject* ltypes;  // memoized tuple of ltypes
 
     pydatatable::obj* core_dt;  // TODO: remove
 
@@ -52,11 +53,12 @@ class Frame : public PyObject {
 
     oobj get_ncols() const;
     oobj get_nrows() const;
-    void set_nrows(obj);
     oobj get_shape() const;
     oobj get_stypes() const;
+    oobj get_ltypes() const;
     oobj get_key() const;
     oobj get_internal() const;
+    void set_nrows(obj);
     void set_internal(obj _dt);
 
     friend void pydatatable::_clear_types(pydatatable::obj*); // temp

--- a/c/frame/py_frame.h
+++ b/c/frame/py_frame.h
@@ -73,6 +73,7 @@ class Frame : public PyObject {
     void _init_inames() const;
     void _fill_default_names();
     void _dedup_and_save_names(py::list);
+    void _replace_names_from_map(py::odict);
 
     friend void pydatatable::_clear_types(pydatatable::obj*); // temp
     friend PyObject* pydatatable::check(pydatatable::obj*, PyObject*); // temp

--- a/c/frame/py_frame.h
+++ b/c/frame/py_frame.h
@@ -11,6 +11,12 @@
 #include "datatable.h"
 #include "py_datatable.h"
 
+namespace pydatatable {  // temp
+  void _clear_types(obj*);
+  PyObject* check(obj*, PyObject*);
+}
+
+
 namespace py {
 
 
@@ -22,6 +28,7 @@ namespace py {
 class Frame : public PyObject {
   private:
     DataTable* dt;
+    mutable PyObject* stypes;  // memoized tuple of stypes
 
     pydatatable::obj* core_dt;  // TODO: remove
 
@@ -47,10 +54,13 @@ class Frame : public PyObject {
     oobj get_nrows() const;
     void set_nrows(obj);
     oobj get_shape() const;
+    oobj get_stypes() const;
     oobj get_key() const;
     oobj get_internal() const;
     void set_internal(obj _dt);
 
+    friend void pydatatable::_clear_types(pydatatable::obj*); // temp
+    friend PyObject* pydatatable::check(pydatatable::obj*, PyObject*); // temp
 };
 
 

--- a/c/frame/py_frame.h
+++ b/c/frame/py_frame.h
@@ -21,15 +21,17 @@ namespace py {
 
 
 /**
- * [WIP]
- * This class is exposed to python via `datatable.lib.core.Frame`, but it is
- * not directly usable yet.
+ * This class currently serves as a base for datatable.Frame, but eventually
+ * all functionality will be moved here, and this class will be the main
+ * user-facing Frame class.
  */
 class Frame : public PyObject {
   private:
     DataTable* dt;
     mutable PyObject* stypes;  // memoized tuple of stypes
     mutable PyObject* ltypes;  // memoized tuple of ltypes
+    mutable PyObject* names;   // memoized tuple of column names
+    mutable PyObject* inames;  // memoized dict of {column name: index}
 
     pydatatable::obj* core_dt;  // TODO: remove
 
@@ -37,7 +39,7 @@ class Frame : public PyObject {
     class Type : public ExtType<Frame> {
       public:
         static PKArgs args___init__;
-        static PKArgs args_test;
+        static PKArgs args_colindex;
         static const char* classname();
         static const char* classdoc();
         static bool is_subclassable() { return true; }
@@ -56,10 +58,21 @@ class Frame : public PyObject {
     oobj get_shape() const;
     oobj get_stypes() const;
     oobj get_ltypes() const;
+    oobj get_names() const;
     oobj get_key() const;
     oobj get_internal() const;
     void set_nrows(obj);
-    void set_internal(obj _dt);
+    void set_names(obj);
+    void set_internal(obj);
+
+    oobj colindex(PKArgs&);
+
+  private:
+    void _clear_names();
+    void _init_names() const;
+    void _init_inames() const;
+    void _fill_default_names();
+    void _dedup_and_save_names(py::list);
 
     friend void pydatatable::_clear_types(pydatatable::obj*); // temp
     friend PyObject* pydatatable::check(pydatatable::obj*, PyObject*); // temp

--- a/c/frame/py_frame_init.cc
+++ b/c/frame/py_frame_init.cc
@@ -62,7 +62,7 @@ class DTMaker {
 };
 
 
-
+/*
 static std::vector<std::string> _get_names(const Arg& arg) {
   if (arg.is_undefined() || arg.is_none()) {
     return std::vector<std::string>();
@@ -73,6 +73,7 @@ static std::vector<std::string> _get_names(const Arg& arg) {
   // TODO: also allow a single-column Frame of string type
   throw TypeError() << arg.name() << " must be a list/tuple of column names";
 }
+*/
 
 
 static Column* _make_column_from_listlike(py::obj src) {
@@ -127,10 +128,10 @@ static DataTable* _make_frame_from_list(py::list list) {
 // Main constructor
 //------------------------------------------------------------------------------
 
-void Frame::m__init__(PKArgs& args) {
-  const Arg& src        = args[0];
-  const Arg& names_arg  = args[1];
-  const Arg& stypes_arg = args[2];
+void Frame::m__init__(PKArgs&) {
+  // const Arg& src        = args[0];
+  // const Arg& names_arg  = args[1];
+  // const Arg& stypes_arg = args[2];
 
   dt = nullptr;
   core_dt = nullptr;

--- a/c/frame/py_frame_init.cc
+++ b/c/frame/py_frame_init.cc
@@ -136,6 +136,7 @@ void Frame::m__init__(PKArgs&) {
   dt = nullptr;
   core_dt = nullptr;
   stypes = nullptr;
+  ltypes = nullptr;
 
   // bool names_defined = !names_arg.is_undefined();
   // auto names = _get_names(names_arg);

--- a/c/frame/py_frame_init.cc
+++ b/c/frame/py_frame_init.cc
@@ -135,6 +135,7 @@ void Frame::m__init__(PKArgs&) {
 
   dt = nullptr;
   core_dt = nullptr;
+  stypes = nullptr;
 
   // bool names_defined = !names_arg.is_undefined();
   // auto names = _get_names(names_arg);

--- a/c/frame/py_frame_init.cc
+++ b/c/frame/py_frame_init.cc
@@ -137,6 +137,8 @@ void Frame::m__init__(PKArgs&) {
   core_dt = nullptr;
   stypes = nullptr;
   ltypes = nullptr;
+  names = nullptr;
+  inames = nullptr;
 
   // bool names_defined = !names_arg.is_undefined();
   // auto names = _get_names(names_arg);

--- a/c/frame/py_frame_names.cc
+++ b/c/frame/py_frame_names.cc
@@ -1,0 +1,311 @@
+//------------------------------------------------------------------------------
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// © H2O.ai 2018
+//------------------------------------------------------------------------------
+#include "frame/py_frame.h"
+#include "python/int.h"
+#include "python/string.h"
+#include "python/tuple.h"
+#include "utils/assert.h"
+
+namespace py {
+
+
+// Clear existing memoized names
+void Frame::_clear_names() {
+  Py_XDECREF(names);
+  Py_XDECREF(inames);
+  names = nullptr;
+  inames = nullptr;
+}
+
+
+void Frame::_init_names() const {
+  if (names) return;
+  xassert(dt->names.size() == static_cast<size_t>(dt->ncols));
+
+  py::otuple onames(dt->ncols);
+  for (size_t i = 0; i < onames.size(); ++i) {
+    onames.set(i, py::ostring(dt->names[i]));
+  }
+  names = onames.release();
+}
+
+
+void Frame::_init_inames() const {
+  if (inames) return;
+  xassert(dt->names.size() == static_cast<size_t>(dt->ncols));
+  _init_names();
+
+  // TODO: use py::dict
+  PyObject* dict = PyDict_New();
+  if (!dict) throw PyError();
+  for (int64_t i = 0; i < dt->ncols; ++i) {
+    PyObject* name = PyTuple_GET_ITEM(names, i);
+    PyObject* index = PyLong_FromLong(i);
+    PyDict_SetItem(dict, name, index);
+    Py_DECREF(index);
+  }
+  inames = dict;
+}
+
+
+void Frame::_fill_default_names() {
+  auto index0 = static_cast<size_t>(config::frame_names_auto_index);
+  auto prefix = config::frame_names_auto_prefix;
+  auto ncols  = static_cast<size_t>(dt->ncols);
+
+  dt->names.clear();
+  dt->names.reserve(ncols);
+  for (size_t i = 0; i < ncols; ++i) {
+    dt->names.push_back(prefix + std::to_string(i + index0));
+  }
+}
+
+
+/**
+ * This is a main method to assign column names to a Frame. It checks that the
+ * names are valid, not duplicate, and if necessary modifies them to enforce
+ * such constraints.
+ */
+void Frame::_dedup_and_save_names(list nameslist) {
+  auto ncols = static_cast<size_t>(dt->ncols);
+  if (nameslist.size() != ncols) {
+    throw ValueError() << "The `names` list has length " << nameslist.size()
+        << ", while the Frame has "
+        << (ncols < nameslist.size() && ncols? "only " : "")
+        << ncols << " column" << (ncols == 1? "" : "s");
+  }
+
+  // Prepare the containers for placing the new column names there
+  // TODO: use proxy classes py::otuple and py::odict
+  dt->names.clear();
+  dt->names.reserve(ncols);
+  PyObject* list = PyTuple_New(dt->ncols);
+  PyObject* dict = PyDict_New();
+  std::vector<std::string> duplicates;
+
+  // If any name is empty or None, it will be replaced with the default name
+  // in the end. The reason we don't replace immediately upon seeing an empty
+  // name is to ensure that the auto-generated names do not clash with the
+  // user-specified names somewhere later in the list.
+  bool fill_default_names = false;
+
+  for (size_t i = 0; i < ncols; ++i) {
+    py::obj name = nameslist[i];
+    if (!name.is_string() && !name.is_none()) {
+      throw TypeError() << "Invalid `names` list: element " << i
+          << " is not a string";
+    }
+    // Convert to a C-style name object. Note that if `name` is python None,
+    // then the resulting `cname` will be `{nullptr, 0}`.
+    CString cname = name.to_cstring();
+    char* strname = const_cast<char*>(cname.ch);
+    size_t namelen = static_cast<size_t>(cname.size);
+    if (namelen == 0) {
+      fill_default_names = true;
+      dt->names.push_back(std::string());
+      continue;
+    }
+    // Ensure there are no invalid characters in the column's name. Invalid
+    // characters are considered those with ASCII codes \x00 - \x1F. If any
+    // such characters found, we perform substitution s/[\x00-\x1F]+/./g.
+    PyObject* pyname;
+    std::string resname;
+    for (size_t j = 0; j < namelen; ++j) {
+      if (static_cast<uint8_t>(strname[j]) < 0x20) {
+        resname = std::string(strname, j) + ".";
+        bool written_dot = true;
+        for (; j < namelen; ++j) {
+          char ch = strname[j];
+          if (static_cast<uint8_t>(ch) < 0x20) {
+            if (!written_dot) {
+              resname += ".";
+              written_dot = true;
+            }
+          } else {
+            resname += ch;
+            written_dot = false;
+          }
+        }
+      }
+    }
+    if (resname.empty()) {
+      pyname = name.to_pyobject_newref();
+      resname = std::string(strname, namelen);
+    } else {
+      pyname = py::ostring(resname).release();
+    }
+    // Check for name duplicates. If the name was already seen before, we
+    // replace it with a modified name (by incrementing the name's digital
+    // suffix if it has one, or otherwise by adding such a suffix).
+    if (PyDict_GetItem(dict, pyname)) {
+      duplicates.push_back(resname);
+      size_t j = namelen;
+      for (; j > 0; --j) {
+        char ch = strname[j - 1];
+        if (ch < '0' || ch > '9') break;
+      }
+      std::string basename(resname, 0, j);
+      int64_t count = 0;
+      if (j < namelen) {
+        for (; j < namelen; ++j) {
+          char ch = strname[j];
+          count = count * 10 + static_cast<int64_t>(ch - '0');
+        }
+      } else {
+        basename += ".";
+      }
+      while (PyDict_GetItem(dict, pyname)) {
+        count++;
+        resname = basename + std::to_string(count);
+        Py_DECREF(pyname);
+        pyname = py::ostring(resname).release();
+      }
+    }
+
+    // Store the name in all containers
+    dt->names.push_back(resname);
+    PyTuple_SET_ITEM(list, static_cast<Py_ssize_t>(i), pyname);
+    PyObject* index = PyLong_FromSize_t(i);
+    PyDict_SetItem(dict, pyname, index);
+    Py_DECREF(index);
+  }
+
+  // If during the processing we discovered any empty names, they must be
+  // replaced with auto-generated ones.
+  if (fill_default_names) {
+    // Config variables to be used for name auto-generation
+    int64_t index0 = config::frame_names_auto_index;
+    std::string prefix = config::frame_names_auto_prefix;
+    const char* prefixptr = prefix.data();
+    size_t prefixlen = prefix.size();
+
+    // Within the existing names, find ones with the pattern "{prefix}<num>".
+    // If such names exist, we'll start autonaming with 1 + max(<num>), where
+    // the maximum is taken among all such names.
+    for (size_t i = 0; i < ncols; ++i) {
+      size_t namelen = dt->names[i].size();
+      const char* nameptr = dt->names[i].data();
+      if (namelen <= prefixlen) continue;
+      if (std::strncmp(nameptr, prefixptr, prefixlen) != 0) continue;
+      int64_t value = 0;
+      for (size_t j = prefixlen; j < namelen; ++j) {
+        char ch = nameptr[j];
+        if (ch < '0' || ch > '9') goto next_name;
+        value = value * 10 + static_cast<int64_t>(ch - '0');
+      }
+      if (value >= index0) {
+        index0 = value + 1;
+      }
+      next_name:;
+    }
+
+    // Now actually fill the empty names
+    for (size_t i = 0; i < ncols; ++i) {
+      if (!dt->names[i].empty()) continue;
+      dt->names[i] = prefix + std::to_string(index0);
+      PyObject* pyname = py::ostring(dt->names[i]).release();
+      PyTuple_SET_ITEM(list, static_cast<Py_ssize_t>(i), pyname);
+      PyObject* pyindex = PyLong_FromSize_t(i);
+      PyDict_SetItem(dict, pyname, pyindex);
+      Py_DECREF(pyindex);
+      index0++;
+    }
+  }
+
+  // If there were any duplicate names, issue a warning
+  size_t ndup = duplicates.size();
+  if (ndup) {
+    Warning w;
+    if (ndup == 1) {
+      w << "Duplicate column name '" << duplicates[0] << "' found, and was "
+           "assigned a unique name";
+    } else {
+      w << "Duplicate column names found: ";
+      for (size_t i = 0; i < ndup; ++i) {
+        w << (i == 0? "'" :
+              i < ndup - 1? ", '" : " and '");
+        w << duplicates[i] << "'";
+      }
+      w << "; they were assigned unique names";
+    }
+    // as `w` goes out of scope, the warning is sent to Python
+  }
+
+  // Store the pythonic tuple / dict of names
+  names = list;
+  inames = dict;
+
+  xassert(ncols == dt->names.size());
+  xassert(ncols == static_cast<size_t>(PyTuple_Size(list)));
+  xassert(ncols == static_cast<size_t>(PyDict_Size(dict)));
+}
+
+
+
+//------------------------------------------------------------------------------
+// External API
+//------------------------------------------------------------------------------
+
+oobj Frame::get_names() const {
+  if (names == nullptr) _init_names();
+  return oobj(names);
+}
+
+
+void Frame::set_names(obj pynames)
+{
+  _clear_names();
+  if (pynames.is_none()) {
+    _fill_default_names();
+  }
+  else if (pynames.is_list() || pynames.is_tuple()) {
+    py::list nameslist = pynames.to_pylist();
+    _dedup_and_save_names(nameslist);
+  }
+  else {
+    throw TypeError() << "Expected a list or a tuple of column names, got "
+        << pynames.typeobj();
+  }
+}
+
+
+
+oobj Frame::colindex(PKArgs& args)
+{
+  auto col = args[0];
+
+  if (col.is_string()) {
+    if (!inames) _init_inames();
+    PyObject* colname = col.to_borrowed_ref();
+    // If key is not in the dict, PyDict_GetItem(dict, key) returns NULL
+    // without setting an exception.
+    PyObject* index = PyDict_GetItem(inames, colname);  // borrowed ref
+    if (index) {
+      return oobj(index);
+    }
+    throw ValueError()
+        << "Column `" << PyUnicode_AsUTF8(colname) << "` does not exist in "
+           "Frame";  // TODO: add frame repr here
+  }
+  if (col.is_int()) {
+    int64_t colidx = col.to_int64_strict();
+    if (colidx < 0 && colidx + dt->ncols >= 0) {
+      colidx += dt->ncols;
+    }
+    if (colidx >= 0 && colidx < dt->ncols) {
+      return py::oInt(colidx);
+    }
+    throw ValueError() << "Column index `" << colidx << "` is invalid for a "
+        "Frame with " << dt->ncols << " column" << (dt->ncols==1? "" : "s");
+  }
+  throw TypeError() << "The argument to Frame.colindex() should be a string "
+      "or an integer, not " << col.typeobj();
+}
+
+
+} // namespace py

--- a/c/frame/py_frame_names.cc
+++ b/c/frame/py_frame_names.cc
@@ -27,7 +27,7 @@ oobj Frame::get_names() const {
 
 void Frame::set_names(obj arg)
 {
-  if (arg.is_none()) {
+  if (arg.is_undefined() || arg.is_none()) {
     _fill_default_names();
   }
   else if (arg.is_list() || arg.is_tuple()) {

--- a/c/py_column.cc
+++ b/c/py_column.cc
@@ -65,13 +65,13 @@ PyObject* get_mtype(pycolumn::obj* self) {
 
 PyObject* get_stype(pycolumn::obj* self) {
   SType stype = self->ref->stype();
-  return info(stype).py_stype();
+  return info(stype).py_stype().release();
 }
 
 
 PyObject* get_ltype(pycolumn::obj* self) {
   SType stype = self->ref->stype();
-  return info(stype).py_ltype();
+  return info(stype).py_ltype().release();
 }
 
 

--- a/c/py_datatable.cc
+++ b/c/py_datatable.cc
@@ -45,7 +45,6 @@ PyObject* wrap(DataTable* dt)
   if (pydt) {
     auto pypydt = reinterpret_cast<pydatatable::obj*>(pydt);
     pypydt->ref = dt;
-    pypydt->names = nullptr;
     pypydt->_frame = nullptr;
     pypydt->use_stype_for_buffers = SType::VOID;
   }
@@ -177,13 +176,13 @@ PyObject* get_alloc_size(obj* self) {
   sz += sizeof(*self);
   // if (self->ltypes) sz += _PySys_GetSizeOf(self->ltypes);
   // if (self->stypes) sz += _PySys_GetSizeOf(self->stypes);
-  if (self->names) {
-    PyObject* names = self->names;
-    sz += _PySys_GetSizeOf(names);
-    for (Py_ssize_t i = 0; i < Py_SIZE(names); ++i) {
-      sz += _PySys_GetSizeOf(PyTuple_GET_ITEM(names, i));
-    }
-  }
+  // if (self->names) {
+  //   PyObject* names = self->names;
+  //   sz += _PySys_GetSizeOf(names);
+  //   for (Py_ssize_t i = 0; i < Py_SIZE(names); ++i) {
+  //     sz += _PySys_GetSizeOf(PyTuple_GET_ITEM(names, i));
+  //   }
+  // }
   return PyLong_FromSize_t(sz);
 }
 
@@ -274,8 +273,9 @@ PyObject* check(obj* self, PyObject*) {
     }
   }
 
-  PyObject* names = self->names;
-  PyObject* inames = self->inames;
+  if (self->_frame) {
+  PyObject* names = self->_frame->names;
+  PyObject* inames = self->_frame->inames;
   if (names) {
     if (!PyTuple_Check(names)) {
       throw AssertionError() << "Frame.names is not a tuple";
@@ -316,6 +316,7 @@ PyObject* check(obj* self, PyObject*) {
         }
       }
     }
+  }
   }
 
   Py_RETURN_NONE;
@@ -647,16 +648,17 @@ PyObject* sum1    (obj* self, PyObject*) { return _scalar_stat(self->ref, &Colum
 PyObject* materialize(obj* self, PyObject*) {
   DataTable* dt = self->ref;
 
-  Column** cols = dt::amalloc<Column*>(dt->ncols + 1);
   for (int64_t i = 0; i < dt->ncols; ++i) {
-    cols[i] = dt->columns[i]->shallowcopy();
-    cols[i]->reify();
+    Column* oldcol = dt->columns[i];
+    if (!oldcol->rowindex()) continue;
+    Column* newcol = oldcol->shallowcopy();
+    newcol->reify();
+    delete oldcol;
+    dt->columns[i] = newcol;
   }
-  cols[dt->ncols] = nullptr;
+  dt->rowindex.clear();
 
-  DataTable* newdt = new DataTable(cols);
-  newdt->names = dt->names;
-  return wrap(newdt);
+  Py_RETURN_NONE;
 }
 
 
@@ -698,314 +700,6 @@ PyObject* save_jay(obj* self, PyObject* args) {
 
   dt->save_jay(filename, colnames, sstrategy);
   Py_RETURN_NONE;
-}
-
-
-//------------------------------------------------------------------------------
-// Handling of names
-//------------------------------------------------------------------------------
-
-// Clear existing memoized names
-static void _clear_names(obj* self) {
-  Py_XDECREF(self->names);
-  Py_XDECREF(self->inames);
-  self->names = nullptr;
-  self->inames = nullptr;
-}
-
-
-static void _init_names(obj* self) {
-  if (self->names) return;
-  DataTable* dt = self->ref;
-  xassert(dt->names.size() == static_cast<size_t>(dt->ncols));
-  int64_t i = dt->ncols;
-  PyObject* list = PyTuple_New(i);
-  if (list == nullptr) throw PyError();
-  while (--i >= 0) {
-    std::string& name = dt->names[static_cast<size_t>(i)];
-    PyObject* str = py::ostring(name).release();
-    PyTuple_SET_ITEM(list, i, str);
-  }
-  self->names = list;
-}
-
-
-static void _init_inames(obj* self) {
-  if (self->inames) return;
-  _init_names(self);
-  DataTable* dt = self->ref;
-  xassert(dt->names.size() == static_cast<size_t>(dt->ncols));
-  PyObject* dict = PyDict_New();
-  if (!dict) throw PyError();
-  for (int64_t i = 0; i < dt->ncols; ++i) {
-    PyObject* name = PyTuple_GET_ITEM(self->names, i);
-    PyObject* index = PyLong_FromLong(i);
-    PyDict_SetItem(dict, name, index);
-    Py_DECREF(index);
-  }
-  self->inames = dict;
-}
-
-
-static void _fill_default_names(DataTable* dt)
-{
-  auto index0 = static_cast<size_t>(config::frame_names_auto_index);
-  auto prefix = config::frame_names_auto_prefix;
-  auto ncols  = static_cast<size_t>(dt->ncols);
-
-  dt->names.clear();
-  dt->names.reserve(ncols);
-  for (size_t i = 0; i < ncols; ++i) {
-    dt->names.push_back(prefix + std::to_string(i + index0));
-  }
-}
-
-
-
-/**
- * This is a main method to assign column names to a Frame. It checks that the
- * names are valid, not duplicate, and if necessary modifies them to enforce
- * such constraints.
- */
-static void _dedup_and_save_names(obj* self, py::list names) {
-  auto dt = self->ref;
-  auto ncols = static_cast<size_t>(dt->ncols);
-  if (names.size() != ncols) {
-    throw ValueError() << "The `names` list has length " << names.size()
-        << ", while the Frame has "
-        << (ncols < names.size() && ncols? "only " : "")
-        << ncols << " column" << (ncols == 1? "" : "s");
-  }
-
-  // Prepare the containers for placing the new column names there
-  // TODO: use proxy classes py::otuple and py::odict
-  dt->names.clear();
-  dt->names.reserve(ncols);
-  PyObject* list = PyTuple_New(dt->ncols);
-  PyObject* dict = PyDict_New();
-  std::vector<std::string> duplicates;
-
-  // If any name is empty or None, it will be replaced with the default name
-  // in the end. The reason we don't replace immediately upon seeing an empty
-  // name is to ensure that the auto-generated names do not clash with the
-  // user-specified names somewhere later in the list.
-  bool fill_default_names = false;
-
-  for (size_t i = 0; i < ncols; ++i) {
-    py::obj name = names[i];
-    if (!name.is_string() && !name.is_none()) {
-      throw TypeError() << "Invalid `names` list: element " << i
-          << " is not a string";
-    }
-    // Convert to a C-style name object. Note that if `name` is python None,
-    // then the resulting `cname` will be `{nullptr, 0}`.
-    CString cname = name.to_cstring();
-    char* strname = const_cast<char*>(cname.ch);
-    size_t namelen = static_cast<size_t>(cname.size);
-    if (namelen == 0) {
-      fill_default_names = true;
-      dt->names.push_back(std::string());
-      continue;
-    }
-    // Ensure there are no invalid characters in the column's name. Invalid
-    // characters are considered those with ASCII codes \x00 - \x1F. If any
-    // such characters found, we perform substitution s/[\x00-\x1F]+/./g.
-    PyObject* pyname;
-    std::string resname;
-    for (size_t j = 0; j < namelen; ++j) {
-      if (static_cast<uint8_t>(strname[j]) < 0x20) {
-        resname = std::string(strname, j) + ".";
-        bool written_dot = true;
-        for (; j < namelen; ++j) {
-          char ch = strname[j];
-          if (static_cast<uint8_t>(ch) < 0x20) {
-            if (!written_dot) {
-              resname += ".";
-              written_dot = true;
-            }
-          } else {
-            resname += ch;
-            written_dot = false;
-          }
-        }
-      }
-    }
-    if (resname.empty()) {
-      pyname = name.to_pyobject_newref();
-      resname = std::string(strname, namelen);
-    } else {
-      pyname = py::ostring(resname).release();
-    }
-    // Check for name duplicates. If the name was already seen before, we
-    // replace it with a modified name (by incrementing the name's digital
-    // suffix if it has one, or otherwise by adding such a suffix).
-    if (PyDict_GetItem(dict, pyname)) {
-      duplicates.push_back(resname);
-      size_t j = namelen;
-      for (; j > 0; --j) {
-        char ch = strname[j - 1];
-        if (ch < '0' || ch > '9') break;
-      }
-      std::string basename(resname, 0, j);
-      int64_t count = 0;
-      if (j < namelen) {
-        for (; j < namelen; ++j) {
-          char ch = strname[j];
-          count = count * 10 + static_cast<int64_t>(ch - '0');
-        }
-      } else {
-        basename += ".";
-      }
-      while (PyDict_GetItem(dict, pyname)) {
-        count++;
-        resname = basename + std::to_string(count);
-        Py_DECREF(pyname);
-        pyname = py::ostring(resname).release();
-      }
-    }
-
-    // Store the name in all containers
-    dt->names.push_back(resname);
-    PyTuple_SET_ITEM(list, static_cast<Py_ssize_t>(i), pyname);
-    PyObject* index = PyLong_FromSize_t(i);
-    PyDict_SetItem(dict, pyname, index);
-    Py_DECREF(index);
-  }
-
-  // If during the processing we discovered any empty names, they must be
-  // replaced with auto-generated ones.
-  if (fill_default_names) {
-    // Config variables to be used for name auto-generation
-    int64_t index0 = config::frame_names_auto_index;
-    std::string prefix = config::frame_names_auto_prefix;
-    const char* prefixptr = prefix.data();
-    size_t prefixlen = prefix.size();
-
-    // Within the existing names, find ones with the pattern "{prefix}<num>".
-    // If such names exist, we'll start autonaming with 1 + max(<num>), where
-    // the maximum is taken among all such names.
-    for (size_t i = 0; i < ncols; ++i) {
-      size_t namelen = dt->names[i].size();
-      const char* nameptr = dt->names[i].data();
-      if (namelen <= prefixlen) continue;
-      if (std::strncmp(nameptr, prefixptr, prefixlen) != 0) continue;
-      int64_t value = 0;
-      for (size_t j = prefixlen; j < namelen; ++j) {
-        char ch = nameptr[j];
-        if (ch < '0' || ch > '9') goto next_name;
-        value = value * 10 + static_cast<int64_t>(ch - '0');
-      }
-      if (value >= index0) {
-        index0 = value + 1;
-      }
-      next_name:;
-    }
-
-    // Now actually fill the empty names
-    for (size_t i = 0; i < ncols; ++i) {
-      if (!dt->names[i].empty()) continue;
-      dt->names[i] = prefix + std::to_string(index0);
-      PyObject* pyname = py::ostring(dt->names[i]).release();
-      PyTuple_SET_ITEM(list, static_cast<Py_ssize_t>(i), pyname);
-      PyObject* pyindex = PyLong_FromSize_t(i);
-      PyDict_SetItem(dict, pyname, pyindex);
-      Py_DECREF(pyindex);
-      index0++;
-    }
-  }
-
-  // If there were any duplicate names, issue a warning
-  size_t ndup = duplicates.size();
-  if (ndup) {
-    Warning w;
-    if (ndup == 1) {
-      w << "Duplicate column name '" << duplicates[0] << "' found, and was "
-           "assigned a unique name";
-    } else {
-      w << "Duplicate column names found: ";
-      for (size_t i = 0; i < ndup; ++i) {
-        w << (i == 0? "'" :
-              i < ndup - 1? ", '" : " and '");
-        w << duplicates[i] << "'";
-      }
-      w << "; they were assigned unique names";
-    }
-    // as `w` goes out of scope, the warning is sent to Python
-  }
-
-  // Store the pythonic tuple / dict of names
-  self->names = list;
-  self->inames = dict;
-
-  xassert(ncols == dt->names.size());
-  xassert(ncols == static_cast<size_t>(PyTuple_Size(list)));
-  xassert(ncols == static_cast<size_t>(PyDict_Size(dict)));
-}
-
-
-PyObject* get_names(obj* self) {
-  if (!self->names) _init_names(self);
-  Py_INCREF(self->names);
-  return self->names;
-}
-
-
-PyObject* _set_names(obj* self, PyObject* args) {
-  DataTable* dt = self->ref;
-  PyObject* arg1;
-  if (!PyArg_ParseTuple(args, "O", &arg1)) return nullptr;
-  py::obj pynames(arg1);
-
-  _clear_names(self);
-  if (pynames.is_none()) {
-    _fill_default_names(dt);
-  }
-  else if (pynames.is_list() || pynames.is_tuple()) {
-    py::list names = pynames.to_pylist();
-    _dedup_and_save_names(self, names);
-  }
-  else {
-    throw TypeError() << "The `names` argument must be a list or a tuple of "
-        "column names, got " << pynames.typeobj();
-  }
-
-  Py_RETURN_NONE;
-}
-
-
-PyObject* colindex(obj* self, PyObject* args) {
-  DataTable* dt = self->ref;
-  PyObject* arg1;
-  if (!PyArg_ParseTuple(args, "O:colindex", &arg1)) return nullptr;
-  py::obj col(arg1);
-
-  if (col.is_string()) {
-    if (!self->inames) _init_inames(self);
-    PyObject* colname = col.to_borrowed_ref();
-    // If key is not in the dict, PyDict_GetItem(dict, key) returns NULL
-    // without setting an exception.
-    PyObject* index = PyDict_GetItem(self->inames, colname);  // borrowed ref
-    if (index) {
-      Py_INCREF(index);
-      return index;
-    }
-    throw ValueError()
-        << "Column `" << PyUnicode_AsUTF8(colname) << "` does not exist in "
-           "Frame";  // TODO: add frame repr here
-  }
-  if (col.is_int()) {
-    int64_t colidx = col.to_int64_strict();
-    if (colidx < 0 && colidx + dt->ncols >= 0) {
-      colidx += dt->ncols;
-    }
-    if (colidx >= 0 && colidx < dt->ncols) {
-      return py::oInt(colidx).release();
-    }
-    throw ValueError() << "Column index `" << colidx << "` is invalid for a "
-        "Frame with " << dt->ncols << " column" << (dt->ncols==1? "" : "s");
-  }
-  throw TypeError() << "The argument to Frame.colindex() should be a string "
-      "or an integer, not " << Py_TYPE(col.to_borrowed_ref());
 }
 
 
@@ -1065,13 +759,10 @@ static PyMethodDef datatable_methods[] = {
   METHODv(apply_na_mask),
   METHODv(use_stype_for_buffers),
   METHODv(save_jay),
-  METHODv(_set_names),
-  METHODv(colindex),
   {nullptr, nullptr, 0, nullptr}           /* sentinel */
 };
 
 static PyGetSetDef datatable_getseters[] = {
-  GETTER(names),
   GETTER(isview),
   GETTER(rowindex),
   GETSET(groupby),

--- a/c/py_datatable.h
+++ b/c/py_datatable.h
@@ -11,7 +11,7 @@
 #include "datatable.h"
 #include "options.h"
 #include "py_utils.h"
-
+namespace py { class Frame; }
 
 #define BASECLS pydatatable::obj
 #define CLSNAME DataTable
@@ -37,9 +37,9 @@ namespace pydatatable
 struct obj : public PyObject {
   DataTable* ref;
   PyObject* ltypes;  // memoized tuple of ltypes
-  PyObject* stypes;  // memoized tuple of stypes
   PyObject* names;   // memoized tuple of column names
   PyObject* inames;  // memoized dict of {column name: index}
+  py::Frame* _frame;
   SType use_stype_for_buffers;
   int64_t : 56;
 };
@@ -73,10 +73,6 @@ DECLARE_GETTER(
 DECLARE_GETTER(
   ltypes,
   "List of logical types for all columns")
-
-DECLARE_GETTER(
-  stypes,
-  "List of \"storage\" types for all columns")
 
 DECLARE_GETTER(
   names,

--- a/c/py_datatable.h
+++ b/c/py_datatable.h
@@ -36,7 +36,6 @@ namespace pydatatable
  */
 struct obj : public PyObject {
   DataTable* ref;
-  PyObject* ltypes;  // memoized tuple of ltypes
   PyObject* names;   // memoized tuple of column names
   PyObject* inames;  // memoized dict of {column name: index}
   py::Frame* _frame;
@@ -69,10 +68,6 @@ DECLARE_DESTRUCTOR()
 DECLARE_GETTER(
   isview,
   "Is the datatable view or now?")
-
-DECLARE_GETTER(
-  ltypes,
-  "List of logical types for all columns")
 
 DECLARE_GETTER(
   names,

--- a/c/py_datatable.h
+++ b/c/py_datatable.h
@@ -36,8 +36,6 @@ namespace pydatatable
  */
 struct obj : public PyObject {
   DataTable* ref;
-  PyObject* names;   // memoized tuple of column names
-  PyObject* inames;  // memoized dict of {column name: index}
   py::Frame* _frame;
   SType use_stype_for_buffers;
   int64_t : 56;
@@ -68,10 +66,6 @@ DECLARE_DESTRUCTOR()
 DECLARE_GETTER(
   isview,
   "Is the datatable view or now?")
-
-DECLARE_GETTER(
-  names,
-  "Tuple of column names")
 
 DECLARE_GETTER(
   rowindex_type,
@@ -277,22 +271,6 @@ DECLARE_METHOD(
    nmodal1,
    "Get the number of modal values in a single-column DataTable")
 
-DECLARE_METHOD(  // temporary
-  _set_names,
-  "Set column names")
-
-DECLARE_METHOD(
-  colindex,
-  "colindex(self, name)\n"
-  "--\n\n"
-  "Return index of the column ``name``\n"
-  "\n"
-  ":param name: name of the column to find the index for. This can also\n"
-  "    be an index of a column, in which case the index is checked that\n"
-  "    it doesn't go out-of-bounds, and negative index is converted into\n"
-  "    positive.\n"
-  ":raises ValueError: if the requested column does not exist.\n"
-  )
 
 
 //---- Python API --------------------------------------------------------------

--- a/c/py_datawindow.cc
+++ b/c/py_datawindow.cc
@@ -123,8 +123,8 @@ static int _init_(obj* self, PyObject* args, PyObject* kwds)
 
     // Create and fill-in the `stypes` list
     info info_stype(col->stype());
-    PyList_SET_ITEM(ltypes, s, info_stype.py_ltype());
-    PyList_SET_ITEM(stypes, s, info_stype.py_stype());
+    PyList_SET_ITEM(ltypes, s, info_stype.py_ltype().release());
+    PyList_SET_ITEM(stypes, s, info_stype.py_stype().release());
   }
 
   self->row0 = row0;
@@ -216,8 +216,8 @@ static int _init_hexview(
   if (!stypes || !ltypes) goto fail;
   info itype(SType::STR32);
   for (int64_t i = 0; i < ncols; i++) {
-    PyList_SET_ITEM(ltypes, i, itype.py_ltype());
-    PyList_SET_ITEM(stypes, i, itype.py_stype());
+    PyList_SET_ITEM(ltypes, i, itype.py_ltype().release());
+    PyList_SET_ITEM(stypes, i, itype.py_stype().release());
   }
 
   self->row0 = row0;

--- a/c/python/arg.cc
+++ b/c/python/arg.cc
@@ -7,6 +7,7 @@
 //------------------------------------------------------------------------------
 #include "python/arg.h"
 #include "python/args.h"        // py::PKArgs
+#include "python/int.h"
 #include "utils/exceptions.h"
 
 namespace py {
@@ -65,66 +66,10 @@ bool Arg::is_range()         const { return pyobj.is_range(); }
 // Type conversions
 //------------------------------------------------------------------------------
 
-py::list  Arg::to_pylist() const { return pyobj.to_pylist(*this); }
+int32_t  Arg::to_int32_strict() const { return pyobj.to_int32_strict(*this); }
+int64_t  Arg::to_int64_strict() const { return pyobj.to_int64_strict(*this); }
+py::list Arg::to_pylist()       const { return pyobj.to_pylist(*this); }
 
-/*
-Arg::operator int32_t() const {
-  _check_missing();
-  if (!PyLong_Check(pyobj)) {
-    throw TypeError() << name() << " should be an integer";
-  }
-  int overflow;
-  long value = PyLong_AsLongAndOverflow(pyobj, &overflow);
-  int32_t res = static_cast<int32_t>(value);
-  if (overflow || value != static_cast<long>(res)) {
-    throw TypeError() << name() << " is too large for an int32: " << pyobj;
-  }
-  return res;
-}
-
-
-Arg::operator int64_t() const {
-  static_assert(sizeof(int64_t) == sizeof(long), "Unexpected size of long");
-  _check_missing();
-  if (!PyLong_Check(pyobj)) {
-    throw TypeError() << name() << " should be an integer";
-  }
-  int overflow;
-  long value = PyLong_AsLongAndOverflow(pyobj, &overflow);
-  if (overflow) {
-    throw TypeError() << name() << " is too large for an int64: " << pyobj;
-  }
-  return value;
-}
-
-
-Arg::operator list() const {
-  _check_missing();
-  _check_list_or_tuple();
-  return list(pyobj);
-}
-
-
-std::vector<std::string> Arg::to_list_of_strs() const {
-  _check_missing();
-  _check_list_or_tuple();
-  auto size = static_cast<size_t>(Py_SIZE(pyobj));
-  std::vector<std::string> res(size);
-  for (size_t i = 0; i < size; ++i) {
-    PyObject* item = PyList_GET_ITEM(pyobj, i);  // works for tuples too
-    if (!PyUnicode_Check(item)) {
-      auto item_type = reinterpret_cast<PyObject*>(Py_TYPE(item));
-      throw TypeError() << name() << " should be a list of strings; but its "
-          << _nth(i + 1) << " element was " << item_type;
-    }
-    Py_ssize_t str_size;
-    const char* str = PyUnicode_AsUTF8AndSize(item, &str_size);
-    if (!str) throw PyError();
-    res[i] = std::string(str, static_cast<size_t>(str_size));
-  }
-  return res;
-}
-*/
 
 
 //------------------------------------------------------------------------------

--- a/c/python/arg.h
+++ b/c/python/arg.h
@@ -51,6 +51,8 @@ class Arg : public _obj::error_manager {
     bool is_range() const;
 
     //---- Type conversions ------------
+    int32_t     to_int32_strict  () const;
+    int64_t     to_int64_strict  () const;
     py::list    to_pylist        () const;
 
 
@@ -59,6 +61,8 @@ class Arg : public _obj::error_manager {
 
     // ?
     PyObject* obj() { return pyobj.to_pyobject_newref(); }
+    PyObject* to_borrowed_ref() { return pyobj.to_borrowed_ref(); }
+    PyTypeObject* typeobj() { return pyobj.typeobj(); }
     void print() const;
 
     /**

--- a/c/python/dict.cc
+++ b/c/python/dict.cc
@@ -1,0 +1,75 @@
+//------------------------------------------------------------------------------
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// © H2O.ai 2018
+//------------------------------------------------------------------------------
+#include "python/dict.h"
+
+namespace py {
+
+
+//------------------------------------------------------------------------------
+// odict
+//------------------------------------------------------------------------------
+
+odict::odict() {
+  v = PyDict_New();
+}
+
+
+obj odict::get(obj key) const {
+  // PyDict_GetItem returns a borrowed ref; or NULL if key is not present
+  return obj(PyDict_GetItem(v, key.to_borrowed_ref()));
+}
+
+dict_iterator odict::begin() const {
+  return dict_iterator(v, 0);
+}
+
+dict_iterator odict::end() const {
+  return dict_iterator(v, -1);
+}
+
+
+
+//------------------------------------------------------------------------------
+// dict_iterator
+//------------------------------------------------------------------------------
+
+dict_iterator::dict_iterator(PyObject* p, Py_ssize_t i0)
+  : dict(p), pos(i0), curr_value(obj(nullptr), obj(nullptr))
+{
+  advance();
+}
+
+dict_iterator& dict_iterator::operator++() {
+  advance();
+  return *this;
+}
+
+dict_iterator::value_type dict_iterator::operator*() const {
+  return curr_value;
+}
+
+bool dict_iterator::operator==(const dict_iterator& other) const {
+  return (pos == other.pos);
+}
+
+bool dict_iterator::operator!=(const dict_iterator& other) const {
+  return (pos != other.pos);
+}
+
+void dict_iterator::advance() {
+  if (pos == -1) return;
+  PyObject *key, *value;
+  if (PyDict_Next(dict, &pos, &key, &value)) {
+    curr_value = value_type(py::obj(key), py::obj(value));
+  } else {
+    pos = -1;
+  }
+}
+
+
+}

--- a/c/python/dict.cc
+++ b/c/python/dict.cc
@@ -19,10 +19,21 @@ odict::odict() {
 }
 
 
+bool odict::has(obj key) const {
+  return PyDict_GetItem(v, key.to_borrowed_ref()) != nullptr;
+}
+
 obj odict::get(obj key) const {
   // PyDict_GetItem returns a borrowed ref; or NULL if key is not present
   return obj(PyDict_GetItem(v, key.to_borrowed_ref()));
 }
+
+void odict::set(_obj key, _obj val) {
+  // PyDict_SetItem INCREFs both key and value internally
+  int r = PyDict_SetItem(v, key.to_borrowed_ref(), val.to_borrowed_ref());
+  if (r) throw PyError();
+}
+
 
 dict_iterator odict::begin() const {
   return dict_iterator(v, 0);

--- a/c/python/dict.h
+++ b/c/python/dict.h
@@ -20,7 +20,9 @@ class odict : public oobj {
     using iterator = dict_iterator;
     odict();
 
+    bool has(obj key) const;
     obj get(obj key) const;
+    void set(_obj key, _obj val);
 
     iterator begin() const;
     iterator end() const;

--- a/c/python/dict.h
+++ b/c/python/dict.h
@@ -1,0 +1,58 @@
+//------------------------------------------------------------------------------
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// © H2O.ai 2018
+//------------------------------------------------------------------------------
+#ifndef dt_PYTHON_DICT_h
+#define dt_PYTHON_DICT_h
+#include <Python.h>
+#include "python/obj.h"
+
+namespace py {
+class dict_iterator;
+
+
+class odict : public oobj {
+  public:
+    using oobj::oobj;
+    using iterator = dict_iterator;
+    odict();
+
+    obj get(obj key) const;
+
+    iterator begin() const;
+    iterator end() const;
+};
+
+
+
+class dict_iterator {
+  public:
+    using value_type = std::pair<py::obj, py::obj>;
+    using category_type = std::input_iterator_tag;
+
+  private:
+    PyObject*  dict;
+    Py_ssize_t pos;
+    value_type curr_value;
+
+  public:
+    dict_iterator(PyObject* d, Py_ssize_t i0);
+    dict_iterator(const dict_iterator&) = default;
+    dict_iterator& operator=(const dict_iterator&) = default;
+
+    dict_iterator& operator++();
+    value_type operator*() const;
+    bool operator==(const dict_iterator&) const;
+    bool operator!=(const dict_iterator&) const;
+
+  private:
+    void advance();
+};
+
+
+}
+
+#endif

--- a/c/python/list.cc
+++ b/c/python/list.cc
@@ -151,5 +151,37 @@ obj list::operator[](size_t i) const {
                     : PyTuple_GET_ITEM(v, i));
 }
 
+void list::set(int64_t i, const _obj& value) {
+  if (is_list) {
+    PyList_SET_ITEM(v, i, value.to_pyobject_newref());
+  } else {
+    PyTuple_SET_ITEM(v, i, value.to_pyobject_newref());
+  }
+}
+
+void list::set(int64_t i, oobj&& value) {
+  if (is_list) {
+    PyList_SET_ITEM(v, i, value.release());
+  } else {
+    PyTuple_SET_ITEM(v, i, value.release());
+  }
+}
+
+void list::set(size_t i, const _obj& value) {
+  set(static_cast<int64_t>(i), value);
+}
+
+void list::set(size_t i, oobj&& value) {
+  set(static_cast<int64_t>(i), std::move(value));
+}
+
+void list::set(int i, const _obj& value) {
+  set(static_cast<int64_t>(i), value);
+}
+
+void list::set(int i, oobj&& value) {
+  set(static_cast<int64_t>(i), std::move(value));
+}
+
 
 }

--- a/c/python/list.h
+++ b/c/python/list.h
@@ -130,6 +130,13 @@ class list : public oobj {
     size_t size() const;
     obj operator[](size_t i) const;
 
+    void set(size_t i,  const _obj& value);
+    void set(int64_t i, const _obj& value);
+    void set(int i,     const _obj& value);
+    void set(size_t i,  oobj&& value);
+    void set(int64_t i, oobj&& value);
+    void set(int i,     oobj&& value);
+
     friend class Arg;
 };
 

--- a/c/python/obj.cc
+++ b/c/python/obj.cc
@@ -106,24 +106,22 @@ oobj::~oobj() {
 // Type checks
 //------------------------------------------------------------------------------
 
-bool _obj::is_undefined() const{ return (v == nullptr);}
-bool _obj::is_none() const     { return (v == Py_None); }
-bool _obj::is_ellipsis() const { return (v == Py_Ellipsis); }
-bool _obj::is_true() const     { return (v == Py_True); }
-bool _obj::is_false() const    { return (v == Py_False); }
-bool _obj::is_bool() const     { return is_true() || is_false(); }
-bool _obj::is_int() const      { return v && PyLong_Check(v) && !is_bool(); }
-bool _obj::is_float() const    { return v && PyFloat_Check(v); }
-bool _obj::is_numeric() const  { return v && (is_float() || is_int()); }
-bool _obj::is_string() const   { return v && PyUnicode_Check(v); }
-bool _obj::is_list() const     { return v && PyList_Check(v); }
-bool _obj::is_tuple() const    { return v && PyTuple_Check(v); }
-bool _obj::is_dict() const     { return v && PyDict_Check(v); }
-bool _obj::is_buffer() const   { return v && PyObject_CheckBuffer(v); }
-bool _obj::is_range() const    { return v && PyRange_Check(v); }
-bool _obj::is_list_or_tuple() const {
-  return v && (PyList_Check(v) || PyTuple_Check(v));
-}
+bool _obj::is_undefined()     const noexcept { return (v == nullptr);}
+bool _obj::is_none()          const noexcept { return (v == Py_None); }
+bool _obj::is_ellipsis()      const noexcept { return (v == Py_Ellipsis); }
+bool _obj::is_true()          const noexcept { return (v == Py_True); }
+bool _obj::is_false()         const noexcept { return (v == Py_False); }
+bool _obj::is_bool()          const noexcept { return is_true() || is_false(); }
+bool _obj::is_numeric()       const noexcept { return is_float() || is_int(); }
+bool _obj::is_list_or_tuple() const noexcept { return is_list() || is_tuple(); }
+bool _obj::is_int()           const noexcept { return v && PyLong_Check(v) && !is_bool(); }
+bool _obj::is_float()         const noexcept { return v && PyFloat_Check(v); }
+bool _obj::is_string()        const noexcept { return v && PyUnicode_Check(v); }
+bool _obj::is_list()          const noexcept { return v && PyList_Check(v); }
+bool _obj::is_tuple()         const noexcept { return v && PyTuple_Check(v); }
+bool _obj::is_dict()          const noexcept { return v && PyDict_Check(v); }
+bool _obj::is_buffer()        const noexcept { return v && PyObject_CheckBuffer(v); }
+bool _obj::is_range()         const noexcept { return v && PyRange_Check(v); }
 
 
 

--- a/c/python/obj.cc
+++ b/c/python/obj.cc
@@ -11,6 +11,7 @@
 #include "py_datatable.h"
 #include "py_groupby.h"
 #include "py_rowindex.h"
+#include "python/dict.h"
 #include "python/int.h"
 #include "python/float.h"
 #include "python/list.h"
@@ -339,6 +340,13 @@ py::list _obj::to_pylist(const error_manager& em) const {
 }
 
 
+py::odict _obj::to_pydict(const error_manager& em) const {
+  if (is_none()) return py::odict();
+  if (is_dict()) return py::odict(v);
+  throw em.error_not_dict(v);
+}
+
+
 char** _obj::to_cstringlist(const error_manager&) const {
   if (v == Py_None) {
     return nullptr;
@@ -492,6 +500,11 @@ oobj _obj::invoke(const char* fn, const char* format, ...) const {
 }
 
 
+ostring _obj::str() const {
+  return ostring::from_new_reference(PyObject_Str(v));
+}
+
+
 PyTypeObject* _obj::typeobj() const noexcept {
   return Py_TYPE(v);
 }
@@ -549,6 +562,10 @@ Error _obj::error_manager::error_not_column(PyObject* o) const {
 Error _obj::error_manager::error_not_list(PyObject* o) const {
   return TypeError() << "Expected a list or tuple, instead got "
       << Py_TYPE(o);
+}
+
+Error _obj::error_manager::error_not_dict(PyObject* o) const {
+  return TypeError() << "Expected a dict, instead got " << Py_TYPE(o);
 }
 
 Error _obj::error_manager::error_int32_overflow(PyObject* o) const {

--- a/c/python/obj.h
+++ b/c/python/obj.h
@@ -19,6 +19,8 @@ class Groupby;
 class RowIndex;
 
 namespace py {
+
+// Forward declarations
 class Arg;
 class Int;
 class oInt;
@@ -125,22 +127,25 @@ class _obj {
     oobj invoke(const char* fn, const char* format, ...) const;
     PyTypeObject* typeobj() const noexcept;  // borrowed ref
 
-    bool is_undefined() const;
-    bool is_none() const;
-    bool is_ellipsis() const;
-    bool is_true() const;
-    bool is_false() const;
-    bool is_bool() const;
-    bool is_int() const;
-    bool is_float() const;
-    bool is_numeric() const;
-    bool is_string() const;
-    bool is_list() const;
-    bool is_tuple() const;
-    bool is_list_or_tuple() const;
-    bool is_dict() const;
-    bool is_buffer() const;
-    bool is_range() const;
+    //--------------------------------------------------------------------------
+    // Type tests
+    //--------------------------------------------------------------------------
+    bool is_undefined()     const noexcept;
+    bool is_none()          const noexcept;
+    bool is_ellipsis()      const noexcept;
+    bool is_true()          const noexcept;
+    bool is_false()         const noexcept;
+    bool is_bool()          const noexcept;
+    bool is_int()           const noexcept;
+    bool is_float()         const noexcept;
+    bool is_numeric()       const noexcept;
+    bool is_string()        const noexcept;
+    bool is_list()          const noexcept;
+    bool is_tuple()         const noexcept;
+    bool is_list_or_tuple() const noexcept;
+    bool is_dict()          const noexcept;
+    bool is_buffer()        const noexcept;
+    bool is_range()         const noexcept;
 
     int8_t      to_bool          (const error_manager& = _em0) const;
     int8_t      to_bool_strict   (const error_manager& = _em0) const;

--- a/c/python/obj.h
+++ b/c/python/obj.h
@@ -29,6 +29,7 @@ class oFloat;
 class string;
 class ostring;
 class list;
+class odict;
 class obj;
 class oobj;
 using strvec = std::vector<std::string>;
@@ -125,6 +126,7 @@ class _obj {
   public:
     oobj get_attr(const char* attr) const;
     oobj invoke(const char* fn, const char* format, ...) const;
+    ostring str() const;
     PyTypeObject* typeobj() const noexcept;  // borrowed ref
 
     //--------------------------------------------------------------------------
@@ -168,6 +170,7 @@ class _obj {
     char**      to_cstringlist   (const error_manager& = _em0) const;
     strvec      to_stringlist    (const error_manager& = _em0) const;
     py::list    to_pylist        (const error_manager& = _em0) const;
+    py::odict   to_pydict        (const error_manager& = _em0) const;
 
     Column*     to_column        (const error_manager& = _em0) const;
     Groupby*    to_groupby       (const error_manager& = _em0) const;
@@ -196,6 +199,7 @@ class _obj {
       virtual Error error_not_frame      (PyObject*) const;
       virtual Error error_not_column     (PyObject*) const;
       virtual Error error_not_list       (PyObject*) const;
+      virtual Error error_not_dict       (PyObject*) const;
       virtual Error error_int32_overflow (PyObject*) const;
       virtual Error error_int64_overflow (PyObject*) const;
       virtual Error error_double_overflow(PyObject*) const;

--- a/c/python/string.cc
+++ b/c/python/string.cc
@@ -70,6 +70,12 @@ ostring::ostring(ostring&& other) : ostring() {
   swap(*this, other);
 }
 
+ostring ostring::from_new_reference(PyObject* ref) {
+  ostring res;
+  res.obj = ref;
+  return res;
+}
+
 ostring::~ostring() {
   Py_XDECREF(obj);
 }

--- a/c/python/string.h
+++ b/c/python/string.h
@@ -40,8 +40,10 @@ class ostring : public string {
     ostring(const ostring&);
     ostring(ostring&&);
     ~ostring();
+    static ostring from_new_reference(PyObject*);
     friend oobj::oobj(ostring&&);
 
+    PyObject* to_borrowed_ref() const { return obj; }
     PyObject* release();
 };
 

--- a/c/python/tuple.cc
+++ b/c/python/tuple.cc
@@ -23,7 +23,13 @@ size_t otuple::size() const {
   return static_cast<size_t>(Py_SIZE(v));
 }
 
+obj otuple::get(size_t i) const {
+  // PyTuple_GET_ITEM returns a borrowed reference
+  return obj(PyTuple_GET_ITEM(v, i));
+}
+
 void otuple::set(size_t i, const _obj& value) {
+  // PyTuple_SET_ITEM "steals" a reference to the last argument
   PyTuple_SET_ITEM(v, i, value.to_pyobject_newref());
 }
 

--- a/c/python/tuple.h
+++ b/c/python/tuple.h
@@ -13,6 +13,14 @@
 namespace py {
 
 
+/**
+ * Class representing a pythonic tuple of elements.
+ *
+ * This can be either a tuple passed down from Python, or a new tuple object.
+ * If `otuple` is created from an existing PyObject, its elements must not be
+ * modified. On the contrary, if a tuple is created from scratch, its elements
+ * must be properly initialized before the tuple can be returned to Python.
+ */
 class otuple : public oobj {
   public:
     using oobj::oobj;
@@ -21,6 +29,7 @@ class otuple : public oobj {
     otuple(int64_t n);
 
     size_t size() const;
+    obj  get(size_t i) const;
     void set(size_t i, const _obj& value);
     void set(size_t i, oobj&& value);
 };

--- a/c/read/column.cc
+++ b/c/read/column.cc
@@ -235,7 +235,7 @@ py::oobj Column::py_descriptor() const {
   static PyTypeObject* name_type_pytuple = init_nametypepytuple();
   PyObject* nt_tuple = PyStructSequence_New(name_type_pytuple);  // new ref
   if (!nt_tuple) throw PyError();
-  PyObject* stype = info(ParserLibrary::info(ptype).stype).py_stype();
+  PyObject* stype = info(ParserLibrary::info(ptype).stype).py_stype().release();
   PyObject* cname = py::oobj(py::ostring(name)).release();
   PyStructSequence_SetItem(nt_tuple, 0, cname);
   PyStructSequence_SetItem(nt_tuple, 1, stype);

--- a/c/types.cc
+++ b/c/types.cc
@@ -5,6 +5,7 @@
 //
 // © H2O.ai 2018
 //------------------------------------------------------------------------------
+#include "python/obj.h"
 #include "utils/assert.h"
 #include "types.h"
 #include "utils.h"
@@ -285,14 +286,10 @@ LType info::ltype() const {
   return stype_info[stype].ltype;
 }
 
-PyObject* info::py_ltype() const {
-  PyObject* res = py_ltype_objs[static_cast<uint8_t>(ltype())];
-  Py_INCREF(res);
-  return res;
+py::oobj info::py_ltype() const {
+  return py::oobj(py_ltype_objs[static_cast<uint8_t>(ltype())]);
 }
 
-PyObject* info::py_stype() const {
-  PyObject* res = py_stype_objs[stype];
-  Py_INCREF(res);
-  return res;
+py::oobj info::py_stype() const {
+  return py::oobj(py_stype_objs[stype]);
 }

--- a/c/types.h
+++ b/c/types.h
@@ -307,6 +307,7 @@ constexpr size_t DT_STYPES_COUNT = static_cast<size_t>(SType::OBJ) + 1;
 
 
 //==============================================================================
+namespace py { class oobj; }
 
 class info {
   private:
@@ -318,8 +319,8 @@ class info {
     size_t elemsize() const;
     bool is_varwidth() const;
     LType ltype() const;
-    PyObject* py_stype() const;  // new ref
-    PyObject* py_ltype() const;  // new ref
+    py::oobj py_stype() const;
+    py::oobj py_ltype() const;
 };
 
 

--- a/c/utils/exceptions.h
+++ b/c/utils/exceptions.h
@@ -20,6 +20,11 @@ extern CErrno Errno;
 
 void exception_to_python(const std::exception&);
 
+namespace py {
+  class _obj;
+  class ostring;
+}
+
 
 //------------------------------------------------------------------------------
 
@@ -49,6 +54,8 @@ public:
   Error& operator<<(double);
   Error& operator<<(SType);
   Error& operator<<(const CErrno&);
+  Error& operator<<(const py::_obj&);
+  Error& operator<<(const py::ostring&);
   Error& operator<<(PyObject*);
   Error& operator<<(PyTypeObject*);
   #ifdef __APPLE__

--- a/datatable/dt_append.py
+++ b/datatable/dt_append.py
@@ -139,7 +139,7 @@ def _rbind(self, *frames, force=False, bynames=True):
     # Perform the append operation on C level
     _dt = self.internal
     _dt.rbind(len(final_names), spec)
-    _dt._set_names(final_names)
+    self.names = final_names
     return self
 
 
@@ -222,5 +222,5 @@ def _cbind(self, *frames, force=False, inplace=True):
 
     _dt = src.internal
     _dt.cbind(datatables)
-    _dt._set_names(column_names)
+    src.names = column_names
     return src

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -74,11 +74,6 @@ class Frame(core.Frame):
         """Tuple of column types."""
         return self._dt.ltypes
 
-    @property
-    def stypes(self):
-        """Tuple of column storage types."""
-        return self._dt.stypes
-
 
     #---------------------------------------------------------------------------
     # Property setters

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -69,11 +69,6 @@ class Frame(core.Frame):
         """Tuple of column names."""
         return self._dt.names
 
-    @property
-    def ltypes(self):
-        """Tuple of column types."""
-        return self._dt.ltypes
-
 
     #---------------------------------------------------------------------------
     # Property setters

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -621,30 +621,6 @@ class Frame(core.Frame):
         return self._dt.nmodal1()
 
 
-
-    @typed()
-    def rename(self, columns: Union[Dict[str, str], Dict[int, str], List[str],
-                                    Tuple[str, ...]]):
-        """
-        Rename columns of the datatable.
-
-        :param columns: dictionary of the {old_name: new_name} entries.
-        :returns: None
-        """
-        if isinstance(columns, (list, tuple)):
-            names = columns
-            if len(names) != self.ncols:
-                raise TValueError("Cannot rename columns to %r: expected %s"
-                                  % (names, plural(self.ncols, "name")))
-        else:
-            names = list(self.names)
-            for oldname, newname in columns.items():
-                idx = self.colindex(oldname)
-                names[idx] = newname
-        self.names = names
-
-
-
     #---------------------------------------------------------------------------
     # Converters
     #---------------------------------------------------------------------------

--- a/datatable/graph/cols_node.py
+++ b/datatable/graph/cols_node.py
@@ -211,7 +211,7 @@ class ArrayCSNode(ColumnSetNode):
             else:
                 new_names[j] = name
         dt.internal.replace_column_array(self._elems, ri, replacement.internal)
-        dt.internal._set_names(new_names)
+        dt.names = new_names
         assert dt.ncols == n
 
 

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -636,6 +636,15 @@ def test_rename_bad5():
             "but got <class 'int'>" == str(e.value))
 
 
+@pytest.mark.run(order=8.2)
+def test_rename_default():
+    d0 = dt.Frame([[1], [2], ["hello"]], names=("a", "b", "c"))
+    del d0.names
+    assert d0.names == ("C0", "C1", "C2")
+    d0.names = None
+    assert d0.names == ("C0", "C1", "C2")
+
+
 
 #-------------------------------------------------------------------------------
 # Test conversions into Pandas / Numpy

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -628,12 +628,12 @@ def test_rename_bad():
     assert "Column `xxx` does not exist" in str(e.value)
     with pytest.raises(ValueError) as e:
         d0.names = ['1', '2', '3', '5']
-    assert ("Cannot rename columns to ['1', '2', '3', '5']: "
-            "expected 3 names" in str(e.value))
+    assert ("The `names` list has length 4, while the Frame has only 3 columns"
+            in str(e.value))
     with pytest.raises(ValueError) as e:
         d0.names = ('k', )
-    assert ("Cannot rename columns to ('k',): "
-            "expected 3 names" in str(e.value))
+    assert ("The `names` list has length 1, while the Frame has 3 columns"
+            in str(e.value))
 
 
 @pytest.mark.run(order=8.2)

--- a/tests/test_dt_create.py
+++ b/tests/test_dt_create.py
@@ -244,14 +244,14 @@ def test_create_names_bad1():
 def test_create_names_bad2():
     with pytest.raises(TypeError) as e:
         dt.Frame([[1], [2], [3]], names="xyz")
-    assert ("The `names` argument must be a list or a tuple of column names, "
+    assert ("Expected a list or a tuple of column names, "
             "got <class 'str'>" == str(e.value))
 
 
 def test_create_names_bad3():
     with pytest.raises(TypeError) as e:
         dt.Frame(range(5), names={"x": 1})
-    assert ("The `names` argument must be a list or a tuple of column names, "
+    assert ("Expected a list or a tuple of column names, "
             "got <class 'dict'>" == str(e.value))
 
 

--- a/tests/test_dt_create.py
+++ b/tests/test_dt_create.py
@@ -244,15 +244,13 @@ def test_create_names_bad1():
 def test_create_names_bad2():
     with pytest.raises(TypeError) as e:
         dt.Frame([[1], [2], [3]], names="xyz")
-    assert ("Expected a list or a tuple of column names, "
-            "got <class 'str'>" == str(e.value))
+    assert "Expected a list of strings, got <class 'str'>" == str(e.value)
 
 
 def test_create_names_bad3():
     with pytest.raises(TypeError) as e:
         dt.Frame(range(5), names={"x": 1})
-    assert ("Expected a list or a tuple of column names, "
-            "got <class 'dict'>" == str(e.value))
+    assert "Expected a list of strings, got <class 'dict'>" == str(e.value)
 
 
 def test_create_names_bad4():

--- a/tests/test_nff.py
+++ b/tests/test_nff.py
@@ -77,9 +77,11 @@ def test_save_view(tempdir):
     dt0 = dt.Frame([4, 0, -2, 3, 17, 2, 0, 1, 5], names=["fancy"])
     dt1 = dt0.sort(0)
     assert dt1.internal.isview
-    dt.save(dt1, tempdir)
+    dt1.internal.check()
+    dt1.save(tempdir)
     dt2 = dt.open(tempdir)
     assert not dt2.internal.isview
+    dt2.internal.check()
     assert dt2.names == dt1.names
     assert dt2.topython() == dt1.topython()
 


### PR DESCRIPTION
This PR continues work to bring some of the Python functionality over to C++ `core.Frame` class. In particular, in this PR:

* `Frame.rename()` is removed -- `Frame.name` setter can be used instead;
* Getters for `stypes` and `ltypes` moved to `core.Frame` class and converted to `py::obj` API;
* Getter/setter for `names` implemented in C++ in `core.Frame`;
* `.colindex()` method reimplemented in C++ in `core.Frame`
* Better documentation for `.names` setter;
* Created `py::odict` class;
* Added element setters for `py::list`;
* Minor API improvements to `py::_obj`, `py::tuple` and `py::string`;
* `info::py_stype()` and `info::py_ltype()` now return `py::oobj`s instead of `PyObject*`s;
* `_dt.materialize()` now an in-place operation;
* Added more tests related to column renaming.