### PR TITLE
Cleanup of py:: API

### DIFF
--- a/c/column.h
+++ b/c/column.h
@@ -88,7 +88,7 @@ public:
   static Column* new_xbuf_column(SType, int64_t nrows, Py_buffer* pybuffer);
   static Column* new_mbuf_column(SType, MemoryRange&&);
   static Column* new_mbuf_column(SType, MemoryRange&&, MemoryRange&&);
-  static Column* from_pylist(const py::list& list, int stype0 = 0, int ltype0 = 0);
+  static Column* from_pylist(const py::olist& list, int stype0 = 0, int ltype0 = 0);
   static Column* from_buffer(PyObject* buffer);
 
   Column(const Column&) = delete;

--- a/c/column_from_pylist.cc
+++ b/c/column_from_pylist.cc
@@ -225,7 +225,7 @@ static void force_as_real(const py::olist& list, MemoryRange& membuf)
       outdata[i] = litem.value<T>(&overflow);
       continue;
     }
-    py::oFloat fitem = item.to_pyfloat_force();
+    py::ofloat fitem = item.to_pyfloat_force();
     outdata[i] = fitem.value<T>();
   }
   PyErr_Clear();  // in case an overflow occurred

--- a/c/column_from_pylist.cc
+++ b/c/column_from_pylist.cc
@@ -385,7 +385,7 @@ static bool parse_as_pyobj(const py::olist& list, MemoryRange& membuf)
     if (item.is_float() && std::isnan(item.to_double())) {
       outdata[i] = py::None().release();
     } else {
-      outdata[i] = item.release();
+      outdata[i] = std::move(item).release();
     }
   }
   return true;

--- a/c/column_from_pylist.cc
+++ b/c/column_from_pylist.cc
@@ -12,8 +12,8 @@
 #include "py_types.h"     // PyLong_AsInt64AndOverflow
 #include "python/float.h" // py::Float
 #include "python/int.h"   // py::Int
-#include "python/list.h"  // py::list
-#include "python/string.h"// py::string
+#include "python/list.h"  // py::olist
+#include "python/string.h"// py::ostring
 #include "utils.h"
 #include "utils/exceptions.h"
 
@@ -39,7 +39,7 @@ extern PyObject* Py_Zero;
  * pythonic `False` or number 0 as "false" values, and pythonic `None` as NA.
  * If any other value is encountered, the parse will fail.
  */
-static bool parse_as_bool(const py::list& list, MemoryRange& membuf, size_t& from)
+static bool parse_as_bool(const py::olist& list, MemoryRange& membuf, size_t& from)
 {
   size_t nrows = list.size();
   membuf.resize(nrows);
@@ -71,7 +71,7 @@ static bool parse_as_bool(const py::list& list, MemoryRange& membuf, size_t& fro
  * fails for any reason (for example, method `__bool__()` raised an exception)
  * then the value will be converted into NA.
  */
-static void force_as_bool(const py::list& list, MemoryRange& membuf)
+static void force_as_bool(const py::olist& list, MemoryRange& membuf)
 {
   size_t nrows = list.size();
   membuf.resize(nrows);
@@ -101,7 +101,7 @@ static void force_as_bool(const py::list& list, MemoryRange& membuf)
  * parser will fail if the `int` value does not fit into the range of type `T`.
  */
 template <typename T>
-static bool parse_as_int(const py::list& list, MemoryRange& membuf, size_t& from)
+static bool parse_as_int(const py::olist& list, MemoryRange& membuf, size_t& from)
 {
   size_t nrows = list.size();
   membuf.resize(nrows * sizeof(T));
@@ -142,7 +142,7 @@ static bool parse_as_int(const py::list& list, MemoryRange& membuf, size_t& from
  * as C++'s `static_cast<T>`).
  */
 template <typename T>
-static void force_as_int(const py::list& list, MemoryRange& membuf)
+static void force_as_int(const py::olist& list, MemoryRange& membuf)
 {
   size_t nrows = list.size();
   membuf.resize(nrows * sizeof(T));
@@ -170,7 +170,7 @@ static void force_as_int(const py::list& list, MemoryRange& membuf)
  * as doubles, and it's extremely hard to determine whether that number should
  * have been a float instead...
  */
-static bool parse_as_double(const py::list& list, MemoryRange& membuf, size_t& from)
+static bool parse_as_double(const py::olist& list, MemoryRange& membuf, size_t& from)
 {
   size_t nrows = list.size();
   membuf.resize(nrows * sizeof(double));
@@ -206,7 +206,7 @@ static bool parse_as_double(const py::list& list, MemoryRange& membuf, size_t& f
 
 
 template <typename T>
-static void force_as_real(const py::list& list, MemoryRange& membuf)
+static void force_as_real(const py::olist& list, MemoryRange& membuf)
 {
   size_t nrows = list.size();
   membuf.resize(nrows * sizeof(T));
@@ -238,7 +238,7 @@ static void force_as_real(const py::list& list, MemoryRange& membuf)
 //------------------------------------------------------------------------------
 
 template <typename T>
-static bool parse_as_str(const py::list& list, MemoryRange& offbuf,
+static bool parse_as_str(const py::olist& list, MemoryRange& offbuf,
                          MemoryRange& strbuf)
 {
   size_t nrows = list.size();
@@ -311,7 +311,7 @@ static bool parse_as_str(const py::list& list, MemoryRange& offbuf,
  * `int32_t`.
  */
 template <typename T>
-static void force_as_str(const py::list& list, MemoryRange& offbuf,
+static void force_as_str(const py::olist& list, MemoryRange& offbuf,
                          MemoryRange& strbuf)
 {
   size_t nrows = list.size();
@@ -374,7 +374,7 @@ static void force_as_str(const py::list& list, MemoryRange& offbuf,
 // Object
 //------------------------------------------------------------------------------
 
-static bool parse_as_pyobj(const py::list& list, MemoryRange& membuf)
+static bool parse_as_pyobj(const py::olist& list, MemoryRange& membuf)
 {
   size_t nrows = list.size();
   membuf.resize(nrows * sizeof(PyObject*));
@@ -431,7 +431,7 @@ static int find_next_stype(int curr_stype, int stype0, int ltype0) {
 
 
 
-Column* Column::from_pylist(const py::list& list, int stype0, int ltype0)
+Column* Column::from_pylist(const py::olist& list, int stype0, int ltype0)
 {
   if (stype0 && ltype0) {
     throw ValueError() << "Cannot fix both stype and ltype";

--- a/c/column_from_pylist.cc
+++ b/c/column_from_pylist.cc
@@ -11,7 +11,7 @@
 #include <type_traits>    // std::is_same
 #include "py_types.h"     // PyLong_AsInt64AndOverflow
 #include "python/float.h" // py::Float
-#include "python/int.h"   // py::Int
+#include "python/int.h"   // py::oint
 #include "python/list.h"  // py::olist
 #include "python/string.h"// py::ostring
 #include "utils.h"
@@ -120,7 +120,7 @@ static bool parse_as_int(const py::olist& list, MemoryRange& membuf, size_t& fro
         continue;
       }
       if (item.is_int()) {
-        py::Int litem = item.to_pyint();
+        py::oint litem = item.to_pyint();
         outdata[i] = litem.value<T>(&overflow);
         if (!overflow) continue;
       }
@@ -154,7 +154,7 @@ static void force_as_int(const py::olist& list, MemoryRange& membuf)
       outdata[i] = GETNA<T>();
       continue;
     }
-    py::Int litem = item.to_pyint_force();
+    py::oint litem = item.to_pyint_force();
     outdata[i] = litem.masked_value<T>();
   }
 }
@@ -188,7 +188,7 @@ static bool parse_as_double(const py::olist& list, MemoryRange& membuf, size_t& 
         continue;
       }
       if (item.is_int()) {
-        py::Int litem = item.to_pyint();
+        py::oint litem = item.to_pyint();
         outdata[i] = litem.value<double>(&overflow);
         continue;
       }
@@ -221,7 +221,7 @@ static void force_as_real(const py::olist& list, MemoryRange& membuf)
       continue;
     }
     if (item.is_int()) {
-      py::Int litem = item.to_pyint();
+      py::oint litem = item.to_pyint();
       outdata[i] = litem.value<T>(&overflow);
       continue;
     }

--- a/c/column_from_pylist.cc
+++ b/c/column_from_pylist.cc
@@ -336,7 +336,7 @@ static void force_as_str(const py::olist& list, MemoryRange& offbuf,
       continue;
     }
     if (!item.is_string()) {
-      item = py::oobj(item.to_pystring_force());
+      item = item.to_pystring_force();
     }
     if (item.is_string()) {
       CString cstr = item.to_cstring();

--- a/c/csv/reader.cc
+++ b/c/csv/reader.cc
@@ -763,9 +763,9 @@ void GenericReader::report_columns_to_python() {
   size_t ncols = columns.size();
 
   if (override_column_types) {
-    PyyList colDescriptorList(ncols);
+    py::list colDescriptorList(ncols);
     for (size_t i = 0; i < ncols; i++) {
-      colDescriptorList[i] = columns[i].py_descriptor();
+      colDescriptorList.set(i, columns[i].py_descriptor());
     }
 
     py::list newTypesList =
@@ -779,9 +779,9 @@ void GenericReader::report_columns_to_python() {
       }
     }
   } else {
-    PyyList colNamesList(ncols);
+    py::list colNamesList(ncols);
     for (size_t i = 0; i < ncols; ++i) {
-      colNamesList[i] = py::ostring(columns[i].get_name());
+      colNamesList.set(i, py::ostring(columns[i].get_name()));
     }
     freader.invoke("_set_column_names", "(O)", colNamesList.release());
   }

--- a/c/csv/reader.cc
+++ b/c/csv/reader.cc
@@ -770,7 +770,7 @@ void GenericReader::report_columns_to_python() {
 
     py::olist newTypesList =
       freader.invoke("_override_columns0", "(O)",
-                     colDescriptorList.release()).to_pylist();
+                     std::move(colDescriptorList).release()).to_pylist();
 
     if (newTypesList) {
       for (size_t i = 0; i < ncols; i++) {
@@ -783,7 +783,8 @@ void GenericReader::report_columns_to_python() {
     for (size_t i = 0; i < ncols; ++i) {
       colNamesList.set(i, py::ostring(columns[i].get_name()));
     }
-    freader.invoke("_set_column_names", "(O)", colNamesList.release());
+    freader.invoke("_set_column_names", "(O)",
+                   std::move(colNamesList).release());
   }
 }
 

--- a/c/csv/reader.cc
+++ b/c/csv/reader.cc
@@ -763,12 +763,12 @@ void GenericReader::report_columns_to_python() {
   size_t ncols = columns.size();
 
   if (override_column_types) {
-    py::list colDescriptorList(ncols);
+    py::olist colDescriptorList(ncols);
     for (size_t i = 0; i < ncols; i++) {
       colDescriptorList.set(i, columns[i].py_descriptor());
     }
 
-    py::list newTypesList =
+    py::olist newTypesList =
       freader.invoke("_override_columns0", "(O)",
                      colDescriptorList.release()).to_pylist();
 
@@ -779,7 +779,7 @@ void GenericReader::report_columns_to_python() {
       }
     }
   } else {
-    py::list colNamesList(ncols);
+    py::olist colNamesList(ncols);
     for (size_t i = 0; i < ncols; ++i) {
       colNamesList.set(i, py::ostring(columns[i].get_name()));
     }

--- a/c/frame/py_frame.cc
+++ b/c/frame/py_frame.cc
@@ -169,7 +169,7 @@ oobj Frame::get_stypes() const {
       SType st = dt->columns[i]->stype();
       ostypes.set(i, info(st).py_stype());
     }
-    stypes = ostypes.release();
+    stypes = std::move(ostypes).release();
   }
   return oobj(stypes);
 }
@@ -182,7 +182,7 @@ oobj Frame::get_ltypes() const {
       SType st = dt->columns[i]->stype();
       oltypes.set(i, info(st).py_ltype());
     }
-    ltypes = oltypes.release();
+    ltypes = std::move(oltypes).release();
   }
   return oobj(ltypes);
 }

--- a/c/frame/py_frame.cc
+++ b/c/frame/py_frame.cc
@@ -133,12 +133,12 @@ void Frame::m__release_buffer__(Py_buffer*) const {
 //------------------------------------------------------------------------------
 
 oobj Frame::get_ncols() const {
-  return py::oInt(dt->ncols);
+  return py::oint(dt->ncols);
 }
 
 
 oobj Frame::get_nrows() const {
-  return py::oInt(dt->nrows);
+  return py::oint(dt->nrows);
 }
 
 void Frame::set_nrows(obj nr) {

--- a/c/frame/py_frame.h
+++ b/c/frame/py_frame.h
@@ -72,7 +72,7 @@ class Frame : public PyObject {
     void _init_names() const;
     void _init_inames() const;
     void _fill_default_names();
-    void _dedup_and_save_names(py::list);
+    void _dedup_and_save_names(py::olist);
     void _replace_names_from_map(py::odict);
 
     friend void pydatatable::_clear_types(pydatatable::obj*); // temp

--- a/c/frame/py_frame_init.cc
+++ b/c/frame/py_frame_init.cc
@@ -90,7 +90,7 @@ static Column* _make_column_from_listlike(py::obj src) {
 }
 
 
-static DataTable* _make_frame_from_list_of_listlike(py::list list) {
+static DataTable* _make_frame_from_list_of_listlike(py::olist list) {
   DTMaker dtm;
   size_t ncols = list.size();
   for (size_t i = 0; i < ncols; ++i) {
@@ -101,7 +101,7 @@ static DataTable* _make_frame_from_list_of_listlike(py::list list) {
 }
 
 
-static DataTable* _make_frame_from_list(py::list list) {
+static DataTable* _make_frame_from_list(py::olist list) {
   if (list.size() == 0) {
     return DTMaker().to_datatable();
   }

--- a/c/frame/py_frame_init.cc
+++ b/c/frame/py_frame_init.cc
@@ -81,7 +81,7 @@ static Column* _make_column_from_listlike(py::obj src) {
     return Column::from_buffer(src.to_borrowed_ref());
   }
   else if (src.is_list()) {
-    return Column::from_pylist(src.to_pylist().to_pyylist(), 0);
+    return Column::from_pylist(src.to_pylist(), 0);
   }
   else if (src.is_range()) {
     // return Column::from_range(src.to_range());

--- a/c/frame/py_frame_names.cc
+++ b/c/frame/py_frame_names.cc
@@ -100,7 +100,7 @@ void Frame::_init_names() const {
   for (size_t i = 0; i < onames.size(); ++i) {
     onames.set(i, py::ostring(dt->names[i]));
   }
-  names = onames.release();
+  names = std::move(onames).release();
 }
 
 
@@ -298,8 +298,8 @@ void Frame::_dedup_and_save_names(py::olist nameslist) {
   }
 
   // Store the pythonic tuple / dict of names
-  names  = new_names.release();
-  inames = new_inames.release();
+  names  = std::move(new_names).release();
+  inames = std::move(new_inames).release();
 
   xassert(ncols == dt->names.size());
   xassert(ncols == static_cast<size_t>(PyTuple_Size(names)));

--- a/c/frame/py_frame_names.cc
+++ b/c/frame/py_frame_names.cc
@@ -313,7 +313,7 @@ void Frame::_replace_names_from_map(py::odict replacements)
   if (!names)  _init_names();
   if (!inames) _init_inames();
 
-  py::odict names_map(inames);
+  py::odict names_map  = py::obj(inames).to_pydict();
   py::olist names_list = py::obj(names).to_pylist();
   _clear_names();
   for (auto kv : replacements) {

--- a/c/frame/py_frame_names.cc
+++ b/c/frame/py_frame_names.cc
@@ -65,7 +65,7 @@ oobj Frame::colindex(PKArgs& args)
       colidx += dt->ncols;
     }
     if (colidx >= 0 && colidx < dt->ncols) {
-      return py::oInt(colidx);
+      return py::oint(colidx);
     }
     throw ValueError() << "Column index `" << colidx << "` is invalid for a "
         "Frame with " << dt->ncols << " column" << (dt->ncols==1? "" : "s");
@@ -234,7 +234,7 @@ void Frame::_dedup_and_save_names(py::olist nameslist) {
 
     // Store the name in all containers
     dt->names.push_back(resname);
-    new_inames.set(newname, oobj(oInt(i)));
+    new_inames.set(newname, oint(i));
     new_names.set(i, std::move(newname));
   }
 
@@ -272,7 +272,7 @@ void Frame::_dedup_and_save_names(py::olist nameslist) {
       if (!dt->names[i].empty()) continue;
       dt->names[i] = prefix + std::to_string(index0);
       oobj newname = py::ostring(dt->names[i]);
-      new_inames.set(newname, oobj(oInt(i)));
+      new_inames.set(newname, oint(i));
       new_names.set(i, std::move(newname));
       index0++;
     }

--- a/c/frame/py_frame_names.cc
+++ b/c/frame/py_frame_names.cc
@@ -314,7 +314,7 @@ void Frame::_replace_names_from_map(py::odict replacements)
   if (!inames) _init_inames();
 
   py::odict names_map(inames);
-  py::olist names_list(names);
+  py::olist names_list = py::obj(names).to_pylist();
   _clear_names();
   for (auto kv : replacements) {
     obj key = kv.first;

--- a/c/frame/py_frame_names.cc
+++ b/c/frame/py_frame_names.cc
@@ -139,7 +139,7 @@ void Frame::_fill_default_names() {
  * names are valid, not duplicate, and if necessary modifies them to enforce
  * such constraints.
  */
-void Frame::_dedup_and_save_names(py::list nameslist) {
+void Frame::_dedup_and_save_names(py::olist nameslist) {
   auto ncols = static_cast<size_t>(dt->ncols);
   if (nameslist.size() != ncols) {
     throw ValueError() << "The `names` list has length " << nameslist.size()
@@ -314,7 +314,7 @@ void Frame::_replace_names_from_map(py::odict replacements)
   if (!inames) _init_inames();
 
   py::odict names_map(inames);
-  py::list  names_list(names);
+  py::olist names_list(names);
   _clear_names();
   for (auto kv : replacements) {
     obj key = kv.first;

--- a/c/py_column.cc
+++ b/c/py_column.cc
@@ -184,12 +184,12 @@ PyObject* topython(pycolumn::obj* self, PyObject*) {
 
   int itype = static_cast<int>(col->stype());
   auto formatter = py_stype_formatters[itype];
-  PyyList out(static_cast<size_t>(col->nrows));
+  py::list out(static_cast<size_t>(col->nrows));
 
   col->rowindex().strided_loop2(0, col->nrows, 1,
     [&](int64_t i, int64_t j) {
-      PyObject* val = ISNA(j)? none() : formatter(col, j);
-      out[static_cast<size_t>(i)] = val;
+      out.set(i, ISNA(j)? py::None()
+                        : py::oobj::from_new_reference(formatter(col, j)));
     });
 
   return out.release();

--- a/c/py_column.cc
+++ b/c/py_column.cc
@@ -184,7 +184,7 @@ PyObject* topython(pycolumn::obj* self, PyObject*) {
 
   int itype = static_cast<int>(col->stype());
   auto formatter = py_stype_formatters[itype];
-  py::olist out(static_cast<size_t>(col->nrows));
+  py::olist out(col->nrows);
 
   col->rowindex().strided_loop2(0, col->nrows, 1,
     [&](int64_t i, int64_t j) {
@@ -192,7 +192,7 @@ PyObject* topython(pycolumn::obj* self, PyObject*) {
                         : py::oobj::from_new_reference(formatter(col, j)));
     });
 
-  return out.release();
+  return std::move(out).release();
 }
 
 

--- a/c/py_column.cc
+++ b/c/py_column.cc
@@ -46,7 +46,7 @@ PyObject* column_from_list(PyObject*, PyObject* args) {
   int stype = 0, ltype = 0;
   if (!PyArg_ParseTuple(args, "O|ii", &arg1, &stype, &ltype))
     return nullptr;
-  py::list list = py::obj(arg1).to_pylist();
+  py::olist list = py::obj(arg1).to_pylist();
 
   Column* col = Column::from_pylist(list, stype, ltype);
   return from_column(col, nullptr, 0);
@@ -184,7 +184,7 @@ PyObject* topython(pycolumn::obj* self, PyObject*) {
 
   int itype = static_cast<int>(col->stype());
   auto formatter = py_stype_formatters[itype];
-  py::list out(static_cast<size_t>(col->nrows));
+  py::olist out(static_cast<size_t>(col->nrows));
 
   col->rowindex().strided_loop2(0, col->nrows, 1,
     [&](int64_t i, int64_t j) {

--- a/c/py_columnset.cc
+++ b/c/py_columnset.cc
@@ -78,7 +78,7 @@ PyObject* columns_from_mixed(PyObject*, PyObject *args)
                         &arg1, &pydatatable::unwrap, &dt,
                         &nrows, &rawptr))
     return nullptr;
-  py::list pyspec = py::obj(arg1).to_pylist();
+  py::olist pyspec = py::obj(arg1).to_pylist();
 
   columnset_mapfn* fnptr = reinterpret_cast<columnset_mapfn*>(rawptr);
   size_t ncols = pyspec.size();

--- a/c/py_datatable.cc
+++ b/c/py_datatable.cc
@@ -594,7 +594,7 @@ PyObject* join(obj* self, PyObject* args) {
   DataTable* dt = self->ref;
   DataTable* jdt = py::obj(arg2).to_frame();
   RowIndex ri = py::obj(arg1).to_rowindex();
-  py::olist cols(arg3);
+  py::olist cols = py::obj(arg3).to_pylist();
 
   if (cols.size() != 1) {
     throw NotImplError() << "Only single-column joins are currently supported";

--- a/c/py_datatable.cc
+++ b/c/py_datatable.cc
@@ -100,7 +100,7 @@ PyObject* open_jay(PyObject*, PyObject* args) {
   for (size_t i = 0; i < colnames.size(); ++i) {
     collist.set(i, py::ostring(colnames[i]));
   }
-  PyObject* pylist = collist.release();
+  PyObject* pylist = std::move(collist).release();
 
   return Py_BuildValue("OO", pydt, pylist);
 }

--- a/c/py_datatable.cc
+++ b/c/py_datatable.cc
@@ -96,7 +96,7 @@ PyObject* open_jay(PyObject*, PyObject* args) {
   DataTable* dt = DataTable::open_jay(filename, colnames);
   PyObject* pydt = wrap(dt);
 
-  py::list collist(colnames.size());
+  py::olist collist(colnames.size());
   for (size_t i = 0; i < colnames.size(); ++i) {
     collist.set(i, py::ostring(colnames[i]));
   }
@@ -432,7 +432,7 @@ PyObject* replace_column_array(obj* self, PyObject* args) {
   PyObject *arg1, *arg2, *arg3;
   if (!PyArg_ParseTuple(args, "OOO:replace_column_array", &arg1, &arg2, &arg3))
       return nullptr;
-  py::list cols = py::obj(arg1).to_pylist();
+  py::olist cols = py::obj(arg1).to_pylist();
   RowIndex rows_ri = py::obj(arg2).to_rowindex();
   DataTable* repl = py::obj(arg3).to_frame();
   int64_t rrows = repl->nrows;
@@ -594,7 +594,7 @@ PyObject* join(obj* self, PyObject* args) {
   DataTable* dt = self->ref;
   DataTable* jdt = py::obj(arg2).to_frame();
   RowIndex ri = py::obj(arg1).to_rowindex();
-  py::list cols(arg3);
+  py::olist cols(arg3);
 
   if (cols.size() != 1) {
     throw NotImplError() << "Only single-column joins are currently supported";

--- a/c/py_datatable.cc
+++ b/c/py_datatable.cc
@@ -89,16 +89,16 @@ PyObject* datatable_load(PyObject*, PyObject* args) {
 
 PyObject* open_jay(PyObject*, PyObject* args) {
   PyObject* arg1;
-  if (!PyArg_ParseTuple(args, "O:open_jay_fb", &arg1)) return nullptr;
+  if (!PyArg_ParseTuple(args, "O:open_jay", &arg1)) return nullptr;
   std::string filename = py::obj(arg1).to_string();
 
   std::vector<std::string> colnames;
   DataTable* dt = DataTable::open_jay(filename, colnames);
   PyObject* pydt = wrap(dt);
 
-  PyyList collist(colnames.size());
+  py::list collist(colnames.size());
   for (size_t i = 0; i < colnames.size(); ++i) {
-    collist[i] = py::ostring(colnames[i]);
+    collist.set(i, py::ostring(colnames[i]));
   }
   PyObject* pylist = collist.release();
 
@@ -432,7 +432,7 @@ PyObject* replace_column_array(obj* self, PyObject* args) {
   PyObject *arg1, *arg2, *arg3;
   if (!PyArg_ParseTuple(args, "OOO:replace_column_array", &arg1, &arg2, &arg3))
       return nullptr;
-  PyyList cols(arg1);
+  py::list cols = py::obj(arg1).to_pylist();
   RowIndex rows_ri = py::obj(arg2).to_rowindex();
   DataTable* repl = py::obj(arg3).to_frame();
   int64_t rrows = repl->nrows;

--- a/c/py_datatable_fromlist.cc
+++ b/c/py_datatable_fromlist.cc
@@ -29,8 +29,8 @@ PyObject* pydatatable::datatable_from_list(PyObject*, PyObject* args)
   PyObject* arg2;
   if (!PyArg_ParseTuple(args, "OO:from_list", &arg1, &arg2))
     return nullptr;
-  py::list srcs = py::obj(arg1).to_pylist();
-  py::list types = py::obj(arg2).to_pylist();
+  py::olist srcs = py::obj(arg1).to_pylist();
+  py::olist types = py::obj(arg2).to_pylist();
 
   if (srcs && types && srcs.size() != types.size()) {
     throw ValueError() << "The list of sources has size " << srcs.size()
@@ -48,7 +48,7 @@ PyObject* pydatatable::datatable_from_list(PyObject*, PyObject* args)
     if (item.is_buffer()) {
       cols[i] = Column::from_buffer(item.to_borrowed_ref());
     } else if (item.is_list()) {
-      py::list list = item.to_pylist();
+      py::olist list = item.to_pylist();
       int stype = 0;
       if (types) {
         stype = types[i].to_int32();

--- a/c/py_datatable_fromlist.cc
+++ b/c/py_datatable_fromlist.cc
@@ -54,7 +54,7 @@ PyObject* pydatatable::datatable_from_list(PyObject*, PyObject* args)
         stype = types[i].to_int32();
         if (ISNA<int32_t>(stype)) stype = 0;
       }
-      cols[i] = Column::from_pylist(list.to_pyylist(), stype);
+      cols[i] = Column::from_pylist(list, stype);
     } else {
       throw ValueError() << "Source list is not list-of-lists";
     }

--- a/c/py_groupby.cc
+++ b/c/py_groupby.cc
@@ -7,6 +7,7 @@
 //------------------------------------------------------------------------------
 #define dt_PY_GROUPBY_cc
 #include "py_groupby.h"
+#include "python/int.h"
 #include "python/list.h"
 
 namespace pygroupby
@@ -50,9 +51,9 @@ PyObject* get_group_sizes(obj* self) {
   Groupby* grpby = self->ref;
   size_t ng = grpby->ngroups();
   const int32_t* offsets = grpby->offsets_r();
-  PyyList res(ng);
+  py::list res(ng);
   for (size_t i = 0; i < ng; ++i) {
-    res[i] = PyLong_FromLongLong(offsets[i + 1] - offsets[i]);
+    res.set(i, py::oInt(offsets[i + 1] - offsets[i]));
   }
   return res.release();
 }
@@ -61,9 +62,9 @@ PyObject* get_group_offsets(obj* self) {
   Groupby* grpby = self->ref;
   size_t ng = grpby->ngroups();
   const int32_t* offsets = grpby->offsets_r();
-  PyyList res(ng + 1);
+  py::list res(ng + 1);
   for (size_t i = 0; i <= ng; ++i) {
-    res[i] = PyLong_FromLongLong(offsets[i]);
+    res.set(i, py::oInt(offsets[i]));
   }
   return res.release();
 }

--- a/c/py_groupby.cc
+++ b/c/py_groupby.cc
@@ -53,7 +53,7 @@ PyObject* get_group_sizes(obj* self) {
   const int32_t* offsets = grpby->offsets_r();
   py::olist res(ng);
   for (size_t i = 0; i < ng; ++i) {
-    res.set(i, py::oInt(offsets[i + 1] - offsets[i]));
+    res.set(i, py::oint(offsets[i + 1] - offsets[i]));
   }
   return res.release();
 }
@@ -64,7 +64,7 @@ PyObject* get_group_offsets(obj* self) {
   const int32_t* offsets = grpby->offsets_r();
   py::olist res(ng + 1);
   for (size_t i = 0; i <= ng; ++i) {
-    res.set(i, py::oInt(offsets[i]));
+    res.set(i, py::oint(offsets[i]));
   }
   return res.release();
 }

--- a/c/py_groupby.cc
+++ b/c/py_groupby.cc
@@ -51,7 +51,7 @@ PyObject* get_group_sizes(obj* self) {
   Groupby* grpby = self->ref;
   size_t ng = grpby->ngroups();
   const int32_t* offsets = grpby->offsets_r();
-  py::list res(ng);
+  py::olist res(ng);
   for (size_t i = 0; i < ng; ++i) {
     res.set(i, py::oInt(offsets[i + 1] - offsets[i]));
   }
@@ -62,7 +62,7 @@ PyObject* get_group_offsets(obj* self) {
   Groupby* grpby = self->ref;
   size_t ng = grpby->ngroups();
   const int32_t* offsets = grpby->offsets_r();
-  py::list res(ng + 1);
+  py::olist res(ng + 1);
   for (size_t i = 0; i <= ng; ++i) {
     res.set(i, py::oInt(offsets[i]));
   }

--- a/c/py_groupby.cc
+++ b/c/py_groupby.cc
@@ -55,7 +55,7 @@ PyObject* get_group_sizes(obj* self) {
   for (size_t i = 0; i < ng; ++i) {
     res.set(i, py::oint(offsets[i + 1] - offsets[i]));
   }
-  return res.release();
+  return std::move(res).release();
 }
 
 PyObject* get_group_offsets(obj* self) {
@@ -66,7 +66,7 @@ PyObject* get_group_offsets(obj* self) {
   for (size_t i = 0; i <= ng; ++i) {
     res.set(i, py::oint(offsets[i]));
   }
-  return res.release();
+  return std::move(res).release();
 }
 
 

--- a/c/python/arg.cc
+++ b/c/python/arg.cc
@@ -66,9 +66,9 @@ bool Arg::is_range()         const { return pyobj.is_range(); }
 // Type conversions
 //------------------------------------------------------------------------------
 
-int32_t  Arg::to_int32_strict() const { return pyobj.to_int32_strict(*this); }
-int64_t  Arg::to_int64_strict() const { return pyobj.to_int64_strict(*this); }
-py::list Arg::to_pylist()       const { return pyobj.to_pylist(*this); }
+int32_t   Arg::to_int32_strict() const { return pyobj.to_int32_strict(*this); }
+int64_t   Arg::to_int64_strict() const { return pyobj.to_int64_strict(*this); }
+py::olist Arg::to_pylist()       const { return pyobj.to_pylist(*this); }
 
 
 

--- a/c/python/arg.h
+++ b/c/python/arg.h
@@ -53,7 +53,7 @@ class Arg : public _obj::error_manager {
     //---- Type conversions ------------
     int32_t     to_int32_strict  () const;
     int64_t     to_int64_strict  () const;
-    py::list    to_pylist        () const;
+    py::olist   to_pylist        () const;
 
 
     //---- Error messages --------------

--- a/c/python/dict.cc
+++ b/c/python/dict.cc
@@ -11,26 +11,51 @@ namespace py {
 
 
 //------------------------------------------------------------------------------
-// odict
+// Constructors
 //------------------------------------------------------------------------------
 
 odict::odict() {
   v = PyDict_New();
 }
 
+odict::odict(PyObject* src) : oobj(src) {}
 
-bool odict::has(obj key) const {
-  return PyDict_GetItem(v, key.to_borrowed_ref()) != nullptr;
+odict::odict(const odict& other) : oobj(other) {}
+
+odict::odict(odict&& other) : oobj(std::move(other)) {}
+
+odict& odict::operator=(const odict& other) {
+  oobj::operator=(other);
+  return *this;
 }
 
-obj odict::get(obj key) const {
+odict& odict::operator=(odict&& other) {
+  oobj::operator=(std::move(other));
+  return *this;
+}
+
+
+
+//------------------------------------------------------------------------------
+// Element accessors
+//------------------------------------------------------------------------------
+
+bool odict::has(_obj key) const {
+  PyObject* _key = key.to_borrowed_ref();
+  return PyDict_GetItem(v, _key) != nullptr;
+}
+
+obj odict::get(_obj key) const {
   // PyDict_GetItem returns a borrowed ref; or NULL if key is not present
-  return obj(PyDict_GetItem(v, key.to_borrowed_ref()));
+  PyObject* _key = key.to_borrowed_ref();
+  return obj(PyDict_GetItem(v, _key));
 }
 
 void odict::set(_obj key, _obj val) {
   // PyDict_SetItem INCREFs both key and value internally
-  int r = PyDict_SetItem(v, key.to_borrowed_ref(), val.to_borrowed_ref());
+  PyObject* _key = key.to_borrowed_ref();
+  PyObject* _val = val.to_borrowed_ref();
+  int r = PyDict_SetItem(v, _key, _val);
   if (r) throw PyError();
 }
 

--- a/c/python/dict.h
+++ b/c/python/dict.h
@@ -14,22 +14,38 @@ namespace py {
 class dict_iterator;
 
 
+/**
+ * Python dict wrapper.
+ *
+ * Keys / values are `py::obj`s. This class supports retrieving a value by
+ * its key, querying existence of a key, inserting new key/value pair, and
+ * iterating over all key/values.
+ */
 class odict : public oobj {
   public:
-    using oobj::oobj;
-    using iterator = dict_iterator;
     odict();
+    odict(const odict&);
+    odict(odict&&);
+    odict& operator=(const odict&);
+    odict& operator=(odict&&);
 
-    bool has(obj key) const;
-    obj get(obj key) const;
+    bool has(_obj key) const;
+    obj  get(_obj key) const;
     void set(_obj key, _obj val);
 
-    iterator begin() const;
-    iterator end() const;
+    dict_iterator begin() const;
+    dict_iterator end() const;
+
+  private:
+    odict(PyObject*);
+    friend class _obj;
 };
 
 
 
+/**
+ * Helper class for iterating over a `py::odict`.
+ */
 class dict_iterator {
   public:
     using value_type = std::pair<py::obj, py::obj>;

--- a/c/python/ext_type.h
+++ b/c/python/ext_type.h
@@ -225,7 +225,7 @@ namespace _impl {
   PyObject* _safe_repr(PyObject* self) {
     try {
       oobj res = static_cast<T*>(self)->m__repr__();
-      return res.release();
+      return std::move(res).release();
     } catch (const std::exception& e) {
       exception_to_python(e);
       return nullptr;
@@ -269,7 +269,7 @@ namespace _impl {
     try {
       T* t = static_cast<T*>(self);
       oobj res = (t->*F)();
-      return res.release();
+      return std::move(res).release();
     } catch (const std::exception& e) {
       exception_to_python(e);
       return nullptr;
@@ -294,7 +294,7 @@ namespace _impl {
       T* tself = static_cast<T*>(self);
       ARGS.bind(args, kwds);
       oobj res = (tself->*F)(ARGS);
-      return res.release();
+      return std::move(res).release();
     } catch (const std::exception& e) {
       exception_to_python(e);
       return nullptr;

--- a/c/python/float.cc
+++ b/c/python/float.cc
@@ -15,58 +15,33 @@ namespace py {
 // Constructors
 //------------------------------------------------------------------------------
 
-Float::Float() : obj(nullptr) {}
+ofloat::ofloat() : oobj() {}
 
-Float::Float(PyObject* src) {
-  if (!src) throw PyError();
-  if (src == Py_None) {
-    obj = nullptr;
-  } else {
-    obj = src;
-    if (!PyFloat_Check(src)) {
-      throw TypeError() << "Object " << src << " is not a float";
-    }
-  }
+ofloat::ofloat(PyObject* src) : oobj(src) {}
+
+ofloat::ofloat(const ofloat& other) : oobj(other) {}
+
+ofloat::ofloat(ofloat&& other) : oobj(std::move(other)) {}
+
+ofloat& ofloat::operator=(const ofloat& other) {
+  oobj::operator=(other);
+  return *this;
 }
 
-Float::Float(const Float& other) {
-  obj = other.obj;
+ofloat& ofloat::operator=(ofloat&& other) {
+  oobj::operator=(std::move(other));
+  return *this;
 }
 
-
-
-oFloat::oFloat() {}
-
-oFloat::oFloat(double v) {
-  obj = PyFloat_FromDouble(v);  // new ref
-}
-
-oFloat::oFloat(PyObject* src) : Float(src) {
-  Py_XINCREF(obj);
-}
-
-oFloat::oFloat(const oFloat& other) {
-  obj = other.obj;
-  Py_XINCREF(obj);
-}
-
-oFloat::oFloat(oFloat&& other) : oFloat() {
-  swap(*this, other);
-}
-
-oFloat oFloat::_from_pyobject_no_checks(PyObject* v) {
-  oFloat res;
-  res.obj = v;
+ofloat ofloat::from_new_reference(PyObject* ref) {
+  ofloat res;
+  res.v = ref;
   return res;
 }
 
-oFloat::~oFloat() {
-  Py_XDECREF(obj);
-}
 
-
-void swap(Float& first, Float& second) noexcept {
-  std::swap(first.obj, second.obj);
+ofloat::ofloat(double src) {
+  v = PyFloat_FromDouble(src);  // new ref
 }
 
 
@@ -76,14 +51,14 @@ void swap(Float& first, Float& second) noexcept {
 //------------------------------------------------------------------------------
 
 template<typename T>
-T Float::value() const {
-  if (!obj) return GETNA<T>();
-  return static_cast<T>(PyFloat_AS_DOUBLE(obj));
+T ofloat::value() const {
+  if (!v) return GETNA<T>();
+  return static_cast<T>(PyFloat_AS_DOUBLE(v));
 }
 
 
 
-template float  Float::value() const;
-template double Float::value() const;
+template float  ofloat::value() const;
+template double ofloat::value() const;
 
 }  // namespace py

--- a/c/python/float.h
+++ b/c/python/float.h
@@ -13,38 +13,32 @@
 namespace py {
 
 
-class Float {
-  protected:
-    PyObject* obj;
-
+/**
+ * Python float object.
+ */
+class ofloat : public oobj {
   public:
-    Float();
-    Float(PyObject*);
-    Float(const Float&);
-    friend void swap(Float& first, Float& second) noexcept;
+    ofloat();
+    ofloat(double x);
+
+    ofloat(const ofloat&);
+    ofloat(ofloat&&);
+    ofloat& operator=(const ofloat&);
+    ofloat& operator=(ofloat&&);
 
     template <typename T> T value() const;
-};
 
-
-class oFloat : public Float {
-  public:
-    oFloat();
-    oFloat(double x);
-    oFloat(PyObject*);
-    oFloat(const oFloat&);
-    oFloat(oFloat&&);
-    static oFloat _from_pyobject_no_checks(PyObject* v);
-    ~oFloat();
-
-    friend oobj::oobj(oFloat&&);
+  private:
+    ofloat(PyObject*);
+    static ofloat from_new_reference(PyObject*);
+    friend class _obj;
 };
 
 
 
 // Explicit instantiation
-extern template float  Float::value() const;
-extern template double Float::value() const;
+extern template float  ofloat::value() const;
+extern template double ofloat::value() const;
 
 
 }  // namespace py

--- a/c/python/int.h
+++ b/c/python/int.h
@@ -32,66 +32,55 @@ namespace py {
  *   truncate it using `static_cast<T>`.
  *
  */
-class Int {  // capitalized, because lowercase `int` is a reserved word
-  protected:
-    PyObject* obj;
-
+class oint : public oobj {
   public:
-    Int();
-    Int(PyObject*);
-    Int(const Int&);
-    friend void swap(Int& first, Int& second) noexcept;
+    oint();
+    oint(int32_t n);
+    oint(int64_t n);
+    oint(size_t n);
+    oint(double x);
+
+    oint(const oint&);
+    oint(oint&&);
+    oint& operator=(const oint&);
+    oint& operator=(oint&&);
 
     template<typename T> T value() const;
     template<typename T> T value(int* overflow) const;
     template<typename T> T masked_value() const;
+
+  private:
+    oint(PyObject*);
+    static oint from_new_reference(PyObject*);
+    friend class _obj;
 };
 
-
-class oInt : public Int {
-  public:
-    oInt();
-    oInt(int32_t n);
-    oInt(int64_t n);
-    oInt(size_t n);
-    oInt(double x);
-    oInt(PyObject*);
-    oInt(const oInt&);
-    oInt(oInt&&);
-    oInt(oobj&&);
-    ~oInt();
-
-    static oInt _from_pyobject_no_checks(PyObject* v);
-    friend oobj::oobj(oInt&&);
-
-    PyObject* release();
-};
 
 
 // Explicit specializations
-template<> float     Int::value<float>(int*) const;
-template<> double    Int::value<double>(int*) const;
-template<> long      Int::value<long>(int*) const;
-template<> long long Int::value<long long>(int*) const;
-template<> long long Int::masked_value<long long>() const;
+template<> float     oint::value<float>(int*) const;
+template<> double    oint::value<double>(int*) const;
+template<> long      oint::value<long>(int*) const;
+template<> long long oint::value<long long>(int*) const;
+template<> long long oint::masked_value<long long>() const;
 
 // Forward-declare explicit instantiations
-extern template int8_t  Int::value() const;
-extern template int16_t Int::value() const;
-extern template int32_t Int::value() const;
-extern template int64_t Int::value() const;
-extern template float   Int::value() const;
-extern template double  Int::value() const;
+extern template int8_t  oint::value() const;
+extern template int16_t oint::value() const;
+extern template int32_t oint::value() const;
+extern template int64_t oint::value() const;
+extern template float   oint::value() const;
+extern template double  oint::value() const;
 
-extern template int8_t  Int::value(int*) const;
-extern template int16_t Int::value(int*) const;
-extern template int32_t Int::value(int*) const;
-extern template int64_t Int::value(int*) const;
+extern template int8_t  oint::value(int*) const;
+extern template int16_t oint::value(int*) const;
+extern template int32_t oint::value(int*) const;
+extern template int64_t oint::value(int*) const;
 
-extern template int8_t  Int::masked_value() const;
-extern template int16_t Int::masked_value() const;
-extern template int32_t Int::masked_value() const;
-extern template int64_t Int::masked_value() const;
+extern template int8_t  oint::masked_value() const;
+extern template int16_t oint::masked_value() const;
+extern template int32_t oint::masked_value() const;
+extern template int64_t oint::masked_value() const;
 
 
 }  // namespace py

--- a/c/python/list.cc
+++ b/c/python/list.cc
@@ -11,33 +11,44 @@
 namespace py {
 
 
+//------------------------------------------------------------------------------
+// Constructors
+//------------------------------------------------------------------------------
 
-list::list() { v = nullptr; }
+olist::olist() {
+  v = nullptr;
+}
 
-list::list(PyObject* src) : oobj(src) {
+olist::olist(PyObject* src) : oobj(src) {
   is_list = PyList_Check(src);
 }
 
-list::list(size_t n) {
+olist::olist(size_t n) {
   is_list = true;
   v = PyList_New(static_cast<Py_ssize_t>(n));
   if (!v) throw PyError();
 }
 
+olist::operator bool() const noexcept {
+  return v != nullptr;
+}
 
 
-list::operator bool() const { return v != nullptr; }
 
-size_t list::size() const {
+//------------------------------------------------------------------------------
+// Element accessors
+//------------------------------------------------------------------------------
+
+size_t olist::size() const noexcept {
   return static_cast<size_t>(Py_SIZE(v));
 }
 
-obj list::operator[](size_t i) const {
+obj olist::operator[](size_t i) const {
   return obj(is_list? PyList_GET_ITEM(v, i)
                     : PyTuple_GET_ITEM(v, i));
 }
 
-void list::set(int64_t i, const _obj& value) {
+void olist::set(int64_t i, const _obj& value) {
   if (is_list) {
     PyList_SET_ITEM(v, i, value.to_pyobject_newref());
   } else {
@@ -45,7 +56,7 @@ void list::set(int64_t i, const _obj& value) {
   }
 }
 
-void list::set(int64_t i, oobj&& value) {
+void olist::set(int64_t i, oobj&& value) {
   if (is_list) {
     PyList_SET_ITEM(v, i, value.release());
   } else {
@@ -53,19 +64,19 @@ void list::set(int64_t i, oobj&& value) {
   }
 }
 
-void list::set(size_t i, const _obj& value) {
+void olist::set(size_t i, const _obj& value) {
   set(static_cast<int64_t>(i), value);
 }
 
-void list::set(size_t i, oobj&& value) {
+void olist::set(size_t i, oobj&& value) {
   set(static_cast<int64_t>(i), std::move(value));
 }
 
-void list::set(int i, const _obj& value) {
+void olist::set(int i, const _obj& value) {
   set(static_cast<int64_t>(i), value);
 }
 
-void list::set(int i, oobj&& value) {
+void olist::set(int i, oobj&& value) {
   set(static_cast<int64_t>(i), std::move(value));
 }
 

--- a/c/python/list.cc
+++ b/c/python/list.cc
@@ -15,10 +15,6 @@ namespace py {
 // Constructors
 //------------------------------------------------------------------------------
 
-olist::olist() {
-  v = nullptr;
-}
-
 olist::olist(PyObject* src) : oobj(src) {
   is_list = PyList_Check(src);
 }

--- a/c/python/list.cc
+++ b/c/python/list.cc
@@ -84,9 +84,9 @@ void olist::set(int64_t i, const _obj& value) {
 
 void olist::set(int64_t i, oobj&& value) {
   if (is_list) {
-    PyList_SET_ITEM(v, i, value.release());
+    PyList_SET_ITEM(v, i, std::move(value).release());
   } else {
-    PyTuple_SET_ITEM(v, i, value.release());
+    PyTuple_SET_ITEM(v, i, std::move(value).release());
   }
 }
 

--- a/c/python/list.cc
+++ b/c/python/list.cc
@@ -6,6 +6,7 @@
 // © H2O.ai 2018
 //------------------------------------------------------------------------------
 #include "python/list.h"
+#include "utils/assert.h"
 #include "utils/exceptions.h"
 
 namespace py {
@@ -16,7 +17,7 @@ namespace py {
 //------------------------------------------------------------------------------
 
 olist::olist(PyObject* src) : oobj(src) {
-  is_list = PyList_Check(src);
+  is_list = src && PyList_Check(src);
 }
 
 olist::olist(size_t n) {
@@ -39,10 +40,20 @@ size_t olist::size() const noexcept {
   return static_cast<size_t>(Py_SIZE(v));
 }
 
-obj olist::operator[](size_t i) const {
+
+obj olist::operator[](int64_t i) const {
   return obj(is_list? PyList_GET_ITEM(v, i)
                     : PyTuple_GET_ITEM(v, i));
 }
+
+obj olist::operator[](size_t i) const {
+  return this->operator[](static_cast<int64_t>(i));
+}
+
+obj olist::operator[](int i) const {
+  return this->operator[](static_cast<int64_t>(i));
+}
+
 
 void olist::set(int64_t i, const _obj& value) {
   if (is_list) {

--- a/c/python/list.cc
+++ b/c/python/list.cc
@@ -6,127 +6,10 @@
 // © H2O.ai 2018
 //------------------------------------------------------------------------------
 #include "python/list.h"
-#include "python/int.h"
-#include "python/float.h"
-#include "utils/assert.h"
 #include "utils/exceptions.h"
 
-
-
-//------------------------------------------------------------------------------
-// Constructors
-//------------------------------------------------------------------------------
-
-PyyList::PyyList() : list(nullptr) {}
-
-PyyList::PyyList(size_t n) {
-  list = PyList_New(static_cast<Py_ssize_t>(n));
-  if (!list) throw PyError();
-}
-
-PyyList::PyyList(PyObject* src) {
-  if (!src) throw PyError();
-  if (src == Py_None) {
-    list = nullptr;
-  } else {
-    list = src;
-    if (!PyList_Check(src)) {
-      throw TypeError() << "Object " << src << " is not a list";
-    }
-    Py_INCREF(list);
-  }
-}
-
-PyyList::PyyList(const PyyList& other) : PyyList(other.list) {}
-
-PyyList::PyyList(PyyList&& other) : PyyList() {
-  swap(*this, other);
-}
-
-PyyList::~PyyList() {
-  Py_XDECREF(list);
-}
-
-
-void swap(PyyList& first, PyyList& second) noexcept {
-  std::swap(first.list, second.list);
-}
-
-
-
-//------------------------------------------------------------------------------
-// PyyList API
-//------------------------------------------------------------------------------
-
-size_t PyyList::size() const noexcept {
-  return static_cast<size_t>(PyList_GET_SIZE(list));
-}
-
-
-PyyList::operator bool() const noexcept {
-  return (list != nullptr);
-}
-
-
-PyyListEntry PyyList::operator[](size_t i) const {
-  return PyyListEntry(list, static_cast<Py_ssize_t>(i));
-}
-
-
-PyObject* PyyList::release() {
-  PyObject* o = list;
-  list = nullptr;
-  return o;
-}
-
-
-
-//------------------------------------------------------------------------------
-// PyyListEntry API
-//------------------------------------------------------------------------------
-
-PyyListEntry::PyyListEntry(PyObject* pylist, Py_ssize_t index)
-  : list(pylist), i(index) {}
-
-
-PyyListEntry& PyyListEntry::operator=(PyObject* s) {
-  xassert(list);
-  PyList_SET_ITEM(list, i, s);
-  return *this;
-}
-
-
-PyyListEntry& PyyListEntry::operator=(py::oobj&& o) {
-  PyObject* item = o.release();
-  PyList_SET_ITEM(list, i, item);
-  return *this;
-}
-
-
-PyObject* PyyListEntry::get() const {
-  xassert(list);
-  return PyList_GET_ITEM(list, i);
-}
-
-
-PyyListEntry::operator py::oobj() const { return py::oobj(get()); }
-PyyListEntry::operator py::obj() const { return py::obj(get()); }
-PyyListEntry::operator PyyList() const { return PyyList(get()); }
-PyyListEntry::operator py::Float() const { return py::Float(get()); }
-
-
-PyObject* PyyListEntry::as_new_ref() const {
-  PyObject* res = PyList_GET_ITEM(list, i);
-  Py_XINCREF(res);
-  return res;
-}
-
-
-
-//------------------------------------------------------------------------------
-// py::List
-//------------------------------------------------------------------------------
 namespace py {
+
 
 
 list::list() { v = nullptr; }
@@ -135,9 +18,12 @@ list::list(PyObject* src) : oobj(src) {
   is_list = PyList_Check(src);
 }
 
-list::list(const PyyList& src) : list(src.list) {}
+list::list(size_t n) {
+  is_list = true;
+  v = PyList_New(static_cast<Py_ssize_t>(n));
+  if (!v) throw PyError();
+}
 
-PyyList list::to_pyylist() const { return PyyList(v); }
 
 
 list::operator bool() const { return v != nullptr; }

--- a/c/python/list.h
+++ b/c/python/list.h
@@ -14,19 +14,19 @@ namespace py {
 class Arg;
 
 
-class list : public oobj {
+class olist : public oobj {
   private:
     bool is_list;
     size_t : 56;
 
   public:
     using oobj::oobj;
-    list();
-    list(PyObject*);
-    list(size_t n);
+    olist();
+    olist(PyObject*);
+    olist(size_t n);
 
-    operator bool() const;
-    size_t size() const;
+    operator bool() const noexcept;
+    size_t size() const noexcept;
     obj operator[](size_t i) const;
 
     void set(size_t i,  const _obj& value);

--- a/c/python/list.h
+++ b/c/python/list.h
@@ -11,7 +11,6 @@
 #include "python/obj.h"
 
 namespace py {
-class Arg;
 
 
 /**
@@ -60,7 +59,6 @@ class olist : public oobj {
     olist(PyObject* src);
 
     friend class _obj;
-    friend class Arg;
 };
 
 

--- a/c/python/list.h
+++ b/c/python/list.h
@@ -10,106 +10,6 @@
 #include <Python.h>
 #include "python/obj.h"
 
-class PyyList;
-// class PyyLong;
-// class PyyFloat;
-namespace py { class list; class Float; }
-
-
-class PyyListEntry {
-  private:
-    PyObject* list;  // borrowed ref
-    Py_ssize_t i;
-
-  public:
-    PyyListEntry(PyObject* list, Py_ssize_t i);
-
-    operator py::oobj() const;
-    operator py::obj() const;
-    operator PyyList() const;
-    // operator PyyLong() const;
-    operator py::Float() const;
-    PyyListEntry& operator=(PyObject*);
-    PyyListEntry& operator=(py::oobj&&);
-
-    PyObject* as_new_ref() const;
-
-  private:
-    PyObject* get() const;  // returns a borrowed ref
-};
-
-
-
-/**
- * PyyList: C++ wrapper around pythonic PyList class. The wrapper holds a
- * persistent reference to the underlying `list` (in the sense that it INCREFs
- * it upon acquiral and decrefs during destruction).
- *
- * Construction
- * ------------
- * PyyList()
- *   Construct a void PyyList object (not backed by any PyObject*).
- *
- * PyyList(size_t n)
- *   Creates a new Pythonic list of size `n` and returns it as PyyList object.
- *   Initially the list is filled with NULLs, the user must fill it with actual
- *   values before returning to Python.
- *
- * PyyList(PyObject* src)
- *   Construct PyyList from the provided PyObject (which must be an instance of
- *   PyList_Object, or Py_None). If `src` is NULL or not a PyList, an exception
- *   will be raised. If `src` was a "newref", the caller is still responsible
- *   for decrefing it.
- *
- * PyyList(const PyyList&)
- * PyyList(PyyList&&)
- *   Copy- and move- constructors.
- *
- *
- * Public API
- * ----------
- * size()
- *   Returns the number of elements in the list.
- *
- * operator bool()
- *   Returns true if the object is non-void (i.e. wraps a non-NULL PyObject).
- *   Note that this will return true even if the underlying list has 0 size.
- *
- * operator[](i)
- *   Returns i-th element of the list as a PyyListEntry object. This entry acts
- *   as a reference: it can be both read (by casting into `obj`) and written
- *   by assigning a `PyObject*` / `oobj` to it.
- *
- * release()
- *   Converts PyyList into the primitive `PyObject*` which can be used by
- *   Python. This method is destructive: the PyyList object becomes "void" after
- *   this method is called. Note that the returned value is a "new reference":
- *   the caller is responsible for dec-refing it eventually.
- *
- */
-class PyyList {
-  private:
-    PyObject* list;
-
-  public:
-    PyyList();
-    PyyList(size_t n);
-    PyyList(PyObject*);
-    PyyList(const PyyList&);
-    PyyList(PyyList&&);
-    ~PyyList();
-
-    size_t size() const noexcept;
-    operator bool() const noexcept;
-    PyyListEntry operator[](size_t i) const;
-    PyObject* release();
-
-    friend void swap(PyyList& first, PyyList& second) noexcept;
-    friend py::list;
-};
-
-
-
 namespace py {
 class Arg;
 
@@ -123,8 +23,7 @@ class list : public oobj {
     using oobj::oobj;
     list();
     list(PyObject*);
-    list(const PyyList&);  // temp
-    PyyList to_pyylist() const;
+    list(size_t n);
 
     operator bool() const;
     size_t size() const;

--- a/c/python/list.h
+++ b/c/python/list.h
@@ -35,6 +35,10 @@ class olist : public oobj {
 
   public:
     olist(size_t n);
+    olist(const olist&);
+    olist(olist&&);
+    olist& operator=(const olist&);
+    olist& operator=(olist&&);
 
     operator bool() const noexcept;
     size_t size() const noexcept;

--- a/c/python/list.h
+++ b/c/python/list.h
@@ -21,8 +21,6 @@ class olist : public oobj {
 
   public:
     using oobj::oobj;
-    olist();
-    olist(PyObject*);
     olist(size_t n);
 
     operator bool() const noexcept;
@@ -36,6 +34,12 @@ class olist : public oobj {
     void set(int64_t i, oobj&& value);
     void set(int i,     oobj&& value);
 
+  private:
+    // Wrap an existing PyObject* into an `olist`. This constructor is private,
+    // use `py::org(src).to_pylist()` instead.
+    olist(PyObject* src);
+
+    friend class _obj;
     friend class Arg;
 };
 

--- a/c/python/list.h
+++ b/c/python/list.h
@@ -14,18 +14,34 @@ namespace py {
 class Arg;
 
 
+/**
+ * Python list of objects.
+ *
+ * There are 2 ways of instantiating this class: either by creating a new list
+ * of `n` elements via `olist(n)`, or by casting a `py::obj` into a list using
+ * `.to_pylist()` method. The former method is used when you want to create a
+ * new list and return it to Python, the latter when you're processing a list
+ * which came from Python.
+ *
+ * In most cases when some function/method accepts a pythonic list, it should
+ * work just as well when passed a tuple instead. Because of this, `olist`
+ * objects can actually wrap both `PyList` objects and `PyTuple` objects --
+ * transparently to the user.
+ */
 class olist : public oobj {
   private:
     bool is_list;
     size_t : 56;
 
   public:
-    using oobj::oobj;
     olist(size_t n);
 
     operator bool() const noexcept;
     size_t size() const noexcept;
+
     obj operator[](size_t i) const;
+    obj operator[](int64_t i) const;
+    obj operator[](int i) const;
 
     void set(size_t i,  const _obj& value);
     void set(int64_t i, const _obj& value);

--- a/c/python/obj.cc
+++ b/c/python/obj.cc
@@ -494,7 +494,7 @@ PyTypeObject* _obj::typeobj() const noexcept {
 }
 
 
-PyObject* oobj::release() {
+PyObject* oobj::release() && {
   PyObject* t = v;
   v = nullptr;
   return t;

--- a/c/python/obj.cc
+++ b/c/python/obj.cc
@@ -71,10 +71,6 @@ oobj::oobj(oFloat&& other) {
   other.obj = nullptr;;
 }
 
-oobj::oobj(ostring&& other) {
-  v = other.obj;
-  other.obj = nullptr;;
-}
 
 
 oobj& oobj::operator=(const oobj& other) {

--- a/c/python/obj.cc
+++ b/c/python/obj.cc
@@ -331,10 +331,10 @@ py::ostring _obj::to_pystring_force(const error_manager&) const noexcept {
 // List conversions
 //------------------------------------------------------------------------------
 
-py::list _obj::to_pylist(const error_manager& em) const {
-  if (is_none()) return py::list();
+py::olist _obj::to_pylist(const error_manager& em) const {
+  if (is_none()) return py::olist();
   if (is_list() || is_tuple()) {
-    return py::list(v);
+    return py::olist(v);
   }
   throw em.error_not_list(v);
 }

--- a/c/python/obj.cc
+++ b/c/python/obj.cc
@@ -61,11 +61,6 @@ oobj::oobj(oobj&& other) {
   other.v = nullptr;
 }
 
-oobj::oobj(oInt&& other) {
-  v = other.obj;
-  other.obj = nullptr;;
-}
-
 oobj::oobj(oFloat&& other) {
   v = other.obj;
   other.obj = nullptr;;
@@ -220,24 +215,22 @@ int64_t _obj::to_int64_strict(const error_manager& em) const {
 }
 
 
-py::Int _obj::to_pyint(const error_manager& em) const {
-  if (PyLong_Check(v) || v == Py_None) {
-    return py::Int(v);
-  }
+py::oint _obj::to_pyint(const error_manager& em) const {
+  if (v == Py_None) return py::oint();
+  if (PyLong_Check(v)) return py::oint(v);
   throw em.error_not_integer(v);
 }
 
 
-py::oInt _obj::to_pyint_force(const error_manager&) const noexcept {
-  if (PyLong_Check(v) || v == Py_None) {
-    return py::oInt(v);
-  }
+py::oint _obj::to_pyint_force(const error_manager&) const noexcept {
+  if (v == Py_None) return py::oint();
+  if (PyLong_Check(v)) return py::oint(v);
   PyObject* num = PyNumber_Long(v);  // new ref
   if (!num) {
     PyErr_Clear();
     num = nullptr;
   }
-  return py::oInt::_from_pyobject_no_checks(num);
+  return py::oint::from_new_reference(num);
 }
 
 

--- a/c/python/obj.cc
+++ b/c/python/obj.cc
@@ -61,11 +61,6 @@ oobj::oobj(oobj&& other) {
   other.v = nullptr;
 }
 
-oobj::oobj(oFloat&& other) {
-  v = other.obj;
-  other.obj = nullptr;;
-}
-
 
 
 oobj& oobj::operator=(const oobj& other) {
@@ -253,16 +248,16 @@ double _obj::to_double(const error_manager& em) const {
 }
 
 
-oFloat _obj::to_pyfloat_force(const error_manager&) const noexcept {
+ofloat _obj::to_pyfloat_force(const error_manager&) const noexcept {
   if (PyFloat_Check(v) || v == Py_None) {
-    return py::oFloat(v);
+    return py::ofloat(v);
   }
   PyObject* num = PyNumber_Float(v);  // new ref
   if (!num) {
     PyErr_Clear();
     num = nullptr;
   }
-  return py::oFloat::_from_pyobject_no_checks(num);
+  return py::ofloat::from_new_reference(num);
 }
 
 

--- a/c/python/obj.cc
+++ b/c/python/obj.cc
@@ -78,9 +78,9 @@ oobj::oobj(ostring&& other) {
 
 
 oobj& oobj::operator=(const oobj& other) {
+  Py_XINCREF(other.v);
   Py_XDECREF(v);
   v = other.v;
-  Py_XINCREF(v);
   return *this;
 }
 

--- a/c/python/obj.cc
+++ b/c/python/obj.cc
@@ -50,7 +50,7 @@ oobj::oobj() {
 
 oobj::oobj(PyObject* p) {
   v = p;
-  Py_INCREF(p);
+  Py_XINCREF(p);
 }
 
 oobj::oobj(const oobj& other) : oobj(other.v) {}
@@ -332,7 +332,7 @@ py::ostring _obj::to_pystring_force(const error_manager&) const noexcept {
 //------------------------------------------------------------------------------
 
 py::olist _obj::to_pylist(const error_manager& em) const {
-  if (is_none()) return py::olist();
+  if (is_none()) return py::olist(nullptr);
   if (is_list() || is_tuple()) {
     return py::olist(v);
   }

--- a/c/python/obj.h
+++ b/c/python/obj.h
@@ -236,7 +236,6 @@ class oobj : public _obj {
     oobj(oobj&&);
     oobj(oInt&&);
     oobj(oFloat&&);
-    oobj(ostring&&);
     oobj& operator=(const oobj&);
     oobj& operator=(oobj&&);
     ~oobj();

--- a/c/python/obj.h
+++ b/c/python/obj.h
@@ -27,9 +27,9 @@ class oInt;
 class Float;
 class oFloat;
 class string;
-class ostring;
-class list;
 class odict;
+class olist;
+class ostring;
 class obj;
 class oobj;
 using strvec = std::vector<std::string>;
@@ -169,7 +169,7 @@ class _obj {
 
     char**      to_cstringlist   (const error_manager& = _em0) const;
     strvec      to_stringlist    (const error_manager& = _em0) const;
-    py::list    to_pylist        (const error_manager& = _em0) const;
+    py::olist   to_pylist        (const error_manager& = _em0) const;
     py::odict   to_pydict        (const error_manager& = _em0) const;
 
     Column*     to_column        (const error_manager& = _em0) const;

--- a/c/python/obj.h
+++ b/c/python/obj.h
@@ -238,7 +238,12 @@ class oobj : public _obj {
     ~oobj();
 
     static oobj from_new_reference(PyObject* p);
-    PyObject* release();
+
+    // Return the underlying PyObject*, as a new ref, but invalidating this
+    // object in the process. Use as:
+    //    std::move(x).release();
+    //
+    PyObject* release() &&;
 };
 
 

--- a/c/python/obj.h
+++ b/c/python/obj.h
@@ -22,8 +22,7 @@ namespace py {
 
 // Forward declarations
 class Arg;
-class Int;
-class oInt;
+class oint;
 class Float;
 class oFloat;
 class string;
@@ -157,8 +156,8 @@ class _obj {
     int64_t     to_int64         (const error_manager& = _em0) const;
     int32_t     to_int32_strict  (const error_manager& = _em0) const;
     int64_t     to_int64_strict  (const error_manager& = _em0) const;
-    py::Int     to_pyint         (const error_manager& = _em0) const;
-    py::oInt    to_pyint_force   (const error_manager& = _em0) const noexcept;
+    py::oint    to_pyint         (const error_manager& = _em0) const;
+    py::oint    to_pyint_force   (const error_manager& = _em0) const noexcept;
 
     double      to_double        (const error_manager& = _em0) const;
     py::oFloat  to_pyfloat_force (const error_manager& = _em0) const noexcept;
@@ -234,7 +233,6 @@ class oobj : public _obj {
     oobj(const oobj&);
     oobj(const obj&);
     oobj(oobj&&);
-    oobj(oInt&&);
     oobj(oFloat&&);
     oobj& operator=(const oobj&);
     oobj& operator=(oobj&&);

--- a/c/python/obj.h
+++ b/c/python/obj.h
@@ -24,7 +24,7 @@ namespace py {
 class Arg;
 class oint;
 class Float;
-class oFloat;
+class ofloat;
 class string;
 class odict;
 class olist;
@@ -96,7 +96,7 @@ using strvec = std::vector<std::string>;
  *    exception is raised.
  *
  * to_pyfloat_force:  [noexcept]
- *    Convert into a py::oFloat instance, possibly applying pythonic `float(x)`
+ *    Convert into a py::ofloat instance, possibly applying pythonic `float(x)`
  *    function. If the function raises an exception, the value will be
  *    converted into NA.
  *
@@ -160,7 +160,7 @@ class _obj {
     py::oint    to_pyint_force   (const error_manager& = _em0) const noexcept;
 
     double      to_double        (const error_manager& = _em0) const;
-    py::oFloat  to_pyfloat_force (const error_manager& = _em0) const noexcept;
+    py::ofloat  to_pyfloat_force (const error_manager& = _em0) const noexcept;
 
     CString     to_cstring       (const error_manager& = _em0) const;
     std::string to_string        (const error_manager& = _em0) const;
@@ -233,7 +233,6 @@ class oobj : public _obj {
     oobj(const oobj&);
     oobj(const obj&);
     oobj(oobj&&);
-    oobj(oFloat&&);
     oobj& operator=(const oobj&);
     oobj& operator=(oobj&&);
     ~oobj();

--- a/c/python/string.cc
+++ b/c/python/string.cc
@@ -11,86 +11,51 @@
 namespace py {
 
 
-
 //------------------------------------------------------------------------------
 // Constructors
 //------------------------------------------------------------------------------
 
-string::string() : obj(nullptr) {}
+ostring::ostring() : oobj() {}
 
-string::string(PyObject* src) {
-  if (!src) throw PyError();
-  if (src == Py_None) {
-    obj = nullptr;
-  } else {
-    obj = src;
-    if (!PyUnicode_Check(src)) {
-      throw TypeError() << "Object " << src << " is not a string";
-    }
-  }
+ostring::ostring(PyObject* src) : oobj(src) {}
+
+ostring ostring::from_new_reference(PyObject* ref) {
+  ostring res;
+  res.v = ref;
+  return res;
 }
 
-string::string(const string& other) {
-  obj = other.obj;
-}
-
-void swap(string& first, string& second) noexcept {
-  std::swap(first.obj, second.obj);
-}
-
-
-
-ostring::ostring() {}
 
 ostring::ostring(const std::string& s) {
   Py_ssize_t slen = static_cast<Py_ssize_t>(s.size());
-  obj = PyUnicode_FromStringAndSize(s.data(), slen);
+  v = PyUnicode_FromStringAndSize(s.data(), slen);
 }
 
 ostring::ostring(const char* str, size_t len) {
   Py_ssize_t slen = static_cast<Py_ssize_t>(len);
-  obj = PyUnicode_FromStringAndSize(str, slen);
+  v = PyUnicode_FromStringAndSize(str, slen);
 }
 
 ostring::ostring(const char* str) {
   Py_ssize_t slen = static_cast<Py_ssize_t>(std::strlen(str));
-  obj = PyUnicode_FromStringAndSize(str, slen);
-}
-
-ostring::ostring(PyObject* src) : string(src) {
-  Py_XINCREF(src);
-}
-
-ostring::ostring(const ostring& other) {
-  obj = other.obj;
-  Py_XINCREF(obj);
-}
-
-ostring::ostring(ostring&& other) : ostring() {
-  swap(*this, other);
-}
-
-ostring ostring::from_new_reference(PyObject* ref) {
-  ostring res;
-  res.obj = ref;
-  return res;
-}
-
-ostring::~ostring() {
-  Py_XDECREF(obj);
+  v = PyUnicode_FromStringAndSize(str, slen);
 }
 
 
+ostring::ostring(const ostring& other) : oobj(other) {}
 
-//------------------------------------------------------------------------------
-// Other
-//------------------------------------------------------------------------------
+ostring::ostring(ostring&& other) : oobj(std::move(other)) {}
 
-PyObject* ostring::release() {
-  PyObject* t = obj;
-  obj = nullptr;
-  return t;
+ostring& ostring::operator=(const ostring& other) {
+  oobj::operator=(other);
+  return *this;
 }
+
+ostring& ostring::operator=(ostring&& other) {
+  oobj::operator=(std::move(other));
+  return *this;
+}
+
 
 
 }  // namespace py

--- a/c/python/string.h
+++ b/c/python/string.h
@@ -15,36 +15,23 @@ namespace py {
 
 
 /**
- * C++ wrapper around PyUnicode_Object (python `str` object).
+ * Wrapper around a Python string.
  */
-class string {
-  protected:
-    PyObject* obj;
-
-  public:
-    string();
-    string(PyObject*);
-    string(const string&);
-    friend void swap(string& first, string& second) noexcept;
-};
-
-
-
-class ostring : public string {
+class ostring : public oobj {
   public:
     ostring();
     ostring(const std::string& s);
     ostring(const char* str);
     ostring(const char* str, size_t len);
-    ostring(PyObject*);
     ostring(const ostring&);
     ostring(ostring&&);
-    ~ostring();
-    static ostring from_new_reference(PyObject*);
-    friend oobj::oobj(ostring&&);
+    ostring& operator=(const ostring&);
+    ostring& operator=(ostring&&);
 
-    PyObject* to_borrowed_ref() const { return obj; }
-    PyObject* release();
+  private:
+    ostring(PyObject*);
+    static ostring from_new_reference(PyObject*);
+    friend class _obj;
 };
 
 

--- a/c/python/tuple.cc
+++ b/c/python/tuple.cc
@@ -10,6 +10,10 @@
 namespace py {
 
 
+//------------------------------------------------------------------------------
+// Constructors
+//------------------------------------------------------------------------------
+
 otuple::otuple(int n) : otuple(static_cast<int64_t>(n)) {}
 
 otuple::otuple(size_t n) : otuple(static_cast<int64_t>(n)) {}
@@ -18,23 +22,83 @@ otuple::otuple(int64_t n) {
   v = PyTuple_New(n);
 }
 
-
-size_t otuple::size() const {
-  return static_cast<size_t>(Py_SIZE(v));
+otuple::otuple(const otuple& other) {
+  v = other.v;
+  Py_XINCREF(v);
 }
 
-obj otuple::get(size_t i) const {
+otuple::otuple(otuple&& other) {
+  v = other.v;
+  other.v = nullptr;
+}
+
+otuple& otuple::operator=(const otuple& other) {
+  Py_XINCREF(other.v);
+  Py_XDECREF(v);
+  v = other.v;
+  return *this;
+}
+
+otuple& otuple::operator=(otuple&& other) {
+  Py_XDECREF(v);
+  v = other.v;
+  other.v = nullptr;
+  return *this;
+}
+
+
+
+//------------------------------------------------------------------------------
+// Element accessors
+//------------------------------------------------------------------------------
+
+obj otuple::operator[](int64_t i) const {
   // PyTuple_GET_ITEM returns a borrowed reference
   return obj(PyTuple_GET_ITEM(v, i));
 }
 
-void otuple::set(size_t i, const _obj& value) {
+obj otuple::operator[](size_t i) const {
+  return this->operator[](static_cast<int64_t>(i));
+}
+
+obj otuple::operator[](int i) const {
+  return this->operator[](static_cast<int64_t>(i));
+}
+
+
+void otuple::set(int64_t i, const _obj& value) {
   // PyTuple_SET_ITEM "steals" a reference to the last argument
   PyTuple_SET_ITEM(v, i, value.to_pyobject_newref());
 }
 
-void otuple::set(size_t i, oobj&& value) {
+void otuple::set(int64_t i, oobj&& value) {
   PyTuple_SET_ITEM(v, i, value.release());
+}
+
+void otuple::set(size_t i, const _obj& value) {
+  set(static_cast<int64_t>(i), value);
+}
+
+void otuple::set(size_t i, oobj&& value) {
+  set(static_cast<int64_t>(i), std::move(value));
+}
+
+void otuple::set(int i, const _obj& value) {
+  set(static_cast<int64_t>(i), value);
+}
+
+void otuple::set(int i, oobj&& value) {
+  set(static_cast<int64_t>(i), std::move(value));
+}
+
+
+
+//------------------------------------------------------------------------------
+// Misc
+//------------------------------------------------------------------------------
+
+size_t otuple::size() const noexcept {
+  return static_cast<size_t>(Py_SIZE(v));
 }
 
 

--- a/c/python/tuple.cc
+++ b/c/python/tuple.cc
@@ -72,7 +72,7 @@ void otuple::set(int64_t i, const _obj& value) {
 }
 
 void otuple::set(int64_t i, oobj&& value) {
-  PyTuple_SET_ITEM(v, i, value.release());
+  PyTuple_SET_ITEM(v, i, std::move(value).release());
 }
 
 void otuple::set(size_t i, const _obj& value) {

--- a/c/python/tuple.h
+++ b/c/python/tuple.h
@@ -14,7 +14,7 @@ namespace py {
 
 
 /**
- * Class representing a pythonic tuple of elements.
+ * Python tuple of elements.
  *
  * This can be either a tuple passed down from Python, or a new tuple object.
  * If `otuple` is created from an existing PyObject, its elements must not be
@@ -23,15 +23,26 @@ namespace py {
  */
 class otuple : public oobj {
   public:
-    using oobj::oobj;
     otuple(int n);
     otuple(size_t n);
     otuple(int64_t n);
+    otuple(const otuple&);
+    otuple(otuple&&);
+    otuple& operator=(const otuple&);
+    otuple& operator=(otuple&&);
 
-    size_t size() const;
-    obj  get(size_t i) const;
-    void set(size_t i, const _obj& value);
-    void set(size_t i, oobj&& value);
+    size_t size() const noexcept;
+
+    obj operator[](int64_t i) const;
+    obj operator[](size_t i) const;
+    obj operator[](int i) const;
+
+    void set(int64_t i, const _obj& value);
+    void set(size_t i,  const _obj& value);
+    void set(int i,     const _obj& value);
+    void set(int64_t i, oobj&& value);
+    void set(size_t i,  oobj&& value);
+    void set(int i,     oobj&& value);
 };
 
 

--- a/c/read/column.cc
+++ b/c/read/column.cc
@@ -236,7 +236,7 @@ py::oobj Column::py_descriptor() const {
   PyObject* nt_tuple = PyStructSequence_New(name_type_pytuple);  // new ref
   if (!nt_tuple) throw PyError();
   PyObject* stype = info(ParserLibrary::info(ptype).stype).py_stype().release();
-  PyObject* cname = py::oobj(py::ostring(name)).release();
+  PyObject* cname = py::ostring(name).release();
   PyStructSequence_SetItem(nt_tuple, 0, cname);
   PyStructSequence_SetItem(nt_tuple, 1, stype);
   return py::oobj::from_new_reference(nt_tuple);


### PR DESCRIPTION
This PR enforces consistent API among all `py::` classes.
From this point onward we should try to use the new API only, and stay away from pure-C pythonic API.

Closes #1257