### PR TITLE
Fread bug with column containing mixed NaN/int values

### DIFF
--- a/c/csv/fread.cc
+++ b/c/csv/fread.cc
@@ -125,30 +125,30 @@ std::unique_ptr<DataTable> FreadReader::read()
 
     if (firstTime) {
       fo.t_data_read = fo.t_data_reread = wallclock();
-      size_t ncols = columns.size();
-      size_t ncols_to_reread = columns.nColumnsToReread();
-      if (ncols_to_reread) {
-        fo.n_cols_reread += ncols_to_reread;
-        size_t n_type_bump_cols = 0;
-        for (size_t j = 0; j < ncols; j++) {
-          dt::read::Column& col = columns[j];
-          if (!col.is_in_output()) continue;
-          bool bumped = col.is_type_bumped();
-          col.reset_type_bumped();
-          col.set_in_buffer(bumped);
-          n_type_bump_cols += bumped;
-        }
-        firstTime = false;
-        if (verbose) {
-          trace(n_type_bump_cols == 1
-                ? "%zu column needs to be re-read because its type has changed"
-                : "%zu columns need to be re-read because their types have changed",
-                n_type_bump_cols);
-        }
-        goto read;
-      }
     } else {
       fo.t_data_reread = wallclock();
+    }
+    size_t ncols = columns.size();
+    size_t ncols_to_reread = columns.nColumnsToReread();
+    if (ncols_to_reread) {
+      fo.n_cols_reread += ncols_to_reread;
+      size_t n_type_bump_cols = 0;
+      for (size_t j = 0; j < ncols; j++) {
+        dt::read::Column& col = columns[j];
+        if (!col.is_in_output()) continue;
+        bool bumped = col.is_type_bumped();
+        col.reset_type_bumped();
+        col.set_in_buffer(bumped);
+        n_type_bump_cols += bumped;
+      }
+      firstTime = false;
+      if (verbose) {
+        trace(n_type_bump_cols == 1
+              ? "%zu column needs to be re-read because its type has changed"
+              : "%zu columns need to be re-read because their types have changed",
+              n_type_bump_cols);
+      }
+      goto read;
     }
 
     fo.n_rows_read = columns.get_nrows();

--- a/tests/fread/test_fread_issues.py
+++ b/tests/fread/test_fread_issues.py
@@ -481,3 +481,11 @@ def test_issue1030():
     src = "".join(lines)
     with pytest.raises(RuntimeError):
         dt.fread(src, verbose=True)
+
+
+def test_issue1233():
+    # The problem with this example is because the type hierarchy is not
+    # strictly linear, we end up type-bumping the column more than once,
+    # which means the re-read has to happen more than once too...
+    d0 = dt.fread("NaN\n2\n")
+    assert d0.topython() == [[None, 2.0]]


### PR DESCRIPTION
Due to imperfect type hierarchy, this file triggers re-reads more than once. However, fread had just one re-read hardcoded before -- now there will be as many re-reads as necessary...

Closes #1233