### PR TITLE
Frame constructor improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `Frame.resize()` was removed -- same functionality is available via
   assigning to `Frame.nrows`.
 - `Frame.rename()` was removed -- .name setter can be used instead.
+- `Frame([])` now creates a 0x0 Frame instead of 0x1.
 
 #### Fixed
 - bug in dt.cbind() where the first Frame in the list was ignored.

--- a/c/column.h
+++ b/c/column.h
@@ -90,6 +90,7 @@ public:
   static Column* new_mbuf_column(SType, MemoryRange&&, MemoryRange&&);
   static Column* from_pylist(const py::olist& list, int stype0 = 0, int ltype0 = 0);
   static Column* from_buffer(PyObject* buffer);
+  static Column* from_range(int64_t start, int64_t stop, int64_t step, SType s);
 
   Column(const Column&) = delete;
   Column(Column&&) = delete;

--- a/c/csv/py_csv.cc
+++ b/c/csv/py_csv.cc
@@ -13,6 +13,7 @@
 #include <vector>
 #include <stdbool.h>
 #include <stdlib.h>
+#include "frame/py_frame.h"
 #include "options.h"
 #include "py_datatable.h"
 #include "py_utils.h"
@@ -87,7 +88,9 @@ PyObject* gread(PyObject*, PyObject* args)
 
   GenericReader rdr(pyreader);
   std::unique_ptr<DataTable> dtptr = rdr.read();
-  return pydatatable::wrap(dtptr.release());
+  py::Frame* res = py::Frame::from_datatable(dtptr.release());
+  res->set_names(pyreader.get_attr("_colnames"));
+  return res;
 }
 
 

--- a/c/datatable.cc
+++ b/c/datatable.cc
@@ -243,7 +243,9 @@ DataTable* DataTable::_statdt(colmakerfn f) const {
     out_cols[i] = (columns[i]->*f)();
   }
   out_cols[ncols] = nullptr;
-  return new DataTable(out_cols);
+  DataTable* res = new DataTable(out_cols);
+  res->names = names;
+  return res;
 }
 
 DataTable* DataTable::countna_datatable() const { return _statdt(&Column::countna_column); }

--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -96,6 +96,7 @@ PyObject* register_function(PyObject*, PyObject *args) {
   else if (n == 4) replace_typeError(fnref);
   else if (n == 5) replace_valueError(fnref);
   else if (n == 6) replace_dtWarning(fnref);
+  else if (n == 7) py::Frame_Type = fnref;
   else {
     throw ValueError() << "Incorrect function index: " << n;
   }

--- a/c/extras/aggregator.h
+++ b/c/extras/aggregator.h
@@ -41,6 +41,7 @@ class Aggregator {
     int32_t nd_bins;
     int32_t max_dimensions;
     unsigned int seed;
+    int : 32;
     PyObject* progress_fn;
 
     // Grouping and aggregating functions

--- a/c/frame/py_frame.cc
+++ b/c/frame/py_frame.cc
@@ -17,7 +17,7 @@ namespace py {
 // Declare Frame's API
 //------------------------------------------------------------------------------
 
-PKArgs Frame::Type::args___init__(1, 0, 3, false, false,
+PKArgs Frame::Type::args___init__(1, 0, 3, false, true,
                                   {"src", "names", "stypes", "stype"});
 PKArgs Frame::Type::args_colindex(1, 0, 0, false, false, {"name"});
 

--- a/c/frame/py_frame.cc
+++ b/c/frame/py_frame.cc
@@ -12,6 +12,8 @@
 
 namespace py {
 
+PyObject* Frame_Type = nullptr;
+
 
 //------------------------------------------------------------------------------
 // Declare Frame's API
@@ -110,6 +112,26 @@ void Frame::Type::init_methods(Methods& mm) {
 //------------------------------------------------------------------------------
 // Misc
 //------------------------------------------------------------------------------
+bool Frame::internal_construction = false;
+
+
+Frame* Frame::from_datatable(DataTable* dt) {
+  // PyObject* pytype = reinterpret_cast<PyObject*>(&Frame::Type::type);
+  Frame::internal_construction = true;
+  PyObject* res = PyObject_CallObject(Frame_Type, nullptr);
+  Frame::internal_construction = false;
+  if (!res) throw PyError();
+
+  PyObject* _dt = pydatatable::wrap(dt);
+  if (!_dt) throw PyError();
+
+  Frame* frame = reinterpret_cast<Frame*>(res);
+  frame->dt = dt;
+  frame->core_dt = reinterpret_cast<pydatatable::obj*>(_dt);
+  frame->core_dt->_frame = frame;
+  return frame;
+}
+
 
 void Frame::m__dealloc__() {
   Py_XDECREF(core_dt);

--- a/c/frame/py_frame.h
+++ b/c/frame/py_frame.h
@@ -63,22 +63,26 @@ class Frame : public PyObject {
     oobj get_internal() const;
     void set_nrows(obj);
     void set_names(obj);
+    void set_names(const std::vector<std::string>&);
     void set_internal(obj);
 
     oobj colindex(PKArgs&);
 
   private:
+    class NameProvider;
     void _clear_names();
     void _init_names() const;
     void _init_inames() const;
     void _fill_default_names();
-    void _dedup_and_save_names(py::olist);
+    void _dedup_and_save_names(NameProvider*);
     void _replace_names_from_map(py::odict);
     Error _name_not_found_error(const std::string& name);
 
     friend void pydatatable::_clear_types(pydatatable::obj*); // temp
     friend PyObject* pydatatable::check(pydatatable::obj*, PyObject*); // temp
     friend class FrameInitializationManager;
+    friend class pylistNP;
+    friend class strvecNP;
 };
 
 

--- a/c/frame/py_frame.h
+++ b/c/frame/py_frame.h
@@ -78,6 +78,7 @@ class Frame : public PyObject {
 
     friend void pydatatable::_clear_types(pydatatable::obj*); // temp
     friend PyObject* pydatatable::check(pydatatable::obj*, PyObject*); // temp
+    friend class FrameInitializationManager;
 };
 
 

--- a/c/frame/py_frame.h
+++ b/c/frame/py_frame.h
@@ -48,6 +48,10 @@ class Frame : public PyObject {
         static void init_methods(Methods& gs);
     };
 
+    // Internal "constructor" of Frame objects. We do not use real constructors
+    // because Frame objects must be allocated/initialized by Python.
+    static Frame* from_datatable(DataTable* dt);
+
     void m__init__(PKArgs&);
     void m__dealloc__();
     void m__get_buffer__(Py_buffer* buf, int flags) const;
@@ -69,6 +73,7 @@ class Frame : public PyObject {
     oobj colindex(PKArgs&);
 
   private:
+    static bool internal_construction;
     class NameProvider;
     void _clear_names();
     void _init_names() const;
@@ -85,7 +90,7 @@ class Frame : public PyObject {
     friend class strvecNP;
 };
 
-
+extern PyObject* Frame_Type;
 
 }  // namespace py
 

--- a/c/frame/py_frame_init.cc
+++ b/c/frame/py_frame_init.cc
@@ -151,14 +151,14 @@ void Frame::m__init__(PKArgs& args) {
   // if (src.is_list_or_tuple()) {
   //   dt = _make_frame_from_list(src.to_pylist());
   // }
-  // else if (src.is_undefined() || src.is_none()) {
-  //   dt = DTMaker().to_datatable();
-  // }
-  // else {
-  //   std::cout << "Creating a frame from ";
-  //   src.print();
-  // }
-  {
+  // else
+  if ((src.is_undefined() || src.is_none()) && args.num_varkwd_args() == 0) {
+    dt = DTMaker().to_datatable();
+  }
+
+  if (dt) {
+    core_dt = static_cast<pydatatable::obj*>(pydatatable::wrap(dt));
+  } else {
     py::oobj osrc(src.to_borrowed_ref());
     py::oobj ostypes(stypes_arg.to_borrowed_ref());
     if (stype_arg) {

--- a/c/frame/py_frame_init.cc
+++ b/c/frame/py_frame_init.cc
@@ -101,7 +101,7 @@ class FrameInitializationManager {
       else if (src.is_list_or_tuple()) {
         py::olist collist = src.to_pylist();
         if (collist.size() == 0) {
-          // _init_empty_frame();
+          _init_empty_frame();
         }
         else {
           py::obj item0 = collist[0];

--- a/c/frame/py_frame_init.cc
+++ b/c/frame/py_frame_init.cc
@@ -99,6 +99,9 @@ class FrameInitializationManager {
       else if (src.is_dict()) {
         _init_from_dict();
       }
+      else if (src.is_range()) {
+        _init_from_list_of_primitives();
+      }
       else if (src.is_undefined() || src.is_none()) {
         _init_empty_frame();
       }
@@ -125,7 +128,7 @@ class FrameInitializationManager {
       }
       if (nnames != ncols) {
         throw ValueError()
-            << "`names` argument contains " << nnames
+            << "The `names` argument contains " << nnames
             << " element" << (nnames==1? "" : "s") << ", which is "
             << (nnames < ncols? "less" : "more") << " than the number of "
                "columns being created (" << ncols << ")";
@@ -145,7 +148,7 @@ class FrameInitializationManager {
       }
       if (nstypes != ncols) {
         throw ValueError()
-            << "`stypes` argument contains " << nstypes
+            << "The `stypes` argument contains " << nstypes
             << " element" << (nstypes==1? "" : "s") << ", which is "
             << (nstypes < ncols? "less" : "more") << " than the number of "
                "columns being created (" << ncols << ")";

--- a/c/frame/py_frame_init.cc
+++ b/c/frame/py_frame_init.cc
@@ -284,7 +284,7 @@ class FrameInitializationManager {
         auto i = newnames.size();
         auto name = kv.first.to_string();
         auto stype = get_stype_for_column(i, &name);
-        newnames.push_back(name);
+        newnames.push_back(std::move(name));
         _make_column(kv.second, stype);
       }
       frame->dt = make_datatable();
@@ -304,7 +304,7 @@ class FrameInitializationManager {
         auto i = newnames.size();
         auto name = kv.first;
         auto stype = get_stype_for_column(i, &name);
-        newnames.push_back(name);
+        newnames.push_back(std::move(name));
         _make_column(kv.second, stype);
       }
       frame->dt = make_datatable();

--- a/c/frame/py_frame_init.cc
+++ b/c/frame/py_frame_init.cc
@@ -208,18 +208,15 @@ class FrameInitializationManager {
 
     void _init_from_list_of_lists() {
       py::olist collist = src.to_pylist();
-      // check for collist.size() names & stypes
+      _check_names(collist.size());
+      _check_stypes(collist.size());
       for (size_t i = 0; i < collist.size(); ++i) {
         py::obj item = collist[i];
-        // get stype for index `i`
-        // add column built from `item`
+        SType s = _get_stype(i);
+        _make_column(item, s);
       }
-      // size_t ncols = list.size();
-      // for (size_t i = 0; i < ncols; ++i) {
-      //   Column* col = _make_column_from_listlike(list[i]);
-      //   dtm.push_back(col);
-      // }
-      // return dtm.to_datatable();
+      frame->dt = _make_datatable();
+      frame->set_names(names_arg.to_pyobj());
     }
 
     void _init_from_list_of_dicts() {
@@ -301,6 +298,7 @@ void Frame::m__init__(PKArgs& args) {
 
   if (dt) {
     core_dt = static_cast<pydatatable::obj*>(pydatatable::wrap(dt));
+    core_dt->_frame = this;
   } else {
     py::oobj osrc(src.to_borrowed_ref());
     py::oobj ostypes(stypes_arg.to_borrowed_ref());

--- a/c/frame/py_frame_names.cc
+++ b/c/frame/py_frame_names.cc
@@ -76,7 +76,7 @@ size_t strvecNP::size() const {
 }
 
 CString strvecNP::item_as_cstring(size_t i) {
-  auto name = names[i];
+  const std::string& name = names[i];
   return CString { name.data(), static_cast<int64_t>(name.size()) };
 }
 

--- a/c/py_columnset.cc
+++ b/c/py_columnset.cc
@@ -8,6 +8,7 @@
 #define dt_PY_COLUMNSET_cc
 #include "py_columnset.h"
 #include "columnset.h"
+#include "frame/py_frame.h"
 #include "py_column.h"
 #include "py_datatable.h"
 #include "py_rowindex.h"
@@ -127,10 +128,17 @@ PyObject* columns_from_columns(PyObject*, PyObject* args)
 // Methods
 //==============================================================================
 
-PyObject* to_datatable(obj* self, PyObject*) {
+PyObject* to_frame(obj* self, PyObject* args) {
+  PyObject* arg1;
+  if (!PyArg_ParseTuple(args, "O:to_frame", &arg1)) return nullptr;
+  py::obj names(arg1);
+
   Column** columns = self->columns;
   self->columns = nullptr;
-  return pydatatable::wrap(new DataTable(columns));
+  DataTable* dt = new DataTable(columns);
+  auto frame = py::Frame::from_datatable(dt);
+  frame->set_names(names);
+  return frame;
 }
 
 
@@ -192,7 +200,7 @@ static PyObject* repr(obj* self)
 //==============================================================================
 
 static PyMethodDef methods[] = {
-  METHOD0(to_datatable),
+  METHODv(to_frame),
   METHODv(append_columns),
   {nullptr, nullptr, 0, nullptr}           /* sentinel */
 };

--- a/c/py_columnset.h
+++ b/c/py_columnset.h
@@ -41,8 +41,10 @@ DECLARE_DESTRUCTOR()
 //---- Methods -----------------------------------------------------------------
 
 DECLARE_METHOD(
-  to_datatable,
-  "Convert this ColumnSet into a DataTable.")
+  to_frame,
+  "to_frame(self, names)\n"
+  "--\n\n"
+  "Convert this ColumnSet into a Frame, with the provided names.")
 
 DECLARE_METHOD(
   append_columns,

--- a/c/py_datatable.cc
+++ b/c/py_datatable.cc
@@ -615,17 +615,17 @@ PyObject* join(obj* self, PyObject* args) {
 
 
 
-PyObject* get_min    (obj* self, PyObject*) { return wrap(self->ref->min_datatable()); }
-PyObject* get_max    (obj* self, PyObject*) { return wrap(self->ref->max_datatable()); }
-PyObject* get_mode   (obj* self, PyObject*) { return wrap(self->ref->mode_datatable()); }
-PyObject* get_mean   (obj* self, PyObject*) { return wrap(self->ref->mean_datatable()); }
-PyObject* get_sd     (obj* self, PyObject*) { return wrap(self->ref->sd_datatable()); }
-PyObject* get_skew   (obj* self, PyObject*) { return wrap(self->ref->skew_datatable()); }
-PyObject* get_kurt   (obj* self, PyObject*) { return wrap(self->ref->kurt_datatable()); }
-PyObject* get_sum    (obj* self, PyObject*) { return wrap(self->ref->sum_datatable()); }
-PyObject* get_countna(obj* self, PyObject*) { return wrap(self->ref->countna_datatable()); }
-PyObject* get_nunique(obj* self, PyObject*) { return wrap(self->ref->nunique_datatable()); }
-PyObject* get_nmodal (obj* self, PyObject*) { return wrap(self->ref->nmodal_datatable()); }
+PyObject* get_min    (obj* self, PyObject*) { return py::Frame::from_datatable(self->ref->min_datatable()); }
+PyObject* get_max    (obj* self, PyObject*) { return py::Frame::from_datatable(self->ref->max_datatable()); }
+PyObject* get_mode   (obj* self, PyObject*) { return py::Frame::from_datatable(self->ref->mode_datatable()); }
+PyObject* get_mean   (obj* self, PyObject*) { return py::Frame::from_datatable(self->ref->mean_datatable()); }
+PyObject* get_sd     (obj* self, PyObject*) { return py::Frame::from_datatable(self->ref->sd_datatable()); }
+PyObject* get_skew   (obj* self, PyObject*) { return py::Frame::from_datatable(self->ref->skew_datatable()); }
+PyObject* get_kurt   (obj* self, PyObject*) { return py::Frame::from_datatable(self->ref->kurt_datatable()); }
+PyObject* get_sum    (obj* self, PyObject*) { return py::Frame::from_datatable(self->ref->sum_datatable()); }
+PyObject* get_countna(obj* self, PyObject*) { return py::Frame::from_datatable(self->ref->countna_datatable()); }
+PyObject* get_nunique(obj* self, PyObject*) { return py::Frame::from_datatable(self->ref->nunique_datatable()); }
+PyObject* get_nmodal (obj* self, PyObject*) { return py::Frame::from_datatable(self->ref->nmodal_datatable()); }
 
 typedef PyObject* (Column::*scalarstatfn)() const;
 static PyObject* _scalar_stat(DataTable* dt, scalarstatfn f) {

--- a/c/py_datatable_fromlist.cc
+++ b/c/py_datatable_fromlist.cc
@@ -10,6 +10,7 @@
 #include "py_types.h"
 #include "py_utils.h"
 #include "python/list.h"
+#include "python/orange.h"
 #include "utils/exceptions.h"
 
 
@@ -45,17 +46,19 @@ PyObject* pydatatable::datatable_from_list(PyObject*, PyObject* args)
   int64_t nrows = 0;
   for (size_t i = 0; i < ncols; ++i) {
     py::obj item = srcs[i];
+    int stype = 0;
+    if (types) {
+      stype = types[i].to_int32();
+      if (ISNA<int32_t>(stype)) stype = 0;
+    }
     if (item.is_buffer()) {
       cols[i] = Column::from_buffer(item.to_borrowed_ref());
     } else if (item.is_range()) {
-
+      py::orange r = item.to_pyrange();
+      cols[i] = Column::from_range(r.start(), r.stop(), r.step(),
+                                   static_cast<SType>(stype));
     } else if (item.is_list()) {
       py::olist list = item.to_pylist();
-      int stype = 0;
-      if (types) {
-        stype = types[i].to_int32();
-        if (ISNA<int32_t>(stype)) stype = 0;
-      }
       cols[i] = Column::from_pylist(list, stype);
     } else {
       throw ValueError() << "Source list is not list-of-lists";

--- a/c/py_datatable_fromlist.cc
+++ b/c/py_datatable_fromlist.cc
@@ -47,6 +47,8 @@ PyObject* pydatatable::datatable_from_list(PyObject*, PyObject* args)
     py::obj item = srcs[i];
     if (item.is_buffer()) {
       cols[i] = Column::from_buffer(item.to_borrowed_ref());
+    } else if (item.is_range()) {
+
     } else if (item.is_list()) {
       py::olist list = item.to_pylist();
       int stype = 0;

--- a/c/python/arg.cc
+++ b/c/python/arg.cc
@@ -74,6 +74,7 @@ py::olist   Arg::to_pylist()       const { return pyobj.to_pylist(*this); }
 py::odict   Arg::to_pydict()       const { return pyobj.to_pydict(*this); }
 std::string Arg::to_string()       const { return pyobj.to_string(*this); }
 strvec      Arg::to_stringlist()   const { return pyobj.to_stringlist(*this); }
+SType       Arg::to_stype()        const { return pyobj.to_stype(*this); }
 
 
 
@@ -84,6 +85,10 @@ strvec      Arg::to_stringlist()   const { return pyobj.to_stringlist(*this); }
 Error Arg::error_not_list(PyObject* src) const {
   return TypeError() << name() << " should be a list or tuple, instead got "
       << Py_TYPE(src);
+}
+
+Error Arg::error_not_stype(PyObject* src) const {
+  return TypeError() << name() << " cannot be converted into an stype: " << src;
 }
 
 

--- a/c/python/arg.cc
+++ b/c/python/arg.cc
@@ -7,7 +7,9 @@
 //------------------------------------------------------------------------------
 #include "python/arg.h"
 #include "python/args.h"        // py::PKArgs
+#include "python/dict.h"
 #include "python/int.h"
+#include "python/list.h"
 #include "utils/exceptions.h"
 
 namespace py {
@@ -69,7 +71,9 @@ bool Arg::is_range()         const { return pyobj.is_range(); }
 int32_t     Arg::to_int32_strict() const { return pyobj.to_int32_strict(*this); }
 int64_t     Arg::to_int64_strict() const { return pyobj.to_int64_strict(*this); }
 py::olist   Arg::to_pylist()       const { return pyobj.to_pylist(*this); }
+py::odict   Arg::to_pydict()       const { return pyobj.to_pydict(*this); }
 std::string Arg::to_string()       const { return pyobj.to_string(*this); }
+strvec      Arg::to_stringlist()   const { return pyobj.to_stringlist(*this); }
 
 
 

--- a/c/python/arg.cc
+++ b/c/python/arg.cc
@@ -75,6 +75,7 @@ py::odict   Arg::to_pydict()       const { return pyobj.to_pydict(*this); }
 std::string Arg::to_string()       const { return pyobj.to_string(*this); }
 strvec      Arg::to_stringlist()   const { return pyobj.to_stringlist(*this); }
 SType       Arg::to_stype()        const { return pyobj.to_stype(*this); }
+SType       Arg::to_stype(const error_manager& em) const { return pyobj.to_stype(em); }
 
 
 

--- a/c/python/arg.h
+++ b/c/python/arg.h
@@ -65,9 +65,9 @@ class Arg : public _obj::error_manager {
 
     // ?
     operator bool() const noexcept { return pyobj.operator bool(); }
-    PyObject* obj() { return pyobj.to_pyobject_newref(); }
+    PyObject* obj() const { return pyobj.to_pyobject_newref(); }
     PyObject* to_borrowed_ref() const { return pyobj.to_borrowed_ref(); }
-    PyTypeObject* typeobj() { return pyobj.typeobj(); }
+    PyTypeObject* typeobj() const { return pyobj.typeobj(); }
     void print() const;
 
     /**

--- a/c/python/arg.h
+++ b/c/python/arg.h
@@ -54,7 +54,10 @@ class Arg : public _obj::error_manager {
     int32_t     to_int32_strict  () const;
     int64_t     to_int64_strict  () const;
     py::olist   to_pylist        () const;
+    py::odict   to_pydict        () const;
     std::string to_string        () const;
+    strvec      to_stringlist    () const;
+    py::obj     to_pyobj         () const { return pyobj; }
 
 
     //---- Error messages --------------

--- a/c/python/arg.h
+++ b/c/python/arg.h
@@ -61,8 +61,9 @@ class Arg : public _obj::error_manager {
     virtual Error error_not_list       (PyObject*) const;
 
     // ?
+    operator bool() const noexcept { return pyobj.operator bool(); }
     PyObject* obj() { return pyobj.to_pyobject_newref(); }
-    PyObject* to_borrowed_ref() { return pyobj.to_borrowed_ref(); }
+    PyObject* to_borrowed_ref() const { return pyobj.to_borrowed_ref(); }
     PyTypeObject* typeobj() { return pyobj.typeobj(); }
     void print() const;
 

--- a/c/python/arg.h
+++ b/c/python/arg.h
@@ -57,11 +57,13 @@ class Arg : public _obj::error_manager {
     py::odict   to_pydict        () const;
     std::string to_string        () const;
     strvec      to_stringlist    () const;
+    SType       to_stype         () const;
     py::obj     to_pyobj         () const { return pyobj; }
 
 
     //---- Error messages --------------
     virtual Error error_not_list       (PyObject*) const;
+    virtual Error error_not_stype      (PyObject*) const;
 
     // ?
     operator bool() const noexcept { return pyobj.operator bool(); }

--- a/c/python/arg.h
+++ b/c/python/arg.h
@@ -58,6 +58,7 @@ class Arg : public _obj::error_manager {
     std::string to_string        () const;
     strvec      to_stringlist    () const;
     SType       to_stype         () const;
+    SType       to_stype         (const error_manager&) const;
     py::obj     to_pyobj         () const { return pyobj; }
 
 

--- a/c/python/args.cc
+++ b/c/python/args.cc
@@ -123,10 +123,10 @@ void PKArgs::bind(PyObject* _args, PyObject* _kwds)
     bound_args[i].set(nullptr);
   }
 
+  n_varkwds = 0;
   if (_kwds) {
     PyObject* key, *value;
     Py_ssize_t pos = 0;
-    n_varkwds = 0;
     while (PyDict_Next(_kwds, &pos, &key, &value)) {
       size_t ikey = _find_kwd(key);
       if (ikey == size_t(-1)) {
@@ -245,7 +245,11 @@ VarArgsIterator VarArgsIterable::end() const {
 VarKwdsIterator::VarKwdsIterator(const PKArgs& args, Py_ssize_t i0)
     : parent(args), pos(i0), curr_value(std::string(), py::obj(nullptr))
 {
-  advance();
+  if (parent.kwds_dict) {
+    advance();
+  } else {
+    pos = -1;
+  }
 }
 
 VarKwdsIterator& VarKwdsIterator::operator++() {

--- a/c/python/dict.cc
+++ b/c/python/dict.cc
@@ -41,6 +41,10 @@ odict& odict::operator=(odict&& other) {
 // Element accessors
 //------------------------------------------------------------------------------
 
+size_t odict::size() const {
+  return static_cast<size_t>(PyDict_Size(v));
+}
+
 bool odict::has(_obj key) const {
   PyObject* _key = key.to_borrowed_ref();
   return PyDict_GetItem(v, _key) != nullptr;

--- a/c/python/dict.h
+++ b/c/python/dict.h
@@ -29,6 +29,7 @@ class odict : public oobj {
     odict& operator=(const odict&);
     odict& operator=(odict&&);
 
+    size_t size() const;
     bool has(_obj key) const;
     obj  get(_obj key) const;
     void set(_obj key, _obj val);

--- a/c/python/list.cc
+++ b/c/python/list.cc
@@ -22,6 +22,11 @@ olist::olist(size_t n) {
   if (!v) throw PyError();
 }
 
+olist::olist(int n) : olist(static_cast<size_t>(n)) {}
+
+olist::olist(int64_t n) : olist(static_cast<size_t>(n)) {}
+
+
 olist::olist(const olist& other) {
   v = other.v;
   is_list = other.is_list;

--- a/c/python/list.h
+++ b/c/python/list.h
@@ -33,7 +33,9 @@ class olist : public oobj {
     size_t : 56;
 
   public:
+    olist(int n);
     olist(size_t n);
+    olist(int64_t n);
     olist(const olist&);
     olist(olist&&);
     olist& operator=(const olist&);

--- a/c/python/obj.cc
+++ b/c/python/obj.cc
@@ -444,7 +444,11 @@ Column* _obj::to_column(const error_manager& em) const {
 
 
 SType _obj::to_stype(const error_manager& em) const {
-  return stype_from_pyobject(v);
+  int s = stype_from_pyobject(v);
+  if (s == -1) {
+    throw em.error_not_stype(v);
+  }
+  return static_cast<SType>(s);
 }
 
 
@@ -571,6 +575,10 @@ Error _obj::error_manager::error_not_dict(PyObject* o) const {
 
 Error _obj::error_manager::error_not_range(PyObject* o) const {
   return TypeError() << "Expected a range, instead got " << Py_TYPE(o);
+}
+
+Error _obj::error_manager::error_not_stype(PyObject* o) const {
+  return TypeError() << "Expected an stype, instead got " << Py_TYPE(o);
 }
 
 Error _obj::error_manager::error_int32_overflow(PyObject* o) const {

--- a/c/python/obj.cc
+++ b/c/python/obj.cc
@@ -93,6 +93,8 @@ oobj::~oobj() {
 // Type checks
 //------------------------------------------------------------------------------
 
+_obj::operator bool() const noexcept { return (v != nullptr); }
+
 bool _obj::is_undefined()     const noexcept { return (v == nullptr);}
 bool _obj::is_none()          const noexcept { return (v == Py_None); }
 bool _obj::is_ellipsis()      const noexcept { return (v == Py_Ellipsis); }

--- a/c/python/obj.cc
+++ b/c/python/obj.cc
@@ -15,6 +15,7 @@
 #include "python/int.h"
 #include "python/float.h"
 #include "python/list.h"
+#include "python/orange.h"
 #include "python/string.h"
 
 namespace py {
@@ -326,13 +327,6 @@ py::olist _obj::to_pylist(const error_manager& em) const {
 }
 
 
-py::odict _obj::to_pydict(const error_manager& em) const {
-  if (is_none()) return py::odict();
-  if (is_dict()) return py::odict(v);
-  throw em.error_not_dict(v);
-}
-
-
 char** _obj::to_cstringlist(const error_manager&) const {
   if (v == Py_None) {
     return nullptr;
@@ -454,6 +448,21 @@ PyObject* _obj::to_pyobject_newref() const noexcept {
 }
 
 
+py::odict _obj::to_pydict(const error_manager& em) const {
+  if (is_none()) return py::odict();
+  if (is_dict()) return py::odict(v);
+  throw em.error_not_dict(v);
+}
+
+
+py::orange _obj::to_pyrange(const error_manager& em) const {
+  if (is_none()) return py::orange(nullptr);
+  if (is_range()) return py::orange(v);
+  throw em.error_not_range(v);
+}
+
+
+
 
 //------------------------------------------------------------------------------
 // Misc
@@ -552,6 +561,10 @@ Error _obj::error_manager::error_not_list(PyObject* o) const {
 
 Error _obj::error_manager::error_not_dict(PyObject* o) const {
   return TypeError() << "Expected a dict, instead got " << Py_TYPE(o);
+}
+
+Error _obj::error_manager::error_not_range(PyObject* o) const {
+  return TypeError() << "Expected a range, instead got " << Py_TYPE(o);
 }
 
 Error _obj::error_manager::error_int32_overflow(PyObject* o) const {

--- a/c/python/obj.cc
+++ b/c/python/obj.cc
@@ -110,6 +110,7 @@ bool _obj::is_string()        const noexcept { return v && PyUnicode_Check(v); }
 bool _obj::is_list()          const noexcept { return v && PyList_Check(v); }
 bool _obj::is_tuple()         const noexcept { return v && PyTuple_Check(v); }
 bool _obj::is_dict()          const noexcept { return v && PyDict_Check(v); }
+bool _obj::is_iterable()      const noexcept { return v && PyIter_Check(v); }
 bool _obj::is_buffer()        const noexcept { return v && PyObject_CheckBuffer(v); }
 bool _obj::is_range()         const noexcept { return v && PyRange_Check(v); }
 
@@ -439,6 +440,11 @@ Column* _obj::to_column(const error_manager& em) const {
     throw em.error_not_column(v);
   }
   return reinterpret_cast<pycolumn::obj*>(v)->ref;
+}
+
+
+SType _obj::to_stype(const error_manager& em) const {
+  return stype_from_pyobject(v);
 }
 
 

--- a/c/python/obj.h
+++ b/c/python/obj.h
@@ -144,6 +144,7 @@ class _obj {
     bool is_list()          const noexcept;
     bool is_tuple()         const noexcept;
     bool is_list_or_tuple() const noexcept;
+    bool is_iterable()      const noexcept;
     bool is_dict()          const noexcept;
     bool is_buffer()        const noexcept;
     bool is_range()         const noexcept;
@@ -176,6 +177,7 @@ class _obj {
     Groupby*    to_groupby       (const error_manager& = _em0) const;
     RowIndex    to_rowindex      (const error_manager& = _em0) const;
     DataTable*  to_frame         (const error_manager& = _em0) const;
+    SType       to_stype         (const error_manager& = _em0) const;
 
     PyObject*   to_pyobject_newref() const noexcept;
     PyObject*   to_borrowed_ref() const { return v; }

--- a/c/python/obj.h
+++ b/c/python/obj.h
@@ -203,6 +203,7 @@ class _obj {
       virtual Error error_not_list       (PyObject*) const;
       virtual Error error_not_dict       (PyObject*) const;
       virtual Error error_not_range      (PyObject*) const;
+      virtual Error error_not_stype      (PyObject*) const;
       virtual Error error_int32_overflow (PyObject*) const;
       virtual Error error_int64_overflow (PyObject*) const;
       virtual Error error_double_overflow(PyObject*) const;

--- a/c/python/obj.h
+++ b/c/python/obj.h
@@ -131,6 +131,7 @@ class _obj {
     //--------------------------------------------------------------------------
     // Type tests
     //--------------------------------------------------------------------------
+    operator bool() const noexcept;  // opposite of is_undefined()
     bool is_undefined()     const noexcept;
     bool is_none()          const noexcept;
     bool is_ellipsis()      const noexcept;

--- a/c/python/obj.h
+++ b/c/python/obj.h
@@ -22,13 +22,12 @@ namespace py {
 
 // Forward declarations
 class Arg;
-class oint;
-class Float;
-class ofloat;
-class string;
 class odict;
+class ofloat;
+class oint;
 class olist;
 class ostring;
+class orange;
 class obj;
 class oobj;
 using strvec = std::vector<std::string>;
@@ -171,6 +170,7 @@ class _obj {
     strvec      to_stringlist    (const error_manager& = _em0) const;
     py::olist   to_pylist        (const error_manager& = _em0) const;
     py::odict   to_pydict        (const error_manager& = _em0) const;
+    py::orange  to_pyrange       (const error_manager& = _em0) const;
 
     Column*     to_column        (const error_manager& = _em0) const;
     Groupby*    to_groupby       (const error_manager& = _em0) const;
@@ -200,6 +200,7 @@ class _obj {
       virtual Error error_not_column     (PyObject*) const;
       virtual Error error_not_list       (PyObject*) const;
       virtual Error error_not_dict       (PyObject*) const;
+      virtual Error error_not_range      (PyObject*) const;
       virtual Error error_int32_overflow (PyObject*) const;
       virtual Error error_int64_overflow (PyObject*) const;
       virtual Error error_double_overflow(PyObject*) const;

--- a/c/python/obj.h
+++ b/c/python/obj.h
@@ -119,7 +119,6 @@ using strvec = std::vector<std::string>;
 class _obj {
   protected:
     PyObject* v;
-    struct error_manager;  // see below
 
   public:
     oobj get_attr(const char* attr) const;
@@ -149,6 +148,7 @@ class _obj {
     bool is_buffer()        const noexcept;
     bool is_range()         const noexcept;
 
+    struct error_manager;  // see below
     int8_t      to_bool          (const error_manager& = _em0) const;
     int8_t      to_bool_strict   (const error_manager& = _em0) const;
     int8_t      to_bool_force    (const error_manager& = _em0) const noexcept;
@@ -182,7 +182,6 @@ class _obj {
     PyObject*   to_pyobject_newref() const noexcept;
     PyObject*   to_borrowed_ref() const { return v; }
 
-  protected:
     /**
      * `error_manager` is a factory function for different error messages. It
      * is used to customize error messages when they are thrown from an `Arg`
@@ -208,6 +207,8 @@ class _obj {
       virtual Error error_int64_overflow (PyObject*) const;
       virtual Error error_double_overflow(PyObject*) const;
     };
+
+  protected:
     static error_manager _em0;
 
     // `_obj` class is not directly constructible: create either `obj` or

--- a/c/python/orange.cc
+++ b/c/python/orange.cc
@@ -1,0 +1,75 @@
+//------------------------------------------------------------------------------
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// © H2O.ai 2018
+//------------------------------------------------------------------------------
+#include "python/orange.h"
+#include "python/int.h"
+#include "python/tuple.h"
+
+namespace py {
+
+
+//------------------------------------------------------------------------------
+// Constructors
+//------------------------------------------------------------------------------
+
+orange::orange(int64_t start, int64_t stop, int64_t step) {
+  py::otuple args(3);
+  args.set(0, ISNA(start)? py::None() : py::oint(start));
+  args.set(1, ISNA(stop) ? py::None() : py::oint(stop));
+  args.set(2, ISNA(step) ? py::None() : py::oint(step));
+  v = PyObject_CallObject(reinterpret_cast<PyObject*>(&PyRange_Type),
+                          args.to_borrowed_ref());
+  if (!v) throw PyError();
+}
+
+orange::orange(const orange& other) {
+  v = other.v;
+  Py_XINCREF(v);
+}
+
+orange::orange(orange&& other) {
+  v = other.v;
+  other.v = nullptr;
+}
+
+orange& orange::operator=(const orange& other) {
+  Py_XINCREF(other.v);
+  Py_XDECREF(v);
+  v = other.v;
+  return *this;
+}
+
+orange& orange::operator=(orange&& other) {
+  Py_XDECREF(v);
+  v = other.v;
+  other.v = nullptr;
+  return *this;
+}
+
+orange::orange(PyObject* src) : oobj(src) {}
+
+
+
+//------------------------------------------------------------------------------
+// Accessors
+//------------------------------------------------------------------------------
+
+int64_t orange::start() const {
+  return get_attr("start").to_int64();
+}
+
+int64_t orange::stop() const {
+  return get_attr("stop").to_int64();
+}
+
+int64_t orange::step() const {
+  return get_attr("step").to_int64();
+}
+
+
+
+}  // namespace py

--- a/c/python/orange.h
+++ b/c/python/orange.h
@@ -1,0 +1,44 @@
+//------------------------------------------------------------------------------
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// © H2O.ai 2018
+//------------------------------------------------------------------------------
+#ifndef dt_PYTHON_ORANGE_h
+#define dt_PYTHON_ORANGE_h
+#include <Python.h>
+#include "python/obj.h"
+
+namespace py {
+
+
+/**
+ * Python range(start, stop, step) object.
+ *
+ * Bounds that are None are represented as GETNA<int64_t>().
+ */
+class orange : public oobj {
+  public:
+    orange(int64_t start, int64_t stop, int64_t step);
+    orange(const orange&);
+    orange(orange&&);
+    orange& operator=(const orange&);
+    orange& operator=(orange&&);
+
+    int64_t start() const;
+    int64_t stop()  const;
+    int64_t step()  const;
+
+  private:
+    // Wrap an existing PyObject* into an `orange`. This constructor is
+    // private, use `py::org(src).to_pyrange()` instead.
+    orange(PyObject* src);
+
+    friend class _obj;
+};
+
+
+}  // namespace py
+
+#endif

--- a/c/types.cc
+++ b/c/types.cc
@@ -236,11 +236,14 @@ SType stype_from_string(const std::string& str)
 }
 
 
-SType stype_from_pyobject(PyObject* s) {
+int stype_from_pyobject(PyObject* s) {
   PyObject* res = PyObject_CallFunction(py_stype, "O", s);
-  if (res == nullptr) throw PyError();
+  if (res == nullptr) {
+    PyErr_Clear();
+    return -1;
+  }
   int32_t value = py::obj(res).get_attr("value").to_int32();
-  return static_cast<SType>(value);
+  return value;
 }
 
 

--- a/c/types.cc
+++ b/c/types.cc
@@ -12,6 +12,7 @@
 
 static PyObject* py_ltype_objs[DT_LTYPES_COUNT];
 static PyObject* py_stype_objs[DT_STYPES_COUNT];
+static PyObject* py_stype;
 
 
 
@@ -235,12 +236,21 @@ SType stype_from_string(const std::string& str)
 }
 
 
+SType stype_from_pyobject(PyObject* s) {
+  PyObject* res = PyObject_CallFunction(py_stype, "O", s);
+  if (res == nullptr) throw PyError();
+  int32_t value = py::obj(res).get_attr("value").to_int32();
+  return static_cast<SType>(value);
+}
+
+
 SType common_stype_for_buffer(SType stype1, SType stype2) {
   return stype_upcast_map[int(stype1)][int(stype2)];
 }
 
 
 void init_py_stype_objs(PyObject* stype_enum) {
+  py_stype = stype_enum;
   for (size_t i = 0; i < DT_STYPES_COUNT; ++i) {
     // The call may raise an exception -- that's ok
     py_stype_objs[i] = PyObject_CallFunction(stype_enum, "i", i);

--- a/c/types.h
+++ b/c/types.h
@@ -399,7 +399,7 @@ void init_types(void);
 void init_py_stype_objs(PyObject* stype_enum);
 void init_py_ltype_objs(PyObject* ltype_enum);
 
-
+SType stype_from_pyobject(PyObject* s);
 SType stype_from_string(const std::string&);
 SType common_stype_for_buffer(SType stype1, SType stype2);
 

--- a/c/types.h
+++ b/c/types.h
@@ -399,7 +399,7 @@ void init_types(void);
 void init_py_stype_objs(PyObject* stype_enum);
 void init_py_ltype_objs(PyObject* ltype_enum);
 
-SType stype_from_pyobject(PyObject* s);
+int stype_from_pyobject(PyObject* s);
 SType stype_from_string(const std::string&);
 SType common_stype_for_buffer(SType stype1, SType stype2);
 

--- a/datatable/extras/aggregate.py
+++ b/datatable/extras/aggregate.py
@@ -34,5 +34,6 @@ def aggregate(self, n_bins=500, nx_bins=50, ny_bins=50, max_dimensions=50, seed=
     names_exemplars = self.names + ("count",)
     names_members = ("exemplar_id",)
     dt_members = core.aggregate(self._dt, n_bins, nx_bins, ny_bins, max_dimensions, seed)
-    self.__init__(self.internal, names_exemplars)
+    self.names = names_exemplars
+    # self.__init__(self.internal, names_exemplars)
     return Frame(dt_members, names=names_members)

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -7,7 +7,6 @@
 import collections
 import re
 import time
-from typing import Tuple, Dict, List, Union
 
 from datatable.lib import core
 import datatable
@@ -18,7 +17,7 @@ from datatable.nff import save as dt_save
 from datatable.utils.misc import plural_form as plural
 from datatable.utils.misc import load_module
 from datatable.utils.typechecks import (
-    TTypeError, TValueError, DatatableWarning, U, is_type, Frame_t, dtwarn,
+    TTypeError, TValueError, DatatableWarning, U, is_type, Frame_t,
     typed, PandasDataFrame_t, PandasSeries_t, NumpyArray_t, NumpyMaskedArray_t)
 from datatable.graph import make_datatable, resolve_selector
 from datatable.csv import write_csv
@@ -40,23 +39,6 @@ class Frame(core.Frame):
 
     This is a primary data structure for datatable module.
     """
-
-    def __init__(self, src=None, names=None, stypes=None, **kwargs):
-        super().__init__()
-        if "stype" in kwargs:
-            stypes = [kwargs.pop("stype")]
-        if kwargs:
-            if src is None:
-                src = kwargs
-            else:
-                dtwarn("Unknown options %r to Frame()" % kwargs)
-        # self._dt = None      # type: core.DataTable
-        self._fill_from_source(src, names=names, stypes=stypes)
-
-
-    #---------------------------------------------------------------------------
-    # Basic properties
-    #---------------------------------------------------------------------------
 
     @property
     def key(self):

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -111,12 +111,7 @@ class Frame(core.Frame):
     #---------------------------------------------------------------------------
 
     def _fill_from_source(self, src, names, stypes):
-        if isinstance(src, dict):
-            if isinstance(stypes, dict):
-                stypes = [stypes.get(n, None) for n in src.keys()]
-            self._fill_from_list(list(src.values()), names=tuple(src.keys()),
-                                 stypes=stypes)
-        elif isinstance(src, core.DataTable):
+        if isinstance(src, core.DataTable):
             self._dt = src
             self.names = names
         elif isinstance(src, str):
@@ -136,27 +131,8 @@ class Frame(core.Frame):
             self._fill_from_pandas(src, names)
         elif is_type(src, NumpyArray_t):
             self._fill_from_numpy(src, names=names)
-        elif src is Ellipsis:
-            self._fill_from_list([42], "?", None)
         else:
             raise TTypeError("Cannot create Frame from %r" % type(src))
-
-
-    def _fill_from_list(self, src, names, stypes):
-        types = None
-        if stypes:
-            if len(stypes) == 1:
-                types = [stype(stypes[0]).value] * len(src)
-            elif len(stypes) == len(src):
-                types = [0 if s is None else stype(s).value
-                         for s in stypes]
-            else:
-                raise TValueError("Number of stypes (%d) is different from "
-                                  "the number of source columns (%d)"
-                                  % (len(stypes), len(src)))
-        _dt = core.datatable_from_list(src, types)
-        self._dt = _dt
-        self.names = names
 
 
     def _fill_from_pandas(self, pddf, names=None):

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -111,11 +111,7 @@ class Frame(core.Frame):
     #---------------------------------------------------------------------------
 
     def _fill_from_source(self, src, names, stypes):
-        if isinstance(src, list):
-            if len(src) == 0:
-                src = [src]
-            self._fill_from_list(src, names=names, stypes=stypes)
-        elif isinstance(src, (tuple, set, range)):
+        if isinstance(src, (set, range)):
             self._fill_from_list([list(src)], names=names, stypes=stypes)
         elif isinstance(src, dict):
             if isinstance(stypes, dict):
@@ -149,9 +145,6 @@ class Frame(core.Frame):
 
 
     def _fill_from_list(self, src, names, stypes):
-        if not (isinstance(src[0], (range, list)) or
-                is_type(src[0], NumpyArray_t)):
-            src = [src]
         types = None
         if stypes:
             if len(stypes) == 1:

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -112,7 +112,6 @@ class Frame(core.Frame):
 
     def _fill_from_source(self, src, names, stypes):
         if isinstance(src, core.DataTable):
-            # assert False
             self._dt = src
             self.names = names
         elif isinstance(src, str):
@@ -443,7 +442,7 @@ class Frame(core.Frame):
         A new datatable of shape (1, ncols) containing the computed minimum
         values for each column (or NA if not applicable).
         """
-        return Frame(self._dt.get_min(), names=self.names)
+        return self._dt.get_min()
 
     def max(self):
         """
@@ -454,7 +453,7 @@ class Frame(core.Frame):
         A new datatable of shape (1, ncols) containing the computed maximum
         values for each column (or NA if not applicable).
         """
-        return Frame(self._dt.get_max(), names=self.names)
+        return self._dt.get_max()
 
     def mode(self):
         """
@@ -465,7 +464,7 @@ class Frame(core.Frame):
         A new datatable of shape (1, ncols) containing the computed count of
         most frequent values for each column.
         """
-        return Frame(self._dt.get_mode(), names=self.names)
+        return self._dt.get_mode()
 
     def sum(self):
         """
@@ -476,7 +475,7 @@ class Frame(core.Frame):
         A new datatable of shape (1, ncols) containing the computed sums
         for each column (or NA if not applicable).
         """
-        return Frame(self._dt.get_sum(), names=self.names)
+        return self._dt.get_sum()
 
     def mean(self):
         """
@@ -487,7 +486,7 @@ class Frame(core.Frame):
         A new datatable of shape (1, ncols) containing the computed mean
         values for each column (or NA if not applicable).
         """
-        return Frame(self._dt.get_mean(), names=self.names)
+        return self._dt.get_mean()
 
     def sd(self):
         """
@@ -498,7 +497,7 @@ class Frame(core.Frame):
         A new datatable of shape (1, ncols) containing the computed standard
         deviation values for each column (or NA if not applicable).
         """
-        return Frame(self._dt.get_sd(), names=self.names)
+        return self._dt.get_sd()
 
     def countna(self):
         """
@@ -509,7 +508,7 @@ class Frame(core.Frame):
         A new datatable of shape (1, ncols) containing the counted number of NA
         values in each column.
         """
-        return Frame(self._dt.get_countna(), names=self.names)
+        return self._dt.get_countna()
 
     def nunique(self):
         """
@@ -520,7 +519,7 @@ class Frame(core.Frame):
         A new datatable of shape (1, ncols) containing the counted number of
         unique values in each column.
         """
-        return Frame(self._dt.get_nunique(), names=self.names)
+        return self._dt.get_nunique()
 
     def nmodal(self):
         """
@@ -531,7 +530,7 @@ class Frame(core.Frame):
         A new datatable of shape (1, ncols) containing the counted number of
         most frequent values in each column.
         """
-        return Frame(self._dt.get_nmodal(), names=self.names)
+        return self._dt.get_nmodal()
 
     def min1(self):
         return self._dt.min1()

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -112,6 +112,7 @@ class Frame(core.Frame):
 
     def _fill_from_source(self, src, names, stypes):
         if isinstance(src, core.DataTable):
+            # assert False
             self._dt = src
             self.names = names
         elif isinstance(src, str):
@@ -124,7 +125,7 @@ class Frame(core.Frame):
             if names is None:
                 names = src.names
             _dt = core.columns_from_slice(src.internal, None, 0, src.ncols, 1) \
-                      .to_datatable()
+                      .to_frame(None).internal
             self._dt = _dt
             self.names = names
         elif is_type(src, PandasDataFrame_t, PandasSeries_t):
@@ -426,8 +427,7 @@ class Frame(core.Frame):
         idx = self.colindex(by)
         ri = self._dt.sort(idx)[0]
         cs = core.columns_from_slice(self._dt, ri, 0, self.ncols, 1)
-        _dt = cs.to_datatable()
-        return Frame(_dt, names=self.names)
+        return cs.to_frame(self.names)
 
 
     #---------------------------------------------------------------------------
@@ -709,6 +709,7 @@ core.register_function(1, column_hexview)
 core.register_function(4, TTypeError)
 core.register_function(5, TValueError)
 core.register_function(6, DatatableWarning)
+core.register_function(7, Frame)
 core.install_buffer_hooks(Frame())
 
 

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -5,7 +5,6 @@
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #-------------------------------------------------------------------------------
 import collections
-import re
 import time
 
 from datatable.lib import core
@@ -670,9 +669,6 @@ class Frame(core.Frame):
         return self._dt.alloc_size
 
 
-
-_dedup_names_re0 = re.compile(r"[\x00-\x1F]+")
-_dedup_names_re1 = re.compile(r"^(.*)(\d+)$")
 
 
 

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -111,9 +111,7 @@ class Frame(core.Frame):
     #---------------------------------------------------------------------------
 
     def _fill_from_source(self, src, names, stypes):
-        if isinstance(src, (set, range)):
-            self._fill_from_list([list(src)], names=names, stypes=stypes)
-        elif isinstance(src, dict):
+        if isinstance(src, dict):
             if isinstance(stypes, dict):
                 stypes = [stypes.get(n, None) for n in src.keys()]
             self._fill_from_list(list(src.values()), names=tuple(src.keys()),
@@ -141,7 +139,7 @@ class Frame(core.Frame):
         elif src is Ellipsis:
             self._fill_from_list([42], "?", None)
         else:
-            raise TTypeError("Cannot create Frame from %r" % src)
+            raise TTypeError("Cannot create Frame from %r" % type(src))
 
 
     def _fill_from_list(self, src, names, stypes):

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -131,8 +131,6 @@ class Frame(core.Frame):
                 names = srcdt.names
             self._dt = srcdt.internal
             self.names = names
-        elif src is None:
-            self._fill_from_list([], names=None, stypes=None)
         elif is_type(src, Frame_t):
             if names is None:
                 names = src.names

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -149,16 +149,9 @@ class Frame(core.Frame):
 
 
     def _fill_from_list(self, src, names, stypes):
-        for i in range(len(src)):
-            e = src[i]
-            if isinstance(e, range):
-                src[i] = list(e)
-            elif isinstance(e, list) or is_type(e, NumpyArray_t):
-                pass
-            else:
-                if i == 0:
-                    src = [src]
-                break
+        if not (isinstance(src[0], (range, list)) or
+                is_type(src[0], NumpyArray_t)):
+            src = [src]
         types = None
         if stypes:
             if len(stypes) == 1:

--- a/datatable/fread.py
+++ b/datatable/fread.py
@@ -715,16 +715,12 @@ class GenericReader(object):
                     self._txt = txt
                     self._colnames = None
                     try:
-                        _dt = core.gread(self)
-                        dt = Frame(_dt, names=self._colnames)
-                        res[src] = dt
+                        res[src] = core.gread(self)
                     except Exception as e:
                         res[src] = e
                 return res
             else:
-                _dt = core.gread(self)
-                dt = Frame(_dt, names=self._colnames)
-                return dt
+                return core.gread(self)
         finally:
             self._clear_temporary_files()
 

--- a/datatable/fread.py
+++ b/datatable/fread.py
@@ -419,7 +419,7 @@ class GenericReader(object):
                                            -stype.str32.value)
                      for i in range(ws.ncols)]
             colset = core.columns_from_columns(cols0)
-            res = Frame(colset.to_datatable(), names=colnames)
+            res = colset.to_frame(colnames)
             self._result[ws.name] = res
         if len(self._result) == 0:
             self._result = None

--- a/datatable/graph/__init__.py
+++ b/datatable/graph/__init__.py
@@ -90,8 +90,8 @@ def make_datatable(dt, rows, select, groupby=None, join=None, sort=None,
                     pass
                 elif isinstance(replacement, BaseExpr):
                     _col = replacement.evaluate_eager(ee)
-                    _dt = core.columns_from_columns([_col]).to_datatable()
-                    replacement = datatable.Frame(_dt)
+                    _colset = core.columns_from_columns([_col])
+                    replacement = _colset.to_frame(None)
                 else:
                     replacement = datatable.Frame(replacement)
                 rowsnode.execute()
@@ -103,8 +103,7 @@ def make_datatable(dt, rows, select, groupby=None, join=None, sort=None,
             grbynode.execute()
 
         colsnode.execute()
-        res_dt = ee.columns.to_datatable()
-        res_dt = datatable.Frame(res_dt, names=colsnode.column_names)
+        res_dt = ee.columns.to_frame(colsnode.column_names)
         if grbynode and res_dt.nrows == dt.nrows:
             res_dt.internal.groupby = ee.groupby
         return res_dt

--- a/datatable/graph/groupby_node.py
+++ b/datatable/graph/groupby_node.py
@@ -22,7 +22,7 @@ class SimpleGroupbyNode:
         col = self._col
         if ee.rowindex:
             cf = core.columns_from_slice(df, ee.rowindex, col, 1, 1)
-            df = cf.to_datatable()
+            df = cf.to_frame(None).internal
             col = 0
         rowindex, groupby = df.sort(col, True)
         f.set_rowindex(rowindex)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -120,9 +120,12 @@ def random_string(n):
 def find_file(*nameparts):
     root_var = "DT_LARGE_TESTS_ROOT"
     d = os.environ.get(root_var, "").strip()
+    filename = os.path.join(d, *nameparts)
     if not d:
         pytest.skip("%s is not defined" % root_var)
     elif not os.path.isdir(d):
         pytest.fail("Directory '%s' does not exist" % d)
+    elif not os.path.isfile(filename):
+        pytest.skip("File %s not found" % filename)
     else:
-        return os.path.join(d, *nameparts)
+        return filename

--- a/tests/munging/test_dt_append.py
+++ b/tests/munging/test_dt_append.py
@@ -217,8 +217,9 @@ def test_rbind_views0():
     dt0 = dt0[3:7, :]
     dt1 = dt.Frame({"d": [-1, -2], "s": ["the", "end"]})
     dt0.rbind(dt1)
-    dtr = dt.Frame({"d": [3, 4, 5, 6, -1, -2],
-                    "s": ["d", "e", "f", "g", "the", "end"]})
+    dtr = dt.Frame([[3, 4, 5, 6, -1, -2],
+                    ["d", "e", "f", "g", "the", "end"]],
+                   names=["d", "s"], stypes=[stype.int32, stype.str32])
     assert_equals(dt0, dtr)
 
 

--- a/tests/munging/test_dt_cbind.py
+++ b/tests/munging/test_dt_cbind.py
@@ -150,7 +150,7 @@ def test_cbind_views1():
     d0 = dt.Frame({"A": range(100)})
     d1 = d0[:5, :]
     assert d1.internal.isview
-    d2 = dt.Frame({"B": [3, 6, 9, 12, 15]})
+    d2 = dt.Frame({"B": [3, 6, 9, 12, 15]}, stype=stype.int32)
     d1.cbind(d2)
     assert not d1.internal.isview
     dr = dt.Frame({"A": range(5), "B": range(3, 18, 3)})
@@ -158,7 +158,7 @@ def test_cbind_views1():
 
 
 def test_cbind_views2():
-    d0 = dt.Frame({"A": range(10)})
+    d0 = dt.Frame({"A": range(10)}, stype=stype.int8)
     d1 = d0[2:5, :]
     assert d1.internal.isview
     d2 = dt.Frame({"B": list("abcdefghij")})

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -151,7 +151,10 @@ def test_dt_properties(dt0):
 
 @pytest.mark.run(order=2)
 def test_dt_call(dt0, capsys):
+    print("before computing dt1")
     dt1 = dt0(timeit=True)
+    print("dt1 computed")
+    dt1.internal.check()
     assert dt1.shape == dt0.shape
     assert not dt1.internal.isview
     out, err = capsys.readouterr()

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -225,6 +225,7 @@ def test_dt_colindex_fuzzy_suggestions():
         assert str(e.value).endswith(suggestions)
 
     d0 = dt.Frame([[0]] * 3, names=["foo", "bar", "baz"])
+    d0.internal.check()
     check(d0, "fo", "; did you mean `foo`?")
     check(d0, "foe", "; did you mean `foo`?")
     check(d0, "fooo", "; did you mean `foo`?")
@@ -233,6 +234,7 @@ def test_dt_colindex_fuzzy_suggestions():
     check(d0, "bazb", "; did you mean `baz` or `bar`?")
     check(d0, "ababa", "Frame")
     d1 = dt.Frame([[0]] * 50)
+    d1.internal.check()
     check(d1, "A", "Frame")
     check(d1, "C", "; did you mean `C0`, `C1` or `C2`?")
     check(d1, "c1", "; did you mean `C1`, `C0` or `C2`?")
@@ -240,6 +242,7 @@ def test_dt_colindex_fuzzy_suggestions():
     check(d1, "V0", "; did you mean `C0`?")
     check(d1, "Va", "Frame")
     d2 = dt.Frame(varname=[1])
+    d2.internal.check()
     check(d2, "vraname", "; did you mean `varname`?")
     check(d2, "VRANAME", "; did you mean `varname`?")
     check(d2, "var_name", "; did you mean `varname`?")

--- a/tests/test_dt_create.py
+++ b/tests/test_dt_create.py
@@ -76,29 +76,29 @@ def test_stypes_dict():
 
 def test_create_from_nothing():
     d0 = dt.Frame()
+    d0.internal.check()
     assert d0.shape == (0, 0)
     assert d0.names == tuple()
     assert d0.ltypes == tuple()
     assert d0.stypes == tuple()
-    d0.internal.check()
 
 
 def test_create_from_none():
     d0 = dt.Frame(None)
+    d0.internal.check()
     assert d0.shape == (0, 0)
     assert d0.names == tuple()
     assert d0.ltypes == tuple()
     assert d0.stypes == tuple()
-    d0.internal.check()
 
 
 def test_create_from_empty_list():
     d0 = dt.Frame([])
+    d0.internal.check()
     assert d0.shape == (0, 0)
     assert d0.names == tuple()
     assert d0.ltypes == tuple()
     assert d0.stypes == tuple()
-    d0.internal.check()
 
 
 def test_create_from_empty_list_with_params():
@@ -128,25 +128,25 @@ def test_create_from_empty_list_bad():
 
 def test_create_from_list():
     d0 = dt.Frame([1, 2, 3])
+    d0.internal.check()
     assert d0.shape == (3, 1)
     assert d0.names == ("C0", )
     assert d0.ltypes == (ltype.int, )
-    d0.internal.check()
 
 
 def test_create_from_list_of_lists():
     d1 = dt.Frame([[1, 2], [True, False], [.3, -0]], names=list("ABC"))
+    d1.internal.check()
     assert d1.shape == (2, 3)
     assert d1.names == ("A", "B", "C")
     assert d1.ltypes == (ltype.int, ltype.bool, ltype.real)
-    d1.internal.check()
 
 
 def test_create_from_tuple():
     d2 = dt.Frame((3, 5, 6, 0))
+    d2.internal.check()
     assert d2.shape == (4, 1)
     assert d2.ltypes == (ltype.int, )
-    d2.internal.check()
 
 
 def test_create_from_set():
@@ -171,10 +171,10 @@ def test_create_from_list_of_ranges():
 
 def test_create_from_empty_list_of_lists():
     d6 = dt.Frame([[]])
+    d6.internal.check()
     assert d6.shape == (0, 1)
     assert d6.names == ("C0", )
     assert d6.ltypes == (ltype.bool, )
-    d6.internal.check()
 
 
 def test_create_from_dict():
@@ -187,7 +187,14 @@ def test_create_from_dict():
     d7.internal.check()
 
 
-def test_create_from_kwargs():
+def test_create_from_kwargs0():
+    d0 = dt.Frame(varname=[1])
+    d0.internal.check()
+    assert d0.names == ("varname",)
+    assert d0.topython() == [[1]]
+
+
+def test_create_from_kwargs1():
     d0 = dt.Frame(A=[1, 2, 3], B=[True, None, False], C=["a", "b", "c"])
     d0.internal.check()
     assert same_iterables(d0.names, ("A", "B", "C"))
@@ -209,7 +216,9 @@ def test_create_from_frame():
     d0 = dt.Frame(A=[1, 4, 3],
                   B=[False, True, False],
                   C=["str1", "str2", "str3"])
+    d0.internal.check()
     d1 = dt.Frame(d0)
+    d1.internal.check()
     assert_equals(d0, d1)
     # Now check that d1 is a true copy of d0, rather than reference
     del d1["C"]
@@ -313,6 +322,7 @@ def test_create_as_str64():
                                 stype.float32, stype.float64, stype.str32])
 def test_create_range_as_stype(st):
     d0 = dt.Frame(range(10), stype=st)
+    d0.internal.check()
     assert d0.stypes == (st,)
     if st == stype.str32:
         assert d0.topython()[0] == [str(x) for x in range(10)]
@@ -328,6 +338,8 @@ def test_create_range_as_stype(st):
 def test_create_names0():
     d1 = dt.Frame(range(10), names=["xyz"])
     d2 = dt.Frame(range(10), names=("xyz",))
+    d1.internal.check()
+    d2.internal.check()
     assert d1.shape == d2.shape == (10, 1)
     assert d1.names == d2.names == ("xyz",)
 
@@ -368,33 +380,33 @@ def test_create_names_bad4():
 def test_create_from_pandas(pandas):
     p = pandas.DataFrame({"A": [2, 5, 8], "B": ["e", "r", "qq"]})
     d = dt.Frame(p)
+    d.internal.check()
     assert d.shape == (3, 2)
     assert same_iterables(d.names, ("A", "B"))
-    d.internal.check()
 
 
 def test_create_from_pandas2(pandas, numpy):
     p = pandas.DataFrame(numpy.ones((3, 5)))
     d = dt.Frame(p)
+    d.internal.check()
     assert d.shape == (3, 5)
     assert d.names == ("0", "1", "2", "3", "4")
-    d.internal.check()
 
 
 def test_create_from_pandas_series(pandas):
     p = pandas.Series([1, 5, 9, -12])
     d = dt.Frame(p)
-    assert d.shape == (4, 1)
     d.internal.check()
+    assert d.shape == (4, 1)
     assert d.topython() == [[1, 5, 9, -12]]
 
 
 def test_create_from_pandas_with_names(pandas):
     p = pandas.DataFrame({"A": [2, 5, 8], "B": ["e", "r", "qq"]})
     d = dt.Frame(p, names=["miniature", "miniscule"])
+    d.internal.check()
     assert d.shape == (3, 2)
     assert same_iterables(d.names, ("miniature", "miniscule"))
-    d.internal.check()
 
 
 def test_create_from_pandas_series_with_names(pandas):
@@ -435,27 +447,27 @@ def test_create_from_pandas_issue1235(pandas):
 def test_create_from_0d_numpy_array(numpy):
     a = numpy.array(100)
     d = dt.Frame(a)
+    d.internal.check()
     assert d.shape == (1, 1)
     assert d.names == ("C0", )
-    d.internal.check()
     assert d.topython() == [[100]]
 
 
 def test_create_from_1d_numpy_array(numpy):
     a = numpy.array([1, 2, 3])
     d = dt.Frame(a)
+    d.internal.check()
     assert d.shape == (3, 1)
     assert d.names == ("C0", )
-    d.internal.check()
     assert d.topython() == [[1, 2, 3]]
 
 
 def test_create_from_2d_numpy_array(numpy):
     a = numpy.array([[5, 4, 3, 10, 12], [-2, -1, 0, 1, 7]])
     d = dt.Frame(a)
+    d.internal.check()
     assert d.shape == a.shape
     assert d.names == ("C0", "C1", "C2", "C3", "C4")
-    d.internal.check()
     assert d.topython() == a.T.tolist()
 
 
@@ -480,9 +492,9 @@ def test_create_from_masked_numpy_array1(numpy):
     m = numpy.array([False, True, False, False, True])
     arr = numpy.ma.array(a, mask=m)
     d = dt.Frame(arr)
+    d.internal.check()
     assert d.shape == (5, 1)
     assert d.stypes == (stype.bool8, )
-    d.internal.check()
     assert d.topython() == [[True, None, True, False, None]]
 
 
@@ -492,9 +504,9 @@ def test_create_from_masked_numpy_array2(numpy):
     m = numpy.random.randn(n) > 1
     arr = numpy.ma.array(a, mask=m, dtype="int16")
     d = dt.Frame(arr)
+    d.internal.check()
     assert d.shape == (n, 1)
     assert d.stypes == (stype.int16, )
-    d.internal.check()
     assert d.topython() == [arr.tolist()]
 
 
@@ -504,9 +516,9 @@ def test_create_from_masked_numpy_array3(numpy):
     m = numpy.random.randn(n) > 1
     arr = numpy.ma.array(a, mask=m, dtype="int32")
     d = dt.Frame(arr)
+    d.internal.check()
     assert d.shape == (n, 1)
     assert d.stypes == (stype.int32, )
-    d.internal.check()
     assert d.topython() == [arr.tolist()]
 
 
@@ -516,18 +528,18 @@ def test_create_from_masked_numpy_array4(numpy):
     m = numpy.random.randn(n) > 1
     arr = numpy.ma.array(a, mask=m, dtype="float64")
     d = dt.Frame(arr)
+    d.internal.check()
     assert d.shape == (n, 1)
     assert d.stypes == (stype.float64, )
-    d.internal.check()
     assert list_equals(d.topython(), [arr.tolist()])
 
 
 def test_create_from_numpy_array_with_names(numpy):
     a = numpy.array([1, 2, 3])
     d = dt.Frame(a, names=["gargantuan"])
+    d.internal.check()
     assert d.shape == (3, 1)
     assert d.names == ("gargantuan", )
-    d.internal.check()
     assert d.topython() == [[1, 2, 3]]
 
 
@@ -590,13 +602,13 @@ def test_bad():
 
 def test_issue_42():
     d = dt.Frame([-1])
+    d.internal.check()
     assert d.shape == (1, 1)
     assert d.ltypes == (ltype.int, )
-    d.internal.check()
     d = dt.Frame([-1, 2, 5, "hooray"])
+    d.internal.check()
     assert d.shape == (4, 1)
     assert d.ltypes == (ltype.obj, )
-    d.internal.check()
 
 
 def test_issue_409():
@@ -612,6 +624,7 @@ def test_issue_409():
 def test_duplicate_names1():
     with pytest.warns(DatatableWarning) as ws:
         d = dt.Frame([[1], [2], [3]], names=["A", "A", "A"])
+        d.internal.check()
         assert d.names == ("A", "A.1", "A.2")
     assert len(ws) == 1
     assert "Duplicate column names found: 'A' and 'A'" in ws[0].message.args[0]
@@ -620,6 +633,7 @@ def test_duplicate_names1():
 def test_duplicate_names2():
     with pytest.warns(DatatableWarning):
         d = dt.Frame([[1], [2], [3], [4]], names=("A", "A.1", "A", "A.2"))
+        d.internal.check()
         assert d.names == ("A", "A.1", "A.2", "A.3")
 
 
@@ -629,6 +643,7 @@ def test_special_characters_in_names():
                         "help\nneeded",
                         "foo\t\tbar\t \tbaz",
                         "A\n\rB\n\rC\n\rD\n\r"))
+    d.internal.check()
     assert d.names == (".", "help.needed", "foo.bar. .baz", "A.B.C.D.")
 
 
@@ -640,6 +655,6 @@ def test_special_characters_in_names():
 def test_create_datatable():
     """DataTable is old symbol for Frame."""
     d = dt.DataTable([1, 2, 3])
-    assert d.__class__.__name__ == "Frame"
     d.internal.check()
+    assert d.__class__.__name__ == "Frame"
     assert d.topython() == [[1, 2, 3]]

--- a/tests/test_dt_create.py
+++ b/tests/test_dt_create.py
@@ -62,6 +62,13 @@ def test_unknown_args():
             "'A', 'B', ..., 'E'" == str(e.value))
 
 
+def test_stypes_dict():
+    with pytest.raises(TypeError) as e:
+        dt.Frame([1, 2, 3], stypes={"A": float})
+    assert ("When parameter `stypes` is a dictionary, column `names` must "
+            "be explicitly specified" == str(e.value))
+
+
 
 #-------------------------------------------------------------------------------
 # Create empty Frame

--- a/tests/test_dt_create.py
+++ b/tests/test_dt_create.py
@@ -222,6 +222,17 @@ def test_create_as_str64():
     assert d0.topython() == [[str(n) for n in range(10)]]
 
 
+@pytest.mark.parametrize("st", [stype.int8, stype.int16, stype.int64,
+                                stype.float32, stype.float64, stype.str32])
+def test_create_range_as_stype(st):
+    d0 = dt.Frame(range(10), stype=st)
+    assert d0.stypes == (st,)
+    if st == stype.str32:
+        assert d0.topython()[0] == [str(x) for x in range(10)]
+    else:
+        assert d0.topython()[0] == list(range(10))
+
+
 
 #-------------------------------------------------------------------------------
 # Create with names
@@ -470,8 +481,8 @@ def test_create_from_mixed_sources(numpy):
     df.internal.check()
     assert df.shape == (5, 4)
     assert same_iterables(df.names, ("A", "B", "C", "D"))
-    assert same_iterables(df.stypes,
-                          (stype.float64, stype.int8, stype.str32, stype.int32))
+    assert same_iterables(df.stypes, (stype.float64, stype.int32, stype.str32,
+                                      stype.int32))
 
 
 

--- a/tests/test_dt_create.py
+++ b/tests/test_dt_create.py
@@ -59,11 +59,11 @@ def test_create_from_empty_list_with_params():
 def test_create_from_empty_list_bad():
     with pytest.raises(ValueError) as e:
         dt.Frame([], names=["A"])
-    assert ("`names` argument contains 1 element, which is more than the "
+    assert ("The `names` argument contains 1 element, which is more than the "
             "number of columns being created (0)" in str(e.value))
     with pytest.raises(ValueError) as e:
         dt.Frame([], stypes=["int32", "str32"])
-    assert ("`stypes` argument contains 2 elements, which is more than the "
+    assert ("The `stypes` argument contains 2 elements, which is more than the "
             "number of columns being created (0)" in str(e.value))
     with pytest.raises(TypeError) as e:
         dt.Frame([], stypes=[], stype="float32")
@@ -100,10 +100,9 @@ def test_create_from_tuple():
 
 
 def test_create_from_set():
-    d3 = dt.Frame({1, 13, 15, -16, -10, 7, 9, 1})
-    assert d3.shape == (7, 1)
-    assert d3.ltypes == (ltype.int, )
-    d3.internal.check()
+    with pytest.raises(TypeError) as e:
+        dt.Frame({1, 13, 15, -16, -10, 7, 9, 1})
+    assert ("Cannot create Frame from <class 'set'>" == str(e.value))
 
 
 def test_create_from_range():
@@ -286,8 +285,8 @@ def test_create_names0():
 def test_create_names_bad1():
     with pytest.raises(ValueError) as e:
         dt.Frame(range(10), names=["a", "b"])
-    assert ("The `names` list has length 2, while the Frame has only 1 "
-            "column" == str(e.value))
+    assert ("The `names` argument contains 2 elements, which is more than the "
+            "number of columns being created (1)" == str(e.value))
 
 
 def test_create_names_bad2():
@@ -300,7 +299,8 @@ def test_create_names_bad2():
 def test_create_names_bad3():
     with pytest.raises(TypeError) as e:
         dt.Frame(range(5), names={"x": 1})
-    assert "Expected a list of strings, got <class 'dict'>" == str(e.value)
+    assert ("Argument `names` in Frame.__init__() should be a list of strings, "
+            "instead received <class 'dict'>" == str(e.value))
 
 
 def test_create_names_bad4():
@@ -532,10 +532,10 @@ def test_create_from_mixed_sources(numpy):
 def test_bad():
     with pytest.raises(TypeError) as e:
         dt.Frame(1)
-    assert "Cannot create Frame from 1" in str(e.value)
+    assert "Cannot create Frame from <class 'int'>" == str(e.value)
     with pytest.raises(TypeError) as e:
         dt.Frame(dt)
-    assert "Cannot create Frame from <module 'datatable'" in str(e.value)
+    assert "Cannot create Frame from <class 'module'>" == str(e.value)
 
 
 def test_issue_42():

--- a/tests/test_dt_create.py
+++ b/tests/test_dt_create.py
@@ -17,6 +17,38 @@ from tests import same_iterables, list_equals, assert_equals
 
 
 #-------------------------------------------------------------------------------
+# Create empty Frame
+#-------------------------------------------------------------------------------
+
+def test_create_from_nothing():
+    d0 = dt.Frame()
+    assert d0.shape == (0, 0)
+    assert d0.names == tuple()
+    assert d0.ltypes == tuple()
+    assert d0.stypes == tuple()
+    d0.internal.check()
+
+
+def test_create_from_none():
+    d0 = dt.Frame(None)
+    assert d0.shape == (0, 0)
+    assert d0.names == tuple()
+    assert d0.ltypes == tuple()
+    assert d0.stypes == tuple()
+    d0.internal.check()
+
+
+def test_create_from_empty_list():
+    d0 = dt.Frame([])
+    assert d0.shape == (0, 0)
+    assert d0.names == tuple()
+    assert d0.ltypes == tuple()
+    assert d0.stypes == tuple()
+    d0.internal.check()
+
+
+
+#-------------------------------------------------------------------------------
 # Create from primitives
 #-------------------------------------------------------------------------------
 
@@ -62,24 +94,6 @@ def test_create_from_list_of_ranges():
     d0.internal.check()
     assert d0.shape == (6, 2)
     assert d0.topython() == [list(range(6)), list(range(0, 12, 2))]
-
-
-def test_create_from_nothing():
-    d4 = dt.Frame()
-    assert d4.shape == (0, 0)
-    assert d4.names == tuple()
-    assert d4.ltypes == tuple()
-    assert d4.stypes == tuple()
-    d4.internal.check()
-
-
-def test_create_from_empty_list():
-    d5 = dt.Frame([])
-    assert d5.shape == (0, 1)
-    assert d5.names == ("C0", )
-    assert d5.ltypes == (ltype.bool, )
-    assert d5.stypes == (stype.bool8, )
-    d5.internal.check()
 
 
 def test_create_from_empty_list_of_lists():

--- a/tests/test_dt_create.py
+++ b/tests/test_dt_create.py
@@ -47,6 +47,30 @@ def test_create_from_empty_list():
     d0.internal.check()
 
 
+def test_create_from_empty_list_with_params():
+    d0 = dt.Frame([], names=[], stypes=[])
+    d0.internal.check()
+    assert d0.shape == (0, 0)
+    d1 = dt.Frame([], stype=stype.int64)
+    d1.internal.check()
+    assert d1.shape == (0, 0)
+
+
+def test_create_from_empty_list_bad():
+    with pytest.raises(ValueError) as e:
+        dt.Frame([], names=["A"])
+    assert ("`names` argument contains 1 element, which is more than the "
+            "number of columns being created (0)" in str(e.value))
+    with pytest.raises(ValueError) as e:
+        dt.Frame([], stypes=["int32", "str32"])
+    assert ("`stypes` argument contains 2 elements, which is more than the "
+            "number of columns being created (0)" in str(e.value))
+    with pytest.raises(TypeError) as e:
+        dt.Frame([], stypes=[], stype="float32")
+    assert ("Parameters `stypes` and `stype` cannot be passed to Frame() "
+            "simultaneously" in str(e.value))
+
+
 
 #-------------------------------------------------------------------------------
 # Create from primitives

--- a/tests/test_dt_create.py
+++ b/tests/test_dt_create.py
@@ -293,7 +293,8 @@ def test_create_names_bad1():
 def test_create_names_bad2():
     with pytest.raises(TypeError) as e:
         dt.Frame([[1], [2], [3]], names="xyz")
-    assert "Expected a list of strings, got <class 'str'>" == str(e.value)
+    assert ("Argument `names` in Frame.__init__() should be a list of strings, "
+            "instead received <class 'str'>" == str(e.value))
 
 
 def test_create_names_bad3():

--- a/tests/test_dt_create.py
+++ b/tests/test_dt_create.py
@@ -15,6 +15,53 @@ from datatable import ltype, stype, DatatableWarning
 from tests import same_iterables, list_equals, assert_equals
 
 
+#-------------------------------------------------------------------------------
+# Test wrong parameters
+#-------------------------------------------------------------------------------
+
+def test_stypes_stype():
+    with pytest.raises(TypeError) as e:
+        dt.Frame(stypes=[], stype="float32")
+    assert ("You can pass either parameter `stypes` or `stype` to Frame() "
+            "constructor, but not both at the same time" == str(e.value))
+
+
+def test_bad_stype():
+    with pytest.raises(TypeError) as e:
+        dt.Frame(stype=-1)
+    assert ("Invalid value for `stype` parameter in Frame() constructor" ==
+            str(e.value))
+
+
+def test_unknown_arg():
+    with pytest.raises(TypeError) as e:
+        dt.Frame([1], dtype="int32")
+    assert ("Frame() constructor got an unexpected keyword argument 'dtype'" ==
+            str(e.value))
+
+
+@pytest.mark.usefixtures("py36")
+def test_unknown_args():
+    # Under py35 the order of kw parameters will be random, which will affect
+    # the error message
+    with pytest.raises(TypeError) as e:
+        dt.Frame([1], A=1, B=2)
+    assert ("Frame() constructor got 2 unexpected keyword arguments: "
+            "'A' and 'B'" == str(e.value))
+    with pytest.raises(TypeError) as e:
+        dt.Frame([1], A=1, B=2, C=3)
+    assert ("Frame() constructor got 3 unexpected keyword arguments: "
+            "'A', 'B' and 'C'" == str(e.value))
+    with pytest.raises(TypeError) as e:
+        dt.Frame([1], A=1, B=2, C=3, D=4)
+    assert ("Frame() constructor got 4 unexpected keyword arguments: "
+            "'A', 'B', ..., 'D'" == str(e.value))
+    with pytest.raises(TypeError) as e:
+        dt.Frame([1], A=1, B=2, C=3, D=4, E=5)
+    assert ("Frame() constructor got 5 unexpected keyword arguments: "
+            "'A', 'B', ..., 'E'" == str(e.value))
+
+
 
 #-------------------------------------------------------------------------------
 # Create empty Frame
@@ -65,10 +112,6 @@ def test_create_from_empty_list_bad():
         dt.Frame([], stypes=["int32", "str32"])
     assert ("The `stypes` argument contains 2 elements, which is more than the "
             "number of columns being created (0)" in str(e.value))
-    with pytest.raises(TypeError) as e:
-        dt.Frame([], stypes=[], stype="float32")
-    assert ("Parameters `stypes` and `stype` cannot be passed to Frame() "
-            "simultaneously" in str(e.value))
 
 
 

--- a/tests/test_dt_sort.py
+++ b/tests/test_dt_sort.py
@@ -348,7 +348,7 @@ def test_int64_small():
 
 def test_int64_small_stable():
     d0 = dt.Frame([[0, None, -1000, 11**11] * 3, range(12)])
-    assert d0.stypes == (stype.int64, stype.int8)
+    assert d0.stypes == (stype.int64, stype.int32)
     d1 = d0(sort=0, select=1)
     d1.internal.check()
     assert d1.topython() == [[1, 5, 9, 2, 6, 10, 0, 4, 8, 3, 7, 11]]

--- a/tests/test_dt_stats.py
+++ b/tests/test_dt_stats.py
@@ -15,7 +15,7 @@ from tests import list_equals
 
 srcs_bool = [[False, True, False, False, True],
              [True, None, None, True, False],
-             [True], [False], [None] * 10, []]
+             [True], [False], [None] * 10]
 srcs_int = [[5, -3, 6, 3, 0],
             [None, -1, 0, 26, -3],
             [129, 38, 27, -127, 8],
@@ -167,7 +167,7 @@ def test_dt_mean(src):
                                       ([-inf, 0, inf], None),
                                       ])
 def test_dt_mean_special_cases(src, res):
-    dt0 = dt.Frame(src)
+    dt0 = dt.Frame([src])
     dtr = dt0.mean()
     dtr.internal.check()
     assert dt0.names == dtr.names
@@ -212,7 +212,7 @@ def test_dt_sd(src):
                                       ([-inf, 0, inf], None),
                                       ])
 def test_dt_sd_special_cases(src, res):
-    dt0 = dt.Frame(src)
+    dt0 = dt.Frame([src])
     dtr = dt0.sd()
     dtr.internal.check()
     assert dtr.stypes == (stype.float64, )
@@ -352,10 +352,12 @@ def test_bad_call():
 @pytest.mark.parametrize("st", [dt.int8, dt.int16, dt.int32, dt.int64,
                                 dt.float32, dt.float64, dt.str32, dt.str64])
 def test_empty_frame(st):
-    f0 = dt.Frame([], stype=st)
+    f0 = dt.Frame([[]], stype=st)
     f1 = dt.Frame([None], stype=st)
     f0.internal.check()
     f1.internal.check()
+    assert f0.shape == (0, 1)
+    assert f1.shape == (1, 1)
     assert f0.stypes == f1.stypes == (st, )
     assert f0.countna1() == 0
     assert f0.nunique1() == 0

--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -14,7 +14,8 @@ from datatable import join, ltype, stype, f, g, mean
 
 def test_join_simple():
     d0 = dt.Frame([[1, 3, 2, 1, 1, 2, 0], list("abcdefg")], names=("A", "B"))
-    d1 = dt.Frame([range(4), ["zero", "one", "two", "three"]], names=("A", "V"))
+    d1 = dt.Frame([range(4), ["zero", "one", "two", "three"]], names=("A", "V"),
+                  stypes=d0.stypes)
     d1.key = "A"
     res = d0[:, :, join(d1)]
     res.internal.check()


### PR DESCRIPTION
This PR transfers handling of some of the most common types of constructor arguments in Frame() into C++ `core.Frame` object. Improved robustness of handling of some of the inputs. Better error messages. Additional tests.

This is a WIP towards #1066 