### PR TITLE
Frame initialization improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   when creating the frame.
 - Frame() can now be constructed from a list of named tuples, which will
   be treated as rows and field names will be used as column names.
+- frame.copy() can now be used to create a copy of the Frame.
 
 #### Changed
 - `names` argument in `Frame()` constructor can no longer be a string --

--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -27,6 +27,10 @@
 
 extern void init_jay();
 
+namespace py {
+  PyObject* fread_fn = nullptr;
+}
+
 
 PyMODINIT_FUNC PyInit__datatable(void);
 
@@ -94,6 +98,7 @@ PyObject* register_function(PyObject*, PyObject *args) {
   else if (n == 5) replace_valueError(fnref);
   else if (n == 6) replace_dtWarning(fnref);
   else if (n == 7) py::Frame_Type = fnref;
+  else if (n == 8) py::fread_fn = fnref;
   else {
     throw ValueError() << "Incorrect function index: " << n;
   }

--- a/c/extras/aggregator.cc
+++ b/c/extras/aggregator.cc
@@ -8,6 +8,7 @@
 #define dt_EXTRAS_AGGREGATOR_cc
 #include "extras/aggregator.h"
 #include <cstdlib>
+#include "frame/py_frame.h"
 #include "py_utils.h"
 #include "python/obj.h"
 #include "rowindex.h"
@@ -22,20 +23,21 @@ PyObject* aggregate(PyObject*, PyObject* args) {
 
   int32_t min_rows, n_bins, nx_bins, ny_bins, nd_bins, max_dimensions;
   unsigned int seed;
-  PyObject* arg1;
+  PyObject* arg1, *arg_names;
   PyObject* progress_fn;
 
-  if (!PyArg_ParseTuple(args, "OiiiiiiIO:aggregate", &arg1, &min_rows, &n_bins,
+  if (!PyArg_ParseTuple(args, "OiiiiiiIOO:aggregate", &arg1, &min_rows, &n_bins,
                         &nx_bins, &ny_bins, &nd_bins, &max_dimensions, &seed,
-                        &progress_fn)) return nullptr;
-
+                        &progress_fn, &arg_names)) return nullptr;
   DataTable* dt_in = py::obj(arg1).to_frame();
-  DataTablePtr dt_members = nullptr;
 
   Aggregator agg(min_rows, n_bins, nx_bins, ny_bins, nd_bins, max_dimensions,
                  seed, progress_fn);
-  dt_members = agg.aggregate(dt_in);
-  return pydatatable::wrap(dt_members.release());
+  DataTable* dt_out = agg.aggregate(dt_in).release();
+  py::Frame* frame = py::Frame::from_datatable(dt_out);
+  frame->set_names(py::obj(arg_names));
+
+  return frame;
 }
 
 

--- a/c/frame/py_frame.h
+++ b/c/frame/py_frame.h
@@ -40,10 +40,10 @@ class Frame : public PyObject {
       public:
         static PKArgs args___init__;
         static PKArgs args_colindex;
+        static NoArgs args_copy;
         static const char* classname();
         static const char* classdoc();
         static bool is_subclassable() { return true; }
-
         static void init_getsetters(GetSetters& gs);
         static void init_methods(Methods& gs);
     };
@@ -51,6 +51,7 @@ class Frame : public PyObject {
     // Internal "constructor" of Frame objects. We do not use real constructors
     // because Frame objects must be allocated/initialized by Python.
     static Frame* from_datatable(DataTable* dt);
+    DataTable* get_datatable() const { return dt; }
 
     void m__init__(PKArgs&);
     void m__dealloc__();
@@ -71,6 +72,7 @@ class Frame : public PyObject {
     void set_internal(obj);
 
     oobj colindex(PKArgs&);
+    oobj copy(NoArgs&);
 
   private:
     static bool internal_construction;

--- a/c/frame/py_frame.h
+++ b/c/frame/py_frame.h
@@ -93,6 +93,7 @@ class Frame : public PyObject {
 };
 
 extern PyObject* Frame_Type;
+extern PyObject* fread_fn;
 
 }  // namespace py
 

--- a/c/frame/py_frame_init.cc
+++ b/c/frame/py_frame_init.cc
@@ -450,6 +450,7 @@ Error FrameInitializationManager::em::error_not_stype(PyObject*) const {
 //------------------------------------------------------------------------------
 
 void Frame::m__init__(PKArgs& args) {
+  if (dt) m__dealloc__();
   dt = nullptr;
   core_dt = nullptr;
   stypes = nullptr;

--- a/c/py_datatable.cc
+++ b/c/py_datatable.cc
@@ -99,15 +99,9 @@ PyObject* open_jay(PyObject*, PyObject* args) {
 
   std::vector<std::string> colnames;
   DataTable* dt = DataTable::open_jay(filename, colnames);
-  PyObject* pydt = wrap(dt);
-
-  py::olist collist(colnames.size());
-  for (size_t i = 0; i < colnames.size(); ++i) {
-    collist.set(i, py::ostring(colnames[i]));
-  }
-  PyObject* pylist = std::move(collist).release();
-
-  return Py_BuildValue("OO", pydt, pylist);
+  py::Frame* frame = py::Frame::from_datatable(dt);
+  frame->set_names(colnames);
+  return frame;
 }
 
 

--- a/c/py_datatable.cc
+++ b/c/py_datatable.cc
@@ -80,10 +80,15 @@ PyObject* datatable_load(PyObject*, PyObject* args) {
   int64_t nrows;
   const char* path;
   int recode;
-  if (!PyArg_ParseTuple(args, "O&nsi:datatable_load",
-                        &unwrap, &colspec, &nrows, &path, &recode))
+  PyObject* names;
+  if (!PyArg_ParseTuple(args, "O&nsiO:datatable_load",
+                        &unwrap, &colspec, &nrows, &path, &recode, &names))
     return nullptr;
-  return wrap(DataTable::load(colspec, nrows, path, recode));
+
+  DataTable* dt = DataTable::load(colspec, nrows, path, recode);
+  py::Frame* frame = py::Frame::from_datatable(dt);
+  frame->set_names(py::obj(names));
+  return frame;
 }
 
 

--- a/c/py_datatable.h
+++ b/c/py_datatable.h
@@ -291,9 +291,8 @@ DECLARE_FUNCTION(
 
 DECLARE_FUNCTION(
   open_jay,
-  "open_jay(file)\n\n"
-  "Open DataTable from a .jay file, and return as a tuple (frame, colnames),\n"
-  "where `colnames` is a list of column names.\n",
+  "open_jay(file)\n--\n\n"
+  "Open a Frame from the provided .jay file.\n",
   HOMEFLAG)
 
 

--- a/c/python/arg.cc
+++ b/c/python/arg.cc
@@ -61,6 +61,7 @@ bool Arg::is_list_or_tuple() const { return pyobj.is_list_or_tuple(); }
 bool Arg::is_dict()          const { return pyobj.is_dict(); }
 bool Arg::is_string()        const { return pyobj.is_string(); }
 bool Arg::is_range()         const { return pyobj.is_range(); }
+bool Arg::is_frame()         const { return pyobj.is_frame(); }
 
 
 
@@ -76,6 +77,7 @@ std::string Arg::to_string()       const { return pyobj.to_string(*this); }
 strvec      Arg::to_stringlist()   const { return pyobj.to_stringlist(*this); }
 SType       Arg::to_stype()        const { return pyobj.to_stype(*this); }
 SType       Arg::to_stype(const error_manager& em) const { return pyobj.to_stype(em); }
+DataTable*  Arg::to_frame()        const { return pyobj.to_frame(*this); }
 
 
 

--- a/c/python/arg.h
+++ b/c/python/arg.h
@@ -49,6 +49,7 @@ class Arg : public _obj::error_manager {
     bool is_dict() const;
     bool is_string() const;
     bool is_range() const;
+    bool is_frame() const;
 
     //---- Type conversions ------------
     int32_t     to_int32_strict  () const;
@@ -60,6 +61,7 @@ class Arg : public _obj::error_manager {
     SType       to_stype         () const;
     SType       to_stype         (const error_manager&) const;
     py::obj     to_pyobj         () const { return pyobj; }
+    DataTable*  to_frame         () const;
 
 
     //---- Error messages --------------

--- a/c/python/obj.cc
+++ b/c/python/obj.cc
@@ -17,6 +17,7 @@
 #include "python/float.h"
 #include "python/list.h"
 #include "python/orange.h"
+#include "python/tuple.h"
 #include "python/string.h"
 
 namespace py {
@@ -518,6 +519,21 @@ oobj _obj::invoke(const char* fn, const char* format, ...) const {
   } while (0);
   Py_XDECREF(callable);
   Py_XDECREF(args);
+  if (!res) throw PyError();
+  return oobj::from_new_reference(res);
+}
+
+
+oobj _obj::call(otuple args) const {
+  PyObject* res = PyObject_Call(v, args.to_borrowed_ref(), nullptr);
+  if (!res) throw PyError();
+  return oobj::from_new_reference(res);
+}
+
+
+oobj _obj::call(otuple args, odict kws) const {
+  PyObject* res = PyObject_Call(v, args.to_borrowed_ref(),
+                                kws.to_borrowed_ref());
   if (!res) throw PyError();
   return oobj::from_new_reference(res);
 }

--- a/c/python/obj.h
+++ b/c/python/obj.h
@@ -148,6 +148,7 @@ class _obj {
     bool is_dict()          const noexcept;
     bool is_buffer()        const noexcept;
     bool is_range()         const noexcept;
+    bool is_frame()         const noexcept;
 
     struct error_manager;  // see below
     int8_t      to_bool          (const error_manager& = _em0) const;

--- a/c/python/obj.h
+++ b/c/python/obj.h
@@ -28,6 +28,7 @@ class oint;
 class olist;
 class ostring;
 class orange;
+class otuple;
 class obj;
 class oobj;
 using strvec = std::vector<std::string>;
@@ -124,6 +125,8 @@ class _obj {
     oobj get_attr(const char* attr) const;
     bool has_attr(const char* attr) const;
     oobj invoke(const char* fn, const char* format, ...) const;
+    oobj call(otuple args) const;
+    oobj call(otuple args, odict kws) const;
     ostring str() const;
     PyTypeObject* typeobj() const noexcept;  // borrowed ref
 

--- a/datatable/extras/aggregate.py
+++ b/datatable/extras/aggregate.py
@@ -5,7 +5,6 @@
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #-------------------------------------------------------------------------------
 import datatable as dt
-from datatable import Frame
 from datatable.lib import core
 
 
@@ -48,7 +47,7 @@ def aggregate(self, min_rows=500, n_bins=500, nx_bins=50, ny_bins=50,
     names_members = ("exemplar_id",)
 
     dt_members = core.aggregate(self._dt, min_rows, n_bins, nx_bins, ny_bins,
-                                nd_bins, max_dimensions, seed, progress_fn)
+                                nd_bins, max_dimensions, seed, progress_fn,
+                                names_members)
     self.names = names_exemplars
-
-    return Frame(dt_members, names=names_members)
+    return dt_members

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -110,10 +110,7 @@ class Frame(core.Frame):
     #---------------------------------------------------------------------------
 
     def _fill_from_source(self, src, names, stypes):
-        if isinstance(src, core.DataTable):
-            self._dt = src
-            self.names = names
-        elif isinstance(src, str):
+        if isinstance(src, str):
             srcdt = datatable.fread(src)
             if names is None:
                 names = srcdt.names
@@ -193,7 +190,6 @@ class Frame(core.Frame):
 
     def __call__(self, rows=None, select=None, verbose=False, timeit=False,
                  groupby=None, join=None, sort=None, engine=None
-                 #update=None, limit=None
                  ):
         """
         Perform computation on a datatable, and return the result.

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -113,7 +113,6 @@ class Frame(core.Frame):
         if isinstance(src, core.DataTable):
             self._dt = src
             self.names = names
-            # assert False
         elif isinstance(src, str):
             srcdt = datatable.fread(src)
             if names is None:

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -113,6 +113,7 @@ class Frame(core.Frame):
         if isinstance(src, core.DataTable):
             self._dt = src
             self.names = names
+            # assert False
         elif isinstance(src, str):
             srcdt = datatable.fread(src)
             if names is None:

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -116,13 +116,6 @@ class Frame(core.Frame):
                 names = srcdt.names
             self._dt = srcdt.internal
             self.names = names
-        elif is_type(src, Frame_t):
-            if names is None:
-                names = src.names
-            _dt = core.columns_from_slice(src.internal, None, 0, src.ncols, 1) \
-                      .to_frame(None).internal
-            self._dt = _dt
-            self.names = names
         elif is_type(src, PandasDataFrame_t, PandasSeries_t):
             self._fill_from_pandas(src, names)
         elif is_type(src, NumpyArray_t):

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -16,7 +16,7 @@ from datatable.nff import save as dt_save
 from datatable.utils.misc import plural_form as plural
 from datatable.utils.misc import load_module
 from datatable.utils.typechecks import (
-    TTypeError, TValueError, DatatableWarning, U, is_type, Frame_t,
+    TTypeError, TValueError, DatatableWarning, U, is_type,
     typed, PandasDataFrame_t, PandasSeries_t, NumpyArray_t, NumpyMaskedArray_t)
 from datatable.graph import make_datatable, resolve_selector
 from datatable.csv import write_csv
@@ -110,13 +110,7 @@ class Frame(core.Frame):
     #---------------------------------------------------------------------------
 
     def _fill_from_source(self, src, names, stypes):
-        if isinstance(src, str):
-            srcdt = datatable.fread(src)
-            if names is None:
-                names = srcdt.names
-            self._dt = srcdt.internal
-            self.names = names
-        elif is_type(src, PandasDataFrame_t, PandasSeries_t):
+        if is_type(src, PandasDataFrame_t, PandasSeries_t):
             self._fill_from_pandas(src, names)
         elif is_type(src, NumpyArray_t):
             self._fill_from_numpy(src, names=names)

--- a/datatable/fread.py
+++ b/datatable/fread.py
@@ -12,7 +12,7 @@ import re
 import shutil
 import tempfile
 import warnings
-from typing import List, Union, Callable, Optional, Tuple, Dict, Set
+from typing import List, Union, Optional
 
 from datatable.lib import core
 from datatable.frame import Frame
@@ -948,7 +948,7 @@ class GenericReader(object):
         n = len(colsdesc)
         nn = len(collist)
         if n != nn:
-            raise TValueError("Input file contains %s, whereas `columns` "
+            raise TValueError("Input contains %s, whereas `columns` "
                               "parameter specifies only %s"
                               % (plural(n, "column"), plural(nn, "column")))
         colnames = []
@@ -1071,6 +1071,8 @@ _pathlike = (str, bytes, os.PathLike) if hasattr(os, "PathLike") else \
 options.register_option(
     "fread.anonymize", xtype=bool, default=False, core=True)
 
+core.register_function(8, fread)
+
 
 
 #-------------------------------------------------------------------------------
@@ -1093,6 +1095,7 @@ class rtype(enum.Enum):
 
 _rtypes_map = {
     None:          rtype.rdrop,
+    ...:           rtype.rauto,
     bool:          rtype.rbool,
     int:           rtype.rint,
     float:         rtype.rfloat,

--- a/datatable/nff.py
+++ b/datatable/nff.py
@@ -123,7 +123,7 @@ def open(path):
     f0 = dt.fread(metafile, sep=",", columns=coltypes)
     f1 = f0(select=["filename", "stype"])
     colnames = f0["colname"].topython()[0]
-    _dt = core.datatable_load(f1.internal, nrows, path, nff_version < 2)
-    df = dt.Frame(_dt, names=colnames)
+    df = core.datatable_load(f1.internal, nrows, path, nff_version < 2,
+                             colnames)
     assert df.nrows == nrows, "Wrong number of rows read: %d" % df.nrows
     return df

--- a/datatable/nff.py
+++ b/datatable/nff.py
@@ -85,8 +85,7 @@ def open(path):
         raise ValueError(msg)
 
     if not os.path.isdir(path):
-        _dt, colnames = core.open_jay(path)
-        return dt.Frame(_dt, names=colnames)
+        return core.open_jay(path)
 
     nff_version = None
     nrows = 0

--- a/tests/extras/test_aggregate.py
+++ b/tests/extras/test_aggregate.py
@@ -8,12 +8,10 @@
 # Test aggregating different types of data
 #
 #-------------------------------------------------------------------------------
-import math
-import pytest
 import datatable as dt
-from datatable import ltype, stype, DatatableWarning
+from datatable import ltype
 from datatable.extras.aggregate import aggregate
-from datatable import stype
+
 
 
 #-------------------------------------------------------------------------------
@@ -23,7 +21,7 @@ from datatable import stype
 def test_aggregate_1d_continuous_integer_equal():
     n_bins = 3
     d_in = dt.Frame([0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
-    d_members = aggregate(d_in, min_rows = 1, n_bins = n_bins)
+    d_members = aggregate(d_in, min_rows=1, n_bins=n_bins)
     d_members.internal.check()
     assert d_members.shape == (10, 1)
     assert d_members.ltypes == (ltype.int,)
@@ -37,7 +35,7 @@ def test_aggregate_1d_continuous_integer_equal():
 def test_aggregate_1d_continuous_integer_sorted():
     n_bins = 3
     d_in = dt.Frame([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
-    d_members = aggregate(d_in, min_rows = 1, n_bins = n_bins)
+    d_members = aggregate(d_in, min_rows=1, n_bins=n_bins)
     d_members.internal.check()
     assert d_members.shape == (10, 1)
     assert d_members.ltypes == (ltype.int,)
@@ -52,7 +50,7 @@ def test_aggregate_1d_continuous_integer_sorted():
 def test_aggregate_1d_continuous_integer_random():
     n_bins = 3
     d_in = dt.Frame([9, 8, 2, 3, 3, 0, 5, 5, 8, 1])
-    d_members = aggregate(d_in, min_rows = 1, n_bins = n_bins)
+    d_members = aggregate(d_in, min_rows=1, n_bins=n_bins)
     d_members.internal.check()
     assert d_members.shape == (10, 1)
     assert d_members.ltypes == (ltype.int,)
@@ -67,7 +65,7 @@ def test_aggregate_1d_continuous_integer_random():
 def test_aggregate_1d_continuous_real_sorted():
     n_bins = 3
     d_in = dt.Frame([0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9])
-    d_members = aggregate(d_in, min_rows = 1, n_bins = n_bins)
+    d_members = aggregate(d_in, min_rows=1, n_bins=n_bins)
     d_members.internal.check()
     assert d_members.shape == (10, 1)
     assert d_members.ltypes == (ltype.int,)
@@ -82,7 +80,7 @@ def test_aggregate_1d_continuous_real_sorted():
 def test_aggregate_1d_continuous_real_random():
     n_bins = 3
     d_in = dt.Frame([0.7, 0.7, 0.5, 0.1, 0.0, 0.9, 0.1, 0.3, 0.4, 0.2])
-    d_members = aggregate(d_in, min_rows = 1, n_bins = n_bins)
+    d_members = aggregate(d_in, min_rows=1, n_bins=n_bins)
     d_members.internal.check()
     assert d_members.shape == (10, 1)
     assert d_members.ltypes == (ltype.int,)
@@ -102,8 +100,8 @@ def test_aggregate_2d_continuous_integer_sorted():
     nx_bins = 3
     ny_bins = 3
     d_in = dt.Frame([[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-                   [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]])
-    d_members = aggregate(d_in, min_rows = 1, nx_bins = nx_bins, ny_bins = ny_bins)
+                     [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]])
+    d_members = aggregate(d_in, min_rows=1, nx_bins=nx_bins, ny_bins=ny_bins)
     d_members.internal.check()
     assert d_members.shape == (10, 1)
     assert d_members.ltypes == (ltype.int,)
@@ -120,8 +118,8 @@ def test_aggregate_2d_continuous_integer_random():
     nx_bins = 3
     ny_bins = 3
     d_in = dt.Frame([[9, 8, 2, 3, 3, 0, 5, 5, 8, 1],
-                   [3, 5, 8, 1, 4, 4, 8, 7, 6, 1]])
-    d_members = aggregate(d_in, min_rows = 1, nx_bins = nx_bins, ny_bins = ny_bins)
+                     [3, 5, 8, 1, 4, 4, 8, 7, 6, 1]])
+    d_members = aggregate(d_in, min_rows=1, nx_bins=nx_bins, ny_bins=ny_bins)
     d_members.internal.check()
     assert d_members.shape == (10, 1)
     assert d_members.ltypes == (ltype.int,)
@@ -138,8 +136,8 @@ def test_aggregate_2d_continuous_real_sorted():
     nx_bins = 3
     ny_bins = 3
     d_in = dt.Frame([[0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9],
-                   [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]])
-    d_members = aggregate(d_in, min_rows = 1, nx_bins = nx_bins, ny_bins = ny_bins)
+                     [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]])
+    d_members = aggregate(d_in, min_rows=1, nx_bins=nx_bins, ny_bins=ny_bins)
     d_members.internal.check()
     assert d_members.shape == (10, 1)
     assert d_members.ltypes == (ltype.int,)
@@ -156,8 +154,8 @@ def test_aggregate_2d_continuous_real_random():
     nx_bins = 3
     ny_bins = 3
     d_in = dt.Frame([[0.9, 0.8, 0.2, 0.3, 0.3, 0.0, 0.5, 0.5, 0.8, 0.1],
-                   [0.3, 0.5, 0.8, 0.1, 0.4, 0.4, 0.8, 0.7, 0.6, 0.1]])
-    d_members = aggregate(d_in, min_rows = 1, nx_bins = nx_bins, ny_bins = ny_bins)
+                     [0.3, 0.5, 0.8, 0.1, 0.4, 0.4, 0.8, 0.7, 0.6, 0.1]])
+    d_members = aggregate(d_in, min_rows=1, nx_bins=nx_bins, ny_bins=ny_bins)
     d_members.internal.check()
     assert d_members.shape == (10, 1)
     assert d_members.ltypes == (ltype.int,)
@@ -171,41 +169,41 @@ def test_aggregate_2d_continuous_real_random():
 
 
 def test_aggregate_1d_categorical_sorted():
-    d_in = dt.Frame(["blue", "green", "indigo", "orange", "red", "violet", 
+    d_in = dt.Frame(["blue", "green", "indigo", "orange", "red", "violet",
                      "yellow"])
-    d_members = aggregate(d_in, min_rows = 1)
+    d_members = aggregate(d_in, min_rows=1)
     assert d_members.shape == (7, 1)
     assert d_members.ltypes == (ltype.int,)
     assert d_members.topython() == [[0, 1, 2, 3, 4, 5, 6]]
     d_in.internal.check()
     assert d_in.shape == (7, 2)
     assert d_in.ltypes == (ltype.str, ltype.int)
-    assert d_in.topython() == [["blue", "green", "indigo", "orange", "red", 
+    assert d_in.topython() == [["blue", "green", "indigo", "orange", "red",
                                 "violet", "yellow"],
                                [1, 1, 1, 1, 1, 1, 1]]
 
 
 def test_aggregate_1d_categorical_random():
-    d_in = dt.Frame(["blue", "orange", "yellow", "green", "blue", "indigo", 
+    d_in = dt.Frame(["blue", "orange", "yellow", "green", "blue", "indigo",
                      "violet"])
-    d_members = aggregate(d_in, min_rows = 1)
+    d_members = aggregate(d_in, min_rows=1)
     assert d_members.shape == (7, 1)
     assert d_members.ltypes == (ltype.int,)
     assert d_members.topython() == [[0, 3, 5, 1, 0, 2, 4]]
     d_in.internal.check()
     assert d_in.shape == (6, 2)
     assert d_in.ltypes == (ltype.str, ltype.int)
-    assert d_in.topython() == [["blue", "green", "indigo", "orange", "violet", 
+    assert d_in.topython() == [["blue", "green", "indigo", "orange", "violet",
                                 "yellow"],
                                [2, 1, 1, 1, 1, 1]]
 
 
 def test_aggregate_2d_categorical_sorted():
-    d_in = dt.Frame([["blue", "green", "indigo", "orange", "red", "violet", 
+    d_in = dt.Frame([["blue", "green", "indigo", "orange", "red", "violet",
                       "yellow"],
-                     ["Friday", "Monday", "Saturday", "Sunday", "Thursday", 
+                     ["Friday", "Monday", "Saturday", "Sunday", "Thursday",
                       "Tuesday", "Wednesday"]])
-    d_members = aggregate(d_in, min_rows = 1)
+    d_members = aggregate(d_in, min_rows=1)
     d_members.internal.check()
     assert d_members.shape == (7, 1)
     assert d_members.ltypes == (ltype.int,)
@@ -213,20 +211,20 @@ def test_aggregate_2d_categorical_sorted():
     d_in.internal.check()
     assert d_in.shape == (7, 3)
     assert d_in.ltypes == (ltype.str, ltype.str, ltype.int)
-    assert d_in.topython() == [["blue", "green", "indigo", "orange", "red", 
+    assert d_in.topython() == [["blue", "green", "indigo", "orange", "red",
                                 "violet", "yellow"],
-                               ["Friday", "Monday", "Saturday", "Sunday", 
+                               ["Friday", "Monday", "Saturday", "Sunday",
                                 "Thursday", "Tuesday", "Wednesday"],
                                [1, 1, 1, 1, 1, 1, 1]]
 
 
 def test_aggregate_2d_categorical_random():
-    d_in = dt.Frame([["blue", "indigo", "red", "violet", "yellow", "violet", 
+    d_in = dt.Frame([["blue", "indigo", "red", "violet", "yellow", "violet",
                       "red"],
-                     ["Monday", "Monday", "Wednesday", "Saturday", "Thursday", 
+                     ["Monday", "Monday", "Wednesday", "Saturday", "Thursday",
                       "Friday", "Wednesday"]])
 
-    d_members = aggregate(d_in, min_rows = 1)
+    d_members = aggregate(d_in, min_rows=1)
     d_members.internal.check()
     d_in.internal.check()
     assert d_members.shape == (7, 1)
@@ -235,9 +233,9 @@ def test_aggregate_2d_categorical_random():
     d_in.internal.check()
     assert d_in.shape == (6, 3)
     assert d_in.ltypes == (ltype.str, ltype.str, ltype.int)
-    assert d_in.topython() == [['violet', 'blue', 'indigo', 'violet', 'yellow', 
+    assert d_in.topython() == [['violet', 'blue', 'indigo', 'violet', 'yellow',
                                 'red'],
-                               ['Friday', 'Monday', 'Monday', 'Saturday', 
+                               ['Friday', 'Monday', 'Monday', 'Saturday',
                                 'Thursday', 'Wednesday'],
                                [1, 1, 1, 1, 1, 2]]
 
@@ -245,9 +243,9 @@ def test_aggregate_2d_categorical_random():
 def test_aggregate_2d_mixed_sorted():
     nx_bins = 7
     d_in = dt.Frame([[0, 1, 2, 3, 4, 5, 6],
-                     ["blue", "green", "indigo", "orange", "red", "violet", 
+                     ["blue", "green", "indigo", "orange", "red", "violet",
                       "yellow"]])
-    d_members = aggregate(d_in, min_rows = 1, nx_bins = nx_bins)
+    d_members = aggregate(d_in, min_rows=1, nx_bins=nx_bins)
     d_members.internal.check()
     assert d_members.shape == (7, 1)
     assert d_members.ltypes == (ltype.int,)
@@ -256,7 +254,7 @@ def test_aggregate_2d_mixed_sorted():
     assert d_in.shape == (7, 3)
     assert d_in.ltypes == (ltype.int, ltype.str, ltype.int)
     assert d_in.topython() == [[0, 1, 2, 3, 4, 5, 6],
-                               ["blue", "green", "indigo", "orange", "red", 
+                               ["blue", "green", "indigo", "orange", "red",
                                 "violet", "yellow"],
                                [1, 1, 1, 1, 1, 1, 1]]
 
@@ -264,9 +262,9 @@ def test_aggregate_2d_mixed_sorted():
 def test_aggregate_2d_mixed_random():
     nx_bins = 6
     d_in = dt.Frame([[3, 0, 6, 6, 1, 2, 4],
-                     ["blue", "indigo", "red", "violet", "yellow", "violet", 
+                     ["blue", "indigo", "red", "violet", "yellow", "violet",
                       "red"]])
-    d_members = aggregate(d_in, min_rows = 1, nx_bins = nx_bins)
+    d_members = aggregate(d_in, min_rows=1, nx_bins=nx_bins)
     d_members.internal.check()
     assert d_members.shape == (7, 1)
     assert d_members.ltypes == (ltype.int,)
@@ -275,7 +273,6 @@ def test_aggregate_2d_mixed_random():
     assert d_in.shape == (7, 3)
     assert d_in.ltypes == (ltype.int, ltype.str, ltype.int)
     assert d_in.topython() == [[3, 0, 4, 6, 2, 6, 1],
-                               ['blue', 'indigo', 'red', 'red', 'violet', 
+                               ['blue', 'indigo', 'red', 'red', 'violet',
                                 'violet', 'yellow'],
                                [1, 1, 1, 1, 1, 1, 1]]
-

--- a/tests/extras/test_aggregate.py
+++ b/tests/extras/test_aggregate.py
@@ -32,6 +32,7 @@ def test_aggregate_1d_continuous_integer_equal():
     assert d_in.topython() == [[0],
                                [10]]
 
+
 def test_aggregate_1d_continuous_integer_sorted():
     n_bins = 3
     d_in = dt.Frame([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])

--- a/tests/fread/test_fread_api.py
+++ b/tests/fread/test_fread_api.py
@@ -437,7 +437,7 @@ def test_fread_columns_list_of_types():
 def test_fread_columns_list_bad1():
     with pytest.raises(ValueError) as e:
         dt.fread(text="C1,C2\n1,2\n3,4\n", columns=["C2"])
-    assert ("Input file contains 2 columns, whereas `columns` parameter "
+    assert ("Input contains 2 columns, whereas `columns` parameter "
             "specifies only 1 column" in str(e.value))
 
 
@@ -464,7 +464,7 @@ def test_fread_columns_list_bad4():
            in str(e)
     with pytest.raises(ValueError) as e:
         dt.fread(src, columns=[str, str])
-    assert ("Input file contains 3 columns, whereas `columns` parameter "
+    assert ("Input contains 3 columns, whereas `columns` parameter "
             "specifies only 2 columns" in str(e.value))
 
 

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -602,7 +602,7 @@ def test_resize_bad():
 
 
 #-------------------------------------------------------------------------------
-# ...
+# Renaming columns
 #-------------------------------------------------------------------------------
 
 @pytest.mark.run(order=8)
@@ -948,10 +948,32 @@ def test_keys_simple():
 
 
 #-------------------------------------------------------------------------------
+# Frame copy
+#-------------------------------------------------------------------------------
+
+def test_copy_frame():
+    d0 = dt.Frame(A=range(5),
+                  B=["dew", None, "strab", "g", None],
+                  C=[1.0 - i * 0.2 for i in range(5)],
+                  D=[True, False, None, False, True])
+    assert sorted(d0.names) == list("ABCD")
+    d1 = d0.copy()
+    d0.internal.check()
+    d1.internal.check()
+    assert d0.names == d1.names
+    assert d0.stypes == d1.stypes
+    assert d0.topython() == d1.topython()
+    d0[1, "A"] = 100
+    assert d0.topython() != d1.topython()
+    d0.names = ("w", "x", "y", "z")
+    assert d1.names != d0.names
+
+
+
+#-------------------------------------------------------------------------------
 # Misc
 #-------------------------------------------------------------------------------
 
-@pytest.mark.run(order=9)
 def test_internal_rowindex():
     d0 = dt.Frame(range(100))
     d1 = d0[:20, :]
@@ -959,7 +981,6 @@ def test_internal_rowindex():
     assert repr(d1.internal.rowindex) == "_RowIndex(0/20/1)"
 
 
-@pytest.mark.run(order=33)
 def test_issue898():
     """
     Test that reification of obj column views does not lead to any disastrous


### PR DESCRIPTION
* Added method `frame.copy()`;
* Several modes of Frame initialization are now done in C++ instead of in Python;
* Creating a Frame from `core._DataTable` object is no longer supported (the use of these objects will be slowly phased out).

WIP for #1066 