### PR TITLE
Make frame from a list of dicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Frame() can now be constructed from a list of named tuples, which will
   be treated as rows and field names will be used as column names.
 - frame.copy() can now be used to create a copy of the Frame.
+- Frame() can now be constructed from a list of dictionaries, where each
+  item in the list represents a single row.
 
 #### Changed
 - `names` argument in `Frame()` constructor can no longer be a string --

--- a/c/column.h
+++ b/c/column.h
@@ -91,6 +91,7 @@ public:
   static Column* new_mbuf_column(SType, MemoryRange&&, MemoryRange&&);
   static Column* from_pylist(const py::olist& list, int stype0 = 0);
   static Column* from_pylist_of_tuples(const py::olist& list, size_t index, int stype0);
+  static Column* from_pylist_of_dicts(const py::olist& list, py::obj name, int stype0);
   static Column* from_buffer(PyObject* buffer);
   static Column* from_range(int64_t start, int64_t stop, int64_t step, SType s);
 

--- a/c/python/dict.cc
+++ b/c/python/dict.cc
@@ -45,6 +45,10 @@ size_t odict::size() const {
   return static_cast<size_t>(PyDict_Size(v));
 }
 
+size_t rdict::size() const {
+  return static_cast<size_t>(PyDict_Size(v));
+}
+
 bool odict::has(_obj key) const {
   PyObject* _key = key.to_borrowed_ref();
   return PyDict_GetItem(v, _key) != nullptr;
@@ -54,6 +58,18 @@ obj odict::get(_obj key) const {
   // PyDict_GetItem returns a borrowed ref; or NULL if key is not present
   PyObject* _key = key.to_borrowed_ref();
   return obj(PyDict_GetItem(v, _key));
+}
+
+obj rdict::get(_obj key) const {
+  PyObject* _key = key.to_borrowed_ref();
+  return obj(PyDict_GetItem(v, _key));
+}
+
+obj rdict::get_or_none(_obj key) const {
+  PyObject* _key = key.to_borrowed_ref();
+  PyObject* res = PyDict_GetItem(v, _key);
+  if (!res) res = Py_None;
+  return obj(res);
 }
 
 void odict::set(_obj key, _obj val) {

--- a/c/python/dict.cc
+++ b/c/python/dict.cc
@@ -89,6 +89,14 @@ dict_iterator odict::end() const {
   return dict_iterator(v, -1);
 }
 
+dict_iterator rdict::begin() const {
+  return dict_iterator(v, 0);
+}
+
+dict_iterator rdict::end() const {
+  return dict_iterator(v, -1);
+}
+
 
 
 //------------------------------------------------------------------------------

--- a/c/python/dict.h
+++ b/c/python/dict.h
@@ -49,6 +49,8 @@ class rdict : public obj {
     size_t size() const;
     obj get(_obj key) const;
     obj get_or_none(_obj key) const;
+    dict_iterator begin() const;
+    dict_iterator end() const;
 };
 
 

--- a/c/python/dict.h
+++ b/c/python/dict.h
@@ -43,6 +43,14 @@ class odict : public oobj {
 };
 
 
+class rdict : public obj {
+  public:
+    using obj::obj;
+    size_t size() const;
+    obj get(_obj key) const;
+    obj get_or_none(_obj key) const;
+};
+
 
 /**
  * Helper class for iterating over a `py::odict`.

--- a/c/python/list.cc
+++ b/c/python/list.cc
@@ -111,6 +111,11 @@ void olist::set(int i, oobj&& value) {
   set(static_cast<int64_t>(i), std::move(value));
 }
 
+void olist::append(const _obj& value) {
+  int ret = PyList_Append(v, value.to_borrowed_ref());
+  if (ret == -1) throw PyError();
+}
+
 
 
 //------------------------------------------------------------------------------

--- a/c/python/list.h
+++ b/c/python/list.h
@@ -55,6 +55,8 @@ class olist : public oobj {
     void set(int64_t i, oobj&& value);
     void set(int i,     oobj&& value);
 
+    void append(const _obj& value);
+
   private:
     // Wrap an existing PyObject* into an `olist`. This constructor is private,
     // use `py::org(src).to_pylist()` instead.

--- a/c/python/obj.cc
+++ b/c/python/obj.cc
@@ -46,6 +46,11 @@ obj& obj::operator=(const obj& other) {
   return *this;
 }
 
+obj& obj::operator=(const _obj& other) {
+  v = other.v;
+  return *this;
+}
+
 
 oobj::oobj() {
   v = nullptr;
@@ -559,7 +564,7 @@ PyObject* oobj::release() && {
 oobj None()  { return oobj(Py_None); }
 oobj True()  { return oobj(Py_True); }
 oobj False() { return oobj(Py_False); }
-
+obj rnone() { return obj(Py_None); }
 
 
 //------------------------------------------------------------------------------

--- a/c/python/obj.h
+++ b/c/python/obj.h
@@ -233,6 +233,7 @@ class obj : public _obj {
     obj(const obj&);
     obj(const oobj&);
     obj& operator=(const obj&);
+    obj& operator=(const _obj&);
 };
 
 
@@ -264,6 +265,7 @@ class oobj : public _obj {
 oobj None();
 oobj True();
 oobj False();
+obj rnone();
 
 
 }  // namespace py

--- a/c/python/oset.cc
+++ b/c/python/oset.cc
@@ -1,0 +1,78 @@
+//------------------------------------------------------------------------------
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// © H2O.ai 2018
+//------------------------------------------------------------------------------
+#include "python/oset.h"
+
+namespace py {
+
+
+//------------------------------------------------------------------------------
+// Constructors
+//------------------------------------------------------------------------------
+
+oset::oset() {
+  v = PySet_New(nullptr);
+  if (!v) throw PyError();
+}
+
+oset::oset(const oset& other) {
+  v = other.v;
+  Py_XINCREF(v);
+}
+
+oset::oset(oset&& other) {
+  v = other.v;
+  other.v = nullptr;
+}
+
+oset& oset::operator=(const oset& other) {
+  Py_XINCREF(other.v);
+  Py_XDECREF(v);
+  v = other.v;
+  return *this;
+}
+
+oset& oset::operator=(oset&& other) {
+  Py_XDECREF(v);
+  v = other.v;
+  other.v = nullptr;
+  return *this;
+}
+
+oset::oset(PyObject* src) : oobj(src) {}
+
+
+
+//------------------------------------------------------------------------------
+// Accessors
+//------------------------------------------------------------------------------
+
+size_t oset::size() const {
+  return static_cast<size_t>(PySet_Size(v));
+}
+
+/**
+ * Test whether the `key` is present in the set. If the lookup raises an error
+ * (for example if key is not hashable), discard it and return `false`.
+ */
+bool oset::has(const _obj& key) const {
+  int ret = PySet_Contains(v, key.to_borrowed_ref());
+  if (ret == -1) PyErr_Clear();
+  return (ret == 1);
+}
+
+/**
+ * Insert the provided `key` into the set.
+ */
+void oset::add(const _obj& key) {
+  int ret = PySet_Add(v, key.to_borrowed_ref());
+  if (ret == -1) throw PyError();
+}
+
+
+
+}  // namespace py

--- a/c/python/oset.h
+++ b/c/python/oset.h
@@ -1,0 +1,41 @@
+//------------------------------------------------------------------------------
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// © H2O.ai 2018
+//------------------------------------------------------------------------------
+#ifndef dt_PYTHON_OSET_h
+#define dt_PYTHON_OSET_h
+#include <Python.h>
+#include "python/obj.h"
+
+namespace py {
+
+
+/**
+ * Python set() object.
+ */
+class oset : public oobj {
+  public:
+    oset();
+    oset(const oset&);
+    oset(oset&&);
+    oset& operator=(const oset&);
+    oset& operator=(oset&&);
+
+    size_t size() const;
+    bool has(const _obj& key) const;
+    void add(const _obj& key);
+
+  private:
+    // Wrap an existing PyObject* into an `oset`.
+    oset(PyObject* src);
+
+    friend class _obj;
+};
+
+
+}  // namespace py
+
+#endif

--- a/tests/test_dt_create.py
+++ b/tests/test_dt_create.py
@@ -313,6 +313,32 @@ def test_create_from_list_of_namedtuples_names_override():
     assert d0.topython() == [[5, 3], [6, 2], [7, 1]]
 
 
+@pytest.mark.usefixtures("py36")
+def test_create_from_list_of_dicts1():
+    d0 = dt.Frame([{"a": 5, "b": 7, "c": "Hey"},
+                   {"a": 99},
+                   {"a": -4, "c": "Yay", "d": 2.17},
+                   {"d": 1e10}, {}])
+    d0.internal.check()
+    assert d0.shape == (5, 4)
+    assert d0.names == ("a", "b", "c", "d")
+    assert d0.ltypes == (ltype.int, ltype.int, ltype.str, ltype.real)
+    assert d0.topython() == [[5, 99, -4, None, None],
+                             [7, None, None, None, None],
+                             ["Hey", None, "Yay", None, None],
+                             [None, None, 2.17, 1e10, None]]
+
+
+@pytest.mark.usefixtures("py36")
+def test_create_from_list_of_dicts2():
+    d0 = dt.Frame([{"foo": 11, "bar": 34}, {"argh": 17, "foo": 4}, {"_": 0}])
+    d0.internal.check()
+    assert d0.shape == (3, 4)
+    assert d0.names == ("foo", "bar", "argh", "_")
+    assert d0.topython() == [[11, 4, None], [34, None, None],
+                             [None, 17, None], [None, None, 0]]
+
+
 def test_create_from_list_of_dicts_with_names1():
     d0 = dt.Frame([{"a": 5, "b": 7, "c": "Hey"},
                    {"a": 99},
@@ -335,11 +361,32 @@ def test_create_from_list_of_dicts_with_names2():
     assert d0.shape == (0, 0)
 
 
-def test_create_from_list_of_dicts_with_names_bad():
+def test_create_from_list_of_dicts_bad1():
     with pytest.raises(TypeError) as e:
         dt.Frame([{"a": 5}, {"b": 6}, None, {"c": 11}], names=[])
     assert ("The source is not a list of dicts: element 2 is a "
             "<class 'NoneType'>" == str(e.value))
+    with pytest.raises(TypeError) as e:
+        dt.Frame([{"a": 5}, {"b": 6}, None, {"c": 11}])
+    assert ("The source is not a list of dicts: element 2 is a "
+            "<class 'NoneType'>" == str(e.value))
+
+
+def test_create_from_list_of_dicts_bad2():
+    with pytest.raises(TypeError) as e:
+        dt.Frame([{"a": 11}, {1: 4}])
+    assert ("Invalid data in Frame() constructor: row 1 dictionary contains "
+            "a key of type <class 'int'>, only string keys are allowed" ==
+            str(e.value))
+
+
+def test_create_from_list_of_dicts_bad3():
+    with pytest.raises(TypeError) as e:
+        dt.Frame([{"a": 11}, {"b": 4}], stypes=[int, int])
+    assert ("If the Frame() source is a list of dicts, then either the `names` "
+            "list has to be provided explicitly, or `stypes` parameter has "
+            "to be a dictionary (or missing)" == str(e.value))
+
 
 
 

--- a/tests/test_dt_create.py
+++ b/tests/test_dt_create.py
@@ -313,6 +313,34 @@ def test_create_from_list_of_namedtuples_names_override():
     assert d0.topython() == [[5, 3], [6, 2], [7, 1]]
 
 
+def test_create_from_list_of_dicts_with_names1():
+    d0 = dt.Frame([{"a": 5, "b": 7, "c": "Hey"},
+                   {"a": 99},
+                   {"a": -4, "c": "Yay", "d": 2.17},
+                   {"d": 1e10}, {}],
+                  names=["c", "a", "d", "e"])
+    d0.internal.check()
+    assert d0.shape == (5, 4)
+    assert d0.names == ("c", "a", "d", "e")
+    assert d0.ltypes == (ltype.str, ltype.int, ltype.real, ltype.bool)
+    assert d0.topython() == [["Hey", None, "Yay", None, None],
+                             [5, 99, -4, None, None],
+                             [None, None, 2.17, 1e10, None],
+                             [None, None, None, None, None]]
+
+
+def test_create_from_list_of_dicts_with_names2():
+    d0 = dt.Frame([{"a": 5}, {"b": 6}, {"c": 11}, {}], names=[])
+    d0.internal.check()
+    assert d0.shape == (0, 0)
+
+
+def test_create_from_list_of_dicts_with_names_bad():
+    with pytest.raises(TypeError) as e:
+        dt.Frame([{"a": 5}, {"b": 6}, None, {"c": 11}], names=[])
+    assert ("The source is not a list of dicts: element 2 is a "
+            "<class 'NoneType'>" == str(e.value))
+
 
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
Add 2 new modes for Frame construction:
1) from a list of dictionaries when the column names are provided explicitly;
2) from a list of dictionaries when the column names are deduced.

Also small improvements to `py::` library:
* Added `pylist::append()` method
* Added `py::oset` class
* Added `py::rdict` class

Closes #1266