### PR TITLE
(py)names properties moved to core DataTable class

### DIFF
--- a/c/csv/py_csv.cc
+++ b/c/csv/py_csv.cc
@@ -88,9 +88,7 @@ PyObject* gread(PyObject*, PyObject* args)
 
   GenericReader rdr(pyreader);
   std::unique_ptr<DataTable> dtptr = rdr.read();
-  py::Frame* res = py::Frame::from_datatable(dtptr.release());
-  res->set_names(pyreader.get_attr("_colnames"));
-  return res;
+  return py::Frame::from_datatable(dtptr.release());
 }
 
 

--- a/c/csv/reader.cc
+++ b/c/csv/reader.cc
@@ -710,7 +710,7 @@ std::unique_ptr<DataTable> GenericReader::read_empty_input() {
     trace("Input is empty, returning a (0 x 0) DataTable");
     Column** cols = static_cast<Column**>(malloc(sizeof(Column*)));
     cols[0] = nullptr;
-    return std::unique_ptr<DataTable>(new DataTable(cols));
+    return std::unique_ptr<DataTable>(new DataTable(cols, nullptr));
   }
   return nullptr;
 }
@@ -805,5 +805,6 @@ DataTablePtr GenericReader::makeDatatable() {
                                        std::move(strbuf));
     j++;
   }
-  return DataTablePtr(new DataTable(ccols));
+  py::olist names = freader.get_attr("_colnames").to_pylist();
+  return DataTablePtr(new DataTable(ccols, names));
 }

--- a/c/datatable.cc
+++ b/c/datatable.cc
@@ -16,6 +16,34 @@
 static int _compare_ints(const void *a, const void *b);
 
 
+//------------------------------------------------------------------------------
+// Constructors
+//------------------------------------------------------------------------------
+
+DataTable::DataTable(Column** cols, std::nullptr_t)
+  : DataTable(cols)
+{
+  set_names_to_default();
+}
+
+DataTable::DataTable(Column** cols, const py::olist& namessrc)
+  : DataTable(cols)
+{
+  set_names(namessrc);
+}
+
+DataTable::DataTable(Column** cols, const std::vector<std::string>& namessrc)
+  : DataTable(cols)
+{
+  set_names(namessrc);
+}
+
+DataTable::DataTable(Column** cols, const DataTable* namessrc)
+  : DataTable(cols)
+{
+  copy_names_from(namessrc);
+}
+
 
 DataTable::DataTable(Column** cols)
   : nrows(0),
@@ -62,6 +90,11 @@ DataTable::~DataTable()
   delete columns;
 }
 
+
+
+//------------------------------------------------------------------------------
+// Public API
+//------------------------------------------------------------------------------
 
 /**
  * Make a shallow copy of the current DataTable.

--- a/c/datatable.cc
+++ b/c/datatable.cc
@@ -305,6 +305,7 @@ void DataTable::verify_integrity() const {
   }
 
   _integrity_check_names();
+  _integrity_check_pynames();
 
   // Check the number of columns; the number of allocated columns should be
   // equal to `ncols + 1` (with extra column being NULL). Sometimes the

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -68,7 +68,10 @@ class DataTable {
     mutable py::odict  py_inames;  // memoized dict of {column name: index}
 
   public:
-    DataTable(Column**);
+    DataTable(Column** cols, std::nullptr_t);
+    DataTable(Column** cols, const py::olist& namessrc);
+    DataTable(Column** cols, const std::vector<std::string>& namessrc);
+    DataTable(Column** cols, const DataTable* namessrc);
     ~DataTable();
     DataTable* delete_columns(int*, int64_t);
     void resize_rows(int64_t n);
@@ -97,7 +100,7 @@ class DataTable {
     int64_t colindex(const py::_obj& pyname) const;
     void copy_names_from(const DataTable* other);
     void set_names_to_default();
-    void set_names(py::olist names_list);
+    void set_names(const py::olist& names_list);
     void set_names(const std::vector<std::string>& names_list);
     void replace_names(py::odict replacements);
 
@@ -126,6 +129,7 @@ class DataTable {
     static DataTable* open_jay(const std::string& path);
 
   private:
+    DataTable(Column**);
     void _init_pynames() const;
     void _set_names_impl(NameProvider*);
     void _integrity_check_names() const;
@@ -133,7 +137,9 @@ class DataTable {
 
     DataTable* _statdt(colmakerfn f) const;
 
-    friend void dttest::cover_names_integrity_checks();
+    #ifdef DTTEST
+      friend void dttest::cover_names_integrity_checks();
+    #endif
 };
 
 

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -14,6 +14,7 @@
 #include "rowindex.h"
 #include "types.h"
 #include "column.h"
+#include "ztest.h"
 
 // avoid circular dependency between .h files
 class Column;
@@ -131,6 +132,8 @@ class DataTable {
     void _integrity_check_pynames() const;
 
     DataTable* _statdt(colmakerfn f) const;
+
+    friend void dttest::cover_names_integrity_checks();
 };
 
 

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -128,6 +128,7 @@ class DataTable {
     void _init_pynames() const;
     void _set_names_impl(NameProvider*);
     void _integrity_check_names() const;
+    void _integrity_check_pynames() const;
 
     DataTable* _statdt(colmakerfn f) const;
 };

--- a/c/extras/aggregator.cc
+++ b/c/extras/aggregator.cc
@@ -67,8 +67,7 @@ DataTablePtr Aggregator::aggregate(DataTable* dt) {
   Column** cols_members = dt::amalloc<Column*>(static_cast<int64_t>(2));
   cols_members[0] = Column::new_data_column(SType::INT32, dt->nrows);
   cols_members[1] = nullptr;
-  dt_members = DataTablePtr(new DataTable(cols_members));
-  dt_members->set_names({"?1"});
+  dt_members = DataTablePtr(new DataTable(cols_members, nullptr));
 
   if (dt->nrows > min_rows) {
     DataTablePtr dt_double = nullptr;
@@ -86,7 +85,7 @@ DataTablePtr Aggregator::aggregate(DataTable* dt) {
     }
 
     cols_double[ncols] = nullptr;
-    dt_double = DataTablePtr(new DataTable(cols_double));
+    dt_double = DataTablePtr(new DataTable(cols_double, nullptr));
 
     switch (dt_double->ncols) {
       case 1:  group_1d(dt_double, dt_members); break;
@@ -127,8 +126,7 @@ void Aggregator::aggregate_exemplars(DataTable* dt_exemplars,
   cols_counts[0] = Column::new_data_column(SType::INT32,
                                            static_cast<int64_t>(gb_members.ngroups()));
   cols_counts[1] = nullptr;
-  dt_counts = new DataTable(cols_counts);
-  dt_counts->set_names({ "counts" });
+  dt_counts = new DataTable(cols_counts, {"counts"});
   auto d_counts = static_cast<int32_t*>(dt_counts->columns[0]->data_w());
   std::memset(d_counts, 0, static_cast<size_t>(gb_members.ngroups()) * sizeof(int32_t));
 

--- a/c/extras/aggregator.cc
+++ b/c/extras/aggregator.cc
@@ -34,9 +34,8 @@ PyObject* aggregate(PyObject*, PyObject* args) {
   Aggregator agg(min_rows, n_bins, nx_bins, ny_bins, nd_bins, max_dimensions,
                  seed, progress_fn);
   DataTable* dt_out = agg.aggregate(dt_in).release();
+  dt_out->set_names(py::obj(arg_names).to_pylist());
   py::Frame* frame = py::Frame::from_datatable(dt_out);
-  frame->set_names(py::obj(arg_names));
-
   return frame;
 }
 
@@ -69,6 +68,7 @@ DataTablePtr Aggregator::aggregate(DataTable* dt) {
   cols_members[0] = Column::new_data_column(SType::INT32, dt->nrows);
   cols_members[1] = nullptr;
   dt_members = DataTablePtr(new DataTable(cols_members));
+  dt_members->set_names({"?1"});
 
   if (dt->nrows > min_rows) {
     DataTablePtr dt_double = nullptr;
@@ -128,6 +128,7 @@ void Aggregator::aggregate_exemplars(DataTable* dt_exemplars,
                                            static_cast<int64_t>(gb_members.ngroups()));
   cols_counts[1] = nullptr;
   dt_counts = new DataTable(cols_counts);
+  dt_counts->set_names({ "counts" });
   auto d_counts = static_cast<int32_t*>(dt_counts->columns[0]->data_w());
   std::memset(d_counts, 0, static_cast<size_t>(gb_members.ngroups()) * sizeof(int32_t));
 

--- a/c/frame/names.cc
+++ b/c/frame/names.cc
@@ -260,7 +260,8 @@ void DataTable::set_names_to_default() {
 }
 
 
-void DataTable::set_names(py::olist names_list) {
+void DataTable::set_names(const py::olist& names_list) {
+  if (!names_list) return set_names_to_default();
   pylistNP np(names_list);
   _set_names_impl(&np);
 }

--- a/c/frame/py_frame.cc
+++ b/c/frame/py_frame.cc
@@ -149,8 +149,6 @@ void Frame::m__dealloc__() {
   Py_XDECREF(core_dt);
   Py_XDECREF(stypes);
   Py_XDECREF(ltypes);
-  Py_XDECREF(names);
-  Py_XDECREF(inames);
   dt = nullptr;  // `dt` is already managed by `core_dt`
 }
 
@@ -162,19 +160,9 @@ void Frame::m__release_buffer__(Py_buffer*) const {
 
 
 oobj Frame::copy(NoArgs&) {
-  Column** cols = new Column*[dt->ncols + 1];
-  for (int64_t i = 0; i < dt->ncols; ++i) {
-    cols[i] = dt->columns[i]->shallowcopy();
-  }
-  cols[dt->ncols] = nullptr;
-
-  DataTable* newdt = new DataTable(cols);
-  newdt->names = dt->names;
-  Frame* newframe = Frame::from_datatable(newdt);
+  Frame* newframe = Frame::from_datatable(dt->copy());
   newframe->stypes = stypes;  Py_XINCREF(stypes);
   newframe->ltypes = ltypes;  Py_XINCREF(ltypes);
-  newframe->names  = names;   Py_XINCREF(names);
-  newframe->inames = inames;  Py_XINCREF(inames);
   return py::oobj::from_new_reference(newframe);
 }
 

--- a/c/frame/py_frame.h
+++ b/c/frame/py_frame.h
@@ -95,10 +95,4 @@ extern PyObject* fread_fn;
 
 }  // namespace py
 
-
-#ifdef DTTEST
-void cover_py_FrameInitializationManager_em();
-void cover_py_FrameNameProviders();
-#endif
-
 #endif

--- a/c/frame/py_frame.h
+++ b/c/frame/py_frame.h
@@ -30,8 +30,6 @@ class Frame : public PyObject {
     DataTable* dt;
     mutable PyObject* stypes;  // memoized tuple of stypes
     mutable PyObject* ltypes;  // memoized tuple of ltypes
-    mutable PyObject* names;   // memoized tuple of column names
-    mutable PyObject* inames;  // memoized dict of {column name: index}
 
     pydatatable::obj* core_dt;  // TODO: remove
 
@@ -68,7 +66,6 @@ class Frame : public PyObject {
     oobj get_internal() const;
     void set_nrows(obj);
     void set_names(obj);
-    void set_names(const std::vector<std::string>&);
     void set_internal(obj);
 
     oobj colindex(PKArgs&);

--- a/c/frame/py_frame.h
+++ b/c/frame/py_frame.h
@@ -93,11 +93,12 @@ extern PyObject* Frame_Type;
 extern PyObject* fread_fn;
 
 
+}  // namespace py
+
+
 #ifdef DTTEST
 void cover_py_FrameInitializationManager_em();
 void cover_py_FrameNameProviders();
 #endif
-
-}  // namespace py
 
 #endif

--- a/c/frame/py_frame_init.cc
+++ b/c/frame/py_frame_init.cc
@@ -523,7 +523,7 @@ class FrameInitializationManager {
 
 
     #ifdef DTTEST
-      friend void cover_py_FrameInitializationManager_em();
+      friend void ::cover_py_FrameInitializationManager_em();
     #endif
 };
 
@@ -583,12 +583,14 @@ void Frame::m__init__(PKArgs& args) {
 }
 
 
+}  // namespace py
+
 
 // This test ensures coverage for `_ZN2py26FrameInitializationManager2emD0Ev`
 // symbol. See https://stackoverflow.com/questions/46447674 for details.
 #ifdef DTTEST
   void cover_py_FrameInitializationManager_em() {
-    auto t = new FrameInitializationManager::em;
+    auto t = new py::FrameInitializationManager::em;
     delete t;
   }
 #endif
@@ -597,5 +599,3 @@ void Frame::m__init__(PKArgs& args) {
 // to auto-generated exception-handling code, and they are not covered because
 // those exceptions are almost impossible to trigger.
 // See https://stackoverflow.com/questions/46367192
-
-}  // namespace py

--- a/c/frame/py_frame_init.cc
+++ b/c/frame/py_frame_init.cc
@@ -388,7 +388,7 @@ class FrameInitializationManager {
         _make_column(kv.second, stype);
       }
       frame->dt = make_datatable();
-      frame->set_names(newnames);
+      frame->dt->set_names(newnames);
     }
 
 
@@ -409,14 +409,14 @@ class FrameInitializationManager {
         _make_column(kv.second, stype);
       }
       frame->dt = make_datatable();
-      frame->set_names(newnames);
+      frame->dt->set_names(newnames);
     }
 
 
     void init_mystery_frame() {
       cols.push_back(Column::from_range(42, 43, 1, SType::VOID));
       frame->dt = make_datatable();
-      frame->set_names(strvec { "?" });
+      frame->dt->set_names(strvec { "?" });
     }
 
 
@@ -434,11 +434,9 @@ class FrameInitializationManager {
       }
       frame->dt = make_datatable();
       if (names_arg) {
-        frame->set_names(names_arg.to_pyobj());
+        frame->dt->set_names(names_arg.to_pylist());
       } else {
-        // Copy names without checking for validity, since we know they were
-        // already verified in `srcdt`.
-        frame->dt->names = srcdt->names;
+        frame->dt->copy_names_from(srcdt);
       }
     }
 
@@ -451,8 +449,6 @@ class FrameInitializationManager {
       if (res.is_frame()) {
         Frame* resframe = static_cast<Frame*>(res.to_borrowed_ref());
         std::swap(frame->dt,      resframe->dt);
-        std::swap(frame->names,   resframe->names);
-        std::swap(frame->inames,  resframe->inames);
         std::swap(frame->stypes,  resframe->stypes);
         std::swap(frame->ltypes,  resframe->ltypes);
         std::swap(frame->core_dt, resframe->core_dt);
@@ -554,8 +550,6 @@ void Frame::m__init__(PKArgs& args) {
   core_dt = nullptr;
   stypes = nullptr;
   ltypes = nullptr;
-  names = nullptr;
-  inames = nullptr;
   if (Frame::internal_construction) return;
 
   FrameInitializationManager fim(args, this);

--- a/c/frame/py_frame_init.cc
+++ b/c/frame/py_frame_init.cc
@@ -16,6 +16,7 @@
 #include "python/string.h"
 #include "python/tuple.h"
 #include "utils/alloc.h"
+#include "ztest.h"
 
 namespace py {
 
@@ -523,7 +524,7 @@ class FrameInitializationManager {
 
 
     #ifdef DTTEST
-      friend void ::cover_py_FrameInitializationManager_em();
+      friend void dttest::cover_init_FrameInitializationManager_em();
     #endif
 };
 
@@ -589,10 +590,14 @@ void Frame::m__init__(PKArgs& args) {
 // This test ensures coverage for `_ZN2py26FrameInitializationManager2emD0Ev`
 // symbol. See https://stackoverflow.com/questions/46447674 for details.
 #ifdef DTTEST
-  void cover_py_FrameInitializationManager_em() {
+namespace dttest {
+
+  void cover_init_FrameInitializationManager_em() {
     auto t = new py::FrameInitializationManager::em;
     delete t;
   }
+
+}
 #endif
 
 // Two lines in the file are marked as LCOV_EXCL_LINE: these lines are related

--- a/c/frame/py_frame_init.cc
+++ b/c/frame/py_frame_init.cc
@@ -518,7 +518,7 @@ class FrameInitializationManager {
 
     void make_datatable(nullptr_t) {
       frame->dt = new DataTable(prepare_columns(), nullptr);
-    }  // L/COV_EXCL_LINE
+    }
 
     void make_datatable(const Arg& names) {
       if (names) {
@@ -526,19 +526,19 @@ class FrameInitializationManager {
       } else {
         frame->dt = new DataTable(prepare_columns(), nullptr);
       }
-    }  // L/COV_EXCL_LINE
+    }
 
     void make_datatable(const py::olist& names) {
       frame->dt = new DataTable(prepare_columns(), names);
-    }  // L/COV_EXCL_LINE
+    }
 
     void make_datatable(const std::vector<std::string>& names) {
       frame->dt = new DataTable(prepare_columns(), names);
-    }  // L/COV_EXCL_LINE
+    }
 
     void make_datatable(const DataTable* names_src) {
       frame->dt = new DataTable(prepare_columns(), names_src);
-    }  // L/COV_EXCL_LINE
+    }
 
 
     #ifdef DTTEST

--- a/c/frame/py_frame_init.cc
+++ b/c/frame/py_frame_init.cc
@@ -44,6 +44,7 @@ class FrameInitializationManager {
       Error error_not_stype(PyObject*) const override;
     };
 
+
   //----------------------------------------------------------------------------
   // External API
   //----------------------------------------------------------------------------
@@ -122,6 +123,237 @@ class FrameInitializationManager {
         return init_mystery_frame();
       }
     }
+
+
+
+  //----------------------------------------------------------------------------
+  // Frame creation methods
+  //----------------------------------------------------------------------------
+  private:
+    void init_empty_frame() {
+      check_names_count(0);
+      check_stypes_count(0);
+      make_datatable(nullptr);
+    }
+
+
+    void init_from_list_of_lists() {
+      py::olist collist = src.to_pylist();
+      check_names_count(collist.size());
+      check_stypes_count(collist.size());
+      for (size_t i = 0; i < collist.size(); ++i) {
+        py::obj item = collist[i];
+        SType s = get_stype_for_column(i);
+        _make_column(item, s);
+      }
+      make_datatable(names_arg);
+    }
+
+
+    void init_from_list_of_dicts_fixed_keys() {
+      xassert(names_arg);
+      py::olist srclist = src.to_pylist();
+      py::olist nameslist = names_arg.to_pylist();
+      size_t nrows = srclist.size();
+      size_t ncols = nameslist.size();
+      check_stypes_count(ncols);
+      for (size_t i = 0; i < nrows; ++i) {
+        py::obj item = srclist[i];
+        if (!item.is_dict()) {
+          throw TypeError() << "The source is not a list of dicts: element "
+              << i << " is a " << item.typeobj();
+        }
+      }
+      init_from_list_of_dicts_with_keys(nameslist);
+    }
+
+
+    void init_from_list_of_dicts_auto_keys() {
+      xassert(!names_arg);
+      if (stypes_arg && !stypes_arg.is_dict()) {
+        throw TypeError() << "If the Frame() source is a list of dicts, then "
+            "either the `names` list has to be provided explicitly, or "
+            "`stypes` parameter has to be a dictionary (or missing)";
+      }
+      py::olist srclist = src.to_pylist();
+      py::olist nameslist(0);
+      py::oset  namesset;
+      size_t nrows = srclist.size();
+      for (size_t i = 0; i < nrows; ++i) {
+        py::obj item = srclist[i];
+        if (!item.is_dict()) {
+          throw TypeError() << "The source is not a list of dicts: element "
+              << i << " is a " << item.typeobj();
+        }
+        py::rdict row(item);
+        for (auto kv : row) {
+          py::obj& name = kv.first;
+          if (!namesset.has(name)) {
+            if (!name.is_string()) {
+              throw TypeError() << "Invalid data in Frame() constructor: row "
+                  << i << " dictionary contains a key of type "
+                  << name.typeobj() << ", only string keys are allowed";
+            }
+            nameslist.append(name);
+            namesset.add(name);
+          }
+        }
+      }
+      init_from_list_of_dicts_with_keys(nameslist);
+    }
+
+
+    void init_from_list_of_dicts_with_keys(const py::olist& nameslist) {
+      py::olist srclist = src.to_pylist();
+      size_t ncols = nameslist.size();
+      for (size_t j = 0; j < ncols; ++j) {
+        py::obj name = nameslist[j];
+        SType s = get_stype_for_column(j, &name);
+        Column* col = Column::from_pylist_of_dicts(srclist, name, int(s));
+        cols.push_back(col);
+      }
+      make_datatable(nameslist);
+    }
+
+
+    void init_from_list_of_tuples() {
+      py::olist srclist = src.to_pylist();
+      py::rtuple item0 = py::rtuple(srclist[0]);
+      size_t nrows = srclist.size();
+      size_t ncols = item0.size();
+      check_names_count(ncols);
+      check_stypes_count(ncols);
+      // Check that all entries are proper tuples
+      for (size_t i = 0; i < nrows; ++i) {
+        py::obj item = srclist[i];
+        if (!item.is_tuple()) {
+          throw TypeError() << "The source is not a list of tuples: element "
+              << i << " is a " << item.typeobj();
+        }
+        size_t this_ncols = rtuple(item).size();
+        if (this_ncols != ncols) {
+          throw ValueError() << "Misshaped rows in Frame() constructor: "
+              "row " << i << " contains " << this_ncols << " element"
+              << (this_ncols == 1? "" : "s") << ", while "
+              << (i == 1? "the previous row" : "previous rows")
+              << " had " << ncols << " element" << (ncols == 1? "" : "s");
+        }
+      }
+      // Create the columns
+      for (size_t j = 0; j < ncols; ++j) {
+        SType s = get_stype_for_column(j);
+        cols.push_back(Column::from_pylist_of_tuples(srclist, j, int(s)));
+      }
+      if (names_arg || !item0.has_attr("_fields")) {
+        make_datatable(names_arg);
+      } else {
+        make_datatable(item0.get_attr("_fields").to_pylist());
+      }
+    }
+
+
+    void init_from_list_of_primitives() {
+      check_names_count(1);
+      check_stypes_count(1);
+      SType s = get_stype_for_column(0);
+      _make_column(src.to_pyobj(), s);
+      make_datatable(names_arg);
+    }
+
+
+    void init_from_dict() {
+      if (defined_names) {
+        throw TypeError() << "Parameter `names` cannot be used when "
+            "constructing a Frame from a dictionary";
+      }
+      py::odict coldict = src.to_pydict();
+      size_t ncols = coldict.size();
+      check_stypes_count(ncols);
+      strvec newnames;
+      newnames.reserve(ncols);
+      for (auto kv : coldict) {
+        size_t i = newnames.size();
+        py::obj name = kv.first;
+        SType stype = get_stype_for_column(i, &name);
+        newnames.push_back(name.to_string());
+        _make_column(kv.second, stype);
+      }
+      make_datatable(newnames);
+    }
+
+
+    void init_from_varkwds() {
+      if (defined_names) {
+        throw TypeError() << "Parameter `names` cannot be used when "
+            "constructing a Frame from varkwd arguments";
+      }
+      size_t ncols = all_args.num_varkwd_args();
+      check_stypes_count(ncols);
+      strvec newnames;
+      newnames.reserve(ncols);
+      for (auto kv: all_args.varkwds()) {
+        size_t i = newnames.size();
+        const py::ostring oname(kv.first);
+        SType stype = get_stype_for_column(i, &oname);
+        newnames.push_back(std::move(kv.first));
+        _make_column(kv.second, stype);
+      }
+      make_datatable(newnames);
+    }
+
+
+    void init_mystery_frame() {
+      cols.push_back(Column::from_range(42, 43, 1, SType::VOID));
+      make_datatable(strvec { "?" });
+    }
+
+
+    void init_from_frame() {
+      DataTable* srcdt = src.to_frame();
+      size_t ncols = static_cast<size_t>(srcdt->ncols);
+      check_names_count(ncols);
+      if (stypes_arg || stype_arg) {
+        // TODO: allow this use case
+        throw TypeError() << "Parameter `stypes` is not allowed when making "
+            "a copy of a Frame";
+      }
+      for (size_t i = 0; i < ncols; ++i) {
+        cols.push_back(srcdt->columns[i]->shallowcopy());
+      }
+      if (names_arg) {
+        make_datatable(names_arg.to_pylist());
+      } else {
+        make_datatable(srcdt);
+      }
+    }
+
+
+    void init_from_string() {
+      py::otuple call_args(1);
+      call_args.set(0, src.to_pyobj());
+
+      py::oobj res = py::obj(py::fread_fn).call(call_args);
+      if (res.is_frame()) {
+        Frame* resframe = static_cast<Frame*>(res.to_borrowed_ref());
+        std::swap(frame->dt,      resframe->dt);
+        std::swap(frame->stypes,  resframe->stypes);
+        std::swap(frame->ltypes,  resframe->ltypes);
+        std::swap(frame->core_dt, resframe->core_dt);
+        frame->core_dt->_frame = frame;
+      } else {
+        xassert(res.is_dict());
+        auto err = ValueError();
+        err << "Frame cannot be initialized from multiple source files: ";
+        size_t i = 0;
+        for (auto kv : res.to_pydict()) {
+          if (i == 1) err << ", ";
+          if (i == 2) { err << ", ..."; break; }
+          err << '\'' << kv.first << '\'';
+        }
+        throw err;
+      }
+    }
+
 
 
   //----------------------------------------------------------------------------
@@ -218,257 +450,6 @@ class FrameInitializationManager {
     }
 
 
-    DataTable* make_datatable() {
-      size_t ncols = cols.size();
-      size_t allocsize = sizeof(Column*) * (ncols + 1);
-      Column** newcols = dt::malloc<Column*>(allocsize);
-      if (ncols) {
-        std::memcpy(newcols, cols.data(), sizeof(Column*) * ncols);
-      }
-      newcols[ncols] = nullptr;
-      cols.clear();
-      return new DataTable(newcols);
-    }  // LCOV_EXCL_LINE
-
-
-
-  //----------------------------------------------------------------------------
-  // Frame creation methods
-  //----------------------------------------------------------------------------
-  private:
-    void init_empty_frame() {
-      check_names_count(0);
-      check_stypes_count(0);
-      frame->dt = make_datatable();
-    }
-
-
-    void init_from_list_of_lists() {
-      py::olist collist = src.to_pylist();
-      check_names_count(collist.size());
-      check_stypes_count(collist.size());
-      for (size_t i = 0; i < collist.size(); ++i) {
-        py::obj item = collist[i];
-        SType s = get_stype_for_column(i);
-        _make_column(item, s);
-      }
-      frame->dt = make_datatable();
-      frame->set_names(names_arg.to_pyobj());
-    }
-
-
-    void init_from_list_of_dicts_fixed_keys() {
-      xassert(names_arg);
-      py::olist srclist = src.to_pylist();
-      py::olist nameslist = names_arg.to_pylist();
-      size_t nrows = srclist.size();
-      size_t ncols = nameslist.size();
-      check_stypes_count(ncols);
-      for (size_t i = 0; i < nrows; ++i) {
-        py::obj item = srclist[i];
-        if (!item.is_dict()) {
-          throw TypeError() << "The source is not a list of dicts: element "
-              << i << " is a " << item.typeobj();
-        }
-      }
-      init_from_list_of_dicts_with_keys(nameslist);
-    }
-
-
-    void init_from_list_of_dicts_auto_keys() {
-      xassert(!names_arg);
-      if (stypes_arg && !stypes_arg.is_dict()) {
-        throw TypeError() << "If the Frame() source is a list of dicts, then "
-            "either the `names` list has to be provided explicitly, or "
-            "`stypes` parameter has to be a dictionary (or missing)";
-      }
-      py::olist srclist = src.to_pylist();
-      py::olist nameslist(0);
-      py::oset  namesset;
-      size_t nrows = srclist.size();
-      for (size_t i = 0; i < nrows; ++i) {
-        py::obj item = srclist[i];
-        if (!item.is_dict()) {
-          throw TypeError() << "The source is not a list of dicts: element "
-              << i << " is a " << item.typeobj();
-        }
-        py::rdict row(item);
-        for (auto kv : row) {
-          py::obj& name = kv.first;
-          if (!namesset.has(name)) {
-            if (!name.is_string()) {
-              throw TypeError() << "Invalid data in Frame() constructor: row "
-                  << i << " dictionary contains a key of type "
-                  << name.typeobj() << ", only string keys are allowed";
-            }
-            nameslist.append(name);
-            namesset.add(name);
-          }
-        }
-      }
-      init_from_list_of_dicts_with_keys(nameslist);
-    }
-
-
-    void init_from_list_of_dicts_with_keys(py::olist& nameslist) {
-      py::olist srclist = src.to_pylist();
-      size_t ncols = nameslist.size();
-      for (size_t j = 0; j < ncols; ++j) {
-        py::obj name = nameslist[j];
-        SType s = get_stype_for_column(j, &name);
-        Column* col = Column::from_pylist_of_dicts(srclist, name, int(s));
-        cols.push_back(col);
-      }
-      frame->dt = make_datatable();
-      frame->set_names(nameslist);
-    }
-
-
-    void init_from_list_of_tuples() {
-      py::olist srclist = src.to_pylist();
-      py::rtuple item0 = py::rtuple(srclist[0]);
-      size_t nrows = srclist.size();
-      size_t ncols = item0.size();
-      check_names_count(ncols);
-      check_stypes_count(ncols);
-      // Check that all entries are proper tuples
-      for (size_t i = 0; i < nrows; ++i) {
-        py::obj item = srclist[i];
-        if (!item.is_tuple()) {
-          throw TypeError() << "The source is not a list of tuples: element "
-              << i << " is a " << item.typeobj();
-        }
-        size_t this_ncols = rtuple(item).size();
-        if (this_ncols != ncols) {
-          throw ValueError() << "Misshaped rows in Frame() constructor: "
-              "row " << i << " contains " << this_ncols << " element"
-              << (this_ncols == 1? "" : "s") << ", while "
-              << (i == 1? "the previous row" : "previous rows")
-              << " had " << ncols << " element" << (ncols == 1? "" : "s");
-        }
-      }
-      // Create the columns
-      for (size_t j = 0; j < ncols; ++j) {
-        SType s = get_stype_for_column(j);
-        cols.push_back(Column::from_pylist_of_tuples(srclist, j, int(s)));
-      }
-      frame->dt = make_datatable();
-      if (names_arg || !item0.has_attr("_fields")) {
-        frame->set_names(names_arg.to_pyobj());
-      } else {
-        frame->set_names(item0.get_attr("_fields"));
-      }
-    }
-
-
-    void init_from_list_of_primitives() {
-      check_names_count(1);
-      check_stypes_count(1);
-      SType s = get_stype_for_column(0);
-      _make_column(src.to_pyobj(), s);
-      frame->dt = make_datatable();
-      frame->set_names(names_arg.to_pyobj());
-    }
-
-
-    void init_from_dict() {
-      if (defined_names) {
-        throw TypeError() << "Parameter `names` cannot be used when "
-            "constructing a Frame from a dictionary";
-      }
-      py::odict coldict = src.to_pydict();
-      size_t ncols = coldict.size();
-      check_stypes_count(ncols);
-      strvec newnames;
-      newnames.reserve(ncols);
-      for (auto kv : coldict) {
-        size_t i = newnames.size();
-        py::obj name = kv.first;
-        SType stype = get_stype_for_column(i, &name);
-        newnames.push_back(name.to_string());
-        _make_column(kv.second, stype);
-      }
-      frame->dt = make_datatable();
-      frame->dt->set_names(newnames);
-    }
-
-
-    void init_from_varkwds() {
-      if (defined_names) {
-        throw TypeError() << "Parameter `names` cannot be used when "
-            "constructing a Frame from varkwd arguments";
-      }
-      size_t ncols = all_args.num_varkwd_args();
-      check_stypes_count(ncols);
-      strvec newnames;
-      newnames.reserve(ncols);
-      for (auto kv: all_args.varkwds()) {
-        size_t i = newnames.size();
-        const py::ostring oname(kv.first);
-        SType stype = get_stype_for_column(i, &oname);
-        newnames.push_back(std::move(kv.first));
-        _make_column(kv.second, stype);
-      }
-      frame->dt = make_datatable();
-      frame->dt->set_names(newnames);
-    }
-
-
-    void init_mystery_frame() {
-      cols.push_back(Column::from_range(42, 43, 1, SType::VOID));
-      frame->dt = make_datatable();
-      frame->dt->set_names(strvec { "?" });
-    }
-
-
-    void init_from_frame() {
-      DataTable* srcdt = src.to_frame();
-      size_t ncols = static_cast<size_t>(srcdt->ncols);
-      check_names_count(ncols);
-      if (stypes_arg || stype_arg) {
-        // TODO: allow this use case
-        throw TypeError() << "Parameter `stypes` is not allowed when making "
-            "a copy of a Frame";
-      }
-      for (size_t i = 0; i < ncols; ++i) {
-        cols.push_back(srcdt->columns[i]->shallowcopy());
-      }
-      frame->dt = make_datatable();
-      if (names_arg) {
-        frame->dt->set_names(names_arg.to_pylist());
-      } else {
-        frame->dt->copy_names_from(srcdt);
-      }
-    }
-
-
-    void init_from_string() {
-      py::otuple call_args(1);
-      call_args.set(0, src.to_pyobj());
-
-      py::oobj res = py::obj(py::fread_fn).call(call_args);
-      if (res.is_frame()) {
-        Frame* resframe = static_cast<Frame*>(res.to_borrowed_ref());
-        std::swap(frame->dt,      resframe->dt);
-        std::swap(frame->stypes,  resframe->stypes);
-        std::swap(frame->ltypes,  resframe->ltypes);
-        std::swap(frame->core_dt, resframe->core_dt);
-        frame->core_dt->_frame = frame;
-      } else {
-        xassert(res.is_dict());
-        auto err = ValueError();
-        err << "Frame cannot be initialized from multiple source files: ";
-        size_t i = 0;
-        for (auto kv : res.to_pydict()) {
-          if (i == 1) err << ", ";
-          if (i == 2) { err << ", ..."; break; }
-          err << '\'' << kv.first << '\'';
-        }
-        throw err;
-      }
-    }
-
-
     Error _error_unknown_kwargs() {
       size_t n = all_args.num_varkwd_args();
       auto err = TypeError() << "Frame() constructor got ";
@@ -521,6 +502,43 @@ class FrameInitializationManager {
         }
       }
     }
+
+
+    Column** prepare_columns() {
+      size_t ncols = cols.size();
+      size_t allocsize = sizeof(Column*) * (ncols + 1);
+      Column** newcols = dt::malloc<Column*>(allocsize);
+      if (ncols) {
+        std::memcpy(newcols, cols.data(), sizeof(Column*) * ncols);
+      }
+      newcols[ncols] = nullptr;
+      cols.clear();
+      return newcols;
+    }
+
+    void make_datatable(nullptr_t) {
+      frame->dt = new DataTable(prepare_columns(), nullptr);
+    }  // L/COV_EXCL_LINE
+
+    void make_datatable(const Arg& names) {
+      if (names) {
+        frame->dt = new DataTable(prepare_columns(), names.to_pylist());
+      } else {
+        frame->dt = new DataTable(prepare_columns(), nullptr);
+      }
+    }  // L/COV_EXCL_LINE
+
+    void make_datatable(const py::olist& names) {
+      frame->dt = new DataTable(prepare_columns(), names);
+    }  // L/COV_EXCL_LINE
+
+    void make_datatable(const std::vector<std::string>& names) {
+      frame->dt = new DataTable(prepare_columns(), names);
+    }  // L/COV_EXCL_LINE
+
+    void make_datatable(const DataTable* names_src) {
+      frame->dt = new DataTable(prepare_columns(), names_src);
+    }  // L/COV_EXCL_LINE
 
 
     #ifdef DTTEST

--- a/c/frame/py_frame_names.cc
+++ b/c/frame/py_frame_names.cc
@@ -12,14 +12,13 @@
 #include "python/tuple.h"
 #include "utils/assert.h"
 
-namespace py {
 
 
 //------------------------------------------------------------------------------
 // "Names provider" helper classes
 //------------------------------------------------------------------------------
 
-class Frame::NameProvider {
+class NameProvider {
   public:
     virtual ~NameProvider();  // LCOV_EXCL_LINE
     virtual size_t size() const = 0;
@@ -28,19 +27,19 @@ class Frame::NameProvider {
 };
 
 
-class pylistNP : public Frame::NameProvider {
+class pylistNP : public NameProvider {
   private:
-    py::olist names;
+    const py::olist& names;
 
   public:
-    pylistNP(py::obj arg) : names(arg.to_pylist()) {}
+    pylistNP(const py::olist& arg) : names(arg) {}
     virtual size_t size() const override;
     virtual CString item_as_cstring(size_t i) override;
     virtual py::oobj item_as_pyoobj(size_t i) override;
 };
 
 
-class strvecNP : public Frame::NameProvider {
+class strvecNP : public NameProvider {
   private:
     const std::vector<std::string>& names;
 
@@ -54,7 +53,7 @@ class strvecNP : public Frame::NameProvider {
 
 //------------------------------------------------------------------------------
 
-Frame::NameProvider::~NameProvider() {}
+NameProvider::~NameProvider() {}
 
 size_t pylistNP::size() const {
   return names.size();
@@ -90,36 +89,30 @@ py::oobj strvecNP::item_as_pyoobj(size_t i) {
 
 
 //------------------------------------------------------------------------------
-// User-facing API
+// Frame API
 //------------------------------------------------------------------------------
+namespace py {
+
 
 oobj Frame::get_names() const {
-  if (names == nullptr) _init_names();
-  return oobj(names);
+  return dt->get_pynames();
 }
 
 
 void Frame::set_names(obj arg)
 {
   if (arg.is_undefined() || arg.is_none()) {
-    _fill_default_names();
+    dt->set_names_to_default();
   }
   else if (arg.is_list() || arg.is_tuple()) {
-    pylistNP np(arg);
-    _dedup_and_save_names(&np);
+    dt->set_names(arg.to_pylist());
   }
-  else if (arg.is_dict() && !dt->names.empty()) {
-    _replace_names_from_map(arg.to_pydict());
+  else if (arg.is_dict()) {
+    dt->replace_names(arg.to_pydict());
   }
   else {
     throw TypeError() << "Expected a list of strings, got " << arg.typeobj();
   }
-}
-
-
-void Frame::set_names(const std::vector<std::string>& arg) {
-  strvecNP np(arg);
-  _dedup_and_save_names(&np);
 }
 
 
@@ -128,26 +121,23 @@ oobj Frame::colindex(PKArgs& args)
   auto col = args[0];
 
   if (col.is_string()) {
-    if (!inames) _init_inames();
-    PyObject* colname = col.to_borrowed_ref();
-    // If key is not in the dict, PyDict_GetItem(dict, key) returns NULL
-    // without setting an exception.
-    PyObject* index = PyDict_GetItem(inames, colname);  // borrowed ref
-    if (index) {
-      return oobj(index);
+    int64_t index = dt->colindex(col.to_pyobj());
+    if (index == -1) {
+      throw _name_not_found_error(col.to_string());
     }
-    throw _name_not_found_error(col.to_string());
+    return py::oint(index);
   }
   if (col.is_int()) {
     int64_t colidx = col.to_int64_strict();
-    if (colidx < 0 && colidx + dt->ncols >= 0) {
-      colidx += dt->ncols;
+    int64_t ncols = dt->ncols;
+    if (colidx < 0 && colidx + ncols >= 0) {
+      colidx += ncols;
     }
-    if (colidx >= 0 && colidx < dt->ncols) {
+    if (colidx >= 0 && colidx < ncols) {
       return py::oint(colidx);
     }
     throw ValueError() << "Column index `" << colidx << "` is invalid for a "
-        "Frame with " << dt->ncols << " column" << (dt->ncols==1? "" : "s");
+        "Frame with " << ncols << " column" << (ncols==1? "" : "s");
   }
   throw TypeError() << "The argument to Frame.colindex() should be a string "
       "or an integer, not " << col.typeobj();
@@ -158,251 +148,6 @@ oobj Frame::colindex(PKArgs& args)
 //------------------------------------------------------------------------------
 // Private helper methods
 //------------------------------------------------------------------------------
-
-// Clear existing memoized names
-void Frame::_clear_names() {
-  Py_XDECREF(names);
-  Py_XDECREF(inames);
-  names = nullptr;
-  inames = nullptr;
-  dt->names.clear();
-  dt->names.reserve(static_cast<size_t>(dt->ncols));
-}
-
-
-void Frame::_init_names() const {
-  if (names) return;
-  xassert(dt->names.size() == static_cast<size_t>(dt->ncols));
-
-  py::otuple onames(dt->ncols);
-  for (size_t i = 0; i < onames.size(); ++i) {
-    onames.set(i, py::ostring(dt->names[i]));
-  }
-  names = std::move(onames).release();
-}
-
-
-void Frame::_init_inames() const {
-  if (inames) return;
-  _init_names();
-  py::olist new_names = py::obj(names).to_pylist();
-
-  py::odict new_inames;
-  for (int64_t i = 0; i < dt->ncols; ++i) {
-    new_inames.set(new_names[i], py::oint(i));
-  }
-  inames = std::move(new_inames).release();
-}
-
-
-void Frame::_fill_default_names() {
-  auto index0 = static_cast<size_t>(config::frame_names_auto_index);
-  auto prefix = config::frame_names_auto_prefix;
-  auto ncols  = static_cast<size_t>(dt->ncols);
-
-  _clear_names();
-  for (size_t i = 0; i < ncols; ++i) {
-    dt->names.push_back(prefix + std::to_string(i + index0));
-  }
-}
-
-
-/**
- * This is a main method to assign column names to a Frame. It checks that the
- * names are valid, not duplicate, and if necessary modifies them to enforce
- * such constraints.
- */
-void Frame::_dedup_and_save_names(NameProvider* nameslist) {
-  auto ncols = static_cast<size_t>(dt->ncols);
-  if (nameslist->size() != ncols) {
-    throw ValueError() << "The `names` list has length " << nameslist->size()
-        << ", while the Frame has "
-        << (ncols < nameslist->size() && ncols? "only " : "")
-        << ncols << " column" << (ncols == 1? "" : "s");
-  }
-
-  // Prepare the containers for placing the new column names there
-  _clear_names();
-  py::otuple new_names(dt->ncols);
-  py::odict  new_inames;
-  std::vector<std::string> duplicates;
-
-  // If any name is empty or None, it will be replaced with the default name
-  // in the end. The reason we don't replace immediately upon seeing an empty
-  // name is to ensure that the auto-generated names do not clash with the
-  // user-specified names somewhere later in the list.
-  bool fill_default_names = false;
-
-  for (size_t i = 0; i < ncols; ++i) {
-    // Convert to a C-style name object. Note that if `name` is python None,
-    // then the resulting `cname` will be `{nullptr, 0}`.
-    CString cname = nameslist->item_as_cstring(i);
-    char* strname = const_cast<char*>(cname.ch);
-    size_t namelen = static_cast<size_t>(cname.size);
-    if (namelen == 0) {
-      fill_default_names = true;
-      dt->names.push_back(std::string());
-      continue;
-    }
-    // Ensure there are no invalid characters in the column's name. Invalid
-    // characters are considered those with ASCII codes \x00 - \x1F. If any
-    // such characters found, we perform substitution s/[\x00-\x1F]+/./g.
-    std::string resname;
-    bool name_mangled = false;
-    for (size_t j = 0; j < namelen; ++j) {
-      if (static_cast<uint8_t>(strname[j]) < 0x20) {
-        name_mangled = true;
-        resname = std::string(strname, j) + ".";
-        bool written_dot = true;
-        for (; j < namelen; ++j) {
-          char ch = strname[j];
-          if (static_cast<uint8_t>(ch) < 0x20) {
-            if (!written_dot) {
-              resname += ".";
-              written_dot = true;
-            }
-          } else {
-            resname += ch;
-            written_dot = false;
-          }
-        }
-      }
-    }
-    if (!name_mangled) {
-      resname = std::string(strname, namelen);
-    }
-    py::oobj newname = name_mangled? oobj(ostring(resname))
-                                   : nameslist->item_as_pyoobj(i);
-    // Check for name duplicates. If the name was already seen before, we
-    // replace it with a modified name (by incrementing the name's digital
-    // suffix if it has one, or otherwise by adding such a suffix).
-    if (new_inames.has(newname)) {
-      duplicates.push_back(resname);
-      size_t j = namelen;
-      for (; j > 0; --j) {
-        char ch = strname[j - 1];
-        if (ch < '0' || ch > '9') break;
-      }
-      std::string basename(resname, 0, j);
-      int64_t count = 0;
-      if (j < namelen) {
-        for (; j < namelen; ++j) {
-          char ch = strname[j];
-          count = count * 10 + static_cast<int64_t>(ch - '0');
-        }
-      } else {
-        basename += ".";
-      }
-      while (new_inames.has(newname)) {
-        count++;
-        resname = basename + std::to_string(count);
-        newname = py::ostring(resname);
-      }
-    }
-
-    // Store the name in all containers
-    dt->names.push_back(resname);
-    new_inames.set(newname, oint(i));
-    new_names.set(i, std::move(newname));
-  }
-
-  // If during the processing we discovered any empty names, they must be
-  // replaced with auto-generated ones.
-  if (fill_default_names) {
-    // Config variables to be used for name auto-generation
-    int64_t index0 = config::frame_names_auto_index;
-    std::string prefix = config::frame_names_auto_prefix;
-    const char* prefixptr = prefix.data();
-    size_t prefixlen = prefix.size();
-
-    // Within the existing names, find ones with the pattern "{prefix}<num>".
-    // If such names exist, we'll start autonaming with 1 + max(<num>), where
-    // the maximum is taken among all such names.
-    for (size_t i = 0; i < ncols; ++i) {
-      size_t namelen = dt->names[i].size();
-      const char* nameptr = dt->names[i].data();
-      if (namelen <= prefixlen) continue;
-      if (std::strncmp(nameptr, prefixptr, prefixlen) != 0) continue;
-      int64_t value = 0;
-      for (size_t j = prefixlen; j < namelen; ++j) {
-        char ch = nameptr[j];
-        if (ch < '0' || ch > '9') goto next_name;
-        value = value * 10 + static_cast<int64_t>(ch - '0');
-      }
-      if (value >= index0) {
-        index0 = value + 1;
-      }
-      next_name:;
-    }
-
-    // Now actually fill the empty names
-    for (size_t i = 0; i < ncols; ++i) {
-      if (!dt->names[i].empty()) continue;
-      dt->names[i] = prefix + std::to_string(index0);
-      oobj newname = py::ostring(dt->names[i]);
-      new_inames.set(newname, oint(i));
-      new_names.set(i, std::move(newname));
-      index0++;
-    }
-  }
-
-  // If there were any duplicate names, issue a warning
-  size_t ndup = duplicates.size();
-  if (ndup) {
-    Warning w;
-    if (ndup == 1) {
-      w << "Duplicate column name '" << duplicates[0] << "' found, and was "
-           "assigned a unique name";
-    } else {
-      w << "Duplicate column names found: ";
-      for (size_t i = 0; i < ndup; ++i) {
-        w << (i == 0? "'" :
-              i < ndup - 1? ", '" : " and '");
-        w << duplicates[i] << "'";
-      }
-      w << "; they were assigned unique names";
-    }
-    // as `w` goes out of scope, the warning is sent to Python
-  }
-
-  // Store the pythonic tuple / dict of names
-  names  = std::move(new_names).release();
-  inames = std::move(new_inames).release();
-
-  xassert(ncols == dt->names.size());
-  xassert(ncols == static_cast<size_t>(PyTuple_Size(names)));
-  xassert(ncols == static_cast<size_t>(PyDict_Size(inames)));
-}
-
-
-
-void Frame::_replace_names_from_map(py::odict replacements)
-{
-  if (!names)  _init_names();
-  if (!inames) _init_inames();
-
-  py::odict names_map  = py::obj(inames).to_pydict();
-  py::olist names_list = py::obj(names).to_pylist();
-  _clear_names();
-  for (auto kv : replacements) {
-    obj key = kv.first;
-    obj val = kv.second;
-    obj idx = names_map.get(key);
-    if (idx.is_undefined()) {
-      throw ValueError() << "Cannot find column `" << key.str()
-        << "` in the Frame";
-    }
-    if (!val.is_string()) {
-      throw TypeError() << "The replacement name for column `" << key.str()
-        << "` should be a string, but got " << val.typeobj();
-    }
-    int64_t i = idx.to_int64_strict();
-    names_list.set(i, val);
-  }
-  pylistNP np(names_list);
-  _dedup_and_save_names(&np);
-}
-
 
 /**
  * Compute Levenshtein distance between two strings `a` and `b`, as described in
@@ -479,6 +224,7 @@ static double _dlevenshtein(
 
 
 Error Frame::_name_not_found_error(const std::string& name) {
+  const std::vector<std::string>& names = dt->get_names();
   auto tmp = std::unique_ptr<double[]>(new double[name.size() + 1]);
   double* vtmp = tmp.get();
   double maxdist = name.size() <= 3? 1 :
@@ -492,8 +238,8 @@ Error Frame::_name_not_found_error(const std::string& name) {
   auto col0 = scored_column { 0, 100.0 };
   auto col1 = scored_column { 0, 100.0 };
   auto col2 = scored_column { 0, 100.0 };
-  for (size_t i = 0; i < dt->names.size(); ++i) {
-    double dist = _dlevenshtein(name, dt->names[i], vtmp);
+  for (size_t i = 0; i < names.size(); ++i) {
+    double dist = _dlevenshtein(name, names[i], vtmp);
     if (dist <= maxdist) {
       auto curr = scored_column { i, dist };
       if (curr.score < col0.score) {
@@ -509,12 +255,12 @@ Error Frame::_name_not_found_error(const std::string& name) {
   auto err = ValueError();
   err << "Column `" << name << "` does not exist in the Frame";
   if (col0.score < 10) {
-    err << "; did you mean `" << dt->names[col0.index] << "`";
+    err << "; did you mean `" << names[col0.index] << "`";
     if (col1.score < 10) {
       err << (col2.score < 10? ", " : " or ");
-      err << "`" << dt->names[col1.index] << "`";
+      err << "`" << names[col1.index] << "`";
       if (col2.score < 10) {
-        err << " or `" << dt->names[col2.index] << "`";
+        err << " or `" << names[col2.index] << "`";
       }
     }
     err << "?";
@@ -526,7 +272,7 @@ Error Frame::_name_not_found_error(const std::string& name) {
 
 #ifdef DTTEST
   void cover_py_FrameNameProviders() {
-    pylistNP* t1 = new pylistNP(py::rnone());
+    pylistNP* t1 = new pylistNP(py::olist(0));
     delete t1;
 
     strvec src2 = {"\xFF__", "foo"};
@@ -544,3 +290,335 @@ Error Frame::_name_not_found_error(const std::string& name) {
 #endif
 
 } // namespace py
+
+
+
+//------------------------------------------------------------------------------
+// DataTable methods
+//------------------------------------------------------------------------------
+
+/**
+ * Return DataTable column names as a C++ vector of strings.
+ */
+const std::vector<std::string>& DataTable::get_names() const {
+  return names;
+}
+
+
+/**
+ * Return DataTable column names as a python tuple.
+ */
+py::otuple DataTable::get_pynames() const {
+  if (!py_names) _init_pynames();
+  return py_names;
+}
+
+
+/**
+ * Return the index of a column given its name; or -1 if such column does not
+ * exist in the DataTable.
+ */
+int64_t DataTable::colindex(const py::_obj& pyname) const {
+  if (!py_inames) _init_pynames();
+  py::obj pyindex = py_inames.get(pyname);
+  return pyindex? pyindex.to_int64_strict() : -1;
+}
+
+
+/**
+ * Copy names without checking for validity, since we know they were already
+ * verified in DataTable `other`.
+ */
+void DataTable::copy_names_from(const DataTable* other) {
+  names = other->names;
+  py_names = other->py_names;
+  py_inames = other->py_inames;
+}
+
+
+/**
+ * Initialize DataTable's column names to the default "C0", "C1", "C2", ...
+ */
+void DataTable::set_names_to_default() {
+  auto index0 = static_cast<size_t>(config::frame_names_auto_index);
+  auto prefix = config::frame_names_auto_prefix;
+  auto zcols  = static_cast<size_t>(ncols);
+  py_names  = py::otuple();
+  py_inames = py::odict(nullptr);
+  names.clear();
+  names.reserve(zcols);
+  for (size_t i = 0; i < zcols; ++i) {
+    names.push_back(prefix + std::to_string(i + index0));
+  }
+}
+
+
+void DataTable::set_names(py::olist names_list) {
+  pylistNP np(names_list);
+  _set_names_impl(&np);
+}
+
+
+void DataTable::set_names(const std::vector<std::string>& names_list) {
+  strvecNP np(names_list);
+  _set_names_impl(&np);
+}
+
+
+void DataTable::replace_names(py::odict replacements) {
+  py::olist newnames(ncols);
+
+  for (int64_t i = 0; i < ncols; ++i) {
+    newnames.set(i, py_names[i]);
+  }
+  for (auto kv : replacements) {
+    py::obj key = kv.first;
+    py::obj val = kv.second;
+    py::obj idx = py_inames.get(key);
+    if (idx.is_undefined()) {
+      throw ValueError() << "Cannot find column `" << key.str()
+        << "` in the Frame";
+    }
+    if (!val.is_string()) {
+      throw TypeError() << "The replacement name for column `" << key.str()
+        << "` should be a string, but got " << val.typeobj();
+    }
+    int64_t i = idx.to_int64_strict();
+    newnames.set(i, val);
+  }
+  set_names(newnames);
+}
+
+
+
+
+
+//------------------------------------------------------------------------------
+// DataTable private helpers
+//------------------------------------------------------------------------------
+
+void DataTable::_init_pynames() const {
+  if (py_names) return;
+  size_t zcols = static_cast<size_t>(ncols);
+  xassert(names.size() == zcols);
+
+  py_names = py::otuple(zcols);
+  py_inames = py::odict();
+  for (size_t i = 0; i < zcols; ++i) {
+    py::ostring pyname(names[i]);
+    py_inames.set(pyname, py::oint(i));
+    py_names.set(i, std::move(pyname));
+  }
+}
+
+
+/**
+ * This is a main method to assign column names to a Frame. It checks that the
+ * names are valid, not duplicate, and if necessary modifies them to enforce
+ * such constraints.
+ */
+void DataTable::_set_names_impl(NameProvider* nameslist) {
+  size_t zcols = static_cast<size_t>(ncols);
+  if (nameslist->size() != zcols) {
+    throw ValueError() << "The `names` list has length " << nameslist->size()
+        << ", while the Frame has "
+        << (zcols < nameslist->size() && zcols? "only " : "")
+        << zcols << " column" << (zcols == 1? "" : "s");
+  }
+
+  // Prepare the containers for placing the new column names there
+  py_names  = py::otuple(zcols);
+  py_inames = py::odict();
+  names.clear();
+  names.reserve(zcols);
+  std::vector<std::string> duplicates;
+
+  // If any name is empty or None, it will be replaced with the default name
+  // in the end. The reason we don't replace immediately upon seeing an empty
+  // name is to ensure that the auto-generated names do not clash with the
+  // user-specified names somewhere later in the list.
+  bool fill_default_names = false;
+
+  for (size_t i = 0; i < zcols; ++i) {
+    // Convert to a C-style name object. Note that if `name` is python None,
+    // then the resulting `cname` will be `{nullptr, 0}`.
+    CString cname = nameslist->item_as_cstring(i);
+    char* strname = const_cast<char*>(cname.ch);
+    size_t namelen = static_cast<size_t>(cname.size);
+    if (namelen == 0) {
+      fill_default_names = true;
+      names.push_back(std::string());
+      continue;
+    }
+    // Ensure there are no invalid characters in the column's name. Invalid
+    // characters are considered those with ASCII codes \x00 - \x1F. If any
+    // such characters found, we perform substitution s/[\x00-\x1F]+/./g.
+    std::string resname;
+    bool name_mangled = false;
+    for (size_t j = 0; j < namelen; ++j) {
+      if (static_cast<uint8_t>(strname[j]) < 0x20) {
+        name_mangled = true;
+        resname = std::string(strname, j) + ".";
+        bool written_dot = true;
+        for (; j < namelen; ++j) {
+          char ch = strname[j];
+          if (static_cast<uint8_t>(ch) < 0x20) {
+            if (!written_dot) {
+              resname += ".";
+              written_dot = true;
+            }
+          } else {
+            resname += ch;
+            written_dot = false;
+          }
+        }
+      }
+    }
+    if (!name_mangled) {
+      resname = std::string(strname, namelen);
+    }
+    py::oobj newname = name_mangled? py::ostring(resname)
+                                   : nameslist->item_as_pyoobj(i);
+    // Check for name duplicates. If the name was already seen before, we
+    // replace it with a modified name (by incrementing the name's digital
+    // suffix if it has one, or otherwise by adding such a suffix).
+    if (py_inames.has(newname)) {
+      duplicates.push_back(resname);
+      size_t j = namelen;
+      for (; j > 0; --j) {
+        char ch = strname[j - 1];
+        if (ch < '0' || ch > '9') break;
+      }
+      std::string basename(resname, 0, j);
+      int64_t count = 0;
+      if (j < namelen) {
+        for (; j < namelen; ++j) {
+          char ch = strname[j];
+          count = count * 10 + static_cast<int64_t>(ch - '0');
+        }
+      } else {
+        basename += ".";
+      }
+      while (py_inames.has(newname)) {
+        count++;
+        resname = basename + std::to_string(count);
+        newname = py::ostring(resname);
+      }
+    }
+
+    // Store the name in all containers
+    names.push_back(resname);
+    py_inames.set(newname, py::oint(i));
+    py_names.set(i, std::move(newname));
+  }
+
+  // If during the processing we discovered any empty names, they must be
+  // replaced with auto-generated ones.
+  if (fill_default_names) {
+    // Config variables to be used for name auto-generation
+    int64_t index0 = config::frame_names_auto_index;
+    std::string prefix = config::frame_names_auto_prefix;
+    const char* prefixptr = prefix.data();
+    size_t prefixlen = prefix.size();
+
+    // Within the existing names, find ones with the pattern "{prefix}<num>".
+    // If such names exist, we'll start autonaming with 1 + max(<num>), where
+    // the maximum is taken among all such names.
+    for (size_t i = 0; i < zcols; ++i) {
+      size_t namelen = names[i].size();
+      const char* nameptr = names[i].data();
+      if (namelen <= prefixlen) continue;
+      if (std::strncmp(nameptr, prefixptr, prefixlen) != 0) continue;
+      int64_t value = 0;
+      for (size_t j = prefixlen; j < namelen; ++j) {
+        char ch = nameptr[j];
+        if (ch < '0' || ch > '9') goto next_name;
+        value = value * 10 + static_cast<int64_t>(ch - '0');
+      }
+      if (value >= index0) {
+        index0 = value + 1;
+      }
+      next_name:;
+    }
+
+    // Now actually fill the empty names
+    for (size_t i = 0; i < zcols; ++i) {
+      if (!names[i].empty()) continue;
+      names[i] = prefix + std::to_string(index0);
+      py::oobj newname = py::ostring(names[i]);
+      py_inames.set(newname, py::oint(i));
+      py_names.set(i, std::move(newname));
+      index0++;
+    }
+  }
+
+  // If there were any duplicate names, issue a warning
+  size_t ndup = duplicates.size();
+  if (ndup) {
+    Warning w;
+    if (ndup == 1) {
+      w << "Duplicate column name '" << duplicates[0] << "' found, and was "
+           "assigned a unique name";
+    } else {
+      w << "Duplicate column names found: ";
+      for (size_t i = 0; i < ndup; ++i) {
+        w << (i == 0? "'" :
+              i < ndup - 1? ", '" : " and '");
+        w << duplicates[i] << "'";
+      }
+      w << "; they were assigned unique names";
+    }
+    // as `w` goes out of scope, the warning is sent to Python
+  }
+
+  xassert(zcols == names.size());
+  xassert(zcols == py_names.size());
+  xassert(zcols == py_inames.size());
+}
+
+
+
+void DataTable::_integrity_check_names() const {
+  if (!py_names && !py_inames) return;
+  if (!py_names || !py_inames) {
+    throw AssertionError() << "One of DataTable.py_names or DataTable.py_inames"
+      " is not properly computed";
+  }
+  if (!py_names.is_tuple()) {
+    throw AssertionError() << "DataTable.py_names is not a tuple";
+  }
+  if (!py_inames.is_dict()) {
+    throw AssertionError() << "DataTable.py_inames is not a dict";
+  }
+  size_t zcols = static_cast<size_t>(ncols);
+  if (py_names.size() != zcols) {
+    throw AssertionError() << "len(.py_names) is " << py_names.size()
+        << ", whereas .ncols = " << zcols;
+  }
+  if (py_inames.size() != zcols) {
+    throw AssertionError() << ".inames has " << py_inames.size()
+      << " elements, while the Frame has " << zcols << " columns";
+  }
+  for (size_t i = 0; i < zcols; ++i) {
+    py::obj elem = py_names[i];
+    if (!elem.is_string()) {
+      throw AssertionError() << "Element " << i << " of .py_names is not "
+          "a string but " << elem.typeobj();
+    }
+    std::string sname = elem.to_string();
+    if (sname != names[i]) {
+      throw AssertionError() << "Element " << i << " of .py_names is '"
+          << sname << "', but the actual column name is '" << names[i] << "'";
+    }
+    py::obj res = py_inames.get(elem);
+    if (!res) {
+      throw AssertionError() << "Column " << i << " '" << names[i] << "' is "
+          "absent from the .py_inames dictionary";
+    }
+    int64_t v = res.to_int64_strict();
+    if (v != static_cast<int64_t>(i)) {
+      throw AssertionError() << "Column " << i << " '" << names[i] << "' maps "
+          "to " << v << " in the .py_inames dictionary";
+    }
+  }
+}

--- a/c/jay/open_jay.cc
+++ b/c/jay/open_jay.cc
@@ -20,10 +20,9 @@ static Column* column_from_jay(const jay::Column* jaycol, MemoryRange& jaybuf);
 // Open DataTable
 //------------------------------------------------------------------------------
 
-DataTable* DataTable::open_jay(const std::string& path,
-                               std::vector<std::string>& colnames)
+DataTable* DataTable::open_jay(const std::string& path)
 {
-  xassert(colnames.empty());
+  std::vector<std::string> colnames;
   MemoryRange mbuf = MemoryRange::mmap(path);
 
   const uint8_t* ptr = static_cast<const uint8_t*>(mbuf.rptr());
@@ -70,6 +69,7 @@ DataTable* DataTable::open_jay(const std::string& path,
 
   auto dt = new DataTable(columns);
   dt->nkeys = frame->nkeys();
+  dt->set_names(colnames);
   return dt;
 }
 

--- a/c/py_columnset.cc
+++ b/c/py_columnset.cc
@@ -131,14 +131,12 @@ PyObject* columns_from_columns(PyObject*, PyObject* args)
 PyObject* to_frame(obj* self, PyObject* args) {
   PyObject* arg1;
   if (!PyArg_ParseTuple(args, "O:to_frame", &arg1)) return nullptr;
-  py::obj names(arg1);
+  py::olist names = py::obj(arg1).to_pylist();
 
   Column** columns = self->columns;
   self->columns = nullptr;
-  DataTable* dt = new DataTable(columns);
-  auto frame = py::Frame::from_datatable(dt);
-  frame->set_names(names);
-  return frame;
+  DataTable* dt = new DataTable(columns, names);
+  return py::Frame::from_datatable(dt);
 }
 
 

--- a/c/py_datatable.cc
+++ b/c/py_datatable.cc
@@ -97,10 +97,8 @@ PyObject* open_jay(PyObject*, PyObject* args) {
   if (!PyArg_ParseTuple(args, "O:open_jay", &arg1)) return nullptr;
   std::string filename = py::obj(arg1).to_string();
 
-  std::vector<std::string> colnames;
-  DataTable* dt = DataTable::open_jay(filename, colnames);
+  DataTable* dt = DataTable::open_jay(filename);
   py::Frame* frame = py::Frame::from_datatable(dt);
-  frame->set_names(colnames);
   return frame;
 }
 
@@ -270,52 +268,6 @@ PyObject* check(obj* self, PyObject*) {
             << elem << ", for a column of type " << eexp;
       }
     }
-  }
-
-  if (self->_frame) {
-  PyObject* names = self->_frame->names;
-  PyObject* inames = self->_frame->inames;
-  if (names) {
-    if (!PyTuple_Check(names)) {
-      throw AssertionError() << "Frame.names is not a tuple";
-    }
-    if (inames && !PyDict_Check(inames)) {
-      throw AssertionError() << ".inames is not a dict: " << Py_TYPE(inames);
-    }
-    if (PyTuple_Size(names) != dt->ncols) {
-      throw AssertionError() << "len(Frame.names) is " << PyTuple_Size(names)
-          << ", whereas .ncols = " << dt->ncols;
-    }
-    if (inames && PyDict_Size(inames) != dt->ncols) {
-      throw AssertionError() << ".inames has " << PyDict_Size(inames)
-        << " elements, but the Frame has " << dt->ncols << " columns";
-    }
-    for (Py_ssize_t i = 0; i < dt->ncols; ++i) {
-      PyObject* elem = PyTuple_GET_ITEM(names, i);
-      if (!PyUnicode_Check(elem)) {
-        throw AssertionError() << "Element " << i << " of Frame.names is not "
-            "a string but " << Py_TYPE(elem);
-      }
-      std::string sname = std::string(PyUnicode_AsUTF8(elem));
-      std::string ename = dt->names[static_cast<size_t>(i)];
-      if (sname != ename) {
-        throw AssertionError() << "Element " << i << " of Frame.names is '"
-            << sname << "', but internal column's name is '" << ename << "'";
-      }
-      if (inames) {
-        PyObject* res = PyDict_GetItem(inames, elem);
-        if (!res) {
-          throw AssertionError() << "Column " << i << " '" << ename << "' is "
-              "absent from the .inames dictionary";
-        }
-        long v = PyLong_AsLong(res);
-        if (v != i) {
-          throw AssertionError() << "Column " << i << " '" << ename << "' maps "
-              "to " << v << " in the .inames dictionary";
-        }
-      }
-    }
-  }
   }
 
   Py_RETURN_NONE;

--- a/c/py_datatable.h
+++ b/c/py_datatable.h
@@ -277,7 +277,8 @@ DECLARE_METHOD(
 
 DECLARE_FUNCTION(
   datatable_from_list,
-  "datatable_from_list(list, types)\n\n"
+  "datatable_from_list(list, types, names)\n\n"
+  "[DEPRECATED]\n"
   "Create a DataTable from a list of Python objects (each will be converted\n"
   "into a column). Optional `types` list may be provided to force a\n"
   "particular stype for each column. The lengths of `types` list must be the\n"

--- a/c/py_datatable_fromlist.cc
+++ b/c/py_datatable_fromlist.cc
@@ -28,10 +28,12 @@ PyObject* pydatatable::datatable_from_list(PyObject*, PyObject* args)
 {
   PyObject* arg1;
   PyObject* arg2;
-  if (!PyArg_ParseTuple(args, "OO:from_list", &arg1, &arg2))
+  PyObject* arg3;
+  if (!PyArg_ParseTuple(args, "OOO:from_list", &arg1, &arg2, &arg3))
     return nullptr;
   py::olist srcs = py::obj(arg1).to_pylist();
   py::olist types = py::obj(arg2).to_pylist();
+  py::olist names = py::obj(arg3).to_pylist();
 
   if (srcs && types && srcs.size() != types.size()) {
     throw ValueError() << "The list of sources has size " << srcs.size()
@@ -71,5 +73,7 @@ PyObject* pydatatable::datatable_from_list(PyObject*, PyObject* args)
     }
   }
 
-  return pydatatable::wrap(new DataTable(cols));
+  DataTable* dt = names? new DataTable(cols, names)
+                       : new DataTable(cols, nullptr);
+  return pydatatable::wrap(dt);
 }

--- a/c/python/dict.cc
+++ b/c/python/dict.cc
@@ -82,6 +82,12 @@ void odict::set(_obj key, _obj val) {
   if (r) throw PyError();
 }
 
+void odict::del(_obj key) {
+  PyObject* _key = key.to_borrowed_ref();
+  int r = PyDict_DelItem(v, _key);
+  if (r) throw PyError();
+}
+
 
 dict_iterator odict::begin() const {
   return dict_iterator(v, 0);

--- a/c/python/dict.cc
+++ b/c/python/dict.cc
@@ -19,6 +19,8 @@ odict::odict() {
   if (!v) throw PyError();
 }
 
+odict::odict(std::nullptr_t) : oobj(nullptr) {}
+
 odict::odict(PyObject* src) : oobj(src) {}
 
 odict::odict(const odict& other) : oobj(other) {}

--- a/c/python/dict.h
+++ b/c/python/dict.h
@@ -34,6 +34,7 @@ class odict : public oobj {
     bool has(_obj key) const;
     obj  get(_obj key) const;
     void set(_obj key, _obj val);
+    void del(_obj key);
 
     dict_iterator begin() const;
     dict_iterator end() const;

--- a/c/python/dict.h
+++ b/c/python/dict.h
@@ -24,6 +24,7 @@ class dict_iterator;
 class odict : public oobj {
   public:
     odict();
+    odict(std::nullptr_t);
     odict(const odict&);
     odict(odict&&);
     odict& operator=(const odict&);

--- a/c/python/tuple.cc
+++ b/c/python/tuple.cc
@@ -14,6 +14,8 @@ namespace py {
 // Constructors
 //------------------------------------------------------------------------------
 
+otuple::otuple() : oobj(nullptr) {}
+
 otuple::otuple(int n) : otuple(static_cast<int64_t>(n)) {}
 
 otuple::otuple(size_t n) : otuple(static_cast<int64_t>(n)) {}

--- a/c/python/tuple.h
+++ b/c/python/tuple.h
@@ -23,6 +23,7 @@ namespace py {
  */
 class otuple : public oobj {
   public:
+    otuple();
     otuple(int n);
     otuple(size_t n);
     otuple(int64_t n);

--- a/c/utils/exceptions.cc
+++ b/c/utils/exceptions.cc
@@ -188,6 +188,14 @@ bool PyError::is_keyboard_interrupt() const {
   return exc_type == PyExc_KeyboardInterrupt;
 }
 
+bool PyError::is_assertion_error() const {
+  return exc_type == PyExc_AssertionError;
+}
+
+std::string PyError::message() const {
+  return py::obj(exc_value).to_pystring_force().to_string();
+}
+
 
 
 //==============================================================================

--- a/c/utils/exceptions.h
+++ b/c/utils/exceptions.h
@@ -86,6 +86,8 @@ public:
 
   void topython() const override;
   bool is_keyboard_interrupt() const;
+  bool is_assertion_error() const;
+  std::string message() const;
 };
 
 

--- a/c/ztest.cc
+++ b/c/ztest.cc
@@ -1,0 +1,46 @@
+//------------------------------------------------------------------------------
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// © H2O.ai 2018
+//------------------------------------------------------------------------------
+#ifdef DTTEST
+#include "ztest.h"
+#include "utils/exceptions.h"
+namespace dttest {
+
+
+void run_tests() {
+  cover_init_FrameInitializationManager_em();
+  cover_names_FrameNameProviders();
+  cover_names_integrity_checks();
+}
+
+
+/**
+ * Check that calling `f()` causes an AssertionError with the specified
+ * message string.
+ */
+void test_assert(const std::function<void(void)>& f,
+                 const std::string& expected_error) {
+  try {
+    f();
+  } catch (const std::exception& e) {
+    exception_to_python(e);
+    PyError pye;
+    if (!pye.is_assertion_error()) throw pye;
+    std::string error_message = pye.message();
+    if (error_message.find(expected_error) == std::string::npos) {
+      throw ValueError() << "Expected exception message <<" << expected_error
+          << ">>, got <<" << error_message << ">>";
+    }
+    return;
+  }
+  throw ValueError() << "Assertion error <<" << expected_error
+      << ">> was not raised";
+}
+
+
+}  // namespace dttest
+#endif

--- a/c/ztest.h
+++ b/c/ztest.h
@@ -17,8 +17,8 @@ void run_tests();
 
 
 void run_tests() {
-  py::cover_py_FrameInitializationManager_em();
-  py::cover_py_FrameNameProviders();
+  cover_py_FrameInitializationManager_em();
+  cover_py_FrameNameProviders();
 }
 
 

--- a/c/ztest.h
+++ b/c/ztest.h
@@ -5,23 +5,24 @@
 //
 // © H2O.ai 2018
 //------------------------------------------------------------------------------
-//
-// This file should only be included from `datatablemodule.cc`
-//
+#ifndef dt_ZTEST_h
+#define dt_ZTEST_h
 #ifdef DTTEST
-#include "frame/py_frame.h"
+#include <functional>
+#include <string>
 
 namespace dttest {
 
+
 void run_tests();
+void test_assert(const std::function<void(void)>&, const std::string&);
 
-
-void run_tests() {
-  cover_py_FrameInitializationManager_em();
-  cover_py_FrameNameProviders();
-}
+void cover_init_FrameInitializationManager_em();
+void cover_names_FrameNameProviders();
+void cover_names_integrity_checks();
 
 
 }  // namespace dttest
 
+#endif
 #endif

--- a/datatable/dt_append.py
+++ b/datatable/dt_append.py
@@ -191,7 +191,6 @@ def _cbind(self, *frames, force=False, inplace=True):
     containing all Frames concatenated, if `inplace` is False.
     """
     datatables = []
-    column_names = list(self.names)
 
     # Which Frame to operate upon. If not `inplace` then we will create
     # a blank Frame and merge everything to it.
@@ -218,9 +217,7 @@ def _cbind(self, *frames, force=False, inplace=True):
                     "anyways, then use option `force=True`"
                     % (plural(nn, "row"), plural(nrows, "row")))
         datatables.append(df.internal)
-        column_names.extend(list(df.names))
 
     _dt = src.internal
     _dt.cbind(datatables)
-    src.names = column_names
     return src

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -136,9 +136,8 @@ class Frame(core.Frame):
                 assert coldtype.isnative
             if coldtype.char == 'e' and str(coldtype) == "float16":
                 colarrays[i] = colarrays[i].astype("float32")
-        dt = core.datatable_from_list(colarrays, None)
+        dt = core.datatable_from_list(colarrays, None, names)
         self._dt = dt
-        self.names = names
 
 
     def _fill_from_numpy(self, arr, names):
@@ -158,16 +157,14 @@ class Frame(core.Frame):
         ncols = arr.shape[1]
         if is_type(arr, NumpyMaskedArray_t):
             dt = core.datatable_from_list([arr.data[:, i]
-                                           for i in range(ncols)], None)
+                                           for i in range(ncols)], None, names)
             mask = core.datatable_from_list([arr.mask[:, i]
-                                             for i in range(ncols)], None)
+                                             for i in range(ncols)], None, None)
             dt.apply_na_mask(mask)
         else:
             dt = core.datatable_from_list([arr[:, i]
-                                           for i in range(ncols)], None)
-
+                                           for i in range(ncols)], None, names)
         self._dt = dt
-        self.names = names
 
 
 

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -638,6 +638,21 @@ def test_rename_dict():
     assert d0.colindex("z") == 2
 
 
+def test_rename_frame_copy():
+    # Check that when copying a frame, the changes to memoized .py_names and
+    # .py_inames do not get propagated to the original Frame.
+    d0 = dt.Frame([[1], [2], [3]])
+    assert d0.names == ("C0", "C1", "C2")
+    d1 = d0.copy()
+    assert d1.names == ("C0", "C1", "C2")
+    d1.names = {"C1": "ha!"}
+    assert d1.names == ("C0", "ha!", "C2")
+    assert d0.names == ("C0", "C1", "C2")
+    assert d1.colindex("ha!") == 1
+    with pytest.raises(ValueError):
+        d0.colindex("ha!")
+
+
 @pytest.mark.run(order=8.11)
 def test_rename_bad1():
     d0 = dt.Frame([[1], [2], ["hello"]], names=("a", "b", "c"))


### PR DESCRIPTION
* `Frame.names` moved to `DataTable.py_names`;
* `Frame.inames` moved to `DataTable.py_inames`;
* Cleaned up integrity checks for `.names`, `.py_names` and `.py_inames` in `DataTable`;
* `DataTable` has now multiple constructors, depending on how the names of the columns should be initialized;
* Added C++ tests to ensure proper coverage of integrity checks;
* `.open_jay()` no longer takes string vector reference as a parameter -- instead it directly assign names to the DataTable returned;
* `.cbind()` now produces DataTable with correct names already set;

Closes #1270