### PR TITLE
Extra options to generate better coverage report

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,8 +134,8 @@ coverage:
 		--cov=datatable --cov-report=xml:build/coverage.xml \
 		tests
 	chmod +x ci/llvm-gcov.sh
-	lcov --gcov-tool ci/llvm-gcov.sh --capture --directory . --output-file build/coverage.info
-	genhtml build/coverage.info --output-directory build/coverage-c
+	lcov --gcov-tool ci/llvm-gcov.sh --capture --directory . --no-external --output-file build/coverage.info
+	genhtml --legend --output-directory build/coverage-c --demangle-cpp build/coverage.info
 	mv .coverage build/
 
 dist: build

--- a/c/frame/names.cc
+++ b/c/frame/names.cc
@@ -88,7 +88,7 @@ CString strvecNP::item_as_cstring(size_t i) {
 
 py::oobj strvecNP::item_as_pyoobj(size_t i) {
   return py::ostring(names[i]);
-}
+}  // LCOV_EXCL_LINE
 
 
 
@@ -101,7 +101,7 @@ namespace py {
 
 oobj Frame::get_names() const {
   return dt->get_pynames();
-}
+}  // LCOV_EXCL_LINE
 
 
 void Frame::set_names(obj arg)


### PR DESCRIPTION
* `--no-external`: prevent system libraries from showing up in the coverage report;
* `--legend`: add into the generated HTML an explanation what each color means;
* `--demangle-cpp`: replace mangled c++ names with human-readable names;
* exclude 2 lines in `names.cc` which are spuriously marked as non-covered.