### PR TITLE
Fix crash when saving a Frame to CSV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   that the column contains many non-ASCII characters.
 - f-column-selectors should no longer throw errors and produce only unique
   ids when stringified (#1241).
+- crash when saving a frame with many boolean columns into CSV (#1278).
 
 
 ### [v0.6.0](https://github.com/h2oai/datatable/compare/v0.6.0...v0.5.0) — 2018-06-05

--- a/c/csv/writer.cc
+++ b/c/csv/writer.cc
@@ -311,6 +311,7 @@ void CsvWriter::write()
   create_column_writers(ncols);
   size_t nstrcols32 = strcolumns32.size();
   size_t nstrcols64 = strcolumns64.size();
+  if (nthreads > nchunks) nthreads = nchunks;
 
   OmpExceptionManager oem;
 

--- a/c/csv/writer.cc
+++ b/c/csv/writer.cc
@@ -386,9 +386,8 @@ void CsvWriter::write()
             }
             thch[-1] = '\n';
           });
-        // for (int64_t row = row0; row < row1; row++) {
-        // }
         th_write_size = static_cast<size_t>(thch - thbuf);
+        xassert(th_write_size <= thbufsize);
       } catch (...) {
         oem.capture_exception();
       }
@@ -464,6 +463,7 @@ size_t CsvWriter::estimate_output_size()
   size_t ncols = static_cast<size_t>(dt->ncols);
   size_t total_string_size = 0;
   size_t total_columns_size = 0;
+  fixed_size_per_row = ncols;  // 1 byte per separator
   for (size_t i = 0; i < ncols; i++) {
     Column *col = dt->columns[i];
     if (auto scol32 = dynamic_cast<StringColumn<uint32_t>*>(col)) {

--- a/tests/test_tocsv.py
+++ b/tests/test_tocsv.py
@@ -331,3 +331,10 @@ def test_save_str64():
         "baar,q\n"
         "ba,\n"
         ",bvqpoeqnperoin;dj\n")
+
+
+def test_issue_1278():
+    f0 = dt.Frame([[True, False] * 10] * 1000)
+    a = f0.to_csv()
+    # Header + \n + 2 byte per value (0/1 + sep)
+    assert len(a) == len(",".join(f0.names)) + 1 + f0.ncols * f0.nrows * 2


### PR DESCRIPTION
The crash came because of mis-estimating the line length (forgot to account for the separators).

Closes #1278