### PR TITLE
Parallelize groupby calculations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Frame() can now be constructed from a list of dictionaries, where each
   item in the list represents a single row.
 - Frame() can now be created from a datetime64 numpy array (#1274).
+- Groupby calculations are now parallel.
 
 #### Changed
 - `names` argument in `Frame()` constructor can no longer be a string --

--- a/c/csv/writer.cc
+++ b/c/csv/writer.cc
@@ -311,7 +311,7 @@ void CsvWriter::write()
   create_column_writers(ncols);
   size_t nstrcols32 = strcolumns32.size();
   size_t nstrcols64 = strcolumns64.size();
-  if (nthreads > nchunks) nthreads = nchunks;
+  if (nthreads > nchunks) nthreads = static_cast<int>(nchunks);
 
   OmpExceptionManager oem;
 

--- a/c/expr/reduceop.cc
+++ b/c/expr/reduceop.cc
@@ -10,6 +10,7 @@
 #include <limits>     // std::numeric_limits<?>::max, ::infinity
 #include <type_traits>
 #include "types.h"
+#include "utils/omp.h"
 
 namespace expr
 {
@@ -317,6 +318,8 @@ Column* reduceop(int opcode, Column* arg, const Groupby& groupby)
 
   int32_t _grps[2] = {0, static_cast<int32_t>(arg->nrows)};
   const int32_t* grps = ngrps == 1? _grps : groupby.offsets_r();
+
+  #pragma omp parallel for schedule(static)
   for (int32_t g = 0; g < ngrps; ++g) {
     (*fn)(grps, g, params);
   }


### PR DESCRIPTION
Testing on my laptop (8 cores) with the following script:
```python
import datatable as dt
import random
import time
from datatable import sum, f
n = 10**8
col1 = [random.randint(1, 100) for _ in range(1000)] * (n // 1000)
col2 = [random.random() for _ in range(20000)] * (n // 20000)
assert len(col1) == len(col2) == n

fr = dt.Frame(A=col1, B=col2)
for _ in range(5):
    t0 = time.time()
    fg = fr[:, sum(f.B), f.A]
    t1 = time.time()
    print("Time taken: %.3fs" % (t1 - t0))
```

Before this change, timings were:
```
Time taken: 2.600s
Time taken: 2.184s
Time taken: 2.140s
Time taken: 2.196s
Time taken: 2.196s
```

After this change, timings are:
```
Time taken: 1.383s
Time taken: 1.028s
Time taken: 1.066s
Time taken: 1.040s
Time taken: 1.051s
```

Closes #1284 