### PR TITLE
Split string and nhot-encode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Groupby calculations are now parallel.
 - `Frame.cbind()` now accepts a list of frames as the argument.
 - Frame can now be sorted by multiple columns.
+- new function `split_into_nhot()` to split a string column into fragments
+  and then convert them into a set of indicator variables ("n-hot encode").
 
 #### Changed
 - `names` argument in `Frame()` constructor can no longer be a string --

--- a/c/datatable.cc
+++ b/c/datatable.cc
@@ -13,12 +13,26 @@
 #include "types.h"
 
 // Forward declarations
+using colvec = std::vector<Column*>;
+static Column** prepare_columns(colvec&);
 static int _compare_ints(const void *a, const void *b);
 
 
 //------------------------------------------------------------------------------
 // Constructors
 //------------------------------------------------------------------------------
+
+DataTable::DataTable(colvec&& cols, std::nullptr_t)
+  : DataTable(prepare_columns(cols), nullptr) {}
+
+DataTable::DataTable(colvec&& cols, const py::olist& nn)
+  : DataTable(prepare_columns(cols), nn) {}
+
+DataTable::DataTable(colvec&& cols, const std::vector<std::string>& nn)
+  : DataTable(prepare_columns(cols), nn) {}
+
+DataTable::DataTable(colvec&& cols, const DataTable* nn)
+  : DataTable(prepare_columns(cols), nn) {}
 
 DataTable::DataTable(Column** cols, std::nullptr_t)
   : DataTable(cols)
@@ -88,6 +102,18 @@ DataTable::~DataTable()
     delete columns[i];
   }
   delete columns;
+}
+
+static Column** prepare_columns(colvec& cols) {
+  size_t ncols = cols.size();
+  size_t allocsize = sizeof(Column*) * (ncols + 1);
+  Column** newcols = dt::malloc<Column*>(allocsize);
+  if (ncols) {
+    std::memcpy(newcols, cols.data(), sizeof(Column*) * ncols);
+  }
+  newcols[ncols] = nullptr;
+  cols.clear();
+  return newcols;
 }
 
 

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -72,6 +72,10 @@ class DataTable {
     DataTable(Column** cols, const py::olist& namessrc);
     DataTable(Column** cols, const std::vector<std::string>& namessrc);
     DataTable(Column** cols, const DataTable* namessrc);
+    DataTable(std::vector<Column*>&& cols, std::nullptr_t);
+    DataTable(std::vector<Column*>&& cols, const py::olist&);
+    DataTable(std::vector<Column*>&& cols, const std::vector<std::string>&);
+    DataTable(std::vector<Column*>&& cols, const DataTable*);
     ~DataTable();
     DataTable* delete_columns(int*, int64_t);
     void resize_rows(int64_t n);

--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -6,6 +6,7 @@
 // © H2O.ai 2018
 //------------------------------------------------------------------------------
 #define dt_DATATABLEMODULE_cc
+#include "datatablemodule.h"
 #include <Python.h>
 #include "capi.h"
 #include "csv/py_csv.h"
@@ -14,7 +15,6 @@
 #include "extras/aggregator.h"
 #include "frame/py_frame.h"
 #include "options.h"
-#include "python/ext_module.h"
 #include "py_column.h"
 #include "py_columnset.h"
 #include "py_datatable.h"
@@ -169,21 +169,6 @@ PyObject* has_omp_support(PyObject*, PyObject*) {
 // Module definition
 //------------------------------------------------------------------------------
 
-class DatatableModule : public py::ExtModule<DatatableModule> {
-  public:
-    const char* name() const { return "_datatable"; }
-    const char* doc() const;
-    void init_methods();
-};
-
-static DatatableModule dtmod;
-
-
-const char* DatatableModule::doc() const {
-  return "module doc...";
-}
-
-
 void DatatableModule::init_methods() {
   add(METHODv(pycolumnset::columns_from_mixed));
   add(METHODv(pycolumnset::columns_from_slice));
@@ -213,6 +198,7 @@ void DatatableModule::init_methods() {
   add(METHOD0(is_debug_mode));
   add(METHOD0(has_omp_support));
   add(METHODv(aggregate));
+  init_methods_str();
 }
 
 
@@ -223,6 +209,7 @@ PyInit__datatable()
   init_csvwrite_constants();
   init_exceptions();
 
+  static DatatableModule dtmod;
   PyObject* m = dtmod.init();
 
   // Initialize submodules

--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -14,6 +14,7 @@
 #include "extras/aggregator.h"
 #include "frame/py_frame.h"
 #include "options.h"
+#include "python/ext_module.h"
 #include "py_column.h"
 #include "py_columnset.h"
 #include "py_datatable.h"
@@ -168,87 +169,84 @@ PyObject* has_omp_support(PyObject*, PyObject*) {
 // Module definition
 //------------------------------------------------------------------------------
 
-static PyMethodDef DatatableModuleMethods[] = {
-    METHODv(pycolumnset::columns_from_mixed),
-    METHODv(pycolumnset::columns_from_slice),
-    METHODv(pycolumnset::columns_from_columns),
-    METHODv(pycolumn::column_from_list),
-    METHODv(pyrowindex::rowindex_from_slice),
-    METHODv(pyrowindex::rowindex_from_slicelist),
-    METHODv(pyrowindex::rowindex_from_array),
-    METHODv(pyrowindex::rowindex_from_column),
-    METHODv(pyrowindex::rowindex_from_filterfn),
-    METHODv(pydatatable::datatable_load),
-    METHODv(pydatatable::open_jay),
-    METHODv(pydatatable::install_buffer_hooks),
-    METHODv(config::set_option),
-    METHODv(gread),
-    METHODv(write_csv),
-    METHODv(exec_function),
-    METHODv(register_function),
-    METHOD0(get_internal_function_ptrs),
-    METHOD0(get_integer_sizes),
-    METHODv(expr_binaryop),
-    METHODv(expr_cast),
-    METHODv(expr_column),
-    METHODv(expr_reduceop),
-    METHODv(expr_count),
-    METHODv(expr_unaryop),
-    METHOD0(is_debug_mode),
-    METHOD0(has_omp_support),
-    METHODv(aggregate),
-
-    {nullptr, nullptr, 0, nullptr}  /* Sentinel */
+class DatatableModule : public py::ExtModule<DatatableModule> {
+  public:
+    const char* name() const { return "_datatable"; }
+    const char* doc() const;
+    void init_methods();
 };
 
-static PyModuleDef datatablemodule = {
-    PyModuleDef_HEAD_INIT,
-    "_datatable",  /* name of the module */
-    "module doc",  /* module documentation */
-    -1,            /* size of per-interpreter state of the module, or -1
-                      if the module keeps state in global variables */
-    DatatableModuleMethods,
+static DatatableModule dtmod;
 
-    // https://docs.python.org/3/c-api/module.html#multi-phase-initialization
-    nullptr,       /* m_slots */
-    nullptr,       /* m_traverse */
-    nullptr,       /* m_clear */
-    nullptr,       /* m_free */
-};
+
+const char* DatatableModule::doc() const {
+  return "module doc...";
+}
+
+
+void DatatableModule::init_methods() {
+  add(METHODv(pycolumnset::columns_from_mixed));
+  add(METHODv(pycolumnset::columns_from_slice));
+  add(METHODv(pycolumnset::columns_from_columns));
+  add(METHODv(pycolumn::column_from_list));
+  add(METHODv(pyrowindex::rowindex_from_slice));
+  add(METHODv(pyrowindex::rowindex_from_slicelist));
+  add(METHODv(pyrowindex::rowindex_from_array));
+  add(METHODv(pyrowindex::rowindex_from_column));
+  add(METHODv(pyrowindex::rowindex_from_filterfn));
+  add(METHODv(pydatatable::datatable_load));
+  add(METHODv(pydatatable::open_jay));
+  add(METHODv(pydatatable::install_buffer_hooks));
+  add(METHODv(config::set_option));
+  add(METHODv(gread));
+  add(METHODv(write_csv));
+  add(METHODv(exec_function));
+  add(METHODv(register_function));
+  add(METHOD0(get_internal_function_ptrs));
+  add(METHOD0(get_integer_sizes));
+  add(METHODv(expr_binaryop));
+  add(METHODv(expr_cast));
+  add(METHODv(expr_column));
+  add(METHODv(expr_reduceop));
+  add(METHODv(expr_count));
+  add(METHODv(expr_unaryop));
+  add(METHOD0(is_debug_mode));
+  add(METHOD0(has_omp_support));
+  add(METHODv(aggregate));
+}
 
 
 /* Called when Python program imports the module */
 PyMODINIT_FUNC
-PyInit__datatable(void) {
-    init_csvwrite_constants();
-    init_exceptions();
+PyInit__datatable()
+{
+  init_csvwrite_constants();
+  init_exceptions();
 
-    // Instantiate module object
-    PyObject* m = PyModule_Create(&datatablemodule);
-    if (m == nullptr) return nullptr;
+  PyObject* m = dtmod.init();
 
-    // Initialize submodules
-    if (!init_py_types(m)) return nullptr;
-    if (!pydatawindow::static_init(m)) return nullptr;
-    if (!pycolumn::static_init(m)) return nullptr;
-    if (!pycolumnset::static_init(m)) return nullptr;
-    if (!pydatatable::static_init(m)) return nullptr;
-    if (!pygroupby::static_init(m)) return nullptr;
-    if (!pyrowindex::static_init(m)) return nullptr;
-    if (!init_py_encodings(m)) return nullptr;
-    init_jay();
+  // Initialize submodules
+  if (!init_py_types(m)) return nullptr;
+  if (!pydatawindow::static_init(m)) return nullptr;
+  if (!pycolumn::static_init(m)) return nullptr;
+  if (!pycolumnset::static_init(m)) return nullptr;
+  if (!pydatatable::static_init(m)) return nullptr;
+  if (!pygroupby::static_init(m)) return nullptr;
+  if (!pyrowindex::static_init(m)) return nullptr;
+  if (!init_py_encodings(m)) return nullptr;
+  init_jay();
 
-    try {
-      py::Frame::Type::init(m);
+  try {
+    py::Frame::Type::init(m);
 
-      #ifdef DTTEST
-        dttest::run_tests();
-      #endif
+    #ifdef DTTEST
+      dttest::run_tests();
+    #endif
 
-    } catch (const std::exception& e) {
-      exception_to_python(e);
-      return nullptr;
-    }
+  } catch (const std::exception& e) {
+    exception_to_python(e);
+    return nullptr;
+  }
 
-    return m;
+  return m;
 }

--- a/c/datatablemodule.h
+++ b/c/datatablemodule.h
@@ -1,0 +1,35 @@
+//------------------------------------------------------------------------------
+// Copyright 2018 H2O.ai
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//------------------------------------------------------------------------------
+#ifndef dt_DATATABLEMODULE_h
+#define dt_DATATABLEMODULE_h
+#include "python/ext_module.h"
+
+
+class DatatableModule : public py::ExtModule<DatatableModule> {
+  public:
+    const char* name() const {
+      return "_datatable";
+    }
+    const char* doc() const {
+      return "module doc...";
+    }
+
+    void init_methods();
+    void init_methods_str();  // defined in str/py_str.cc
+};
+
+
+#endif

--- a/c/frame/py_frame_init.cc
+++ b/c/frame/py_frame_init.cc
@@ -589,40 +589,28 @@ class FrameInitializationManager {
     }
 
 
-    Column** prepare_columns() {
-      size_t ncols = cols.size();
-      size_t allocsize = sizeof(Column*) * (ncols + 1);
-      Column** newcols = dt::malloc<Column*>(allocsize);
-      if (ncols) {
-        std::memcpy(newcols, cols.data(), sizeof(Column*) * ncols);
-      }
-      newcols[ncols] = nullptr;
-      cols.clear();
-      return newcols;
-    }
-
     void make_datatable(nullptr_t) {
-      frame->dt = new DataTable(prepare_columns(), nullptr);
+      frame->dt = new DataTable(std::move(cols), nullptr);
     }
 
     void make_datatable(const Arg& names) {
       if (names) {
-        frame->dt = new DataTable(prepare_columns(), names.to_pylist());
+        frame->dt = new DataTable(std::move(cols), names.to_pylist());
       } else {
-        frame->dt = new DataTable(prepare_columns(), nullptr);
+        frame->dt = new DataTable(std::move(cols), nullptr);
       }
     }
 
     void make_datatable(const py::olist& names) {
-      frame->dt = new DataTable(prepare_columns(), names);
+      frame->dt = new DataTable(std::move(cols), names);
     }
 
     void make_datatable(const std::vector<std::string>& names) {
-      frame->dt = new DataTable(prepare_columns(), names);
+      frame->dt = new DataTable(std::move(cols), names);
     }
 
     void make_datatable(const DataTable* names_src) {
-      frame->dt = new DataTable(prepare_columns(), names_src);
+      frame->dt = new DataTable(std::move(cols), names_src);
     }
 
 

--- a/c/py_columnset.cc
+++ b/c/py_columnset.cc
@@ -71,15 +71,14 @@ PyObject* columns_from_slice(PyObject*, PyObject *args) {
 
 PyObject* columns_from_mixed(PyObject*, PyObject *args)
 {
-  PyObject* arg1;
-  DataTable* dt;
+  PyObject* arg1, *arg2;
   long int nrows;
   long long rawptr;
-  if (!PyArg_ParseTuple(args, "OO&lL:columns_from_mixed",
-                        &arg1, &pydatatable::unwrap, &dt,
-                        &nrows, &rawptr))
+  if (!PyArg_ParseTuple(args, "OOlL:columns_from_mixed",
+                        &arg1, &arg2, &nrows, &rawptr))
     return nullptr;
   py::olist pyspec = py::obj(arg1).to_pylist();
+  DataTable* dt = py::obj(arg2).to_frame();
 
   columnset_mapfn* fnptr = reinterpret_cast<columnset_mapfn*>(rawptr);
   size_t ncols = pyspec.size();

--- a/c/python/ext_module.h
+++ b/c/python/ext_module.h
@@ -1,0 +1,85 @@
+//------------------------------------------------------------------------------
+// Copyright 2018 H2O.ai
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//------------------------------------------------------------------------------
+#ifndef dt_PYTHON_EXT_MODULE_h
+#define dt_PYTHON_EXT_MODULE_h
+#include <vector>
+#include <Python.h>
+
+namespace py {
+
+
+/**
+ *
+ */
+template <class T>
+class ExtModule {
+  private:
+    PyModuleDef module_def;
+    std::vector<PyMethodDef> methods;
+    PyObject* pymodule;
+
+  public:
+    PyObject* init();
+
+    void init_methods() {}
+    void add(PyMethodDef);
+
+  private:
+    PyMethodDef* get_methods();
+};
+
+
+template <class T>
+void ExtModule<T>::add(PyMethodDef def) {
+  methods.push_back(def);
+}
+
+template <class T>
+PyMethodDef* ExtModule<T>::get_methods() {
+  static_cast<T*>(this)->init_methods();
+  methods.push_back(PyMethodDef {nullptr, nullptr, 0, nullptr});
+  return methods.data();
+}
+
+
+template <class T>
+PyObject* ExtModule<T>::init() {
+  T* self = static_cast<T*>(this);
+
+  module_def = {
+    PyModuleDef_HEAD_INIT,
+    self->name(),  /* name of the module */
+    self->doc(),   /* module documentation */
+    -1,            /* size of per-interpreter state of the module, or -1
+                      if the module keeps state in global variables */
+    self->get_methods(),
+
+    // https://docs.python.org/3/c-api/module.html#multi-phase-initialization
+    nullptr,       /* m_slots */
+    nullptr,       /* m_traverse */
+    nullptr,       /* m_clear */
+    nullptr,       /* m_free */
+  };
+
+  pymodule = PyModule_Create(&module_def);
+  if (pymodule == nullptr) throw PyError();  // LCOV_EXCL_LINE
+  return pymodule;
+}
+
+
+}
+
+#endif

--- a/c/python/ext_type.h
+++ b/c/python/ext_type.h
@@ -1,9 +1,17 @@
 //------------------------------------------------------------------------------
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright 2018 H2O.ai
 //
-// © H2O.ai 2018
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //------------------------------------------------------------------------------
 #ifndef dt_PYTHON_EXT_TYPE_h
 #define dt_PYTHON_EXT_TYPE_h

--- a/c/str/py_str.cc
+++ b/c/str/py_str.cc
@@ -1,0 +1,58 @@
+//------------------------------------------------------------------------------
+// Copyright 2018 H2O.ai
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//------------------------------------------------------------------------------
+#include "py_str.h"
+#include "datatablemodule.h"
+#include "frame/py_frame.h"
+#include "types.h"
+#include "utils/exceptions.h"
+
+namespace py {
+
+
+  static PKArgs split_into_nhot_args(1, 0, 1, false, false, {"col", "sep"});
+
+  static py::oobj split_into_nhot(const PKArgs& args) {
+    DataTable* dt = args[0].to_frame();
+    std::string sep = args[1]? args[1].to_string() : ",";
+
+    Column* col0 = dt->ncols == 1? dt->columns[0] : nullptr;
+    if (!col0) {
+      throw ValueError() << "Function split_into_nhot() may only be applied to "
+        "a single-column Frame of type string;" << " got frame with "
+        << dt->ncols << " columns";
+    }
+    SType st = col0->stype();
+    if (!(st == SType::STR32 || st == SType::STR64)) {
+      throw TypeError() << "Function split_into_nhot() may only be applied to "
+        "a single-column Frame of type string;" << " received a column of type "
+        << info(st).name();
+    }
+    if (sep.size() != 1) {
+      throw ValueError() << "Parameter `sep` in split_into_nhot() must be a "
+        "single character; got '" << sep << "'";
+    }
+
+    DataTable* res = dt::split_into_nhot(col0, sep[0]);
+    return py::Frame::from_datatable(res);
+  }
+
+}
+
+void DatatableModule::init_methods_str() {
+  add<&py::split_into_nhot, py::split_into_nhot_args>("split_into_nhot", "");
+}
+
+

--- a/c/str/py_str.cc
+++ b/c/str/py_str.cc
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //------------------------------------------------------------------------------
-#include "py_str.h"
+#include "str/py_str.h"
 #include "datatablemodule.h"
 #include "frame/py_frame.h"
 #include "types.h"

--- a/c/str/py_str.h
+++ b/c/str/py_str.h
@@ -1,0 +1,26 @@
+//------------------------------------------------------------------------------
+// Copyright 2018 H2O.ai
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//------------------------------------------------------------------------------
+#ifndef dt_STR_PY_STR_h
+#define dt_STR_PY_STR_h
+#include "datatable.h"
+
+
+namespace dt {
+  DataTable* split_into_nhot(Column* col, char sep);
+}
+
+
+#endif

--- a/c/str/split_into_nhot.cc
+++ b/c/str/split_into_nhot.cc
@@ -1,0 +1,157 @@
+//------------------------------------------------------------------------------
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// © H2O.ai 2018
+//------------------------------------------------------------------------------
+#include <unordered_map>
+#include <vector>
+#include "datatable.h"
+#include "utils/exceptions.h"
+#include "utils/omp.h"
+#include "utils/shared_mutex.h"
+
+namespace dt {
+
+/**
+ * Split string into tokens
+ */
+static void tokenize_string(
+    std::vector<std::string>& tokens,
+    const char* strstart,
+    const char* strend,
+    char sep
+) {
+  tokens.clear();
+  const char* ch = strstart;
+  while (ch < strend) {
+    if (*ch == ' ' || *ch == '\t' || *ch == '\n' || *ch == sep) {
+      ch++;
+    }
+    else {
+      const char* ch0 = ch;
+      // Handle the case of quoted token
+      if (*ch == '\'' || *ch == '"') {
+        char quote = *ch++;
+        while (ch < strend && *ch != quote) {
+          ch += 1 + (*ch == '\\');
+        }
+        if (ch < strend) {
+          tokens.emplace_back(ch0 + 1, ch);
+          ch++;  // move over the closing quote
+          continue;
+        }
+        // fall-through
+      }
+      // Regular non-quoted token, parse until the next sep
+      while (ch < strend && *ch != sep) {
+        ch++;
+      }
+      const char* ch1 = ch;
+      while (ch1 > ch0) {  // also omit trailing spaces
+        char c = *(ch1 - 1);
+        if (!(c == ' ' || c == '\t' || c == '\n')) break;
+        ch1--;
+      }
+      tokens.emplace_back(ch0, ch1);
+      ch++;  // move over the sep
+    }
+  }
+}
+
+
+
+DataTable* split_into_nhot(Column* col, char sep) {
+  bool is32 = (col->stype() == SType::STR32);
+  bool is64 = (col->stype() == SType::STR64);
+  xassert(is32 || is64);
+  const uint32_t* offsets32;
+  const uint64_t* offsets64;
+  const char* strdata;
+  if (is32) {
+    auto scol = static_cast<StringColumn<uint32_t>*>(col);
+    offsets32 = scol->offsets();
+    strdata = scol->strdata();
+  } else {
+    auto scol = static_cast<StringColumn<uint64_t>*>(col);
+    offsets64 = scol->offsets();
+    strdata = scol->strdata();
+  }
+
+  size_t nrows = static_cast<size_t>(col->nrows);
+  std::unordered_map<std::string, size_t> colsmap;
+  std::vector<Column*> outcols;
+  std::vector<int8_t*> outdata;
+  std::vector<std::string> outnames;
+  dt::shared_mutex shmutex;
+
+  OmpExceptionManager oem;
+  #pragma omp parallel
+  {
+    try {
+      size_t ith = static_cast<size_t>(omp_get_thread_num());
+      size_t nth = static_cast<size_t>(omp_get_num_threads());
+      std::vector<std::string> chunks;
+
+      for (size_t irow = ith; irow < nrows; irow += nth) {
+        const char* strstart, *strend;
+        if (is32) {
+          if (ISNA(offsets32[irow])) continue;
+          strstart = strdata + (offsets32[irow - 1] & ~GETNA<uint32_t>());
+          strend = strdata + offsets32[irow];
+        } else {
+          if (ISNA(offsets64[irow])) continue;
+          strstart = strdata + (offsets64[irow - 1] & ~GETNA<uint64_t>());
+          strend = strdata + offsets64[irow];
+        }
+        if (strstart == strend) continue;
+        char chfirst = *strstart;
+        char chlast = strend[-1];
+        if ((chfirst == '(' && chlast == ')') ||
+            (chfirst == '[' && chlast == ']') ||
+            (chfirst == '{' && chlast == '}')) {
+          strstart++;
+          strend--;
+        }
+
+        tokenize_string(chunks, strstart, strend, sep);
+
+        dt::shared_lock lock(shmutex);
+        for (const std::string& s : chunks) {
+          if (colsmap.count(s)) {
+            size_t j = colsmap[s];
+            outdata[j][irow] = 1;
+          } else {
+            lock.exclusive_start();
+            if (colsmap.count(s) == 0) {
+              colsmap[s] = outcols.size();
+              BoolColumn* newcol = new BoolColumn(col->nrows);
+              int8_t* data = newcol->elements_w();
+              std::memset(data, 0, nrows);
+              data[irow] = 1;
+              outcols.push_back(newcol);
+              outdata.push_back(data);
+              outnames.push_back(s);
+            } else {
+              // In case the name was already added from another thread while we
+              // were waiting for the exclusive lock
+              size_t j = colsmap[s];
+              outdata[j][irow] = 1;
+            }
+            lock.exclusive_end();
+          }
+        }
+      }
+    } catch (...) {
+      oem.capture_exception();
+    }
+  }  // end of #pragma omp parallel
+
+  oem.rethrow_exception_if_any();
+
+  return new DataTable(std::move(outcols), std::move(outnames));
+}
+
+
+} // namespace dt

--- a/c/str/split_into_nhot.cc
+++ b/c/str/split_into_nhot.cc
@@ -5,6 +5,7 @@
 //
 // © H2O.ai 2018
 //------------------------------------------------------------------------------
+#include "str/py_str.h"
 #include <unordered_map>
 #include <vector>
 #include "datatable.h"
@@ -43,6 +44,7 @@ static void tokenize_string(
           continue;
         }
         // fall-through
+        ch = ch0;
       }
       // Regular non-quoted token, parse until the next sep
       while (ch < strend && *ch != sep) {
@@ -144,8 +146,8 @@ DataTable* split_into_nhot(Column* col, char sep) {
         }
       }
     } catch (...) {
-      oem.capture_exception();
-    }
+      oem.capture_exception();  // LCOV_EXCL_LINE
+    }                           // LCOV_EXCL_LINE
   }  // end of #pragma omp parallel
 
   oem.rethrow_exception_if_any();

--- a/datatable/__init__.py
+++ b/datatable/__init__.py
@@ -17,6 +17,7 @@ from .types import stype, ltype
 from .utils.typechecks import TTypeError as TypeError
 from .utils.typechecks import TValueError as ValueError
 from .utils.typechecks import DatatableWarning
+from .str import split_into_nhot
 try:
     from .__git__ import __git_revision__
 except:
@@ -31,7 +32,8 @@ __all__ = ("__version__", "__git_revision__",
            "DataTable", "options",
            "bool8", "int8", "int16", "int32", "int64",
            "float32", "float64", "str32", "str64", "obj64",
-           "cbind", "rbind")
+           "cbind", "rbind",
+           "split_into_nhot")
 
 bool8 = stype.bool8
 int8 = stype.int8

--- a/datatable/str.py
+++ b/datatable/str.py
@@ -1,0 +1,20 @@
+#-------------------------------------------------------------------------------
+# Copyright 2018 H2O.ai
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#-------------------------------------------------------------------------------
+
+from datatable.lib._datatable import split_into_nhot
+
+
+__all__ = ["split_into_nhot"]

--- a/tests/munging/test_str.py
+++ b/tests/munging/test_str.py
@@ -15,6 +15,8 @@
 #-------------------------------------------------------------------------------
 import datatable as dt
 import pytest
+import random
+from datatable import stype
 
 
 
@@ -63,6 +65,23 @@ def test_split_into_nhot1():
     assert f1.topython() == fr.topython()
 
 
+def test_split_into_nhot_sep():
+    f0 = dt.Frame(["a|b|c", "b|a", "a|c"])
+    f1 = dt.split_into_nhot(f0, sep="|")
+    assert set(f1.names) == {"a", "b", "c"}
+    fr = dt.Frame(a=[1, 1, 1], b=[1, 1, 0], c=[1, 0, 1])
+    assert set(f1.names) == set(fr.names)
+    assert f1.topython() == fr[:, f1.names].topython()
+
+
+def test_split_into_nhot_quotes():
+    f0 = dt.split_into_nhot(dt.Frame(['foo, "bar, baz"']))
+    f1 = dt.split_into_nhot(dt.Frame(['foo, "bar, baz']))
+    assert set(f0.names) == {"foo", "bar, baz"}
+    assert set(f1.names) == {"foo", '"bar', "baz"}
+
+
+
 def test_split_into_nhot_bad():
     f0 = dt.Frame([[1.25], ["foo"], ["bar"]])
     with pytest.raises(ValueError) as e:
@@ -70,8 +89,39 @@ def test_split_into_nhot_bad():
     assert ("Function split_into_nhot() may only be applied to a single-column "
             "Frame of type string; got frame with 3 columns" == str(e.value))
 
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(TypeError) as e:
         dt.split_into_nhot(f0[:, 0])
     assert ("Function split_into_nhot() may only be applied to a single-column "
             "Frame of type string; received a column of type r8" ==
             str(e.value))
+
+    with pytest.raises(ValueError) as e:
+        dt.split_into_nhot(f0[:, 1], sep=",;-")
+    assert ("Parameter `sep` in split_into_nhot() must be a single character"
+            in str(e.value))
+
+
+@pytest.mark.parametrize("seed, st", [(random.getrandbits(32), stype.str32),
+                                      (random.getrandbits(32), stype.str64)])
+def test_split_into_nhot_long(seed, st):
+    random.seed(seed)
+    n = int(random.expovariate(0.0001) + 100)
+    col1 = [random.getrandbits(1) for _ in range(n)]
+    col2 = [random.getrandbits(1) for _ in range(n)]
+    col3 = [random.getrandbits(1) for _ in range(n)]
+    col4 = [0] * n
+    data = [",".join(["liberty"] * col1[i] +
+                     ["equality"] * col2[i] +
+                     ["justice"] * col3[i]) for i in range(n)]
+    i = random.randint(0, n - 1)
+    col4[i] = 1
+    data[i] += ", freedom"
+    f0 = dt.Frame(data, stype=st)
+    assert f0.stypes == (st,)
+    assert f0.shape == (n, 1)
+    f1 = dt.split_into_nhot(f0)
+    assert f1.shape == (n, 4)
+    fr = dt.Frame(liberty=col1, equality=col2, justice=col3, freedom=col4)
+    assert set(f1.names) == set(fr.names)
+    f1 = f1[..., fr.names]
+    assert f1.topython() == fr.topython()

--- a/tests/munging/test_str.py
+++ b/tests/munging/test_str.py
@@ -1,0 +1,77 @@
+#-------------------------------------------------------------------------------
+# Copyright 2018 H2O.ai
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#-------------------------------------------------------------------------------
+import datatable as dt
+import pytest
+
+
+
+#-------------------------------------------------------------------------------
+# split_into_nhot
+#-------------------------------------------------------------------------------
+
+def test_split_into_nhot0():
+    f0 = dt.Frame(["cat, dog, mouse, peacock, frog",
+                   "armadillo, fox, hedgehog",
+                   "dog, fox, mouse, cat, peacock",
+                   "horse, raccoon, cat, frog, dog"])
+    f1 = dt.split_into_nhot(f0)
+    f1.internal.check()
+    fr = dt.Frame({"cat":       [1, 0, 1, 1],
+                   "dog":       [1, 0, 1, 1],
+                   "mouse":     [1, 0, 1, 0],
+                   "peacock":   [1, 0, 1, 0],
+                   "frog":      [1, 0, 0, 1],
+                   "armadillo": [0, 1, 0, 0],
+                   "fox":       [0, 1, 1, 0],
+                   "hedgehog":  [0, 1, 0, 0],
+                   "horse":     [0, 0, 0, 1],
+                   "raccoon":   [0, 0, 0, 1]})
+    assert set(f1.names) == set(fr.names)
+    fr = fr[:, f1.names]
+    assert f1.names == fr.names
+    assert f1.stypes == (dt.stype.bool8, ) * f1.ncols
+    assert f1.shape == fr.shape
+    assert f1.topython() == fr.topython()
+
+
+def test_split_into_nhot1():
+    f0 = dt.Frame(["  meow  \n",
+                   "[ meow]",
+                   "['meow' ,purr]",
+                   '(\t"meow", \'purr\')',
+                   "{purr}"])
+    f1 = dt.split_into_nhot(f0)
+    f1.internal.check()
+    fr = dt.Frame(meow=[1, 1, 1, 1, 0], purr=[0, 0, 1, 1, 1])
+    assert set(f1.names) == set(fr.names)
+    fr = fr[..., f1.names]
+    assert f1.shape == fr.shape == (5, 2)
+    assert f1.stypes == (dt.stype.bool8, dt.stype.bool8)
+    assert f1.topython() == fr.topython()
+
+
+def test_split_into_nhot_bad():
+    f0 = dt.Frame([[1.25], ["foo"], ["bar"]])
+    with pytest.raises(ValueError) as e:
+        dt.split_into_nhot(f0)
+    assert ("Function split_into_nhot() may only be applied to a single-column "
+            "Frame of type string; got frame with 3 columns" == str(e.value))
+
+    with pytest.raises(ValueError) as e:
+        dt.split_into_nhot(f0[:, 0])
+    assert ("Function split_into_nhot() may only be applied to a single-column "
+            "Frame of type string; received a column of type r8" ==
+            str(e.value))


### PR DESCRIPTION
This PR adds a new function `dt.split_into_nhot(frame, sep)`, which acts upon an `n x 1` Frame (of str32 or str64 type) and produces an `n x k` Frame with boolean columns. Each value in the input column is split according to the provided separator, the whitespace is trimmed, and the resulting pieces are converted into individual columns in the output frame.

For example, frame
```
| cat,dog       |
| mouse         |
| cat,mouse     |
| dog,rooster   |
| mouse,dog,cat |
```
gets converted into
```
| cat  dog  mouse rooster |
|   1    1      0       0 |
|   0    0      1       0 |
|   1    0      1       0 |
|   0    1      0       1 |
|   1    1      1       0 |
```

Closes #1298 