### PR TITLE
Single-element getter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `Frame.cbind()` no longer returns anything (previously it returned self,
   but this was confusing w.r.t whether it modifies the target, or returns
   a modified copy).
+- `DT[i, j]` now returns a python scalar value if `i` is integer, and `j`
+  is integer/string. This is referred to as "explicit element selection".
+  In the unlikely scenario when a single element needs to be returned as
+  a frame, one can always write `DT[i:i+1, j]` or `DT[[i], j]`.
+- The performance of explicit element selection improved by a factor of 200x.
 
 #### Fixed
 - bug in dt.cbind() where the first Frame in the list was ignored.

--- a/c/column.cc
+++ b/c/column.cc
@@ -438,3 +438,4 @@ void VoidColumn::init_xbuf(Py_buffer*) {}
 Stats* VoidColumn::get_stats() const { return nullptr; }
 void VoidColumn::fill_na() {}
 RowIndex VoidColumn::join(const Column*) const { return RowIndex(); }
+py::oobj VoidColumn::get_value_at_index(int64_t) const { return py::oobj(); }

--- a/c/column.h
+++ b/c/column.h
@@ -211,6 +211,8 @@ public:
    */
   virtual void reify() = 0;
 
+  virtual py::oobj get_value_at_index(int64_t i) const = 0;
+
   virtual RowIndex join(const Column* keycol) const = 0;
 
   virtual void save_to_disk(const std::string&, WritableBuffer::Strategy);
@@ -401,6 +403,8 @@ public:
   PyObject* mean_pyscalar() const override;
   PyObject* sd_pyscalar() const override;
 
+  py::oobj get_value_at_index(int64_t i) const override;
+
   protected:
   BooleanStats* get_stats() const override;
 
@@ -458,6 +462,8 @@ public:
   PyObject* sd_pyscalar() const override;
   PyObject* skew_pyscalar() const override;
   PyObject* kurt_pyscalar() const override;
+
+  py::oobj get_value_at_index(int64_t i) const override;
 
 protected:
   IntegerStats<T>* get_stats() const override;
@@ -523,6 +529,8 @@ public:
   PyObject* skew_pyscalar() const override;
   PyObject* kurt_pyscalar() const override;
 
+  py::oobj get_value_at_index(int64_t i) const override;
+
 protected:
   RealStats<T>* get_stats() const override;
 
@@ -574,6 +582,8 @@ public:
   PyObjectColumn(int64_t nrows);
   PyObjectColumn(int64_t nrows, MemoryRange&&);
   virtual SType stype() const override;
+
+  py::oobj get_value_at_index(int64_t i) const override;
 
 protected:
   PyObjectColumn();
@@ -645,6 +655,8 @@ public:
 
   void verify_integrity(const std::string& name) const override;
 
+  py::oobj get_value_at_index(int64_t i) const override;
+
 protected:
   StringColumn();
   void init_data() override;
@@ -700,6 +712,7 @@ class VoidColumn : public Column {
     void apply_na_mask(const BoolColumn*) override;
     void replace_values(RowIndex, const Column*) override;
     RowIndex join(const Column* keycol) const override;
+    py::oobj get_value_at_index(int64_t i) const override;
   protected:
     VoidColumn();
     void init_data() override;

--- a/c/column_bool.cc
+++ b/c/column_bool.cc
@@ -16,6 +16,12 @@ SType BoolColumn::stype() const {
   return SType::BOOL;
 }
 
+py::oobj BoolColumn::get_value_at_index(int64_t i) const {
+  int64_t j = ri.nth(i);
+  int8_t x = elements_r()[j];
+  return ISNA(x)? py::None() : x? py::True() : py::False();
+}
+
 
 
 //------------------------------------------------------------------------------

--- a/c/column_int.cc
+++ b/c/column_int.cc
@@ -7,6 +7,7 @@
 //------------------------------------------------------------------------------
 #include "column.h"
 #include "csv/toa.h"
+#include "python/int.h"
 #include "py_types.h"
 #include "py_utils.h"
 #include "utils/omp.h"
@@ -19,6 +20,13 @@ SType IntColumn<T>::stype() const {
          sizeof(T) == 2? SType::INT16 :
          sizeof(T) == 4? SType::INT32 :
          sizeof(T) == 8? SType::INT64 : SType::VOID;
+}
+
+template <typename T>
+py::oobj IntColumn<T>::get_value_at_index(int64_t i) const {
+  int64_t j = (this->ri).nth(i);
+  T x = this->elements_r()[j];
+  return ISNA<T>(x)? py::None() : py::oint(x);
 }
 
 

--- a/c/column_pyobj.cc
+++ b/c/column_pyobj.cc
@@ -32,6 +32,12 @@ SType PyObjectColumn::stype() const {
   return SType::OBJ;
 }
 
+py::oobj PyObjectColumn::get_value_at_index(int64_t i) const {
+  int64_t j = (this->ri).nth(i);
+  PyObject* x = this->elements_r()[j];
+  return py::oobj(x);
+}
+
 
 // "PyObject" columns cannot be properly saved. So if somehow they were, then
 // when opening, we'll just fill the column with NAs.

--- a/c/column_real.cc
+++ b/c/column_real.cc
@@ -8,6 +8,7 @@
 #include "column.h"
 #include "csv/toa.h"
 #include "utils/omp.h"
+#include "python/float.h"
 #include "py_utils.h"
 
 
@@ -16,6 +17,13 @@ template <typename T>
 SType RealColumn<T>::stype() const {
   return sizeof(T) == 4? SType::FLOAT32 :
          sizeof(T) == 8? SType::FLOAT64 : SType::VOID;
+}
+
+template <typename T>
+py::oobj RealColumn<T>::get_value_at_index(int64_t i) const {
+  int64_t j = (this->ri).nth(i);
+  T x = this->elements_r()[j];
+  return ISNA<T>(x)? py::None() : py::ofloat(x);
 }
 
 

--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -31,6 +31,7 @@ extern void init_jay();
 
 namespace py {
   PyObject* fread_fn = nullptr;
+  PyObject* fallback_makedatatable = nullptr;
 }
 
 
@@ -101,6 +102,7 @@ PyObject* register_function(PyObject*, PyObject *args) {
   else if (n == 6) replace_dtWarning(fnref);
   else if (n == 7) py::Frame_Type = fnref;
   else if (n == 8) py::fread_fn = fnref;
+  else if (n == 9) py::fallback_makedatatable = fnref;
   else {
     throw ValueError() << "Incorrect function index: " << n;
   }

--- a/c/frame/cbind.cc
+++ b/c/frame/cbind.cc
@@ -1,9 +1,17 @@
 //------------------------------------------------------------------------------
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright 2018 H2O.ai
 //
-// © H2O.ai 2018
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //------------------------------------------------------------------------------
 #include "datatable.h"
 #include "frame/py_frame.h"

--- a/c/frame/getset.cc
+++ b/c/frame/getset.cc
@@ -1,0 +1,53 @@
+//------------------------------------------------------------------------------
+// Copyright 2018 H2O.ai
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//------------------------------------------------------------------------------
+#include "frame/py_frame.h"
+#include "python/tuple.h"
+
+namespace py {
+
+
+oobj Frame::m__getitem__(const obj item) const {
+
+  otuple args(5);
+  args.set(0, py::obj(this));
+  if (item.is_tuple()) {
+    otuple argslist = item.to_pytuple();
+    size_t n = argslist.size();
+    if (n == 1) {
+      args.set(1, py::None());
+      args.set(2, argslist[0]);
+    }
+    else if (n >= 2) {
+      args.set(1, argslist[0]);
+      args.set(2, argslist[1]);
+      if (n == 3) {
+        args.set(3, argslist[2]);
+      } else if (n >= 4) {
+        throw ValueError() << "Selector " << item << " is not supported";
+      }
+    }
+  } else {
+    args.set(1, py::None());
+    args.set(2, item);
+  }
+  if (!args[3]) args.set(3, py::None());
+  if (!args[4]) args.set(4, py::None());
+  return obj(py::fallback_makedatatable).call(args);
+}
+
+
+
+}  // namespace py

--- a/c/frame/names.cc
+++ b/c/frame/names.cc
@@ -1,9 +1,17 @@
 //------------------------------------------------------------------------------
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright 2018 H2O.ai
 //
-// © H2O.ai 2018
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //------------------------------------------------------------------------------
 #include "frame/py_frame.h"
 #include <unordered_set>

--- a/c/frame/py_frame.cc
+++ b/c/frame/py_frame.cc
@@ -1,9 +1,17 @@
 //------------------------------------------------------------------------------
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright 2018 H2O.ai
 //
-// © H2O.ai 2018
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //------------------------------------------------------------------------------
 #include "frame/py_frame.h"
 #include <iostream>

--- a/c/frame/py_frame.h
+++ b/c/frame/py_frame.h
@@ -66,7 +66,8 @@ class Frame : public PyObject {
     void m__dealloc__();
     void m__get_buffer__(Py_buffer* buf, int flags) const;
     void m__release_buffer__(Py_buffer* buf) const;
-    oobj m__getitem__(const obj item) const;
+    oobj m__getitem__(obj item);
+    void m__setitem__(obj item, obj value);
 
     oobj get_ncols() const;
     oobj get_nrows() const;
@@ -95,6 +96,7 @@ class Frame : public PyObject {
     void _dedup_and_save_names(NameProvider*);
     void _replace_names_from_map(py::odict);
     Error _name_not_found_error(const std::string& name);
+    oobj _getset(obj item, obj value);
 
     friend void pydatatable::_clear_types(pydatatable::obj*); // temp
     friend PyObject* pydatatable::check(pydatatable::obj*, PyObject*); // temp

--- a/c/frame/py_frame.h
+++ b/c/frame/py_frame.h
@@ -96,7 +96,11 @@ class Frame : public PyObject {
     void _dedup_and_save_names(NameProvider*);
     void _replace_names_from_map(py::odict);
     Error _name_not_found_error(const std::string& name);
-    oobj _getset(obj item, obj value);
+
+    // getitem / setitem support
+    oobj _fast_getset(obj item, obj value);
+    oobj _main_getset(obj item, obj value);
+    oobj _fallback_getset(obj item, obj value);
 
     friend void pydatatable::_clear_types(pydatatable::obj*); // temp
     friend PyObject* pydatatable::check(pydatatable::obj*, PyObject*); // temp

--- a/c/frame/py_frame.h
+++ b/c/frame/py_frame.h
@@ -1,9 +1,17 @@
 //------------------------------------------------------------------------------
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright 2018 H2O.ai
 //
-// © H2O.ai 2018
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //------------------------------------------------------------------------------
 #ifndef dt_FRAME_PYFRAME_h
 #define dt_FRAME_PYFRAME_h
@@ -58,6 +66,7 @@ class Frame : public PyObject {
     void m__dealloc__();
     void m__get_buffer__(Py_buffer* buf, int flags) const;
     void m__release_buffer__(Py_buffer* buf) const;
+    oobj m__getitem__(const obj item) const;
 
     oobj get_ncols() const;
     oobj get_nrows() const;
@@ -96,7 +105,7 @@ class Frame : public PyObject {
 
 extern PyObject* Frame_Type;
 extern PyObject* fread_fn;
-
+extern PyObject* fallback_makedatatable;
 
 }  // namespace py
 

--- a/c/frame/py_frame_init.cc
+++ b/c/frame/py_frame_init.cc
@@ -1,9 +1,17 @@
 //------------------------------------------------------------------------------
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright 2018 H2O.ai
 //
-// © H2O.ai 2018
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //------------------------------------------------------------------------------
 #include "frame/py_frame.h"
 #include <iostream>

--- a/c/python/ext_type.h
+++ b/c/python/ext_type.h
@@ -262,7 +262,7 @@ namespace _impl {
   template <typename T>
   PyObject* _safe_getitem(PyObject* self, PyObject* key) {
     try {
-      const T* tself = static_cast<const T*>(self);
+      T* tself = static_cast<T*>(self);
       py::oobj res = tself->m__getitem__(py::obj(key));
       return std::move(res).release();
     } catch (const std::exception& e) {
@@ -272,14 +272,14 @@ namespace _impl {
   }
 
   template <typename T>
-  PyObject* _safe_setitem(PyObject* self, PyObject* key, PyObject* val) {
+  int _safe_setitem(PyObject* self, PyObject* key, PyObject* val) {
     try {
       T* tself = static_cast<T*>(self);
       tself->m__setitem__(py::obj(key), py::obj(val));
-      Py_RETURN_NONE;
+      return 0;
     } catch (const std::exception& e) {
       exception_to_python(e);
-      return nullptr;
+      return -1;
     }
   }
 

--- a/c/python/ext_type.h
+++ b/c/python/ext_type.h
@@ -260,6 +260,30 @@ namespace _impl {
   }
 
   template <typename T>
+  PyObject* _safe_getitem(PyObject* self, PyObject* key) {
+    try {
+      T* tself = static_cast<T*>(self);
+      py::oobj res = tself->m__getitem__(py::obj(key));
+      return std::move(res).release();
+    } catch (const std::exception& e) {
+      exception_to_python(e);
+      return nullptr;
+    }
+  }
+
+  template <typename T>
+  PyObject* _safe_setitem(PyObject* self, PyObject* key, PyObject* val) {
+    try {
+      T* tself = static_cast<T*>(self);
+      tself->m__setitem__(py::obj(key), py::obj(val));
+      Py_RETURN_NONE;
+    } catch (const std::exception& e) {
+      exception_to_python(e);
+      return nullptr;
+    }
+  }
+
+  template <typename T>
   int _safe_getbuffer(PyObject* self, Py_buffer* buf, int flags) {
     try {
       T* tself = static_cast<T*>(self);
@@ -339,7 +363,9 @@ namespace _impl {
    *   has<T>::_init_   returns true if T has method `m__init__`
    *   has<T>::_repr_   returns true if T has method `m__repr__`
    *   has<T>::dealloc  returns true if T has method `m__dealloc__`
-   *   has<T>::mgs      returns true if T::Type has `init_methods_and_getsets`
+   *   has<T>::mthgtst  returns true if T::Type has `init_methods_and_getsets`
+   *   has<T>::getitem  returns true if T has method `m__getitem__`
+   *   has<T>::setitem  returns true if T has method `m__setitem__`
    */
   template <typename T>
   class has {
@@ -353,6 +379,10 @@ namespace _impl {
     template <class C> static long test_buf(...);
     template <class C> static char test_mgs(decltype(&C::Type::init_methods_and_getsets));
     template <class C> static long test_mgs(...);
+    template <class C> static char test_getitem(decltype(&C::m__getitem__));
+    template <class C> static long test_getitem(...);
+    template <class C> static char test_setitem(decltype(&C::m__setitem__));
+    template <class C> static long test_setitem(...);
 
   public:
     static constexpr bool _init_  = (sizeof(test_init<T>(nullptr)) == 1);
@@ -360,6 +390,8 @@ namespace _impl {
     static constexpr bool dealloc = (sizeof(test_dealloc<T>(nullptr)) == 1);
     static constexpr bool buffers = (sizeof(test_buf<T>(nullptr)) == 1);
     static constexpr bool mthgtst = (sizeof(test_mgs<T>(nullptr)) == 1);
+    static constexpr bool getitem = (sizeof(test_getitem<T>(nullptr)) == 1);
+    static constexpr bool setitem = (sizeof(test_setitem<T>(nullptr)) == 1);
   };
 
   /**
@@ -377,6 +409,8 @@ namespace _impl {
     static void _repr_(PyTypeObject&) {}
     static void buffers(PyTypeObject&) {}
     static void methods_and_getsets(PyTypeObject&) {}
+    static void getitem(PyTypeObject&) {}
+    static void setitem(PyTypeObject&) {}
   };
 
   template <typename T>
@@ -409,6 +443,25 @@ namespace _impl {
       if (mm) type.tp_methods = mm.finalize();
       if (gs) type.tp_getset = gs.finalize();
     }
+
+    static void getitem(PyTypeObject& type) {
+      init_tp_as_mapping(type);
+      type.tp_as_mapping->mp_subscript = _safe_getitem<T>;
+    }
+
+    static void setitem(PyTypeObject& type) {
+      init_tp_as_mapping(type);
+      type.tp_as_mapping->mp_ass_subscript = _safe_setitem<T>;
+    }
+
+    private:
+      static void init_tp_as_mapping(PyTypeObject& type) {
+        if (type.tp_as_mapping) return;
+        type.tp_as_mapping = new PyMappingMethods;
+        type.tp_as_mapping->mp_length = nullptr;
+        type.tp_as_mapping->mp_subscript = nullptr;
+        type.tp_as_mapping->mp_ass_subscript = nullptr;
+      }
   };
 
 }  // namespace _impl
@@ -443,11 +496,13 @@ void ExtType<T>::init(PyObject* module) {
   type.tp_alloc     = &PyType_GenericAlloc;
   type.tp_new       = &PyType_GenericNew;
 
-  _impl::init<T, _impl::has<T>::_init_>::_init_(type);
-  _impl::init<T, _impl::has<T>::_repr_>::_repr_(type);
+  _impl::init<T, _impl::has<T>::_init_ >::_init_(type);
+  _impl::init<T, _impl::has<T>::_repr_ >::_repr_(type);
   _impl::init<T, _impl::has<T>::dealloc>::dealloc(type);
   _impl::init<T, _impl::has<T>::buffers>::buffers(type);
   _impl::init<T, _impl::has<T>::mthgtst>::methods_and_getsets(type);
+  _impl::init<T, _impl::has<T>::getitem>::getitem(type);
+  _impl::init<T, _impl::has<T>::setitem>::setitem(type);
 
   // Finish type initialization
   int r = PyType_Ready(&type);

--- a/c/python/ext_type.h
+++ b/c/python/ext_type.h
@@ -262,7 +262,7 @@ namespace _impl {
   template <typename T>
   PyObject* _safe_getitem(PyObject* self, PyObject* key) {
     try {
-      T* tself = static_cast<T*>(self);
+      const T* tself = static_cast<const T*>(self);
       py::oobj res = tself->m__getitem__(py::obj(key));
       return std::move(res).release();
     } catch (const std::exception& e) {

--- a/c/python/float.cc
+++ b/c/python/float.cc
@@ -44,6 +44,10 @@ ofloat::ofloat(double src) {
   v = PyFloat_FromDouble(src);  // new ref
 }
 
+ofloat::ofloat(float src) {
+  v = PyFloat_FromDouble(static_cast<double>(src));  // new ref
+}
+
 
 
 //------------------------------------------------------------------------------

--- a/c/python/float.h
+++ b/c/python/float.h
@@ -20,6 +20,7 @@ class ofloat : public oobj {
   public:
     ofloat();
     ofloat(double x);
+    ofloat(float x);
 
     ofloat(const ofloat&);
     ofloat(ofloat&&);

--- a/c/python/obj.cc
+++ b/c/python/obj.cc
@@ -390,6 +390,15 @@ py::olist _obj::to_pylist(const error_manager& em) const {
 }
 
 
+py::otuple _obj::to_pytuple(const error_manager& em) const {
+  if (is_none()) return py::otuple(nullptr);
+  if (is_tuple()) {
+    return py::otuple(v);
+  }
+  throw em.error_not_list(v);
+}
+
+
 char** _obj::to_cstringlist(const error_manager&) const {
   if (v == Py_None) {
     return nullptr;

--- a/c/python/obj.cc
+++ b/c/python/obj.cc
@@ -682,8 +682,7 @@ oobj None()     { return oobj(Py_None); }
 oobj True()     { return oobj(Py_True); }
 oobj False()    { return oobj(Py_False); }
 oobj Ellipsis() { return oobj(Py_Ellipsis); }
-obj rnone() { return obj(Py_None); }
-
+obj rnone()     { return obj(Py_None); }
 
 
 //------------------------------------------------------------------------------

--- a/c/python/obj.h
+++ b/c/python/obj.h
@@ -186,6 +186,7 @@ class _obj {
     char**      to_cstringlist   (const error_manager& = _em0) const;
     strvec      to_stringlist    (const error_manager& = _em0) const;
     py::olist   to_pylist        (const error_manager& = _em0) const;
+    py::otuple  to_pytuple       (const error_manager& = _em0) const;
     py::odict   to_pydict        (const error_manager& = _em0) const;
     py::orange  to_pyrange       (const error_manager& = _em0) const;
     py::oiter   to_pyiter        (const error_manager& = _em0) const;

--- a/c/python/tuple.cc
+++ b/c/python/tuple.cc
@@ -16,6 +16,8 @@ namespace py {
 
 otuple::otuple() : oobj(nullptr) {}
 
+otuple::otuple(PyObject* v) : oobj(v) {}
+
 otuple::otuple(int n) : otuple(static_cast<int64_t>(n)) {}
 
 otuple::otuple(size_t n) : otuple(static_cast<int64_t>(n)) {}

--- a/c/python/tuple.h
+++ b/c/python/tuple.h
@@ -61,6 +61,10 @@ class otuple : public oobj {
     void replace(int64_t i, oobj&& value);
     void replace(size_t i,  oobj&& value);
     void replace(int i,     oobj&& value);
+
+  private:
+    otuple(PyObject*);
+    friend class _obj;
 };
 
 

--- a/c/rowindex.h
+++ b/c/rowindex.h
@@ -226,7 +226,7 @@ class RowIndex {
     size_t zlength() const { return static_cast<size_t>(length()); }
     int64_t min() const { return impl? impl->min : 0; }
     int64_t max() const { return impl? impl->max : 0; }
-    int64_t nth(int64_t i) const { return impl? impl->nth(i) : 0; }
+    int64_t nth(int64_t i) const { return impl? impl->nth(i) : i; }
     const int32_t* indices32() const { return impl_asarray()->indices32(); }
     const int64_t* indices64() const { return impl_asarray()->indices64(); }
     int64_t slice_start() const { return impl_asslice()->start; }

--- a/c/str/split_into_nhot.cc
+++ b/c/str/split_into_nhot.cc
@@ -1,9 +1,17 @@
 //------------------------------------------------------------------------------
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright 2018 H2O.ai
 //
-// © H2O.ai 2018
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //------------------------------------------------------------------------------
 #include "str/py_str.h"
 #include <unordered_map>

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -263,20 +263,6 @@ class Frame(core.Frame):
         return res
 
 
-    def __getitem__(self, item):
-        """
-        Simpler version than __call__, but allows slice literals.
-
-        Example:
-            df[5]        # 6-th column
-            df[5, :]     # 6-th row
-            df[:10, -1]  # first 10 rows of the last column
-            df[::-1, :]  # all rows of the Frame in reverse order
-        etc.
-        """
-        return make_datatable(self, *resolve_selector(item))
-
-
     def __setitem__(self, item, value):
         """
         Update values in Frame, in-place.
@@ -592,6 +578,7 @@ class Frame(core.Frame):
 core.register_function(4, TTypeError)
 core.register_function(5, TValueError)
 core.register_function(7, Frame)
+core.register_function(9, make_datatable)
 core.install_buffer_hooks(Frame())
 
 

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -16,7 +16,7 @@ from datatable.nff import save as dt_save
 from datatable.utils.misc import plural_form as plural
 from datatable.utils.misc import load_module
 from datatable.utils.typechecks import (TTypeError, TValueError)
-from datatable.graph import make_datatable, resolve_selector
+from datatable.graph import make_datatable
 from datatable.csv import write_csv
 from datatable.options import options
 from datatable.types import stype
@@ -261,29 +261,6 @@ class Frame(core.Frame):
         if timeit:
             print("Time taken: %d ms" % (1000 * (time.time() - time0)))
         return res
-
-
-    def __setitem__(self, item, value):
-        """
-        Update values in Frame, in-place.
-        """
-        return make_datatable(self, *resolve_selector(item),
-                              mode="update", replacement=value)
-
-
-    def __delitem__(self, item):
-        """
-        Delete columns / rows from the Frame.
-
-        Example:
-            del df["colA"]
-            del df[:, ["A", "B"]]
-            del df[::2]
-            del df["col5":"col9"]
-            del df[(i for i in range(df.ncols) if i % 3 <= 1)]
-        """
-        return make_datatable(self, *resolve_selector(item),
-                              mode="delete")
 
 
     def _delete_columns(self, cols):

--- a/datatable/graph/__init__.py
+++ b/datatable/graph/__init__.py
@@ -16,8 +16,7 @@ from datatable.expr import BaseExpr
 from datatable.lib import core
 from datatable.utils.typechecks import TValueError
 
-__all__ = ("make_datatable",
-           "resolve_selector",
+__all__ = ("make_datatable", "f", "g", "join",
            "SliceCSNode")
 
 
@@ -112,27 +111,3 @@ def make_datatable(dt, rows, select, groupby=None, join=None, sort=None,
         return res_dt
 
     raise RuntimeError("Unable to calculate the result")  # pragma: no cover
-
-
-
-
-def resolve_selector(item):
-    rows = None
-    grby = None
-    jointo = None
-    if isinstance(item, tuple):
-        if len(item) == 1:
-            cols = item[0]
-        elif len(item) == 2:
-            rows, cols = item
-        elif len(item) == 3:
-            rows, cols, x = item
-            if isinstance(x, join):
-                jointo = x
-            else:
-                grby = x
-        else:
-            raise TValueError("Selector %r is not supported" % (item, ))
-    else:
-        cols = item
-    return (rows, cols, grby, jointo)

--- a/datatable/graph/__init__.py
+++ b/datatable/graph/__init__.py
@@ -31,6 +31,9 @@ def make_datatable(dt, rows, select, groupby=None, join=None, sort=None,
     evaluating various transformations when they are applied to a target
     Frame.
     """
+    if isinstance(groupby, datatable.join):
+        join = groupby
+        groupby = None
     update_mode = mode == "update"
     delete_mode = mode == "delete"
     jframe = join.joinframe if join else None


### PR DESCRIPTION
- `DT[i, j]` now returns a python scalar value if `i` is integer, and `j` is integer/string. This is referred to as "explicit element selection". In the unlikely scenario when a single element needs to be returned as a frame, one can always write `DT[i:i+1, j]` or `DT[[i], j]`.
- The performance of explicit element selection improved by a factor of 200x.

Closes #1306