### PR TITLE
Added abs() function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   and then convert them into a set of indicator variables ("n-hot encode").
 - ability to convert object columns into strings.
 - implemented `Frame.replace()` function.
+- function `abs()` to find the absolute value of elements in the frame.
 
 #### Changed
 - `names` argument in `Frame()` constructor can no longer be a string --

--- a/c/expr/unaryop.cc
+++ b/c/expr/unaryop.cc
@@ -16,6 +16,7 @@ enum OpCode {
   Minus  = 2,
   Plus   = 3,
   Invert = 4,
+  Abs    = 5,
 };
 
 
@@ -60,6 +61,16 @@ inline static int8_t op_isna(T x) {
   return ISNA<T>(x);
 }
 
+template <typename T>
+inline static T op_abs(T x) {
+  // If T is floating point and x is NA, then (x < 0) will evaluate to false;
+  // If T is integer and x is NA, then (x < 0) will be true, but -x will be
+  // equal to x.
+  // Thus, in all cases we'll have `abs(NA) == NA`.
+  return (x < 0) ? -x : x;
+}
+
+
 template<typename T>
 struct Inverse {
   inline static T impl(T x) {
@@ -92,6 +103,7 @@ static mapperfn resolve1(int opcode) {
   switch (opcode) {
     case IsNa:    return map_n<IT, int8_t, op_isna<IT>>;
     case Minus:   return map_n<IT, IT, op_minus<IT>>;
+    case Abs:     return map_n<IT, IT, op_abs<IT>>;
     case Invert:
       if (std::is_floating_point<IT>::value) return nullptr;
       return map_n<IT, IT, Inverse<IT>::impl>;

--- a/datatable/__init__.py
+++ b/datatable/__init__.py
@@ -8,7 +8,7 @@
 from .__version__ import version as __version__
 from .dt_append import rbind, cbind
 from .frame import Frame
-from .expr import mean, min, max, sd, isna, sum, count, first
+from .expr import mean, min, max, sd, isna, sum, count, first, abs
 from .fread import fread, GenericReader, FreadWarning
 from .graph import f, g, join
 from .nff import save, open
@@ -27,7 +27,7 @@ except:
 __all__ = ("__version__", "__git_revision__",
            "Frame", "max", "mean", "min", "open", "sd", "sum", "count", "first",
            "isna", "fread", "GenericReader", "save", "stype", "ltype", "f", "g",
-           "join",
+           "join", "abs",
            "TypeError", "ValueError", "DatatableWarning", "FreadWarning",
            "DataTable", "options",
            "bool8", "int8", "int16", "int32", "int64",

--- a/datatable/expr/__init__.py
+++ b/datatable/expr/__init__.py
@@ -6,6 +6,7 @@
 #-------------------------------------------------------------------------------
 
 from datatable.graph.dtproxy import f
+from .abs_expr import abs
 from .base_expr import BaseExpr
 from .binary_expr import BinaryOpExpr
 from .cast_expr import CastExpr
@@ -20,6 +21,7 @@ from .sd_expr import StdevReducer, sd
 from .unary_expr import UnaryOpExpr
 
 __all__ = (
+    "abs",
     "max",
     "mean",
     "min",

--- a/datatable/expr/abs_expr.py
+++ b/datatable/expr/abs_expr.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+#-------------------------------------------------------------------------------
+# Copyright 2018 H2O.ai
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#-------------------------------------------------------------------------------
+from .base_expr import BaseExpr
+from .unary_expr import UnaryOpExpr
+from datatable.graph.dtproxy import f
+from datatable.lib import core
+
+__all__ = ("abs", )
+
+_builtin_abs = abs
+
+def abs(x):
+    if isinstance(x, BaseExpr):
+        return UnaryOpExpr("abs", x)
+    if isinstance(x, core.Frame):
+        return x[:, {col: UnaryOpExpr("abs", f[col])
+                     for col in x.names}]
+    if x is None:
+        return None
+    return _builtin_abs(x)

--- a/datatable/expr/consts.py
+++ b/datatable/expr/consts.py
@@ -132,6 +132,7 @@ for st in stype_bool | stype_int:
 for st in stype_int | stype_float:
     unary_ops_rules[("-", st)] = st
     unary_ops_rules[("+", st)] = st
+    unary_ops_rules[("abs", st)] = st
 
 # Synchronize with OpCode in c/expr/unaryop.cc
 unary_op_codes = {
@@ -140,6 +141,7 @@ unary_op_codes = {
     "+": 3,
     "~": 4,
     "!": 4,  # same as '~'
+    "abs": 5,
 }
 
 

--- a/datatable/expr/unary_expr.py
+++ b/datatable/expr/unary_expr.py
@@ -21,7 +21,7 @@ class UnaryOpExpr(BaseExpr):
         self._arg = arg
 
     def is_reduce_expr(self, ee):
-        return self._arg.is_reduce_expr(arg)
+        return self._arg.is_reduce_expr(ee)
 
     def resolve(self):
         self._arg.resolve()

--- a/tests/test_dt_expr.py
+++ b/tests/test_dt_expr.py
@@ -229,6 +229,41 @@ def test_dt_isna(src):
 
 
 #-------------------------------------------------------------------------------
+# abs()
+#-------------------------------------------------------------------------------
+
+def test_abs():
+    from datatable import abs
+    assert abs(1) == 1
+    assert abs(-5) == 5
+    assert abs(-2.5e12) == 2.5e12
+    assert abs(None) is None
+
+
+@pytest.mark.parametrize("src", dt_int + dt_float)
+def test_abs_srcs(src):
+    dt0 = dt.Frame(src)
+    dt1 = dt.abs(dt0)
+    dt1.internal.check()
+    assert dt0.stypes == dt1.stypes
+    pyans = [None if x is None else abs(x) for x in src]
+    assert dt1.topython()[0] == pyans
+
+
+def test_abs_all_stypes():
+    from datatable import abs
+    src = [[-127, -5, -1, 0, 2, 127],
+           [-32767, -299, -7, 32767, 12, -543],
+           [-2147483647, -1000, 3, -589, 2147483647, 0],
+           [-2**63 + 1, 2**63 - 1, 0, -2**32, 2**32, -793]]
+    dt0 = dt.Frame(src, stypes=[dt.int8, dt.int16, dt.int32, dt.int64])
+    dt1 = dt0[:, [abs(f[i]) for i in range(4)]]
+    dt1.internal.check()
+    assert dt1.topython() == [[abs(x) for x in col] for col in src]
+
+
+
+#-------------------------------------------------------------------------------
 # type-cast
 #-------------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR adds `abs()` function, exported from the `datatable` namespace, to compute the absolute value of columns in a Frame. This function can safely replace the builtin python `abs()`. Use as follows:
```python
>>> import datatable as dt
>>> from datatable import f, abs
>>> DT = dt.Frame(X=[-3, 4, 1], Y = [7, 0, 6])
>>> DT1 = DT[:, abs(f.X - f.Y)]  # absolute value of difference between columns X and Y
```

Closes #1323