### PR TITLE
Improve handling of Excel files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - ability to convert object columns into strings.
 - implemented `Frame.replace()` function.
 - function `abs()` to find the absolute value of elements in the frame.
+- improved handling of Excel files by fread:
+  * sheet name can now be used as a path component in the file name,
+    causing only that particular sheet to be parsed;
+  * further, a cell range can be specified as a path component after the
+    sheet name, forcing fread to consider only the provided cell range;
+  * fread can now handle the situation when a spreadsheet has multiple
+    separate tables in the same sheet. They will now be detected automatically
+    and returned to the user as separate Frame objects (the name of each
+    frame will contain the sheet name and cell range from where the data was
+    extracted).
 
 #### Changed
 - `names` argument in `Frame()` constructor can no longer be a string --

--- a/c/frame/py_frame_init.cc
+++ b/c/frame/py_frame_init.cc
@@ -148,9 +148,20 @@ class FrameInitializationManager {
   //----------------------------------------------------------------------------
   private:
     void init_empty_frame() {
-      check_names_count(0);
-      check_stypes_count(0);
-      make_datatable(nullptr);
+      if (defined_names) {
+        if (!names_arg.is_list_or_tuple()) check_names_count(0);
+        size_t ncols = names_arg.to_pylist().size();
+        check_stypes_count(ncols);
+        py::olist empty_list(0);
+        for (size_t i = 0; i < ncols; ++i) {
+          SType s = get_stype_for_column(i);
+          make_column(empty_list, s);
+        }
+        make_datatable(names_arg);
+      } else {
+        check_stypes_count(0);
+        make_datatable(nullptr);
+      }
     }
 
 

--- a/datatable/fread.py
+++ b/datatable/fread.py
@@ -24,6 +24,7 @@ from datatable.utils.misc import (normalize_slice, normalize_range,
                                   humanize_bytes)
 from datatable.utils.misc import plural_form as plural
 from datatable.types import stype, ltype
+from datatable.xls import read_xls_workbook
 
 
 _log_color = term.bright_black
@@ -392,39 +393,11 @@ class GenericReader(object):
                 self.logger.debug("Extracted: size = %d" % len(self._text))
 
         elif ext == ".xlsx" or ext == ".xls":
-            self._process_excel_file(filename)
+            self._result = read_xls_workbook(filename, subpath)
 
         else:
             self._file = filename
 
-
-    def _process_excel_file(self, filename):
-        try:
-            import xlrd
-        except ImportError:
-            raise TValueError("Module `xlrd` is required in order to read "
-                              "Excel file '%s'. You can install this module "
-                              "by running `pip install xlrd` in the command "
-                              "line." % filename)
-        if self._result is None:
-            self._result = {}
-        wb = xlrd.open_workbook(filename)
-        for ws in wb.sheets():
-            # If the worksheet is empty, skip it
-            if ws.ncols == 0:
-                continue
-            # Assume first row contains headers
-            colnames = ws.row_values(0)
-            cols0 = [core.column_from_list(ws.col_values(i, start_rowx=1),
-                                           -stype.str32.value)
-                     for i in range(ws.ncols)]
-            colset = core.columns_from_columns(cols0)
-            res = colset.to_frame(colnames)
-            self._result[ws.name] = res
-        if len(self._result) == 0:
-            self._result = None
-        if len(self._result) == 1:
-            self._result = [*self._result.values()][0]
 
 
     #---------------------------------------------------------------------------

--- a/datatable/xls.py
+++ b/datatable/xls.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+#-------------------------------------------------------------------------------
+# Copyright 2018 H2O.ai
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#-------------------------------------------------------------------------------
+import datatable as dt
+import re
+from datatable.utils.typechecks import TValueError
+
+
+
+def read_xls_workbook(filename, subpath):
+    try:
+        import xlrd
+    except ImportError:
+        raise TValueError("Module `xlrd` is required in order to read "
+                          "Excel file '%s'" % filename)
+
+    if subpath:
+        wb = xlrd.open_workbook(filename, on_demand=True, ragged_rows=True)
+        range2d = None
+        if subpath in wb.sheet_names():
+            sheetname = subpath
+        else:
+            if "/" in subpath:
+                sheetname, xlsrange = subpath.rsplit('/', 1)
+                range2d = _excel_coords_to_range2d(xlsrange)
+            if not(sheetname in wb.sheet_names() and range2d is not None):
+                raise TValueError("Sheet `%s` is not found in the XLS file"
+                                  % subpath)
+        ws = wb.sheet_by_name(sheetname)
+        result = read_xls_worksheet(ws, range2d)
+    else:
+        wb = xlrd.open_workbook(filename, ragged_rows=True)
+        result = {}
+        for ws in wb.sheets():
+            out = read_xls_worksheet(ws)
+            if out is None:
+                continue
+            for i, frame in out.items():
+                result["%s/%s" % (ws.name, i)] = frame
+
+    if len(result) == 0:
+        return None
+    elif len(result) == 1:
+        for v in result.values():
+            return v
+    else:
+        return result
+
+
+
+def read_xls_worksheet(ws, subrange=None):
+    # Get the worksheet's internal data arrays directly, for efficienct
+    values = ws._cell_values
+    types = ws._cell_types
+    assert len(values) == len(types)
+    # If the worksheet is empty, skip it
+    if not values:
+        return None
+
+    if subrange is None:
+        ranges2d = _combine_ranges([_parse_row(values[i], types[i])
+                                    for i in range(len(values))])
+        ranges2d.sort(key=lambda x: -(x[1] - x[0]) * (x[3] - x[2]))
+    else:
+        ranges2d = [subrange]
+
+    results = {}
+    for range2d in ranges2d:
+        row0, row1, col0, col1 = range2d
+        ncols = col1 - col0
+        if row0 < len(values):
+            colnames = [str(n) for n in values[row0][col0:col1]]
+            if len(colnames) < ncols:
+                colnames += [None] * (ncols - len(colnames))
+        else:
+            colnames = [None] * ncols
+        rowdata = []
+        if row1 > len(values):
+            values += [[]] * (row1 - len(values))
+        for irow in range(row0 + 1, row1):
+            vv = values[irow]
+            row = tuple(vv[col0:col1])
+            if len(row) < ncols:
+                row += (None,) * (ncols - len(row))
+            rowdata.append(row)
+        frame = dt.Frame(rowdata, names=colnames)
+        results[_range2d_to_excel_coords(range2d)] = frame
+    return results
+
+
+
+def _parse_row(rowvalues, rowtypes):
+    """
+    Scan a single row from an Excel file, and return the list of ranges
+    corresponding to each consecutive span of non-empty cells in this row.
+    If all cells are empty, return an empty list. Each "range" in the list
+    is a tuple of the form `(startcol, endcol)`.
+
+    For example, if the row is the following:
+
+        [ ][ 1.0 ][ 23 ][ "foo" ][ ][ "hello" ][ ]
+
+    then the returned list of ranges will be:
+
+        [(1, 4), (5, 6)]
+
+    This algorithm considers a cell to be empty if its type is 0 (XL_EMPTY),
+    or 6 (XL_BLANK), or if it's a text cell containing empty string, or a
+    whitespace-only string. Numeric `0` is not considered empty.
+    """
+    n = len(rowvalues)
+    assert n == len(rowtypes)
+    if not n:
+        return []
+    range_start = None
+    ranges = []
+    for i in range(n):
+        ctype = rowtypes[i]
+        cval = rowvalues[i]
+        # Check whether the cell is empty or not. If it is empty, and there is
+        # an active range being tracked - terminate it. On the other hand, if
+        # the cell is not empty and there isn't an active range, then start it.
+        if ctype == 0 or ctype == 6 or (ctype == 1 and
+                                        (cval == "" or cval.isspace())):
+            if range_start is not None:
+                ranges.append((range_start, i))
+                range_start = None
+        else:
+            if range_start is None:
+                range_start = i
+    if range_start is not None:
+        ranges.append((range_start, n))
+    return ranges
+
+
+def _combine_ranges(ranges):
+    """
+    This function takes a list of row-ranges (as returned by `_parse_row`)
+    ordered by rows, and produces a list of distinct rectangular ranges
+    within this grid.
+
+    Within this function we define a 2d-range as a rectangular set of cells
+    such that:
+      - there are no empty rows / columns within this rectangle;
+      - the rectangle is surrounded by empty rows / columns on all sides;
+      - no subset of this rectangle comprises a valid 2d-range;
+      - separate 2d-ranges are allowed to touch at a corner.
+    """
+    ranges2d = []
+    for irow, rowranges in enumerate(ranges):
+        ja = 0
+        jc = 0
+        while jc < len(rowranges):
+            ccol0, ccol1 = rowranges[jc]
+            if ja < len(ranges2d):
+                arow0, arow1, acol0, acol1 = ranges2d[ja]
+                if arow1 < irow:
+                    ja += 1
+                    continue
+                assert arow1 == irow or arow1 == irow + 1
+            else:
+                acol0 = acol1 = 1000000000
+
+            if ccol0 == acol0 and ccol1 == acol1:
+                ranges2d[ja][1] = irow + 1
+                ja += 1
+                jc += 1
+            elif ccol1 <= acol0:
+                ranges2d.insert(ja, [irow, irow + 1, ccol0, ccol1])
+                ja += 1
+                jc += 1
+            elif ccol0 >= acol1:
+                ja += 1
+            else:
+                assert ja < len(ranges2d)
+                ranges2d[ja][1] = irow + 1
+                if ccol0 < acol0:
+                    ranges2d[ja][2] = ccol0
+                if ccol1 > acol1:
+                    ranges2d[ja][3] = acol1 = ccol1
+                    jn = 0
+                    while jn < len(ranges2d):
+                        if jn == ja:
+                            jn += 1
+                            continue
+                        nrow0, nrow1, ncol0, ncol1 = ranges2d[jn]
+                        if ncol0 <= acol1 and nrow1 >= arow0 and \
+                                not(ncol0 == acol1 and nrow1 == arow0):
+                            ranges2d[ja][0] = arow0 = min(arow0, nrow0)
+                            ranges2d[ja][3] = acol1 = max(acol1, ncol1)
+                            del ranges2d[jn]
+                            if jn < ja:
+                                ja -= 1
+                        else:
+                            jn += 1
+                jc += 1
+    return ranges2d
+
+
+def _range2d_to_excel_coords(range2d):
+    def colname(i):
+        r = ""
+        while i >= 0:
+            r = chr(ord('A') + i % 26) + r
+            i = (i // 26) - 1
+        return r
+
+    row0, row1, col0, col1 = range2d
+    return "%s%d:%s%d" % (colname(col0), row0 + 1,
+                          colname(col1 - 1), row1)
+
+
+def _excel_coords_to_range2d(ec):
+    def colindex(n):
+        i = 0
+        for c in n:
+            i = i * 26 + (ord(c) - ord('A')) + 1
+        return i - 1
+
+    mm = re.match("([A-Z]+)(\d+):([A-Z]+)(\d+)", ec)
+    if not mm:
+        return None
+    row0 = int(mm.group(2)) - 1
+    row1 = int(mm.group(4))
+    col0 = colindex(mm.group(1))
+    col1 = colindex(mm.group(3)) + 1
+    if row0 > row1:
+        row0, row1 = row1, row0
+    if col0 > col1:
+        col0, col1 = col1, col0
+    return (row0, row1, col0, col1)

--- a/tests/test_dt_create.py
+++ b/tests/test_dt_create.py
@@ -137,11 +137,14 @@ def test_create_from_empty_list_with_params():
     assert d1.shape == (0, 0)
 
 
+def test_create_from_nothing_with_names():
+    d0 = dt.Frame(names=["A", "B"])
+    d0.internal.check()
+    assert d0.shape == (0, 2)
+    assert d0.names == ("A", "B")
+
+
 def test_create_from_empty_list_bad():
-    with pytest.raises(ValueError) as e:
-        dt.Frame([], names=["A"])
-    assert ("The `names` argument contains 1 element, which is more than the "
-            "number of columns being created (0)" in str(e.value))
     with pytest.raises(ValueError) as e:
         dt.Frame([], stypes=["int32", "str32"])
     assert ("The `stypes` argument contains 2 elements, which is more than the "


### PR DESCRIPTION
* sheet name can now be used as a path component in the file name, causing only that particular sheet to be parsed;
* further, a cell range can be specified as a path component after the sheet name, forcing fread to consider only the provided cell range. For example, the following request is now valid:
   ``` 
   dt.fread("../h2oai/tests/data/diabetes_tiny_two_sheets.xlsx/Sheet1/A10:BC30")   
   ```
* fread can now handle the situation when a spreadsheet has multiple separate tables in the same sheet. They will now be detected automatically and returned to the user as separate Frame objects (the name of each frame will contain the sheet name and cell range from where the data was extracted).