### PR TITLE
Do proper N/A handling in 1D and 2D

### DIFF
--- a/c/extras/aggregator.cc
+++ b/c/extras/aggregator.cc
@@ -245,7 +245,7 @@ void Aggregator::group_2d(const DataTablePtr& dt, DataTablePtr& dt_members) {
 */
 void Aggregator::group_1d_continuous(const DataTablePtr& dt,
                                      DataTablePtr& dt_members) {
-  const auto c0 = static_cast<RealColumn<double>*>(dt->columns[0]);
+  auto c0 = static_cast<const RealColumn<double>*>(dt->columns[0]);
   const double* d_c0 = c0->elements_r();
   auto d_members = static_cast<int32_t*>(dt_members->columns[0]->data_w());
 
@@ -268,8 +268,8 @@ void Aggregator::group_1d_continuous(const DataTablePtr& dt,
 */
 void Aggregator::group_2d_continuous(const DataTablePtr& dt,
                                      DataTablePtr& dt_members) {
-  const auto c0 = static_cast<RealColumn<double>*>(dt->columns[0]);
-  const auto c1 = static_cast<RealColumn<double>*>(dt->columns[1]);
+  auto c0 = static_cast<const RealColumn<double>*>(dt->columns[0]);
+  auto c1 = static_cast<const RealColumn<double>*>(dt->columns[1]);
   const double* d_c0 = c0->elements_r();
   const double* d_c1 = c1->elements_r();
   auto d_members = static_cast<int32_t*>(dt_members->columns[0]->data_w());
@@ -349,8 +349,8 @@ void Aggregator::group_2d_categorical (const DataTablePtr& dt,
 template<typename T0, typename T1>
 void Aggregator::group_2d_categorical_str(const DataTablePtr& dt,
                                           DataTablePtr& dt_members) {
-  const auto c0 = static_cast<StringColumn<T0>*>(dt->columns[0]);
-  const auto c1 = static_cast<StringColumn<T1>*>(dt->columns[1]);
+  auto c0 = static_cast<const StringColumn<T0>*>(dt->columns[0]);
+  auto c1 = static_cast<const StringColumn<T1>*>(dt->columns[1]);
   const T0* d_c0 = c0->offsets();
   const T1* d_c1 = c1->offsets();
 
@@ -419,7 +419,7 @@ void Aggregator::group_2d_mixed (bool cont_index, const DataTablePtr& dt,
 template<typename T>
 void Aggregator::group_2d_mixed_str (bool cont_index, const DataTablePtr& dt,
                                      DataTablePtr& dt_members) {
-  const auto c_cat = static_cast<StringColumn<T>*>(dt->columns[!cont_index]);
+  auto c_cat = static_cast<const StringColumn<T>*>(dt->columns[!cont_index]);
   const T* d_cat = c_cat->offsets();
 
   arr32_t cols(1);

--- a/c/extras/aggregator.h
+++ b/c/extras/aggregator.h
@@ -46,24 +46,27 @@ class Aggregator {
     unsigned int nthreads;
     PyObject* progress_fn;
 
-    // Grouping and aggregating functions
+    // Grouping and aggregating methods
     void group_0d(const DataTable*, DataTablePtr&);
-    void group_1d(DataTablePtr&, DataTablePtr&);
-    void group_2d(DataTablePtr&, DataTablePtr&);
-    void group_nd(DataTablePtr&, DataTablePtr&);
-    void test(DataTablePtr&, DataTablePtr&);
-    void group_1d_continuous(DataTablePtr&, DataTablePtr&);
-    void group_2d_continuous(DataTablePtr&, DataTablePtr&);
-    void group_1d_categorical(DataTablePtr&, DataTablePtr&);
-    void group_2d_categorical(DataTablePtr&, DataTablePtr&);
-    void group_2d_mixed(bool, DataTablePtr&, DataTablePtr&);
+    void group_1d(const DataTablePtr&, DataTablePtr&);
+    void group_2d(const DataTablePtr&, DataTablePtr&);
+    void group_nd(const DataTablePtr&, DataTablePtr&);
+    void group_1d_continuous(const DataTablePtr&, DataTablePtr&);
+    void group_2d_continuous(const DataTablePtr&, DataTablePtr&);
+    void group_1d_categorical(const DataTablePtr&, DataTablePtr&);
+    void group_2d_categorical(const DataTablePtr&, DataTablePtr&);
+    template<typename T1, typename T2>
+    void group_2d_categorical_str(const DataTablePtr&, DataTablePtr&);
+    void group_2d_mixed(bool, const DataTablePtr&, DataTablePtr&);
+    template<typename T>
+    void group_2d_mixed_str(bool, const DataTablePtr&, DataTablePtr&);
     void aggregate_exemplars(DataTable*, DataTablePtr&);
 
-    // Helper functions
-    int32_t get_nthreads(DataTablePtr&);
-    DoublePtr generate_pmatrix(DataTablePtr&);
-    void normalize_row(DataTablePtr&, DoublePtr&, int32_t);
-    void project_row(DataTablePtr&, DoublePtr&, int32_t, DoublePtr&);
+    // Helper methods
+    int32_t get_nthreads(const DataTablePtr&);
+    DoublePtr generate_pmatrix(const DataTablePtr&);
+    void normalize_row(const DataTablePtr&, DoublePtr&, int32_t);
+    void project_row(const DataTablePtr&, DoublePtr&, int32_t, DoublePtr&);
     double calculate_distance(DoublePtr&, DoublePtr&, int64_t, double,
                               bool early_exit=true);
     void adjust_delta(double&, std::vector<ExPtr>&, std::vector<int64_t>&,

--- a/datatable/extras/aggregate.py
+++ b/datatable/extras/aggregate.py
@@ -31,7 +31,9 @@ def aggregate(self, min_rows=500, n_bins=500, nx_bins=50, ny_bins=50,
     seed: int
         Seed to be used for the projection method.
     progress_fn: object
-        Python function to be used for progress reporting.
+        Python function for progress reporting accepting two arguments:
+        - `progress`, that is a value from 0 to 1;
+        - `status_code`, 0 – in progress, 1 – completed.
     nthreads: int
         Number of OpenMP threads ND aggregator will use. Default is 0,
         i.e. automatically figure out the optimal number.

--- a/tests/extras/test_aggregate.py
+++ b/tests/extras/test_aggregate.py
@@ -60,7 +60,7 @@ def test_aggregate_1d_continuous_integer_tiny():
     
     
 def test_aggregate_1d_continuous_integer_equal():
-    n_bins = 3
+    n_bins = 2
     d_in = dt.Frame([0, 0, None, 0, None, 0, 0, 0, 0, 0])
     d_members = aggregate(d_in, min_rows=0, n_bins=n_bins)
     d_members.internal.check()
@@ -211,53 +211,53 @@ def test_aggregate_2d_continuous_real_random():
 
 
 def test_aggregate_1d_categorical_sorted():
-    d_in = dt.Frame(["blue", "green", "indigo", "orange", "red", "violet",
+    d_in = dt.Frame([None, "blue", "green", "indigo", "orange", "red", "violet",
                      "yellow"])
     d_members = aggregate(d_in, min_rows=0)
-    assert d_members.shape == (7, 1)
+    assert d_members.shape == (8, 1)
     assert d_members.ltypes == (ltype.int,)
-    assert d_members.topython() == [[0, 1, 2, 3, 4, 5, 6]]
+    assert d_members.topython() == [[0, 1, 2, 3, 4, 5, 6, 7]]
     d_in.internal.check()
-    assert d_in.shape == (7, 2)
+    assert d_in.shape == (8, 2)
     assert d_in.ltypes == (ltype.str, ltype.int)
-    assert d_in.topython() == [["blue", "green", "indigo", "orange", "red",
+    assert d_in.topython() == [[None, "blue", "green", "indigo", "orange", "red",
                                 "violet", "yellow"],
-                               [1, 1, 1, 1, 1, 1, 1]]
+                               [1, 1, 1, 1, 1, 1, 1, 1]]
 
 
 def test_aggregate_1d_categorical_random():
-    d_in = dt.Frame(["blue", "orange", "yellow", "green", "blue", "indigo",
-                     "violet"])
+    d_in = dt.Frame(["blue", "orange", "yellow", None, "green", "blue", "indigo",
+                     None, "violet"])
     d_members = aggregate(d_in, min_rows=0)
-    assert d_members.shape == (7, 1)
+    assert d_members.shape == (9, 1)
     assert d_members.ltypes == (ltype.int,)
-    assert d_members.topython() == [[0, 3, 5, 1, 0, 2, 4]]
+    assert d_members.topython() == [[1, 4, 6, 0, 2, 1, 3, 0, 5]]
     d_in.internal.check()
-    assert d_in.shape == (6, 2)
+    assert d_in.shape == (7, 2)
     assert d_in.ltypes == (ltype.str, ltype.int)
-    assert d_in.topython() == [["blue", "green", "indigo", "orange", "violet",
+    assert d_in.topython() == [[None, "blue", "green", "indigo", "orange", "violet",
                                 "yellow"],
-                               [2, 1, 1, 1, 1, 1]]
+                               [2, 2, 1, 1, 1, 1, 1]]
 
 
 def test_aggregate_2d_categorical_sorted():
-    d_in = dt.Frame([["blue", "green", "indigo", "orange", "red", "violet",
+    d_in = dt.Frame([[None, None, "abc", "blue", "green", "indigo", "orange", "red", "violet",
                       "yellow"],
-                     ["Friday", "Monday", "Saturday", "Sunday", "Thursday",
+                     [None, "abc", None, "Friday", "Monday", "Saturday", "Sunday", "Thursday",
                       "Tuesday", "Wednesday"]])
     d_members = aggregate(d_in, min_rows=0)
     d_members.internal.check()
-    assert d_members.shape == (7, 1)
+    assert d_members.shape == (10, 1)
     assert d_members.ltypes == (ltype.int,)
-    assert d_members.topython() == [[0, 1, 2, 3, 4, 5, 6]]
+    assert d_members.topython() == [[0, 0, 0, 1, 2, 3, 4, 5, 6, 7]]
     d_in.internal.check()
-    assert d_in.shape == (7, 3)
+    assert d_in.shape == (8, 3)
     assert d_in.ltypes == (ltype.str, ltype.str, ltype.int)
-    assert d_in.topython() == [["blue", "green", "indigo", "orange", "red",
+    assert d_in.topython() == [[None, "blue", "green", "indigo", "orange", "red",
                                 "violet", "yellow"],
-                               ["Friday", "Monday", "Saturday", "Sunday",
+                               [None, "Friday", "Monday", "Saturday", "Sunday",
                                 "Thursday", "Tuesday", "Wednesday"],
-                               [1, 1, 1, 1, 1, 1, 1]]
+                               [3, 1, 1, 1, 1, 1, 1, 1]]
 
 
 def test_aggregate_2d_categorical_random():
@@ -284,21 +284,21 @@ def test_aggregate_2d_categorical_random():
 
 def test_aggregate_2d_mixed_sorted():
     nx_bins = 7
-    d_in = dt.Frame([[0, 1, 2, 3, 4, 5, 6],
-                     ["blue", "green", "indigo", "orange", "red", "violet",
+    d_in = dt.Frame([[None, None, 0, 0, 1, 2, 3, 4, 5, 6],
+                     [None, "a", None, "blue", "green", "indigo", "orange", "red", "violet",
                       "yellow"]])
     d_members = aggregate(d_in, min_rows=0, nx_bins=nx_bins)
     d_members.internal.check()
-    assert d_members.shape == (7, 1)
+    assert d_members.shape == (10, 1)
     assert d_members.ltypes == (ltype.int,)
-    assert d_members.topython() == [[0, 1, 2, 3, 4, 5, 6]]
+    assert d_members.topython() == [[0, 0, 0, 1, 2, 3, 4, 5, 6, 7]]
     d_in.internal.check()
-    assert d_in.shape == (7, 3)
+    assert d_in.shape == (8, 3)
     assert d_in.ltypes == (ltype.int, ltype.str, ltype.int)
-    assert d_in.topython() == [[0, 1, 2, 3, 4, 5, 6],
-                               ["blue", "green", "indigo", "orange", "red",
+    assert d_in.topython() == [[None, 0, 1, 2, 3, 4, 5, 6],
+                               [None, "blue", "green", "indigo", "orange", "red",
                                 "violet", "yellow"],
-                               [1, 1, 1, 1, 1, 1, 1]]
+                               [3, 1, 1, 1, 1, 1, 1, 1]]
 
 
 def test_aggregate_2d_mixed_random():
@@ -310,14 +310,14 @@ def test_aggregate_2d_mixed_random():
     d_members.internal.check()
     assert d_members.shape == (11, 1)
     assert d_members.ltypes == (ltype.int,)
-    assert d_members.topython() == [[1, 2, 3, 0, 0, 5, 7, 0, 8, 6, 4]]
+    assert d_members.topython() == [[0, 1, 2, 0, 0, 4, 6, 0, 7, 5, 3]]
     d_in.internal.check()
-    assert d_in.shape == (9, 3)
+    assert d_in.shape == (8, 3)
     assert d_in.ltypes == (ltype.int, ltype.str, ltype.int)
-    assert d_in.topython() == [[None, 1, 3, 0, 4, 6, 2, 6, 1],
-                               ['abc', None, 'blue', 'indigo', 'red', 'red', 'violet',
+    assert d_in.topython() == [[1, 3, 0, 4, 6, 2, 6, 1],
+                               [None, 'blue', 'indigo', 'red', 'red', 'violet',
                                 'violet', 'yellow'],
-                               [3, 1, 1, 1, 1, 1, 1, 1, 1]]
+                               [4, 1, 1, 1, 1, 1, 1, 1]]
 
 
 #-------------------------------------------------------------------------------

--- a/tests/extras/test_aggregate.py
+++ b/tests/extras/test_aggregate.py
@@ -61,77 +61,77 @@ def test_aggregate_1d_continuous_integer_tiny():
     
 def test_aggregate_1d_continuous_integer_equal():
     n_bins = 3
-    d_in = dt.Frame([0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+    d_in = dt.Frame([0, 0, None, 0, None, 0, 0, 0, 0, 0])
     d_members = aggregate(d_in, min_rows=0, n_bins=n_bins)
     d_members.internal.check()
     assert d_members.shape == (10, 1)
     assert d_members.ltypes == (ltype.int,)
-    assert d_members.topython() == [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0]]
+    assert d_members.topython() == [[1, 1, 0, 1, 0, 1, 1, 1, 1, 1]]
     d_in.internal.check()
-    assert d_in.shape == (1, 2)
+    assert d_in.shape == (2, 2)
     assert d_in.ltypes == (ltype.bool, ltype.int)
-    assert d_in.topython() == [[0],
-                               [10]]
+    assert d_in.topython() == [[None, 0],
+                               [2, 8]]
 
 
 def test_aggregate_1d_continuous_integer_sorted():
     n_bins = 3
-    d_in = dt.Frame([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    d_in = dt.Frame([0, 1, None, 2, 3, 4, 5, 6, 7, None, 8, 9])
     d_members = aggregate(d_in, min_rows=0, n_bins=n_bins)
     d_members.internal.check()
-    assert d_members.shape == (10, 1)
+    assert d_members.shape == (12, 1)
     assert d_members.ltypes == (ltype.int,)
-    assert d_members.topython() == [[0, 0, 0, 0, 1, 1, 1, 2, 2, 2]]
+    assert d_members.topython() == [[1, 1, 0, 1, 1, 2, 2, 2, 3, 0, 3, 3]]
     d_in.internal.check()
-    assert d_in.shape == (3, 2)
+    assert d_in.shape == (4, 2)
     assert d_in.ltypes == (ltype.int, ltype.int)
-    assert d_in.topython() == [[0, 4, 7],
-                               [4, 3, 3]]
+    assert d_in.topython() == [[None, 0, 4, 7],
+                               [2, 4, 3, 3]]
 
 
 def test_aggregate_1d_continuous_integer_random():
     n_bins = 3
-    d_in = dt.Frame([9, 8, 2, 3, 3, 0, 5, 5, 8, 1])
+    d_in = dt.Frame([None, 9, 8, None, 2, 3, 3, 0, 5, 5, 8, 1, None])
     d_members = aggregate(d_in, min_rows=0, n_bins=n_bins)
     d_members.internal.check()
-    assert d_members.shape == (10, 1)
+    assert d_members.shape == (13, 1)
     assert d_members.ltypes == (ltype.int,)
-    assert d_members.topython() == [[2, 2, 0, 0, 0, 0, 1, 1, 2, 0]]
+    assert d_members.topython() == [[0, 3, 3, 0, 1, 1, 1, 1, 2, 2, 3, 1, 0]]
     d_in.internal.check()
-    assert d_in.shape == (3, 2)
+    assert d_in.shape == (4, 2)
     assert d_in.ltypes == (ltype.int, ltype.int)
-    assert d_in.topython() == [[2, 5, 9],
-                               [5, 2, 3]]
+    assert d_in.topython() == [[None, 2, 5, 9],
+                               [3, 5, 2, 3]]
 
 
 def test_aggregate_1d_continuous_real_sorted():
     n_bins = 3
-    d_in = dt.Frame([0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9])
+    d_in = dt.Frame([0.0, None, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9])
     d_members = aggregate(d_in, min_rows=0, n_bins=n_bins)
     d_members.internal.check()
-    assert d_members.shape == (10, 1)
+    assert d_members.shape == (11, 1)
     assert d_members.ltypes == (ltype.int,)
-    assert d_members.topython() == [[0, 0, 0, 0, 1, 1, 1, 2, 2, 2]]
+    assert d_members.topython() == [[1, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3]]
     d_in.internal.check()
-    assert d_in.shape == (3, 2)
+    assert d_in.shape == (4, 2)
     assert d_in.ltypes == (ltype.real, ltype.int)
-    assert d_in.topython() == [[0.0, 0.4, 0.7],
-                               [4, 3, 3]]
+    assert d_in.topython() == [[None, 0.0, 0.4, 0.7],
+                               [1, 4, 3, 3]]
 
 
 def test_aggregate_1d_continuous_real_random():
     n_bins = 3
-    d_in = dt.Frame([0.7, 0.7, 0.5, 0.1, 0.0, 0.9, 0.1, 0.3, 0.4, 0.2])
+    d_in = dt.Frame([0.7, 0.7, 0.5, 0.1, 0.0, 0.9, 0.1, 0.3, 0.4, 0.2, None, None, None])
     d_members = aggregate(d_in, min_rows=0, n_bins=n_bins)
     d_members.internal.check()
-    assert d_members.shape == (10, 1)
+    assert d_members.shape == (13, 1)
     assert d_members.ltypes == (ltype.int,)
-    assert d_members.topython() == [[2, 2, 1, 0, 0, 2, 0, 0, 1, 0]]
+    assert d_members.topython() == [[3, 3, 2, 1, 1, 3, 1, 1, 2, 1, 0, 0, 0]]
     d_in.internal.check()
-    assert d_in.shape == (3, 2)
+    assert d_in.shape == (4, 2)
     assert d_in.ltypes == (ltype.real, ltype.int)
-    assert d_in.topython() == [[0.1, 0.5, 0.7],
-                               [5, 2, 3]]
+    assert d_in.topython() == [[None, 0.1, 0.5, 0.7],
+                               [3, 5, 2, 3]]
 
 
 #-------------------------------------------------------------------------------
@@ -141,73 +141,73 @@ def test_aggregate_1d_continuous_real_random():
 def test_aggregate_2d_continuous_integer_sorted():
     nx_bins = 3
     ny_bins = 3
-    d_in = dt.Frame([[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-                     [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]])
+    d_in = dt.Frame([[None, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+                     [0, None, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9]])
     d_members = aggregate(d_in, min_rows=0, nx_bins=nx_bins, ny_bins=ny_bins)
     d_members.internal.check()
-    assert d_members.shape == (10, 1)
+    assert d_members.shape == (12, 1)
     assert d_members.ltypes == (ltype.int,)
-    assert d_members.topython() == [[0, 0, 0, 0, 1, 1, 1, 2, 2, 2]]
+    assert d_members.topython() == [[0, 0, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3]]
     d_in.internal.check()
-    assert d_in.shape == (3, 3)
+    assert d_in.shape == (4, 3)
     assert d_in.ltypes == (ltype.int, ltype.int, ltype.int)
-    assert d_in.topython() == [[0, 4, 7],
-                               [0, 4, 7],
-                               [4, 3, 3]]
+    assert d_in.topython() == [[None, 0, 4, 7],
+                               [0, 0, 4, 7],
+                               [2, 4, 3, 3]]
 
 
 def test_aggregate_2d_continuous_integer_random():
     nx_bins = 3
     ny_bins = 3
-    d_in = dt.Frame([[9, 8, 2, 3, 3, 0, 5, 5, 8, 1],
-                     [3, 5, 8, 1, 4, 4, 8, 7, 6, 1]])
+    d_in = dt.Frame([[9, None, 8, 2, 3, 3, 0, 5, 5, 8, 1],
+                     [3, None, 5, 8, 1, 4, 4, 8, 7, 6, 1]])
     d_members = aggregate(d_in, min_rows=0, nx_bins=nx_bins, ny_bins=ny_bins)
     d_members.internal.check()
-    assert d_members.shape == (10, 1)
+    assert d_members.shape == (11, 1)
     assert d_members.ltypes == (ltype.int,)
-    assert d_members.topython() == [[1, 3, 4, 0, 2, 2, 5, 5, 6, 0]]
+    assert d_members.topython() == [[2, 0, 4, 5, 1, 3, 3, 6, 6, 7, 1]]
     d_in.internal.check()
-    assert d_in.shape == (7, 3)
+    assert d_in.shape == (8, 3)
     assert d_in.ltypes == (ltype.int, ltype.int, ltype.int)
-    assert d_in.topython() == [[3, 9, 3, 8, 2, 5, 8],
-                               [1, 3, 4, 5, 8, 8, 6],
-                               [2, 1, 2, 1, 1, 2, 1]]
+    assert d_in.topython() == [[None, 3, 9, 3, 8, 2, 5, 8],
+                               [None, 1, 3, 4, 5, 8, 8, 6],
+                               [1, 2, 1, 2, 1, 1, 2, 1]]
 
 
 def test_aggregate_2d_continuous_real_sorted():
     nx_bins = 3
     ny_bins = 3
-    d_in = dt.Frame([[0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9],
-                     [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]])
+    d_in = dt.Frame([[0.0, 0.0, 0.1, 0.2, None, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, None],
+                     [None, 0.0, 0.1, 0.2, None, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.0]])
     d_members = aggregate(d_in, min_rows=0, nx_bins=nx_bins, ny_bins=ny_bins)
     d_members.internal.check()
-    assert d_members.shape == (10, 1)
+    assert d_members.shape == (13, 1)
     assert d_members.ltypes == (ltype.int,)
-    assert d_members.topython() == [[0, 0, 0, 0, 1, 1, 1, 2, 2, 2]]
+    assert d_members.topython() == [[0, 1, 1, 1, 0, 1, 2, 2, 2, 3, 3, 3, 0]]
     d_in.internal.check()
-    assert d_in.shape == (3, 3)
+    assert d_in.shape == (4, 3)
     assert d_in.ltypes == (ltype.real, ltype.real, ltype.int)
-    assert d_in.topython() == [[0.0, 0.4, 0.7],
-                               [0.0, 0.4, 0.7],
-                               [4, 3, 3]]
+    assert d_in.topython() == [[0.0, 0.0, 0.4, 0.7],
+                               [None, 0.0, 0.4, 0.7],
+                               [3, 4, 3, 3]]
 
 
 def test_aggregate_2d_continuous_real_random():
     nx_bins = 3
     ny_bins = 3
-    d_in = dt.Frame([[0.9, 0.8, 0.2, 0.3, 0.3, 0.0, 0.5, 0.5, 0.8, 0.1],
-                     [0.3, 0.5, 0.8, 0.1, 0.4, 0.4, 0.8, 0.7, 0.6, 0.1]])
+    d_in = dt.Frame([[None, 0.9, 0.8, 0.2, 0.3, None, 0.3, 0.0, 0.5, 0.5, 0.8, 0.1],
+                     [None, 0.3, 0.5, 0.8, 0.1, None, 0.4, 0.4, 0.8, 0.7, 0.6, 0.1]])
     d_members = aggregate(d_in, min_rows=0, nx_bins=nx_bins, ny_bins=ny_bins)
     d_members.internal.check()
-    assert d_members.shape == (10, 1)
+    assert d_members.shape == (12, 1)
     assert d_members.ltypes == (ltype.int,)
-    assert d_members.topython() == [[1, 3, 4, 0, 2, 2, 5, 5, 6, 0]]
+    assert d_members.topython() == [[0, 2, 4, 5, 1, 0, 3, 3, 6, 6, 7, 1]]
     d_in.internal.check()
-    assert d_in.shape == (7, 3)
+    assert d_in.shape == (8, 3)
     assert d_in.ltypes == (ltype.real, ltype.real, ltype.int)
-    assert d_in.topython() == [[0.3, 0.9, 0.3, 0.8, 0.2, 0.5, 0.8],
-                               [0.1, 0.3, 0.4, 0.5, 0.8, 0.8, 0.6],
-                               [2, 1, 2, 1, 1, 2, 1]]
+    assert d_in.topython() == [[None, 0.3, 0.9, 0.3, 0.8, 0.2, 0.5, 0.8],
+                               [None, 0.1, 0.3, 0.4, 0.5, 0.8, 0.8, 0.6],
+                               [2, 2, 1, 2, 1, 1, 2, 1]]
 
 
 def test_aggregate_1d_categorical_sorted():
@@ -303,21 +303,21 @@ def test_aggregate_2d_mixed_sorted():
 
 def test_aggregate_2d_mixed_random():
     nx_bins = 6
-    d_in = dt.Frame([[3, 0, 6, 6, 1, 2, 4],
-                     ["blue", "indigo", "red", "violet", "yellow", "violet",
-                      "red"]])
+    d_in = dt.Frame([[1, 3, 0, None, None, 6, 6, None, 1, 2, 4],
+                     [None, "blue", "indigo", "abc", "def", "red", "violet", "ghi", "yellow", 
+                      "violet", "red"]])
     d_members = aggregate(d_in, min_rows=0, nx_bins=nx_bins)
     d_members.internal.check()
-    assert d_members.shape == (7, 1)
+    assert d_members.shape == (11, 1)
     assert d_members.ltypes == (ltype.int,)
-    assert d_members.topython() == [[0, 1, 3, 5, 6, 4, 2]]
+    assert d_members.topython() == [[1, 2, 3, 0, 0, 5, 7, 0, 8, 6, 4]]
     d_in.internal.check()
-    assert d_in.shape == (7, 3)
+    assert d_in.shape == (9, 3)
     assert d_in.ltypes == (ltype.int, ltype.str, ltype.int)
-    assert d_in.topython() == [[3, 0, 4, 6, 2, 6, 1],
-                               ['blue', 'indigo', 'red', 'red', 'violet',
+    assert d_in.topython() == [[None, 1, 3, 0, 4, 6, 2, 6, 1],
+                               ['abc', None, 'blue', 'indigo', 'red', 'red', 'violet',
                                 'violet', 'yellow'],
-                               [1, 1, 1, 1, 1, 1, 1]]
+                               [3, 1, 1, 1, 1, 1, 1, 1, 1]]
 
 
 #-------------------------------------------------------------------------------

--- a/tests/extras/test_aggregate.py
+++ b/tests/extras/test_aggregate.py
@@ -25,6 +25,15 @@ def get_default_args(func):
         for k, v in signature.parameters.items()
         if v.default is not inspect.Parameter.empty
     }
+    
+    
+#-------------------------------------------------------------------------------
+# Test the progress reporting function at the same time
+#-------------------------------------------------------------------------------
+    
+def report_progress(progress, status_code):
+    assert status_code in (0, 1)
+    assert progress >= 0 and progress <= 1
 
 #-------------------------------------------------------------------------------
 # Aggregate 1D
@@ -33,7 +42,7 @@ def get_default_args(func):
 def test_aggregate_1d_empty():
     n_bins = 1
     d_in = dt.Frame([])
-    d_members = aggregate(d_in, min_rows=0, n_bins=n_bins)
+    d_members = aggregate(d_in, min_rows=0, n_bins=n_bins, progress_fn=report_progress)
     d_members.internal.check()
     assert d_members.shape == (0, 1)
     assert d_members.ltypes == (ltype.int,)
@@ -47,7 +56,7 @@ def test_aggregate_1d_empty():
 def test_aggregate_1d_continuous_integer_tiny():
     n_bins = 1
     d_in = dt.Frame([5])
-    d_members = aggregate(d_in, min_rows=0, n_bins=n_bins)
+    d_members = aggregate(d_in, min_rows=0, n_bins=n_bins, progress_fn=report_progress)
     d_members.internal.check()
     assert d_members.shape == (1, 1)
     assert d_members.ltypes == (ltype.int,)
@@ -62,7 +71,7 @@ def test_aggregate_1d_continuous_integer_tiny():
 def test_aggregate_1d_continuous_integer_equal():
     n_bins = 2
     d_in = dt.Frame([0, 0, None, 0, None, 0, 0, 0, 0, 0])
-    d_members = aggregate(d_in, min_rows=0, n_bins=n_bins)
+    d_members = aggregate(d_in, min_rows=0, n_bins=n_bins, progress_fn=report_progress)
     d_members.internal.check()
     assert d_members.shape == (10, 1)
     assert d_members.ltypes == (ltype.int,)
@@ -77,7 +86,7 @@ def test_aggregate_1d_continuous_integer_equal():
 def test_aggregate_1d_continuous_integer_sorted():
     n_bins = 3
     d_in = dt.Frame([0, 1, None, 2, 3, 4, 5, 6, 7, None, 8, 9])
-    d_members = aggregate(d_in, min_rows=0, n_bins=n_bins)
+    d_members = aggregate(d_in, min_rows=0, n_bins=n_bins, progress_fn=report_progress)
     d_members.internal.check()
     assert d_members.shape == (12, 1)
     assert d_members.ltypes == (ltype.int,)
@@ -92,7 +101,7 @@ def test_aggregate_1d_continuous_integer_sorted():
 def test_aggregate_1d_continuous_integer_random():
     n_bins = 3
     d_in = dt.Frame([None, 9, 8, None, 2, 3, 3, 0, 5, 5, 8, 1, None])
-    d_members = aggregate(d_in, min_rows=0, n_bins=n_bins)
+    d_members = aggregate(d_in, min_rows=0, n_bins=n_bins, progress_fn=report_progress)
     d_members.internal.check()
     assert d_members.shape == (13, 1)
     assert d_members.ltypes == (ltype.int,)
@@ -107,7 +116,7 @@ def test_aggregate_1d_continuous_integer_random():
 def test_aggregate_1d_continuous_real_sorted():
     n_bins = 3
     d_in = dt.Frame([0.0, None, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9])
-    d_members = aggregate(d_in, min_rows=0, n_bins=n_bins)
+    d_members = aggregate(d_in, min_rows=0, n_bins=n_bins, progress_fn=report_progress)
     d_members.internal.check()
     assert d_members.shape == (11, 1)
     assert d_members.ltypes == (ltype.int,)
@@ -122,7 +131,7 @@ def test_aggregate_1d_continuous_real_sorted():
 def test_aggregate_1d_continuous_real_random():
     n_bins = 3
     d_in = dt.Frame([0.7, 0.7, 0.5, 0.1, 0.0, 0.9, 0.1, 0.3, 0.4, 0.2, None, None, None])
-    d_members = aggregate(d_in, min_rows=0, n_bins=n_bins)
+    d_members = aggregate(d_in, min_rows=0, n_bins=n_bins, progress_fn=report_progress)
     d_members.internal.check()
     assert d_members.shape == (13, 1)
     assert d_members.ltypes == (ltype.int,)
@@ -143,7 +152,8 @@ def test_aggregate_2d_continuous_integer_sorted():
     ny_bins = 3
     d_in = dt.Frame([[None, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
                      [0, None, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9]])
-    d_members = aggregate(d_in, min_rows=0, nx_bins=nx_bins, ny_bins=ny_bins)
+    d_members = aggregate(d_in, min_rows=0, nx_bins=nx_bins, ny_bins=ny_bins,
+                          progress_fn=report_progress)
     d_members.internal.check()
     assert d_members.shape == (12, 1)
     assert d_members.ltypes == (ltype.int,)
@@ -161,7 +171,8 @@ def test_aggregate_2d_continuous_integer_random():
     ny_bins = 3
     d_in = dt.Frame([[9, None, 8, 2, 3, 3, 0, 5, 5, 8, 1],
                      [3, None, 5, 8, 1, 4, 4, 8, 7, 6, 1]])
-    d_members = aggregate(d_in, min_rows=0, nx_bins=nx_bins, ny_bins=ny_bins)
+    d_members = aggregate(d_in, min_rows=0, nx_bins=nx_bins, ny_bins=ny_bins,
+                          progress_fn=report_progress)
     d_members.internal.check()
     assert d_members.shape == (11, 1)
     assert d_members.ltypes == (ltype.int,)
@@ -179,7 +190,8 @@ def test_aggregate_2d_continuous_real_sorted():
     ny_bins = 3
     d_in = dt.Frame([[0.0, 0.0, 0.1, 0.2, None, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, None],
                      [None, 0.0, 0.1, 0.2, None, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.0]])
-    d_members = aggregate(d_in, min_rows=0, nx_bins=nx_bins, ny_bins=ny_bins)
+    d_members = aggregate(d_in, min_rows=0, nx_bins=nx_bins, ny_bins=ny_bins,
+                          progress_fn=report_progress)
     d_members.internal.check()
     assert d_members.shape == (13, 1)
     assert d_members.ltypes == (ltype.int,)
@@ -197,7 +209,8 @@ def test_aggregate_2d_continuous_real_random():
     ny_bins = 3
     d_in = dt.Frame([[None, 0.9, 0.8, 0.2, 0.3, None, 0.3, 0.0, 0.5, 0.5, 0.8, 0.1],
                      [None, 0.3, 0.5, 0.8, 0.1, None, 0.4, 0.4, 0.8, 0.7, 0.6, 0.1]])
-    d_members = aggregate(d_in, min_rows=0, nx_bins=nx_bins, ny_bins=ny_bins)
+    d_members = aggregate(d_in, min_rows=0, nx_bins=nx_bins, ny_bins=ny_bins,
+                          progress_fn=report_progress)
     d_members.internal.check()
     assert d_members.shape == (12, 1)
     assert d_members.ltypes == (ltype.int,)
@@ -213,7 +226,7 @@ def test_aggregate_2d_continuous_real_random():
 def test_aggregate_1d_categorical_sorted():
     d_in = dt.Frame([None, "blue", "green", "indigo", "orange", "red", "violet",
                      "yellow"])
-    d_members = aggregate(d_in, min_rows=0)
+    d_members = aggregate(d_in, min_rows=0, progress_fn=report_progress)
     assert d_members.shape == (8, 1)
     assert d_members.ltypes == (ltype.int,)
     assert d_members.topython() == [[0, 1, 2, 3, 4, 5, 6, 7]]
@@ -228,7 +241,7 @@ def test_aggregate_1d_categorical_sorted():
 def test_aggregate_1d_categorical_random():
     d_in = dt.Frame(["blue", "orange", "yellow", None, "green", "blue", "indigo",
                      None, "violet"])
-    d_members = aggregate(d_in, min_rows=0)
+    d_members = aggregate(d_in, min_rows=0, progress_fn=report_progress)
     assert d_members.shape == (9, 1)
     assert d_members.ltypes == (ltype.int,)
     assert d_members.topython() == [[1, 4, 6, 0, 2, 1, 3, 0, 5]]
@@ -245,7 +258,7 @@ def test_aggregate_2d_categorical_sorted():
                       "yellow"],
                      [None, "abc", None, "Friday", "Monday", "Saturday", "Sunday", "Thursday",
                       "Tuesday", "Wednesday"]])
-    d_members = aggregate(d_in, min_rows=0)
+    d_members = aggregate(d_in, min_rows=0, progress_fn=report_progress)
     d_members.internal.check()
     assert d_members.shape == (10, 1)
     assert d_members.ltypes == (ltype.int,)
@@ -266,7 +279,7 @@ def test_aggregate_2d_categorical_random():
                      ["Monday", "Monday", "Wednesday", "Saturday", "Thursday",
                       "Friday", "Wednesday"]])
 
-    d_members = aggregate(d_in, min_rows=0)
+    d_members = aggregate(d_in, min_rows=0, progress_fn=report_progress)
     d_members.internal.check()
     d_in.internal.check()
     assert d_members.shape == (7, 1)
@@ -287,7 +300,7 @@ def test_aggregate_2d_mixed_sorted():
     d_in = dt.Frame([[None, None, 0, 0, 1, 2, 3, 4, 5, 6],
                      [None, "a", None, "blue", "green", "indigo", "orange", "red", "violet",
                       "yellow"]])
-    d_members = aggregate(d_in, min_rows=0, nx_bins=nx_bins)
+    d_members = aggregate(d_in, min_rows=0, nx_bins=nx_bins, progress_fn=report_progress)
     d_members.internal.check()
     assert d_members.shape == (10, 1)
     assert d_members.ltypes == (ltype.int,)
@@ -306,7 +319,7 @@ def test_aggregate_2d_mixed_random():
     d_in = dt.Frame([[1, 3, 0, None, None, 6, 6, None, 1, 2, 4],
                      [None, "blue", "indigo", "abc", "def", "red", "violet", "ghi", "yellow", 
                       "violet", "red"]])
-    d_members = aggregate(d_in, min_rows=0, nx_bins=nx_bins)
+    d_members = aggregate(d_in, min_rows=0, nx_bins=nx_bins, progress_fn=report_progress)
     d_members.internal.check()
     assert d_members.shape == (11, 1)
     assert d_members.ltypes == (ltype.int,)
@@ -332,7 +345,7 @@ def test_aggregate_3d_categorical():
     exemplar_id = [i for i in range(rows)]
     d_in = dt.Frame(a_in)
                     
-    d_members = aggregate(d_in)
+    d_members = aggregate(d_in, progress_fn=report_progress)
     assert d_members.shape == (rows, 1)
     assert d_members.ltypes == (ltype.int,)
     assert d_members.topython() == [exemplar_id]
@@ -346,7 +359,7 @@ def test_aggregate_3d_real():
     d_in = dt.Frame([[0.95, 0.50, 0.55, 0.10, 0.90, 0.50, 0.90, 0.50, 0.90, 1.00],
                      [1.00, 0.55, 0.45, 0.05, 0.95, 0.45, 0.90, 0.40, 1.00, 0.90],
                      [0.90, 0.50, 0.55, 0.00, 1.00, 0.50, 0.95, 0.45, 0.95, 0.95]])
-    d_members = aggregate(d_in, min_rows=0, nd_max_bins=3)
+    d_members = aggregate(d_in, min_rows=0, nd_max_bins=3, progress_fn=report_progress)
     a_members = d_members.topython()[0]
     d = d_in.sort("C0")
     ri = d.internal.rowindex.tolist()    
@@ -387,7 +400,8 @@ def aggregate_nd(nd):
     out_value = [[i for i in range(div)]]*nd + [[nrows//div for i in range(div)]]
         
     d_in = dt.Frame(matrix)
-    d_members = aggregate(d_in, min_rows=0, nd_max_bins=div, seed=1)
+    d_members = aggregate(d_in, min_rows=0, nd_max_bins=div, seed=1,
+                          progress_fn=report_progress)
 
     a_members = d_members.topython()[0]
     d = d_in.sort("C0")


### PR DESCRIPTION
For all 1D and 2D aggregators, if N/A is present in one of the columns, the row goes to a special N/A bin, that at the end becomes zero bin. An exemplar for this bin is just the first row that contains even one N/A value.

Tests are updated according to the above changes.

Closes #1337 