### PR TITLE
Make Frame.sort() work when no arguments provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - crash when saving a frame with many boolean columns into CSV (#1278).
 - incorrect .stypes/.ltypes property after calling cbind().
 - calculation of min/max values in internal rowindex upon row resizing.
+- frame.sort() with no arguments no longer produces an error.
 
 
 ### [v0.6.0](https://github.com/h2oai/datatable/compare/v0.6.0...v0.5.0) — 2018-06-05

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -288,19 +288,25 @@ class Frame(core.Frame):
 
     def sort(self, *cols):
         """
-        Sort datatable by the specified column.
+        Sort datatable by the specified column(s).
 
         Parameters
         ----------
-        cols: str or int
-            Name or index of the columns to sort by.
+        cols: List[str | int]
+            Names or indices of the columns to sort by. If no columns are given,
+            the Frame will be sorted on all columns.
 
         Returns
         -------
         New datatable sorted by the provided column(s). The target datatable
         remains unmodified.
         """
-        indexes = [self.colindex(col) for col in cols]
+        if not cols:
+            indexes = list(range(self.ncols))
+        elif len(cols) == 1 and isinstance(cols[0], list):
+            indexes = [self.colindex(col) for col in cols[0]]
+        else:
+            indexes = [self.colindex(col) for col in cols]
         ri = self._dt.sort(*indexes)[0]
         cs = core.columns_from_slice(self._dt, ri, 0, self.ncols, 1)
         return cs.to_frame(self.names)

--- a/tests/test_dt_sort.py
+++ b/tests/test_dt_sort.py
@@ -791,3 +791,22 @@ def test_sort_random_multi(seed):
     # dt.Frame(sorted_data).save("test.jay", format="jay")
     d1 = d0.sort("B", "C", "D")
     assert d1.topython() == sorted_data
+
+
+
+
+#-------------------------------------------------------------------------------
+# Misc issues
+#-------------------------------------------------------------------------------
+
+def sort_api():
+    df = dt.Frame([[1, 2, 1, 2], [3.3, 2.7, 0.1, 4.5]], names=["A", "B"])
+    df1 = df.sort("A")
+    df2 = df.sort("B")
+    df3 = df.sort("A", "B")
+    df4 = df.sort(["A", "B"])
+    df5 = df.sort()  # issue 1354
+    assert df1.topython() == [[1, 1, 2, 2], [0.1, 3.3, 2.7, 4.5]]
+    assert df2.topython() == [[1, 2, 1, 2], [0.1, 2.7, 3.3, 4.5]]
+    assert df3.topython() == [[1, 1, 2, 2], [0.1, 2.7, 3.3, 4.5]]
+    assert df4.topython() == df5.topython() == df3.topython()


### PR DESCRIPTION
All of the following now work as expected:
```
df.sort()
df.sort("A")
df.sort("A", "B")
df.sort(["A", "B"])
```

Closes #1354 