### PR TITLE
Make installing on a machine without Llvm/Clang easier.

### DIFF
--- a/c/frame/py_frame.cc
+++ b/c/frame/py_frame.cc
@@ -180,7 +180,7 @@ oobj Frame::get_shape() const {
   py::otuple shape(2);
   shape.set(0, get_nrows());
   shape.set(1, get_ncols());
-  return shape;
+  return std::move(shape);
 }
 
 
@@ -213,7 +213,7 @@ oobj Frame::get_ltypes() const {
 oobj Frame::get_key() const {
   py::otuple key(dt->nkeys);
   // Fill in the keys...
-  return key;
+  return std::move(key);
 }
 
 oobj Frame::get_internal() const {

--- a/c/python/args.h
+++ b/c/python/args.h
@@ -81,7 +81,7 @@ class PKArgs : public Args {
     const size_t n_all_args;
     const bool   has_varargs;
     const bool   has_varkwds;
-    const size_t : 48;
+    size_t : 48;
     const std::vector<const char*> arg_names;
 
     // Runtime arguments

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -129,3 +129,8 @@ def find_file(*nameparts):
         pytest.skip("File %s not found" % filename)
     else:
         return filename
+
+
+def has_llvm():
+    import datatable as dt
+    return dt.graph.llvm.llvm.available

--- a/tests/fread/test_fread_small.py
+++ b/tests/fread/test_fread_small.py
@@ -1057,7 +1057,7 @@ def test_under_allocation(capsys):
     src = "A,B\n" + "\n".join(lines)
     d0 = dt.fread(src, verbose=True)
     out, err = capsys.readouterr()
-    mm = re.search("Initial alloc = (\d+) rows", out)
+    mm = re.search("Initial alloc = (\\d+) rows", out)
     assert mm
     assert int(mm.group(1)) < n, "Under-allocation didn't happen"
     assert "Too few rows allocated" in out

--- a/tests/munging/test_dt_cols.py
+++ b/tests/munging/test_dt_cols.py
@@ -6,7 +6,7 @@
 #-------------------------------------------------------------------------------
 import pytest
 import datatable as dt
-from tests import same_iterables
+from tests import same_iterables, has_llvm
 from datatable import ltype, f
 
 
@@ -264,14 +264,16 @@ def test_cols_expression2():
     selector = OrderedDict([("foo", f.A), ("bar", -f.A)])
     f0 = dt.Frame({"A": range(10)})
     f1 = f0(select=selector, engine="eager")
-    f2 = f0(select=selector, engine="llvm")
     f1.internal.check()
-    f2.internal.check()
-    assert f1.names == f2.names == ("foo", "bar")
-    assert f1.stypes == f2.stypes == f0.stypes * 2
-    assert f1.topython() == f2.topython() == [list(range(10)),
-                                              list(range(0, -10, -1))]
-
+    assert f1.names == ("foo", "bar")
+    assert f1.stypes == f0.stypes * 2
+    assert f1.topython() == [list(range(10)), list(range(0, -10, -1))]
+    if has_llvm():
+        f2 = f0(select=selector, engine="llvm")
+        f2.internal.check()
+        assert f2.stypes == f1.stypes
+        assert f2.names == f1.names
+        assert f2.topython() == f1.topython()
 
 
 def test_cols_bad_arguments(dt0):

--- a/tests/munging/test_dt_rows.py
+++ b/tests/munging/test_dt_rows.py
@@ -7,7 +7,7 @@
 import pytest
 import datatable as dt
 from datatable import stype, ltype, f
-from tests import same_iterables
+from tests import same_iterables, has_llvm
 
 
 #-------------------------------------------------------------------------------
@@ -472,113 +472,138 @@ def _fixture2():
 
 def test_rows_equal(df1):
     dt1 = df1(f.A == f.B, engine="eager")
-    dt2 = df1(f.A == f.B, engine="llvm")
     dt1.internal.check()
-    dt2.internal.check()
-    assert dt1.names == dt2.names == df1.names
-    assert dt1.topython() == dt2.topython() == [[3, 4, None, 9],
-                                                [3, 4, None, 9]]
+    assert dt1.names == df1.names
+    assert dt1.topython() == [[3, 4, None, 9], [3, 4, None, 9]]
+    if has_llvm():
+        dt2 = df1(f.A == f.B, engine="llvm")
+        dt2.internal.check()
+        assert dt1.names == dt2.names
+        assert dt1.topython() == dt2.topython()
 
 
 def test_rows_not_equal(df1):
     dt1 = df1(f.A != f.B, engine="eager")
-    dt2 = df1(f.A != f.B, engine="llvm")
     dt1.internal.check()
-    dt2.internal.check()
-    assert dt1.names == dt2.names == df1.names
-    assert dt1.topython() == dt2.topython() == [[0, 1, 2, 5, 6, 7, None],
-                                                [3, 2, 1, 0, 2, None, 8]]
+    assert dt1.names == df1.names
+    assert dt1.topython() == [[0, 1, 2, 5, 6, 7, None],
+                              [3, 2, 1, 0, 2, None, 8]]
+    if has_llvm():
+        dt2 = df1(f.A != f.B, engine="llvm")
+        dt2.internal.check()
+        assert dt1.names == dt2.names
+        assert dt1.topython() == dt2.topython()
 
 
 def test_rows_less_than(df1):
     dt1 = df1(f.A < f.B, engine="eager")
-    dt2 = df1(f.A < f.B, engine="llvm")
     dt1.internal.check()
-    dt2.internal.check()
-    assert dt1.names == dt2.names == df1.names
-    assert dt1.topython() == dt2.topython() == [[0, 1],
-                                                [3, 2]]
+    assert dt1.names == df1.names
+    assert dt1.topython() == [[0, 1], [3, 2]]
+    if has_llvm():
+        dt2 = df1(f.A < f.B, engine="llvm")
+        dt2.internal.check()
+        assert dt1.names == dt2.names
+        assert dt1.topython() == dt2.topython()
 
 
 def test_rows_greater_than(df1):
     dt1 = df1(f.A > f.B, engine="eager")
-    dt2 = df1(f.A > f.B, engine="llvm")
     dt1.internal.check()
-    dt2.internal.check()
-    assert dt1.names == dt2.names == df1.names
-    assert dt1.topython() == dt2.topython() == [[2, 5, 6],
-                                                [1, 0, 2]]
+    assert dt1.names == df1.names
+    assert dt1.topython() == [[2, 5, 6], [1, 0, 2]]
+    if has_llvm():
+        dt2 = df1(f.A > f.B, engine="llvm")
+        dt2.internal.check()
+        assert dt1.names == dt2.names
+        assert dt1.topython() == dt2.topython()
 
 
 def test_rows_less_than_or_equal(df1):
     dt1 = df1(f.A <= f.B, engine="eager")
-    dt2 = df1(f.A <= f.B, engine="llvm")
     dt1.internal.check()
-    dt2.internal.check()
-    assert dt1.names == dt2.names == df1.names
-    assert dt1.topython() == dt2.topython() == [[0, 1, 3, 4, None, 9],
-                                                [3, 2, 3, 4, None, 9]]
+    assert dt1.names == df1.names
+    assert dt1.topython() == [[0, 1, 3, 4, None, 9], [3, 2, 3, 4, None, 9]]
+    if has_llvm():
+        dt2 = df1(f.A <= f.B, engine="llvm")
+        dt2.internal.check()
+        assert dt1.names == dt2.names
+        assert dt1.topython() == dt2.topython()
 
 
 def test_rows_greater_than_or_equal(df1):
     dt1 = df1(f.A >= f.B, engine="eager")
-    dt2 = df1(f.A >= f.B, engine="llvm")
     dt1.internal.check()
-    dt2.internal.check()
-    assert dt1.names == dt2.names == df1.names
-    assert dt1.topython() == dt2.topython() == [[2, 3, 4, 5, 6, None, 9],
-                                                [1, 3, 4, 0, 2, None, 9]]
+    assert dt1.names == df1.names
+    assert dt1.topython() == [[2, 3, 4, 5, 6, None, 9],
+                              [1, 3, 4, 0, 2, None, 9]]
+    if has_llvm():
+        dt2 = df1(f.A >= f.B, engine="llvm")
+        dt2.internal.check()
+        assert dt1.names == dt2.names
+        assert dt1.topython() == dt2.topython()
+
 
 def test_rows_compare_to_scalar_gt(df1):
     dt1 = df1(f.A > 3, engine="eager")
-    dt2 = df1(f.A > 3, engine="llvm")
     dt1.internal.check()
-    dt2.internal.check()
-    assert dt1.names == dt2.names == df1.names
-    assert dt1.topython() == dt2.topython() == [[4, 5, 6, 7, 9],
-                                                [4, 0, 2, None, 9]]
+    assert dt1.names == df1.names
+    assert dt1.topython() == [[4, 5, 6, 7, 9], [4, 0, 2, None, 9]]
+    if has_llvm():
+        dt2 = df1(f.A > 3, engine="llvm")
+        dt2.internal.check()
+        assert dt1.names == dt2.names
+        assert dt1.topython() == dt2.topython()
 
 
 def test_rows_compare_to_scalar_lt(df1):
     dt1 = df1(f.A < 3, engine="eager")
-    dt2 = df1(f.A < 3, engine="llvm")
     dt1.internal.check()
-    dt2.internal.check()
-    assert dt1.names == dt2.names == df1.names
-    assert dt1.topython() == dt2.topython() == [[0, 1, 2],
-                                                [3, 2, 1]]
+    assert dt1.names == df1.names
+    assert dt1.topython() == [[0, 1, 2], [3, 2, 1]]
+    if has_llvm():
+        dt2 = df1(f.A < 3, engine="llvm")
+        dt2.internal.check()
+        assert dt1.names == dt2.names
+        assert dt1.topython() == dt2.topython()
 
 
 # noinspection PyComparisonWithNone
 def test_rows_compare_to_scalar_eq(df1):
     dt1 = df1(f.A == None, engine="eager")
-    dt2 = df1(f.A == None, engine="llvm")
     dt1.internal.check()
-    dt2.internal.check()
-    assert dt1.names == dt2.names == df1.names
-    assert dt1.topython() == dt2.topython() == [[None, None],
-                                                [None, 8]]
+    assert dt1.names == df1.names
+    assert dt1.topython() == [[None, None], [None, 8]]
+    if has_llvm():
+        dt2 = df1(f.A == None, engine="llvm")
+        dt2.internal.check()
+        assert dt1.names == dt2.names
+        assert dt1.topython() == dt2.topython()
 
 
 def test_rows_unary_minus(df1):
     dt1 = df1(-f.A < -3, engine="eager")
-    dt2 = df1(-f.A < -3, engine="llvm")
     dt1.internal.check()
-    dt2.internal.check()
-    assert dt1.names == dt2.names == df1.names
-    assert dt1.topython() == dt2.topython() == [[4, 5, 6, 7, 9],
-                                                [4, 0, 2, None, 9]]
+    assert dt1.names == df1.names
+    assert dt1.topython() == [[4, 5, 6, 7, 9], [4, 0, 2, None, 9]]
+    if has_llvm():
+        dt2 = df1(-f.A < -3, engine="llvm")
+        dt2.internal.check()
+        assert dt1.names == dt2.names
+        assert dt1.topython() == dt2.topython()
 
 
 def test_rows_isna(df1):
     from datatable import isna
     dt1 = df1(isna(f.A), engine="eager")
-    dt2 = df1(isna(f.A), engine="llvm")
     dt1.internal.check()
-    dt2.internal.check()
-    assert dt1.names == dt2.names == df1.names
-    assert dt1.topython() == dt2.topython() == [[None, None],
-                                                [None, 8]]
+    assert dt1.names == df1.names
+    assert dt1.topython() == [[None, None], [None, 8]]
+    if has_llvm():
+        dt2 = df1(isna(f.A), engine="llvm")
+        dt2.internal.check()
+        assert dt1.names == dt2.names
+        assert dt1.topython() == dt2.topython()
 
 
 def test_rows_mean():
@@ -653,11 +678,12 @@ def test_filter_on_view3():
     df0 = dt.Frame({"A": range(20)})
     df1 = df0[::5, :]
     df2 = df1(f.A <= 10, engine="eager")
-    df3 = df1(f.A <= 10, engine="llvm")
     df2.internal.check()
-    df3.internal.check()
     assert df2.topython() == [[0, 5, 10]]
-    assert df3.topython() == [[0, 5, 10]]
+    if has_llvm():
+        df3 = df1(f.A <= 10, engine="llvm")
+        df3.internal.check()
+        assert df3.topython() == [[0, 5, 10]]
 
 
 def test_chained_slice(dt0):


### PR DESCRIPTION
With this PR I was able to install `datatable` on a clean Mac after merely doing `brew install llvm` (i.e. no need to download Clang/Llvm manually, or set up any environment variables).

Additional changes:
* Fixed few warnings / errors emitted in Clang7;
* Tests that test the "llvm" execution engine are now optional: if llvm is not detected on a system, the tests will be skipped instead of failing;
* In addition to `LLVM4`, `LLVM5`, `LLVM6` environment variables, also check `LLVM` and `LLVM7`.