### PR TITLE
Allow datatable to be compiled with gcc on linux

### DIFF
--- a/c/csv/reader.cc
+++ b/c/csv/reader.cc
@@ -427,11 +427,9 @@ const char* GenericReader::repr_binary(
   char* ptr = buf + pos;
   char* out = ptr;
   char* end = ptr + limit;
-  char* saved = ptr;
   bool stopped_at_newline = false;
   while (out < end) {
     stopped_at_newline = true;
-    saved = out;
     if (ch == endch) break;
     uint8_t c = static_cast<uint8_t>(*ch++);
 

--- a/c/csv/reader_fread.cc
+++ b/c/csv/reader_fread.cc
@@ -1249,7 +1249,7 @@ void FreadObserver::type_bump_info(
   static const int BUF_SIZE = 1000;
   char temp[BUF_SIZE + 1];
   int n = snprintf(temp, BUF_SIZE,
-    "Column %zu (%s) bumped from %s to %s due to <<%.*s>> on row %llu",
+    "Column %zu (%s) bumped from %s to %s due to <<%.*s>> on row %lld",
     icol, col.repr_name(g), col.typeName(),
     ParserLibrary::info(new_type).cname(),
     static_cast<int>(len), field, lineno);

--- a/c/expr/binaryop.cc
+++ b/c/expr/binaryop.cc
@@ -181,7 +181,7 @@ inline static VT op_div(LT x, RT y) {
   VT vx = static_cast<VT>(x);
   VT vy = static_cast<VT>(y);
   VT res = vx / vy;
-  if (vx < 0 != vy < 0 && vx != res * vy) {
+  if ((vx < 0) != (vy < 0) && vx != res * vy) {
     --res;
   }
   return res;
@@ -192,7 +192,7 @@ struct Mod {
   inline static VT impl(LT x, RT y)  {
     if (IsIntNA<LT>(x) || IsIntNA<RT>(y) || y == 0) return GETNA<VT>();
     VT res = static_cast<VT>(x) % static_cast<VT>(y);
-    if (x < 0 != y < 0 && res != 0) {
+    if ((x < 0) != (y < 0) && res != 0) {
       res += static_cast<VT>(y);
     }
     return res;
@@ -334,8 +334,7 @@ static mapperfn resolve2(OpMode mode) {
     case N_to_N:   return map_n_to_n<LT, RT, VT, OP>;
     case N_to_One: return map_n_to_1<LT, RT, VT, OP>;
     case One_to_N: return map_1_to_n<LT, RT, VT, OP>;
-    case Error:    return nullptr;
-
+    default:       return nullptr;
   }
 }
 

--- a/c/jay/open_jay.cc
+++ b/c/jay/open_jay.cc
@@ -31,8 +31,8 @@ DataTable* DataTable::open_jay(const std::string& path)
     throw IOError() << "Invalid Jay file of size " << len;
   }
   if (std::memcmp(ptr, "JAY1\0\0\0\0", 8) != 0 ||
-      std::memcmp(ptr + len - 8, "\0\0\0\0" "1JAY", 8) *
-      std::memcmp(ptr + len - 8, "\0\0\0\0" "JAY1", 8))
+      (std::memcmp(ptr + len - 8, "\0\0\0\0" "1JAY", 8) != 0 &&
+       std::memcmp(ptr + len - 8, "\0\0\0\0" "JAY1", 8) != 0))
   {
     throw IOError() << "Invalid signature for a Jay file";
   }

--- a/c/memrange.cc
+++ b/c/memrange.cc
@@ -736,7 +736,9 @@
     // threads called this method at the same time, then only one will proceed,
     // while all others will wait until the lock is released, and then exit
     // because flag `mapped` will now be true.
-    #pragma clang diagnostic ignored "-Wexit-time-destructors"
+    #ifdef __clang__
+      #pragma clang diagnostic ignored "-Wexit-time-destructors"
+    #endif
     static std::mutex mmp_mutex;
     std::lock_guard<std::mutex> lock(mmp_mutex);
     if (mapped) return;

--- a/c/memrange.cc
+++ b/c/memrange.cc
@@ -736,9 +736,7 @@
     // threads called this method at the same time, then only one will proceed,
     // while all others will wait until the lock is released, and then exit
     // because flag `mapped` will now be true.
-    #ifdef __clang__
-      #pragma clang diagnostic ignored "-Wexit-time-destructors"
-    #endif
+    #pragma clang diagnostic ignored "-Wexit-time-destructors"
     static std::mutex mmp_mutex;
     std::lock_guard<std::mutex> lock(mmp_mutex);
     if (mapped) return;

--- a/c/options.cc
+++ b/c/options.cc
@@ -99,10 +99,11 @@ void set_fread_anonymize(int8_t v) {
 
 
 
-static py::PKArgs set_option_args(
-    2, 0, 0, false, false, {"name", "value"}, "set_option", "");
+static py::PKArgs args_set_option(
+    2, 0, 0, false, false,
+    {"name", "value"}, "set_option", "",
 
-static py::oobj set_option(const py::PKArgs& args) {
+[](const py::PKArgs& args) -> py::oobj {
   std::string name = args[0].to_string();
   py::obj value = args[1];
 
@@ -146,11 +147,15 @@ static py::oobj set_option(const py::PKArgs& args) {
     // throw ValueError() << "Unknown option `" << name << "`";
   }
   return py::None();
-}
+});
 
 
 
-static py::oobj get_option(const py::PKArgs& args) {
+static py::PKArgs args_get_option(
+    1, 0, 0, false, false,
+    {"name"}, "get_option", "",
+
+[](const py::PKArgs& args) -> py::oobj {
   std::string name = args[0].to_string();
 
   if (name == "nthreads") {
@@ -192,13 +197,7 @@ static py::oobj get_option(const py::PKArgs& args) {
   } else {
     throw ValueError() << "Unknown option `" << name << "`";
   }
-}
-
-static py::PKArgs args_get_option(
-    1, 0, 0, false, false,
-    {"name"}, "get_option", "",
-    &get_option
-);
+});
 
 
 
@@ -207,7 +206,7 @@ static py::PKArgs args_get_option(
 
 void DatatableModule::init_methods_options() {
   ADDFN(config::args_get_option);
-  add<&config::set_option, config::set_option_args>();
+  ADDFN(config::args_set_option);
 }
 
 

--- a/c/options.cc
+++ b/c/options.cc
@@ -99,8 +99,8 @@ void set_fread_anonymize(int8_t v) {
 
 
 
-static py::PKArgs set_option_args(2, 0, 0, false, false, {"name", "value"},
-                                  "set_option", "");
+static py::PKArgs set_option_args(
+    2, 0, 0, false, false, {"name", "value"}, "set_option", "");
 
 static py::oobj set_option(const py::PKArgs& args) {
   std::string name = args[0].to_string();
@@ -150,9 +150,6 @@ static py::oobj set_option(const py::PKArgs& args) {
 
 
 
-static py::PKArgs get_option_args(1, 0, 0, false, false, {"name"},
-                                  "get_option", "");
-
 static py::oobj get_option(const py::PKArgs& args) {
   std::string name = args[0].to_string();
 
@@ -197,12 +194,19 @@ static py::oobj get_option(const py::PKArgs& args) {
   }
 }
 
+static py::PKArgs args_get_option(
+    1, 0, 0, false, false,
+    {"name"}, "get_option", "",
+    &get_option
+);
+
+
 
 }; // namespace config
 
 
 void DatatableModule::init_methods_options() {
-  add<&config::get_option, config::get_option_args>();
+  ADDFN(config::args_get_option);
   add<&config::set_option, config::set_option_args>();
 }
 

--- a/c/python/args.h
+++ b/c/python/args.h
@@ -91,6 +91,8 @@ class PKArgs : public Args {
     size_t n_varkwds;
     PyObject* args_tuple;  // for var-args iteration
     PyObject* kwds_dict;   // for var-kwds iteration
+    void (*fn0)(const PKArgs&);
+    py::oobj (*fn1)(const PKArgs&);
 
   public:
     /**
@@ -105,9 +107,12 @@ class PKArgs : public Args {
      */
     PKArgs(size_t npo, size_t npk, size_t nko, bool vargs, bool vkwds,
            std::initializer_list<const char*> names,
-           const char* name = nullptr, const char* doc = nullptr);
+           const char* name = nullptr, const char* doc = nullptr,
+           py::oobj (*f)(const PKArgs&) = nullptr);
 
     void bind(PyObject* _args, PyObject* _kws) override;
+
+    PyObject* exec(PyObject* args, PyObject* kwds) noexcept;
 
     /**
      * Returns the name of argument `i`, which will usually be in one of the

--- a/c/sort.cc
+++ b/c/sort.cc
@@ -828,7 +828,7 @@ class SortContext {
   template<typename TI, typename TO, bool OUT> void _reorder_impl() {
     TI* xi = x.data<TI>();
     TO* xo;
-    TI mask;
+    TI mask = 0;
     if (OUT) {
       xo = xx.data<TO>();
       mask = static_cast<TI>((1ULL << shift) - 1);

--- a/c/sort.cc
+++ b/c/sort.cc
@@ -827,7 +827,7 @@ class SortContext {
 
   template<typename TI, typename TO, bool OUT> void _reorder_impl() {
     TI* xi = x.data<TI>();
-    TO* xo;
+    TO* xo = nullptr;
     TI mask = 0;
     if (OUT) {
       xo = xx.data<TO>();

--- a/c/stats.cc
+++ b/c/stats.cc
@@ -39,6 +39,7 @@ static const char* stat_name(Stat s) {
     case Stat::NModal:  return "NModal";
     case Stat::NUnique: return "NUnique";
   }
+  throw RuntimeError() << "Unknown stat " << int(s);
 }
 
 

--- a/c/str/py_str.cc
+++ b/c/str/py_str.cc
@@ -22,10 +22,11 @@
 namespace py {
 
 
-static PKArgs split_into_nhot_args(1, 0, 1, false, false, {"col", "sep"},
-                                   "split_into_nhot", "");
+static PKArgs split_into_nhot_args(
+    1, 0, 1, false, false,
+    {"col", "sep"}, "split_into_nhot", "",
 
-static py::oobj split_into_nhot(const PKArgs& args) {
+[](const py::PKArgs& args) -> py::oobj {
   DataTable* dt = args[0].to_frame();
   std::string sep = args[1]? args[1].to_string() : ",";
 
@@ -48,12 +49,12 @@ static py::oobj split_into_nhot(const PKArgs& args) {
 
   DataTable* res = dt::split_into_nhot(col0, sep[0]);
   return py::Frame::from_datatable(res);
-}
+});
 
-}
+
+} // namespace py
+
 
 void DatatableModule::init_methods_str() {
-  add<&py::split_into_nhot, py::split_into_nhot_args>();
+  ADDFN(py::split_into_nhot_args);
 }
-
-

--- a/c/str/split_into_nhot.cc
+++ b/c/str/split_into_nhot.cc
@@ -74,10 +74,9 @@ static void tokenize_string(
 
 DataTable* split_into_nhot(Column* col, char sep) {
   bool is32 = (col->stype() == SType::STR32);
-  bool is64 = (col->stype() == SType::STR64);
-  xassert(is32 || is64);
-  const uint32_t* offsets32;
-  const uint64_t* offsets64;
+  xassert(is32 || (col->stype() == SType::STR64));
+  const uint32_t* offsets32 = nullptr;
+  const uint64_t* offsets64 = nullptr;
   const char* strdata;
   if (is32) {
     auto scol = static_cast<StringColumn<uint32_t>*>(col);

--- a/c/types.h
+++ b/c/types.h
@@ -7,9 +7,10 @@
 //------------------------------------------------------------------------------
 #ifndef dt_TYPES_H
 #define dt_TYPES_H
-#include <string>
+#include <cstring>   // std::strncmp
 #include <cmath>     // isnan
 #include <limits>    // std::numeric_limits
+#include <string>    // std::string
 #include <Python.h>
 
 

--- a/c/utils/parallel.h
+++ b/c/utils/parallel.h
@@ -26,10 +26,14 @@
   #define omp_set_num_threads(n)
   #define omp_get_thread_num() 0
 #else
-  #pragma clang diagnostic push
-  #pragma clang diagnostic ignored "-Wreserved-id-macro"
-  #include <omp.h>
-  #pragma clang diagnostic pop
+  #ifdef __clang__
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wreserved-id-macro"
+    #include <omp.h>
+    #pragma clang diagnostic pop
+  #else
+    #include <omp.h>
+  #endif
 #endif
 
 
@@ -105,7 +109,7 @@ class map_fw2str : private ordered_job {
 
     Column* result() {
       execute();
-      return std::move(outcol)->to_column();
+      return std::move(outcol).to_column();
     }
 
   private:

--- a/c/utils/shared_mutex.h
+++ b/c/utils/shared_mutex.h
@@ -140,7 +140,7 @@ class shared_bmutex {
         if (state_old & WRITE_ENTERED) continue;
 
         #pragma omp atomic capture
-        {state_old = state; ++state;}
+        state_old = state++;
 
         if (state_old & WRITE_ENTERED) {
           #pragma omp atomic update

--- a/ci/setup_utils.py
+++ b/ci/setup_utils.py
@@ -435,7 +435,13 @@ def get_extra_compile_flags():
         if is_gcc():
             # Ignored warnings:
             #   -Wunused-value: generates spurious warnings for OMP code.
-            flags += ["-Wall", "-Wno-unused-value"]
+            #   -Wunknown-pragmas: do not warn about clang-specific macros,
+            #       ignoring them is just fine...
+            flags += [
+                "-Wall",
+                "-Wno-unused-value",
+                "-Wno-unknown-pragmas"
+            ]
 
         for d in get_compile_includes():
             flags += ["-I" + d]

--- a/ci/setup_utils.py
+++ b/ci/setup_utils.py
@@ -375,6 +375,9 @@ def get_default_compile_flags():
     flags = re.sub(r"\s*-DNDEBUG\s*", " ", flags)
     # remove '=format-security' because this is not even a real flag...
     flags = re.sub(r"=format-security", "", flags)
+    # Clear additional flags not recognized by Clang
+    flags = re.sub(r"-fuse-linker-plugin", "", flags)
+    flags = re.sub(r"-ffat-lto-objects", "", flags)
     # Add the python include dir as '-isystem' to prevent warnings in Python.h
     if sysconfig.get_config_var("CONFINCLUDEPY"):
         flags += " -isystem %s" % sysconfig.get_config_var("CONFINCLUDEPY")

--- a/ci/setup_utils.py
+++ b/ci/setup_utils.py
@@ -403,7 +403,7 @@ def get_extra_compile_flags():
             flags += ["-g", "--coverage", "-O0"]
             flags += ["-DDTTEST"]
         else:
-            flags += ["-O3"]
+            flags += ["-O3", "-g0"]
 
         if "CI_EXTRA_COMPILE_ARGS" in os.environ:
             flags += [os.environ["CI_EXTRA_COMPILE_ARGS"]]
@@ -491,6 +491,7 @@ def get_extra_link_args():
         # this option the size of the executable is ~25% smaller...
         if "DTDEBUG" not in os.environ:
             flags += ["-s"]
+            flags += ["-g0"]
 
         if islinux() and is_clang():
             # On linux we need to pass -shared flag to clang linker which

--- a/ci/setup_utils.py
+++ b/ci/setup_utils.py
@@ -369,9 +369,13 @@ def get_default_compile_flags():
     flags = re.sub(r"\s*-O\d\s*", " ", flags)
     # remove -DNDEBUG so that the program can use asserts if needed
     flags = re.sub(r"\s*-DNDEBUG\s*", " ", flags)
+    # remove '=format-security' because this is not even a real flag...
+    flags = re.sub(r"=format-security", "", flags)
     # Add the python include dir as '-isystem' to prevent warnings in Python.h
     if sysconfig.get_config_var("CONFINCLUDEPY"):
         flags += " -isystem %s" % sysconfig.get_config_var("CONFINCLUDEPY")
+    # Squash spaces
+    flags = re.sub(r"\s+", " ", flags)
     return flags
 
 
@@ -491,7 +495,6 @@ def get_extra_link_args():
         # this option the size of the executable is ~25% smaller...
         if "DTDEBUG" not in os.environ:
             flags += ["-s"]
-            flags += ["-g0"]
 
         if islinux() and is_clang():
             # On linux we need to pass -shared flag to clang linker which

--- a/ci/setup_utils.py
+++ b/ci/setup_utils.py
@@ -398,6 +398,10 @@ def get_extra_compile_flags():
         if omp_enabled():
             flags.insert(0, "-fopenmp")
 
+        # Generate 'Position-independent code'. This is required for any
+        # dynamically-linked library.
+        flags += ["-fPIC"]
+
         if "DTDEBUG" in os.environ:
             flags += ["-g", "-ggdb", "-O0"]
             flags += ["-DDTTEST"]

--- a/ci/setup_utils.py
+++ b/ci/setup_utils.py
@@ -427,7 +427,9 @@ def get_extra_compile_flags():
                 "-Wno-weak-template-vtables",
             ]
         if is_gcc:
-            flags += ["-Wall"]
+            # Ignored warnings:
+            #   -Wunused-value: generates spurious warnings for OMP code.
+            flags += ["-Wall", "-Wno-unused-value"]
 
         for d in get_compile_includes():
             flags += ["-I" + d]

--- a/ci/setup_utils.py
+++ b/ci/setup_utils.py
@@ -489,6 +489,8 @@ def get_extra_link_args():
             # On linux we need to pass -shared flag to clang linker which
             # is not used for some reason at linux
             flags += ["-lc++", "-shared"]
+        if is_gcc():
+            flags += ["-lstdc++"]
 
         if "DTASAN" in os.environ:
             flags += ["-fsanitize=address", "-shared-libasan"]

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,14 @@ from ci.setup_utils import (get_datatable_version, make_git_version_file,
                             get_extra_link_args, find_linked_dynamic_libraries,
                             TaskContext, islinux, ismacos, iswindows)
 
+print()
+cmd = ""
+with TaskContext("Start setup.py") as log:
+    if len(sys.argv) > 1:
+        cmd = sys.argv[1]
+    log.info("command = `%s`" % cmd)
+
+
 
 #-------------------------------------------------------------------------------
 # Generic helpers
@@ -77,52 +85,53 @@ def get_test_dependencies():
 #-------------------------------------------------------------------------------
 # Prepare the environment
 #-------------------------------------------------------------------------------
-print()
 
-with TaskContext("Prepare the environment") as log:
-    # Check whether the environment is sane...
-    if not(islinux() or ismacos() or iswindows()):
-        log.warn("Unknown platform=%s os=%s" % (sys.platform, os.name))
+if cmd in ("build", "bdist_wheel", "build_ext"):
+    with TaskContext("Prepare the environment") as log:
+        # Check whether the environment is sane...
+        if not(islinux() or ismacos() or iswindows()):
+            log.warn("Unknown platform=%s os=%s" % (sys.platform, os.name))
 
-    # Compiler
-    os.environ["CC"] = os.environ["CXX"] = get_compiler()
+        # Compiler
+        os.environ["CC"] = os.environ["CXX"] = get_compiler()
 
-    # Linker
-    # On linux we need to pass proper flag to clang linker which
-    # is not used for some reason at linux
-    if islinux() and os.environ.get("DTCOVERAGE"):
-        os.environ["LDSHARED"] = os.environ["CC"]
+        # Linker
+        # On linux we need to pass proper flag to clang linker which
+        # is not used for some reason at linux
+        if islinux() and os.environ.get("DTCOVERAGE"):
+            os.environ["LDSHARED"] = os.environ["CC"]
 
-    if ismacos() and not os.environ.get("MACOSX_DEPLOYMENT_TARGET"):
-        os.environ["MACOSX_DEPLOYMENT_TARGET"] = "10.13"
+        if ismacos() and not os.environ.get("MACOSX_DEPLOYMENT_TARGET"):
+            os.environ["MACOSX_DEPLOYMENT_TARGET"] = "10.13"
 
-    # Force to build for a 64-bit platform only
-    os.environ["ARCHFLAGS"] = "-m64"
+        # Force to build for a 64-bit platform only
+        os.environ["ARCHFLAGS"] = "-m64"
 
-    for n in ["CC", "CXX", "LDFLAGS", "ARCHFLAGS", "LLVM_CONFIG",
-              "MACOSX_DEPLOYMENT_TARGET"]:
-        log.info("%s = %s" % (n, os.environ.get(n, "")))
+        for n in ["CC", "CXX", "LDFLAGS", "ARCHFLAGS", "LLVM_CONFIG",
+                  "MACOSX_DEPLOYMENT_TARGET"]:
+            log.info("%s = %s" % (n, os.environ.get(n, "")))
 
 
 # Create the git version file
-if sys.argv[1] in ("build", "fast", "dist", "sdist"):
-    force = sys.argv[1] in ("dist", "sdist")
-    make_git_version_file(force)
+if cmd in ("build", "sdist", "bdist_wheel"):
+    make_git_version_file(True)
 
 
-with TaskContext("Copy dynamic libraries") as log:
-    # Copy system libraries into the datatable/lib folder, so that they can be
-    # packaged with the wheel
-    libs = find_linked_dynamic_libraries()
-    if ismacos() or iswindows():
-        libs = libs[:1]
-    for libpath in libs:
-        trgfile = os.path.join("datatable", "lib", os.path.basename(libpath))
-        if os.path.exists(trgfile):
-            log.info("File %s already exists, skipped" % trgfile)
-        else:
-            log.info("Copying %s to %s" % (libpath, trgfile))
-            shutil.copy(libpath, trgfile)
+if cmd == "bdist_wheel":
+    with TaskContext("Copy dynamic libraries") as log:
+        # Copy system libraries into the datatable/lib folder, so that they can
+        # be packaged with the wheel
+        libs = find_linked_dynamic_libraries()
+        if ismacos() or iswindows():
+            libs = libs[:1]
+        for libpath in libs:
+            trgfile = os.path.join("datatable", "lib",
+                                   os.path.basename(libpath))
+            if os.path.exists(trgfile):
+                log.info("File %s already exists, skipped" % trgfile)
+            else:
+                log.info("Copying %s to %s" % (libpath, trgfile))
+                shutil.copy(libpath, trgfile)
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,9 @@ def get_test_dependencies():
 #-------------------------------------------------------------------------------
 # Prepare the environment
 #-------------------------------------------------------------------------------
+cpp_files = []
+extra_compile_args = []
+extra_link_args = []
 
 if cmd in ("build", "bdist_wheel", "build_ext", "install"):
     with TaskContext("Prepare the environment") as log:
@@ -111,13 +114,10 @@ if cmd in ("build", "bdist_wheel", "build_ext", "install"):
                   "MACOSX_DEPLOYMENT_TARGET"]:
             log.info("%s = %s" % (n, os.environ.get(n, "")))
 
+    extra_compile_args = get_extra_compile_flags()
+    extra_link_args = get_extra_link_args()
+    cpp_files = get_c_sources("c")
 
-# Create the git version file
-if cmd in ("build", "sdist", "bdist_wheel", "install"):
-    make_git_version_file(True)
-
-
-if cmd == "bdist_wheel":
     with TaskContext("Copy dynamic libraries") as log:
         # Copy system libraries into the datatable/lib folder, so that they can
         # be packaged with the wheel
@@ -132,6 +132,11 @@ if cmd == "bdist_wheel":
             else:
                 log.info("Copying %s to %s" % (libpath, trgfile))
                 shutil.copy(libpath, trgfile)
+
+
+# Create the git version file
+if cmd in ("build", "sdist", "bdist_wheel", "install"):
+    make_git_version_file(True)
 
 
 
@@ -195,9 +200,9 @@ setup(
         Extension(
             "datatable/lib/_datatable",
             include_dirs=["c"],
-            sources=get_c_sources("c"),
-            extra_compile_args=get_extra_compile_flags(),
-            extra_link_args=get_extra_link_args(),
+            sources=cpp_files,
+            extra_compile_args=extra_compile_args,
+            extra_link_args=extra_link_args,
             language="c++",
         ),
     ],

--- a/setup.py
+++ b/setup.py
@@ -122,8 +122,6 @@ if cmd in ("build", "bdist_wheel", "build_ext", "install"):
         # Copy system libraries into the datatable/lib folder, so that they can
         # be packaged with the wheel
         libs = find_linked_dynamic_libraries()
-        if ismacos() or iswindows():
-            libs = libs[:1]
         for libpath in libs:
             trgfile = os.path.join("datatable", "lib",
                                    os.path.basename(libpath))

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ def get_test_dependencies():
 # Prepare the environment
 #-------------------------------------------------------------------------------
 
-if cmd in ("build", "bdist_wheel", "build_ext"):
+if cmd in ("build", "bdist_wheel", "build_ext", "install"):
     with TaskContext("Prepare the environment") as log:
         # Check whether the environment is sane...
         if not(islinux() or ismacos() or iswindows()):
@@ -113,7 +113,7 @@ if cmd in ("build", "bdist_wheel", "build_ext"):
 
 
 # Create the git version file
-if cmd in ("build", "sdist", "bdist_wheel"):
+if cmd in ("build", "sdist", "bdist_wheel", "install"):
     make_git_version_file(True)
 
 

--- a/tests/fread/test_fread_large.py
+++ b/tests/fread/test_fread_large.py
@@ -155,6 +155,8 @@ def test_h2o3_bigdata(f):
         os.path.join("mnist", "t10k-labels-idx1-ubyte.gz"),
         os.path.join("mnist", "train-images-idx3-ubyte.gz"),
         os.path.join("mnist", "train-labels-idx1-ubyte.gz"),
+        # ARFF files
+        os.path.join("parser", "anARFFFile.txt"),
         # zip files having more than 1 file inside
         os.path.join("flights-nyc", "delays14.csv.zip"),
         os.path.join("flights-nyc", "flights14.csv.zip"),


### PR DESCRIPTION
This PR tweaks certain compiler/linker flags, as well as fixes few compilation errors (that inexplicably are perfectly fine with Clang, not even a warning raised). 

The biggest change to code structure is that now python module-level functions are declared using a macro rather than a template. Even though this strays away from C++ ideals, the macro-based solution turns out to be cleaner and the code smaller. In addition, the function's signature is now defined together with the function itself, which makes the code more coherent.

The `setup.py` now does the work for setting up a compiler only when it detects a command that will cause an extension to be built.

With this PR I was able to build `datatable` on Ubuntu 18.04 without downloading Clang/Llvm. The build steps were the following:
1. set up python virtual environment
2. check out this branch from git
3. `$ make build`

@jangorecki -- could you please verify that this fixes your problems with compiling on Ubuntu 18.04?

Closes #1100