### PR TITLE
Add extrema properties to stypes

### DIFF
--- a/datatable/types.py
+++ b/datatable/types.py
@@ -9,6 +9,7 @@ import enum
 import datatable
 from datatable.lib import core
 from datatable.utils.typechecks import TValueError
+from struct import unpack
 
 __all__ = ("stype", "ltype")
 
@@ -120,6 +121,20 @@ class stype(enum.Enum):
         """
         return _stype_2_struct[self]
 
+    @property
+    def min(self):
+        """
+        The smallest finite value that this stype can represent.
+        """
+        return _stype_extrema.get(self, (None, None))[0]
+
+    @property
+    def max(self):
+        """
+        The largest finite value that this stype can represent.
+        """
+        return _stype_extrema.get(self, (None, None))[1]
+
 
 
 #-------------------------------------------------------------------------------
@@ -229,6 +244,16 @@ _stype_2_ctype = {
     stype.str32: ctypes.c_int32,
     stype.str64: ctypes.c_int64,
     stype.obj64: ctypes.py_object,
+}
+
+_stype_extrema = {
+    stype.bool8: (0, 1),
+    stype.int8: (-255, 255),
+    stype.int16: (-65536, 65536),
+    stype.int32: (-4294967296, 4294967296),
+    stype.int64: (-18446744073709551616, 18446744073709551616),
+    stype.float32: (unpack(">f", b'\xff\x7f\xff\xff')[0], unpack(">f", b'\x7f\x7f\xff\xff')[0]),
+    stype.float64: (unpack(">d", b'\xff\xef\xff\xff\xff\xff\xff\xff')[0], unpack(">d", b'\x7f\xef\xff\xff\xff\xff\xff\xff')[0]),
 }
 
 _numpy_init_attempted = False

--- a/datatable/types.py
+++ b/datatable/types.py
@@ -9,7 +9,6 @@ import enum
 import datatable
 from datatable.lib import core
 from datatable.utils.typechecks import TValueError
-from struct import unpack
 
 __all__ = ("stype", "ltype")
 

--- a/datatable/types.py
+++ b/datatable/types.py
@@ -248,7 +248,7 @@ _stype_2_ctype = {
 
 _stype_extrema = {
     stype.bool8: (0, 1),
-    stype.int8: (-255, 255),
+    stype.int8: (-127, 127),
     stype.int16: (-65536, 65536),
     stype.int32: (-4294967296, 4294967296),
     stype.int64: (-18446744073709551616, 18446744073709551616),

--- a/datatable/types.py
+++ b/datatable/types.py
@@ -253,7 +253,7 @@ _stype_extrema = {
     stype.int32: (-2147483647, 2147483647),
     stype.int64: (-9223372036854775807, 9223372036854775807),
     stype.float32: (float.fromhex("-0x1.fffffep+127"), float.fromhex("0x1.fffffep+127")),
-    stype.float64: (unpack(">d", b'\xff\xef\xff\xff\xff\xff\xff\xff')[0], unpack(">d", b'\x7f\xef\xff\xff\xff\xff\xff\xff')[0]),
+    stype.float64: (float.fromhex("-0x1.fffffffffffffp+1023"), float.fromhex("0x1.fffffffffffffp+1023")),
 }
 
 _numpy_init_attempted = False

--- a/datatable/types.py
+++ b/datatable/types.py
@@ -252,7 +252,7 @@ _stype_extrema = {
     stype.int16: (-32767, 32767),
     stype.int32: (-2147483647, 2147483647),
     stype.int64: (-9223372036854775807, 9223372036854775807),
-    stype.float32: (unpack(">f", b'\xff\x7f\xff\xff')[0], unpack(">f", b'\x7f\x7f\xff\xff')[0]),
+    stype.float32: (float.fromhex("-0x1.fffffep+127"), float.fromhex("0x1.fffffep+127")),
     stype.float64: (unpack(">d", b'\xff\xef\xff\xff\xff\xff\xff\xff')[0], unpack(">d", b'\x7f\xef\xff\xff\xff\xff\xff\xff')[0]),
 }
 

--- a/datatable/types.py
+++ b/datatable/types.py
@@ -249,7 +249,7 @@ _stype_2_ctype = {
 _stype_extrema = {
     stype.bool8: (0, 1),
     stype.int8: (-127, 127),
-    stype.int16: (-65536, 65536),
+    stype.int16: (-32767, 32767),
     stype.int32: (-4294967296, 4294967296),
     stype.int64: (-18446744073709551616, 18446744073709551616),
     stype.float32: (unpack(">f", b'\xff\x7f\xff\xff')[0], unpack(">f", b'\x7f\x7f\xff\xff')[0]),

--- a/datatable/types.py
+++ b/datatable/types.py
@@ -251,7 +251,7 @@ _stype_extrema = {
     stype.int8: (-127, 127),
     stype.int16: (-32767, 32767),
     stype.int32: (-2147483647, 2147483647),
-    stype.int64: (-18446744073709551616, 18446744073709551616),
+    stype.int64: (-9223372036854775807, 9223372036854775807),
     stype.float32: (unpack(">f", b'\xff\x7f\xff\xff')[0], unpack(">f", b'\x7f\x7f\xff\xff')[0]),
     stype.float64: (unpack(">d", b'\xff\xef\xff\xff\xff\xff\xff\xff')[0], unpack(">d", b'\x7f\xef\xff\xff\xff\xff\xff\xff')[0]),
 }

--- a/datatable/types.py
+++ b/datatable/types.py
@@ -250,7 +250,7 @@ _stype_extrema = {
     stype.bool8: (0, 1),
     stype.int8: (-127, 127),
     stype.int16: (-32767, 32767),
-    stype.int32: (-4294967296, 4294967296),
+    stype.int32: (-2147483647, 2147483647),
     stype.int64: (-18446744073709551616, 18446744073709551616),
     stype.float32: (unpack(">f", b'\xff\x7f\xff\xff')[0], unpack(">f", b'\x7f\x7f\xff\xff')[0]),
     stype.float64: (unpack(">d", b'\xff\xef\xff\xff\xff\xff\xff\xff')[0], unpack(">d", b'\x7f\xef\xff\xff\xff\xff\xff\xff')[0]),


### PR DESCRIPTION
```
>>> dt.float64.min
-1.7976931348623157e+308
>>> dt.bool8.max
1
```
Non-numeric stypes return `None`