### PR TITLE
Win32

### DIFF
--- a/c/csv/writer.h
+++ b/c/csv/writer.h
@@ -74,8 +74,11 @@ private:
 
 void init_csvwrite_constants();
 
-__attribute__((format(printf, 2, 3)))
-void log_message(void *logger, const char *format, ...);
-
+#ifdef _WIN32
+  void log_message(void *logger, const char *format, ...);
+#else
+  __attribute__((format(printf, 2, 3)))
+  void log_message(void *logger, const char *format, ...);
+#endif
 
 #endif

--- a/c/encodings.cc
+++ b/c/encodings.cc
@@ -39,8 +39,7 @@ extern const uint8_t hexdigits[256];  // defined in c/csv/freadLookups.h
  *     sequences.
  */
 int decode_sbcs(
-    const unsigned char *__restrict__ src, int len,
-    unsigned char *__restrict__ dest, uint32_t *map
+    const uint8_t* src, int len, uint8_t* dest, uint32_t *map
 ) {
   const unsigned char* end = src + len;
   unsigned char* d = dest;

--- a/c/encodings.h
+++ b/c/encodings.h
@@ -16,8 +16,7 @@ int check_escaped_string(const uint8_t* src, size_t len, uint8_t escape_char);
 
 int decode_escaped_csv_string(const uint8_t* src, int len, uint8_t* dest, uint8_t quote);
 
-int decode_sbcs(const unsigned char *__restrict__ src, int len,
-                unsigned char *__restrict__ dest, uint32_t *map);
+int decode_sbcs(const uint8_t* src, int len, uint8_t* dest, uint32_t *map);
 
 int64_t utf32_to_utf8(uint32_t* buf, int64_t maxchars, char* ch);
 

--- a/c/expr/unaryop.cc
+++ b/c/expr/unaryop.cc
@@ -73,7 +73,7 @@ inline static T op_abs(T x) {
 
 template <typename T>
 inline static double op_exp(T x) {
-  return ISNA<T>(x) ? GETNA<double>() : exp(x);
+  return ISNA<T>(x) ? GETNA<double>() : exp(static_cast<double>(x));
 }
 
 

--- a/c/lib/flatbuffers/flatbuffers.h
+++ b/c/lib/flatbuffers/flatbuffers.h
@@ -21,7 +21,6 @@
 #pragma clang diagnostic ignored "-Wweak-vtables"
 #pragma clang diagnostic ignored "-Wdocumentation"
 #pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
-#pragma clang diagnostic ignored "-Wexit-time-destructors"
 #pragma clang diagnostic ignored "-Wsign-conversion"
 #pragma clang diagnostic ignored "-Wold-style-cast"
 #pragma clang diagnostic ignored "-Wpadded"

--- a/c/py_column.cc
+++ b/c/py_column.cc
@@ -103,7 +103,7 @@ PyObject* get_refcount(pycolumn::obj*) {
 
 PyObject* get_nrows(pycolumn::obj* self) {
   Column*& col = self->ref;
-  return PyLong_FromLong(col->nrows);
+  return PyLong_FromInt64(col->nrows);
 }
 
 

--- a/c/py_encodings.h
+++ b/c/py_encodings.h
@@ -13,12 +13,9 @@
 
 int init_py_encodings(PyObject *module);
 
-int decode_iso8859(const unsigned char *__restrict__ src, int len,
-                   unsigned char *__restrict__ dest);
-int decode_win1252(const unsigned char *__restrict__ src, int len,
-                   unsigned char *__restrict__ dest);
-int decode_win1251(const unsigned char *__restrict__ src, int len,
-                   unsigned char *__restrict__ dest);
+int decode_iso8859(const uint8_t* src, int len, uint8_t* dest);
+int decode_win1252(const uint8_t* src, int len, uint8_t* dest);
+int decode_win1251(const uint8_t* src, int len, uint8_t* dest);
 
 
 #endif

--- a/c/utils/file.h
+++ b/c/utils/file.h
@@ -10,6 +10,11 @@
 #include <sys/stat.h>  // fstat
 #include <string>      // std::string
 
+#ifdef _WIN32
+  // mode_t is not defined on Windows
+  typedef int mode_t;
+#endif
+
 
 class File
 {

--- a/ci/setup_utils.py
+++ b/ci/setup_utils.py
@@ -358,7 +358,7 @@ def get_compile_includes():
             if not os.path.isdir(d):
                 includes[i] = None
                 log.info("Directory `%s` not found, ignoring" % d)
-    return sorted(includes)
+    return sorted(i for i in includes if i is not None)
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,11 @@ def get_c_sources(folder, include_headers=False):
     for root, dirs, files in os.walk(folder):
         for name in files:
             ext = os.path.splitext(name)[1]
-            if ext in allowed_extensions:
+            if name == "types.cc":
+                # Make sure `types.cc` is compiled first, as it has multiple
+                # useful static assertions.
+                sources.insert(0, os.path.join(root, name))
+            elif ext in allowed_extensions:
                 sources.append(os.path.join(root, name))
     return sources
 


### PR DESCRIPTION
Tweak code to remove certain compile errors with MSVC (on Windows):
- Added fallback for `uint128_t` type which is not present in MSVC;
- In memrange.cc, throw an exception when trying to memmap a file (there is no `mmap()` function on windows).

WIP for #1369 