### PR TITLE
Replace Column** with std::vector<Column*> in DataTable

### DIFF
--- a/c/columnset.cc
+++ b/c/columnset.cc
@@ -28,12 +28,11 @@ Column** columns_from_slice(DataTable* dt, const RowIndex& rowindex,
                        << " columns";
   }
 
-  Column** srccols = dt->columns;
   Column** columns = dt::amalloc<Column*>(count + 1);
   columns[count] = nullptr;
 
   for (int64_t i = 0, j = start; i < count; i++, j += step) {
-    columns[i] = srccols[j]->shallowcopy(rowindex);
+    columns[i] = dt->columns[j]->shallowcopy(rowindex);
   }
   return columns;
 }

--- a/c/csv/reader.cc
+++ b/c/csv/reader.cc
@@ -706,9 +706,7 @@ std::unique_ptr<DataTable> GenericReader::read_empty_input() {
   size_t size = datasize();
   if (size == 0 || (size == 1 && *sof == '\0')) {
     trace("Input is empty, returning a (0 x 0) DataTable");
-    Column** cols = static_cast<Column**>(malloc(sizeof(Column*)));
-    cols[0] = nullptr;
-    return std::unique_ptr<DataTable>(new DataTable(cols, nullptr));
+    return std::unique_ptr<DataTable>(new DataTable());
   }
   return nullptr;
 }
@@ -789,20 +787,18 @@ void GenericReader::report_columns_to_python() {
 
 
 DataTablePtr GenericReader::makeDatatable() {
-  Column** ccols = nullptr;
   size_t ncols = columns.size();
   size_t ocols = columns.nColumnsInOutput();
-  ccols = dt::malloc<Column*>((ocols + 1) * sizeof(Column*));
-  ccols[ocols] = nullptr;
-  for (size_t i = 0, j = 0; i < ncols; ++i) {
+  std::vector<Column*> ccols;
+  ccols.reserve(ocols);
+  for (size_t i = 0; i < ncols; ++i) {
     dt::read::Column& col = columns[i];
     if (!col.is_in_output()) continue;
     MemoryRange databuf = col.extract_databuf();
     MemoryRange strbuf = col.extract_strbuf();
-    ccols[j] = Column::new_mbuf_column(col.get_stype(), std::move(databuf),
-                                       std::move(strbuf));
-    j++;
+    ccols.push_back(Column::new_mbuf_column(col.get_stype(), std::move(databuf),
+                                       std::move(strbuf)));
   }
   py::olist names = freader.get_attr("_colnames").to_pylist();
-  return DataTablePtr(new DataTable(ccols, names));
+  return DataTablePtr(new DataTable(std::move(ccols), names));
 }

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -74,7 +74,6 @@ class DataTable {
     DataTable(std::vector<Column*>&& cols, const std::vector<std::string>&);
     DataTable(std::vector<Column*>&& cols, const DataTable*);
     ~DataTable();
-    DataTable(Column**); // TEMP
 
     DataTable* delete_columns(int*, int64_t);
     void resize_rows(int64_t n);

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -60,7 +60,7 @@ class DataTable {
     int64_t  nkeys;
     RowIndex rowindex;
     Groupby  groupby;
-    Column** columns;
+    std::vector<Column*> columns;
 
   private:
     std::vector<std::string> names;
@@ -68,15 +68,14 @@ class DataTable {
     mutable py::odict  py_inames;  // memoized dict of {column name: index}
 
   public:
-    DataTable(Column** cols, std::nullptr_t);
-    DataTable(Column** cols, const py::olist& namessrc);
-    DataTable(Column** cols, const std::vector<std::string>& namessrc);
-    DataTable(Column** cols, const DataTable* namessrc);
-    DataTable(std::vector<Column*>&& cols, std::nullptr_t);
+    DataTable();
+    DataTable(std::vector<Column*>&& cols);
     DataTable(std::vector<Column*>&& cols, const py::olist&);
     DataTable(std::vector<Column*>&& cols, const std::vector<std::string>&);
     DataTable(std::vector<Column*>&& cols, const DataTable*);
     ~DataTable();
+    DataTable(Column**); // TEMP
+
     DataTable* delete_columns(int*, int64_t);
     void resize_rows(int64_t n);
     void replace_rowindex(const RowIndex& newri);
@@ -132,7 +131,6 @@ class DataTable {
     static DataTable* open_jay(const std::string& path);
 
   private:
-    DataTable(Column**);
     void _init_pynames() const;
     void _set_names_impl(NameProvider*);
     void _integrity_check_names() const;

--- a/c/datatable_load.cc
+++ b/c/datatable_load.cc
@@ -27,8 +27,8 @@ DataTable* DataTable::load(DataTable* colspec, int64_t nrows, const std::string&
                            bool recode)
 {
     int64_t ncols = colspec->nrows;
-    Column** columns = dt::amalloc<Column*>(ncols + 1);
-    columns[ncols] = nullptr;
+    std::vector<Column*> columns;
+    columns.reserve(ncols);
 
     if (colspec->ncols != 2 && colspec->ncols != 4) {
         throw ValueError() << "colspec table should have had 2 or 4 columns, "
@@ -76,8 +76,9 @@ DataTable* DataTable::load(DataTable* colspec, int64_t nrows, const std::string&
         }
 
         // Load the column
-        columns[i] = Column::open_mmap_column(stype, nrows, filename, recode);
+        Column* newcol = Column::open_mmap_column(stype, nrows, filename, recode);
+        columns.push_back(newcol);
     }
 
-    return new DataTable(columns);
+    return new DataTable(std::move(columns));
 }

--- a/c/datatable_rbind.cc
+++ b/c/datatable_rbind.cc
@@ -33,11 +33,10 @@ void DataTable::rbind(
   // If this is a view datatable, then it must be materialized.
   this->reify();
 
-  columns = dt::arealloc<Column*>(columns, new_ncols + 1);
+  columns.resize(new_ncols);
   for (int64_t i = ncols; i < new_ncols; ++i) {
     columns[i] = new VoidColumn(nrows);
   }
-  columns[new_ncols] = nullptr;
 
   int64_t new_nrows = nrows;
   for (int64_t i = 0; i < ndts; ++i) {

--- a/c/extras/aggregator.cc
+++ b/c/extras/aggregator.cc
@@ -71,9 +71,8 @@ DataTablePtr Aggregator::aggregate(DataTable* dt) {
   DataTablePtr dt_members = nullptr;
   Column** cols_members = dt::amalloc<Column*>(static_cast<int64_t>(2));
 
-  cols_members[0] = Column::new_data_column(SType::INT32, dt->nrows);
-  cols_members[1] = nullptr;
-  dt_members = DataTablePtr(new DataTable(cols_members, {"exemplar_id"}));
+  Column* col0 = Column::new_data_column(SType::INT32, dt->nrows);
+  dt_members = DataTablePtr(new DataTable({col0}, {"exemplar_id"}));
 
   if (dt->nrows >= min_rows) {
     DataTablePtr dt_double = nullptr;
@@ -99,7 +98,7 @@ DataTablePtr Aggregator::aggregate(DataTable* dt) {
     }
 
     cols_double[ncols] = nullptr;
-    dt_double = DataTablePtr(new DataTable(cols_double, nullptr));
+    dt_double = DataTablePtr(new DataTable(cols_double));
     switch (dt_double->ncols) {
       case 0:  group_0d(dt, dt_members);
                max_bins = nd_max_bins;
@@ -208,11 +207,9 @@ void Aggregator::aggregate_exemplars(DataTable* dt,
 
   // Setting up a table for counts
   DataTable* dt_counts;
-  Column** cols_counts = dt::amalloc<Column*>(static_cast<int64_t>(2));
-  cols_counts[0] = Column::new_data_column(SType::INT32,
+  Column* col0 = Column::new_data_column(SType::INT32,
                                            static_cast<int64_t>(n_exemplars));
-  cols_counts[1] = nullptr;
-  dt_counts = new DataTable(cols_counts, {"members_count"});
+  dt_counts = new DataTable({col0}, {"members_count"});
   auto d_counts = static_cast<int32_t*>(dt_counts->columns[0]->data_w());
   std::memset(d_counts, 0, static_cast<size_t>(n_exemplars) * sizeof(int32_t));
 

--- a/c/frame/cbind.cc
+++ b/c/frame/cbind.cc
@@ -155,8 +155,7 @@ DataTable* DataTable::cbind(std::vector<DataTable*> dts)
 
   // Append columns from `dts` into the "main" datatable
   std::vector<std::string> newnames = names;
-  columns = dt::arealloc(columns, t_ncols + 1);
-  columns[t_ncols] = nullptr;
+  columns.resize(t_ncols);
   int64_t j = ncols;
   for (size_t i = 0; i < dts.size(); ++i) {
     int64_t ncolsi = dts[i]->ncols;

--- a/c/frame/names.cc
+++ b/c/frame/names.cc
@@ -287,6 +287,7 @@ int64_t DataTable::colindex(const py::_obj& pyname) const {
  * verified in DataTable `other`.
  */
 void DataTable::copy_names_from(const DataTable* other) {
+  xassert(other);
   names = other->names;
   py_names = other->py_names;
   py_inames = other->py_inames;
@@ -703,13 +704,13 @@ namespace dttest {
 
 
   void cover_names_integrity_checks() {
-    Column** cols = dt::malloc<Column*>(3 * sizeof(Column*));
-    cols[0] = Column::new_data_column(SType::INT32, 1);
-    cols[1] = Column::new_data_column(SType::FLOAT64, 1);
-    cols[2] = nullptr;
-    DataTable* dt = new DataTable(cols);
+    DataTable* dt = new DataTable({
+                        Column::new_data_column(SType::INT32, 1),
+                        Column::new_data_column(SType::FLOAT64, 1)
+                    });
 
     auto check1 = [dt]() { dt->_integrity_check_names(); };
+    dt->names.clear();
     test_assert(check1, "DataTable.names has size 0, however there are 2 "
                         "columns in the Frame");
     dt->names = { "foo", "foo" };

--- a/c/frame/py_frame_init.cc
+++ b/c/frame/py_frame_init.cc
@@ -609,14 +609,14 @@ class FrameInitializationManager {
 
 
     void make_datatable(nullptr_t) {
-      frame->dt = new DataTable(std::move(cols), nullptr);
+      frame->dt = new DataTable(std::move(cols));
     }
 
     void make_datatable(const Arg& names) {
       if (names) {
         frame->dt = new DataTable(std::move(cols), names.to_pylist());
       } else {
-        frame->dt = new DataTable(std::move(cols), nullptr);
+        frame->dt = new DataTable(std::move(cols));
       }
     }
 

--- a/c/jay/open_jay.cc
+++ b/c/jay/open_jay.cc
@@ -54,8 +54,8 @@ DataTable* DataTable::open_jay(const std::string& path)
   size_t nrows = frame->nrows();
   auto msg_columns = frame->columns();
 
-  Column** columns = dt::malloc<Column*>(sizeof(Column*) * size_t(ncols + 1));
-  columns[ncols] = nullptr;
+  std::vector<Column*> columns;
+  columns.reserve(ncols);
   size_t i = 0;
   for (const jay::Column* jcol : *msg_columns) {
     Column* col = column_from_jay(jcol, mbuf);
@@ -63,13 +63,13 @@ DataTable* DataTable::open_jay(const std::string& path)
       throw IOError() << "Length of column " << i << " is " << col->nrows
           << ", however the Frame contains " << nrows << " rows";
     }
-    columns[i++] = col;
+    columns.push_back(col);
     colnames.push_back(jcol->name()->str());
+    ++i;
   }
 
-  auto dt = new DataTable(columns);
+  auto dt = new DataTable(std::move(columns), colnames);
   dt->nkeys = frame->nkeys();
-  dt->set_names(colnames);
   return dt;
 }
 

--- a/c/py_columnset.cc
+++ b/c/py_columnset.cc
@@ -134,7 +134,8 @@ PyObject* to_frame(obj* self, PyObject* args) {
 
   Column** columns = self->columns;
   self->columns = nullptr;
-  DataTable* dt = new DataTable(columns, names);
+  DataTable* dt = new DataTable(columns);
+  dt->set_names(names);
   return py::Frame::from_datatable(dt);
 }
 

--- a/c/py_columnset.cc
+++ b/c/py_columnset.cc
@@ -132,10 +132,12 @@ PyObject* to_frame(obj* self, PyObject* args) {
   if (!PyArg_ParseTuple(args, "O:to_frame", &arg1)) return nullptr;
   py::olist names = py::obj(arg1).to_pylist();
 
-  Column** columns = self->columns;
+  std::vector<Column*> columns;
+  for (Column** pcol = self->columns; *pcol; pcol++) {
+    columns.push_back(*pcol);
+  }
   self->columns = nullptr;
-  DataTable* dt = new DataTable(columns);
-  dt->set_names(names);
+  DataTable* dt = new DataTable(std::move(columns), names);
   return py::Frame::from_datatable(dt);
 }
 

--- a/c/py_datatable.cc
+++ b/c/py_datatable.cc
@@ -400,9 +400,8 @@ PyObject* replace_column_array(obj* self, PyObject* args) {
       throw ValueError() << "Cannot assign to column(s) that are outside of "
                             "the Frame: " << rows_ri;
     }
-    size_t newsize = static_cast<size_t>(dt->ncols + num_new_cols + 1)
-                     * sizeof(Column*);
-    dt->columns = static_cast<Column**>(realloc(dt->columns, newsize));
+    size_t newsize = static_cast<size_t>(dt->ncols + num_new_cols);
+    dt->columns.resize(newsize);
   }
   for (size_t i = 0; i < cols.size(); ++i) {
     py::obj item = cols[i];
@@ -419,7 +418,6 @@ PyObject* replace_column_array(obj* self, PyObject* args) {
       dt->columns[j] = replcol->shallowcopy();
     }
   }
-  dt->columns[dt->ncols] = nullptr;
 
   // Clear cached stypes/ltypes; No need to update names
   _clear_types(self);


### PR DESCRIPTION
* The `Column**` array was a relic from the old C times. At last, it is replaced with a proper container.
* Added default constructor `DataTable()` to create an empty Frame.

This currently generates a lot of warning about `int64_t` to `size_t` conversion. These warnings will be fixed in another PR.

Closes #1377 