### PR TITLE
Fix warnings caused by int64_t <-> size_t conversions

### DIFF
--- a/c/capi.cc
+++ b/c/capi.cc
@@ -11,7 +11,7 @@
 extern "C" {
 
 
-void* datatable_get_column_data(void* dt_, int64_t column)
+void* datatable_get_column_data(void* dt_, size_t column)
 {
   DataTable *dt = static_cast<DataTable*>(dt_);
   return dt->columns[column]->data_w();

--- a/c/capi.h
+++ b/c/capi.h
@@ -8,13 +8,14 @@
 #ifndef dt_CAPI_H
 #define dt_CAPI_H
 #include <stdint.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 
-void* datatable_get_column_data(void* dt, int64_t column);
+void* datatable_get_column_data(void* dt, size_t column);
 void  datatable_unpack_slicerowindex(void *dt, int64_t *start, int64_t *step);
 void  datatable_unpack_arrayrowindex(void *dt, void **indices);
 

--- a/c/column.cc
+++ b/c/column.cc
@@ -425,7 +425,7 @@ VoidColumn::VoidColumn(int64_t nrows) : Column(nrows) {}
 SType VoidColumn::stype() const { return SType::VOID; }
 size_t VoidColumn::elemsize() const { return 0; }
 bool VoidColumn::is_fixedwidth() const { return true; }
-int64_t VoidColumn::data_nrows() const { return nrows; }
+size_t VoidColumn::data_nrows() const { return nrows; }
 void VoidColumn::reify() {}
 void VoidColumn::resize_and_fill(size_t) {}
 void VoidColumn::rbind_impl(std::vector<const Column*>&, size_t, bool) {}

--- a/c/column.cc
+++ b/c/column.cc
@@ -242,9 +242,9 @@ size_t Column::memory_footprint() const
 // Stats
 //------------------------------------------------------------------------------
 
-int64_t Column::countna() const { return get_stats()->countna(this); }
-int64_t Column::nunique() const { return get_stats()->nunique(this); }
-int64_t Column::nmodal() const  { return get_stats()->nmodal(this); }
+size_t Column::countna() const { return get_stats()->countna(this); }
+size_t Column::nunique() const { return get_stats()->nunique(this); }
+size_t Column::nmodal() const  { return get_stats()->nmodal(this); }
 
 
 /**
@@ -262,19 +262,19 @@ Column* Column::sum_column() const  { return new_na_column(stype(), 1); }
 
 Column* Column::countna_column() const {
   IntColumn<int64_t>* col = new IntColumn<int64_t>(1);
-  col->set_elem(0, countna());
+  col->set_elem(0, static_cast<int64_t>(countna()));
   return col;
 }
 
 Column* Column::nunique_column() const {
   IntColumn<int64_t>* col = new IntColumn<int64_t>(1);
-  col->set_elem(0, nunique());
+  col->set_elem(0, static_cast<int64_t>(nunique()));
   return col;
 }
 
 Column* Column::nmodal_column() const {
   IntColumn<int64_t>* col = new IntColumn<int64_t>(1);
-  col->set_elem(0, nmodal());
+  col->set_elem(0, static_cast<int64_t>(nmodal()));
   return col;
 }
 
@@ -371,14 +371,10 @@ void Column::cast_into(PyObjectColumn*) const {
 //------------------------------------------------------------------------------
 
 void Column::verify_integrity(const std::string& name) const {
-  if (nrows < 0) {
-    throw AssertionError()
-      << name << " has a negative value for nrows: " << nrows;
-  }
   mbuf.verify_integrity();
   ri.verify_integrity();
 
-  int64_t mbuf_nrows = data_nrows();
+  size_t mbuf_nrows = data_nrows();
 
   // Check RowIndex
   if (ri.isabsent()) {
@@ -400,7 +396,7 @@ void Column::verify_integrity(const std::string& name) const {
     }
     // Check that the maximum value of the RowIndex does not exceed the maximum
     // row number in the memory buffer
-    if (ri.max() >= mbuf_nrows && ri.max() > 0) {
+    if (static_cast<size_t>(ri.max()) >= mbuf_nrows && ri.max() > 0) {
       throw AssertionError()
           << "Maximum row number in the rowindex of " << name << " exceeds the "
           << "number of rows in the underlying memory buffer: max(rowindex)="
@@ -421,7 +417,7 @@ void Column::verify_integrity(const std::string& name) const {
 //==============================================================================
 
 VoidColumn::VoidColumn() {}
-VoidColumn::VoidColumn(int64_t nrows) : Column(nrows) {}
+VoidColumn::VoidColumn(size_t nrows) : Column(nrows) {}
 SType VoidColumn::stype() const { return SType::VOID; }
 size_t VoidColumn::elemsize() const { return 0; }
 bool VoidColumn::is_fixedwidth() const { return true; }

--- a/c/column.cc
+++ b/c/column.cc
@@ -427,7 +427,7 @@ size_t VoidColumn::elemsize() const { return 0; }
 bool VoidColumn::is_fixedwidth() const { return true; }
 int64_t VoidColumn::data_nrows() const { return nrows; }
 void VoidColumn::reify() {}
-void VoidColumn::resize_and_fill(int64_t) {}
+void VoidColumn::resize_and_fill(size_t) {}
 void VoidColumn::rbind_impl(std::vector<const Column*>&, size_t, bool) {}
 void VoidColumn::apply_na_mask(const BoolColumn*) {}
 void VoidColumn::replace_values(RowIndex, const Column*) {}

--- a/c/column.cc
+++ b/c/column.cc
@@ -15,7 +15,7 @@
 #include "utils/file.h"
 
 
-Column::Column(int64_t nrows_)
+Column::Column(size_t nrows_)
     : stats(nullptr),
       nrows(nrows_) {}
 
@@ -39,21 +39,21 @@ Column* Column::new_column(SType stype) {
 }
 
 
-Column* Column::new_data_column(SType stype, int64_t nrows) {
+Column* Column::new_data_column(SType stype, size_t nrows) {
   Column* col = new_column(stype);
   col->nrows = nrows;
   col->init_data();
   return col;
 }
 
-Column* Column::new_na_column(SType stype, int64_t nrows) {
+Column* Column::new_na_column(SType stype, size_t nrows) {
   Column* col = new_data_column(stype, nrows);
   col->fill_na();
   return col;
 }
 
 
-Column* Column::new_mmap_column(SType stype, int64_t nrows,
+Column* Column::new_mmap_column(SType stype, size_t nrows,
                                 const std::string& filename) {
   Column* col = new_column(stype);
   col->nrows = nrows;
@@ -83,7 +83,7 @@ void Column::save_to_disk(const std::string& filename,
  * This function will not check data validity (i.e. that the buffer contains
  * valid values, and that the extra parameters match the buffer's contents).
  */
-Column* Column::open_mmap_column(SType stype, int64_t nrows,
+Column* Column::open_mmap_column(SType stype, size_t nrows,
                                  const std::string& filename, bool recode)
 {
   Column* col = new_column(stype);
@@ -97,7 +97,7 @@ Column* Column::open_mmap_column(SType stype, int64_t nrows,
  * Construct a column from the externally provided buffer.
  */
 Column* Column::new_xbuf_column(SType stype,
-                                int64_t nrows,
+                                size_t nrows,
                                 Py_buffer* pybuffer)
 {
   Column* col = new_column(stype);
@@ -177,7 +177,7 @@ Column* Column::rbind(std::vector<const Column*>& columns)
   // Is the current column "empty" ?
   bool col_empty = (stype() == SType::VOID);
   // Compute the final number of rows and stype
-  int64_t new_nrows = this->nrows;
+  size_t new_nrows = this->nrows;
   SType new_stype = col_empty? SType::BOOL : stype();
   for (const Column* col : columns) {
     new_nrows += col->nrows;
@@ -428,7 +428,7 @@ bool VoidColumn::is_fixedwidth() const { return true; }
 int64_t VoidColumn::data_nrows() const { return nrows; }
 void VoidColumn::reify() {}
 void VoidColumn::resize_and_fill(int64_t) {}
-void VoidColumn::rbind_impl(std::vector<const Column*>&, int64_t, bool) {}
+void VoidColumn::rbind_impl(std::vector<const Column*>&, size_t, bool) {}
 void VoidColumn::apply_na_mask(const BoolColumn*) {}
 void VoidColumn::replace_values(RowIndex, const Column*) {}
 void VoidColumn::init_data() {}

--- a/c/column.h
+++ b/c/column.h
@@ -217,9 +217,9 @@ public:
 
   virtual void save_to_disk(const std::string&, WritableBuffer::Strategy);
 
-  int64_t countna() const;
-  int64_t nunique() const;
-  int64_t nmodal() const;
+  size_t countna() const;
+  size_t nunique() const;
+  size_t nmodal() const;
   virtual int64_t min_int64() const { return GETNA<int64_t>(); }
   virtual int64_t max_int64() const { return GETNA<int64_t>(); }
 
@@ -698,7 +698,7 @@ extern template class StringColumn<uint64_t>;
 // unknown type. This column cannot be put into a DataTable.
 class VoidColumn : public Column {
   public:
-    VoidColumn(int64_t nrows);
+    VoidColumn(size_t nrows);
     SType stype() const override;
     size_t elemsize() const override;
     bool is_fixedwidth() const override;

--- a/c/column.h
+++ b/c/column.h
@@ -621,8 +621,8 @@ template <typename T> class StringColumn : public Column
   MemoryRange strbuf;
 
 public:
-  StringColumn(int64_t nrows);
-  StringColumn(int64_t nrows, MemoryRange&& offbuf, MemoryRange&& strbuf);
+  StringColumn(size_t nrows);
+  StringColumn(size_t nrows, MemoryRange&& offbuf, MemoryRange&& strbuf);
   void save_to_disk(const std::string& filename,
                     WritableBuffer::Strategy strategy) override;
   void replace_buffer(MemoryRange&&, MemoryRange&&) override;

--- a/c/column.h
+++ b/c/column.h
@@ -78,15 +78,15 @@ protected:
   mutable Stats* stats;
 
 public:  // TODO: convert this into private
-  int64_t nrows;
+  size_t nrows;
 
 public:
-  static Column* new_data_column(SType, int64_t nrows);
-  static Column* new_na_column(SType, int64_t nrows);
-  static Column* new_mmap_column(SType, int64_t nrows, const std::string& filename);
-  static Column* open_mmap_column(SType, int64_t nrows, const std::string& filename,
+  static Column* new_data_column(SType, size_t nrows);
+  static Column* new_na_column(SType, size_t nrows);
+  static Column* new_mmap_column(SType, size_t nrows, const std::string& filename);
+  static Column* open_mmap_column(SType, size_t nrows, const std::string& filename,
                                   bool recode = false);
-  static Column* new_xbuf_column(SType, int64_t nrows, Py_buffer* pybuffer);
+  static Column* new_xbuf_column(SType, size_t nrows, Py_buffer* pybuffer);
   static Column* new_mbuf_column(SType, MemoryRange&&);
   static Column* new_mbuf_column(SType, MemoryRange&&, MemoryRange&&);
   static Column* from_pylist(const py::olist& list, int stype0 = 0);
@@ -277,13 +277,13 @@ public:
   Stats* get_stats_if_exist() const { return stats; }
 
 protected:
-  Column(int64_t nrows = 0);
+  Column(size_t nrows = 0);
   virtual void init_data() = 0;
   virtual void init_mmap(const std::string& filename) = 0;
   virtual void open_mmap(const std::string& filename, bool recode) = 0;
   virtual void init_xbuf(Py_buffer* pybuffer) = 0;
   virtual void rbind_impl(std::vector<const Column*>& columns,
-                          int64_t nrows, bool isempty) = 0;
+                          size_t nrows, bool isempty) = 0;
 
   /**
    * These functions are designed to cast the current column into another type.
@@ -355,7 +355,7 @@ protected:
   void open_mmap(const std::string& filename, bool) override;
   void init_xbuf(Py_buffer* pybuffer) override;
   static constexpr T na_elem = GETNA<T>();
-  void rbind_impl(std::vector<const Column*>& columns, int64_t nrows,
+  void rbind_impl(std::vector<const Column*>& columns, size_t nrows,
                   bool isempty) override;
   void fill_na() override;
 
@@ -601,7 +601,7 @@ protected:
   void cast_into(StringColumn<uint64_t>*) const override;
 
   void replace_buffer(MemoryRange&&) override;
-  void rbind_impl(std::vector<const Column*>& columns, int64_t nrows,
+  void rbind_impl(std::vector<const Column*>& columns, size_t nrows,
                   bool isempty) override;
 
   void resize_and_fill(int64_t nrows) override;
@@ -663,7 +663,7 @@ protected:
   void open_mmap(const std::string& filename, bool recode) override;
   void init_xbuf(Py_buffer* pybuffer) override;
 
-  void rbind_impl(std::vector<const Column*>& columns, int64_t nrows,
+  void rbind_impl(std::vector<const Column*>& columns, size_t nrows,
                   bool isempty) override;
 
   // void cast_into(BoolColumn*) const override;
@@ -705,7 +705,7 @@ class VoidColumn : public Column {
     int64_t data_nrows() const override;
     void reify() override;
     void resize_and_fill(int64_t) override;
-    void rbind_impl(std::vector<const Column*>&, int64_t, bool) override;
+    void rbind_impl(std::vector<const Column*>&, size_t, bool) override;
     void apply_na_mask(const BoolColumn*) override;
     void replace_values(RowIndex, const Column*) override;
     RowIndex join(const Column* keycol) const override;

--- a/c/column.h
+++ b/c/column.h
@@ -133,7 +133,7 @@ public:
    * This method can be used to both increase and reduce the size of the
    * column.
    */
-  virtual void resize_and_fill(int64_t nrows) = 0;
+  virtual void resize_and_fill(size_t nrows) = 0;
 
   /**
    * Modify the Column, replacing values specified by the provided `mask` with
@@ -341,7 +341,7 @@ public:
   void set_elem(int64_t i, T value);
 
   int64_t data_nrows() const override;
-  void resize_and_fill(int64_t nrows) override;
+  void resize_and_fill(size_t nrows) override;
   void apply_na_mask(const BoolColumn* mask) override;
   size_t elemsize() const override;
   bool is_fixedwidth() const override;
@@ -604,7 +604,7 @@ protected:
   void rbind_impl(std::vector<const Column*>& columns, size_t nrows,
                   bool isempty) override;
 
-  void resize_and_fill(int64_t nrows) override;
+  void resize_and_fill(size_t nrows) override;
   void fill_na() override;
   void reify() override;
   friend Column;
@@ -632,7 +632,7 @@ public:
   bool is_fixedwidth() const override;
 
   void reify() override;
-  void resize_and_fill(int64_t nrows) override;
+  void resize_and_fill(size_t nrows) override;
   void apply_na_mask(const BoolColumn* mask) override;
   RowIndex join(const Column* keycol) const override;
 
@@ -704,7 +704,7 @@ class VoidColumn : public Column {
     bool is_fixedwidth() const override;
     int64_t data_nrows() const override;
     void reify() override;
-    void resize_and_fill(int64_t) override;
+    void resize_and_fill(size_t) override;
     void rbind_impl(std::vector<const Column*>&, size_t, bool) override;
     void apply_na_mask(const BoolColumn*) override;
     void replace_values(RowIndex, const Column*) override;

--- a/c/column.h
+++ b/c/column.h
@@ -114,7 +114,7 @@ public:
   size_t alloc_size() const;
 
   const RowIndex& rowindex() const { return ri; }
-  virtual int64_t data_nrows() const = 0;
+  virtual size_t data_nrows() const = 0;
   size_t memory_footprint() const;
 
   RowIndex sort(Groupby* out_groups) const;
@@ -332,15 +332,15 @@ private:
 template <typename T> class FwColumn : public Column
 {
 public:
-  FwColumn(int64_t nrows);
-  FwColumn(int64_t nrows, MemoryRange&&);
+  FwColumn(size_t nrows);
+  FwColumn(size_t nrows, MemoryRange&&);
   void replace_buffer(MemoryRange&&) override;
   const T* elements_r() const;
   T* elements_w();
   T get_elem(int64_t i) const;
   void set_elem(int64_t i, T value);
 
-  int64_t data_nrows() const override;
+  size_t data_nrows() const override;
   void resize_and_fill(size_t nrows) override;
   void apply_na_mask(const BoolColumn* mask) override;
   size_t elemsize() const override;
@@ -577,8 +577,8 @@ extern template class RealColumn<double>;
 class PyObjectColumn : public FwColumn<PyObject*>
 {
 public:
-  PyObjectColumn(int64_t nrows);
-  PyObjectColumn(int64_t nrows, MemoryRange&&);
+  PyObjectColumn(size_t nrows);
+  PyObjectColumn(size_t nrows, MemoryRange&&);
   virtual SType stype() const override;
   PyObjectStats* get_stats() const override;
 
@@ -638,7 +638,7 @@ public:
 
   MemoryRange str_buf() { return strbuf; }
   size_t datasize() const;
-  int64_t data_nrows() const override;
+  size_t data_nrows() const override;
   const char* strdata() const;
   const uint8_t* ustrdata() const;
   const T* offsets() const;
@@ -702,7 +702,7 @@ class VoidColumn : public Column {
     SType stype() const override;
     size_t elemsize() const override;
     bool is_fixedwidth() const override;
-    int64_t data_nrows() const override;
+    size_t data_nrows() const override;
     void reify() override;
     void resize_and_fill(size_t) override;
     void rbind_impl(std::vector<const Column*>&, size_t, bool) override;

--- a/c/column_from_pylist.cc
+++ b/c/column_from_pylist.cc
@@ -584,7 +584,7 @@ template <typename T>
 static Column* _make_range_column(
     int64_t start, int64_t length, int64_t step, SType stype)
 {
-  Column* col = Column::new_data_column(stype, length);
+  Column* col = Column::new_data_column(stype, static_cast<size_t>(length));
   T* elems = static_cast<T*>(col->data_w());
   for (int64_t i = 0, j = start; i < length; ++i) {
     elems[i] = static_cast<T>(j);

--- a/c/column_fw.cc
+++ b/c/column_fw.cc
@@ -213,7 +213,7 @@ void FwColumn<T>::resize_and_fill(int64_t new_nrows)
 
 template <typename T>
 void FwColumn<T>::rbind_impl(std::vector<const Column*>& columns,
-                             int64_t new_nrows, bool col_empty)
+                             size_t new_nrows, bool col_empty)
 {
   const T na = na_elem;
   const void* naptr = static_cast<const void*>(&na);

--- a/c/column_fw.cc
+++ b/c/column_fw.cc
@@ -190,17 +190,17 @@ void FwColumn<T>::reify() {
 
 
 template <typename T>
-void FwColumn<T>::resize_and_fill(int64_t new_nrows)
+void FwColumn<T>::resize_and_fill(size_t new_nrows)
 {
   if (new_nrows == nrows) return;
 
-  mbuf.resize(sizeof(T) * static_cast<size_t>(new_nrows));
+  mbuf.resize(sizeof(T) * new_nrows);
 
   if (new_nrows > nrows) {
     // Replicate the value or fill with NAs
     T fill_value = nrows == 1? get_elem(0) : na_elem;
     T* data_dest = static_cast<T*>(mbuf.wptr());
-    for (int64_t i = nrows; i < new_nrows; ++i) {
+    for (size_t i = nrows; i < new_nrows; ++i) {
       data_dest[i] = fill_value;
     }
   }

--- a/c/column_pyobj.cc
+++ b/c/column_pyobj.cc
@@ -16,11 +16,11 @@ PyObjectColumn::PyObjectColumn() : FwColumn<PyObject*>() {
   mbuf.set_pyobjects(/*clear_data = */ true);
 }
 
-PyObjectColumn::PyObjectColumn(int64_t nrows_) : FwColumn<PyObject*>(nrows_) {
+PyObjectColumn::PyObjectColumn(size_t nrows_) : FwColumn<PyObject*>(nrows_) {
   mbuf.set_pyobjects(/*clear_data = */ true);
 }
 
-PyObjectColumn::PyObjectColumn(int64_t nrows_, MemoryRange&& mb)
+PyObjectColumn::PyObjectColumn(size_t nrows_, MemoryRange&& mb)
     : FwColumn<PyObject*>(nrows_, std::move(mb))
 {
   mbuf.set_pyobjects(/*clear_data = */ true);

--- a/c/column_pyobj.cc
+++ b/c/column_pyobj.cc
@@ -95,7 +95,7 @@ void PyObjectColumn::reify() {
   // element in the column, since we created a new independent reference of
   // each python object.
   PyObject** data = this->elements_w();
-  for (int64_t i = 0; i < nrows; ++i) {
+  for (size_t i = 0; i < nrows; ++i) {
     Py_INCREF(data[i]);
   }
 }
@@ -128,7 +128,7 @@ void PyObjectColumn::rbind_impl(
         col = newcol;
       }
       auto src_data = static_cast<PyObject* const*>(col->data());
-      for (int64_t i = 0; i < col->nrows; ++i) {
+      for (size_t i = 0; i < col->nrows; ++i) {
         Py_INCREF(src_data[i]);
         Py_DECREF(*dest_data);
         *dest_data = src_data[i];
@@ -148,7 +148,7 @@ using MWBPtr = std::unique_ptr<MemoryWritableBuffer>;
 
 template<typename OT>
 inline static MemoryRange cast_str_helper(
-  int64_t nrows, const PyObject* const* src, OT* toffsets)
+  size_t nrows, const PyObject* const* src, OT* toffsets)
 {
   // Warning: Do not attempt to parallelize this: creating new PyObjects
   // is not thread-safe! In addition `to_pystring_force()` may invoke
@@ -157,7 +157,7 @@ inline static MemoryRange cast_str_helper(
   auto wb = MWBPtr(new MemoryWritableBuffer(exp_size));
   OT offset = 0;
   toffsets[-1] = 0;
-  for (int64_t i = 0; i < nrows; ++i) {
+  for (size_t i = 0; i < nrows; ++i) {
     py::ostring xstr = py::obj(src[i]).to_pystring_force();
     CString xcstr = xstr.to_cstring();
     if (xcstr.ch) {
@@ -176,7 +176,7 @@ inline static MemoryRange cast_str_helper(
 void PyObjectColumn::cast_into(PyObjectColumn* target) const {
   PyObject* const* src_data = this->elements_r();
   PyObject** dest_data = target->elements_w();
-  for (int64_t i = 0; i < nrows; ++i) {
+  for (size_t i = 0; i < nrows; ++i) {
     Py_INCREF(src_data[i]);
     Py_DECREF(dest_data[i]);
     dest_data[i] = src_data[i];

--- a/c/column_pyobj.cc
+++ b/c/column_pyobj.cc
@@ -63,17 +63,17 @@ void PyObjectColumn::replace_buffer(MemoryRange&& new_mbuf) {
 }
 
 
-void PyObjectColumn::resize_and_fill(int64_t new_nrows) {
+void PyObjectColumn::resize_and_fill(size_t new_nrows) {
   if (new_nrows == nrows) return;
 
-  mbuf.resize(sizeof(PyObject*) * static_cast<size_t>(new_nrows));
+  mbuf.resize(sizeof(PyObject*) * new_nrows);
 
   if (nrows == 1) {
     // Replicate the value; the case when we need to fill with NAs is already
     // handled by `mbuf.resize()`
     PyObject* fill_value = get_elem(0);
     PyObject** dest_data = this->elements_w();
-    for (int64_t i = 1; i < new_nrows; ++i) {
+    for (size_t i = 1; i < new_nrows; ++i) {
       Py_DECREF(dest_data[i]);
       dest_data[i] = fill_value;
     }

--- a/c/column_pyobj.cc
+++ b/c/column_pyobj.cc
@@ -43,7 +43,7 @@ py::oobj PyObjectColumn::get_value_at_index(int64_t i) const {
 // when opening, we'll just fill the column with NAs.
 void PyObjectColumn::open_mmap(const std::string&, bool) {
   xassert(!ri);
-  mbuf = MemoryRange::mem(static_cast<size_t>(nrows) * sizeof(PyObject*))
+  mbuf = MemoryRange::mem(nrows * sizeof(PyObject*))
          .set_pyobjects(/*clear_data = */ true);
 }
 
@@ -104,8 +104,8 @@ void PyObjectColumn::reify() {
 void PyObjectColumn::rbind_impl(
   std::vector<const Column*>& columns, size_t nnrows, bool col_empty)
 {
-  size_t old_nrows = static_cast<size_t>(nrows);
-  size_t new_nrows = static_cast<size_t>(nnrows);
+  size_t old_nrows = nrows;
+  size_t new_nrows = nnrows;
 
   // Reallocate the column's data buffer
   // `resize` fills all new elements with Py_None
@@ -120,7 +120,7 @@ void PyObjectColumn::rbind_impl(
   }
   for (const Column* col : columns) {
     if (col->stype() == SType::VOID) {
-      dest_data += static_cast<size_t>(col->nrows);
+      dest_data += col->nrows;
     } else {
       if (col->stype() != SType::OBJ) {
         Column* newcol = col->cast(stype());
@@ -153,7 +153,7 @@ inline static MemoryRange cast_str_helper(
   // Warning: Do not attempt to parallelize this: creating new PyObjects
   // is not thread-safe! In addition `to_pystring_force()` may invoke
   // arbitrary python code when stringifying a value...
-  size_t exp_size = static_cast<size_t>(nrows) * sizeof(PyObject*);
+  size_t exp_size = nrows * sizeof(PyObject*);
   auto wb = MWBPtr(new MemoryWritableBuffer(exp_size));
   OT offset = 0;
   toffsets[-1] = 0;

--- a/c/column_pyobj.cc
+++ b/c/column_pyobj.cc
@@ -102,7 +102,7 @@ void PyObjectColumn::reify() {
 
 
 void PyObjectColumn::rbind_impl(
-  std::vector<const Column*>& columns, int64_t nnrows, bool col_empty)
+  std::vector<const Column*>& columns, size_t nnrows, bool col_empty)
 {
   size_t old_nrows = static_cast<size_t>(nrows);
   size_t new_nrows = static_cast<size_t>(nnrows);

--- a/c/column_string.cc
+++ b/c/column_string.cc
@@ -328,27 +328,25 @@ void StringColumn<T>::replace_values(
 
 
 template <typename T>
-void StringColumn<T>::resize_and_fill(int64_t new_nrows)
+void StringColumn<T>::resize_and_fill(size_t new_nrows)
 {
-  int64_t old_nrows = nrows;
-  int64_t diff_rows = new_nrows - old_nrows;
-  if (diff_rows == 0) return;
+  size_t old_nrows = nrows;
+  if (new_nrows == old_nrows) return;
 
   if (new_nrows > INT32_MAX && sizeof(T) == 4) {
-    // TODO: instead of throwing an error, upcast the column to <int64_t>
+    // TODO: instead of throwing an error, upcast the column to <uint64_t>
     // This is only an issue for the case when nrows=1. Maybe we should separate
     // the two methods?
     throw ValueError() << "Nrows is too big for a str32 column: " << new_nrows;
   }
 
-  size_t znrows = static_cast<size_t>(new_nrows);
   size_t old_strbuf_size = strbuf.size();
   size_t new_strbuf_size = old_strbuf_size;
-  size_t new_mbuf_size = sizeof(T) * (znrows + 1);
+  size_t new_mbuf_size = sizeof(T) * (new_nrows + 1);
   if (old_nrows == 1) {
-    new_strbuf_size = old_strbuf_size * znrows;
+    new_strbuf_size = old_strbuf_size * new_nrows;
   }
-  if (diff_rows < 0) {
+  if (new_nrows < old_nrows) {
     T lastoff = mbuf.get_element<T>(new_nrows);
     new_strbuf_size = static_cast<size_t>(lastoff & ~GETNA<T>());
   }
@@ -356,7 +354,7 @@ void StringColumn<T>::resize_and_fill(int64_t new_nrows)
   // Resize the offsets buffer
   mbuf.resize(new_mbuf_size);
 
-  if (diff_rows < 0) {
+  if (new_nrows < old_nrows) {
     strbuf.resize(new_strbuf_size);
   } else {
     // Replicate the value, or fill with NAs
@@ -366,7 +364,7 @@ void StringColumn<T>::resize_and_fill(int64_t new_nrows)
       const char* str_src = static_cast<const char*>(strbuf.rptr());
       char* str_dest = static_cast<char*>(new_strbuf.wptr());
       T src_len = static_cast<T>(old_strbuf_size);
-      for (int64_t i = 0; i < new_nrows; ++i) {
+      for (size_t i = 0; i < new_nrows; ++i) {
         std::memcpy(str_dest, str_src, old_strbuf_size);
         str_dest += old_strbuf_size;
         offsets[i] = static_cast<T>(i + 1) * src_len;
@@ -375,8 +373,7 @@ void StringColumn<T>::resize_and_fill(int64_t new_nrows)
     } else {
       if (old_nrows == 1) xassert(old_strbuf_size == 0);
       T na = static_cast<T>(old_strbuf_size) | GETNA<T>();
-      set_value(offsets + nrows, &na, sizeof(T),
-                static_cast<size_t>(diff_rows));
+      set_value(offsets + nrows, &na, sizeof(T), new_nrows - old_nrows);
     }
   }
   nrows = new_nrows;

--- a/c/column_string.cc
+++ b/c/column_string.cc
@@ -226,7 +226,7 @@ void StringColumn<T>::reify() {
   bool simple_slice = ri.isslice() && ri.slice_step() == 1;
   bool ascending    = ri.isslice() && ri.slice_step() > 0;
 
-  size_t new_mbuf_size = (ri.zlength() + 1) * sizeof(T);
+  size_t new_mbuf_size = (ri.length() + 1) * sizeof(T);
   size_t new_strbuf_size = 0;
   MemoryRange new_strbuf = strbuf;
   MemoryRange new_mbuf = MemoryRange::mem(new_mbuf_size);

--- a/c/column_string.cc
+++ b/c/column_string.cc
@@ -193,9 +193,9 @@ size_t StringColumn<T>::datasize() const{
 }
 
 template <typename T>
-int64_t StringColumn<T>::data_nrows() const {
+size_t StringColumn<T>::data_nrows() const {
   // `mbuf` always contains one more element than the number of rows
-  return static_cast<int64_t>(mbuf.size() / sizeof(T)) - 1;
+  return mbuf.size() / sizeof(T) - 1;
 }
 
 template <typename T>

--- a/c/columnset.cc
+++ b/c/columnset.cc
@@ -20,8 +20,9 @@ Column** columns_from_slice(DataTable* dt, const RowIndex& rowindex,
                             int64_t start, int64_t count, int64_t step)
 {
   if (dt == nullptr) return nullptr;
-  if ((count < 0 || start < 0 || start >= dt->ncols ||
-       start + step < 0 || start + step * (count - 1) >= dt->ncols) &&
+  int64_t icols = static_cast<int64_t>(dt->ncols);
+  if ((count < 0 || start < 0 || start >= icols ||
+       start + step < 0 || start + step * (count - 1) >= icols) &&
       !(count == 0 && start == 0)) {
     throw ValueError() << "Invalid slice " << start << ":" << count << ":"
                        << step << " for a DataTable with " << dt->ncols

--- a/c/columnset.cc
+++ b/c/columnset.cc
@@ -33,7 +33,7 @@ Column** columns_from_slice(DataTable* dt, const RowIndex& rowindex,
   columns[count] = nullptr;
 
   for (int64_t i = 0, j = start; i < count; i++, j += step) {
-    columns[i] = dt->columns[j]->shallowcopy(rowindex);
+    columns[i] = dt->columns[static_cast<size_t>(j)]->shallowcopy(rowindex);
   }
   return columns;
 }
@@ -68,13 +68,13 @@ Column** columns_from_slice(DataTable* dt, const RowIndex& rowindex,
  */
 Column** columns_from_mixed(
     int64_t* spec,
-    int64_t ncols,
-    int64_t nrows,
+    size_t ncols,
+    size_t nrows,
     DataTable* dt,
-    int (*mapfn)(int64_t row0, int64_t row1, void** out)
+    int (*mapfn)(size_t row0, size_t row1, void** out)
 ) {
-  int64_t ncomputedcols = 0;
-  for (int64_t i = 0; i < ncols; i++) {
+  size_t ncomputedcols = 0;
+  for (size_t i = 0; i < ncols; i++) {
     ncomputedcols += (spec[i] < 0);
   }
   if (dt == nullptr && ncomputedcols < ncols) {
@@ -88,12 +88,13 @@ Column** columns_from_mixed(
   Column** columns = dt::amalloc<Column*>(ncols + 1);
   columns[ncols] = nullptr;
 
-  int64_t j = 0;
-  for (int64_t i = 0; i < ncols; i++) {
-    if (spec[i] >= 0) {
-      columns[i] = dt->columns[spec[i]]->shallowcopy();
+  size_t j = 0;
+  for (size_t i = 0; i < ncols; i++) {
+    int64_t s = spec[i];
+    if (s >= 0) {
+      columns[i] = dt->columns[static_cast<size_t>(s)]->shallowcopy();
     } else {
-      SType stype = static_cast<SType>(-spec[i]);
+      SType stype = static_cast<SType>(-s);
       columns[i] = Column::new_data_column(stype, nrows);
       out[j] = columns[i]->data_w();
       j++;

--- a/c/columnset.h
+++ b/c/columnset.h
@@ -13,7 +13,7 @@
 #include "rowindex.h"
 
 
-typedef int (columnset_mapfn)(int64_t row0, int64_t row1, void** out);
+typedef int (columnset_mapfn)(size_t row0, size_t row1, void** out);
 
 Column** columns_from_slice(
   DataTable* dt,
@@ -25,8 +25,8 @@ Column** columns_from_slice(
 
 Column** columns_from_mixed(
   int64_t *spec,
-  int64_t ncols,
-  int64_t nrows,
+  size_t ncols,
+  size_t nrows,
   DataTable *dt,
   columnset_mapfn *fn
 );

--- a/c/csv/py_csv.cc
+++ b/c/csv/py_csv.cc
@@ -53,7 +53,7 @@ PyObject* write_csv(PyObject*, PyObject* args)
     if (nthreads <= 0) nthreads += maxth;
     if (nthreads <= 0) nthreads = 1;
   }
-  cwriter.set_nthreads(nthreads);
+  cwriter.set_nthreads(static_cast<size_t>(nthreads));
 
   // Write CSV
   cwriter.write();

--- a/c/csv/reader.cc
+++ b/c/csv/reader.cc
@@ -786,7 +786,7 @@ void GenericReader::report_columns_to_python() {
 
 
 
-DataTablePtr GenericReader::makeDatatable() {
+dtptr GenericReader::makeDatatable() {
   size_t ncols = columns.size();
   size_t ocols = columns.nColumnsInOutput();
   std::vector<Column*> ccols;
@@ -800,5 +800,5 @@ DataTablePtr GenericReader::makeDatatable() {
                                        std::move(strbuf)));
   }
   py::olist names = freader.get_attr("_colnames").to_pylist();
-  return DataTablePtr(new DataTable(std::move(ccols), names));
+  return dtptr(new DataTable(std::move(ccols), names));
 }

--- a/c/csv/reader.h
+++ b/c/csv/reader.h
@@ -13,6 +13,7 @@
 #include "read/columns.h"   // dt::read::Columns
 
 class DataTable;
+using dtptr = std::unique_ptr<DataTable>;
 
 
 /**
@@ -21,8 +22,6 @@ class DataTable;
  */
 class GenericReader
 {
-  using DataTablePtr = std::unique_ptr<DataTable>;
-
   //---- Input parameters ----
   // nthreads:
   //   Number of threads to use; 0 means use maximum possible, negative number
@@ -113,7 +112,7 @@ class GenericReader
     GenericReader& operator=(const GenericReader&) = delete;
     virtual ~GenericReader();
 
-    DataTablePtr read();
+    dtptr read();
 
     /**
      * Return the pointer to the input data buffer and its size. The method
@@ -178,13 +177,13 @@ class GenericReader
 
     void _message(const char* method, const char* format, va_list args) const;
 
-    DataTablePtr read_empty_input();
+    dtptr read_empty_input();
     void detect_improper_files();
 
   //---- Inherited API ----
   protected:
     GenericReader(const GenericReader&);
-    DataTablePtr makeDatatable();
+    dtptr makeDatatable();
 };
 
 

--- a/c/csv/writer.cc
+++ b/c/csv/writer.cc
@@ -303,7 +303,7 @@ CsvWriter::~CsvWriter()
 void CsvWriter::write()
 {
   size_t nrows = dt->nrows;
-  size_t ncols = static_cast<size_t>(dt->ncols);
+  size_t ncols = dt->ncols;
   size_t bytes_total = estimate_output_size();
   create_target(bytes_total);
   write_column_names();
@@ -461,8 +461,8 @@ double CsvWriter::checkpoint() {
  */
 size_t CsvWriter::estimate_output_size()
 {
-  size_t nrows = static_cast<size_t>(dt->nrows);
-  size_t ncols = static_cast<size_t>(dt->ncols);
+  size_t nrows = dt->nrows;
+  size_t ncols = dt->ncols;
   size_t total_string_size = 0;
   size_t total_columns_size = 0;
   fixed_size_per_row = ncols;  // 1 byte per separator

--- a/c/csv/writer.cc
+++ b/c/csv/writer.cc
@@ -60,7 +60,7 @@ public:
 
   // This should only be called on a CsvColumn of type i4s / i8s!
   template <typename T>
-  size_t strsize(int64_t row0, int64_t row1) {
+  size_t strsize(size_t row0, size_t row1) {
     const T* offsets = static_cast<const T*>(data);
     return (offsets[row1 - 1] - offsets[row0 - 1]) & ~GETNA<T>();
   }
@@ -302,7 +302,7 @@ CsvWriter::~CsvWriter()
 
 void CsvWriter::write()
 {
-  int64_t nrows = dt->nrows;
+  size_t nrows = dt->nrows;
   size_t ncols = static_cast<size_t>(dt->ncols);
   size_t bytes_total = estimate_output_size();
   create_target(bytes_total);
@@ -311,7 +311,7 @@ void CsvWriter::write()
   create_column_writers(ncols);
   size_t nstrcols32 = strcolumns32.size();
   size_t nstrcols64 = strcolumns64.size();
-  if (nthreads > nchunks) nthreads = static_cast<int>(nchunks);
+  if (nthreads > nchunks) nthreads = nchunks;
 
   OmpExceptionManager oem;
 
@@ -343,10 +343,10 @@ void CsvWriter::write()
 
     // Main data-writing loop
     #pragma omp for ordered schedule(dynamic)
-    for (int64_t i = 0; i < nchunks; i++) {
+    for (size_t i = 0; i < nchunks; i++) {
       if (oem.exception_caught()) continue;
-      int64_t row0 = static_cast<int64_t>(i * rows_per_chunk);
-      int64_t row1 = static_cast<int64_t>((i + 1) * rows_per_chunk);
+      size_t row0 = static_cast<size_t>(i * rows_per_chunk);
+      size_t row1 = static_cast<size_t>((i + 1) * rows_per_chunk);
       if (i == nchunks-1) row1 = nrows;  // always go to the last row for last chunk
 
       try {
@@ -379,7 +379,8 @@ void CsvWriter::write()
 
         // Write the data in rows row0..row1 and in all columns
         char* thch = thbuf;
-        dt->rowindex.strided_loop(row0, row1, 1,
+        dt->rowindex.strided_loop(static_cast<int64_t>(row0),
+                                  static_cast<int64_t>(row1), 1,
           [&](int64_t row) {
             for (size_t col = 0; col < ncols; col++) {
               columns[col]->write(&thch, row);
@@ -532,13 +533,13 @@ void CsvWriter::write_column_names()
  * `nthreads`. Its effect is to fill in values `rows_per_chunk`, 'nchunks' and
  * `bytes_per_chunk`.
  */
-void CsvWriter::determine_chunking_strategy(size_t bytes_total, int64_t nrows)
+void CsvWriter::determine_chunking_strategy(size_t bytes_total, size_t nrows)
 {
   static const size_t max_chunk_size = 1024 * 1024;
   static const size_t min_chunk_size = 1024;
 
   double bytes_per_row = nrows? 1.0 * bytes_total / nrows : 0;
-  int min_nchunks = nthreads == 1 ? 1 : nthreads*2;
+  size_t min_nchunks = nthreads == 1 ? 1 : nthreads*2;
   nchunks = 1 + (bytes_total - 1) / max_chunk_size;
   if (nchunks < min_nchunks) nchunks = min_nchunks;
   int attempts = 5;
@@ -580,8 +581,8 @@ void CsvWriter::create_column_writers(size_t ncols)
   columns.reserve(ncols);
   writers_per_stype[int(SType::FLOAT32)] = usehex? write_f4_hex : write_f4_dec;
   writers_per_stype[int(SType::FLOAT64)] = usehex? write_f8_hex : write_f8_dec;
-  for (int64_t i = 0; i < dt->ncols; i++) {
-    Column *dtcol = dt->columns[i];
+  for (size_t i = 0; i < dt->ncols; ++i) {
+    Column* dtcol = dt->columns[i];
     SType stype = dtcol->stype();
     CsvColumn *csvcol = new CsvColumn(dtcol);
     columns.push_back(csvcol);

--- a/c/csv/writer.h
+++ b/c/csv/writer.h
@@ -24,18 +24,18 @@ class CsvWriter {
   std::string path;
   std::vector<std::string> column_names;
   void *logger;
-  int nthreads;
+  size_t nthreads;
   WritableBuffer::Strategy strategy;
   bool usehex;
   bool verbose;
-  int : 8;
+  size_t : 40;
 
   // Intermediate values used while writing the file
   std::unique_ptr<WritableBuffer> wb;
   size_t fixed_size_per_row;
   double rows_per_chunk;
   size_t bytes_per_chunk;
-  int64_t nchunks;
+  size_t nchunks;
   std::vector<CsvColumn*> columns;
   std::vector<CsvColumn*> strcolumns32;
   std::vector<CsvColumn*> strcolumns64;
@@ -51,7 +51,7 @@ public:
   ~CsvWriter();
 
   void set_logger(void *v) { logger = v; }
-  void set_nthreads(int n) { nthreads = n; }
+  void set_nthreads(size_t n) { nthreads = n; }
   void set_usehex(bool v) { usehex = v; }
   void set_verbose(bool v) { verbose = v; }
   void set_strategy(WritableBuffer::Strategy s) { strategy = s; }
@@ -67,7 +67,7 @@ private:
   size_t estimate_output_size();
   void create_target(size_t size);
   void write_column_names();
-  void determine_chunking_strategy(size_t size, int64_t nrows);
+  void determine_chunking_strategy(size_t size, size_t nrows);
   void create_column_writers(size_t ncols);
 };
 

--- a/c/datatable.cc
+++ b/c/datatable.cc
@@ -12,8 +12,6 @@
 #include "rowindex.h"
 #include "types.h"
 
-// Forward declarations
-using strvec = std::vector<std::string>;
 
 
 //------------------------------------------------------------------------------
@@ -131,7 +129,7 @@ DataTable* DataTable::delete_columns(int *cols_to_remove, int64_t n)
 
 
 
-void DataTable::resize_rows(int64_t new_nrows) {
+void DataTable::resize_rows(size_t new_nrows) {
   if (rowindex) {
     if (new_nrows < nrows) {
       rowindex.shrink(new_nrows, ncols);
@@ -144,7 +142,7 @@ void DataTable::resize_rows(int64_t new_nrows) {
     }
   }
   if (new_nrows != nrows) {
-    for (int64_t i = 0; i < ncols; ++i) {
+    for (size_t i = 0; i < ncols; ++i) {
       columns[i]->resize_and_fill(new_nrows);
     }
     nrows = new_nrows;
@@ -157,7 +155,7 @@ void DataTable::replace_rowindex(const RowIndex& newri) {
   if (newri.isabsent() && rowindex.isabsent()) return;
   rowindex = newri;
   nrows = rowindex.length();
-  for (int64_t i = 0; i < ncols; ++i) {
+  for (size_t i = 0; i < ncols; ++i) {
     columns[i]->replace_rowindex(rowindex);
   }
 }
@@ -173,27 +171,21 @@ void DataTable::replace_groupby(const Groupby& newgb) {
 }
 
 
-void DataTable::set_nkeys(int64_t nk) {
-  if (nk < 0) {
-    throw ValueError() << "Number of keys cannot be negative: " << nk;
-  }
-  if (nk > 1) {
-    throw NotImplError() << "More than 1 key column is not supported yet";
-  }
+void DataTable::set_nkeys(size_t nk) {
   if (nk == 0) {
     nkeys = 0;
     return;
   }
 
   Groupby gb;
-  arr32_t cols(static_cast<size_t>(nk));
-  for (int32_t i = 0; i < nk; ++i) {
-    cols[static_cast<size_t>(i)] = i;
+  arr32_t cols(nk);
+  for (size_t i = 0; i < nk; ++i) {
+    cols[i] = i;
   }
   RowIndex ri = sortby(cols, &gb);
   xassert(ri.length() == nrows);
 
-  if (gb.ngroups() != static_cast<size_t>(nrows)) {
+  if (gb.ngroups() != nrows) {
     throw ValueError() << "Cannot set column as a key: the values are not unique";
   }
 

--- a/c/datatable.cc
+++ b/c/datatable.cc
@@ -28,7 +28,7 @@ DataTable::DataTable(colvec&& cols) : DataTable()
   columns = std::move(cols);
   ncols = columns.size();
   if (ncols > 0) {
-    nrows = static_cast<size_t>(columns[0]->nrows);
+    nrows = columns[0]->nrows;
     rowindex = RowIndex(columns[0]->rowindex());
 
     bool need_to_materialize = false;
@@ -161,7 +161,7 @@ void DataTable::replace_rowindex(const RowIndex& newri) {
 
 void DataTable::replace_groupby(const Groupby& newgb) {
   int32_t last_offset = newgb.offsets_r()[newgb.ngroups()];
-  if (last_offset != nrows) {
+  if (static_cast<size_t>(last_offset) != nrows) {
     throw ValueError() << "Cannot apply Groupby of " << last_offset << " rows "
       "to a Frame with " << nrows << " rows";
   }
@@ -178,7 +178,7 @@ void DataTable::set_nkeys(size_t nk) {
   Groupby gb;
   arr32_t cols(nk);
   for (size_t i = 0; i < nk; ++i) {
-    cols[i] = i;
+    cols[i] = static_cast<int32_t>(i);
   }
   RowIndex ri = sortby(cols, &gb);
   xassert(ri.length() == nrows);

--- a/c/datatable.cc
+++ b/c/datatable.cc
@@ -13,10 +13,7 @@
 #include "types.h"
 
 // Forward declarations
-using colvec = std::vector<Column*>;
 using strvec = std::vector<std::string>;
-static Column** prepare_columns(colvec&);
-static int _compare_ints(const void *a, const void *b);
 
 
 //------------------------------------------------------------------------------
@@ -105,7 +102,12 @@ DataTable* DataTable::copy() const {
 DataTable* DataTable::delete_columns(int *cols_to_remove, int64_t n)
 {
   if (n == 0) return this;
-  qsort(cols_to_remove, static_cast<size_t>(n), sizeof(int), _compare_ints);
+  qsort(cols_to_remove, static_cast<size_t>(n), sizeof(int),
+        [](const void *a, const void *b) {
+          const int x = *static_cast<const int*>(a);
+          const int y = *static_cast<const int*>(b);
+          return (x > y) - (x < y);
+        });
   int j = 0;
   int next_col_to_remove = cols_to_remove[0];
   int64_t k = 0;
@@ -199,14 +201,6 @@ void DataTable::set_nkeys(int64_t nk) {
   reify();
 
   nkeys = nk;
-}
-
-
-// Comparator function to sort integers using `qsort`
-static inline int _compare_ints(const void *a, const void *b) {
-  const int x = *static_cast<const int*>(a);
-  const int y = *static_cast<const int*>(b);
-  return (x > y) - (x < y);
 }
 
 

--- a/c/datatable.cc
+++ b/c/datatable.cc
@@ -176,9 +176,9 @@ void DataTable::set_nkeys(size_t nk) {
   }
 
   Groupby gb;
-  arr32_t cols(nk);
+  std::vector<size_t> cols;
   for (size_t i = 0; i < nk; ++i) {
-    cols[i] = static_cast<int32_t>(i);
+    cols.push_back(i);
   }
   RowIndex ri = sortby(cols, &gb);
   xassert(ri.length() == nrows);

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -85,7 +85,7 @@ class DataTable {
     void replace_rowindex(const RowIndex& newri);
     void replace_groupby(const Groupby& newgb);
     void reify();
-    void rbind(DataTable**, int**, int64_t, int64_t);
+    void rbind(std::vector<DataTable*>, std::vector<std::vector<int>>);
     DataTable* cbind(std::vector<DataTable*>);
     DataTable* copy() const;
     size_t memory_footprint();

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -85,7 +85,7 @@ class DataTable {
     void replace_rowindex(const RowIndex& newri);
     void replace_groupby(const Groupby& newgb);
     void reify();
-    void rbind(std::vector<DataTable*>, std::vector<std::vector<int>>);
+    void rbind(std::vector<DataTable*>, std::vector<std::vector<size_t>>);
     DataTable* cbind(std::vector<DataTable*>);
     DataTable* copy() const;
     size_t memory_footprint();

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -99,7 +99,8 @@ class DataTable {
      * If `make_groups` is true, then in addition to sorting, the grouping
      * information will be computed and stored with the RowIndex.
      */
-    RowIndex sortby(const arr32_t& colindices, Groupby* out_grps) const;
+    RowIndex sortby(const std::vector<size_t>& colindices,
+                    Groupby* out_grps) const;
 
     const std::vector<std::string>& get_names() const;
     py::otuple get_pynames() const;

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -59,9 +59,9 @@ using dtptr  = std::unique_ptr<DataTable>;
  */
 class DataTable {
   public:
-    int64_t   nrows;
+    size_t   nrows;
     int64_t   ncols;
-    int64_t   nkeys;
+    size_t   nkeys;
     RowIndex rowindex;
     Groupby  groupby;
     colvec   columns;

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -80,7 +80,7 @@ class DataTable {
     DataTable(colvec&& cols, const DataTable*);
     ~DataTable();
 
-    DataTable* delete_columns(int*, int64_t);
+    DataTable* delete_columns(std::vector<size_t>&);
     void resize_rows(size_t n);
     void replace_rowindex(const RowIndex& newri);
     void replace_groupby(const Groupby& newgb);

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -24,6 +24,7 @@ class NameProvider;
 
 typedef Column* (Column::*colmakerfn)(void) const;
 using colvec = std::vector<Column*>;
+using strvec = std::vector<std::string>;
 using dtptr  = std::unique_ptr<DataTable>;
 
 
@@ -62,25 +63,25 @@ class DataTable {
     size_t   nrows;
     size_t   ncols;
     size_t   nkeys;
-    RowIndex rowindex;
+    RowIndex rowindex;  // DEPRECATED (see #1188)
     Groupby  groupby;
     colvec   columns;
 
   private:
-    std::vector<std::string> names;
+    strvec   names;
     mutable py::otuple py_names;   // memoized tuple of column names
     mutable py::odict  py_inames;  // memoized dict of {column name: index}
 
   public:
     DataTable();
-    DataTable(std::vector<Column*>&& cols);
-    DataTable(std::vector<Column*>&& cols, const py::olist&);
-    DataTable(std::vector<Column*>&& cols, const std::vector<std::string>&);
-    DataTable(std::vector<Column*>&& cols, const DataTable*);
+    DataTable(colvec&& cols);
+    DataTable(colvec&& cols, const py::olist&);
+    DataTable(colvec&& cols, const strvec&);
+    DataTable(colvec&& cols, const DataTable*);
     ~DataTable();
 
     DataTable* delete_columns(int*, int64_t);
-    void resize_rows(int64_t n);
+    void resize_rows(size_t n);
     void replace_rowindex(const RowIndex& newri);
     void replace_groupby(const Groupby& newgb);
     void reify();
@@ -109,7 +110,7 @@ class DataTable {
     void set_names(const std::vector<std::string>& names_list);
     void replace_names(py::odict replacements);
 
-    void set_nkeys(int64_t nk);
+    void set_nkeys(size_t nk);
 
     DataTable* min_datatable() const;
     DataTable* max_datatable() const;

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -60,7 +60,7 @@ using dtptr  = std::unique_ptr<DataTable>;
 class DataTable {
   public:
     size_t   nrows;
-    int64_t   ncols;
+    size_t   ncols;
     size_t   nkeys;
     RowIndex rowindex;
     Groupby  groupby;

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -22,8 +22,9 @@ class Stats;
 class DataTable;
 class NameProvider;
 
-typedef std::unique_ptr<DataTable> DataTablePtr;
 typedef Column* (Column::*colmakerfn)(void) const;
+using colvec = std::vector<Column*>;
+using dtptr  = std::unique_ptr<DataTable>;
 
 
 //==============================================================================
@@ -38,29 +39,32 @@ typedef Column* (Column::*colmakerfn)(void) const;
  *     Data dimensions: number of rows and columns in the datatable. We do not
  *     support more than 2 dimensions (as Numpy or TensorFlow do).
  *     The maximum number of rows is 2**63 - 1. The maximum number of columns
- *     is 2**31 - 1 (even though `ncols` is declared as `int64_t`).
+ *     is 2**31 - 1 (even though `ncols` is declared as `size_t`).
+ *
+ * nkeys
+ *     The number of columns that together constitute the primary key of this
+ *     data frame. The key columns are always located at the beginning of the
+ *     `column` list. The key values are unique, and the frame is sorted by
+ *     these values.
  *
  * rowindex
+ *     [DEPRECATED]
  *     If this field is not NULL, then the current datatable is a "view", that
  *     is, all columns should be accessed not directly but via this rowindex.
  *     When this field is set, it must be that `nrows == rowindex->length`.
  *
  * columns
- *     The array of columns within the datatable. This array contains `ncols+1`
- *     elements, and each column has the same number of rows: `nrows`. The
- *     "extra" column is always NULL: a sentinel.
- *     When `rowindex` is specified, then each column is a copy-by-reference
- *     of a column in some other datatable, and only indices given in the
- *     `rowindex` should be used to access values in each column.
+ *     The array of columns within the datatable. This array contains `ncols`
+ *     elements, and each column has the same number of rows: `nrows`.
  */
 class DataTable {
   public:
-    int64_t  nrows;
-    int64_t  ncols;
-    int64_t  nkeys;
+    int64_t   nrows;
+    int64_t   ncols;
+    int64_t   nkeys;
     RowIndex rowindex;
     Groupby  groupby;
-    std::vector<Column*> columns;
+    colvec   columns;
 
   private:
     std::vector<std::string> names;

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -126,7 +126,7 @@ class DataTable {
 
     void verify_integrity() const;
 
-    static DataTable* load(DataTable* schema, int64_t nrows,
+    static DataTable* load(DataTable* schema, size_t nrows,
                            const std::string& path, bool recode);
 
     void save_jay(const std::string& path,

--- a/c/datatable_load.cc
+++ b/c/datatable_load.cc
@@ -23,10 +23,10 @@
  * nrows
  *     Number of rows in the stored Frame.
  */
-DataTable* DataTable::load(DataTable* colspec, int64_t nrows, const std::string& path,
+DataTable* DataTable::load(DataTable* colspec, size_t nrows, const std::string& path,
                            bool recode)
 {
-    int64_t ncols = colspec->nrows;
+    size_t ncols = colspec->nrows;
     std::vector<Column*> columns;
     columns.reserve(ncols);
 
@@ -53,7 +53,7 @@ DataTable* DataTable::load(DataTable* colspec, int64_t nrows, const std::string&
     if (!(rootdir.empty() || rootdir.back() == '/'))
       rootdir += "/";
 
-    for (int64_t i = 0; i < ncols; ++i) {
+    for (size_t i = 0; i < ncols; ++i) {
         // Extract filename
         size_t fsta = static_cast<size_t>(offf[i - 1] & NONA);
         size_t fend = static_cast<size_t>(offf[i] & NONA);

--- a/c/datatable_rbind.cc
+++ b/c/datatable_rbind.cc
@@ -14,39 +14,39 @@
 
 
 /**
- * Append to datatable `dt` a list of datatables `dts`. There are `ndts` items
- * in this list. The `cols` array of dimensions `ncols x ndts` specifies how
- * the columns should be matched.
- * In particular, the datatable `dt` will be expanded to have `ncols` columns,
+ * Append to this Frame a list of other Frames `dts`. The `cols` array of
+ * specifies how the columns should be matched.
+ *
+ * In particular, the Frame `dt` will be expanded to have `cols.size()` columns,
  * and `dt->nrows + sum(dti->nrows for dti in dts)` rows. The `i`th column
- * in the expanded datatable will have the following structure: first comes the
+ * in the expanded Frame will have the following structure: first comes the
  * data from `i`th column of `dt` (if `i < dt->ncols`, otherwise NAs); after
  * that come `ndts` blocks of rows, each `j`th block having data from column
- * number `cols[i][j]` in datatable `dts[j]` (if `cols[i][j] >= 0`, otherwise
+ * number `cols[i][j]` in Frame `dts[j]` (if `cols[i][j] >= 0`, otherwise
  * NAs).
  */
 void DataTable::rbind(
-    DataTable** dts, int** cols, int64_t ndts, int64_t new_ncols)
+    std::vector<DataTable*> dts, std::vector<std::vector<int>> cols)
 {
+  size_t new_ncols = cols.size();
   xassert(new_ncols >= ncols);
 
-  // If this is a view datatable, then it must be materialized.
+  // If this is a view Frame, then it must be materialized.
   this->reify();
 
-  columns.resize(new_ncols);
-  for (int64_t i = ncols; i < new_ncols; ++i) {
+  columns.resize(new_ncols, nullptr);
+  for (size_t i = ncols; i < new_ncols; ++i) {
     columns[i] = new VoidColumn(nrows);
   }
 
-  int64_t new_nrows = nrows;
-  for (int64_t i = 0; i < ndts; ++i) {
-    new_nrows += dts[i]->nrows;
+  size_t new_nrows = nrows;
+  for (auto dt : dts) {
+    new_nrows += dt->nrows;
   }
 
-  size_t undts = static_cast<size_t>(ndts);
-  std::vector<const Column*> cols_to_append(undts);
-  for (int64_t i = 0; i < new_ncols; ++i) {
-    for (size_t j = 0; j < undts; ++j) {
+  std::vector<const Column*> cols_to_append(dts.size(), nullptr);
+  for (size_t i = 0; i < new_ncols; ++i) {
+    for (size_t j = 0; j < dts.size(); ++j) {
       int k = cols[i][j];
       Column* col = k < 0 ? new VoidColumn(dts[j]->nrows)
                           : dts[j]->columns[k]->shallowcopy();

--- a/c/datatable_rbind.cc
+++ b/c/datatable_rbind.cc
@@ -26,8 +26,9 @@
  * NAs).
  */
 void DataTable::rbind(
-    std::vector<DataTable*> dts, std::vector<std::vector<int>> cols)
+    std::vector<DataTable*> dts, std::vector<std::vector<size_t>> cols)
 {
+  constexpr size_t INVALID_INDEX = size_t(-1);
   size_t new_ncols = cols.size();
   xassert(new_ncols >= ncols);
 
@@ -47,9 +48,10 @@ void DataTable::rbind(
   std::vector<const Column*> cols_to_append(dts.size(), nullptr);
   for (size_t i = 0; i < new_ncols; ++i) {
     for (size_t j = 0; j < dts.size(); ++j) {
-      int k = cols[i][j];
-      Column* col = k < 0 ? new VoidColumn(dts[j]->nrows)
-                          : dts[j]->columns[k]->shallowcopy();
+      size_t k = cols[i][j];
+      Column* col = k == INVALID_INDEX
+                      ? new VoidColumn(dts[j]->nrows)
+                      : dts[j]->columns[k]->shallowcopy();
       col->reify();
       cols_to_append[j] = col;
     }

--- a/c/encodings.cc
+++ b/c/encodings.cc
@@ -173,7 +173,7 @@ int check_escaped_string(const uint8_t* src, size_t len, uint8_t ech)
  * responsibility of the user to ensure that `ch` has sufficient space to write
  * all the bytes (no more than `maxchars*4` bytes will be needed).
  */
-int64_t utf32_to_utf8(uint32_t* buf, int64_t maxchars, char* ch)
+int64_t utf32_to_utf8(uint32_t* buf, size_t maxchars, char* ch)
 {
   char* out0 = ch;
   uint32_t* end = buf + maxchars;

--- a/c/encodings.h
+++ b/c/encodings.h
@@ -18,6 +18,6 @@ int decode_escaped_csv_string(const uint8_t* src, int len, uint8_t* dest, uint8_
 
 int decode_sbcs(const uint8_t* src, int len, uint8_t* dest, uint32_t *map);
 
-int64_t utf32_to_utf8(uint32_t* buf, int64_t maxchars, char* ch);
+int64_t utf32_to_utf8(uint32_t* buf, size_t maxchars, char* ch);
 
 #endif

--- a/c/expr/binaryop.cc
+++ b/c/expr/binaryop.cc
@@ -351,7 +351,7 @@ static mapperfn resolve2str(OpMode mode) {
 
 
 template<typename LT, typename RT, typename VT>
-static mapperfn resolve1(int opcode, SType stype, void** params, int64_t nrows, OpMode mode) {
+static mapperfn resolve1(int opcode, SType stype, void** params, size_t nrows, OpMode mode) {
   if (opcode >= OpCode::Equal) {
     // override stype for relational operators
     stype = SType::BOOL;
@@ -385,7 +385,7 @@ static mapperfn resolve1(int opcode, SType stype, void** params, int64_t nrows, 
 
 
 template<typename T0, typename T1>
-static mapperfn resolve1str(int opcode, void** params, int64_t nrows, OpMode mode) {
+static mapperfn resolve1str(int opcode, void** params, size_t nrows, OpMode mode) {
   if (mode == OpMode::One_to_N) {
     mode = OpMode::N_to_One;
     std::swap(params[0], params[1]);
@@ -400,7 +400,7 @@ static mapperfn resolve1str(int opcode, void** params, int64_t nrows, OpMode mod
 }
 
 
-static mapperfn resolve0(SType lhs_type, SType rhs_type, int opcode, void** params, int64_t nrows, OpMode mode) {
+static mapperfn resolve0(SType lhs_type, SType rhs_type, int opcode, void** params, size_t nrows, OpMode mode) {
   if (mode == OpMode::Error) return nullptr;
   switch (lhs_type) {
     case SType::BOOL:
@@ -513,12 +513,12 @@ Column* binaryop(int opcode, Column* lhs, Column* rhs)
 {
   lhs->reify();
   rhs->reify();
-  int64_t lhs_nrows = lhs->nrows;
-  int64_t rhs_nrows = rhs->nrows;
+  size_t lhs_nrows = lhs->nrows;
+  size_t rhs_nrows = rhs->nrows;
   if (lhs_nrows == 0 || rhs_nrows == 0) {
     lhs_nrows = rhs_nrows = 0;
   }
-  int64_t nrows = std::max(lhs_nrows, rhs_nrows);
+  size_t nrows = std::max(lhs_nrows, rhs_nrows);
   SType lhs_type = lhs->stype();
   SType rhs_type = rhs->stype();
   void* params[3];
@@ -537,7 +537,7 @@ Column* binaryop(int opcode, Column* lhs, Column* rhs)
       << ", nrows=" << lhs->nrows << ") and column2(stype=" << rhs_type
       << ", nrows=" << rhs->nrows << ")";
   }
-  (*mapfn)(0, nrows, params);
+  (*mapfn)(0, static_cast<int64_t>(nrows), params);
 
   return static_cast<Column*>(params[2]);
 }

--- a/c/expr/py_expr.cc
+++ b/c/expr/py_expr.cc
@@ -46,7 +46,7 @@ PyObject* expr_cast(PyObject*, PyObject* args)
 
 PyObject* expr_column(PyObject*, PyObject* args)
 {
-  int64_t index;
+  size_t index;
   PyObject* arg1, *arg3;
   if (!PyArg_ParseTuple(args, "OlO:expr_column", &arg1, &index, &arg3))
     return nullptr;
@@ -55,7 +55,7 @@ PyObject* expr_column(PyObject*, PyObject* args)
   DataTable* dt = pyarg1.to_frame();
   RowIndex ri = pyarg3.to_rowindex();
 
-  if (index < 0 || index >= dt->ncols) {
+  if (index >= dt->ncols) {
     PyErr_Format(PyExc_ValueError, "Invalid column index %lld", index);
   }
   Column* col = dt->columns[index]->shallowcopy(ri);
@@ -101,14 +101,14 @@ PyObject* expr_count(PyObject*, PyObject* args)
   if (grpby == nullptr) {
     res = Column::new_data_column(SType::INT64, static_cast<int64_t>(1));
     auto d_res = static_cast<int64_t*>(res->data_w());
-    d_res[0] = dt->nrows;
+    d_res[0] = static_cast<int64_t>(dt->nrows);
 
   // If there is, return number of rows in each group
   } else {
     size_t ng = grpby->ngroups();
     const int32_t* offsets = grpby->offsets_r();
 
-    res = Column::new_data_column(SType::INT32, static_cast<int32_t>(ng));
+    res = Column::new_data_column(SType::INT32, ng);
     auto d_res = static_cast<int32_t*>(res->data_w());
 
     for (size_t i = 0; i < ng; ++i) {

--- a/c/expr/reduceop.cc
+++ b/c/expr/reduceop.cc
@@ -307,7 +307,7 @@ Column* reduceop(int opcode, Column* arg, const Groupby& groupby)
 
   void* params[2];
   params[0] = arg;
-  params[1] = Column::new_data_column(res_type, ngrps);
+  params[1] = Column::new_data_column(res_type, static_cast<size_t>(ngrps));
 
   gmapperfn fn = resolve0(opcode, arg_type);
   if (!fn) {

--- a/c/expr/unaryop.cc
+++ b/c/expr/unaryop.cc
@@ -171,7 +171,7 @@ Column* unaryop(int opcode, Column* arg)
       << arg_type << ")";
   }
 
-  (*fn)(0, arg->nrows, params);
+  (*fn)(0, static_cast<int64_t>(arg->nrows), params);
 
   return static_cast<Column*>(params[1]);
 }

--- a/c/extras/aggregator.cc
+++ b/c/extras/aggregator.cc
@@ -138,10 +138,8 @@ dtptr Aggregator::aggregate(DataTable* dt) {
 bool Aggregator::random_sampling(dtptr& dt_members, int32_t max_bins, int32_t n_na_bins) {
   bool was_sampled = false;
   // Sorting `dt_members` to calculate total number of exemplars.
-  arr32_t cols(1);
-  cols[0] = 0;
   Groupby gb_members;
-  RowIndex ri_members = dt_members->sortby(cols, &gb_members);
+  RowIndex ri_members = dt_members->sortby({0}, &gb_members);
 
   // Do random sampling if there is too many exemplars, `n_na_bins` accounts
   // for the additional N/A bins that may appear during grouping.
@@ -191,10 +189,8 @@ void Aggregator::aggregate_exemplars(DataTable* dt,
                                      dtptr& dt_members,
                                      bool was_sampled) {
   // Setting up offsets and members row index.
-  arr32_t cols(1);
-  cols[0] = 0;
   Groupby gb_members;
-  RowIndex ri_members = dt_members->sortby(cols, &gb_members);
+  RowIndex ri_members = dt_members->sortby({0}, &gb_members);
   const int32_t* offsets = gb_members.offsets_r();
   size_t n_exemplars = gb_members.ngroups() - was_sampled;
   arr32_t exemplar_indices(n_exemplars);
@@ -374,12 +370,9 @@ void Aggregator::group_2d_continuous(const dtptr& dt,
 /*
 *  Do 1D grouping for a categorical column, i.e. just a `group by` operation.
 */
-void Aggregator::group_1d_categorical(const dtptr& dt,
-                                      dtptr& dt_members) {
-  arr32_t cols(1);
-  cols[0] = 0;
+void Aggregator::group_1d_categorical(const dtptr& dt, dtptr& dt_members) {
   Groupby grpby0;
-  RowIndex ri0 = dt->sortby(cols, &grpby0);
+  RowIndex ri0 = dt->sortby({0}, &grpby0);
   const int32_t* group_indices_0 = ri0.indices32();
 
   auto d_members = static_cast<int32_t*>(dt_members->columns[0]->data_w());
@@ -432,15 +425,12 @@ void Aggregator::group_2d_categorical_str(const dtptr& dt,
   const T0* d_c0 = c0->offsets();
   const T1* d_c1 = c1->offsets();
 
-  arr32_t cols(1);
-  cols[0] = 0;
   Groupby grpby0;
-  RowIndex ri0 = dt->sortby(cols, &grpby0);
+  RowIndex ri0 = dt->sortby({0}, &grpby0);
   const int32_t* group_indices_0 = ri0.indices32();
 
-  cols[0] = 1;
   Groupby grpby1;
-  RowIndex ri1 = dt->sortby(cols, &grpby1);
+  RowIndex ri1 = dt->sortby({1}, &grpby1);
   const int32_t* group_indices_1 = ri1.indices32();
 
   auto d_members = static_cast<int32_t*>(dt_members->columns[0]->data_w());
@@ -501,10 +491,8 @@ void Aggregator::group_2d_mixed_str (bool cont_index, const dtptr& dt,
   auto c_cat = static_cast<const StringColumn<T>*>(dt->columns[!cont_index]);
   const T* d_cat = c_cat->offsets();
 
-  arr32_t cols(1);
-  cols[0] = !cont_index;
   Groupby grpby;
-  RowIndex ri_cat = dt->sortby(cols, &grpby);
+  RowIndex ri_cat = dt->sortby({!cont_index}, &grpby);
   const int32_t* gi_cat = ri_cat.indices32();
 
   auto c_cont = static_cast<RealColumn<double>*>(dt->columns[cont_index]);

--- a/c/extras/aggregator.h
+++ b/c/extras/aggregator.h
@@ -28,20 +28,20 @@ typedef std::unique_ptr<ex> ExPtr;
 
 class Aggregator {
   public:
-    Aggregator(int32_t, int32_t, int32_t, int32_t, int32_t, int32_t,
+    Aggregator(size_t, size_t, size_t, size_t, size_t, size_t,
                unsigned int, PyObject*, unsigned int);
     dtptr aggregate(DataTable*);
     static constexpr double epsilon = 1.0e-15;
-    static void set_norm_coeffs(double&, double&, double, double, int32_t);
+    static void set_norm_coeffs(double&, double&, double, double, size_t);
     static void print_progress(double, int);
 
   private:
-    int32_t min_rows;
-    int32_t n_bins;
-    int32_t nx_bins;
-    int32_t ny_bins;
-    int32_t nd_max_bins;
-    int32_t max_dimensions;
+    size_t min_rows;
+    size_t n_bins;
+    size_t nx_bins;
+    size_t ny_bins;
+    size_t nd_max_bins;
+    size_t max_dimensions;
     unsigned int seed;
     unsigned int nthreads;
     PyObject* progress_fn;
@@ -60,18 +60,18 @@ class Aggregator {
     void group_2d_mixed(bool, const dtptr&, dtptr&);
     template<typename T>
     void group_2d_mixed_str(bool, const dtptr&, dtptr&);
-    bool random_sampling(dtptr&, int32_t, int32_t);
+    bool random_sampling(dtptr&, size_t, size_t);
     void aggregate_exemplars(DataTable*, dtptr&, bool);
 
     // Helper methods
-    int32_t get_nthreads(const dtptr&);
+    size_t get_nthreads(const dtptr&);
     DoublePtr generate_pmatrix(const dtptr&);
-    void normalize_row(const dtptr&, DoublePtr&, int32_t);
-    void project_row(const dtptr&, DoublePtr&, int32_t, DoublePtr&);
-    double calculate_distance(DoublePtr&, DoublePtr&, int64_t, double,
+    void normalize_row(const dtptr&, DoublePtr&, size_t);
+    void project_row(const dtptr&, DoublePtr&, size_t, DoublePtr&);
+    double calculate_distance(DoublePtr&, DoublePtr&, size_t, double,
                               bool early_exit=true);
     void adjust_delta(double&, std::vector<ExPtr>&, std::vector<int64_t>&,
-                      int64_t);
+                      size_t);
     void adjust_members(std::vector<int64_t>&, dtptr&);
     size_t calculate_map(std::vector<int64_t>&, size_t);
     void progress(double, int status_code=0);

--- a/c/extras/aggregator.h
+++ b/c/extras/aggregator.h
@@ -30,7 +30,7 @@ class Aggregator {
   public:
     Aggregator(int32_t, int32_t, int32_t, int32_t, int32_t, int32_t,
                unsigned int, PyObject*, unsigned int);
-    DataTablePtr aggregate(DataTable*);
+    dtptr aggregate(DataTable*);
     static constexpr double epsilon = 1.0e-15;
     static void set_norm_coeffs(double&, double&, double, double, int32_t);
     static void print_progress(double, int);
@@ -47,32 +47,32 @@ class Aggregator {
     PyObject* progress_fn;
 
     // Grouping and aggregating methods
-    void group_0d(const DataTable*, DataTablePtr&);
-    void group_1d(const DataTablePtr&, DataTablePtr&);
-    void group_2d(const DataTablePtr&, DataTablePtr&);
-    void group_nd(const DataTablePtr&, DataTablePtr&);
-    void group_1d_continuous(const DataTablePtr&, DataTablePtr&);
-    void group_2d_continuous(const DataTablePtr&, DataTablePtr&);
-    void group_1d_categorical(const DataTablePtr&, DataTablePtr&);
-    void group_2d_categorical(const DataTablePtr&, DataTablePtr&);
+    void group_0d(const DataTable*, dtptr&);
+    void group_1d(const dtptr&, dtptr&);
+    void group_2d(const dtptr&, dtptr&);
+    void group_nd(const dtptr&, dtptr&);
+    void group_1d_continuous(const dtptr&, dtptr&);
+    void group_2d_continuous(const dtptr&, dtptr&);
+    void group_1d_categorical(const dtptr&, dtptr&);
+    void group_2d_categorical(const dtptr&, dtptr&);
     template<typename T1, typename T2>
-    void group_2d_categorical_str(const DataTablePtr&, DataTablePtr&);
-    void group_2d_mixed(bool, const DataTablePtr&, DataTablePtr&);
+    void group_2d_categorical_str(const dtptr&, dtptr&);
+    void group_2d_mixed(bool, const dtptr&, dtptr&);
     template<typename T>
-    void group_2d_mixed_str(bool, const DataTablePtr&, DataTablePtr&);
-    bool random_sampling(DataTablePtr&, int32_t, int32_t);
-    void aggregate_exemplars(DataTable*, DataTablePtr&, bool);
+    void group_2d_mixed_str(bool, const dtptr&, dtptr&);
+    bool random_sampling(dtptr&, int32_t, int32_t);
+    void aggregate_exemplars(DataTable*, dtptr&, bool);
 
     // Helper methods
-    int32_t get_nthreads(const DataTablePtr&);
-    DoublePtr generate_pmatrix(const DataTablePtr&);
-    void normalize_row(const DataTablePtr&, DoublePtr&, int32_t);
-    void project_row(const DataTablePtr&, DoublePtr&, int32_t, DoublePtr&);
+    int32_t get_nthreads(const dtptr&);
+    DoublePtr generate_pmatrix(const dtptr&);
+    void normalize_row(const dtptr&, DoublePtr&, int32_t);
+    void project_row(const dtptr&, DoublePtr&, int32_t, DoublePtr&);
     double calculate_distance(DoublePtr&, DoublePtr&, int64_t, double,
                               bool early_exit=true);
     void adjust_delta(double&, std::vector<ExPtr>&, std::vector<int64_t>&,
                       int64_t);
-    void adjust_members(std::vector<int64_t>&, DataTablePtr&);
+    void adjust_members(std::vector<int64_t>&, dtptr&);
     size_t calculate_map(std::vector<int64_t>&, size_t);
     void progress(double, int status_code=0);
 };

--- a/c/extras/aggregator.h
+++ b/c/extras/aggregator.h
@@ -17,7 +17,7 @@
 
 typedef std::unique_ptr<double[]> DoublePtr;
 struct ex {
-  int64_t id;
+  size_t id;
   DoublePtr coords;
 };
 typedef std::unique_ptr<ex> ExPtr;
@@ -70,10 +70,10 @@ class Aggregator {
     void project_row(const dtptr&, DoublePtr&, size_t, DoublePtr&);
     double calculate_distance(DoublePtr&, DoublePtr&, size_t, double,
                               bool early_exit=true);
-    void adjust_delta(double&, std::vector<ExPtr>&, std::vector<int64_t>&,
+    void adjust_delta(double&, std::vector<ExPtr>&, std::vector<size_t>&,
                       size_t);
-    void adjust_members(std::vector<int64_t>&, dtptr&);
-    size_t calculate_map(std::vector<int64_t>&, size_t);
+    void adjust_members(std::vector<size_t>&, dtptr&);
+    size_t calculate_map(std::vector<size_t>&, size_t);
     void progress(double, int status_code=0);
 };
 

--- a/c/frame/_repr_html_.cc
+++ b/c/frame/_repr_html_.cc
@@ -33,8 +33,8 @@ class HtmlWidget {
       const size_t maxcols = 15;  // TODO: make configurable
       const size_t maxrows = 15;
       dt = dt_;
-      ncols = static_cast<size_t>(dt->ncols);
-      nrows = static_cast<size_t>(dt->nrows);
+      ncols = dt->ncols;
+      nrows = dt->nrows;
       cols0 = ncols <= maxcols ? ncols : maxcols * 2 / 3;
       cols1 = ncols <= maxcols ? 0 : maxcols - cols0;
       rows0 = nrows <= maxrows ? nrows : maxrows * 2 / 3;

--- a/c/frame/cbind.cc
+++ b/c/frame/cbind.cc
@@ -27,7 +27,7 @@ namespace py {
 
 
 // Forward-declare
-static void check_nrows(DataTable* dt, int64_t* nrows);
+static void check_nrows(DataTable* dt, size_t* nrows);
 static Error item_error(const py::_obj&);
 
 
@@ -74,7 +74,7 @@ force: boolean
 void Frame::cbind(const PKArgs& args) {
   bool force = args[0]? args[0].to_bool_strict() : false;
 
-  int64_t nrows = dt->nrows;
+  size_t nrows = dt->nrows;
   std::vector<DataTable*> dts;
   for (auto va : args.varargs()) {
     if (va.is_frame()) {
@@ -104,8 +104,8 @@ void Frame::cbind(const PKArgs& args) {
 }
 
 
-static void check_nrows(DataTable* dt, int64_t* nrows) {
-  int64_t inrows = dt->nrows;
+static void check_nrows(DataTable* dt, size_t* nrows) {
+  size_t inrows = dt->nrows;
   if (*nrows <= 1) *nrows = inrows;
   if (*nrows == inrows || inrows == 1) return;
   throw ValueError() << "Cannot merge frame with " << inrows << " rows to "
@@ -134,8 +134,8 @@ static Error item_error(const py::_obj& item) {
  */
 DataTable* DataTable::cbind(std::vector<DataTable*> dts)
 {
-  int64_t t_ncols = ncols;
-  int64_t t_nrows = nrows;
+  size_t t_ncols = ncols;
+  size_t t_nrows = nrows;
   for (size_t i = 0; i < dts.size(); ++i) {
     t_ncols += dts[i]->ncols;
     if (t_nrows < dts[i]->nrows) t_nrows = dts[i]->nrows;
@@ -147,7 +147,7 @@ DataTable* DataTable::cbind(std::vector<DataTable*> dts)
 
   // Fix up the main datatable if it has too few rows
   if (nrows < t_nrows) {
-    for (int64_t i = 0; i < ncols; ++i) {
+    for (size_t i = 0; i < ncols; ++i) {
       columns[i]->resize_and_fill(t_nrows);
     }
     nrows = t_nrows;
@@ -156,18 +156,18 @@ DataTable* DataTable::cbind(std::vector<DataTable*> dts)
   // Append columns from `dts` into the "main" datatable
   std::vector<std::string> newnames = names;
   columns.resize(t_ncols);
-  int64_t j = ncols;
+  size_t j = ncols;
   for (size_t i = 0; i < dts.size(); ++i) {
-    int64_t ncolsi = dts[i]->ncols;
-    int64_t nrowsi = dts[i]->nrows;
-    for (int64_t ii = 0; ii < ncolsi; ++ii) {
+    size_t ncolsi = dts[i]->ncols;
+    size_t nrowsi = dts[i]->nrows;
+    for (size_t ii = 0; ii < ncolsi; ++ii) {
       Column *c = dts[i]->columns[ii]->shallowcopy();
       c->reify();
       if (nrowsi < t_nrows) c->resize_and_fill(t_nrows);
       columns[j++] = c;
     }
     const auto& namesi = dts[i]->names;
-    xassert(namesi.size() == static_cast<size_t>(ncolsi));
+    xassert(namesi.size() == ncolsi);
     newnames.insert(newnames.end(), namesi.begin(), namesi.end());
   }
   xassert(j == t_ncols);

--- a/c/frame/getset.cc
+++ b/c/frame/getset.cc
@@ -52,21 +52,23 @@ oobj Frame::_fast_getset(obj item, obj value) {
       bool a1int = arg1.is_int();
       if (a0int && (a1int || arg1.is_string())) {
         int64_t irow = arg0.to_int64_strict();
-        if (irow < 0) irow += dt->nrows;
-        if (irow < 0 || irow >= dt->nrows) {
-          if (irow < 0) irow -= dt->nrows;
+        int64_t nrows = static_cast<int64_t>(dt->nrows);
+        int64_t ncols = static_cast<int64_t>(dt->ncols);
+        if (irow < 0) irow += nrows;
+        if (irow < 0 || irow >= nrows) {
+          if (irow < 0) irow -= nrows;
           throw ValueError() << "Row `" << irow << "` is invalid for a frame "
-              "with " << dt->nrows << " row" << (dt->nrows == 1? "" : "s");
+              "with " << nrows << " row" << (nrows == 1? "" : "s");
         }
         int64_t icol;
         if (a1int) {
           icol = arg1.to_int64_strict();
-          if (icol < 0) icol += dt->ncols;
-          if (icol < 0 || icol >= dt->ncols) {
-            if (icol < 0) icol -= dt->ncols;
+          if (icol < 0) icol += ncols;
+          if (icol < 0 || icol >= ncols) {
+            if (icol < 0) icol -= ncols;
             throw ValueError() << "Column index `" << icol << "` is invalud "
-                "for a frame with " << dt->ncols << " column" <<
-                (dt->ncols == 1? "" : "s");
+                "for a frame with " << ncols << " column" <<
+                (ncols == 1? "" : "s");
           }
         } else {
           icol = dt->colindex(arg1);
@@ -75,7 +77,7 @@ oobj Frame::_fast_getset(obj item, obj value) {
                 "the frame";
           }
         }
-        Column* col = dt->columns[icol];
+        Column* col = dt->columns[static_cast<size_t>(icol)];
         return col->get_value_at_index(irow);
       }
     }

--- a/c/frame/names.cc
+++ b/c/frame/names.cc
@@ -355,12 +355,11 @@ void DataTable::replace_names(py::odict replacements) {
 
 void DataTable::_init_pynames() const {
   if (py_names) return;
-  size_t zcols = static_cast<size_t>(ncols);
-  xassert(names.size() == zcols);
+  xassert(names.size() == ncols);
 
-  py_names = py::otuple(zcols);
+  py_names = py::otuple(ncols);
   py_inames = py::odict();
-  for (size_t i = 0; i < zcols; ++i) {
+  for (size_t i = 0; i < ncols; ++i) {
     py::ostring pyname(names[i]);
     py_inames.set(pyname, py::oint(i));
     py_names.set(i, std::move(pyname));
@@ -374,19 +373,18 @@ void DataTable::_init_pynames() const {
  * such constraints.
  */
 void DataTable::_set_names_impl(NameProvider* nameslist) {
-  size_t zcols = static_cast<size_t>(ncols);
-  if (nameslist->size() != zcols) {
+  if (nameslist->size() != ncols) {
     throw ValueError() << "The `names` list has length " << nameslist->size()
         << ", while the Frame has "
-        << (zcols < nameslist->size() && zcols? "only " : "")
-        << zcols << " column" << (zcols == 1? "" : "s");
+        << (ncols < nameslist->size() && ncols? "only " : "")
+        << ncols << " column" << (ncols == 1? "" : "s");
   }
 
   // Prepare the containers for placing the new column names there
-  py_names  = py::otuple(zcols);
+  py_names  = py::otuple(ncols);
   py_inames = py::odict();
   names.clear();
-  names.reserve(zcols);
+  names.reserve(ncols);
   std::vector<std::string> duplicates;
 
   // If any name is empty or None, it will be replaced with the default name
@@ -395,7 +393,7 @@ void DataTable::_set_names_impl(NameProvider* nameslist) {
   // user-specified names somewhere later in the list.
   bool fill_default_names = false;
 
-  for (size_t i = 0; i < zcols; ++i) {
+  for (size_t i = 0; i < ncols; ++i) {
     // Convert to a C-style name object. Note that if `name` is python None,
     // then the resulting `cname` will be `{nullptr, 0}`.
     CString cname = nameslist->item_as_cstring(i);
@@ -480,7 +478,7 @@ void DataTable::_set_names_impl(NameProvider* nameslist) {
     // Within the existing names, find ones with the pattern "{prefix}<num>".
     // If such names exist, we'll start autonaming with 1 + max(<num>), where
     // the maximum is taken among all such names.
-    for (size_t i = 0; i < zcols; ++i) {
+    for (size_t i = 0; i < ncols; ++i) {
       size_t namelen = names[i].size();
       const char* nameptr = names[i].data();
       if (namelen <= prefixlen) continue;
@@ -498,7 +496,7 @@ void DataTable::_set_names_impl(NameProvider* nameslist) {
     }
 
     // Now actually fill the empty names
-    for (size_t i = 0; i < zcols; ++i) {
+    for (size_t i = 0; i < ncols; ++i) {
       if (!names[i].empty()) continue;
       names[i] = prefix + std::to_string(index0);
       py::oobj newname = py::ostring(names[i]);
@@ -527,18 +525,17 @@ void DataTable::_set_names_impl(NameProvider* nameslist) {
     // as `w` goes out of scope, the warning is sent to Python
   }
 
-  xassert(zcols == names.size());
-  xassert(zcols == py_names.size());
-  xassert(zcols == py_inames.size());
+  xassert(ncols == names.size());
+  xassert(ncols == py_names.size());
+  xassert(ncols == py_inames.size());
 }
 
 
 
 void DataTable::_integrity_check_names() const {
-  size_t zcols = static_cast<size_t>(ncols);
-  if (names.size() != zcols) {
+  if (names.size() != ncols) {
     throw AssertionError() << "DataTable.names has size " << names.size()
-      << ", however there are " << zcols << " columns in the Frame";
+      << ", however there are " << ncols << " columns in the Frame";
   }
   std::unordered_set<std::string> seen_names;
   for (size_t i = 0; i < names.size(); ++i) {
@@ -571,16 +568,15 @@ void DataTable::_integrity_check_pynames() const {
   if (!py_inames.is_dict()) {
     throw AssertionError() << "DataTable.py_inames is not a dict";
   }
-  size_t zcols = static_cast<size_t>(ncols);
-  if (py_names.size() != zcols) {
+  if (py_names.size() != ncols) {
     throw AssertionError() << "len(.py_names) is " << py_names.size()
-        << ", whereas .ncols = " << zcols;
+        << ", whereas .ncols = " << ncols;
   }
-  if (py_inames.size() != zcols) {
+  if (py_inames.size() != ncols) {
     throw AssertionError() << ".py_inames has " << py_inames.size()
-      << " elements, while the Frame has " << zcols << " columns";
+      << " elements, while the Frame has " << ncols << " columns";
   }
-  for (size_t i = 0; i < zcols; ++i) {
+  for (size_t i = 0; i < ncols; ++i) {
     py::obj elem = py_names[i];
     if (!elem.is_string()) {
       throw AssertionError() << "Element " << i << " of .py_names is a "

--- a/c/frame/names.cc
+++ b/c/frame/names.cc
@@ -53,7 +53,7 @@ class pylistNP : public NameProvider {
 
 class strvecNP : public NameProvider {
   private:
-    const std::vector<std::string>& names;
+    const strvec& names;
 
   public:
     strvecNP(const std::vector<std::string>& arg) : names(arg) {}
@@ -184,7 +184,7 @@ oobj Frame::colindex(const PKArgs& args)
   }
   if (col.is_int()) {
     int64_t colidx = col.to_int64_strict();
-    int64_t ncols = dt->ncols;
+    int64_t ncols = static_cast<int64_t>(dt->ncols);
     if (colidx < 0 && colidx + ncols >= 0) {
       colidx += ncols;
     }
@@ -300,12 +300,11 @@ void DataTable::copy_names_from(const DataTable* other) {
 void DataTable::set_names_to_default() {
   auto index0 = static_cast<size_t>(config::frame_names_auto_index);
   auto prefix = config::frame_names_auto_prefix;
-  auto zcols  = static_cast<size_t>(ncols);
   py_names  = py::otuple();
   py_inames = py::odict(nullptr);
   names.clear();
-  names.reserve(zcols);
-  for (size_t i = 0; i < zcols; ++i) {
+  names.reserve(ncols);
+  for (size_t i = 0; i < ncols; ++i) {
     names.push_back(prefix + std::to_string(i + index0));
   }
 }
@@ -318,7 +317,7 @@ void DataTable::set_names(const py::olist& names_list) {
 }
 
 
-void DataTable::set_names(const std::vector<std::string>& names_list) {
+void DataTable::set_names(const strvec& names_list) {
   strvecNP np(names_list);
   _set_names_impl(&np);
 }
@@ -327,7 +326,7 @@ void DataTable::set_names(const std::vector<std::string>& names_list) {
 void DataTable::replace_names(py::odict replacements) {
   py::olist newnames(ncols);
 
-  for (int64_t i = 0; i < ncols; ++i) {
+  for (size_t i = 0; i < ncols; ++i) {
     newnames.set(i, py_names[i]);
   }
   for (auto kv : replacements) {

--- a/c/frame/py_frame.cc
+++ b/c/frame/py_frame.cc
@@ -172,7 +172,7 @@ void Frame::set_nrows(obj nr) {
   if (new_nrows < 0) {
     throw ValueError() << "Number of rows cannot be negative";
   }
-  dt->resize_rows(new_nrows);
+  dt->resize_rows(static_cast<size_t>(new_nrows));
 }
 
 

--- a/c/frame/py_frame_init.cc
+++ b/c/frame/py_frame_init.cc
@@ -338,7 +338,7 @@ class FrameInitializationManager {
 
     void init_from_frame() {
       DataTable* srcdt = src.to_frame();
-      size_t ncols = static_cast<size_t>(srcdt->ncols);
+      size_t ncols = srcdt->ncols;
       check_names_count(ncols);
       if (stypes_arg || stype_arg) {
         // TODO: allow this use case

--- a/c/frame/py_frame_init.cc
+++ b/c/frame/py_frame_init.cc
@@ -596,8 +596,8 @@ class FrameInitializationManager {
       }
       cols.push_back(col);
       if (cols.size() > 1) {
-        int64_t nrows0 = cols.front()->nrows;
-        int64_t nrows1 = cols.back()->nrows;
+        size_t nrows0 = cols.front()->nrows;
+        size_t nrows1 = cols.back()->nrows;
         if (nrows0 != nrows1) {
           throw ValueError()
             << "Column " << cols.size() - 1 << " has different number of "

--- a/c/frame/replace.cc
+++ b/c/frame/replace.cc
@@ -135,8 +135,7 @@ void Frame::replace(const PKArgs& args) {
   ra.parse_x_y(x, y);
   ra.split_x_y_by_type();
 
-  size_t ncols = static_cast<size_t>(dt->ncols);
-  for (size_t i = 0; i < ncols; ++i) {
+  for (size_t i = 0; i < dt->ncols; ++i) {
     Column* col = dt->columns[i];
     switch (col->stype()) {
       case SType::BOOL:    ra.process_bool_column(i); break;
@@ -225,8 +224,7 @@ void ReplaceAgent::split_x_y_by_type() {
        done_real = false,
        done_bool = false,
        done_str = false;
-  size_t ncols = static_cast<size_t>(dt->ncols);
-  for (size_t i = 0; i < ncols; ++i) {
+  for (size_t i = 0; i < dt->ncols; ++i) {
     SType s = dt->columns[i]->stype();
     switch (s) {
       case SType::BOOL: {
@@ -410,12 +408,11 @@ void ReplaceAgent::check_uniqueness(std::vector<T>& data) {
 void ReplaceAgent::process_bool_column(size_t colidx) {
   if (x_bool.empty()) return;
   auto col = static_cast<BoolColumn*>(dt->columns[colidx]);
-  size_t nrows = static_cast<size_t>(col->nrows);
   int8_t* coldata = col->elements_w();
   size_t n = x_bool.size();
   xassert(n == y_bool.size());
   if (n == 0) return;
-  replace_fw<int8_t>(x_bool.data(), y_bool.data(), nrows, coldata, n);
+  replace_fw<int8_t>(x_bool.data(), y_bool.data(), col->nrows, coldata, n);
 }
 
 
@@ -469,9 +466,8 @@ void ReplaceAgent::process_int_column(size_t colidx) {
     size_t n = xfilt.size();
     xassert(n == yfilt.size());
     if (n == 0) return;
-    size_t nrows = static_cast<size_t>(col->nrows);
     T* coldata = col->elements_w();
-    replace_fw<T>(xfilt.data(), yfilt.data(), nrows, coldata, n);
+    replace_fw<T>(xfilt.data(), yfilt.data(), col->nrows, coldata, n);
     col->get_stats()->reset();
   }
 }
@@ -523,9 +519,8 @@ void ReplaceAgent::process_real_column(size_t colidx) {
     size_t n = xfilt.size();
     xassert(n == yfilt.size());
     if (n == 0) return;
-    size_t nrows = static_cast<size_t>(col->nrows);
     T* coldata = col->elements_w();
-    replace_fw<T>(xfilt.data(), yfilt.data(), nrows, coldata, n);
+    replace_fw<T>(xfilt.data(), yfilt.data(), col->nrows, coldata, n);
     col->get_stats()->reset();
   }
 }

--- a/c/groupby.cc
+++ b/c/groupby.cc
@@ -26,7 +26,7 @@ Groupby::Groupby(size_t _n, MemoryRange&& _offs) {
 }
 
 
-Groupby Groupby::single_group(int64_t nrows) {
+Groupby Groupby::single_group(size_t nrows) {
   MemoryRange mr = MemoryRange::mem(2 * sizeof(int32_t));
   mr.set_element<int32_t>(0, 0);
   mr.set_element<int32_t>(1, static_cast<int32_t>(nrows));

--- a/c/groupby.h
+++ b/c/groupby.h
@@ -24,7 +24,7 @@ class Groupby {
     Groupby(Groupby&&) = default;
     Groupby& operator=(const Groupby&) = default;
     Groupby& operator=(Groupby&&) = default;
-    static Groupby single_group(int64_t nrows);
+    static Groupby single_group(size_t nrows);
 
     const int32_t* offsets_r() const;
     size_t ngroups() const;

--- a/c/jay/open_jay.cc
+++ b/c/jay/open_jay.cc
@@ -91,7 +91,7 @@ static void initStats(Stats* stats, const jay::Column* jcol) {
   auto tstats = static_cast<NumericalStats<T, A>*>(stats);
   auto jstats = static_cast<const JStats*>(jcol->stats());
   if (jstats) {
-    tstats->set_countna(static_cast<int64_t>(jcol->nullcount()));
+    tstats->set_countna(jcol->nullcount());
     tstats->set_min(jstats->min());
     tstats->set_max(jstats->max());
   }

--- a/c/jay/open_jay.cc
+++ b/c/jay/open_jay.cc
@@ -59,7 +59,7 @@ DataTable* DataTable::open_jay(const std::string& path)
   size_t i = 0;
   for (const jay::Column* jcol : *msg_columns) {
     Column* col = column_from_jay(jcol, mbuf);
-    if (col->nrows != static_cast<int64_t>(nrows)) {
+    if (col->nrows != nrows) {
       throw IOError() << "Length of column " << i << " is " << col->nrows
           << ", however the Frame contains " << nrows << " rows";
     }
@@ -69,7 +69,7 @@ DataTable* DataTable::open_jay(const std::string& path)
   }
 
   auto dt = new DataTable(std::move(columns), colnames);
-  dt->nkeys = frame->nkeys();
+  dt->nkeys = static_cast<size_t>(frame->nkeys());
   return dt;
 }
 

--- a/c/jay/save_jay.cc
+++ b/c/jay/save_jay.cc
@@ -42,7 +42,7 @@ void DataTable::save_jay(const std::string& path,
   flatbuffers::FlatBufferBuilder fbb(1024);
 
   std::vector<flatbuffers::Offset<jay::Column>> msg_columns;
-  for (size_t i = 0; i < static_cast<size_t>(ncols); ++i) {
+  for (size_t i = 0; i < ncols; ++i) {
     Column* col = columns[i];
     if (col->stype() == SType::OBJ) {
       Warning() << "Column '" << colnames[i] << "' of type obj64 was not saved";
@@ -54,7 +54,7 @@ void DataTable::save_jay(const std::string& path,
   xassert((wb->size() & 7) == 0);
 
   auto frame = jay::CreateFrameDirect(fbb,
-                  static_cast<size_t>(nrows),
+                  nrows,
                   msg_columns.size(),
                   static_cast<int>(nkeys),
                   &msg_columns);

--- a/c/memrange.cc
+++ b/c/memrange.cc
@@ -399,8 +399,8 @@
 
   //---- Element getters/setters -----------------
 
-  static void _oob_check(int64_t i, size_t size, size_t elemsize) {
-    if (i < 0 || static_cast<size_t>(i + 1) * elemsize > size) {
+  static void _oob_check(size_t i, size_t size, size_t elemsize) {
+    if ((i + 1) * elemsize > size) {
       throw ValueError() << "Index " << i << " is out of bounds for a memory "
         "region of size " << size << " viewed as an array of elements of size "
         << elemsize;
@@ -408,14 +408,14 @@
   }
 
   template <typename T>
-  T MemoryRange::get_element(int64_t i) const {
+  T MemoryRange::get_element(size_t i) const {
     _oob_check(i, size(), sizeof(T));
     const T* data = static_cast<const T*>(this->rptr());
     return data[i];
   }
 
   template <>
-  void MemoryRange::set_element(int64_t i, PyObject* value) {
+  void MemoryRange::set_element(size_t i, PyObject* value) {
     _oob_check(i, size(), sizeof(PyObject*));
     xassert(this->is_pyobjects());
     PyObject** data = static_cast<PyObject**>(this->wptr());
@@ -424,7 +424,7 @@
   }
 
   template <typename T>
-  void MemoryRange::set_element(int64_t i, T value) {
+  void MemoryRange::set_element(size_t i, T value) {
     _oob_check(i, size(), sizeof(T));
     T* data = static_cast<T*>(this->wptr());
     data[i] = value;
@@ -1006,12 +1006,12 @@
 // Template instantiations
 //==============================================================================
 
-  template int32_t MemoryRange::get_element(int64_t) const;
-  template int64_t MemoryRange::get_element(int64_t) const;
-  template uint32_t MemoryRange::get_element(int64_t) const;
-  template uint64_t MemoryRange::get_element(int64_t) const;
-  template void MemoryRange::set_element(int64_t, char);
-  template void MemoryRange::set_element(int64_t, int32_t);
-  template void MemoryRange::set_element(int64_t, int64_t);
-  template void MemoryRange::set_element(int64_t, uint32_t);
-  template void MemoryRange::set_element(int64_t, uint64_t);
+  template int32_t MemoryRange::get_element(size_t) const;
+  template int64_t MemoryRange::get_element(size_t) const;
+  template uint32_t MemoryRange::get_element(size_t) const;
+  template uint64_t MemoryRange::get_element(size_t) const;
+  template void MemoryRange::set_element(size_t, char);
+  template void MemoryRange::set_element(size_t, int32_t);
+  template void MemoryRange::set_element(size_t, int64_t);
+  template void MemoryRange::set_element(size_t, uint32_t);
+  template void MemoryRange::set_element(size_t, uint64_t);

--- a/c/memrange.h
+++ b/c/memrange.h
@@ -210,8 +210,8 @@ class MemoryRange
     void* wptr(size_t offset);
     void* xptr() const;
     void* xptr(size_t offset) const;
-    template <typename T> T get_element(int64_t i) const;
-    template <typename T> void set_element(int64_t i, T value);
+    template <typename T> T get_element(size_t i) const;
+    template <typename T> void set_element(size_t i, T value);
 
     // MemoryRange manipulators
     //
@@ -272,17 +272,17 @@ class MemoryRange
 };
 
 
-template <> void MemoryRange::set_element(int64_t, PyObject*);
-extern template int32_t MemoryRange::get_element(int64_t) const;
-extern template int64_t MemoryRange::get_element(int64_t) const;
-extern template uint32_t MemoryRange::get_element(int64_t) const;
-extern template uint64_t MemoryRange::get_element(int64_t) const;
-extern template void MemoryRange::set_element(int64_t, PyObject*);
-extern template void MemoryRange::set_element(int64_t, char);
-extern template void MemoryRange::set_element(int64_t, int32_t);
-extern template void MemoryRange::set_element(int64_t, int64_t);
-extern template void MemoryRange::set_element(int64_t, uint32_t);
-extern template void MemoryRange::set_element(int64_t, uint64_t);
+template <> void MemoryRange::set_element(size_t, PyObject*);
+extern template int32_t MemoryRange::get_element(size_t) const;
+extern template int64_t MemoryRange::get_element(size_t) const;
+extern template uint32_t MemoryRange::get_element(size_t) const;
+extern template uint64_t MemoryRange::get_element(size_t) const;
+extern template void MemoryRange::set_element(size_t, PyObject*);
+extern template void MemoryRange::set_element(size_t, char);
+extern template void MemoryRange::set_element(size_t, int32_t);
+extern template void MemoryRange::set_element(size_t, int64_t);
+extern template void MemoryRange::set_element(size_t, uint32_t);
+extern template void MemoryRange::set_element(size_t, uint64_t);
 
 
 #endif

--- a/c/py_column.cc
+++ b/c/py_column.cc
@@ -140,7 +140,7 @@ PyObject* ungroup(pycolumn::obj* self, PyObject* args)
 
   Column* col = self->ref;
   Groupby* groupby = pygby.to_groupby();
-  if (static_cast<size_t>(col->nrows) != groupby->ngroups()) {
+  if (col->nrows != groupby->ngroups()) {
     throw ValueError() << "Cannot 'ungroup' a Column with " << col->nrows
       << " rows using a Groupby with " << groupby->ngroups() << " groups";
   }

--- a/c/py_column.cc
+++ b/c/py_column.cc
@@ -103,7 +103,7 @@ PyObject* get_refcount(pycolumn::obj*) {
 
 PyObject* get_nrows(pycolumn::obj* self) {
   Column*& col = self->ref;
-  return PyLong_FromInt64(col->nrows);
+  return PyLong_FromSize_t(col->nrows);
 }
 
 
@@ -173,7 +173,7 @@ PyObject* topython(pycolumn::obj* self, PyObject*) {
   auto formatter = py_stype_formatters[itype];
   py::olist out(col->nrows);
 
-  col->rowindex().strided_loop2(0, col->nrows, 1,
+  col->rowindex().strided_loop2(0, static_cast<int64_t>(col->nrows), 1,
     [&](int64_t i, int64_t j) {
       out.set(i, ISNA(j)? py::None()
                         : py::oobj::from_new_reference(formatter(col, j)));

--- a/c/py_columnset.cc
+++ b/c/py_columnset.cc
@@ -72,7 +72,7 @@ PyObject* columns_from_slice(PyObject*, PyObject *args) {
 PyObject* columns_from_mixed(PyObject*, PyObject *args)
 {
   PyObject* arg1, *arg2;
-  long int nrows;
+  size_t nrows;
   long long rawptr;
   if (!PyArg_ParseTuple(args, "OOlL:columns_from_mixed",
                         &arg1, &arg2, &nrows, &rawptr))
@@ -92,8 +92,8 @@ PyObject* columns_from_mixed(PyObject*, PyObject *args)
       spec[i] = -elem.get_attr("itype").to_int64_strict();
     }
   }
-  int64_t icols = static_cast<int64_t>(ncols);
-  return wrap(columns_from_mixed(spec, icols, nrows, dt, fnptr), icols);
+  return wrap(columns_from_mixed(spec, ncols, nrows, dt, fnptr),
+              static_cast<int64_t>(ncols));
 }
 
 

--- a/c/py_columnset.h
+++ b/c/py_columnset.h
@@ -21,7 +21,7 @@ namespace pycolumnset
 
 struct obj : public PyObject {
   Column** columns;
-  int64_t ncols;
+  size_t ncols;
 };
 
 extern PyTypeObject type;

--- a/c/py_datatable.cc
+++ b/c/py_datatable.cc
@@ -600,7 +600,7 @@ PyObject* save_jay(obj* self, PyObject* args) {
                    (strategy == "write") ? WritableBuffer::Strategy::Write :
                                            WritableBuffer::Strategy::Auto;
 
-  if (colnames.size() != static_cast<size_t>(dt->ncols)) {
+  if (colnames.size() != dt->ncols) {
     throw ValueError()
       << "The list of column names has wrong length: " << colnames.size();
   }

--- a/c/py_datatable.cc
+++ b/c/py_datatable.cc
@@ -289,20 +289,20 @@ PyObject* column(obj* self, PyObject* args) {
 
 PyObject* delete_columns(obj* self, PyObject* args) {
   DataTable* dt = self->ref;
-  PyObject* list;
-  if (!PyArg_ParseTuple(args, "O!:delete_columns", &PyList_Type, &list))
+  PyObject* arg1;
+  if (!PyArg_ParseTuple(args, "O:delete_columns", &arg1))
     return nullptr;
+  py::olist list = py::obj(arg1).to_pylist();
+  size_t ncols = list.size();
 
-  int64_t ncols = static_cast<int64_t>(PyList_Size(list));
-  int* cols_to_remove = dt::amalloc<int>(ncols);
-  for (int64_t i = 0; i < ncols; i++) {
-    PyObject* item = PyList_GET_ITEM(list, i);
-    cols_to_remove[i] = static_cast<int>(PyLong_AsLong(item));
+  std::vector<size_t> cols_to_remove;
+  cols_to_remove.reserve(ncols);
+  for (size_t i = 0; i < ncols; ++i) {
+    cols_to_remove.push_back(list[i].to_size_t());
   }
-  dt->delete_columns(cols_to_remove, ncols);
+  dt->delete_columns(cols_to_remove);
 
   _clear_types(self);
-  dt::free(cols_to_remove);
   Py_RETURN_NONE;
 }
 

--- a/c/py_datatable.cc
+++ b/c/py_datatable.cc
@@ -77,7 +77,7 @@ int unwrap(PyObject* object, DataTable** address) {
 
 PyObject* datatable_load(PyObject*, PyObject* args) {
   DataTable* colspec;
-  int64_t nrows;
+  size_t nrows;
   const char* path;
   int recode;
   PyObject* names;

--- a/c/py_datatable.cc
+++ b/c/py_datatable.cc
@@ -111,7 +111,7 @@ PyObject* open_jay(PyObject*, PyObject* args) {
 
 PyObject* get_isview(obj* self) {
   DataTable* dt = self->ref;
-  for (int64_t i = 0; i < dt->ncols; ++i) {
+  for (size_t i = 0; i < dt->ncols; ++i) {
     if (dt->columns[i]->rowindex())
       return incref(Py_True);
   }
@@ -149,11 +149,11 @@ int set_groupby(obj* self, PyObject* value) {
 
 
 PyObject* get_nkeys(obj* self) {
-  return PyLong_FromLongLong(self->ref->nkeys);
+  return PyLong_FromSize_t(self->ref->nkeys);
 }
 
 int set_nkeys(obj* self, PyObject* value) {
-  int64_t nk = py::obj(value).to_int64_strict();
+  size_t nk = py::obj(value).to_size_t();
   self->ref->set_nkeys(nk);
   return 0;
 }
@@ -231,11 +231,11 @@ PyObject* check(obj* self, PyObject*) {
     if (!PyTuple_Check(stypes)) {
       throw AssertionError() << "Frame.stypes is not a tuple";
     }
-    if (PyTuple_Size(stypes) != dt->ncols) {
+    if (static_cast<size_t>(PyTuple_Size(stypes)) != dt->ncols) {
       throw AssertionError() << "len(Frame.stypes) is " << PyTuple_Size(stypes)
           << ", whereas .ncols = " << dt->ncols;
     }
-    for (Py_ssize_t i = 0; i < dt->ncols; ++i) {
+    for (size_t i = 0; i < dt->ncols; ++i) {
       SType st = dt->columns[i]->stype();
       PyObject* elem = PyTuple_GET_ITEM(stypes, i);
       PyObject* eexp = info(st).py_stype().release();
@@ -250,11 +250,11 @@ PyObject* check(obj* self, PyObject*) {
     if (!PyTuple_Check(ltypes)) {
       throw AssertionError() << "Frame.ltypes is not a tuple";
     }
-    if (PyTuple_Size(ltypes) != dt->ncols) {
+    if (static_cast<size_t>(PyTuple_Size(ltypes)) != dt->ncols) {
       throw AssertionError() << "len(Frame.ltypes) is " << PyTuple_Size(ltypes)
           << ", whereas .ncols = " << dt->ncols;
     }
-    for (Py_ssize_t i = 0; i < dt->ncols; ++i) {
+    for (size_t i = 0; i < dt->ncols; ++i) {
       SType st = dt->columns[i]->stype();
       PyObject* elem = PyTuple_GET_ITEM(ltypes, i);
       PyObject* eexp = info(st).py_ltype().release();
@@ -281,7 +281,7 @@ PyObject* column(obj* self, PyObject* args) {
   }
   if (colidx < 0) colidx += dt->ncols;
   pycolumn::obj* pycol =
-      pycolumn::from_column(dt->columns[colidx], self, colidx);
+      pycolumn::from_column(dt->columns[static_cast<size_t>(colidx)], self, colidx);
   return pycol;
 }
 
@@ -324,17 +324,20 @@ PyObject* replace_rowindex(obj* self, PyObject* args) {
 
 PyObject* replace_column_slice(obj* self, PyObject* args) {
   DataTable* dt = self->ref;
-  int64_t start, count, step;
+  int64_t start;
+  size_t count;
+  int64_t step;
   PyObject *arg4, *arg5;
   if (!PyArg_ParseTuple(args, "lllOO:replace_column_slice",
                         &start, &count, &step, &arg4, &arg5)) return nullptr;
   RowIndex rows_ri = py::obj(arg4).to_rowindex();
   DataTable* repl = py::obj(arg5).to_frame();
-  int64_t rrows = repl->nrows;
-  int64_t rcols = repl->ncols;
-  int64_t rrows2 = rows_ri? rows_ri.length() : dt->nrows;
+  size_t rrows = repl->nrows;
+  size_t rcols = repl->ncols;
+  size_t rrows2 = rows_ri? rows_ri.length() : dt->nrows;
 
-  if (!check_slice_triple(start, count, step, dt->ncols - 1)) {
+  if (!check_slice_triple(start, static_cast<int64_t>(count), step,
+                          static_cast<int64_t>(dt->ncols - 1))) {
     throw ValueError() << "Invalid slice " << start << "/" << count
                        << "/" << step << " for a Frame with " << dt->ncols
                        << " columns";
@@ -349,14 +352,15 @@ PyObject* replace_column_slice(obj* self, PyObject* args) {
   dt->reify();  // noop if `dt` is not a view
   repl->reify();
 
-  for (int64_t i = 0; i < count; ++i) {
-    int64_t j = start + i * step;
+  for (size_t i = 0; i < count; ++i) {
+    int64_t j = start + static_cast<int64_t>(i) * step;
+    size_t zj = static_cast<size_t>(j);
     Column* replcol = repl->columns[i % rcols];
     if (rows_ri) {
-      dt->columns[j]->replace_values(rows_ri, replcol);
+      dt->columns[zj]->replace_values(rows_ri, replcol);
     } else {
-      delete dt->columns[j];
-      dt->columns[j] = replcol->shallowcopy();
+      delete dt->columns[zj];
+      dt->columns[zj] = replcol->shallowcopy();
     }
   }
   _clear_types(self);
@@ -407,16 +411,17 @@ PyObject* replace_column_array(obj* self, PyObject* args) {
   for (size_t i = 0; i < cols.size(); ++i) {
     py::obj item = cols[i];
     int64_t j = item.to_int64_strict();
+    size_t zj = static_cast<size_t>(j);
     Column* replcol = repl->columns[i % rcols];
     if (rows_ri) {
-      dt->columns[j]->replace_values(rows_ri, replcol);
+      dt->columns[zj]->replace_values(rows_ri, replcol);
     } else {
       if (j == -1) {
-        j = dt->ncols++;
+        zj = dt->ncols++;
       } else {
-        delete dt->columns[j];
+        delete dt->columns[zj];
       }
-      dt->columns[j] = replcol->shallowcopy();
+      dt->columns[zj] = replcol->shallowcopy();
     }
   }
 
@@ -428,21 +433,21 @@ PyObject* replace_column_array(obj* self, PyObject* args) {
 
 PyObject* rbind(obj* self, PyObject* args) {
   DataTable* dt = self->ref;
-  int64_t final_ncols;
+  size_t final_ncols;
   PyObject* list;
   if (!PyArg_ParseTuple(args, "lO!:delete_columns",
                         &final_ncols, &PyList_Type, &list))
     return nullptr;
-  int64_t ndts = PyList_Size(list);
+  size_t ndts = static_cast<size_t>(PyList_Size(list));
 
   constexpr size_t INVALID_INDEX = size_t(-1);
   std::vector<DataTable*> dts;
   std::vector<std::vector<size_t>> cols_to_append(final_ncols);
   for (size_t j = 0; j < final_ncols; ++j) {
-    cols_to_append[j].resize(static_cast<size_t>(ndts));
+    cols_to_append[j].resize(ndts);
   }
 
-  for (int64_t i = 0; i < ndts; i++) {
+  for (size_t i = 0; i < ndts; i++) {
     PyObject* item = PyList_GET_ITEM(list, i);
     DataTable* dti;
     PyObject* colslist;
@@ -464,7 +469,7 @@ PyObject* rbind(obj* self, PyObject* args) {
       }
     }
     for (; j < final_ncols; ++j) {
-      cols_to_append[j][i] = -1;
+      cols_to_append[j][i] = INVALID_INDEX;
     }
     dts.push_back(dti);
   }
@@ -506,13 +511,13 @@ PyObject* join(obj* self, PyObject* args) {
   DataTable* dt = self->ref;
   DataTable* jdt = py::obj(arg2).to_frame();
   RowIndex ri = py::obj(arg1).to_rowindex();
-  py::olist cols = py::obj(arg3).to_pylist();
+  py::olist cols_arg = py::obj(arg3).to_pylist();
 
-  if (cols.size() != 1) {
+  if (cols_arg.size() != 1) {
     throw NotImplError() << "Only single-column joins are currently supported";
   }
-  int64_t i = cols[0].to_int64();
-  if (i < 0 || i >= dt->ncols) {
+  size_t i = cols_arg[0].to_size_t();
+  if (i >= dt->ncols) {
     throw ValueError() << "Invalid index " << i << " for a Frame with "
         << dt->ncols << " columns";
   }
@@ -560,7 +565,7 @@ PyObject* sum1    (obj* self, PyObject*) { return _scalar_stat(self->ref, &Colum
 PyObject* materialize(obj* self, PyObject*) {
   DataTable* dt = self->ref;
 
-  for (int64_t i = 0; i < dt->ncols; ++i) {
+  for (size_t i = 0; i < dt->ncols; ++i) {
     Column* oldcol = dt->columns[i];
     if (!oldcol->rowindex()) continue;
     Column* newcol = oldcol->shallowcopy();

--- a/c/py_datatable.cc
+++ b/c/py_datatable.cc
@@ -491,9 +491,9 @@ PyObject* sort(obj* self, PyObject* args) {
   bool last_arg_bool = nargs > 1 && arglist[nargs - 1].is_bool();
   bool make_groups = last_arg_bool? arglist[nargs - 1].to_bool_strict() : false;
 
-  arr32_t cols(nargs - last_arg_bool);
-  for (size_t i = 0; i < cols.size(); ++i) {
-    cols[i] = arglist[i].to_int32_strict();
+  std::vector<size_t> cols;
+  for (size_t i = 0; i < nargs - last_arg_bool; ++i) {
+    cols.push_back(arglist[i].to_size_t());
   }
   Groupby grpby;
   RowIndex ri = dt->sortby(cols, make_groups? &grpby : nullptr);

--- a/c/py_datawindow.cc
+++ b/c/py_datawindow.cc
@@ -47,7 +47,7 @@ static int _init_(obj* self, PyObject* args, PyObject* kwds)
   pydatatable::obj *pydt;
   DataTable *dt;
   PyObject *stypes = nullptr, *ltypes = nullptr, *view = nullptr;
-  int64_t row0, row1, col0, col1;
+  size_t row0, row1, col0, col1;
 
   // Parse arguments and check their validity
   static const char* kwlist[] =
@@ -61,8 +61,8 @@ static int _init_(obj* self, PyObject* args, PyObject* kwds)
   try {
   dt = pydt == nullptr? nullptr : pydt->ref;
 
-  if (col0 < 0 || col1 < col0 || col1 > dt->ncols ||
-    row0 < 0 || row1 < row0 || row1 > dt->nrows) {
+  if (col1 < col0 || col1 > dt->ncols ||
+      row1 < row0 || row1 > dt->nrows) {
     throw ValueError() <<
       "Invalid data window bounds: Frame is [" << dt->nrows << " x " <<
       dt->ncols << "], whereas requested window is [" << row0 << ".." <<
@@ -70,8 +70,8 @@ static int _init_(obj* self, PyObject* args, PyObject* kwds)
   }
 
   // Window dimensions
-  int64_t ncols = col1 - col0;
-  int64_t nrows = row1 - row0;
+  size_t ncols = col1 - col0;
+  size_t nrows = row1 - row0;
 
   RowIndex rindex(dt->rowindex);
   int no_rindex = rindex.isabsent();
@@ -83,28 +83,28 @@ static int _init_(obj* self, PyObject* args, PyObject* kwds)
   int64_t rindexstart = rindex_is_slice? rindex.slice_start() : 0;
   int64_t rindexstep = rindex_is_slice? rindex.slice_step() : 0;
 
-  stypes = PyList_New(ncols);
-  ltypes = PyList_New(ncols);
-  view = PyList_New(ncols);
+  stypes = PyList_New(static_cast<int64_t>(ncols));
+  ltypes = PyList_New(static_cast<int64_t>(ncols));
+  view   = PyList_New(static_cast<int64_t>(ncols));
   if (view == nullptr) goto fail;
   if (stypes == nullptr || ltypes == nullptr) goto fail;
-  for (int64_t s = 0; s < col1 - col0; ++s) {
-    int64_t i = s < dt->nkeys? s : s + col0;
-    Column *col = dt->columns[i];
+  for (size_t s = 0; s < col1 - col0; ++s) {
+    size_t i = s < dt->nkeys? s : s + col0;
+    Column* col = dt->columns[i];
 
     // Create and fill-in the `data` list
-    PyObject *py_coldata = PyList_New(nrows);
+    PyObject* py_coldata = PyList_New(static_cast<int64_t>(nrows));
     if (py_coldata == nullptr) goto fail;
     PyList_SET_ITEM(view, s, py_coldata);
 
     int n_init_rows = 0;
-    for (int64_t j = row0; j < row1; ++j) {
+    for (size_t j = row0; j < row1; ++j) {
       // Note: `irow` could be NA, indicating that the value does not
       // exist and therefore should be treated as NA.
-      int64_t irow = no_rindex? j :
+      int64_t irow = no_rindex? static_cast<int64_t>(j) :
                rindex_is_arr32? rindexarr32[j] :
                rindex_is_arr64? rindexarr64[j] :
-                      rindexstart + rindexstep * j;
+                      rindexstart + rindexstep * static_cast<int64_t>(j);
       int itype = static_cast<int>(col->stype());
       PyObject *value = irow >= 0? py_stype_formatters[itype](col, irow)
                                  : py::None().release();
@@ -145,19 +145,19 @@ static int _init_(obj* self, PyObject* args, PyObject* kwds)
 //==============================================================================
 
 PyObject* get_row0(obj* self) {
-  return PyLong_FromLongLong(self->row0);
+  return PyLong_FromSize_t(self->row0);
 }
 
 PyObject* get_row1(obj* self) {
-  return PyLong_FromLongLong(self->row1);
+  return PyLong_FromSize_t(self->row1);
 }
 
 PyObject* get_col0(obj* self) {
-  return PyLong_FromLongLong(self->col0);
+  return PyLong_FromSize_t(self->col0);
 }
 
 PyObject* get_col1(obj* self) {
-  return PyLong_FromLongLong(self->col1);
+  return PyLong_FromSize_t(self->col1);
 }
 
 PyObject* get_types(obj* self) {

--- a/c/py_datawindow.h
+++ b/c/py_datawindow.h
@@ -34,8 +34,8 @@ struct obj : public PyObject {
   // Coordinates of the window returned: `row0`..`row1` x `col0`..`col1`.
   // `row0` is the first row to include, `row1` is one after the last. The
   // number of rows in the window is thus `row1 - row0`. Similarly with cols.
-  int64_t row0, row1;
-  int64_t col0, col1;
+  size_t row0, row1;
+  size_t col0, col1;
 
   // List of types (LType) of each column returned. This list will have
   // `col1 - col0` elements.

--- a/c/py_rowindex.cc
+++ b/c/py_rowindex.cc
@@ -154,7 +154,7 @@ PyObject* rowindex_from_filterfn(PyObject*, PyObject* args)
 //==============================================================================
 
 PyObject* get_nrows(obj* self) {
-  return PyLong_FromLongLong(self->ref->length());
+  return PyLong_FromSize_t(self->ref->length());
 }
 
 PyObject* get_min(obj* self) {
@@ -246,8 +246,8 @@ PyObject* uplift(obj* self, PyObject* args) {
 
 PyObject* inverse(obj* self, PyObject* args) {
   RowIndex& ri = *(self->ref);
-  int64_t nrows;
-  if (!PyArg_ParseTuple(args, "L:RowIndex.inverse", &nrows))
+  size_t nrows;
+  if (!PyArg_ParseTuple(args, "n:RowIndex.inverse", &nrows))
     return nullptr;
   RowIndex res = ri.inverse(nrows);
   return wrap(res);

--- a/c/py_types.cc
+++ b/c/py_types.cc
@@ -37,6 +37,10 @@ PyObject* int_to_py(int64_t x) {
   return ISNA<int64_t>(x)? none() : PyLong_FromInt64(x);
 }
 
+PyObject* int_to_py(size_t x) {
+  return PyLong_FromSize_t(x);
+}
+
 PyObject* float_to_py(float x) {
   return ISNA<float>(x)? none() : PyFloat_FromDouble(static_cast<double>(x));
 }

--- a/c/py_types.h
+++ b/c/py_types.h
@@ -50,6 +50,7 @@ PyObject* int_to_py(int8_t x);
 PyObject* int_to_py(int16_t x);
 PyObject* int_to_py(int32_t x);
 PyObject* int_to_py(int64_t x);
+PyObject* int_to_py(size_t x);
 PyObject* float_to_py(float x);
 PyObject* float_to_py(double x);
 PyObject* string_to_py(const CString& x);

--- a/c/rowindex.cc
+++ b/c/rowindex.cc
@@ -93,7 +93,7 @@ void RowIndex::clear() {
 }
 
 
-void RowIndex::shrink(int64_t nrows, int64_t ncols) {
+void RowIndex::shrink(size_t nrows, size_t ncols) {
   xassert(impl && impl->refcount >= ncols + 1);
   if (impl->refcount == ncols + 1) {
     impl->shrink(nrows);

--- a/c/rowindex.cc
+++ b/c/rowindex.cc
@@ -94,8 +94,8 @@ void RowIndex::clear() {
 
 
 void RowIndex::shrink(size_t nrows, size_t ncols) {
-  xassert(impl && impl->refcount >= ncols + 1);
-  if (impl->refcount == ncols + 1) {
+  xassert(impl && static_cast<size_t>(impl->refcount) >= ncols + 1);
+  if (static_cast<size_t>(impl->refcount) == ncols + 1) {
     impl->shrink(nrows);
   } else {
     impl->refcount--;
@@ -108,7 +108,7 @@ void RowIndex::shrink(size_t nrows, size_t ncols) {
 void RowIndex::extract_into(arr32_t& target) const
 {
   if (!impl) return;
-  size_t szlen = static_cast<size_t>(length());
+  size_t szlen = length();
   xassert(target.size() >= szlen);
   switch (impl->type) {
     case RI_ARR32: {
@@ -152,7 +152,7 @@ RowIndex RowIndex::inverse(size_t nrows) const {
     // return as an empty RowIndex object.
     return RowIndex();
   }
-  if (nrows < max()) {
+  if (nrows < static_cast<size_t>(max())) {
     throw ValueError() << "Invalid nrows=" << nrows << " for a RowIndex with "
                           "largest index " << max();
   }
@@ -171,9 +171,6 @@ void RowIndex::verify_integrity() const {
 
 
 void RowIndexImpl::verify_integrity() const {
-  if (length < 0) {
-    throw AssertionError() << "RowIndex.length is negative: " << length;
-  }
   if (refcount <= 0) {
     throw AssertionError() << "RowIndex has invalid refcount: " << refcount;
   }

--- a/c/rowindex.cc
+++ b/c/rowindex.cc
@@ -141,7 +141,7 @@ RowIndex RowIndex::uplift(const RowIndex& ri2) const {
 }
 
 
-RowIndex RowIndex::inverse(int64_t nrows) const {
+RowIndex RowIndex::inverse(size_t nrows) const {
   if (isabsent()) {
     // No RowIndex is equivalent to having RowIndex over all rows. The inverse
     // of that is a 0-length RowIndex.

--- a/c/rowindex.h
+++ b/c/rowindex.h
@@ -37,7 +37,7 @@ class RowIndexImpl {
   public:
     RowIndexType type;
     int32_t refcount;
-    int64_t length;
+    size_t length;
     int64_t min;
     int64_t max;
 
@@ -51,8 +51,8 @@ class RowIndexImpl {
     virtual int64_t nth(int64_t i) const = 0;
     virtual RowIndexImpl* uplift_from(RowIndexImpl*) = 0;
     virtual RowIndexImpl* inverse(int64_t nrows) const = 0;
-    virtual void shrink(int64_t n) = 0;
-    virtual RowIndexImpl* shrunk(int64_t n) = 0;
+    virtual void shrink(size_t n) = 0;
+    virtual RowIndexImpl* shrunk(size_t n) = 0;
     virtual size_t memory_footprint() const = 0;
     virtual void verify_integrity() const;
 
@@ -87,8 +87,8 @@ class ArrayRowIndexImpl : public RowIndexImpl {
     const int64_t* indices64() const { return ind64.data(); }
     RowIndexImpl* uplift_from(RowIndexImpl*) override;
     RowIndexImpl* inverse(int64_t nrows) const override;
-    void shrink(int64_t n) override;
-    RowIndexImpl* shrunk(int64_t n) override;
+    void shrink(size_t n) override;
+    RowIndexImpl* shrunk(size_t n) override;
     size_t memory_footprint() const override;
     void verify_integrity() const override;
 
@@ -126,8 +126,8 @@ class SliceRowIndexImpl : public RowIndexImpl {
     int64_t nth(int64_t i) const override;
     RowIndexImpl* uplift_from(RowIndexImpl*) override;
     RowIndexImpl* inverse(int64_t nrows) const override;
-    void shrink(int64_t n) override;
-    RowIndexImpl* shrunk(int64_t n) override;
+    void shrink(size_t n) override;
+    RowIndexImpl* shrunk(size_t n) override;
     size_t memory_footprint() const override;
     void verify_integrity() const override;
 
@@ -254,7 +254,7 @@ class RowIndex {
      * RowIndex. Knowing the number of columns allows us to know when the
      * RowIndex can be safely modified in-place, and when it cannot.
      */
-    void shrink(int64_t nrows, int64_t ncols);
+    void shrink(size_t nrows, size_t ncols);
 
     size_t memory_footprint() const;
 

--- a/c/rowindex.h
+++ b/c/rowindex.h
@@ -222,8 +222,7 @@ class RowIndex {
     bool isarray() const { return isarr32() || isarr64(); }
     const void* ptr() const { return static_cast<const void*>(impl); }
 
-    int64_t length() const { return impl? impl->length : 0; }
-    size_t zlength() const { return static_cast<size_t>(length()); }
+    size_t length() const { return impl? static_cast<size_t>(impl->length) : 0; }
     int64_t min() const { return impl? impl->min : 0; }
     int64_t max() const { return impl? impl->max : 0; }
     int64_t nth(int64_t i) const { return impl? impl->nth(i) : i; }

--- a/c/rowindex.h
+++ b/c/rowindex.h
@@ -50,7 +50,7 @@ class RowIndexImpl {
 
     virtual int64_t nth(int64_t i) const = 0;
     virtual RowIndexImpl* uplift_from(RowIndexImpl*) = 0;
-    virtual RowIndexImpl* inverse(int64_t nrows) const = 0;
+    virtual RowIndexImpl* inverse(size_t nrows) const = 0;
     virtual void shrink(size_t n) = 0;
     virtual RowIndexImpl* shrunk(size_t n) = 0;
     virtual size_t memory_footprint() const = 0;
@@ -86,7 +86,7 @@ class ArrayRowIndexImpl : public RowIndexImpl {
     const int32_t* indices32() const { return ind32.data(); }
     const int64_t* indices64() const { return ind64.data(); }
     RowIndexImpl* uplift_from(RowIndexImpl*) override;
-    RowIndexImpl* inverse(int64_t nrows) const override;
+    RowIndexImpl* inverse(size_t nrows) const override;
     void shrink(size_t n) override;
     RowIndexImpl* shrunk(size_t n) override;
     size_t memory_footprint() const override;
@@ -105,7 +105,7 @@ class ArrayRowIndexImpl : public RowIndexImpl {
 
     // Helper for `inverse()`
     template <typename TI, typename TO>
-    RowIndexImpl* inverse_impl(const dt::array<TI>& inp, int64_t nrows) const;
+    RowIndexImpl* inverse_impl(const dt::array<TI>& inp, size_t nrows) const;
 };
 
 
@@ -125,7 +125,7 @@ class SliceRowIndexImpl : public RowIndexImpl {
 
     int64_t nth(int64_t i) const override;
     RowIndexImpl* uplift_from(RowIndexImpl*) override;
-    RowIndexImpl* inverse(int64_t nrows) const override;
+    RowIndexImpl* inverse(size_t nrows) const override;
     void shrink(size_t n) override;
     RowIndexImpl* shrunk(size_t n) override;
     size_t memory_footprint() const override;
@@ -232,7 +232,7 @@ class RowIndex {
     int64_t slice_step() const { return impl_asslice()->step; }
 
     void extract_into(arr32_t&) const;
-    RowIndex inverse(int64_t nrows) const;
+    RowIndex inverse(size_t nrows) const;
 
     /**
      * Return the RowIndex which is the result of applying current RowIndex to

--- a/c/rowindex_array.cc
+++ b/c/rowindex_array.cc
@@ -496,28 +496,27 @@ RowIndexImpl* ArrayRowIndexImpl::inverse(int64_t nrows) const {
 }
 
 
-void ArrayRowIndexImpl::shrink(int64_t n) {
+void ArrayRowIndexImpl::shrink(size_t n) {
   xassert(n < length);
   length = n;
   if (type == RowIndexType::RI_ARR32) {
-    ind32.resize(static_cast<size_t>(n));
+    ind32.resize(n);
     set_min_max(ind32);
   } else {
-    ind64.resize(static_cast<size_t>(n));
+    ind64.resize(n);
     set_min_max(ind64);
   }
 }
 
-RowIndexImpl* ArrayRowIndexImpl::shrunk(int64_t n) {
+RowIndexImpl* ArrayRowIndexImpl::shrunk(size_t n) {
   xassert(n < length);
-  size_t zn = static_cast<size_t>(n);
   if (type == RowIndexType::RI_ARR32) {
-    arr32_t new_ind32(zn);
-    memcpy(new_ind32.data(), ind32.data(), zn * sizeof(int32_t));
+    arr32_t new_ind32(n);
+    memcpy(new_ind32.data(), ind32.data(), n * sizeof(int32_t));
     return new ArrayRowIndexImpl(std::move(new_ind32), is_sorted);
   } else {
-    arr64_t new_ind64(zn);
-    memcpy(new_ind64.data(), ind64.data(), zn * sizeof(int64_t));
+    arr64_t new_ind64(n);
+    memcpy(new_ind64.data(), ind64.data(), n * sizeof(int64_t));
     return new ArrayRowIndexImpl(std::move(new_ind64), is_sorted);
   }
 }

--- a/c/rowindex_array.cc
+++ b/c/rowindex_array.cc
@@ -454,7 +454,7 @@ void ArrayRowIndexImpl::compactify()
 
 template <typename TI, typename TO>
 RowIndexImpl* ArrayRowIndexImpl::inverse_impl(
-    const dt::array<TI>& inputs, int64_t nrows) const
+    const dt::array<TI>& inputs, size_t nrows) const
 {
   size_t newsize = static_cast<size_t>(nrows - length);
   size_t inpsize = inputs.size();
@@ -480,7 +480,7 @@ RowIndexImpl* ArrayRowIndexImpl::inverse_impl(
 }
 
 
-RowIndexImpl* ArrayRowIndexImpl::inverse(int64_t nrows) const {
+RowIndexImpl* ArrayRowIndexImpl::inverse(size_t nrows) const {
   xassert(nrows >= length);
   if (type == RowIndexType::RI_ARR32) {
     if (nrows <= INT32_MAX)

--- a/c/rowindex_slice.cc
+++ b/c/rowindex_slice.cc
@@ -196,13 +196,13 @@ RowIndexImpl* SliceRowIndexImpl::inverse(int64_t nrows) const {
 }
 
 
-void SliceRowIndexImpl::shrink(int64_t n) {
+void SliceRowIndexImpl::shrink(size_t n) {
   length = n;
   if (step > 0) max = start + step * (n - 1);
   if (step < 0) min = start + step * (n - 1);
 }
 
-RowIndexImpl* SliceRowIndexImpl::shrunk(int64_t n) {
+RowIndexImpl* SliceRowIndexImpl::shrunk(size_t n) {
   return new SliceRowIndexImpl(start, n, step);
 }
 

--- a/c/sort.cc
+++ b/c/sort.cc
@@ -1180,7 +1180,8 @@ class SortContext {
  * The function returns nullptr if there is a runtime error (for example an
  * intermediate buffer cannot be allocated).
  */
-RowIndex DataTable::sortby(const arr32_t& colindices, Groupby* out_grps) const
+RowIndex DataTable::sortby(const std::vector<size_t>& colindices,
+                           Groupby* out_grps) const
 {
   size_t nsortcols = colindices.size();
   if (nrows > INT32_MAX) {
@@ -1214,8 +1215,7 @@ RowIndex DataTable::sortby(const arr32_t& colindices, Groupby* out_grps) const
     }
     return RowIndex::from_slice(i, col0->nrows, 1);
   }
-  size_t zrows = static_cast<size_t>(nrows);
-  SortContext sc(zrows, col0->rowindex(),
+  SortContext sc(nrows, col0->rowindex(),
                  (out_grps != nullptr) || (nsortcols > 1));
   sc.start_sort(col0);
   for (size_t j = 1; j < nsortcols; ++j) {

--- a/c/sort.cc
+++ b/c/sort.cc
@@ -1213,7 +1213,7 @@ RowIndex DataTable::sortby(const std::vector<size_t>& colindices,
     if (out_grps) {
       *out_grps = Groupby::single_group(col0->nrows);
     }
-    return RowIndex::from_slice(i, col0->nrows, 1);
+    return RowIndex::from_slice(i, static_cast<int64_t>(col0->nrows), 1);
   }
   SortContext sc(nrows, col0->rowindex(),
                  (out_grps != nullptr) || (nsortcols > 1));
@@ -1231,7 +1231,7 @@ static RowIndex sort_tiny(const Column* col, Groupby* out_grps) {
   if (out_grps) {
     *out_grps = Groupby::single_group(col->nrows);
   }
-  return RowIndex::from_slice(i, col->nrows, 1);
+  return RowIndex::from_slice(i, static_cast<int64_t>(col->nrows), 1);
 }
 
 

--- a/c/sort.cc
+++ b/c/sort.cc
@@ -1239,8 +1239,7 @@ RowIndex Column::sort(Groupby* out_grps) const {
   if (nrows <= 1) {
     return sort_tiny(this, out_grps);
   }
-  size_t zrows = static_cast<size_t>(nrows);
-  SortContext sc(zrows, rowindex(), (out_grps != nullptr));
+  SortContext sc(nrows, rowindex(), (out_grps != nullptr));
   sc.start_sort(this);
   return sc.get_result(out_grps);
 }

--- a/c/stats.cc
+++ b/c/stats.cc
@@ -65,23 +65,23 @@ void Stats::set_computed(Stat s, bool flag) {
 }
 
 
-int64_t Stats::countna(const Column* col) {
+size_t Stats::countna(const Column* col) {
   if (!is_computed(Stat::NaCount)) compute_countna(col);
   return _countna;
 }
 
-int64_t Stats::nunique(const Column* col) {
+size_t Stats::nunique(const Column* col) {
   if (!is_computed(Stat::NUnique)) compute_sorted_stats(col);
   return _nunique;
 }
 
-int64_t Stats::nmodal(const Column* col) {
+size_t Stats::nmodal(const Column* col) {
   if (!is_computed(Stat::NModal)) compute_sorted_stats(col);
   return _nmodal;
 }
 
-void Stats::set_countna(int64_t n) {
-  set_computed(Stat::NaCount, !ISNA<int64_t>(n));
+void Stats::set_countna(size_t n) {
+  set_computed(Stat::NaCount, true);
   _countna = n;
 }
 
@@ -134,7 +134,7 @@ void Stats::verify_stat(Stat s, T value, F getter) const {
  */
 template <typename T, typename A>
 void NumericalStats<T, A>::compute_numerical_stats(const Column* col) {
-  int64_t nrows = col->nrows;
+  size_t nrows = col->nrows;
   const RowIndex& rowindex = col->rowindex();
   const T* data = static_cast<const T*>(col->data());
   int64_t count_notna = 0;
@@ -163,7 +163,7 @@ void NumericalStats<T, A>::compute_numerical_stats(const Column* col) {
     T t_min = infinity<T>();
     T t_max = -infinity<T>();
 
-    rowindex.strided_loop(ith, nrows, nth,
+    rowindex.strided_loop(ith, static_cast<int64_t>(nrows), nth,
       [&](int64_t i) {
         if (ISNA<int64_t>(i)) return;
         T x = data[i];

--- a/c/stats.h
+++ b/c/stats.h
@@ -72,9 +72,9 @@ constexpr uint8_t NSTATS = 14;
 class Stats {
   protected:
     std::bitset<NSTATS> _computed;
-    int64_t _countna;
-    int64_t _nunique;
-    int64_t _nmodal;
+    size_t _countna;
+    size_t _nunique;
+    size_t _nmodal;
 
   public:
     Stats() = default;
@@ -82,13 +82,13 @@ class Stats {
     Stats(const Stats&) = delete;
     void operator=(const Stats&) = delete;
 
-    int64_t countna(const Column*);
-    int64_t nunique(const Column*);
-    int64_t nmodal(const Column*);
+    size_t countna(const Column*);
+    size_t nunique(const Column*);
+    size_t nmodal(const Column*);
 
     bool is_computed(Stat s) const;
     void reset();
-    void set_countna(int64_t n);
+    void set_countna(size_t n);
     virtual void merge_stats(const Stats*);
 
     virtual size_t memory_footprint() const = 0;

--- a/c/str/split_into_nhot.cc
+++ b/c/str/split_into_nhot.cc
@@ -88,7 +88,7 @@ DataTable* split_into_nhot(Column* col, char sep) {
     strdata = scol->strdata();
   }
 
-  size_t nrows = static_cast<size_t>(col->nrows);
+  size_t nrows = col->nrows;
   std::unordered_map<std::string, size_t> colsmap;
   std::vector<Column*> outcols;
   std::vector<int8_t*> outdata;

--- a/c/utils/parallel.h
+++ b/c/utils/parallel.h
@@ -147,9 +147,9 @@ class mapper_str2str : private ordered_job {
 
   public:
     mapper_str2str(StringColumn<T>* col, F _f)
-      : ordered_job(static_cast<size_t>(col->nrows)),
+      : ordered_job(col->nrows),
         inpcol(col),
-        outcol(static_cast<size_t>(col->nrows)),
+        outcol(col->nrows),
         f(_f) {}
     ~mapper_str2str() override = default;
 

--- a/c/wstringcol.cc
+++ b/c/wstringcol.cc
@@ -33,8 +33,7 @@ fixed_height_string_col::fixed_height_string_col(size_t nrows)
 Column* fixed_height_string_col::to_column() && {
   strdata->finalize();
   offdata.set_element<uint32_t>(0, 0);
-  return new StringColumn<uint32_t>(static_cast<int64_t>(n),
-                                    std::move(offdata), strdata->get_mbuf());
+  return new StringColumn<uint32_t>(n, std::move(offdata), strdata->get_mbuf());
 }
 
 

--- a/ci/setup_utils.py
+++ b/ci/setup_utils.py
@@ -553,12 +553,13 @@ def required_link_libraries():
     #   @rpath/libomp.dylib
     #   @rpath/libc++.1.dylib
     #   /usr/lib/libSystem.B.dylib
-    # In addition, `libc++abi.1.dylib` is referenced from `libc++.1.dylib`
+    # In addition, `libc++abi.1.dylib` (or `libc++abi.dylib`) is referenced
+    # from `libc++.1.dylib`.
     # The @rpath- libraries have to be bundled into the datatable package.
     #
     if is_clang():
         if ismacos():
-            return ["libomp.dylib", "libc++.1.dylib", "libc++abi.1.dylib"]
+            return ["libomp.dylib", "libc++.1.dylib", "libc++abi.dylib"]
         if islinux():
             return ["libomp.so", "libc++.so.1", "libc++abi.so.1"]
         if iswindows():
@@ -591,10 +592,11 @@ def find_linked_dynamic_libraries():
             stdout, stderr = proc.communicate()
             if proc.returncode == 0:
                 results = stdout.decode().strip().split("\n")
+                results = [r for r in results if r]
                 if results:
                     results.sort(key=len)
                     fullpath = results[0]
-                    assert os.path.isfile(fullpath)
+                    assert os.path.isfile(fullpath), "Invalid path: %r" % (fullpath,)
                     resolved.append(fullpath)
                     log.info("Library `%s` found at %s" % (libname, fullpath))
                     continue


### PR DESCRIPTION
This is a fairly large code change, with one main theme:
- Values that are always positive but were stored as `int64_t`, are now converted into `size_t`.

The main driving force for this is the desire to reduce the number of `static_cast`s throughout the code, and allow easier integration with the static library (which overwhelmingly uses `size_t`s for indexes and counts).

This affects, first of all, properties `nrows`, `ncols`, `nkeys` in `DataTable` and `Column` class, but also in some other places. Several functions/methods had their signatures changed to better match the new convention.

In addition, several methods were modified to work with `std::vector`s, instead of plain-C arrays or `arr32_t`s.


Closes #1379 