### PR TITLE
Do not instantiate blessed.Terminal if no stdin/stdout

### DIFF
--- a/datatable/utils/terminal.py
+++ b/datatable/utils/terminal.py
@@ -48,6 +48,32 @@ class MyTerminal(blessed.Terminal):
                 self.jupyter = ipy
 
 
+def noop(self, s):
+    return s
+
+class NoTerminal:
+    is_a_tty = False
+    jupyter = False
+    width = 80
+    height = 25
+    _encoding = "UTF8"
+    bold = noop
+    bright_black = noop
+    bright_red = noop
+    bright_white = noop
+    cyan = noop
+    dim_yellow = noop
+    green = noop
+    clear_eol = ""
+    move_up = ""
+
+    def length(self, s):
+        return len(s)
+
+    def move_x(self, n):
+        return ""
+
+
 
 # Save current locale settings
 try:
@@ -59,7 +85,11 @@ except _locale.Error:
     pass
 
 # Instantiate a terminal
-term = MyTerminal()
+if sys.__stdin__ and sys.__stdout__:
+    term = MyTerminal()
+else:
+    term = NoTerminal()
+
 
 # Restore previous locale settings
 for i, ll in enumerate(_lls):


### PR DESCRIPTION
In rare cases, creating a `blessed.Terminal` instance leads to an error:
```
  File "/home/jon/.pyenv/versions/3.6.4/lib/python3.6/site-packages/datatable/utils/terminal.py", line 62, in <module>
    term = MyTerminal()
  File "/home/jon/.pyenv/versions/3.6.4/lib/python3.6/site-packages/datatable/utils/terminal.py", line 20, in __init__
    super().__init__()
  File "/home/jon/.pyenv/versions/3.6.4/lib/python3.6/site-packages/blessed/terminal.py", line 171, in __init__
    self._keyboard_fd = sys.__stdin__.fileno()
AttributeError: 'NoneType' object has no attribute 'fileno'
```

We attempt to prevent such situation by not creating the terminal if no stdin is attached.