### PR TITLE
Set functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
     frame will contain the sheet name and cell range from where the data was
     extracted).
 - HTML rendering of Frames inside a Jupyter notebook.
+- set-theoretic functions: `union`, `intersect`, `setdiff` and `symdiff`.
 
 #### Changed
 - `names` argument in `Frame()` constructor can no longer be a string --

--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -201,6 +201,7 @@ void DatatableModule::init_methods() {
   add(METHODv(aggregate));
   init_methods_str();
   init_methods_options();
+  init_methods_sets();
 }
 
 

--- a/c/datatablemodule.h
+++ b/c/datatablemodule.h
@@ -30,6 +30,7 @@ class DatatableModule : public py::ExtModule<DatatableModule> {
     void init_methods();
     void init_methods_str();      // str/py_str.cc
     void init_methods_options();  // options.cc
+    void init_methods_sets();     // set_funcs.cc
 };
 
 

--- a/c/expr/py_expr.h
+++ b/c/expr/py_expr.h
@@ -61,6 +61,7 @@ typedef void (*gmapperfn)(const int32_t* groups, int32_t grp, void** params);
 Column* unaryop(int opcode, Column* arg);
 Column* binaryop(int opcode, Column* lhs, Column* rhs);
 Column* reduceop(int opcode, Column* arg, const Groupby& groupby);
+Column* reduce_first(const Column* col, const Groupby& groupby);
 
 };
 

--- a/c/expr/reduceop.cc
+++ b/c/expr/reduceop.cc
@@ -38,9 +38,9 @@ constexpr T infinity() {
 // "First" reducer
 //------------------------------------------------------------------------------
 
-static Column* reduce_first(const Column* arg, const Groupby& groupby) {
-  if (arg->nrows == 0) {
-    return Column::new_data_column(arg->stype(), 0);
+Column* reduce_first(const Column* col, const Groupby& groupby) {
+  if (col->nrows == 0) {
+    return Column::new_data_column(col->stype(), 0);
   }
   size_t ngrps = groupby.ngroups();
   // groupby.offsets array has length `ngrps + 1` and contains offsets of the
@@ -49,8 +49,8 @@ static Column* reduce_first(const Column* arg, const Groupby& groupby) {
   // to the column will produce the vector of first elements in that column.
   arr32_t indices(ngrps, groupby.offsets_r());
   RowIndex ri = RowIndex::from_array32(std::move(indices), true)
-                .uplift(arg->rowindex());
-  Column* res = arg->shallowcopy(ri);
+                .uplift(col->rowindex());
+  Column* res = col->shallowcopy(ri);
   if (ngrps == 1) res->reify();
   return res;
 }

--- a/c/set_funcs.cc
+++ b/c/set_funcs.cc
@@ -1,0 +1,59 @@
+//------------------------------------------------------------------------------
+// Copyright 2018 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#include "datatablemodule.h"
+#include "python/args.h"
+
+
+//------------------------------------------------------------------------------
+//
+//------------------------------------------------------------------------------
+
+namespace dt {
+namespace set {
+
+static py::PKArgs args_unique(
+    1, 0, 0, false, false,
+    {"frame"}, "unique",
+R"(unique(frame)\n--
+
+Find the unique values in the ``frame``.
+
+If the Frame has multiple columns, those columns must have the same logical
+type (i.e. either `int` or `real` or `str`, etc). An error will be thrown if
+the columns' ltypes are different.
+)",
+
+[](const PKArgs& args) -> py::oobj {
+  DataTable* dt = args[0].to_frame();
+
+});
+
+
+
+} // namespace set
+} // namespace dt
+
+
+void DatatableModule::init_methods_sets() {
+  // ADDFN(config::args_get_option);
+  // ADDFN(config::args_set_option);
+}

--- a/c/set_funcs.cc
+++ b/c/set_funcs.cc
@@ -19,24 +19,87 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
+#include <tuple>
 #include "datatablemodule.h"
 #include "datatable.h"
 #include "expr/py_expr.h"
 #include "frame/py_frame.h"
 #include "python/args.h"
+#include "python/oiter.h"
+#include "utils/assert.h"
 #include "utils/exceptions.h"
-
-
-//------------------------------------------------------------------------------
-//
-//------------------------------------------------------------------------------
 
 namespace dt {
 namespace set {
 
-static py::PKArgs args_unique(
-    1, 0, 0, false, false,
-    {"frame"}, "unique",
+using ccolvec = std::vector<const Column*>;
+
+struct sort_result {
+  Column* col = nullptr;
+  RowIndex ri;
+  Groupby gb;
+};
+
+
+//------------------------------------------------------------------------------
+// helper functions
+//------------------------------------------------------------------------------
+
+static void verify_frame_1column(DataTable* dt) {
+  if (dt->ncols == 1) return;
+  throw ValueError() << "Only single-column Frames are allowed, but received "
+      "a Frame with " << dt->ncols << " columns";
+}
+
+static ccolvec columns_from_args(const py::PKArgs& args) {
+  ccolvec res;
+  for (auto va : args.varargs()) {
+    if (va.is_frame()) {
+      DataTable* dt = va.to_frame();
+      if (dt->ncols == 0) continue;
+      verify_frame_1column(dt);
+      res.push_back(dt->columns[0]);
+    }
+    else if (va.is_iterable()) {
+      for (auto item : va.to_pyiter()) {
+        DataTable* dt = item.to_frame();
+        if (dt->ncols == 0) continue;
+        verify_frame_1column(dt);
+        res.push_back(dt->columns[0]);
+      }
+    }
+    else {
+      throw TypeError() << args.get_short_name() << "() expected a list or "
+          "sequence of Frames, but got an argument of type " << va.typeobj();
+    }
+  }
+  return res;
+}
+
+static sort_result sort_columns(ccolvec& cols) {
+  xassert(!cols.empty());
+  sort_result res;
+  if (cols.size() == 1) {
+    res.col = cols[0]->shallowcopy();
+    res.col->reify();
+  } else {
+    res.col = (new VoidColumn(0))->rbind(cols);
+  }
+  res.ri = res.col->sort(&res.gb);
+  return res;
+}
+
+
+
+//------------------------------------------------------------------------------
+// unique()
+//------------------------------------------------------------------------------
+
+static py::PKArgs fn_unique(
+    1, 0, 0,        // Number of pos-only, pos/kw, and kw-only args
+    false, false,   // varargs/varkws allowed?
+    {"frame"},      // arg names
+    "unique",       // function name
 R"(unique(frame)
 --
 
@@ -45,6 +108,11 @@ Find the unique values in the ``frame``.
 If the Frame has multiple columns, those columns must have the same logical
 type (i.e. either `int` or `real` or `str`, etc). An error will be thrown if
 the columns' ltypes are different.
+
+This methods sorts the values in order to find the uniques. Thus, the return
+values will be sorted. However, this should be considered an implementation
+detail: in the future we may use a different algorithm (such as hash-based),
+which may return the results in different order.
 )",
 
 [](const py::PKArgs& args) -> py::oobj {
@@ -64,10 +132,43 @@ the columns' ltypes are different.
 
 
 
+//------------------------------------------------------------------------------
+// union()
+//------------------------------------------------------------------------------
+
+static py::PKArgs fn_union(
+    0, 0, 0,
+    true, false,
+    {},
+    "union",
+R"(union(*frames)
+--
+
+Find set union of values in all `frames`.
+
+Each frame must be a single-column, and have the same logical type (i.e. either
+`int` or `real` or `str`). This function will treat each column as a set,
+perform Union operation on these sets, and return the result of this union as a
+single-column Frame.
+
+This operation is equivalent to ``dt.unique(dt.rbind(*frames))``.
+)",
+
+[](const py::PKArgs& args) -> py::oobj {
+  ccolvec cols = columns_from_args(args);
+  sort_result s = sort_columns(cols);
+  throw NotImplError();
+});
+
+
+
+
+
 } // namespace set
 } // namespace dt
 
 
 void DatatableModule::init_methods_sets() {
-  ADDFN(dt::set::args_unique);
+  ADDFN(dt::set::fn_unique);
+  ADDFN(dt::set::fn_union);
 }

--- a/datatable/__init__.py
+++ b/datatable/__init__.py
@@ -32,7 +32,7 @@ __all__ = ("__version__", "__git_revision__",
            "DataTable", "options",
            "bool8", "int8", "int16", "int32", "int64",
            "float32", "float64", "str32", "str64", "obj64",
-           "cbind", "rbind", "unique", "union", "intersect",
+           "cbind", "rbind", "unique", "union", "intersect", "setdiff",
            "split_into_nhot")
 
 bool8 = stype.bool8
@@ -49,5 +49,6 @@ DataTable = Frame
 unique = _core.unique
 union = _core.union
 intersect = _core.intersect
+setdiff = _core.setdiff
 
 Frame.__module__ = "datatable"

--- a/datatable/__init__.py
+++ b/datatable/__init__.py
@@ -32,7 +32,8 @@ __all__ = ("__version__", "__git_revision__",
            "DataTable", "options",
            "bool8", "int8", "int16", "int32", "int64",
            "float32", "float64", "str32", "str64", "obj64",
-           "cbind", "rbind", "unique", "union", "intersect", "setdiff",
+           "cbind", "rbind",
+           "unique", "union", "intersect", "setdiff", "symdiff",
            "split_into_nhot")
 
 bool8 = stype.bool8
@@ -50,5 +51,6 @@ unique = _core.unique
 union = _core.union
 intersect = _core.intersect
 setdiff = _core.setdiff
+symdiff = _core.symdiff
 
 Frame.__module__ = "datatable"

--- a/datatable/__init__.py
+++ b/datatable/__init__.py
@@ -10,13 +10,14 @@ from .frame import Frame
 from .expr import mean, min, max, sd, isna, sum, count, first, abs, exp
 from .fread import fread, GenericReader, FreadWarning
 from .graph import f, g, join, by
+from .lib import core as _core
 from .nff import save, open
 from .options import options
+from .str import split_into_nhot
 from .types import stype, ltype
 from .utils.typechecks import TTypeError as TypeError
 from .utils.typechecks import TValueError as ValueError
 from .utils.typechecks import DatatableWarning
-from .str import split_into_nhot
 try:
     from .__git__ import __git_revision__
 except:
@@ -31,7 +32,7 @@ __all__ = ("__version__", "__git_revision__",
            "DataTable", "options",
            "bool8", "int8", "int16", "int32", "int64",
            "float32", "float64", "str32", "str64", "obj64",
-           "cbind", "rbind",
+           "cbind", "rbind", "unique",
            "split_into_nhot")
 
 bool8 = stype.bool8
@@ -45,5 +46,6 @@ str32 = stype.str32
 str64 = stype.str64
 obj64 = stype.obj64
 DataTable = Frame
+unique = _core.unique
 
 Frame.__module__ = "datatable"

--- a/datatable/__init__.py
+++ b/datatable/__init__.py
@@ -32,7 +32,7 @@ __all__ = ("__version__", "__git_revision__",
            "DataTable", "options",
            "bool8", "int8", "int16", "int32", "int64",
            "float32", "float64", "str32", "str64", "obj64",
-           "cbind", "rbind", "unique",
+           "cbind", "rbind", "unique", "union",
            "split_into_nhot")
 
 bool8 = stype.bool8
@@ -47,5 +47,6 @@ str64 = stype.str64
 obj64 = stype.obj64
 DataTable = Frame
 unique = _core.unique
+union = _core.union
 
 Frame.__module__ = "datatable"

--- a/datatable/__init__.py
+++ b/datatable/__init__.py
@@ -32,7 +32,7 @@ __all__ = ("__version__", "__git_revision__",
            "DataTable", "options",
            "bool8", "int8", "int16", "int32", "int64",
            "float32", "float64", "str32", "str64", "obj64",
-           "cbind", "rbind", "unique", "union",
+           "cbind", "rbind", "unique", "union", "intersect",
            "split_into_nhot")
 
 bool8 = stype.bool8
@@ -48,5 +48,6 @@ obj64 = stype.obj64
 DataTable = Frame
 unique = _core.unique
 union = _core.union
+intersect = _core.intersect
 
 Frame.__module__ = "datatable"

--- a/datatable/expr/column_expr.py
+++ b/datatable/expr/column_expr.py
@@ -151,7 +151,6 @@ class ColSelectorExpr(BaseExpr):
         self.resolve()
         dt = self._dtexpr.get_datatable()
         ri = self._dtexpr.get_rowindex()
-        print("Evaluate eager: %r -> dt=%r, ri=%r" % (self, dt, ri))
         return core.expr_column(dt.internal, self._colid, ri)
 
 

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -515,6 +515,12 @@ class Frame(core.Frame):
         return self._dt.window(0, self.nrows, 0, self.ncols).data
 
 
+    # Preferred names
+    to_list = topython
+    to_pandas = topandas
+    to_numpy = tonumpy
+
+
     def scalar(self):
         """
         For a 1x1 Frame return its content as a python object.

--- a/tests/test_sets.py
+++ b/tests/test_sets.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#-------------------------------------------------------------------------------
+# Copyright 2018 H2O.ai
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#-------------------------------------------------------------------------------
+import datatable as dt
+import pytest
+import random
+
+
+
+#-------------------------------------------------------------------------------
+# General functionality
+#-------------------------------------------------------------------------------
+set_fns = [dt.union, dt.intersect, dt.setdiff, dt.symdiff]
+
+
+@pytest.mark.parametrize("fn", set_fns)
+def test_setfns_0(fn):
+    res = fn()
+    res.internal.check()
+    assert res.shape == (0, 0)
+
+
+@pytest.mark.parametrize("fn", set_fns)
+def test_setfns_1(fn):
+    dt0 = dt.Frame([1, 2, 3, 1])
+    res = fn(dt0)
+    res.internal.check()
+    assert res.shape == (3, 1)
+    assert res.to_list() == [[1, 2, 3]]
+
+
+@pytest.mark.parametrize("fn", set_fns)
+def test_setfns_array_arg(fn):
+    dt0 = dt.Frame([1, 2, 3, 4, 5])
+    dt1 = dt.Frame([3, 5, 7, 9])
+    dt2 = dt.Frame([2, 7, 11])
+    res1 = fn(dt0, dt1, dt2)
+    res2 = fn([dt0, dt1, dt2])
+    res1.internal.check()
+    res2.internal.check()
+    assert res1.names == res2.names
+    assert res1.stypes == res2.stypes
+    assert res1.to_list() == res2.to_list()
+
+
+@pytest.mark.parametrize("fn", set_fns)
+def test_setfns_colname(fn):
+    # The name from the first of the frames shall be retained
+    dt0 = dt.Frame(A=[2, 3, 5])
+    dt1 = dt.Frame(B=range(4))
+    res1 = fn(dt0, dt1)
+    res2 = fn(dt1, dt0)
+    assert res1.stypes == res2.stypes
+    assert res1.names == ("A",)
+    assert res2.names == ("B",)
+
+
+@pytest.mark.parametrize("fn", set_fns)
+def test_setfns_ignore_empty_frames(fn):
+    dt1 = dt.Frame([2, 5, 7, 2, 3])
+    dt2 = dt.Frame([3, 4, 2, 5])
+    res1 = fn(dt1, dt2)
+    res2 = fn(dt1, dt.Frame(), dt2)
+    assert res1.to_list() == res2.to_list()
+
+
+
+
+#-------------------------------------------------------------------------------
+# union()
+#-------------------------------------------------------------------------------
+
+def test_union2():
+    dt1 = dt.Frame([2, 5, 7, 2, 3])
+    dt2 = dt.Frame([3, 4, 2, 5])
+    res = dt.union(dt1, dt2)
+    assert res.to_list() == [[2, 3, 4, 5, 7]]
+    res.internal.check()
+
+
+def test_union3():
+    dt1 = dt.Frame([2, 5, 7, 2, 3])
+    dt2 = dt.Frame([3, 4, 2, 5])
+    dt3 = dt.Frame([0, 3, 2, 2, 2, 2, 2, 2, 0])
+    res = dt.union(dt3, dt1, dt2)
+    assert res.to_list() == [[0, 2, 3, 4, 5, 7]]
+    res.internal.check()
+
+
+
+#-------------------------------------------------------------------------------
+# intersect()
+#-------------------------------------------------------------------------------
+
+def test_intersect2():
+    dt1 = dt.Frame([2, 5, 7, 2, 3])
+    dt2 = dt.Frame([3, 4, 2, 5])
+    res = dt.intersect(dt1, dt2)
+    assert res.to_list() == [[2, 3, 5]]
+    res.internal.check()
+
+
+def test_intersect3():
+    dt1 = dt.Frame([2, 5, 7, 2, 3])
+    dt2 = dt.Frame([3, 4, 2, 5])
+    dt3 = dt.Frame([0, 3, 2, 2, 2, 2, 2, 2, 0])
+    res = dt.intersect(dt3, dt1, dt2)
+    assert res.to_list() == [[2, 3]]
+    res.internal.check()
+
+
+
+#-------------------------------------------------------------------------------
+# setdiff()
+#-------------------------------------------------------------------------------
+
+def test_setdiff2():
+    dt1 = dt.Frame([2, 5, 7, 2, 3])
+    dt2 = dt.Frame([3, 4, 2, 5])
+    res = dt.setdiff(dt1, dt2)
+    assert res.to_list() == [[7]]
+    res.internal.check()
+
+def test_setdiff3():
+    dt1 = dt.Frame([2, 5, 7, 2, 3, 6, 0])
+    dt2 = dt.Frame([3, 4, 2, 5])
+    dt3 = dt.Frame([0, 3, 2, 2, 2, 2, 2, 2, 0])
+    res = dt.setdiff(dt1, dt2, dt3)
+    assert res.to_list() == [[6, 7]]
+    res.internal.check()
+
+
+
+#-------------------------------------------------------------------------------
+# symdiff()
+#-------------------------------------------------------------------------------
+
+def test_symdiff2():
+    dt1 = dt.Frame([2, 5, 7, 2, 3])
+    dt2 = dt.Frame([3, 4, 2, 5])
+    res = dt.symdiff(dt1, dt2)
+    assert res.to_list() == [[4, 7]]
+    res.internal.check()
+
+def test_symdiff3():
+    dt1 = dt.Frame([2, 5, 7, 2, 3, 6, 0])
+    dt2 = dt.Frame([3, 4, 2, 5])
+    dt3 = dt.Frame([0, 3, 2, 2, 2, 2, 2, 2, 0])
+    res = dt.symdiff(dt1, dt2, dt3)
+    assert res.to_list() == [[2, 3, 4, 6, 7]]
+    res.internal.check()
+
+
+
+#-------------------------------------------------------------------------------
+# Random test
+#-------------------------------------------------------------------------------
+
+def union(srcs):
+    res = set()
+    for src in srcs:
+        res.update(src)
+    return sorted(res)
+
+def intersect(srcs):
+    res = set(srcs[0])
+    for src in srcs[1:]:
+        res.intersection_update(src)
+    return sorted(res)
+
+def setdiff(srcs):
+    res = set(srcs[0])
+    for src in srcs[1:]:
+        res.difference_update(src)
+    return sorted(res)
+
+def symdiff(srcs):
+    res = set(srcs[0])
+    for src in srcs[1:]:
+        res.symmetric_difference_update(src)
+    return sorted(res)
+
+
+@pytest.mark.parametrize("seed", [random.getrandbits(32) for _ in range(20)])
+def test_setfns_random(seed):
+    random.seed(seed)
+    nsets = 2 + int(random.expovariate(0.2))
+    span = random.randint(5, nsets * 100)
+    srcs = []
+    for _ in range(nsets):
+        nrows = int(random.expovariate(0.02))
+        src = [random.randint(1, span) for _ in range(nrows)]
+        srcs.append(src)
+    dtfun, pyfun = random.choice([(dt.union, union),
+                                  (dt.intersect, intersect),
+                                  (dt.setdiff, setdiff),
+                                  (dt.symdiff, symdiff)])
+    dts = [dt.Frame([src]) for src in srcs]
+    dtres = dtfun(dts)
+    pyres = pyfun(srcs)
+    assert dtres.to_list()[0] == pyres


### PR DESCRIPTION
Add new set-theoretic functions:
- `union()`,
- `intersect()`,
- `setdiff()`,
- `symdiff()`.

Each function can take arbitrary number of single-column frames, e.g. `union(fr1, fr2, fr3, fr4)`. Column types can be different, in which case they will be upcasted to the smallest common supertype. 

In addition, added function `unique()`, which returns the union of all columns in a single Frame. Also, `Frame.to_list()`, `Frame.to_pandas()`, `Frame.to_numpy()` were added as synonyms for.topython(), .topandas() and .tonumpy().

Closes #1356