### PR TITLE
Fix writing large columns to file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - frame.sort() with no arguments no longer produces an error.
 - f-expressions now do not crash when reused with a different Frame.
 - g-columns can be properly selected in a join (#1352).
+- writing to disk of columns > 2GB in size (#1387).
 
 
 ### [v0.6.0](https://github.com/h2oai/datatable/compare/v0.6.0...v0.5.0) — 2018-06-05


### PR DESCRIPTION
When a large column is written to file (> 2 GB), it will no longer fail with errno 22. Instead, we will write the data in chunks of 1GB until all data is written.

Closes #1387