### PR TITLE
Added support for multi-column keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
     extracted).
 - HTML rendering of Frames inside a Jupyter notebook.
 - set-theoretic functions: `union`, `intersect`, `setdiff` and `symdiff`.
+- support for multi-column keys.
 
 #### Changed
 - `names` argument in `Frame()` constructor can no longer be a string --

--- a/c/datatable.cc
+++ b/c/datatable.cc
@@ -169,31 +169,6 @@ void DataTable::replace_groupby(const Groupby& newgb) {
 }
 
 
-void DataTable::set_nkeys(size_t nk) {
-  if (nk == 0) {
-    nkeys = 0;
-    return;
-  }
-
-  Groupby gb;
-  std::vector<size_t> cols;
-  for (size_t i = 0; i < nk; ++i) {
-    cols.push_back(i);
-  }
-  RowIndex ri = sortby(cols, &gb);
-  xassert(ri.length() == nrows);
-
-  if (gb.ngroups() != nrows) {
-    throw ValueError() << "Cannot set column as a key: the values are not unique";
-  }
-
-  replace_rowindex(ri.uplift(rowindex));
-  reify();
-
-  nkeys = nk;
-}
-
-
 
 /**
  * Convert a DataTable view into an actual DataTable. This is done in-place.

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -102,7 +102,8 @@ class DataTable {
     RowIndex sortby(const std::vector<size_t>& colindices,
                     Groupby* out_grps) const;
 
-    const std::vector<std::string>& get_names() const;
+    // Names
+    const strvec& get_names() const;
     py::otuple get_pynames() const;
     int64_t colindex(const py::_obj& pyname) const;
     size_t xcolindex(const py::_obj& pyname) const;
@@ -111,8 +112,10 @@ class DataTable {
     void set_names(const py::olist& names_list);
     void set_names(const std::vector<std::string>& names_list);
     void replace_names(py::odict replacements);
+    void reorder_names(const std::vector<size_t>& col_indices);
 
     void set_nkeys(size_t nk);
+    void set_keys(std::vector<size_t>& col_indices);
 
     DataTable* min_datatable() const;
     DataTable* max_datatable() const;

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -105,6 +105,7 @@ class DataTable {
     const std::vector<std::string>& get_names() const;
     py::otuple get_pynames() const;
     int64_t colindex(const py::_obj& pyname) const;
+    size_t xcolindex(const py::_obj& pyname) const;
     void copy_names_from(const DataTable* other);
     void set_names_to_default();
     void set_names(const py::olist& names_list);

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -62,12 +62,12 @@ class DataTable {
   public:
     size_t   nrows;
     size_t   ncols;
-    size_t   nkeys;
     RowIndex rowindex;  // DEPRECATED (see #1188)
     Groupby  groupby;
     colvec   columns;
 
   private:
+    size_t   nkeys;
     strvec   names;
     mutable py::otuple py_names;   // memoized tuple of column names
     mutable py::odict  py_inames;  // memoized dict of {column name: index}
@@ -114,8 +114,10 @@ class DataTable {
     void replace_names(py::odict replacements);
     void reorder_names(const std::vector<size_t>& col_indices);
 
-    void set_nkeys(size_t nk);
-    void set_keys(std::vector<size_t>& col_indices);
+    // Key
+    size_t get_nkeys() const;
+    void set_key(std::vector<size_t>& col_indices);
+    void clear_key();
 
     DataTable* min_datatable() const;
     DataTable* max_datatable() const;

--- a/c/frame/key.cc
+++ b/c/frame/key.cc
@@ -132,4 +132,3 @@ void DataTable::set_key(std::vector<size_t>& col_indices) {
 
   nkeys = K;
 }
-

--- a/c/frame/key.cc
+++ b/c/frame/key.cc
@@ -1,0 +1,103 @@
+//------------------------------------------------------------------------------
+// Copyright 2018 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#include "frame/py_frame.h"
+#include "python/list.h"
+
+
+
+py::oobj py::Frame::get_key() const {
+  py::otuple key(dt->nkeys);
+  py::otuple names = get_names().to_pytuple();
+  for (size_t i = 0; i < dt->nkeys; ++i) {
+    key.set(i, names[i]);
+  }
+  return std::move(key);
+}
+
+
+void py::Frame::set_key(obj val) {
+  if (val.is_none()) {
+    dt->nkeys = 0;
+    return;
+  }
+  std::vector<size_t> col_indices;
+  if (val.is_string()) {
+    size_t index = dt->xcolindex(val);
+    col_indices.push_back(index);
+  }
+  else if (val.is_list_or_tuple()) {
+    py::olist vallist = val.to_pylist();
+    for (size_t i = 0; i < vallist.size(); ++i) {
+      py::obj item = vallist[i];
+      if (vallist[i].is_string()) {
+        size_t index = dt->xcolindex(vallist[i]);
+        col_indices.push_back(index);
+      } else {
+        throw TypeError() << "Key should be a list/tuple of column names, "
+            "instead element " << i << " was a " << item.typeobj();
+      }
+    }
+  }
+  _clear_types();
+  dt->set_keys(col_indices);
+}
+
+
+
+void DataTable::set_keys(std::vector<size_t>& col_indices) {
+  if (col_indices.empty()) {
+    nkeys = 0;
+    return;
+  }
+  // Check that col_indices are unique
+  size_t K = col_indices.size();
+  for (size_t i = 0; i < K; ++i) {
+    for (size_t j = i + 1; j < K; ++j) {
+      if (col_indices[i] == col_indices[j]) {
+        throw ValueError() << "Column `" << names[col_indices[i]] << "` is "
+          "specified multiple times within the key";
+      }
+    }
+  }
+  // Fill col_indices with the indices of remaining columns
+  auto is_key_column = [&](size_t i) -> bool {
+    for (size_t j = 0; j < K; ++j) {
+      if (col_indices[j] == i) return true;
+    }
+    return false;
+  };
+  for (size_t i = 0; i < ncols; ++i) {
+    if (!is_key_column(i)) {
+      col_indices.push_back(i);
+    }
+  }
+  xassert(col_indices.size() == ncols);
+  // Reorder the columns
+  std::vector<Column*> new_columns(ncols, nullptr);
+  for (size_t i = 0; i < ncols; ++i) {
+    new_columns[i] = columns[col_indices[i]];
+  }
+  columns = std::move(new_columns);
+  //
+  reorder_names(col_indices);
+  set_nkeys(K);
+}

--- a/c/frame/key.cc
+++ b/c/frame/key.cc
@@ -61,6 +61,10 @@ void py::Frame::set_key(obj val) {
       }
     }
   }
+  else {
+    throw TypeError() << "Key should be a column name, or a list/tuple of "
+        "column names, instead it was a " << val.typeobj();
+  }
   _clear_types();
   dt->set_key(col_indices);
 }

--- a/c/frame/names.cc
+++ b/c/frame/names.cc
@@ -22,8 +22,8 @@
 #include "utils/assert.h"
 #include "ztest.h"
 
-static double _dlevenshtein(
-    const std::string& a, const std::string& b, double* v);
+static double _dlevenshtein(const std::string& a, const std::string& b, double* v);
+static Error _name_not_found_error(const DataTable* dt, const std::string& name);
 
 
 //------------------------------------------------------------------------------
@@ -178,7 +178,7 @@ oobj Frame::colindex(const PKArgs& args)
   if (col.is_string()) {
     int64_t index = dt->colindex(col.to_pyobj());
     if (index == -1) {
-      throw _name_not_found_error(col.to_string());
+      throw _name_not_found_error(dt, col.to_string());
     }
     return py::oint(index);
   }
@@ -198,8 +198,13 @@ oobj Frame::colindex(const PKArgs& args)
       "or an integer, not " << col.typeobj();
 }
 
+} // namespace py
 
-Error Frame::_name_not_found_error(const std::string& name) {
+
+
+static Error _name_not_found_error(
+    const DataTable* dt, const std::string& name
+) {
   const std::vector<std::string>& names = dt->get_names();
   auto tmp = std::unique_ptr<double[]>(new double[name.size() + 1]);
   double* vtmp = tmp.get();
@@ -245,9 +250,6 @@ Error Frame::_name_not_found_error(const std::string& name) {
 }
 
 
-} // namespace py
-
-
 
 
 //------------------------------------------------------------------------------
@@ -279,6 +281,20 @@ int64_t DataTable::colindex(const py::_obj& pyname) const {
   if (!py_inames) _init_pynames();
   py::obj pyindex = py_inames.get(pyname);
   return pyindex? pyindex.to_int64_strict() : -1;
+}
+
+
+/**
+ * Return the index of a column given its name; throw an exception if the
+ * column does not exist in the DataTable.
+ */
+size_t DataTable::xcolindex(const py::_obj& pyname) const {
+  if (!py_inames) _init_pynames();
+  py::obj pyindex = py_inames.get(pyname);
+  if (!pyindex) {
+    throw _name_not_found_error(this, pyname.to_string());
+  }
+  return pyindex.to_size_t();
 }
 
 

--- a/c/frame/names.cc
+++ b/c/frame/names.cc
@@ -364,6 +364,27 @@ void DataTable::replace_names(py::odict replacements) {
 }
 
 
+void DataTable::reorder_names(const std::vector<size_t>& col_indices) {
+  xassert(col_indices.size() == ncols);
+  strvec newnames;
+  newnames.reserve(ncols);
+  for (size_t i = 0; i < ncols; ++i) {
+    newnames.push_back(std::move(names[col_indices[i]]));
+  }
+  names = std::move(newnames);
+  if (py_names) {
+    py::otuple new_py_names(ncols);
+    for (size_t i = 0; i < ncols; ++i) {
+      py::obj pyname = py_names[col_indices[i]];
+      new_py_names.set(i, pyname);
+      py_inames.set(pyname, py::oint(i));
+    }
+    py_names = std::move(new_py_names);
+  }
+}
+
+
+
 
 //------------------------------------------------------------------------------
 // DataTable private helpers

--- a/c/frame/py_frame.cc
+++ b/c/frame/py_frame.cc
@@ -234,29 +234,28 @@ void Frame::set_key(obj val) {
   }
   std::vector<size_t> col_indices;
   if (val.is_string()) {
-    int64_t index = dt->colindex(val);
-    if (index == -1) {
-      throw _name_not_found_error(val.to_string());
-    }
-    col_indices.push_back(static_cast<size_t>(index));
+    size_t index = dt->xcolindex(val);
+    col_indices.push_back(index);
   }
   else if (val.is_list_or_tuple()) {
     py::olist vallist = val.to_pylist();
     for (size_t i = 0; i < vallist.size(); ++i) {
       py::obj item = vallist[i];
       if (vallist[i].is_string()) {
-        int64_t index = dt->colindex(vallist[i]);
-        if (index == -1) {
-          throw _name_not_found_error(vallist[i].to_string());
-        }
-        col_indices.push_back(static_cast<size_t>(index));
+        size_t index = dt->xcolindex(vallist[i]);
+        col_indices.push_back(index);
       } else {
         throw TypeError() << "Key should be a list/tuple of column names, "
-            "instead element " << i << " was a " << elem.typeobj();
+            "instead element " << i << " was a " << item.typeobj();
       }
     }
   }
-
+  if (col_indices.empty()) {
+    dt->nkeys = 0;
+    return;
+  }
+  _clear_types();
+  dt->set_keys(col_indices);
 }
 
 

--- a/c/frame/py_frame.cc
+++ b/c/frame/py_frame.cc
@@ -218,47 +218,6 @@ oobj Frame::get_ltypes() const {
 }
 
 
-oobj Frame::get_key() const {
-  py::otuple key(dt->nkeys);
-  py::otuple names = get_names().to_pytuple();
-  for (size_t i = 0; i < dt->nkeys; ++i) {
-    key.set(i, names[i]);
-  }
-  return std::move(key);
-}
-
-void Frame::set_key(obj val) {
-  if (val.is_none()) {
-    dt->nkeys = 0;
-    return;
-  }
-  std::vector<size_t> col_indices;
-  if (val.is_string()) {
-    size_t index = dt->xcolindex(val);
-    col_indices.push_back(index);
-  }
-  else if (val.is_list_or_tuple()) {
-    py::olist vallist = val.to_pylist();
-    for (size_t i = 0; i < vallist.size(); ++i) {
-      py::obj item = vallist[i];
-      if (vallist[i].is_string()) {
-        size_t index = dt->xcolindex(vallist[i]);
-        col_indices.push_back(index);
-      } else {
-        throw TypeError() << "Key should be a list/tuple of column names, "
-            "instead element " << i << " was a " << item.typeobj();
-      }
-    }
-  }
-  if (col_indices.empty()) {
-    dt->nkeys = 0;
-    return;
-  }
-  _clear_types();
-  dt->set_keys(col_indices);
-}
-
-
 oobj Frame::get_internal() const {
   return oobj(core_dt);
 }

--- a/c/frame/py_frame.h
+++ b/c/frame/py_frame.h
@@ -81,7 +81,7 @@ class Frame : public PyObject {
     oobj get_internal() const;
     void set_nrows(obj);
     void set_names(obj);
-    void set_keys(obj);
+    void set_key(obj);
     void set_internal(obj);
 
     void cbind(const PKArgs&);
@@ -99,7 +99,6 @@ class Frame : public PyObject {
     void _fill_default_names();
     void _dedup_and_save_names(NameProvider*);
     void _replace_names_from_map(py::odict);
-    Error _name_not_found_error(const std::string& name);
 
     // getitem / setitem support
     oobj _fast_getset(obj item, obj value);

--- a/c/frame/py_frame.h
+++ b/c/frame/py_frame.h
@@ -81,6 +81,7 @@ class Frame : public PyObject {
     oobj get_internal() const;
     void set_nrows(obj);
     void set_names(obj);
+    void set_keys(obj);
     void set_internal(obj);
 
     void cbind(const PKArgs&);

--- a/c/py_datatable.cc
+++ b/c/py_datatable.cc
@@ -148,17 +148,6 @@ int set_groupby(obj* self, PyObject* value) {
 }
 
 
-PyObject* get_nkeys(obj* self) {
-  return PyLong_FromSize_t(self->ref->nkeys);
-}
-
-int set_nkeys(obj* self, PyObject* value) {
-  size_t nk = py::obj(value).to_size_t();
-  self->ref->set_nkeys(nk);
-  return 0;
-}
-
-
 PyObject* get_datatable_ptr(obj* self) {
   return PyLong_FromLongLong(reinterpret_cast<long long int>(self->ref));
 }
@@ -670,7 +659,6 @@ static PyGetSetDef datatable_getseters[] = {
   GETTER(isview),
   GETTER(rowindex),
   GETSET(groupby),
-  GETSET(nkeys),
   GETTER(rowindex_type),
   GETTER(datatable_ptr),
   GETTER(alloc_size),

--- a/c/py_datatable.h
+++ b/c/py_datatable.h
@@ -79,10 +79,6 @@ DECLARE_GETSET(
   groupby,
   "Groupby applied to the Frame, or None if no groupby was applied")
 
-DECLARE_GETSET(
-  nkeys,
-  "Number of key columns in the Frame")
-
 DECLARE_GETTER(
   datatable_ptr,
   "Get pointer (converted to an int) to the wrapped DataTable object")

--- a/c/py_datawindow.cc
+++ b/c/py_datawindow.cc
@@ -72,6 +72,7 @@ static int _init_(obj* self, PyObject* args, PyObject* kwds)
   // Window dimensions
   size_t ncols = col1 - col0;
   size_t nrows = row1 - row0;
+  size_t nkeys = dt->get_nkeys();
 
   RowIndex rindex(dt->rowindex);
   int no_rindex = rindex.isabsent();
@@ -89,7 +90,7 @@ static int _init_(obj* self, PyObject* args, PyObject* kwds)
   if (view == nullptr) goto fail;
   if (stypes == nullptr || ltypes == nullptr) goto fail;
   for (size_t s = 0; s < col1 - col0; ++s) {
-    size_t i = s < dt->nkeys? s : s + col0;
+    size_t i = s < nkeys? s : s + col0;
     Column* col = dt->columns[i];
 
     // Create and fill-in the `data` list

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -38,37 +38,6 @@ class Frame(core.Frame):
     This is a primary data structure for datatable module.
     """
 
-    @property
-    def key1(self):
-        """Tuple of column names that comprise the Frame's key. If the Frame
-        is not keyed, this will return an empty tuple."""
-        return self.names[:self._dt.nkeys]
-
-
-    @key1.setter
-    def key1(self, colnames):
-        if colnames is None:
-            self._dt.nkeys = 0
-            return
-        if isinstance(colnames, (int, str)):
-            colnames = [colnames]
-        nk = len(colnames)
-        colindices = [self.colindex(n) for n in colnames]
-        if colindices == list(range(nk)):
-            # The key columns are already in the right order: no need to
-            # rearrange the columns
-            pass
-        elif len(set(colindices)) == nk:
-            allindices = colindices + [i for i in range(self.ncols)
-                                       if i not in colindices]
-            self.__init__(self[:, allindices])
-        else:
-            raise ValueError("Duplicate columns requested for the key: %r"
-                             % [self.names[i] for i in colindices])
-        self._dt.nkeys = nk
-
-
-
     #---------------------------------------------------------------------------
     # Display
     #---------------------------------------------------------------------------
@@ -90,7 +59,7 @@ class Frame(core.Frame):
     def _data_viewer(self, row0, row1, col0, col1):
         view = self._dt.window(row0, row1, col0, col1)
         length = max(2, len(str(row1)))
-        nk = self._dt.nkeys
+        nk = len(self.key)
         return {
             "names": self.names[:nk] + self.names[col0 + nk:col1 + nk],
             "types": view.types,
@@ -100,7 +69,7 @@ class Frame(core.Frame):
         }
 
     def view(self, interactive=True):
-        widget = DataFrameWidget(self.nrows, self.ncols, self._dt.nkeys,
+        widget = DataFrameWidget(self.nrows, self.ncols, len(self.key),
                                  self._data_viewer, interactive)
         widget.render()
 

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -39,14 +39,14 @@ class Frame(core.Frame):
     """
 
     @property
-    def key(self):
+    def key1(self):
         """Tuple of column names that comprise the Frame's key. If the Frame
         is not keyed, this will return an empty tuple."""
         return self.names[:self._dt.nkeys]
 
 
-    @key.setter
-    def key(self, colnames):
+    @key1.setter
+    def key1(self, colnames):
         if colnames is None:
             self._dt.nkeys = 0
             return

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -980,7 +980,7 @@ def test_keys_simple():
                     [3.6, 9.78, 2.01, -4.23, 5.3819]],
                    names=["name", "sex", "avg"])
     assert dt0.key == tuple()
-    dt0.key = "name"
+    dt0.key1 = "name"
     dt0.internal.check()
     assert dt0.key == ("name",)
     assert dt0.shape == (5, 3)
@@ -988,7 +988,7 @@ def test_keys_simple():
     assert dt0.topython() == [["Adam", "Alice", "Joe", "Leslie", "Mary"],
                               [12, 8, 1, 15, 5],
                               [-4.23, 5.3819, 3.6, 2.01, 9.78]]
-    dt0.key = "sex"
+    dt0.key1 = "sex"
     dt0.internal.check()
     assert not dt0.internal.isview
     assert dt0.key == ("sex",)
@@ -997,7 +997,7 @@ def test_keys_simple():
     assert dt0.topython() == [[1, 5, 8, 12, 15],
                               ["Joe", "Mary", "Alice", "Adam", "Leslie"],
                               [3.6, 9.78, 5.3819, -4.23, 2.01]]
-    dt0.key = None
+    dt0.key1 = None
     assert dt0.key == tuple()
 
 

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -971,38 +971,6 @@ def test_single_element_all_stypes(st):
 
 
 #-------------------------------------------------------------------------------
-# Keys
-#-------------------------------------------------------------------------------
-
-def test_keys_simple():
-    dt0 = dt.Frame([["Joe", "Mary", "Leslie", "Adam", "Alice"],
-                    [1, 5, 15, 12, 8],
-                    [3.6, 9.78, 2.01, -4.23, 5.3819]],
-                   names=["name", "sex", "avg"])
-    assert dt0.key == tuple()
-    dt0.key = "name"
-    dt0.internal.check()
-    assert dt0.key == ("name",)
-    assert dt0.shape == (5, 3)
-    assert dt0.names == ("name", "sex", "avg")
-    assert dt0.topython() == [["Adam", "Alice", "Joe", "Leslie", "Mary"],
-                              [12, 8, 1, 15, 5],
-                              [-4.23, 5.3819, 3.6, 2.01, 9.78]]
-    dt0.key = "sex"
-    dt0.internal.check()
-    assert not dt0.internal.isview
-    assert dt0.key == ("sex",)
-    assert dt0.shape == (5, 3)
-    assert dt0.names == ("sex", "name", "avg")
-    assert dt0.topython() == [[1, 5, 8, 12, 15],
-                              ["Joe", "Mary", "Alice", "Adam", "Leslie"],
-                              [3.6, 9.78, 5.3819, -4.23, 2.01]]
-    dt0.key = None
-    assert dt0.key == tuple()
-
-
-
-#-------------------------------------------------------------------------------
 # Frame copy
 #-------------------------------------------------------------------------------
 

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -980,7 +980,7 @@ def test_keys_simple():
                     [3.6, 9.78, 2.01, -4.23, 5.3819]],
                    names=["name", "sex", "avg"])
     assert dt0.key == tuple()
-    dt0.key1 = "name"
+    dt0.key = "name"
     dt0.internal.check()
     assert dt0.key == ("name",)
     assert dt0.shape == (5, 3)
@@ -988,7 +988,7 @@ def test_keys_simple():
     assert dt0.topython() == [["Adam", "Alice", "Joe", "Leslie", "Mary"],
                               [12, 8, 1, 15, 5],
                               [-4.23, 5.3819, 3.6, 2.01, 9.78]]
-    dt0.key1 = "sex"
+    dt0.key = "sex"
     dt0.internal.check()
     assert not dt0.internal.isview
     assert dt0.key == ("sex",)
@@ -997,7 +997,7 @@ def test_keys_simple():
     assert dt0.topython() == [[1, 5, 8, 12, 15],
                               ["Joe", "Mary", "Alice", "Adam", "Leslie"],
                               [3.6, 9.78, 5.3819, -4.23, 2.01]]
-    dt0.key1 = None
+    dt0.key = None
     assert dt0.key == tuple()
 
 

--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -16,7 +16,7 @@ def test_join_simple():
     d0 = dt.Frame([[1, 3, 2, 1, 1, 2, 0], list("abcdefg")], names=("A", "B"))
     d1 = dt.Frame([range(4), ["zero", "one", "two", "three"]], names=("A", "V"),
                   stypes=d0.stypes)
-    d1.key1 = "A"
+    d1.key = "A"
     res = d0[:, :, join(d1)]
     res.internal.check()
     assert res.shape == (7, 3)
@@ -30,7 +30,7 @@ def test_join_simple():
 def test_join_strings():
     d0 = dt.Frame([[1, 3, 2, 1, 1, 2, 0], list("cabdabb")], names=("A", "B"))
     d1 = dt.Frame([list("abcd"), range(0, 20, 5)], names=("B", "V"))
-    d1.key1 = "B"
+    d1.key = "B"
     res = d0[:, :, join(d1)]
     res.internal.check()
     assert res.shape == (7, 3)
@@ -44,7 +44,7 @@ def test_join_strings():
 def test_join_missing_levels():
     d0 = dt.Frame(A=[1, 2, 3])
     d1 = dt.Frame(A=[1, 2], K=[True, False])
-    d1.key1 = "A"
+    d1.key = "A"
     res = d0[:, :, join(d1)]
     res.internal.check()
     assert res.topython() == [[1, 2, 3], [True, False, None]]
@@ -56,7 +56,7 @@ def test_join_errors():
     with pytest.raises(ValueError) as e:
         d0[:, :, join(d1)]
     assert "The join frame is not keyed" in str(e.value)
-    d1.key1 = "B"
+    d1.key = "B"
     with pytest.raises(ValueError) as e:
         d0[:, :, join(d1)]
     assert "Key column `B` does not exist in the left Frame" in str(e.value)
@@ -95,7 +95,7 @@ def test_join_random(seed, lt):
     nkeys = len(keys)
 
     dkey = dt.Frame(KEY=keys, VAL=range(nkeys), stypes={"KEY": st})
-    dkey.key1 = "KEY"
+    dkey.key = "KEY"
     keys, vals = dkey.topython()
     main = [random.choice(keys) for i in range(ndata)]
     dmain = dt.Frame(KEY=main, stype=st)
@@ -112,7 +112,7 @@ def test_join_random(seed, lt):
 def test_join_update():
     d0 = dt.Frame([[1, 2, 3, 2, 3, 1, 3, 2, 2, 1], range(10)], names=("A", "B"))
     d1 = d0[:, mean(f.B), f.A]
-    d1.key1 = "A"
+    d1.key = "A"
     d0[:, "AA", join(d1)] = g.V0
     assert d0.names == ("A", "B", "AA")
     a = 4.75
@@ -127,7 +127,7 @@ def test_join_and_select_g_col():
     # See issue #1352
     F = dt.Frame(a=[0, 2, 3], b=[3, 4, 2])
     G = dt.Frame(b=[2, 4], c=["foo", "bar"])
-    G.key1 = "b"
+    G.key = "b"
     R = F[:, g.c, join(G)]
     R.internal.check()
     assert R.shape == (3, 1)

--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -16,7 +16,7 @@ def test_join_simple():
     d0 = dt.Frame([[1, 3, 2, 1, 1, 2, 0], list("abcdefg")], names=("A", "B"))
     d1 = dt.Frame([range(4), ["zero", "one", "two", "three"]], names=("A", "V"),
                   stypes=d0.stypes)
-    d1.key = "A"
+    d1.key1 = "A"
     res = d0[:, :, join(d1)]
     res.internal.check()
     assert res.shape == (7, 3)
@@ -30,7 +30,7 @@ def test_join_simple():
 def test_join_strings():
     d0 = dt.Frame([[1, 3, 2, 1, 1, 2, 0], list("cabdabb")], names=("A", "B"))
     d1 = dt.Frame([list("abcd"), range(0, 20, 5)], names=("B", "V"))
-    d1.key = "B"
+    d1.key1 = "B"
     res = d0[:, :, join(d1)]
     res.internal.check()
     assert res.shape == (7, 3)
@@ -44,7 +44,7 @@ def test_join_strings():
 def test_join_missing_levels():
     d0 = dt.Frame(A=[1, 2, 3])
     d1 = dt.Frame(A=[1, 2], K=[True, False])
-    d1.key = "A"
+    d1.key1 = "A"
     res = d0[:, :, join(d1)]
     res.internal.check()
     assert res.topython() == [[1, 2, 3], [True, False, None]]
@@ -56,7 +56,7 @@ def test_join_errors():
     with pytest.raises(ValueError) as e:
         d0[:, :, join(d1)]
     assert "The join frame is not keyed" in str(e.value)
-    d1.key = "B"
+    d1.key1 = "B"
     with pytest.raises(ValueError) as e:
         d0[:, :, join(d1)]
     assert "Key column `B` does not exist in the left Frame" in str(e.value)
@@ -95,7 +95,7 @@ def test_join_random(seed, lt):
     nkeys = len(keys)
 
     dkey = dt.Frame(KEY=keys, VAL=range(nkeys), stypes={"KEY": st})
-    dkey.key = "KEY"
+    dkey.key1 = "KEY"
     keys, vals = dkey.topython()
     main = [random.choice(keys) for i in range(ndata)]
     dmain = dt.Frame(KEY=main, stype=st)
@@ -112,7 +112,7 @@ def test_join_random(seed, lt):
 def test_join_update():
     d0 = dt.Frame([[1, 2, 3, 2, 3, 1, 3, 2, 2, 1], range(10)], names=("A", "B"))
     d1 = d0[:, mean(f.B), f.A]
-    d1.key = "A"
+    d1.key1 = "A"
     d0[:, "AA", join(d1)] = g.V0
     assert d0.names == ("A", "B", "AA")
     a = 4.75
@@ -127,7 +127,7 @@ def test_join_and_select_g_col():
     # See issue #1352
     F = dt.Frame(a=[0, 2, 3], b=[3, 4, 2])
     G = dt.Frame(b=[2, 4], c=["foo", "bar"])
-    G.key = "b"
+    G.key1 = "b"
     R = F[:, g.c, join(G)]
     R.internal.check()
     assert R.shape == (3, 1)

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#-------------------------------------------------------------------------------
+# Copyright 2018 H2O.ai
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#-------------------------------------------------------------------------------
+import datatable as dt
+import pytest
+
+
+
+def test_keys_simple():
+    dt0 = dt.Frame([["Joe", "Mary", "Leslie", "Adam", "Alice"],
+                    [1, 5, 15, 12, 8],
+                    [3.6, 9.78, 2.01, -4.23, 5.3819]],
+                   names=["name", "sex", "avg"])
+    assert dt0.key == tuple()
+    dt0.key = "name"
+    dt0.internal.check()
+    assert dt0.key == ("name",)
+    assert dt0.shape == (5, 3)
+    assert dt0.names == ("name", "sex", "avg")
+    assert dt0.topython() == [["Adam", "Alice", "Joe", "Leslie", "Mary"],
+                              [12, 8, 1, 15, 5],
+                              [-4.23, 5.3819, 3.6, 2.01, 9.78]]
+    dt0.key = "sex"
+    dt0.internal.check()
+    assert not dt0.internal.isview
+    assert dt0.key == ("sex",)
+    assert dt0.shape == (5, 3)
+    assert dt0.names == ("sex", "name", "avg")
+    assert dt0.topython() == [[1, 5, 8, 12, 15],
+                              ["Joe", "Mary", "Alice", "Adam", "Leslie"],
+                              [3.6, 9.78, 5.3819, -4.23, 2.01]]
+    dt0.key = None
+    assert dt0.key == tuple()
+
+
+
+def test_no_cache():
+    # Check that assigning a key properly disposes of potentially cached
+    # types / names of the Frame
+    dt0 = dt.Frame([[1.1] * 4, list("ABCD"), [3, 5, 2, 1]],
+                   names=["A", "B", "C"])
+    assert dt0.names == ("A", "B", "C")
+    assert dt0.ltypes == (dt.ltype.real, dt.ltype.str, dt.ltype.int)
+    assert dt0.stypes == (dt.float64, dt.str32, dt.int8)
+    assert dt0.colindex("B") == 1
+    dt0.internal.check()
+    dt0.key = "C"
+    assert dt0.names == ("C", "A", "B")
+    assert dt0.ltypes == (dt.ltype.int, dt.ltype.real, dt.ltype.str)
+    assert dt0.stypes == (dt.int8, dt.float64, dt.str32)
+    assert dt0.colindex("B") == 2
+    dt0.internal.check()
+
+
+
+def test_multi_key():
+    dt0 = dt.Frame(D=range(6), A=[3, 7, 5, 2, 2, 3], B=[1, 2, 2, 3, 4, 4])
+    dt0.key = ["A", "B"]
+    dt0.internal.check()
+    assert dt0.key == ("A", "B")
+    assert dt0.names == ("A", "B", "D")
+    assert dt0.to_list() == [[2, 2, 3, 3, 5, 7],
+                             [3, 4, 1, 4, 2, 2],
+                             [3, 4, 0, 5, 2, 1]]
+
+
+
+def test_key_invalid1():
+    dt0 = dt.Frame(A=range(5), B=[3] * 5)
+    with pytest.raises(TypeError) as e:
+        dt0.key = 0
+    assert ("Key should be a column name, or a list/tuple of column names"
+            in str(e.value))
+    with pytest.raises(TypeError) as e:
+        dt0.key = ["A", None]
+    assert ("Key should be a list/tuple of column names, instead element 1 "
+            "was a <class 'NoneType'>" == str(e.value))
+
+
+
+def test_key_invalid2():
+    dt0 = dt.Frame([["Joe", "Mary", "Leslie", "Adam", "Alice"],
+                    [7, 9, 2, 2, 7],
+                    [3, 4, 5, 3, 4]],
+                   names=["name", "A", "B"])
+    with pytest.raises(ValueError) as e:
+        dt0.key = "A"
+    assert ("the values are not unique" in str(e.value))
+
+    dt0.key = ["A", "B"]
+    assert dt0.key == ("A", "B")
+    assert dt0.names == ("A", "B", "name")
+    assert dt0.to_list() == [[2, 2, 7, 7, 9],
+                             [3, 5, 3, 4, 4],
+                             ["Adam", "Leslie", "Joe", "Alice", "Mary"]]
+
+    with pytest.raises(ValueError) as e:
+        dt0.key = "B"
+    assert ("the values are not unique" in str(e.value))
+    # Check that the columns don't get reordered during a bad key assignment
+    assert dt0.key == ("A", "B")
+    assert dt0.names == ("A", "B", "name")
+
+
+
+def test_key_duplicate():
+    dt0 = dt.Frame(A=range(5))
+    with pytest.raises(ValueError) as e:
+        dt0.key = ("A", "A")
+    assert ("Column `A` is specified multiple times within the key" ==
+            str(e.value))
+
+
+def test_set_empty_key():
+    dt0 = dt.Frame([range(5), [None] * 5], names=["A", "B"])
+    dt0.key = []
+    assert dt0.key == tuple()
+    dt0.key = "A"
+    assert dt0.key == ("A",)
+    dt0.key = []
+    dt0.internal.check()
+    assert dt0.key == tuple()
+    assert dt0.names == ("A", "B")
+
+
+def test_key_save(tempfile):
+    dt0 = dt.Frame(D=range(6), A=[3, 7, 5, 2, 2, 3], B=[1, 2, 2, 3, 4, 4])
+    dt0.key = ["A", "B"]
+    dt0.internal.check()
+    dt0.save(tempfile, format="jay")
+    dt1 = dt.open(tempfile)
+    assert dt1.key == ("A", "B")
+    dt1.internal.check()

--- a/tests/test_nff.py
+++ b/tests/test_nff.py
@@ -98,7 +98,7 @@ def test_jay_simple(tempfile):
     dt0.save(tempfile, format="jay")
     assert os.path.isfile(tempfile)
     with open(tempfile, "rb") as inp:
-        assert inp.read(8) == b"JAY1\0\0\0\0"
+        assert inp.read(8) == b"JAY1\x00\x00\x00\x00"
     dt1 = dt.open(tempfile)
     assert_equals(dt0, dt1)
 
@@ -190,7 +190,7 @@ def test_jay_all_types(tempfile):
 def test_jay_keys(tempfile):
     d0 = dt.Frame([["ab", "cd", "eee", "coo", "aop"],
                    [1, 2, 3, 4, 5]], names=("x", "y"))
-    d0.key = "x"
+    d0.key1 = "x"
     assert len(d0.key) == 1
     assert d0.topython() == [["ab", "aop", "cd", "coo", "eee"],
                              [1, 5, 2, 4, 3]]

--- a/tests/test_nff.py
+++ b/tests/test_nff.py
@@ -190,7 +190,7 @@ def test_jay_all_types(tempfile):
 def test_jay_keys(tempfile):
     d0 = dt.Frame([["ab", "cd", "eee", "coo", "aop"],
                    [1, 2, 3, 4, 5]], names=("x", "y"))
-    d0.key1 = "x"
+    d0.key = "x"
     assert len(d0.key) == 1
     assert d0.topython() == [["ab", "aop", "cd", "coo", "eee"],
                              [1, 5, 2, 4, 3]]


### PR DESCRIPTION
A Frame can now have a multi-column key, for example:
```
frame.key = ("A", "B")
```

Closes #1376