### PR TITLE
Deprecate DT[col]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   a frame, one can always write `DT[i:i+1, j]` or `DT[[i], j]`.
 - The performance of explicit element selection improved by a factor of 200x.
 - Building no longer requires an LLVM distribution.
+- `DT[col]` syntax has been deprecated and now emits a warning. This
+  will be converted to an error in version 0.8.0, and will be interpreted
+  as row selector in 0.9.0.
 
 #### Fixed
 - bug in dt.cbind() where the first Frame in the list was ignored.

--- a/c/frame/getset.cc
+++ b/c/frame/getset.cc
@@ -98,11 +98,7 @@ oobj Frame::_fallback_getset(obj item, obj value) {
   if (item.is_tuple()) {
     otuple argslist = item.to_pytuple();
     size_t n = argslist.size();
-    if (n == 1) {
-      args.set(1, py::None());
-      args.set(2, argslist[0]);
-    }
-    else if (n >= 2) {
+    if (n >= 2) {
       args.set(1, argslist[0]);
       args.set(2, argslist[1]);
       if (n == 3) {
@@ -110,10 +106,15 @@ oobj Frame::_fallback_getset(obj item, obj value) {
       } else if (n >= 4) {
         throw ValueError() << "Selector " << item << " is not supported";
       }
+    } else {
+      throw ValueError() << "Invalid selector " << item;
     }
   } else {
     args.set(1, py::None());
     args.set(2, item);
+    DeprecationWarning() << "Single-item selectors `DT[col]` are deprecated "
+        "since 0.7.0; please use `DT[:, col]` instead. This message will "
+        "become an error in version 0.8.0";
   }
   if (!args[3]) args.set(3, py::None());
   if (!args[4]) args.set(4, py::None());

--- a/c/frame/names.cc
+++ b/c/frame/names.cc
@@ -546,7 +546,7 @@ void DataTable::_set_names_impl(NameProvider* nameslist) {
   // If there were any duplicate names, issue a warning
   size_t ndup = duplicates.size();
   if (ndup) {
-    Warning w;
+    Warning w = DatatableWarning();
     if (ndup == 1) {
       w << "Duplicate column name '" << duplicates[0] << "' found, and was "
            "assigned a unique name";

--- a/c/jay/save_jay.cc
+++ b/c/jay/save_jay.cc
@@ -45,7 +45,8 @@ void DataTable::save_jay(const std::string& path,
   for (size_t i = 0; i < ncols; ++i) {
     Column* col = columns[i];
     if (col->stype() == SType::OBJ) {
-      Warning() << "Column '" << colnames[i] << "' of type obj64 was not saved";
+      DatatableWarning() << "Column `" << colnames[i]
+          << "` of type obj64 was not saved";
     } else {
       auto saved_col = column_to_jay(col, colnames[i], fbb, wb);
       msg_columns.push_back(saved_col);

--- a/c/utils/exceptions.cc
+++ b/c/utils/exceptions.cc
@@ -223,13 +223,17 @@ void init_exceptions() {
 
 //==============================================================================
 
-Warning::Warning()
-  : Error(datatable_warning_class) {}
+Warning::Warning(PyObject* cls) : Error(cls) {}
 
 Warning::~Warning() {
   const std::string errstr = error.str();
   PyErr_WarnEx(pycls, errstr.c_str(), 1);
 }
+
+
+Warning DatatableWarning()  { return Warning(datatable_warning_class); }
+// Note, DeprecationWarnings are ignored by default in python
+Warning DeprecationWarning() { return Warning(PyExc_FutureWarning); }
 
 
 

--- a/c/utils/exceptions.h
+++ b/c/utils/exceptions.h
@@ -112,9 +112,14 @@ void init_exceptions();
 
 class Warning : public Error {
   public:
-    Warning();
+    Warning(PyObject* cls);
+    Warning(const Warning&) = default;
     ~Warning() override;
 };
+
+Warning DatatableWarning();
+Warning DeprecationWarning();
+
 
 
 //------------------------------------------------------------------------------

--- a/datatable/nff.py
+++ b/datatable/nff.py
@@ -121,7 +121,7 @@ def open(path):
         coltypes += [None] * 2
     f0 = dt.fread(metafile, sep=",", columns=coltypes)
     f1 = f0(select=["filename", "stype"])
-    colnames = f0["colname"].topython()[0]
+    colnames = f0[:, "colname"].to_list()[0]
     df = core.datatable_load(f1.internal, nrows, path, nff_version < 2,
                              colnames)
     assert df.nrows == nrows, "Wrong number of rows read: %d" % df.nrows

--- a/tests/fread/test_fread_detect.py
+++ b/tests/fread/test_fread_detect.py
@@ -7,7 +7,6 @@
 # Tests related to datatable's ability to detect various parsing settings, such
 # as sep, ncols, quote rule, presence of headers, etc.
 #-------------------------------------------------------------------------------
-import pytest
 import datatable as dt
 
 
@@ -69,4 +68,4 @@ def test_detect_sep1():
     f0.internal.check()
     assert f0.shape == (3, 6)
     assert f0.names == ("Date Time", "Open", "High", "Low", "Close", "Volume")
-    assert f0["Open"].topython() == [[5683, 5675, 5674]]
+    assert f0[:, "Open"].to_list() == [[5683, 5675, 5674]]

--- a/tests/munging/test_assign.py
+++ b/tests/munging/test_assign.py
@@ -22,17 +22,17 @@ def test_assign_column_slice():
 def test_assign_column_array():
     f0 = dt.Frame({"A": range(10)})
     assert f0.ltypes == (dt.ltype.int,)
-    f0["B"] = 3.5
+    f0[:, "B"] = 3.5
     assert f0.names == ("A", "B")
     assert f0.ltypes == (dt.ltype.int, dt.ltype.real)
     assert f0.shape == (10, 2)
-    f0["C"] = "foo"
+    f0[:, "C"] = "foo"
     assert f0.ltypes == (dt.ltype.int, dt.ltype.real, dt.ltype.str)
     assert f0.topython() == [list(range(10)), [3.5] * 10, ["foo"] * 10]
     f0[:, ["B", "C"]] = False
     assert f0.ltypes == (dt.ltype.int, dt.ltype.bool, dt.ltype.bool)
     assert f0.topython() == [list(range(10)), [False] * 10, [False] * 10]
-    f0["A"] = None
+    f0[:, "A"] = None
     assert f0.ltypes == (dt.ltype.bool,) * 3
 
 
@@ -57,7 +57,7 @@ def test_assign_filtered():
 def test_assign_to_view():
     f0 = dt.Frame({"A": range(10)})
     f1 = f0[::2, :]
-    f1["AA"] = "test"
+    f1[:, "AA"] = "test"
     assert f1.names == ("A", "AA")
     assert f1.ltypes == (dt.ltype.int, dt.ltype.str)
     assert f1.topython() == [list(range(0, 10, 2)), ["test"] * 5]
@@ -67,6 +67,6 @@ def test_assign_to_view():
 def test_assign_frame():
     f0 = dt.Frame({"A": range(10)})
     f1 = dt.Frame([i / 2 for i in range(100)])
-    f0["A"] = f1[:10, :]
+    f0[:, "A"] = f1[:10, :]
     assert f0.names == ("A",)
     assert f0.ltypes == (dt.ltype.real,)

--- a/tests/munging/test_replace.py
+++ b/tests/munging/test_replace.py
@@ -101,8 +101,8 @@ def test_replace_ints(st):
     df.replace({0: 100, 1: -99, 2: 10})
     df.internal.check()
     assert df.stypes == (st, st)
-    assert df["A"].topython() == [[-99, 10, 3, 5, 9, 100]]
-    assert df["B"].topython() == [[100, 10, -99, 3, 10, -99]]
+    assert df[:, "A"].to_list() == [[-99, 10, 3, 5, 9, 100]]
+    assert df[:, "B"].to_list() == [[100, 10, -99, 3, 10, -99]]
 
 
 def test_replace_int_with_upcast():

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -190,6 +190,11 @@ def test_dt_getitem(dt0):
             in ws[0].message.args[0])
 
 
+def test_issue1406(dt0):
+    with pytest.raises(ValueError) as e:
+        dt0[tuple()]
+    assert "Invalid selector ()" == str(e.value)
+
 
 
 #-------------------------------------------------------------------------------
@@ -267,14 +272,14 @@ def smalldt():
 
 def test_del_0cols():
     d0 = smalldt()
-    del d0[[]]
+    del d0[:, []]
     d0.internal.check()
     assert d0.shape == (1, 16)
     assert d0.topython() == smalldt().topython()
 
 def test_del_1col_str_1():
     d0 = smalldt()
-    del d0["A"]
+    del d0[:, "A"]
     d0.internal.check()
     assert d0.shape == (1, 15)
     assert d0.topython() == [[i] for i in range(1, 16)]
@@ -283,7 +288,7 @@ def test_del_1col_str_1():
 
 def test_del_1col_str_2():
     d0 = smalldt()
-    del d0["B"]
+    del d0[:, "B"]
     d0.internal.check()
     assert d0.shape == (1, 15)
     assert d0.topython() == [[i] for i in range(16) if i != 1]
@@ -291,7 +296,7 @@ def test_del_1col_str_2():
 
 def test_del_1col_str_3():
     d0 = smalldt()
-    del d0["P"]
+    del d0[:, "P"]
     d0.internal.check()
     assert d0.shape == (1, 15)
     assert d0.topython() == [[i] for i in range(16) if i != 15]
@@ -299,14 +304,14 @@ def test_del_1col_str_3():
 
 def test_del_1col_int():
     d0 = smalldt()
-    del d0[-1]
+    del d0[:, -1]
     d0.internal.check()
     assert d0.shape == (1, 15)
     assert d0.names == tuple("ABCDEFGHIJKLMNO")
 
 def test_del_cols_strslice():
     d0 = smalldt()
-    del d0["E":"K"]
+    del d0[:, "E":"K"]
     d0.internal.check()
     assert d0.shape == (1, 9)
     assert d0.names == tuple("ABCDLMNOP")
@@ -314,7 +319,7 @@ def test_del_cols_strslice():
 
 def test_del_cols_intslice1():
     d0 = smalldt()
-    del d0[::2]
+    del d0[:, ::2]
     d0.internal.check()
     assert d0.shape == (1, 8)
     assert d0.names == tuple("BDFHJLNP")
@@ -322,7 +327,7 @@ def test_del_cols_intslice1():
 
 def test_del_cols_intslice2():
     d0 = smalldt()
-    del d0[::-2]
+    del d0[:, ::-2]
     d0.internal.check()
     assert d0.shape == (1, 8)
     assert d0.names == tuple("ACEGIKMO")
@@ -330,28 +335,28 @@ def test_del_cols_intslice2():
 
 def test_del_cols_all():
     d0 = smalldt()
-    del d0[:]
+    del d0[:, :]
     d0.internal.check()
     assert d0.names == tuple()
     assert d0.shape == (0, 0)
 
 def test_del_cols_list():
     d0 = smalldt()
-    del d0[[0, 3, 0, 5, 0, 9]]
+    del d0[:, [0, 3, 0, 5, 0, 9]]
     d0.internal.check()
     assert d0.names == tuple("BCEGHIKLMNOP")
     assert d0.shape == (1, 12)
 
 def test_del_cols_multislice():
     d0 = smalldt()
-    del d0[[slice(10), 12, -1]]
+    del d0[:, [slice(10), 12, -1]]
     d0.internal.check()
     assert d0.names == tuple("KLNO")
     assert d0.shape == (1, 4)
 
 def test_del_cols_generator():
     d0 = smalldt()
-    del d0[(i**2 for i in range(4))]
+    del d0[:, (i**2 for i in range(4))]
     d0.internal.check()
     assert d0.names == tuple("CDFGHIKLMNOP")
 
@@ -370,12 +375,12 @@ def test_delitem_invalid_selectors():
     """
     d0 = smalldt()
     with pytest.raises(ValueError) as e:
-        del d0[0.5]
+        del d0[:, 0.5]
     assert "Unknown `select` argument: 0.5" in str(e.value)
     with pytest.raises(ValueError):
-        del d0[d0]
+        del d0[:, d0]
     with pytest.raises(TypeError):
-        del d0[[1, 2, 1, 0.7]]
+        del d0[:, [1, 2, 1, 0.7]]
 
 
 

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -194,6 +194,9 @@ def test_issue1406(dt0):
     with pytest.raises(ValueError) as e:
         dt0[tuple()]
     assert "Invalid selector ()" == str(e.value)
+    with pytest.raises(ValueError) as e:
+        dt0[(None,)]
+    assert "Invalid selector (None,)" == str(e.value)
 
 
 

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -172,10 +172,10 @@ def test_dt_view(dt0, patched_terminal, capsys):
 
 
 def test_dt_getitem(dt0):
-    dt1 = dt0[0]
+    dt1 = dt0[:, 0]
     assert dt1.shape == (4, 1)
     assert dt1.names == ("A", )
-    dt1 = dt0[(4,)]
+    dt1 = dt0[(..., 4)]
     assert dt1.shape == (4, 1)
     assert dt1.names == ("E", )
     elem2 = dt0[0, 1]
@@ -183,6 +183,12 @@ def test_dt_getitem(dt0):
     with pytest.raises(ValueError) as e:
         dt0[0, 1, 2, 3]
     assert "Selector (0, 1, 2, 3) is not supported" in str(e.value)
+    with pytest.warns(FutureWarning) as ws:
+        dt0["A"]
+    assert len(ws) == 1
+    assert ("Single-item selectors `DT[col]` are deprecated"
+            in ws[0].message.args[0])
+
 
 
 

--- a/tests/test_dt_create.py
+++ b/tests/test_dt_create.py
@@ -295,7 +295,7 @@ def test_create_from_frame():
     d1.internal.check()
     assert_equals(d0, d1)
     # Now check that d1 is a true copy of d0, rather than reference
-    del d1["C"]
+    del d1[:, "C"]
     d1.nrows = 10
     assert d1.nrows == 10
     assert d1.ncols == 2

--- a/tests/test_dt_sort.py
+++ b/tests/test_dt_sort.py
@@ -520,7 +520,7 @@ def test_sort_view4():
 
 def test_sort_view_large_strs():
     d0 = dt.Frame(list("abcbpeiuqenvkjqperufhqperofin;d") * 100)
-    d1 = d0[::2].sort(0)
+    d1 = d0[:, ::2].sort(0)
     d1.internal.check()
     elems = d1.topython()[0]
     assert elems == sorted(elems)

--- a/tests/test_nff.py
+++ b/tests/test_nff.py
@@ -147,7 +147,7 @@ def test_jay_object_columns(tempfile):
     with pytest.warns(DatatableWarning) as ws:
         d0.save(tempfile, format="jay")
     assert len(ws) == 1
-    assert "Column 'B' of type obj64 was not saved" in ws[0].message.args[0]
+    assert "Column `B` of type obj64 was not saved" in ws[0].message.args[0]
     d1 = dt.open(tempfile)
     d1.internal.check()
     assert d1.names == ("A",)


### PR DESCRIPTION
As outlined in #1395, syntax `DT[col]` will now be deprecated. Please use `DT[:, col]` instead.

Starting from 0.9.0, `DT[x]` will be interpreted as row-selector instead. For example, `DT[:5]` will be the first 5 rows of the Frame, and `DT["A"]` will return the row keyed by the value "A". 

Closes #1395 
Closes #1406