### PR TITLE
Multi-column join

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - HTML rendering of Frames inside a Jupyter notebook.
 - set-theoretic functions: `union`, `intersect`, `setdiff` and `symdiff`.
 - support for multi-column keys.
+- ability to join Frames on multiple columns.
 
 #### Changed
 - `names` argument in `Frame()` constructor can no longer be a string --

--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -204,6 +204,7 @@ void DatatableModule::init_methods() {
   init_methods_str();
   init_methods_options();
   init_methods_sets();
+  init_methods_join();
 }
 
 

--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -205,6 +205,9 @@ void DatatableModule::init_methods() {
   init_methods_options();
   init_methods_sets();
   init_methods_join();
+  #ifdef DTTEST
+    init_tests();
+  #endif
 }
 
 
@@ -231,11 +234,6 @@ PyInit__datatable()
 
   try {
     py::Frame::Type::init(m);
-
-    #ifdef DTTEST
-      dttest::run_tests();
-    #endif
-
   } catch (const std::exception& e) {
     exception_to_python(e);
     return nullptr;

--- a/c/datatablemodule.h
+++ b/c/datatablemodule.h
@@ -33,6 +33,7 @@ class DatatableModule : public py::ExtModule<DatatableModule> {
     void init_methods_str();      // str/py_str.cc
     void init_methods_options();  // options.cc
     void init_methods_sets();     // set_funcs.cc
+    void init_methods_join();     // frame/join.cc
 };
 
 

--- a/c/datatablemodule.h
+++ b/c/datatablemodule.h
@@ -34,6 +34,10 @@ class DatatableModule : public py::ExtModule<DatatableModule> {
     void init_methods_options();  // options.cc
     void init_methods_sets();     // set_funcs.cc
     void init_methods_join();     // frame/join.cc
+
+    #ifdef DTTEST
+      void init_tests();
+    #endif
 };
 
 

--- a/c/frame/getset.cc
+++ b/c/frame/getset.cc
@@ -66,7 +66,7 @@ oobj Frame::_fast_getset(obj item, obj value) {
           if (icol < 0) icol += ncols;
           if (icol < 0 || icol >= ncols) {
             if (icol < 0) icol -= ncols;
-            throw ValueError() << "Column index `" << icol << "` is invalud "
+            throw ValueError() << "Column index `" << icol << "` is invalid "
                 "for a frame with " << ncols << " column" <<
                 (ncols == 1? "" : "s");
           }

--- a/c/frame/join.cc
+++ b/c/frame/join.cc
@@ -242,11 +242,11 @@ int StringCmp<TX, TJ>::cmp_jrow(size_t row) const {
   const uint8_t* xstr = strdataX + xstart;
   const uint8_t* jstr = strdataJ + jstart;
   for (TJ i = 0; i < jlen; ++i) {
-    if (i == xlen) return 1;  // jstr is shorter than xstr
-    uint8_t ch1 = xstr[i];
-    uint8_t ch2 = jstr[i];
-    if (ch1 != ch2) {
-      return 1 - 2*(ch1 < ch2);
+    if (i == xlen) return 1;  // jstr is longer than xstr
+    uint8_t jch = jstr[i];
+    uint8_t xch = xstr[i];
+    if (xch != jch) {
+      return 1 - 2*(jch < xch);
     }
   }
   return -(jlen != xlen);
@@ -400,10 +400,14 @@ Join two Frames `xdt` and `jdt` on the keys of `jdt`.
 
     // #pragma omp parallel for
     for (size_t i = 0; i < xdt->nrows; ++i) {
-      comparator.set_xrow(i);
-      size_t j = binsearch(&comparator, jdt->nrows);
-      result_indices[i] = (j == NO_MATCH)? GETNA<int32_t>()
-                                         : static_cast<int32_t>(j);
+      int r = comparator.set_xrow(i);
+      if (r == 0) {
+        size_t j = binsearch(&comparator, jdt->nrows);
+        result_indices[i] = (j == NO_MATCH)? GETNA<int32_t>()
+                                           : static_cast<int32_t>(j);
+      } else {
+        result_indices[i] = GETNA<int32_t>();
+      }
     }
   }
 

--- a/c/frame/join.cc
+++ b/c/frame/join.cc
@@ -158,7 +158,8 @@ cmpptr FwCmp<TX, TJ>::make(const Column* col1, const Column* col2) {
 template <typename TX, typename TJ>
 int FwCmp<TX, TJ>::cmp_jrow(size_t row) const {
   TJ jval = dataJ[row];
-  return (jval > x_value) - (jval < x_value);
+  return (jval > x_value) - (jval < x_value) +
+         (std::is_integral<TJ>::value? 0 : ISNA<TJ>(x_value) - ISNA<TJ>(jval));
 }
 
 

--- a/c/frame/join.cc
+++ b/c/frame/join.cc
@@ -1,0 +1,412 @@
+//------------------------------------------------------------------------------
+// Copyright 2018 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#include <limits>
+#include <memory>
+#include <type_traits>
+#include "column.h"
+#include "datatable.h"
+#include "datatablemodule.h"
+#include "options.h"
+#include "py_rowindex.h"
+#include "python/args.h"
+#include "python/obj.h"
+#include "python/tuple.h"
+#include "types.h"
+#include "utils/assert.h"
+
+class Cmp;
+using cmpptr = std::unique_ptr<Cmp>;
+using comparator_maker = cmpptr (*)(const Column*, const Column*);
+static cmpptr make_comparator(const Column* col1, const Column* col2);
+
+
+
+//------------------------------------------------------------------------------
+// Cmp
+//------------------------------------------------------------------------------
+
+/**
+ * Abstract base class that facilitates comparison of rows between two Frames.
+ *
+ * The implementation classes are expected to store references to both Frames,
+ * and then provide the following comparison functions:
+ *
+ *   set_row(size_t row) -> int
+ *     This selects the row within the left Frame. All subsequent comparisons
+ *     will be done against that row.
+ *     The function returns 0 if it succeded, or -1 if the lhs value in the
+ *     given row will not match any value in the rhs Frame.
+ *
+ *   cmp(size_t row) -> int
+ *     compare the `row`th value in the right Frame against the value from the
+ *     left Frame stored during the previous `set_row()` call. Return +1, -1,
+ *     or 0 depending if the row-value is greater than, less than, or equal
+ *     to the value stored.
+ *
+ * This comparison function is then used as the basis for the binary search
+ * algorithm to performa a join between two tables.
+ */
+class Cmp {
+  public:
+    virtual ~Cmp();
+    virtual int cmp(size_t row) const = 0;
+    virtual int set_row(size_t row) = 0;
+};
+
+Cmp::~Cmp() {}
+
+
+
+//------------------------------------------------------------------------------
+// MultiCmp
+//------------------------------------------------------------------------------
+
+class MultiCmp : public Cmp {
+  private:
+    std::vector<cmpptr> col_cmps;
+
+  public:
+    MultiCmp(const colvec& lhs, const colvec& rhs);
+    int set_row(size_t row) override;
+    int cmp(size_t row) const override;
+};
+
+
+MultiCmp::MultiCmp(const colvec& lhs, const colvec& rhs) {
+  xassert(lhs.size() == rhs.size());
+  for (size_t i = 0; i < lhs.size(); ++i) {
+    col_cmps.push_back(make_comparator(lhs[i], rhs[i]));
+  }
+}
+
+int MultiCmp::set_row(size_t row) {
+  int r = 0;
+  for (auto& ch : col_cmps) {
+    r |= ch->set_row(row);
+  }
+  return r;
+}
+
+int MultiCmp::cmp(size_t row) const {
+  for (const auto& ch : col_cmps) {
+    int r = ch->cmp(row);
+    if (r) return r;
+  }
+  return 0;
+}
+
+
+
+//------------------------------------------------------------------------------
+// Fixed-width Cmp
+//------------------------------------------------------------------------------
+
+template <typename T, typename U>
+class FwCmp : public Cmp {
+  private:
+    const T* data1;
+    const U* data2;
+    T value;
+    size_t : (64 - 8 * sizeof(T)) & 63;
+
+  public:
+    FwCmp(const Column*, const Column*);
+    static cmpptr make(const Column*, const Column*);
+
+    int cmp(size_t row) const override;
+    int set_row(size_t row) override;
+};
+
+
+template <typename T, typename U>
+FwCmp<T, U>::FwCmp(const Column* xcol, const Column* jcol) {
+  auto xcol_f = static_cast<const FwColumn<U>*>(xcol);
+  auto jcol_f = static_cast<const FwColumn<T>*>(jcol);
+  data1 = jcol_f->elements_r();
+  data2 = xcol_f->elements_r();
+}
+
+template <typename T, typename U>
+cmpptr FwCmp<T, U>::make(const Column* col1, const Column* col2) {
+  return cmpptr(new FwCmp<T, U>(col1, col2));
+}
+
+
+template <typename T, typename U>
+int FwCmp<T, U>::cmp(size_t row) const {
+  T x = data1[row];
+  return (x > value) - (x < value);
+}
+
+
+template <typename T, typename U>
+int FwCmp<T, U>::set_row(size_t row) {
+  U newval = data2[row];
+  if (ISNA<U>(newval)) {
+    value = GETNA<T>();
+  } else if (std::is_integral<U>::value) {
+    if (std::is_integral<T>::value && sizeof(U) > sizeof(T)) {
+      if (newval > static_cast<U>(std::numeric_limits<T>::max()) ||
+          newval < static_cast<U>(std::numeric_limits<T>::min())) return -1;
+    }
+    value = static_cast<T>(newval);
+  } else {
+    value = static_cast<T>(newval);
+    if (std::is_integral<T>::value) {
+      // If matching floating point value to an integer column, values that
+      // are not round numbers should not match. We return `lt` comparator
+      // in this case, which is not entirely accurate, but it will provide
+      // the desired no-match semantics.
+      if (static_cast<U>(value) != newval) return -1;
+    }
+  }
+  return 0;
+}
+
+
+
+//------------------------------------------------------------------------------
+// String Cmp
+//------------------------------------------------------------------------------
+
+template <typename T, typename U>
+class StringCmp : public Cmp {
+  private:
+    const uint8_t* strdata1;
+    const uint8_t* strdata2;
+    const T* offsets1;
+    const U* offsets2;
+    U start2;
+    U end2;
+    size_t : (128 - 2 * 8 * sizeof(U)) & 63;
+
+  public:
+    StringCmp(const Column*, const Column*);
+    static cmpptr make(const Column*, const Column*);
+
+    int cmp(size_t row) const override;
+    int set_row(size_t row) override;
+};
+
+
+template <typename T, typename U>
+StringCmp<T, U>::StringCmp(const Column* xcol, const Column* jcol) {
+  auto xcol_s = static_cast<const StringColumn<U>*>(xcol);
+  auto jcol_s = static_cast<const StringColumn<T>*>(jcol);
+  strdata1 = jcol_s->ustrdata();
+  strdata2 = xcol_s->ustrdata();
+  offsets1 = jcol_s->offsets();
+  offsets2 = xcol_s->offsets();
+}
+
+template <typename T, typename U>
+cmpptr StringCmp<T, U>::make(const Column* col1, const Column* col2) {
+  return cmpptr(new StringCmp<T, U>(col1, col2));
+}
+
+
+template <typename T, typename U>
+int StringCmp<T, U>::cmp(size_t row) const {
+  T end1 = offsets1[row];
+  if (ISNA<T>(end1)) return ISNA<U>(end2) - 1;
+  if (ISNA<U>(end2)) return 1;
+
+  T start1 = offsets1[row - 1] & ~GETNA<T>();
+  T len1 = end1 - start1;
+  U len2 = end2 - start2;
+  const uint8_t* str1 = strdata1 + start1;
+  const uint8_t* str2 = strdata2 + start2;
+  for (T i = 0; i < len1; ++i) {
+    if (i == len2) return 1;  // str2 is shorter than str1
+    uint8_t ch1 = str1[i];
+    uint8_t ch2 = str2[i];
+    if (ch1 != ch2) {
+      return 1 - 2*(ch1 < ch2);
+    }
+  }
+  return -(len1 != len2);
+}
+
+
+template <typename T, typename U>
+int StringCmp<T, U>::set_row(size_t row) {
+  end2 = offsets2[row];
+  start2 = offsets2[row - 1] & ~GETNA<U>();
+  return 0;
+}
+
+
+
+//------------------------------------------------------------------------------
+// Cmp factory function
+//------------------------------------------------------------------------------
+static comparator_maker cmps[DT_STYPES_COUNT][DT_STYPES_COUNT];
+
+static void _init_comparators() {
+  for (size_t i = 0; i < DT_STYPES_COUNT; ++i) {
+    for (size_t j = 0; j < DT_STYPES_COUNT; ++j) {
+      cmps[i][j] = nullptr;
+    }
+  }
+  size_t int08 = static_cast<size_t>(SType::INT8);
+  size_t int16 = static_cast<size_t>(SType::INT16);
+  size_t int32 = static_cast<size_t>(SType::INT32);
+  size_t int64 = static_cast<size_t>(SType::INT64);
+  size_t flt32 = static_cast<size_t>(SType::FLOAT32);
+  size_t flt64 = static_cast<size_t>(SType::FLOAT64);
+  size_t str32 = static_cast<size_t>(SType::STR32);
+  size_t str64 = static_cast<size_t>(SType::STR64);
+  cmps[int08][int08] = FwCmp<int8_t, int8_t>::make;
+  cmps[int08][int16] = FwCmp<int8_t, int16_t>::make;
+  cmps[int08][int32] = FwCmp<int8_t, int32_t>::make;
+  cmps[int08][int64] = FwCmp<int8_t, int64_t>::make;
+  cmps[int08][flt32] = FwCmp<int8_t, float>::make;
+  cmps[int08][flt64] = FwCmp<int8_t, double>::make;
+  cmps[int16][int08] = FwCmp<int16_t, int8_t>::make;
+  cmps[int16][int16] = FwCmp<int16_t, int16_t>::make;
+  cmps[int16][int32] = FwCmp<int16_t, int32_t>::make;
+  cmps[int16][int64] = FwCmp<int16_t, int64_t>::make;
+  cmps[int16][flt32] = FwCmp<int16_t, float>::make;
+  cmps[int16][flt64] = FwCmp<int16_t, double>::make;
+  cmps[int32][int08] = FwCmp<int32_t, int8_t>::make;
+  cmps[int32][int16] = FwCmp<int32_t, int16_t>::make;
+  cmps[int32][int32] = FwCmp<int32_t, int32_t>::make;
+  cmps[int32][int64] = FwCmp<int32_t, int64_t>::make;
+  cmps[int32][flt32] = FwCmp<int32_t, float>::make;
+  cmps[int32][flt64] = FwCmp<int32_t, double>::make;
+  cmps[int64][int08] = FwCmp<int64_t, int8_t>::make;
+  cmps[int64][int16] = FwCmp<int64_t, int16_t>::make;
+  cmps[int64][int32] = FwCmp<int64_t, int32_t>::make;
+  cmps[int64][int64] = FwCmp<int64_t, int64_t>::make;
+  cmps[int64][flt32] = FwCmp<int64_t, float>::make;
+  cmps[int64][flt64] = FwCmp<int64_t, double>::make;
+  cmps[flt32][int08] = FwCmp<float, int8_t>::make;
+  cmps[flt32][int16] = FwCmp<float, int16_t>::make;
+  cmps[flt32][int32] = FwCmp<float, int32_t>::make;
+  cmps[flt32][int64] = FwCmp<float, int64_t>::make;
+  cmps[flt32][flt32] = FwCmp<float, float>::make;
+  cmps[flt32][flt64] = FwCmp<float, double>::make;
+  cmps[flt64][int08] = FwCmp<double, int8_t>::make;
+  cmps[flt64][int16] = FwCmp<double, int16_t>::make;
+  cmps[flt64][int32] = FwCmp<double, int32_t>::make;
+  cmps[flt64][int64] = FwCmp<double, int64_t>::make;
+  cmps[flt64][flt32] = FwCmp<double, float>::make;
+  cmps[flt64][flt64] = FwCmp<double, double>::make;
+  cmps[str32][str32] = StringCmp<uint32_t, uint32_t>::make;
+  cmps[str32][str64] = StringCmp<uint32_t, uint64_t>::make;
+  cmps[str64][str32] = StringCmp<uint64_t, uint32_t>::make;
+  cmps[str64][str64] = StringCmp<uint64_t, uint64_t>::make;
+}
+
+
+static cmpptr make_comparator(const Column* col1, const Column* col2) {
+  size_t st1 = static_cast<size_t>(col1->stype());
+  size_t st2 = static_cast<size_t>(col2->stype());
+  if (cmps[st1][st2] == nullptr) {
+    throw TypeError() << "Incompatible column types: "
+        << col1->stype() << " and " << col2->stype();
+  }
+  return cmps[st1][st2](col1, col2);
+}
+
+
+
+
+//------------------------------------------------------------------------------
+// Join functionality
+//------------------------------------------------------------------------------
+static constexpr size_t NO_MATCH = size_t(-1);
+
+static size_t binsearch(Cmp* cmp, size_t nrows) {
+  // Use unsigned indices in order to avoid overflows
+  size_t start = 0;
+  size_t end   = nrows - 1;
+  while (start < end) {
+    // We won't ever have as many rows for this to overflow
+    size_t mid = (start + end) >> 1;
+    int r = cmp->cmp(mid);
+    if (r > 0) end = mid - 1;
+    else if (r < 0) start = mid + 1;
+    else return mid;
+  }
+  return cmp->cmp(start) == 0? start : NO_MATCH;
+}
+
+
+
+static py::PKArgs fn_natural_join(
+    2, 0, 0,
+    false, false,
+    {"xdt", "jdt"},
+    "natural_join",
+R"(natural_join(xdt, jdt)
+--
+
+Join two Frames `xdt` and `jdt` on the keys of `jdt`.
+)",
+
+[](const py::PKArgs& args) -> py::oobj {
+  DataTable* xdt = args[0].to_frame();
+  DataTable* jdt = args[1].to_frame();
+  size_t k = jdt->get_nkeys();  // Number of join columns
+  xassert(k > 0);
+
+  colvec xcols, jcols;
+  py::otuple jnames = jdt->get_pynames();
+  for (size_t i = 0; i < k; ++i) {
+    int64_t index = xdt->colindex(jnames[i]);
+    if (index == -1) {
+      throw ValueError() << "Key column `" << jnames[i].to_string() << "` does "
+          "not exist in the left Frame";
+    }
+    xcols.push_back(xdt->columns[static_cast<size_t>(index)]);
+    jcols.push_back(jdt->columns[i]);
+  }
+
+  arr32_t arr_result_indices(xdt->nrows);
+  int32_t* result_indices = arr_result_indices.data();
+
+  size_t nchunks = std::min(xdt->nrows / 2,
+                            static_cast<size_t>(config::nthreads));
+
+  #pragma omp parallel num_threads(nchunks)
+  {
+    MultiCmp comparator(xcols, jcols);
+
+    #pragma omp parallel for
+    for (size_t i = 0; i < xdt->nrows; ++i) {
+      comparator.set_row(i);
+      size_t j = binsearch(&comparator, jdt->nrows);
+      result_indices[i] = (j == NO_MATCH)? GETNA<int32_t>()
+                                         : static_cast<int32_t>(j);
+    }
+  }
+
+  RowIndex res = RowIndex::from_array32(std::move(arr_result_indices));
+  return py::oobj::from_new_reference(pyrowindex::wrap(res));
+});
+
+
+void DatatableModule::init_methods_join() {
+  _init_comparators();
+  ADDFN(fn_natural_join);
+}

--- a/c/frame/join.cc
+++ b/c/frame/join.cc
@@ -351,7 +351,9 @@ static size_t binsearch(Cmp* cmp, size_t nrows) {
     // We won't ever have as many rows for this to overflow
     size_t mid = (start + end) >> 1;
     int r = cmp->cmp_jrow(mid);
-    if (r > 0) end = mid - 1;
+    // Note: `mid` can be 0 (if start == 0 and end == 1), so don't use
+    // `mid - 1` here.
+    if (r > 0) end = mid;
     else if (r < 0) start = mid + 1;
     else return mid;
   }

--- a/c/frame/join.cc
+++ b/c/frame/join.cc
@@ -45,31 +45,34 @@ static cmpptr make_comparator(const Column* col1, const Column* col2);
 //------------------------------------------------------------------------------
 
 /**
- * Abstract base class that facilitates comparison of rows between two Frames.
+ * Abstract base class that facilitates comparison of rows between two frames,
+ * called X and J. The frames have different roles: J is the "look up" frame,
+ * and values within this frame are assumed sorted; X is the "main" frame, and
+ * we will be looking up the values from this Frame in J.
  *
- * The implementation classes are expected to store references to both Frames,
+ * The implementation classes are expected to store references to both frames,
  * and then provide the following comparison functions:
  *
- *   set_row(size_t row) -> int
- *     This selects the row within the left Frame. All subsequent comparisons
+ *   set_xrow(size_t row) -> int
+ *     This selects a row within the X frame. All subsequent comparisons
  *     will be done against that row.
- *     The function returns 0 if it succeded, or -1 if the lhs value in the
- *     given row will not match any value in the rhs Frame.
+ *     The function returns 0 if it succeeds, or -1 if the requested row will
+ *     not be able to match any row in the J frame.
  *
- *   cmp(size_t row) -> int
- *     compare the `row`th value in the right Frame against the value from the
- *     left Frame stored during the previous `set_row()` call. Return +1, -1,
+ *   cmp_jrow(size_t row) -> int
+ *     compare the `row`th value in the J frame against the value from the
+ *     X frame stored during the previous `set_xrow()` call. Returns +1, -1,
  *     or 0 depending if the row-value is greater than, less than, or equal
  *     to the value stored.
  *
  * This comparison function is then used as the basis for the binary search
- * algorithm to performa a join between two tables.
+ * algorithm to perform a join between two tables.
  */
 class Cmp {
   public:
     virtual ~Cmp();
-    virtual int cmp(size_t row) const = 0;
-    virtual int set_row(size_t row) = 0;
+    virtual int cmp_jrow(size_t row) const = 0;
+    virtual int set_xrow(size_t row) = 0;
 };
 
 Cmp::~Cmp() {}
@@ -85,30 +88,30 @@ class MultiCmp : public Cmp {
     std::vector<cmpptr> col_cmps;
 
   public:
-    MultiCmp(const colvec& lhs, const colvec& rhs);
-    int set_row(size_t row) override;
-    int cmp(size_t row) const override;
+    MultiCmp(const colvec& Xcols, const colvec& Jcols);
+    int set_xrow(size_t row) override;
+    int cmp_jrow(size_t row) const override;
 };
 
 
-MultiCmp::MultiCmp(const colvec& lhs, const colvec& rhs) {
-  xassert(lhs.size() == rhs.size());
-  for (size_t i = 0; i < lhs.size(); ++i) {
-    col_cmps.push_back(make_comparator(lhs[i], rhs[i]));
+MultiCmp::MultiCmp(const colvec& Xcols, const colvec& Jcols) {
+  xassert(Xcols.size() == Jcols.size());
+  for (size_t i = 0; i < Xcols.size(); ++i) {
+    col_cmps.push_back(make_comparator(Xcols[i], Jcols[i]));
   }
 }
 
-int MultiCmp::set_row(size_t row) {
+int MultiCmp::set_xrow(size_t row) {
   int r = 0;
-  for (auto& ch : col_cmps) {
-    r |= ch->set_row(row);
+  for (cmpptr& ch : col_cmps) {
+    r |= ch->set_xrow(row);
   }
   return r;
 }
 
-int MultiCmp::cmp(size_t row) const {
-  for (const auto& ch : col_cmps) {
-    int r = ch->cmp(row);
+int MultiCmp::cmp_jrow(size_t row) const {
+  for (const cmpptr& ch : col_cmps) {
+    int r = ch->cmp_jrow(row);
     if (r) return r;
   }
   return 0;
@@ -120,63 +123,65 @@ int MultiCmp::cmp(size_t row) const {
 // Fixed-width Cmp
 //------------------------------------------------------------------------------
 
-template <typename T, typename U>
+template <typename TX, typename TJ>
 class FwCmp : public Cmp {
   private:
-    const T* data1;
-    const U* data2;
-    T value;
-    size_t : (64 - 8 * sizeof(T)) & 63;
+    const TX* dataX;
+    const TJ* dataJ;
+    TJ x_value;  // Current value from X frame, converted to TJ type
+    size_t : (64 - 8 * sizeof(TJ)) & 63;
 
   public:
     FwCmp(const Column*, const Column*);
     static cmpptr make(const Column*, const Column*);
 
-    int cmp(size_t row) const override;
-    int set_row(size_t row) override;
+    int cmp_jrow(size_t row) const override;
+    int set_xrow(size_t row) override;
 };
 
 
-template <typename T, typename U>
-FwCmp<T, U>::FwCmp(const Column* xcol, const Column* jcol) {
-  auto xcol_f = static_cast<const FwColumn<U>*>(xcol);
-  auto jcol_f = static_cast<const FwColumn<T>*>(jcol);
-  data1 = jcol_f->elements_r();
-  data2 = xcol_f->elements_r();
+template <typename TX, typename TJ>
+FwCmp<TX, TJ>::FwCmp(const Column* xcol, const Column* jcol) {
+  auto xcol_f = dynamic_cast<const FwColumn<TX>*>(xcol);
+  auto jcol_f = dynamic_cast<const FwColumn<TJ>*>(jcol);
+  xassert(xcol_f && jcol_f);
+  dataX = xcol_f->elements_r();
+  dataJ = jcol_f->elements_r();
 }
 
-template <typename T, typename U>
-cmpptr FwCmp<T, U>::make(const Column* col1, const Column* col2) {
-  return cmpptr(new FwCmp<T, U>(col1, col2));
-}
-
-
-template <typename T, typename U>
-int FwCmp<T, U>::cmp(size_t row) const {
-  T x = data1[row];
-  return (x > value) - (x < value);
+template <typename TX, typename TJ>
+cmpptr FwCmp<TX, TJ>::make(const Column* col1, const Column* col2) {
+  return cmpptr(new FwCmp<TX, TJ>(col1, col2));
 }
 
 
-template <typename T, typename U>
-int FwCmp<T, U>::set_row(size_t row) {
-  U newval = data2[row];
-  if (ISNA<U>(newval)) {
-    value = GETNA<T>();
-  } else if (std::is_integral<U>::value) {
-    if (std::is_integral<T>::value && sizeof(U) > sizeof(T)) {
-      if (newval > static_cast<U>(std::numeric_limits<T>::max()) ||
-          newval < static_cast<U>(std::numeric_limits<T>::min())) return -1;
-    }
-    value = static_cast<T>(newval);
+template <typename TX, typename TJ>
+int FwCmp<TX, TJ>::cmp_jrow(size_t row) const {
+  TJ jval = dataJ[row];
+  return (jval > x_value) - (jval < x_value);
+}
+
+
+template <typename TX, typename TJ>
+int FwCmp<TX, TJ>::set_xrow(size_t row) {
+  TX newval = dataX[row];
+  if (ISNA<TX>(newval)) {
+    x_value = GETNA<TJ>();
   } else {
-    value = static_cast<T>(newval);
-    if (std::is_integral<T>::value) {
+    x_value = static_cast<TJ>(newval);
+    if (std::is_integral<TJ>::value) {
+      if (std::is_integral<TX>::value &&
+          sizeof(TX) > sizeof(TJ) &&
+          (newval > static_cast<TX>(std::numeric_limits<TJ>::max()) ||
+           newval < static_cast<TX>(std::numeric_limits<TJ>::min())))
+        return -1;
       // If matching floating point value to an integer column, values that
       // are not round numbers should not match. We return `lt` comparator
       // in this case, which is not entirely accurate, but it will provide
       // the desired no-match semantics.
-      if (static_cast<U>(value) != newval) return -1;
+      if (!std::is_integral<TX>::value &&
+          static_cast<TX>(x_value) != newval)
+        return -1;
     }
   }
   return 0;
@@ -188,69 +193,70 @@ int FwCmp<T, U>::set_row(size_t row) {
 // String Cmp
 //------------------------------------------------------------------------------
 
-template <typename T, typename U>
+template <typename TX, typename TJ>
 class StringCmp : public Cmp {
   private:
-    const uint8_t* strdata1;
-    const uint8_t* strdata2;
-    const T* offsets1;
-    const U* offsets2;
-    U start2;
-    U end2;
-    size_t : (128 - 2 * 8 * sizeof(U)) & 63;
+    const uint8_t* strdataX;
+    const uint8_t* strdataJ;
+    const TX* offsetsX;
+    const TJ* offsetsJ;
+    TX xstart;
+    TX xend;
+    size_t : (128 - 2 * 8 * sizeof(TJ)) & 63;
 
   public:
     StringCmp(const Column*, const Column*);
     static cmpptr make(const Column*, const Column*);
 
-    int cmp(size_t row) const override;
-    int set_row(size_t row) override;
+    int cmp_jrow(size_t row) const override;
+    int set_xrow(size_t row) override;
 };
 
 
-template <typename T, typename U>
-StringCmp<T, U>::StringCmp(const Column* xcol, const Column* jcol) {
-  auto xcol_s = static_cast<const StringColumn<U>*>(xcol);
-  auto jcol_s = static_cast<const StringColumn<T>*>(jcol);
-  strdata1 = jcol_s->ustrdata();
-  strdata2 = xcol_s->ustrdata();
-  offsets1 = jcol_s->offsets();
-  offsets2 = xcol_s->offsets();
+template <typename TX, typename TJ>
+StringCmp<TX, TJ>::StringCmp(const Column* xcol, const Column* jcol) {
+  auto xcol_s = dynamic_cast<const StringColumn<TX>*>(xcol);
+  auto jcol_s = dynamic_cast<const StringColumn<TJ>*>(jcol);
+  xassert(xcol_s && jcol_s);
+  strdataX = xcol_s->ustrdata();
+  offsetsX = xcol_s->offsets();
+  strdataJ = jcol_s->ustrdata();
+  offsetsJ = jcol_s->offsets();
 }
 
-template <typename T, typename U>
-cmpptr StringCmp<T, U>::make(const Column* col1, const Column* col2) {
-  return cmpptr(new StringCmp<T, U>(col1, col2));
+template <typename TX, typename TJ>
+cmpptr StringCmp<TX, TJ>::make(const Column* col1, const Column* col2) {
+  return cmpptr(new StringCmp<TX, TJ>(col1, col2));
 }
 
 
-template <typename T, typename U>
-int StringCmp<T, U>::cmp(size_t row) const {
-  T end1 = offsets1[row];
-  if (ISNA<T>(end1)) return ISNA<U>(end2) - 1;
-  if (ISNA<U>(end2)) return 1;
+template <typename TX, typename TJ>
+int StringCmp<TX, TJ>::cmp_jrow(size_t row) const {
+  TJ jend = offsetsJ[row];
+  if (ISNA<TJ>(jend)) return ISNA<TX>(xend) - 1;
+  if (ISNA<TX>(xend)) return 1;
 
-  T start1 = offsets1[row - 1] & ~GETNA<T>();
-  T len1 = end1 - start1;
-  U len2 = end2 - start2;
-  const uint8_t* str1 = strdata1 + start1;
-  const uint8_t* str2 = strdata2 + start2;
-  for (T i = 0; i < len1; ++i) {
-    if (i == len2) return 1;  // str2 is shorter than str1
-    uint8_t ch1 = str1[i];
-    uint8_t ch2 = str2[i];
+  TJ jstart = offsetsJ[row - 1] & ~GETNA<TJ>();
+  TJ jlen = jend - jstart;
+  TX xlen = xend - xstart;
+  const uint8_t* xstr = strdataX + xstart;
+  const uint8_t* jstr = strdataJ + jstart;
+  for (TJ i = 0; i < jlen; ++i) {
+    if (i == xlen) return 1;  // jstr is shorter than xstr
+    uint8_t ch1 = xstr[i];
+    uint8_t ch2 = jstr[i];
     if (ch1 != ch2) {
       return 1 - 2*(ch1 < ch2);
     }
   }
-  return -(len1 != len2);
+  return -(jlen != xlen);
 }
 
 
-template <typename T, typename U>
-int StringCmp<T, U>::set_row(size_t row) {
-  end2 = offsets2[row];
-  start2 = offsets2[row - 1] & ~GETNA<U>();
+template <typename TX, typename TJ>
+int StringCmp<TX, TJ>::set_xrow(size_t row) {
+  xend   = offsetsX[row];
+  xstart = offsetsX[row - 1] & ~GETNA<TX>();
   return 0;
 }
 
@@ -343,12 +349,12 @@ static size_t binsearch(Cmp* cmp, size_t nrows) {
   while (start < end) {
     // We won't ever have as many rows for this to overflow
     size_t mid = (start + end) >> 1;
-    int r = cmp->cmp(mid);
+    int r = cmp->cmp_jrow(mid);
     if (r > 0) end = mid - 1;
     else if (r < 0) start = mid + 1;
     else return mid;
   }
-  return cmp->cmp(start) == 0? start : NO_MATCH;
+  return cmp->cmp_jrow(start) == 0? start : NO_MATCH;
 }
 
 
@@ -388,13 +394,13 @@ Join two Frames `xdt` and `jdt` on the keys of `jdt`.
   size_t nchunks = std::min(xdt->nrows / 2,
                             static_cast<size_t>(config::nthreads));
 
-  #pragma omp parallel num_threads(nchunks)
+  // #pragma omp parallel num_threads(nchunks)
   {
     MultiCmp comparator(xcols, jcols);
 
-    #pragma omp parallel for
+    // #pragma omp parallel for
     for (size_t i = 0; i < xdt->nrows; ++i) {
-      comparator.set_row(i);
+      comparator.set_xrow(i);
       size_t j = binsearch(&comparator, jdt->nrows);
       result_indices[i] = (j == NO_MATCH)? GETNA<int32_t>()
                                          : static_cast<int32_t>(j);

--- a/c/rowindex_array.cc
+++ b/c/rowindex_array.cc
@@ -286,6 +286,8 @@ void ArrayRowIndexImpl::set_min_max(const dt::array<T>& arr) {
     }
     min = tmin;
     max = tmax;
+    if (min == std::numeric_limits<T>::max() &&
+        max == -std::numeric_limits<T>::max()) min = max = 0;
   }
   xassert(min >= 0 && max >= min);
 }

--- a/c/ztest.cc
+++ b/c/ztest.cc
@@ -6,16 +6,24 @@
 // © H2O.ai 2018
 //------------------------------------------------------------------------------
 #ifdef DTTEST
-#include "ztest.h"
+#include "datatablemodule.h"
+#include "python/args.h"
 #include "utils/exceptions.h"
+#include "ztest.h"
 namespace dttest {
 
 
-void run_tests() {
+static py::PKArgs fn_tests(
+  0, 0, 0, false, false, {},
+  "test_internal",
+  "Run internal tests that check functionality of some internal structures",
+
+[](const py::PKArgs&) -> py::oobj {
   cover_init_FrameInitializationManager_em();
   cover_names_FrameNameProviders();
   cover_names_integrity_checks();
-}
+  return py::None();
+});
 
 
 /**
@@ -43,4 +51,11 @@ void test_assert(const std::function<void(void)>& f,
 
 
 }  // namespace dttest
+
+
+
+void DatatableModule::init_tests() {
+  ADDFN(dttest::fn_tests);
+}
+
 #endif

--- a/c/ztest.h
+++ b/c/ztest.h
@@ -14,7 +14,6 @@
 namespace dttest {
 
 
-void run_tests();
 void test_assert(const std::function<void(void)>&, const std::string&);
 
 void cover_init_FrameInitializationManager_em();

--- a/datatable/graph/join_node.py
+++ b/datatable/graph/join_node.py
@@ -5,6 +5,7 @@
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #-------------------------------------------------------------------------------
 from .dtproxy import g
+from datatable.lib import core
 from datatable.utils.typechecks import TValueError, TTypeError
 
 
@@ -21,19 +22,23 @@ class join:
 
     def execute(self, ee):
         dt = ee.dt
-        xcols = [None] * len(self.joinframe.key)
-        for i, colname in enumerate(self.joinframe.key):
-            try:
-                xcols[i] = dt.colindex(colname)
-            except ValueError:
-                raise TValueError("Key column `%s` does not exist in the "
-                                  "left Frame" % colname)
-            l_ltype = dt.ltypes[xcols[i]]
-            r_ltype = self.joinframe.ltypes[i]
-            if l_ltype != r_ltype:
-                raise TTypeError("Join column `%s` has type %s in the left "
-                                 "Frame, and type %s in the right Frame. "
-                                 % (colname, l_ltype.name, r_ltype.name))
-        jindex = dt.internal.join(ee.rowindex, self.joinframe.internal, xcols)
+        jdt = self.joinframe
+        if len(jdt.key) > 1:
+            jindex = core.natural_join(dt, jdt)
+        else:
+            xcols = [None] * len(jdt.key)
+            for i, colname in enumerate(jdt.key):
+                try:
+                    xcols[i] = dt.colindex(colname)
+                except ValueError:
+                    raise TValueError("Key column `%s` does not exist in the "
+                                      "left Frame" % colname)
+                l_ltype = dt.ltypes[xcols[i]]
+                r_ltype = jdt.ltypes[i]
+                if l_ltype != r_ltype:
+                    raise TTypeError("Join column `%s` has type %s in the left "
+                                     "Frame, and type %s in the right Frame. "
+                                     % (colname, l_ltype.name, r_ltype.name))
+            jindex = dt.internal.join(ee.rowindex, jdt.internal, xcols)
         ee.joinindex = jindex
         g.set_rowindex(jindex)

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -144,6 +144,15 @@ def test_dt_properties(dt0):
     assert sys.getsizeof(dt0) >= dt0.internal.alloc_size
 
 
+
+def test_internal():
+    # Run C++ tests
+    from datatable.lib import core
+    if hasattr(core, "test_internal"):
+        core.test_internal()
+
+
+
 def test_dt_call(dt0, capsys):
     print("before computing dt1")
     dt1 = dt0(timeit=True)

--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -1,8 +1,25 @@
 #!/usr/bin/env python
-# © H2O.ai 2018; -*- encoding: utf-8 -*-
-#   This Source Code Form is subject to the terms of the Mozilla Public
-#   License, v. 2.0. If a copy of the MPL was not distributed with this
-#   file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -*- coding: utf-8 -*-
+#-------------------------------------------------------------------------------
+# Copyright 2018 H2O.ai
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
 #-------------------------------------------------------------------------------
 import datatable as dt
 import pytest
@@ -153,7 +170,6 @@ def test_join_multi():
 
 @pytest.mark.parametrize("seed", [random.getrandbits(32) for _ in range(10)])
 def test_join_multi_random(seed):
-    seed = 1806372749
     num_stypes = [dt.int8, dt.int16, dt.int32, dt.int64, dt.float32, dt.float64]
     str_stypes = [dt.str32, dt.str64]
     src0 = [False, True, None]
@@ -162,6 +178,7 @@ def test_join_multi_random(seed):
     src3 = list("abcdefg?") + [None]
     all_srcs = [src0, src1, src2, src3]
     all_stypes = [num_stypes, num_stypes, num_stypes, str_stypes]
+
     random.seed(seed)
     nkeys = random.randint(2, 4)
     isrcs = [random.randint(0, 3) for _ in range(nkeys)]
@@ -178,7 +195,6 @@ def test_join_multi_random(seed):
     jframe.key = jframe.names[:nkeys]
 
     xnrows = int(random.expovariate(0.001) + 5)
-    xnrows = 10
     xstypes = [random.choice(all_stypes[t]) for t in isrcs]
     xsrcrows = [tuple(random.choice(s) for s in jcolsources)
                 for i in range(xnrows)]
@@ -187,9 +203,5 @@ def test_join_multi_random(seed):
     jdict = {jsrcrows[i]: jvalcol[i] for i in range(jnrows)}
     rescol = [jdict.get(xsrcrows[i], None) for i in range(xnrows)]
 
-    print("\n  Joining xframe %r" % (xframe.stypes,))
-    print("  to jframe %r" % (jframe.stypes,))
-    print("    X = %r" % list(zip(*xframe.to_list())))
-    print("    J = %r" % list(zip(*jframe.to_list())))
     joinframe = xframe[:, :, join(jframe)]
     assert joinframe[:, "V"].to_list()[0] == rescol

--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -153,7 +153,7 @@ def test_join_multi():
 
 @pytest.mark.parametrize("seed", [random.getrandbits(32) for _ in range(1)])
 def test_join_multi_random(seed):
-    seed = 4149349689
+    seed = 3820049749
     num_stypes = [dt.int8, dt.int16, dt.int32, dt.int64, dt.float32, dt.float64]
     str_stypes = [dt.str32, dt.str64]
     src0 = [False, True, None]

--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -153,7 +153,7 @@ def test_join_multi():
 
 @pytest.mark.parametrize("seed", [random.getrandbits(32) for _ in range(1)])
 def test_join_multi_random(seed):
-    seed = 222247507
+    seed = 4149349689
     num_stypes = [dt.int8, dt.int16, dt.int32, dt.int64, dt.float32, dt.float64]
     str_stypes = [dt.str32, dt.str64]
     src0 = [False, True, None]
@@ -189,5 +189,7 @@ def test_join_multi_random(seed):
 
     print("\n  Joining xframe %r" % (xframe.stypes,))
     print("  to jframe %r" % (jframe.stypes,))
+    print("    X = %r" % list(zip(*xframe.to_list())))
+    print("    J = %r" % list(zip(*jframe.to_list())))
     joinframe = xframe[:, :, join(jframe)]
     assert joinframe[:, "V"].to_list()[0] == rescol

--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -151,8 +151,9 @@ def test_join_multi():
                               "goo", "blah", "zoe", "goo"]]
 
 
-@pytest.mark.parametrize("seed", [random.getrandbits(32) for _ in range(10)])
+@pytest.mark.parametrize("seed", [random.getrandbits(32) for _ in range(1)])
 def test_join_multi_random(seed):
+    seed = 222247507
     num_stypes = [dt.int8, dt.int16, dt.int32, dt.int64, dt.float32, dt.float64]
     str_stypes = [dt.str32, dt.str64]
     src0 = [False, True, None]
@@ -177,6 +178,7 @@ def test_join_multi_random(seed):
     jframe.key = jframe.names[:nkeys]
 
     xnrows = int(random.expovariate(0.001) + 5)
+    xnrows = 10
     xstypes = [random.choice(all_stypes[t]) for t in isrcs]
     xsrcrows = [tuple(random.choice(s) for s in jcolsources)
                 for i in range(xnrows)]
@@ -185,5 +187,7 @@ def test_join_multi_random(seed):
     jdict = {jsrcrows[i]: jvalcol[i] for i in range(jnrows)}
     rescol = [jdict.get(xsrcrows[i], None) for i in range(xnrows)]
 
+    print("\n  Joining xframe %r" % (xframe.stypes,))
+    print("  to jframe %r" % (jframe.stypes,))
     joinframe = xframe[:, :, join(jframe)]
     assert joinframe[:, "V"].to_list()[0] == rescol

--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -134,3 +134,18 @@ def test_join_and_select_g_col():
     assert R.stypes == (stype.str32,)
     # assert R.names == ("c",)   # not working yet
     assert R.topython() == [[None, "bar", "foo"]]
+
+
+def test_join_multi():
+    fr1 = dt.Frame(A=[1, 2, 1, 2],
+                   B=[3, 3, 4, 4],
+                   C=["goo", "blah", "zoe", "rij"])
+    fr1.key = ("A", "B")
+    fr2 = dt.Frame([[1, 2, 3, 2, 3, 1, 2, 1, 1],
+                    [3, 4, 5, 4, 3, 3, 3, 4, 3]], names=("A", "B"))
+    res = fr2[:, :, join(fr1)]
+    assert res.names == ("A", "B", "C")
+    assert res.to_list() == [[1, 2, 3, 2, 3, 1, 2, 1, 1],
+                             [3, 4, 5, 4, 3, 3, 3, 4, 3],
+                             ["goo", "rij", None, "rij", None,
+                              "goo", "blah", "zoe", "goo"]]

--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -151,9 +151,9 @@ def test_join_multi():
                               "goo", "blah", "zoe", "goo"]]
 
 
-@pytest.mark.parametrize("seed", [random.getrandbits(32) for _ in range(1)])
+@pytest.mark.parametrize("seed", [random.getrandbits(32) for _ in range(10)])
 def test_join_multi_random(seed):
-    seed = 3820049749
+    seed = 1806372749
     num_stypes = [dt.int8, dt.int16, dt.int32, dt.int64, dt.float32, dt.float64]
     str_stypes = [dt.str32, dt.str64]
     src0 = [False, True, None]


### PR DESCRIPTION
Implement (natural) join on multiple columns. The join frame should be keyed on multiple columns, and then the syntax for the join is exactly the same as before:
```
DT1[:, :, join(DT2)]
```

The columns being joined can have different stypes, except that the join of integers/floats to string columns is not allowed.

Additional changes:
- internal C++ tests must now be invoked explicitly, rather than running automatically at startup. This makes it easier to set up breakpoints in lldb;
- fixed typo in error message in getset.cc;
- fixed bug in rowindex_array, when the array contained only NA values.

Closes #1353