### PR TITLE
clean up of "python" sub-module

### DIFF
--- a/c/column.h
+++ b/c/column.h
@@ -91,8 +91,8 @@ public:
   static Column* new_mbuf_column(SType, MemoryRange&&, MemoryRange&&);
   static Column* from_pylist(const py::olist& list, int stype0 = 0);
   static Column* from_pylist_of_tuples(const py::olist& list, size_t index, int stype0);
-  static Column* from_pylist_of_dicts(const py::olist& list, py::obj name, int stype0);
-  static Column* from_buffer(const py::obj& buffer);
+  static Column* from_pylist_of_dicts(const py::olist& list, py::robj name, int stype0);
+  static Column* from_buffer(const py::robj& buffer);
   static Column* from_range(int64_t start, int64_t stop, int64_t step, SType s);
 
   Column(const Column&) = delete;

--- a/c/column_from_pylist.cc
+++ b/c/column_from_pylist.cc
@@ -56,8 +56,8 @@ class ituplist : public iterable {
 
 class idictlist : public iterable {
   private:
-    const py::olist& dict_list;
     const py::robj key;
+    std::vector<py::rdict> dict_list;
 
   public:
     idictlist(const py::olist& src, py::robj name);
@@ -88,13 +88,18 @@ py::robj ituplist::item(size_t i) const {
 }
 
 
-idictlist::idictlist(const py::olist& src, py::robj name)
-    : dict_list(src), key(name) {}
+idictlist::idictlist(const py::olist& src, py::robj name) : key(name) {
+  for (size_t i = 0; i < src.size(); ++i) {
+    dict_list.push_back(src[i].to_rdict());
+  }
+}
 
-size_t idictlist::size() const { return dict_list.size(); }
+size_t idictlist::size() const {
+  return dict_list.size();
+}
 
 py::robj idictlist::item(size_t i) const {
-  return py::rdict(dict_list[i]).get_or_none(key);
+  return dict_list[i].get_or_none(key);
 }
 
 

--- a/c/column_from_pylist.cc
+++ b/c/column_from_pylist.cc
@@ -198,7 +198,7 @@ static bool parse_as_int(const iterable* list, MemoryRange& membuf, size_t& from
       }
       if (item.is_int()) {
         py::oint litem = item.to_pyint();
-        outdata[i] = litem.value<T>(&overflow);
+        outdata[i] = litem.ovalue<T>(&overflow);
         if (!overflow) continue;
       }
       from = i;
@@ -232,7 +232,7 @@ static void force_as_int(const iterable* list, MemoryRange& membuf)
       continue;
     }
     py::oint litem = item.to_pyint_force();
-    outdata[i] = litem.masked_value<T>();
+    outdata[i] = litem.mvalue<T>();
   }
 }
 
@@ -266,7 +266,7 @@ static bool parse_as_double(const iterable* list, MemoryRange& membuf, size_t& f
       }
       if (item.is_int()) {
         py::oint litem = item.to_pyint();
-        outdata[i] = litem.value<double>(&overflow);
+        outdata[i] = litem.ovalue<double>(&overflow);
         continue;
       }
       if (item.is_float()) {
@@ -299,7 +299,7 @@ static void force_as_real(const iterable* list, MemoryRange& membuf)
     }
     if (item.is_int()) {
       py::oint litem = item.to_pyint();
-      outdata[i] = litem.value<T>(&overflow);
+      outdata[i] = litem.ovalue<T>(&overflow);
       continue;
     }
     py::ofloat fitem = item.to_pyfloat_force();

--- a/c/column_pyobj.cc
+++ b/c/column_pyobj.cc
@@ -158,7 +158,7 @@ inline static MemoryRange cast_str_helper(
   OT offset = 0;
   toffsets[-1] = 0;
   for (size_t i = 0; i < nrows; ++i) {
-    py::ostring xstr = py::obj(src[i]).to_pystring_force();
+    py::ostring xstr = py::robj(src[i]).to_pystring_force();
     CString xcstr = xstr.to_cstring();
     if (xcstr.ch) {
       wb->write(static_cast<size_t>(xcstr.size), xcstr.ch);

--- a/c/csv/py_csv.cc
+++ b/c/csv/py_csv.cc
@@ -25,7 +25,7 @@ PyObject* write_csv(PyObject*, PyObject* args)
 {
   PyObject* arg1;
   if (!PyArg_ParseTuple(args, "O:write_csv", &arg1)) return nullptr;
-  py::obj pywr(arg1);
+  py::robj pywr(arg1);
 
   DataTable* dt = pywr.get_attr("datatable").to_frame();
   auto filename = pywr.get_attr("path").to_string();
@@ -84,7 +84,7 @@ PyObject* gread(PyObject*, PyObject* args)
 {
   PyObject* arg1;
   if (!PyArg_ParseTuple(args, "O:gread", &arg1)) return nullptr;
-  py::obj pyreader(arg1);
+  py::robj pyreader(arg1);
 
   GenericReader rdr(pyreader);
   std::unique_ptr<DataTable> dtptr = rdr.read();

--- a/c/csv/reader.cc
+++ b/c/csv/reader.cc
@@ -25,7 +25,7 @@
 // GenericReader initialization
 //------------------------------------------------------------------------------
 
-GenericReader::GenericReader(const py::obj& pyrdr)
+GenericReader::GenericReader(const py::robj& pyrdr)
 {
   sof = nullptr;
   eof = nullptr;
@@ -770,7 +770,7 @@ void GenericReader::report_columns_to_python() {
 
     if (newTypesList) {
       for (size_t i = 0; i < ncols; i++) {
-        py::obj elem = newTypesList[i];
+        py::robj elem = newTypesList[i];
         columns[i].set_rtype(elem.to_int64());
       }
     }

--- a/c/csv/reader.h
+++ b/c/csv/reader.h
@@ -9,7 +9,7 @@
 #define dt_CSV_READER_h
 #include <memory>           // std::unique_ptr
 #include "memrange.h"       // MemoryRange
-#include "python/obj.h"     // py::obj, py::oobj
+#include "python/obj.h"     // py::robj, py::oobj
 #include "read/columns.h"   // dt::read::Columns
 
 class DataTable;
@@ -108,7 +108,7 @@ class GenericReader
 
   //---- Public API ----
   public:
-    GenericReader(const py::obj& pyreader);
+    GenericReader(const py::robj& pyreader);
     GenericReader& operator=(const GenericReader&) = delete;
     virtual ~GenericReader();
 

--- a/c/datatable.cc
+++ b/c/datatable.cc
@@ -20,7 +20,7 @@
 //------------------------------------------------------------------------------
 
 DataTable::DataTable()
-  : nrows(0), ncols(0), nkeys(0), py_inames(nullptr) {}
+  : nrows(0), ncols(0), nkeys(0) {}
 
 
 DataTable::DataTable(colvec&& cols) : DataTable()

--- a/c/expr/py_expr.cc
+++ b/c/expr/py_expr.cc
@@ -19,8 +19,8 @@ PyObject* expr_binaryop(PyObject*, PyObject* args)
   PyObject* arg2;
   if (!PyArg_ParseTuple(args, "iOO:expr_binaryop", &opcode, &arg1, &arg2))
     return nullptr;
-  py::obj py_lhs(arg1);
-  py::obj py_rhs(arg2);
+  py::robj py_lhs(arg1);
+  py::robj py_rhs(arg2);
 
   Column* lhs = py_lhs.to_column();
   Column* rhs = py_rhs.to_column();
@@ -35,7 +35,7 @@ PyObject* expr_cast(PyObject*, PyObject* args)
   PyObject* arg1;
   if (!PyArg_ParseTuple(args, "Oi:expr_cast", &arg1, &stype))
     return nullptr;
-  py::obj pyarg(arg1);
+  py::robj pyarg(arg1);
 
   Column* col = pyarg.to_column();
   col->reify();
@@ -50,8 +50,8 @@ PyObject* expr_column(PyObject*, PyObject* args)
   PyObject* arg1, *arg3;
   if (!PyArg_ParseTuple(args, "OlO:expr_column", &arg1, &index, &arg3))
     return nullptr;
-  py::obj pyarg1(arg1);
-  py::obj pyarg3(arg3);
+  py::robj pyarg1(arg1);
+  py::robj pyarg3(arg3);
   DataTable* dt = pyarg1.to_frame();
   RowIndex ri = pyarg3.to_rowindex();
 
@@ -70,8 +70,8 @@ PyObject* expr_reduceop(PyObject*, PyObject* args)
   PyObject* arg1, *arg2;
   if (!PyArg_ParseTuple(args, "iOO:expr_reduceop", &opcode, &arg1, &arg2))
     return nullptr;
-  py::obj pyarg1(arg1);
-  py::obj pyarg2(arg2);
+  py::robj pyarg1(arg1);
+  py::robj pyarg2(arg2);
 
   Column* col = pyarg1.to_column();
   Groupby* grpby = pyarg2.to_groupby();
@@ -92,8 +92,8 @@ PyObject* expr_count(PyObject*, PyObject* args)
   if (!PyArg_ParseTuple(args, "OO:expr_count", &arg1, &arg2))
     return nullptr;
 
-  DataTable* dt = py::obj(arg1).to_frame();
-  Groupby* grpby = py::obj(arg2).to_groupby();
+  DataTable* dt = py::robj(arg1).to_frame();
+  Groupby* grpby = py::robj(arg2).to_groupby();
 
   Column* res = nullptr;
 
@@ -126,7 +126,7 @@ PyObject* expr_unaryop(PyObject*, PyObject* args)
   PyObject* arg1;
   if (!PyArg_ParseTuple(args, "iO:expr_isna", &opcode, &arg1))
     return nullptr;
-  py::obj pyarg1(arg1);
+  py::robj pyarg1(arg1);
 
   Column* col = pyarg1.to_column();
   Column* res = expr::unaryop(opcode, col);

--- a/c/frame/getset.cc
+++ b/c/frame/getset.cc
@@ -21,16 +21,16 @@
 namespace py {
 
 // Sentinel value for __getitem__() mode
-static obj GETITEM(reinterpret_cast<PyObject*>(-1));
+static robj GETITEM(reinterpret_cast<PyObject*>(-1));
 
 
 
 
-oobj Frame::m__getitem__(obj item) {
+oobj Frame::m__getitem__(robj item) {
   return _fast_getset(item, GETITEM);
 }
 
-void Frame::m__setitem__(obj item, obj value) {
+void Frame::m__setitem__(robj item, robj value) {
   _fast_getset(item, value);
 }
 
@@ -43,11 +43,11 @@ void Frame::m__setitem__(obj item, obj value) {
  * This case should also be handled first, to ensure that it has maximum
  * performance.
  */
-oobj Frame::_fast_getset(obj item, obj value) {
+oobj Frame::_fast_getset(robj item, robj value) {
   if (item.is_tuple()) {
     rtuple targs(item);
     if (targs.size() == 2 && value == GETITEM) {
-      obj arg0 = targs[0], arg1 = targs[1];
+      robj arg0 = targs[0], arg1 = targs[1];
       bool a0int = arg0.is_int();
       bool a1int = arg1.is_int();
       if (a0int && (a1int || arg1.is_string())) {
@@ -86,15 +86,15 @@ oobj Frame::_fast_getset(obj item, obj value) {
 }
 
 
-oobj Frame::_main_getset(obj item, obj value) {
+oobj Frame::_main_getset(robj item, robj value) {
   return _fallback_getset(item, value);
 }
 
 
-oobj Frame::_fallback_getset(obj item, obj value) {
+oobj Frame::_fallback_getset(robj item, robj value) {
   odict kwargs;
   otuple args(5);
-  args.set(0, py::obj(this));
+  args.set(0, py::robj(this));
   if (item.is_tuple()) {
     otuple argslist = item.to_pytuple();
     size_t n = argslist.size();
@@ -125,7 +125,7 @@ oobj Frame::_fallback_getset(obj item, obj value) {
   } else {
     kwargs.set(ostring("mode"), ostring("delete"));
   }
-  return obj(py::fallback_makedatatable).call(args, kwargs);
+  return robj(py::fallback_makedatatable).call(args, kwargs);
 }
 
 

--- a/c/frame/key.cc
+++ b/c/frame/key.cc
@@ -39,7 +39,7 @@ py::oobj py::Frame::get_key() const {
 }
 
 
-void py::Frame::set_key(obj val) {
+void py::Frame::set_key(py::robj val) {
   if (val.is_none()) {
     return dt->clear_key();
   }
@@ -51,7 +51,7 @@ void py::Frame::set_key(obj val) {
   else if (val.is_list_or_tuple()) {
     py::olist vallist = val.to_pylist();
     for (size_t i = 0; i < vallist.size(); ++i) {
-      py::obj item = vallist[i];
+      py::robj item = vallist[i];
       if (vallist[i].is_string()) {
         size_t index = dt->xcolindex(vallist[i]);
         col_indices.push_back(index);

--- a/c/frame/names.cc
+++ b/c/frame/names.cc
@@ -72,7 +72,7 @@ size_t pylistNP::size() const {
 }
 
 CString pylistNP::item_as_cstring(size_t i) {
-  py::obj name = names[i];
+  py::robj name = names[i];
   if (!name.is_string() && !name.is_none()) {
     throw TypeError() << "Invalid `names` list: element " << i
         << " is not a string";
@@ -154,7 +154,7 @@ oobj Frame::get_names() const {
 }  // LCOV_EXCL_LINE
 
 
-void Frame::set_names(obj arg)
+void Frame::set_names(robj arg)
 {
   if (arg.is_undefined() || arg.is_none()) {
     dt->set_names_to_default();
@@ -279,7 +279,7 @@ py::otuple DataTable::get_pynames() const {
  */
 int64_t DataTable::colindex(const py::_obj& pyname) const {
   if (!py_inames) _init_pynames();
-  py::obj pyindex = py_inames.get(pyname);
+  py::robj pyindex = py_inames.get(pyname);
   return pyindex? pyindex.to_int64_strict() : -1;
 }
 
@@ -290,7 +290,7 @@ int64_t DataTable::colindex(const py::_obj& pyname) const {
  */
 size_t DataTable::xcolindex(const py::_obj& pyname) const {
   if (!py_inames) _init_pynames();
-  py::obj pyindex = py_inames.get(pyname);
+  py::robj pyindex = py_inames.get(pyname);
   if (!pyindex) {
     throw _name_not_found_error(this, pyname.to_string());
   }
@@ -346,9 +346,9 @@ void DataTable::replace_names(py::odict replacements) {
     newnames.set(i, py_names[i]);
   }
   for (auto kv : replacements) {
-    py::obj key = kv.first;
-    py::obj val = kv.second;
-    py::obj idx = py_inames.get(key);
+    py::robj key = kv.first;
+    py::robj val = kv.second;
+    py::robj idx = py_inames.get(key);
     if (idx.is_undefined()) {
       throw ValueError() << "Cannot find column `" << key.str()
         << "` in the Frame";
@@ -375,7 +375,7 @@ void DataTable::reorder_names(const std::vector<size_t>& col_indices) {
   if (py_names) {
     py::otuple new_py_names(ncols);
     for (size_t i = 0; i < ncols; ++i) {
-      py::obj pyname = py_names[col_indices[i]];
+      py::robj pyname = py_names[col_indices[i]];
       new_py_names.set(i, pyname);
       py_inames.set(pyname, py::oint(i));
     }
@@ -614,7 +614,7 @@ void DataTable::_integrity_check_pynames() const {
       << " elements, while the Frame has " << ncols << " columns";
   }
   for (size_t i = 0; i < ncols; ++i) {
-    py::obj elem = py_names[i];
+    py::robj elem = py_names[i];
     if (!elem.is_string()) {
       throw AssertionError() << "Element " << i << " of .py_names is a "
           << elem.typeobj();
@@ -624,7 +624,7 @@ void DataTable::_integrity_check_pynames() const {
       throw AssertionError() << "Element " << i << " of .py_names is '"
           << sname << "', but the actual column name is '" << names[i] << "'";
     }
-    py::obj res = py_inames.get(elem);
+    py::robj res = py_inames.get(elem);
     if (!res) {
       throw AssertionError() << "Column " << i << " '" << names[i] << "' is "
           "absent from the .py_inames dictionary";

--- a/c/frame/py_frame.cc
+++ b/c/frame/py_frame.cc
@@ -171,7 +171,7 @@ oobj Frame::get_nrows() const {
   return py::oint(dt->nrows);
 }
 
-void Frame::set_nrows(obj nr) {
+void Frame::set_nrows(py::robj nr) {
   if (!nr.is_int()) {
     throw TypeError() << "Number of rows must be an integer, not "
         << nr.typeobj();

--- a/c/frame/py_frame.h
+++ b/c/frame/py_frame.h
@@ -67,8 +67,8 @@ class Frame : public PyObject {
     void m__dealloc__();
     void m__get_buffer__(Py_buffer* buf, int flags) const;
     void m__release_buffer__(Py_buffer* buf) const;
-    oobj m__getitem__(obj item);
-    void m__setitem__(obj item, obj value);
+    oobj m__getitem__(robj item);
+    void m__setitem__(robj item, robj value);
 
     oobj _repr_html_(const NoArgs&);
     oobj get_ncols() const;
@@ -79,10 +79,10 @@ class Frame : public PyObject {
     oobj get_names() const;
     oobj get_key() const;
     oobj get_internal() const;
-    void set_nrows(obj);
-    void set_names(obj);
-    void set_key(obj);
-    void set_internal(obj);
+    void set_nrows(robj);
+    void set_names(robj);
+    void set_key(robj);
+    void set_internal(robj);
 
     void cbind(const PKArgs&);
     oobj colindex(const PKArgs&);
@@ -101,9 +101,9 @@ class Frame : public PyObject {
     void _replace_names_from_map(py::odict);
 
     // getitem / setitem support
-    oobj _fast_getset(obj item, obj value);
-    oobj _main_getset(obj item, obj value);
-    oobj _fallback_getset(obj item, obj value);
+    oobj _fast_getset(robj item, robj value);
+    oobj _main_getset(robj item, robj value);
+    oobj _fallback_getset(robj item, robj value);
 
     friend void pydatatable::_clear_types(pydatatable::obj*); // temp
     friend PyObject* pydatatable::check(pydatatable::obj*, PyObject*); // temp

--- a/c/frame/py_frame_init.cc
+++ b/c/frame/py_frame_init.cc
@@ -213,7 +213,7 @@ class FrameInitializationManager {
           throw TypeError() << "The source is not a list of dicts: element "
               << i << " is a " << item.typeobj();
         }
-        py::rdict row(item);
+        py::rdict row = item.to_rdict();
         for (auto kv : row) {
           py::robj& name = kv.first;
           if (!namesset.has(name)) {

--- a/c/frame/py_frame_init.cc
+++ b/c/frame/py_frame_init.cc
@@ -94,7 +94,7 @@ class FrameInitializationManager {
         if (collist.size() == 0) {
           return init_empty_frame();
         }
-        py::obj item0 = collist[0];
+        py::robj item0 = collist[0];
         if (item0.is_list() || item0.is_range() || item0.is_buffer()) {
           return init_from_list_of_lists();
         }
@@ -170,7 +170,7 @@ class FrameInitializationManager {
       check_names_count(collist.size());
       check_stypes_count(collist.size());
       for (size_t i = 0; i < collist.size(); ++i) {
-        py::obj item = collist[i];
+        py::robj item = collist[i];
         SType s = get_stype_for_column(i);
         make_column(item, s);
       }
@@ -186,7 +186,7 @@ class FrameInitializationManager {
       size_t ncols = nameslist.size();
       check_stypes_count(ncols);
       for (size_t i = 0; i < nrows; ++i) {
-        py::obj item = srclist[i];
+        py::robj item = srclist[i];
         if (!item.is_dict()) {
           throw TypeError() << "The source is not a list of dicts: element "
               << i << " is a " << item.typeobj();
@@ -208,14 +208,14 @@ class FrameInitializationManager {
       py::oset  namesset;
       size_t nrows = srclist.size();
       for (size_t i = 0; i < nrows; ++i) {
-        py::obj item = srclist[i];
+        py::robj item = srclist[i];
         if (!item.is_dict()) {
           throw TypeError() << "The source is not a list of dicts: element "
               << i << " is a " << item.typeobj();
         }
         py::rdict row(item);
         for (auto kv : row) {
-          py::obj& name = kv.first;
+          py::robj& name = kv.first;
           if (!namesset.has(name)) {
             if (!name.is_string()) {
               throw TypeError() << "Invalid data in Frame() constructor: row "
@@ -235,7 +235,7 @@ class FrameInitializationManager {
       py::olist srclist = src.to_pylist();
       size_t ncols = nameslist.size();
       for (size_t j = 0; j < ncols; ++j) {
-        py::obj name = nameslist[j];
+        py::robj name = nameslist[j];
         SType s = get_stype_for_column(j, &name);
         Column* col = Column::from_pylist_of_dicts(srclist, name, int(s));
         cols.push_back(col);
@@ -253,7 +253,7 @@ class FrameInitializationManager {
       check_stypes_count(ncols);
       // Check that all entries are proper tuples
       for (size_t i = 0; i < nrows; ++i) {
-        py::obj item = srclist[i];
+        py::robj item = srclist[i];
         if (!item.is_tuple()) {
           throw TypeError() << "The source is not a list of tuples: element "
               << i << " is a " << item.typeobj();
@@ -301,7 +301,7 @@ class FrameInitializationManager {
       newnames.reserve(ncols);
       for (auto kv : coldict) {
         size_t i = newnames.size();
-        py::obj name = kv.first;
+        py::robj name = kv.first;
         SType stype = get_stype_for_column(i, &name);
         newnames.push_back(name.to_string());
         make_column(kv.second, stype);
@@ -360,7 +360,7 @@ class FrameInitializationManager {
       py::otuple call_args(1);
       call_args.set(0, src.to_pyobj());
 
-      py::oobj res = py::obj(py::fread_fn).call(call_args);
+      py::oobj res = py::robj(py::fread_fn).call(call_args);
       if (res.is_frame()) {
         Frame* resframe = static_cast<Frame*>(res.to_borrowed_ref());
         std::swap(frame->dt,      resframe->dt);
@@ -388,7 +388,7 @@ class FrameInitializationManager {
         throw TypeError() << "Argument `stypes` is not supported in Frame() "
             "constructor when creating a Frame from pandas DataFrame";
       }
-      py::obj pdsrc = src.to_pyobj();
+      py::robj pdsrc = src.to_pyobj();
       py::olist colnames(0);
       if (src.is_pandas_frame()) {
         py::oiter pdcols = pdsrc.get_attr("columns").to_pyiter();
@@ -530,7 +530,7 @@ class FrameInitializationManager {
           return stypes[i].to_stype();
         }
         else {
-          py::obj oname(nullptr);
+          py::robj oname(nullptr);
           if (name == nullptr) {
             if (!defined_names) {
               throw TypeError() << "When parameter `stypes` is a dictionary, "
@@ -542,7 +542,7 @@ class FrameInitializationManager {
             oname = *name;
           }
           py::odict stypes = stypes_arg.to_pydict();
-          py::obj res = stypes.get(oname);
+          py::robj res = stypes.get(oname);
           if (res) {
             return res.to_stype();
           } else {
@@ -579,7 +579,7 @@ class FrameInitializationManager {
     }
 
 
-    void make_column(py::obj colsrc, SType s) {
+    void make_column(py::robj colsrc, SType s) {
       Column* col = nullptr;
       if (colsrc.is_buffer()) {
         col = Column::from_buffer(colsrc);

--- a/c/frame/replace.cc
+++ b/c/frame/replace.cc
@@ -86,7 +86,7 @@ class ReplaceAgent {
   private:
     DataTable* dt;
     // vx, vy are simple lists of source/target values for replacement
-    std::vector<py::obj> vx, vy;
+    std::vector<py::robj> vx, vy;
 
     std::vector<int8_t> x_bool, y_bool;
     std::vector<int64_t> x_int, y_int;
@@ -265,8 +265,8 @@ void ReplaceAgent::split_x_y_by_type() {
 void ReplaceAgent::split_x_y_bool() {
   size_t n = vx.size();
   for (size_t i = 0; i < n; ++i) {
-    py::obj xelem = vx[i];
-    py::obj yelem = vy[i];
+    py::robj xelem = vx[i];
+    py::robj yelem = vy[i];
     if (xelem.is_none()) {
       if (yelem.is_none()) continue;
       if (!yelem.is_bool()) continue;
@@ -292,8 +292,8 @@ void ReplaceAgent::split_x_y_int() {
   xmin_int = std::numeric_limits<int64_t>::max();
   xmax_int = -xmin_int;
   for (size_t i = 0; i < n; ++i) {
-    py::obj xelem = vx[i];
-    py::obj yelem = vy[i];
+    py::robj xelem = vx[i];
+    py::robj yelem = vy[i];
     if (xelem.is_none()) {
       if (yelem.is_none() || !yelem.is_int()) continue;
       na_repl = yelem.to_int64();
@@ -325,8 +325,8 @@ void ReplaceAgent::split_x_y_real() {
   xmin_real = std::numeric_limits<double>::max();
   xmax_real = -xmin_real;
   for (size_t i = 0; i < n; ++i) {
-    py::obj xelem = vx[i];
-    py::obj yelem = vy[i];
+    py::robj xelem = vx[i];
+    py::robj yelem = vy[i];
     if (xelem.is_none()) {
       if (yelem.is_none() || !yelem.is_float()) continue;
       na_repl = yelem.to_double();
@@ -360,8 +360,8 @@ void ReplaceAgent::split_x_y_str() {
   size_t n = vx.size();
   CString na_repl;
   for (size_t i = 0; i < n; ++i) {
-    py::obj xelem = vx[i];
-    py::obj yelem = vy[i];
+    py::robj xelem = vx[i];
+    py::robj yelem = vy[i];
     if (xelem.is_none()) {
       if (yelem.is_none() || !yelem.is_string()) continue;
       na_repl = yelem.to_cstring();

--- a/c/frame/replace.cc
+++ b/c/frame/replace.cc
@@ -168,9 +168,9 @@ void ReplaceAgent::parse_x_y(const Arg& x, const Arg& y) {
   if (x.is_dict()) {
     if (y) {
       throw TypeError() << "When the first argument to Frame.replace() is a "
-        "dict, there should be no second argument";
+        "dictionary, there should be no other arguments";
     }
-    for (auto kv : rdict(x)) {
+    for (const auto kv : x.to_rdict()) {
       vx.push_back(kv.first);
       vy.push_back(kv.second);
     }

--- a/c/options.cc
+++ b/c/options.cc
@@ -105,7 +105,7 @@ static py::PKArgs args_set_option(
 
 [](const py::PKArgs& args) -> py::oobj {
   std::string name = args[0].to_string();
-  py::obj value = args[1];
+  py::robj value = args[1];
 
   if (name == "nthreads") {
     set_nthreads(value.to_int32_strict());

--- a/c/py_buffers.cc
+++ b/c/py_buffers.cc
@@ -64,7 +64,7 @@ static char strB[] = "B";
 // Construct a DataTable from a list of objects implementing Buffers protocol
 //------------------------------------------------------------------------------
 
-Column* Column::from_buffer(const py::obj& obuffer)
+Column* Column::from_buffer(const py::robj& obuffer)
 {
   PyObject* buffer = obuffer.to_borrowed_ref();
   Py_buffer* view = static_cast<Py_buffer*>(std::calloc(1, sizeof(Py_buffer)));
@@ -97,7 +97,7 @@ Column* Column::from_buffer(const py::obj& obuffer)
   // If buffer is in float16 format, convert it to float32
   if (view->itemsize == 2 && std::strcmp(view->format, "e") == 0) {
     PyBuffer_Release(view);
-    py::oobj newbuf = py::obj(buffer).invoke("astype", "(s)", "float32");
+    py::oobj newbuf = py::robj(buffer).invoke("astype", "(s)", "float32");
     return Column::from_buffer(newbuf);
   }
 

--- a/c/py_column.cc
+++ b/c/py_column.cc
@@ -45,7 +45,7 @@ PyObject* column_from_list(PyObject*, PyObject* args) {
   PyObject* arg1;
   int stype = 0;
   if (!PyArg_ParseTuple(args, "O|i", &arg1, &stype)) return nullptr;
-  py::olist list = py::obj(arg1).to_pylist();
+  py::olist list = py::robj(arg1).to_pylist();
 
   Column* col = Column::from_pylist(list, stype);
   return from_column(col, nullptr, 0);
@@ -117,8 +117,8 @@ PyObject* save_to_disk(pycolumn::obj* self, PyObject* args) {
   PyObject* arg2 = nullptr;
   if (!PyArg_ParseTuple(args, "OO:save_to_disk", &arg1, &arg2))
     return nullptr;
-  py::obj pyfilename(arg1);
-  py::obj pystrategy(arg2);
+  py::robj pyfilename(arg1);
+  py::robj pystrategy(arg2);
 
   Column* col = self->ref;
   const char* filename = pyfilename.to_cstring().ch;
@@ -136,7 +136,7 @@ PyObject* ungroup(pycolumn::obj* self, PyObject* args)
 {
   PyObject* arg1 = nullptr;
   if (!PyArg_ParseTuple(args, "O:ungroup", &arg1)) return nullptr;
-  py::obj pygby(arg1);
+  py::robj pygby(arg1);
 
   Column* col = self->ref;
   Groupby* groupby = pygby.to_groupby();
@@ -154,7 +154,7 @@ PyObject* ungroup(pycolumn::obj* self, PyObject* args)
 PyObject* replace_rowindex(pycolumn::obj* self, PyObject* args) {
   PyObject* arg1;
   if (!PyArg_ParseTuple(args, "O:replace_rowindex", &arg1)) return nullptr;
-  RowIndex newri = py::obj(arg1).to_rowindex();
+  RowIndex newri = py::robj(arg1).to_rowindex();
 
   Column* col = self->ref;
   self->ref = col->shallowcopy(newri);

--- a/c/py_columnset.cc
+++ b/c/py_columnset.cc
@@ -60,8 +60,8 @@ PyObject* columns_from_slice(PyObject*, PyObject *args) {
   if (!PyArg_ParseTuple(args, "OOLLL:columns_from_slice",
                         &arg1, &arg2, &start, &count, &step))
     return nullptr;
-  DataTable* dt = py::obj(arg1).to_frame();
-  RowIndex rowindex = py::obj(arg2).to_rowindex();
+  DataTable* dt = py::robj(arg1).to_frame();
+  RowIndex rowindex = py::robj(arg2).to_rowindex();
 
   Column** columns = columns_from_slice(dt, rowindex, start, count, step);
   PyObject* res = wrap(columns, static_cast<size_t>(count));
@@ -77,8 +77,8 @@ PyObject* columns_from_mixed(PyObject*, PyObject *args)
   if (!PyArg_ParseTuple(args, "OOlL:columns_from_mixed",
                         &arg1, &arg2, &nrows, &rawptr))
     return nullptr;
-  py::olist pyspec = py::obj(arg1).to_pylist();
-  DataTable* dt = py::obj(arg2).to_frame();
+  py::olist pyspec = py::robj(arg1).to_pylist();
+  DataTable* dt = py::robj(arg2).to_frame();
 
   columnset_mapfn* fnptr = reinterpret_cast<columnset_mapfn*>(rawptr);
   size_t ncols = pyspec.size();
@@ -129,7 +129,7 @@ PyObject* columns_from_columns(PyObject*, PyObject* args)
 PyObject* to_frame(obj* self, PyObject* args) {
   PyObject* arg1;
   if (!PyArg_ParseTuple(args, "O:to_frame", &arg1)) return nullptr;
-  py::olist names = py::obj(arg1).to_pylist();
+  py::olist names = py::robj(arg1).to_pylist();
 
   std::vector<Column*> columns;
   for (Column** pcol = self->columns; *pcol; pcol++) {

--- a/c/py_datatable.cc
+++ b/c/py_datatable.cc
@@ -87,7 +87,7 @@ PyObject* datatable_load(PyObject*, PyObject* args) {
 
   DataTable* dt = DataTable::load(colspec, nrows, path, recode);
   py::Frame* frame = py::Frame::from_datatable(dt);
-  frame->set_names(py::obj(names));
+  frame->set_names(py::robj(names));
   return frame;
 }
 
@@ -95,7 +95,7 @@ PyObject* datatable_load(PyObject*, PyObject* args) {
 PyObject* open_jay(PyObject*, PyObject* args) {
   PyObject* arg1;
   if (!PyArg_ParseTuple(args, "O:open_jay", &arg1)) return nullptr;
-  std::string filename = py::obj(arg1).to_string();
+  std::string filename = py::robj(arg1).to_string();
 
   DataTable* dt = DataTable::open_jay(filename);
   py::Frame* frame = py::Frame::from_datatable(dt);
@@ -281,7 +281,7 @@ PyObject* delete_columns(obj* self, PyObject* args) {
   PyObject* arg1;
   if (!PyArg_ParseTuple(args, "O:delete_columns", &arg1))
     return nullptr;
-  py::olist list = py::obj(arg1).to_pylist();
+  py::olist list = py::robj(arg1).to_pylist();
   size_t ncols = list.size();
 
   std::vector<size_t> cols_to_remove;
@@ -303,7 +303,7 @@ PyObject* replace_rowindex(obj* self, PyObject* args) {
   PyObject* arg1;
   if (!PyArg_ParseTuple(args, "O:replace_rowindex", &arg1))
     return nullptr;
-  RowIndex newri = py::obj(arg1).to_rowindex();
+  RowIndex newri = py::robj(arg1).to_rowindex();
 
   dt->replace_rowindex(newri);
   Py_RETURN_NONE;
@@ -319,8 +319,8 @@ PyObject* replace_column_slice(obj* self, PyObject* args) {
   PyObject *arg4, *arg5;
   if (!PyArg_ParseTuple(args, "lllOO:replace_column_slice",
                         &start, &count, &step, &arg4, &arg5)) return nullptr;
-  RowIndex rows_ri = py::obj(arg4).to_rowindex();
-  DataTable* repl = py::obj(arg5).to_frame();
+  RowIndex rows_ri = py::robj(arg4).to_rowindex();
+  DataTable* repl = py::robj(arg5).to_frame();
   size_t rrows = repl->nrows;
   size_t rcols = repl->ncols;
   size_t rrows2 = rows_ri? rows_ri.length() : dt->nrows;
@@ -362,9 +362,9 @@ PyObject* replace_column_array(obj* self, PyObject* args) {
   PyObject *arg1, *arg2, *arg3;
   if (!PyArg_ParseTuple(args, "OOO:replace_column_array", &arg1, &arg2, &arg3))
       return nullptr;
-  py::olist cols = py::obj(arg1).to_pylist();
-  RowIndex rows_ri = py::obj(arg2).to_rowindex();
-  DataTable* repl = py::obj(arg3).to_frame();
+  py::olist cols = py::robj(arg1).to_pylist();
+  RowIndex rows_ri = py::robj(arg2).to_rowindex();
+  DataTable* repl = py::robj(arg3).to_frame();
   size_t rrows = repl->nrows;
   size_t rcols = repl->ncols;
   size_t rrows2 = rows_ri? rows_ri.length() : dt->nrows;
@@ -382,7 +382,7 @@ PyObject* replace_column_array(obj* self, PyObject* args) {
 
   size_t num_new_cols = 0;
   for (size_t i = 0; i < cols.size(); ++i) {
-    py::obj item = cols[i];
+    py::robj item = cols[i];
     int64_t j = item.to_int64_strict();
     num_new_cols += (j == -1);
     if (j < -1 || j >= static_cast<int64_t>(dt->ncols)) {
@@ -398,7 +398,7 @@ PyObject* replace_column_array(obj* self, PyObject* args) {
     dt->columns.resize(newsize);
   }
   for (size_t i = 0; i < cols.size(); ++i) {
-    py::obj item = cols[i];
+    py::robj item = cols[i];
     int64_t j = item.to_int64_strict();
     size_t zj = static_cast<size_t>(j);
     Column* replcol = repl->columns[i % rcols];
@@ -475,7 +475,7 @@ PyObject* rbind(obj* self, PyObject* args) {
 
 PyObject* sort(obj* self, PyObject* args) {
   DataTable* dt = self->ref;
-  py::olist arglist = py::obj(args).to_pylist();
+  py::olist arglist = py::robj(args).to_pylist();
   size_t nargs = arglist.size();
   bool last_arg_bool = nargs > 1 && arglist[nargs - 1].is_bool();
   bool make_groups = last_arg_bool? arglist[nargs - 1].to_bool_strict() : false;
@@ -498,9 +498,9 @@ PyObject* join(obj* self, PyObject* args) {
   if (!PyArg_ParseTuple(args, "OOO:join", &arg1, &arg2, &arg3)) return nullptr;
 
   DataTable* dt = self->ref;
-  DataTable* jdt = py::obj(arg2).to_frame();
-  RowIndex ri = py::obj(arg1).to_rowindex();
-  py::olist cols_arg = py::obj(arg3).to_pylist();
+  DataTable* jdt = py::robj(arg2).to_frame();
+  RowIndex ri = py::robj(arg1).to_rowindex();
+  py::olist cols_arg = py::robj(arg3).to_pylist();
 
   if (cols_arg.size() != 1) {
     throw NotImplError() << "Only single-column joins are currently supported";
@@ -582,9 +582,9 @@ PyObject* save_jay(obj* self, PyObject* args) {
   if (!PyArg_ParseTuple(args, "OOO:save_jay", &arg1, &arg2, &arg3))
     return nullptr;
 
-  auto filename = py::obj(arg1).to_string();
-  auto colnames = py::obj(arg2).to_stringlist();
-  auto strategy = py::obj(arg3).to_string();
+  auto filename = py::robj(arg1).to_string();
+  auto colnames = py::robj(arg2).to_stringlist();
+  auto strategy = py::robj(arg3).to_string();
   auto sstrategy = (strategy == "mmap")  ? WritableBuffer::Strategy::Mmap :
                    (strategy == "write") ? WritableBuffer::Strategy::Write :
                                            WritableBuffer::Strategy::Auto;

--- a/c/py_rowindex.cc
+++ b/c/py_rowindex.cc
@@ -238,7 +238,7 @@ PyObject* uplift(obj* self, PyObject* args) {
   PyObject* arg1;
   if (!PyArg_ParseTuple(args, "O:RowIndex.uplift", &arg1)) return nullptr;
   RowIndex& r1 = *(self->ref);
-  RowIndex  r2 = py::obj(arg1).to_rowindex();
+  RowIndex  r2 = py::robj(arg1).to_rowindex();
   RowIndex res = r1.uplift(r2);
   return wrap(res);
 }

--- a/c/python/_all.h
+++ b/c/python/_all.h
@@ -19,4 +19,5 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
+#include "python/float.h"
 #include "python/int.h"

--- a/c/python/_all.h
+++ b/c/python/_all.h
@@ -1,0 +1,22 @@
+//------------------------------------------------------------------------------
+// Copyright 2018 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#include "python/int.h"

--- a/c/python/_all.h
+++ b/c/python/_all.h
@@ -19,5 +19,6 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
+#include "python/dict.h"
 #include "python/float.h"
 #include "python/int.h"

--- a/c/python/arg.cc
+++ b/c/python/arg.cc
@@ -33,7 +33,7 @@ void Arg::init(size_t i, PKArgs* args) {
 
 
 void Arg::set(PyObject* value) {
-  pyobj = py::obj(value);
+  pyobj = py::robj(value);
 }
 
 

--- a/c/python/arg.cc
+++ b/c/python/arg.cc
@@ -80,6 +80,7 @@ size_t      Arg::to_size_t()       const { return pyobj.to_size_t(*this); }
 double      Arg::to_double()       const { return pyobj.to_double(*this); }
 py::olist   Arg::to_pylist()       const { return pyobj.to_pylist(*this); }
 py::odict   Arg::to_pydict()       const { return pyobj.to_pydict(*this); }
+py::rdict   Arg::to_rdict()        const { return pyobj.to_rdict(*this); }
 std::string Arg::to_string()       const { return pyobj.to_string(*this); }
 strvec      Arg::to_stringlist()   const { return pyobj.to_stringlist(*this); }
 SType       Arg::to_stype()        const { return pyobj.to_stype(*this); }

--- a/c/python/arg.h
+++ b/c/python/arg.h
@@ -27,7 +27,7 @@ class Arg : public _obj::error_manager {
   private:
     size_t pos;
     PKArgs* parent;
-    py::obj pyobj;
+    py::robj pyobj;
     mutable std::string cached_name;
 
   public:
@@ -67,7 +67,7 @@ class Arg : public _obj::error_manager {
     strvec      to_stringlist    () const;
     SType       to_stype         () const;
     SType       to_stype         (const error_manager&) const;
-    py::obj     to_pyobj         () const { return pyobj; }
+    py::robj    to_pyobj         () const { return pyobj; }
     DataTable*  to_frame         () const;
 
 
@@ -77,7 +77,7 @@ class Arg : public _obj::error_manager {
 
     // ?
     explicit operator bool() const noexcept { return pyobj.operator bool(); }
-    PyObject* obj() const { return pyobj.to_pyobject_newref(); }
+    PyObject* robj() const { return pyobj.to_pyobject_newref(); }
     PyObject* to_borrowed_ref() const { return pyobj.to_borrowed_ref(); }
     PyTypeObject* typeobj() const { return pyobj.typeobj(); }
     void print() const;

--- a/c/python/arg.h
+++ b/c/python/arg.h
@@ -63,6 +63,7 @@ class Arg : public _obj::error_manager {
     double      to_double        () const;
     py::olist   to_pylist        () const;
     py::odict   to_pydict        () const;
+    py::rdict   to_rdict         () const;
     std::string to_string        () const;
     strvec      to_stringlist    () const;
     SType       to_stype         () const;

--- a/c/python/args.cc
+++ b/c/python/args.cc
@@ -285,7 +285,7 @@ VarArgsIterator VarArgsIterable::end() const {
 
 
 VarKwdsIterator::VarKwdsIterator(const PKArgs& args, Py_ssize_t i0)
-    : parent(args), pos(i0), curr_value(std::string(), py::obj(nullptr))
+    : parent(args), pos(i0), curr_value(std::string(), py::robj(nullptr))
 {
   if (parent.kwds_dict) {
     advance();
@@ -316,8 +316,8 @@ void VarKwdsIterator::advance() {
   PyObject *key, *value;
   while (PyDict_Next(parent.kwds_dict, &pos, &key, &value)) {
     if (parent.kwd_map.count(key) == 0) {
-      curr_value = value_type(py::obj(key).to_string(),
-                              py::obj(value));
+      curr_value = value_type(py::robj(key).to_string(),
+                              py::robj(value));
       return;
     }
   }
@@ -334,9 +334,9 @@ VarArgsIterator& VarArgsIterator::operator++() {
   return *this;
 }
 
-py::obj VarArgsIterator::operator*() const {
+py::robj VarArgsIterator::operator*() const {
   PyObject* tup = parent.args_tuple;
-  return py::obj(PyTuple_GET_ITEM(tup, static_cast<Py_ssize_t>(pos)));
+  return py::robj(PyTuple_GET_ITEM(tup, static_cast<Py_ssize_t>(pos)));
 }
 
 bool VarArgsIterator::operator==(const VarArgsIterator& other) const {

--- a/c/python/args.h
+++ b/c/python/args.h
@@ -153,7 +153,7 @@ class PKArgs : public Args {
 
 class VarKwdsIterator {
   public:
-    using value_type = std::pair<std::string, py::obj>;
+    using value_type = std::pair<std::string, py::robj>;
     using category_type = std::input_iterator_tag;
 
   private:
@@ -191,7 +191,7 @@ class VarKwdsIterable {
 
 class VarArgsIterator {
   public:
-    using value_type = py::obj;
+    using value_type = py::robj;
     using category_type = std::input_iterator_tag;
 
   private:

--- a/c/python/dict.cc
+++ b/c/python/dict.cc
@@ -56,22 +56,22 @@ bool odict::has(_obj key) const {
   return PyDict_GetItem(v, _key) != nullptr;
 }
 
-obj odict::get(_obj key) const {
+robj odict::get(_obj key) const {
   // PyDict_GetItem returns a borrowed ref; or NULL if key is not present
   PyObject* _key = key.to_borrowed_ref();
-  return obj(PyDict_GetItem(v, _key));
+  return robj(PyDict_GetItem(v, _key));
 }
 
-obj rdict::get(_obj key) const {
+robj rdict::get(_obj key) const {
   PyObject* _key = key.to_borrowed_ref();
-  return obj(PyDict_GetItem(v, _key));
+  return robj(PyDict_GetItem(v, _key));
 }
 
-obj rdict::get_or_none(_obj key) const {
+robj rdict::get_or_none(_obj key) const {
   PyObject* _key = key.to_borrowed_ref();
   PyObject* res = PyDict_GetItem(v, _key);
   if (!res) res = Py_None;
-  return obj(res);
+  return robj(res);
 }
 
 void odict::set(_obj key, _obj val) {
@@ -112,7 +112,7 @@ dict_iterator rdict::end() const {
 //------------------------------------------------------------------------------
 
 dict_iterator::dict_iterator(PyObject* p, Py_ssize_t i0)
-  : dict(p), pos(i0), curr_value(obj(nullptr), obj(nullptr))
+  : dict(p), pos(i0), curr_value(robj(nullptr), robj(nullptr))
 {
   advance();
 }
@@ -138,7 +138,7 @@ void dict_iterator::advance() {
   if (pos == -1) return;
   PyObject *key, *value;
   if (PyDict_Next(dict, &pos, &key, &value)) {
-    curr_value = value_type(py::obj(key), py::obj(value));
+    curr_value = value_type(py::robj(key), py::robj(value));
   } else {
     pos = -1;
   }

--- a/c/python/dict.h
+++ b/c/python/dict.h
@@ -17,7 +17,7 @@ class dict_iterator;
 /**
  * Python dict wrapper.
  *
- * Keys / values are `py::obj`s. This class supports retrieving a value by
+ * Keys / values are `py::robj`s. This class supports retrieving a value by
  * its key, querying existence of a key, inserting new key/value pair, and
  * iterating over all key/values.
  */
@@ -32,7 +32,7 @@ class odict : public oobj {
 
     size_t size() const;
     bool has(_obj key) const;
-    obj  get(_obj key) const;
+    robj get(_obj key) const;
     void set(_obj key, _obj val);
     void del(_obj key);
 
@@ -45,12 +45,12 @@ class odict : public oobj {
 };
 
 
-class rdict : public obj {
+class rdict : public robj {
   public:
-    using obj::obj;
+    using robj::robj;
     size_t size() const;
-    obj get(_obj key) const;
-    obj get_or_none(_obj key) const;
+    robj get(_obj key) const;
+    robj get_or_none(_obj key) const;
     dict_iterator begin() const;
     dict_iterator end() const;
 };
@@ -61,7 +61,7 @@ class rdict : public obj {
  */
 class dict_iterator {
   public:
-    using value_type = std::pair<py::obj, py::obj>;
+    using value_type = std::pair<py::robj, py::robj>;
     using category_type = std::input_iterator_tag;
 
   private:

--- a/c/python/dict.h
+++ b/c/python/dict.h
@@ -1,9 +1,23 @@
 //------------------------------------------------------------------------------
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright 2018 H2O.ai
 //
-// © H2O.ai 2018
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #ifndef dt_PYTHON_DICT_h
 #define dt_PYTHON_DICT_h
@@ -15,24 +29,64 @@ class dict_iterator;
 
 
 /**
- * Python dict wrapper.
+ * C++ interface to Python dict object.
  *
  * Keys / values are `py::robj`s. This class supports retrieving a value by
  * its key, querying existence of a key, inserting new key/value pair, and
  * iterating over all key/values.
+ *
+ * This class does not support "NULL" state, in the sense that the internal
+ * `.v` pointer is never nullptr. In particular, this means that `bool(odict)`
+ * always returns true.
+ *
+ * Public API
+ * ----------
+ * size()
+ *   Return the number of key-value pairs in the dictionary.
+ *
+ * empty()
+ *   Same as `size() == 0`.
+ *
+ * has(key)
+ *   Return true iff the provided `key` is in the dictionary. If `key` is not
+ *   hashable, return false without raising an exception.
+ *
+ * get(key)
+ *   Retrieve the value corresponding to the provided `key`. If the `key` is
+ *   not present (or not hashable), return a "NULL" `robj`.
+ *
+ * get_or_none(key)
+ *   Similar to `get(key)`, but if the key is not present, return python None.
+ *
+ * set(key, val)
+ *   Insert `val` into the dictionary under the key `key`. An exception will
+ *   be thrown if the key is not hashable.
+ *
+ * del(key)
+ *   Delete the entry with key `key`.
+ *
+ * begin() .. end()
+ *   Return iterators over the dictionary key-value pairs. These methods
+ *   provide support for the standard C++11 loops:
+ *
+ *      for (const std::pair<robj, robj>& kv : dict) { ... }
+ *      for (const auto& kv : dict) { ... }
+ *      for (const auto& [key, val] : dict) { ... }  // C++17
+ *
  */
 class odict : public oobj {
   public:
     odict();
-    odict(std::nullptr_t);
-    odict(const odict&);
-    odict(odict&&);
-    odict& operator=(const odict&);
-    odict& operator=(odict&&);
+    odict(const odict&) = default;
+    odict(odict&&) = default;
+    odict& operator=(const odict&) = default;
+    odict& operator=(odict&&) = default;
 
     size_t size() const;
+    bool empty() const;
     bool has(_obj key) const;
     robj get(_obj key) const;
+    robj get_or_none(_obj key) const;
     void set(_obj key, _obj val);
     void del(_obj key);
 
@@ -40,20 +94,35 @@ class odict : public oobj {
     dict_iterator end() const;
 
   private:
-    odict(PyObject*);
+    odict(const robj&);
+    odict(const oobj&);
     friend class _obj;
 };
 
 
+
+/**
+ * Similar to `odict`, however the underlying pointer is not owned.
+ */
 class rdict : public robj {
   public:
     using robj::robj;
+
     size_t size() const;
+    bool empty() const;
+    bool has(_obj key) const;
     robj get(_obj key) const;
     robj get_or_none(_obj key) const;
+
     dict_iterator begin() const;
     dict_iterator end() const;
+
+  private:
+    rdict(const robj&);
+    rdict(const oobj&);
+    friend class _obj;
 };
+
 
 
 /**

--- a/c/python/float.cc
+++ b/c/python/float.cc
@@ -1,9 +1,23 @@
 //------------------------------------------------------------------------------
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright 2018 H2O.ai
 //
-// © H2O.ai 2018
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #include "python/float.h"
 #include "utils/exceptions.h"
@@ -33,13 +47,13 @@ ofloat::ofloat(const oobj& src) : oobj(src) {}
 //------------------------------------------------------------------------------
 
 template<>
-float ofloat::value() const {
+float ofloat::value() const noexcept {
   if (!v) return GETNA<float>();
   return static_cast<float>(PyFloat_AS_DOUBLE(v));
 }
 
 template<>
-double ofloat::value() const {
+double ofloat::value() const noexcept {
   if (!v) return GETNA<double>();
   return PyFloat_AS_DOUBLE(v);
 }

--- a/c/python/float.cc
+++ b/c/python/float.cc
@@ -15,38 +15,16 @@ namespace py {
 // Constructors
 //------------------------------------------------------------------------------
 
-ofloat::ofloat() : oobj() {}
-
-ofloat::ofloat(PyObject* src) : oobj(src) {}
-
-ofloat::ofloat(const ofloat& other) : oobj(other) {}
-
-ofloat::ofloat(ofloat&& other) : oobj(std::move(other)) {}
-
-ofloat& ofloat::operator=(const ofloat& other) {
-  oobj::operator=(other);
-  return *this;
-}
-
-ofloat& ofloat::operator=(ofloat&& other) {
-  oobj::operator=(std::move(other));
-  return *this;
-}
-
-ofloat ofloat::from_new_reference(PyObject* ref) {
-  ofloat res;
-  res.v = ref;
-  return res;
-}
-
-
 ofloat::ofloat(double src) {
   v = PyFloat_FromDouble(src);  // new ref
 }
 
-ofloat::ofloat(float src) {
-  v = PyFloat_FromDouble(static_cast<double>(src));  // new ref
-}
+ofloat::ofloat(float src) : ofloat(static_cast<double>(src)) {}
+
+
+// private constructors
+ofloat::ofloat(const robj& src) : oobj(src) {}
+ofloat::ofloat(const oobj& src) : oobj(src) {}
 
 
 
@@ -54,15 +32,18 @@ ofloat::ofloat(float src) {
 // Value conversions
 //------------------------------------------------------------------------------
 
-template<typename T>
-T ofloat::value() const {
-  if (!v) return GETNA<T>();
-  return static_cast<T>(PyFloat_AS_DOUBLE(v));
+template<>
+float ofloat::value() const {
+  if (!v) return GETNA<float>();
+  return static_cast<float>(PyFloat_AS_DOUBLE(v));
+}
+
+template<>
+double ofloat::value() const {
+  if (!v) return GETNA<double>();
+  return PyFloat_AS_DOUBLE(v);
 }
 
 
-
-template float  ofloat::value() const;
-template double ofloat::value() const;
 
 }  // namespace py

--- a/c/python/float.h
+++ b/c/python/float.h
@@ -1,9 +1,23 @@
 //------------------------------------------------------------------------------
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright 2018 H2O.ai
 //
-// © H2O.ai 2018
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #ifndef dt_PYTHON_FLOAT_h
 #define dt_PYTHON_FLOAT_h
@@ -18,28 +32,30 @@ namespace py {
  */
 class ofloat : public oobj {
   public:
-    ofloat();
+    ofloat() = default;
+    ofloat(const ofloat&) = default;
+    ofloat(ofloat&&) = default;
+    ofloat& operator=(const ofloat&) = default;
+    ofloat& operator=(ofloat&&) = default;
+
     ofloat(double x);
     ofloat(float x);
-
-    ofloat(const ofloat&);
-    ofloat(ofloat&&);
-    ofloat& operator=(const ofloat&);
-    ofloat& operator=(ofloat&&);
 
     template <typename T> T value() const;
 
   private:
-    ofloat(PyObject*);
-    static ofloat from_new_reference(PyObject*);
+    // Private constructors, used from `_obj`. If you need to construct
+    // `ofloat` from `oobj`, use `oobj.to_pyfloat()` instead.
+    ofloat(const robj&);
+    ofloat(const oobj&);
     friend class _obj;
 };
 
 
 
 // Explicit instantiation
-extern template float  ofloat::value() const;
-extern template double ofloat::value() const;
+template<> float  ofloat::value() const;
+template<> double ofloat::value() const;
 
 
 }  // namespace py

--- a/c/python/float.h
+++ b/c/python/float.h
@@ -28,7 +28,14 @@ namespace py {
 
 
 /**
- * Python float object.
+ * C++ interface to python `float`.
+ *
+ * Public API
+ * ----------
+ * value<T>()
+ *   Return the stored value as either float or double. This method does not
+ *   throw exceptions.
+ *
  */
 class ofloat : public oobj {
   public:
@@ -41,7 +48,8 @@ class ofloat : public oobj {
     ofloat(double x);
     ofloat(float x);
 
-    template <typename T> T value() const;
+    template <typename T>
+    T value() const noexcept;
 
   private:
     // Private constructors, used from `_obj`. If you need to construct
@@ -54,8 +62,8 @@ class ofloat : public oobj {
 
 
 // Explicit instantiation
-template<> float  ofloat::value() const;
-template<> double ofloat::value() const;
+template<> float  ofloat::value() const noexcept;
+template<> double ofloat::value() const noexcept;
 
 
 }  // namespace py

--- a/c/python/int.cc
+++ b/c/python/int.cc
@@ -19,6 +19,9 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
+// See https://docs.python.org/3/c-api/long.html
+// for the details of Python API
+//------------------------------------------------------------------------------
 #include <limits>
 #include "python/int.h"
 #include "utils/exceptions.h"
@@ -60,32 +63,84 @@ oint::oint(const oobj& src) : oobj(src) {}
 
 
 //------------------------------------------------------------------------------
-// Value conversions
+// ovalue<T>
 //------------------------------------------------------------------------------
 
-template<> long oint::value<long>(int* overflow) const {
-  if (!v) return GETNA<long>();
-  long value = PyLong_AsLongAndOverflow(v, overflow);
-  if (*overflow) {
-    value = *overflow > 0 ? std::numeric_limits<long>::max()
-                          : -std::numeric_limits<long>::max();
+template<>
+int8_t oint::ovalue(int* overflow) const {
+  if (!v) return GETNA<int8_t>();
+  long res = PyLong_AsLongAndOverflow(v, overflow);
+  int8_t ires = static_cast<int8_t>(res);
+  if (res != ires) {
+    *overflow = (res > 0) - (res < 0);
   }
-  return value;
+  return *overflow == 0? ires :
+         *overflow == 1? std::numeric_limits<int8_t>::max()
+                       : -std::numeric_limits<int8_t>::max();
 }
 
 
-template<> long long oint::value<long long>(int* overflow) const {
+template<>
+int16_t oint::ovalue(int* overflow) const {
+  if (!v) return GETNA<int16_t>();
+  long res = PyLong_AsLongAndOverflow(v, overflow);
+  int16_t ires = static_cast<int16_t>(res);
+  if (res != ires) {
+    *overflow = (res > 0) - (res < 0);
+  }
+  return *overflow == 0? ires :
+         *overflow == 1? std::numeric_limits<int16_t>::max()
+                       : -std::numeric_limits<int16_t>::max();
+}
+
+
+template<>
+int32_t oint::ovalue(int* overflow) const {
+  if (!v) return GETNA<int32_t>();
+  long res = PyLong_AsLongAndOverflow(v, overflow);
+  int32_t ires = static_cast<int32_t>(res);
+  if (res != ires) {
+    *overflow = (res > 0) - (res < 0);
+  }
+  return *overflow? std::numeric_limits<int32_t>::max() * (*overflow)
+                  : ires;
+}
+
+
+template<>
+int64_t oint::ovalue(int* overflow) const {
   if (!v) return GETNA<int64_t>();
-  long long value = PyLong_AsLongLongAndOverflow(v, overflow);
-  if (*overflow) {
-    value = *overflow > 0 ? std::numeric_limits<long long>::max()
-                          : -std::numeric_limits<long long>::max();
-  }
-  return value;
+  #if LONG_MAX==9223372036854775807
+    long res = PyLong_AsLongAndOverflow(v, overflow);
+  #else
+    long long res = PyLong_AsLongLongAndOverflow(v, overflow);
+  #endif
+  return *overflow? std::numeric_limits<int64_t>::max() * (*overflow)
+                  : static_cast<int64_t>(res);
 }
 
 
-template<> double oint::value<double>(int* overflow) const {
+template<>
+float oint::ovalue(int* overflow) const {
+  if (!v) return GETNA<float>();
+  static constexpr double max_float =
+    static_cast<double>(std::numeric_limits<float>::max());
+  double value = PyLong_AsDouble(v);
+  if (value == -1 && PyErr_Occurred()) {
+    int sign = _PyLong_Sign(v);
+    *overflow = sign;
+    return sign > 0 ? std::numeric_limits<float>::infinity()
+                    : -std::numeric_limits<float>::infinity();
+  } else {
+    *overflow = (value > max_float) - (value < -max_float);
+    // If value is greater than float_max, this cast should convert it to inf
+    return static_cast<float>(value);
+  }
+}
+
+
+template<>
+double oint::ovalue(int* overflow) const {
   if (!v) return GETNA<double>();
   double value = PyLong_AsDouble(v);
   if (value == -1 && PyErr_Occurred()) {
@@ -100,63 +155,88 @@ template<> double oint::value<double>(int* overflow) const {
 }
 
 
-template<> float oint::value<float>(int* overflow) const {
-  if (!v) return GETNA<float>();
-  static constexpr double max_float =
-    static_cast<double>(std::numeric_limits<float>::max());
-  double value = PyLong_AsDouble(v);
-  if (value == -1 && PyErr_Occurred()) {
-    int sign = _PyLong_Sign(v);
-    *overflow = 1;
-    return sign > 0 ? std::numeric_limits<float>::infinity()
-                    : -std::numeric_limits<float>::infinity();
-  } else {
-    *overflow = (value > max_float || value < -max_float);
-    // If value is greater than float_max, this cast should convert it to inf
-    return static_cast<float>(value);
-  }
-}
 
+//------------------------------------------------------------------------------
+// xvalue<T>
+//------------------------------------------------------------------------------
 
-template<typename T> T oint::value(int* overflow) const {
-  if (!v) return GETNA<T>();
-  constexpr T MAX = std::numeric_limits<T>::max();
-  long x = value<long>(overflow);
-  if (x > MAX) {
-    *overflow = 1;
-    return MAX;
-  }
-  if (x < -MAX) {
-    *overflow = 1;
-    return -MAX;
-  }
-  return static_cast<T>(x);
-}
-
-
-template<typename T> T oint::value() const {
-  if (!v) return GETNA<T>();
+template<>
+int8_t oint::xvalue() const {
   int overflow;
-  T res = value<T>(&overflow);
+  int8_t res = ovalue<int8_t>(&overflow);
   if (overflow) {
-    throw OverflowError() << "Integer is too large for " << typeid(T).name();
+    throw OverflowError() << "Integer is too large to convert into `int8`";
   }
   return res;
 }
 
 
-template<> long long int oint::masked_value() const {
-  if (!v) return GETNA<int64_t>();
-  unsigned long long x = PyLong_AsUnsignedLongLongMask(v);
-  if (x == static_cast<unsigned long long>(-1) && PyErr_Occurred()) {
-    PyErr_Clear();
-    return std::numeric_limits<long long>::min();  // NA
+template<>
+int16_t oint::xvalue() const {
+  int overflow;
+  int16_t res = ovalue<int16_t>(&overflow);
+  if (overflow) {
+    throw OverflowError() << "Integer is too large to convert into `int16`";
   }
-  return static_cast<long long>(x);
+  return res;
 }
 
 
-template<typename T> T oint::masked_value() const {
+template<>
+int32_t oint::xvalue() const {
+  int overflow;
+  int32_t res = ovalue<int32_t>(&overflow);
+  if (overflow) {
+    throw OverflowError() << "Integer is too large to convert into `int32`";
+  }
+  return res;
+}
+
+
+template<>
+int64_t oint::xvalue() const {
+  int overflow;
+  int64_t res = ovalue<int64_t>(&overflow);
+  if (overflow) {
+    throw OverflowError() << "Integer is too large to convert into `int64`";
+  }
+  return res;
+}
+
+
+template<>
+size_t oint::xvalue() const {
+  if (!v) return size_t(-1);
+  if (Py_SIZE(v) < 0) {  // Implementation detail of python `long` object
+    throw OverflowError() << "Negative integer cannot be converted to `size_t`";
+  }
+  size_t res = PyLong_AsSize_t(v);
+  if (res == static_cast<size_t>(-1) && PyErr_Occurred()) {
+    throw OverflowError() << "Integer is too large to convert into `size_t`";
+  }
+  return res;
+}
+
+
+template<>
+double oint::xvalue() const {
+  if (!v) return GETNA<double>();
+  double value = PyLong_AsDouble(v);
+  if (value == -1 && PyErr_Occurred()) {
+    throw OverflowError() << "Integer is too large to convert into `double`";
+  }
+  return value;
+}
+
+
+
+
+//------------------------------------------------------------------------------
+// mvalue<T>
+//------------------------------------------------------------------------------
+
+template<typename T>
+static T masked_value_long(PyObject* v) {
   if (!v) return GETNA<T>();
   unsigned long x = PyLong_AsUnsignedLongMask(v);
   if (x == static_cast<unsigned long>(-1) && PyErr_Occurred()) {
@@ -167,27 +247,39 @@ template<typename T> T oint::masked_value() const {
 }
 
 
+template<>
+int8_t oint::mvalue() const {
+  return masked_value_long<int8_t>(v);
+}
 
 
-//------------------------------------------------------------------------------
-// Explicit instantiations
-//------------------------------------------------------------------------------
+template<>
+int16_t oint::mvalue() const {
+  return masked_value_long<int16_t>(v);
+}
 
-template int8_t  oint::value() const;
-template int16_t oint::value() const;
-template int32_t oint::value() const;
-template int64_t oint::value() const;
-template float   oint::value() const;
-template double  oint::value() const;
 
-template signed char  oint::value(int*) const;
-template short int    oint::value(int*) const;
-template int          oint::value(int*) const;
+template<>
+int32_t oint::mvalue() const {
+  return masked_value_long<int32_t>(v);
+}
 
-template signed char   oint::masked_value() const;
-template short int     oint::masked_value() const;
-template int           oint::masked_value() const;
-template long int      oint::masked_value() const;
+
+template<>
+int64_t oint::mvalue() const {
+  #if LONG_MAX==9223372036854775807
+    return masked_value_long<int64_t>(v);
+  #else
+    if (!v) return GETNA<int64_t>();
+    unsigned long long x = PyLong_AsUnsignedLongLongMask(v);
+    if (x == static_cast<unsigned long long>(-1) && PyErr_Occurred()) {
+      PyErr_Clear();
+      return GETNA<int64_t>();
+    }
+    return static_cast<int64_t>(x);
+  #endif
+}
+
 
 
 }  // namespace py

--- a/c/python/int.cc
+++ b/c/python/int.cc
@@ -1,10 +1,25 @@
 //------------------------------------------------------------------------------
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright 2018 H2O.ai
 //
-// © H2O.ai 2018
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
 //------------------------------------------------------------------------------
+#include <limits>
 #include "python/int.h"
 #include "utils/exceptions.h"
 
@@ -15,38 +30,18 @@ namespace py {
 // Constructors
 //------------------------------------------------------------------------------
 
-oint::oint() : oobj() {}
-
-oint::oint(PyObject* src) : oobj(src) {}
-
-oint::oint(const oint& other) : oobj(other) {}
-
-oint::oint(oint&& other) : oobj(std::move(other)) {}
-
-oint& oint::operator=(const oint& other) {
-  oobj::operator=(other);
-  return *this;
-}
-
-oint& oint::operator=(oint&& other) {
-  oobj::operator=(std::move(other));
-  return *this;
-}
-
-oint oint::from_new_reference(PyObject* ref) {
-  oint res;
-  res.v = ref;
-  return res;
-}
-
-
 oint::oint(int32_t n) {
   v = PyLong_FromLong(n);
 }
 
 oint::oint(int64_t n) {
-  static_assert(sizeof(long) == sizeof(int64_t), "Wrong size of long");
-  v = PyLong_FromLong(n);
+  #if LONG_MAX==9223372036854775807
+    v = PyLong_FromLong(n);
+  #elif LLONG_MAX==9223372036854775807
+    v = PyLong_FromLongLong(n);
+  #else
+    #error "Cannot determine size of `long`"
+  #endif
 }
 
 oint::oint(size_t n) {
@@ -56,6 +51,11 @@ oint::oint(size_t n) {
 oint::oint(double x) {
   v = PyLong_FromDouble(x);
 }
+
+
+// private constructors
+oint::oint(const obj& src) : oobj(src) {}
+oint::oint(const oobj& src) : oobj(src) {}
 
 
 

--- a/c/python/int.cc
+++ b/c/python/int.cc
@@ -54,7 +54,7 @@ oint::oint(double x) {
 
 
 // private constructors
-oint::oint(const obj& src) : oobj(src) {}
+oint::oint(const robj& src) : oobj(src) {}
 oint::oint(const oobj& src) : oobj(src) {}
 
 

--- a/c/python/int.h
+++ b/c/python/int.h
@@ -50,7 +50,7 @@ class oint : public oobj {
     template<typename T> T masked_value() const;
 
   private:
-    oint(const obj&);
+    oint(const robj&);
     oint(const oobj&);
     friend class _obj;
 };

--- a/c/python/int.h
+++ b/c/python/int.h
@@ -1,9 +1,23 @@
 //------------------------------------------------------------------------------
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright 2018 H2O.ai
 //
-// © H2O.ai 2018
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #ifndef dt_PYTHON_INT_h
 #define dt_PYTHON_INT_h
@@ -14,20 +28,20 @@ namespace py {
 
 
 /**
- * C++ wrapper around PyLong_Object (python `int` object).
+ * C++ wrapper around PyLong_Object (python `int`).
  *
  * Public API
  * ----------
- * value<T>()
- *   Return value as an integral T or double type. If the value cannot be
- *   represented as T, an overflow exception will be thrown.
+ * ovalue<T>(int* overflow)
+ *   Return the value converted into C++ type `T`. If the value cannot be
+ *   converted, set the `overflow` flag to +1/-1, and the value returned will
+ *   be ±MAX<T>.
  *
- * value<T>(int* overflow)
- *   Similar to the previous method, but if the value cannot be represented
- *   as T, sets the `overflow` flag to 1 (or -1) and returns the ±MAX<T>
- *   value depending on the sign of the underlying object.
+ * xvalue<T>()
+ *   Return the value converted into C++ type `T`, or throw an overflow
+ *   exception if the value cannot be converted into `T`.
  *
- * masked_value<T>()
+ * mvalue<T>()
  *   Similar to the first method, but if the value does not fit into <T>
  *   truncate it using `static_cast<T>`.
  *
@@ -45,11 +59,13 @@ class oint : public oobj {
     oint(size_t n);
     oint(double x);
 
-    template<typename T> T value() const;
-    template<typename T> T value(int* overflow) const;
-    template<typename T> T masked_value() const;
+    template<typename T> T ovalue(int*) const;
+    template<typename T> T xvalue() const;
+    template<typename T> T mvalue() const;
 
   private:
+    // Private constructors, used from `_obj`. If you need to construct
+    // `oint` from `oobj`, use `oobj.to_pyint()` instead.
     oint(const robj&);
     oint(const oobj&);
     friend class _obj;
@@ -58,30 +74,25 @@ class oint : public oobj {
 
 
 // Explicit specializations
-template<> float     oint::value<float>(int*) const;
-template<> double    oint::value<double>(int*) const;
-template<> long      oint::value<long>(int*) const;
-template<> long long oint::value<long long>(int*) const;
-template<> long long oint::masked_value<long long>() const;
+template<> int8_t  oint::ovalue(int*) const;
+template<> int16_t oint::ovalue(int*) const;
+template<> int32_t oint::ovalue(int*) const;
+template<> int64_t oint::ovalue(int*) const;
+template<> size_t  oint::ovalue(int*) const;
+template<> float   oint::ovalue(int*) const;
+template<> double  oint::ovalue(int*) const;
 
-// Forward-declare explicit instantiations
-extern template int8_t  oint::value() const;
-extern template int16_t oint::value() const;
-extern template int32_t oint::value() const;
-extern template int64_t oint::value() const;
-extern template float   oint::value() const;
-extern template double  oint::value() const;
+template<> int8_t  oint::xvalue() const;
+template<> int16_t oint::xvalue() const;
+template<> int32_t oint::xvalue() const;
+template<> int64_t oint::xvalue() const;
+template<> size_t  oint::xvalue() const;
+template<> double  oint::xvalue() const;
 
-extern template int8_t  oint::value(int*) const;
-extern template int16_t oint::value(int*) const;
-extern template int32_t oint::value(int*) const;
-extern template int64_t oint::value(int*) const;
-
-extern template int8_t  oint::masked_value() const;
-extern template int16_t oint::masked_value() const;
-extern template int32_t oint::masked_value() const;
-extern template int64_t oint::masked_value() const;
-
+template<> int8_t  oint::mvalue() const;
+template<> int16_t oint::mvalue() const;
+template<> int32_t oint::mvalue() const;
+template<> int64_t oint::mvalue() const;
 
 }  // namespace py
 

--- a/c/python/int.h
+++ b/c/python/int.h
@@ -34,24 +34,24 @@ namespace py {
  */
 class oint : public oobj {
   public:
-    oint();
+    oint() = default;
+    oint(const oint&) = default;
+    oint(oint&&) = default;
+    oint& operator=(const oint&) = default;
+    oint& operator=(oint&&) = default;
+
     oint(int32_t n);
     oint(int64_t n);
     oint(size_t n);
     oint(double x);
-
-    oint(const oint&);
-    oint(oint&&);
-    oint& operator=(const oint&);
-    oint& operator=(oint&&);
 
     template<typename T> T value() const;
     template<typename T> T value(int* overflow) const;
     template<typename T> T masked_value() const;
 
   private:
-    oint(PyObject*);
-    static oint from_new_reference(PyObject*);
+    oint(const obj&);
+    oint(const oobj&);
     friend class _obj;
 };
 

--- a/c/python/list.cc
+++ b/c/python/list.cc
@@ -57,16 +57,16 @@ olist::olist(PyObject* src) : oobj(src) {
 // Element accessors
 //------------------------------------------------------------------------------
 
-obj olist::operator[](int64_t i) const {
-  return obj(is_list? PyList_GET_ITEM(v, i)
-                    : PyTuple_GET_ITEM(v, i));
+robj olist::operator[](int64_t i) const {
+  return robj(is_list? PyList_GET_ITEM(v, i)
+                     : PyTuple_GET_ITEM(v, i));
 }
 
-obj olist::operator[](size_t i) const {
+robj olist::operator[](size_t i) const {
   return this->operator[](static_cast<int64_t>(i));
 }
 
-obj olist::operator[](int i) const {
+robj olist::operator[](int i) const {
   return this->operator[](static_cast<int64_t>(i));
 }
 

--- a/c/python/list.h
+++ b/c/python/list.h
@@ -17,7 +17,7 @@ namespace py {
  * Python list of objects.
  *
  * There are 2 ways of instantiating this class: either by creating a new list
- * of `n` elements via `olist(n)`, or by casting a `py::obj` into a list using
+ * of `n` elements via `olist(n)`, or by casting a `py::robj` into a list using
  * `.to_pylist()` method. The former method is used when you want to create a
  * new list and return it to Python, the latter when you're processing a list
  * which came from Python.
@@ -44,9 +44,9 @@ class olist : public oobj {
     operator bool() const noexcept;
     size_t size() const noexcept;
 
-    obj operator[](size_t i) const;
-    obj operator[](int64_t i) const;
-    obj operator[](int i) const;
+    robj operator[](size_t i) const;
+    robj operator[](int64_t i) const;
+    robj operator[](int i) const;
 
     void set(size_t i,  const _obj& value);
     void set(int64_t i, const _obj& value);

--- a/c/python/obj.cc
+++ b/c/python/obj.cc
@@ -538,8 +538,14 @@ PyObject* _obj::to_pyobject_newref() const noexcept {
 
 py::odict _obj::to_pydict(const error_manager& em) const {
   if (is_none()) return py::odict();
-  if (is_dict()) return py::odict(v);
+  if (is_dict()) return py::odict(robj(v));
   throw em.error_not_dict(v);
+}
+
+
+py::rdict _obj::to_rdict(const error_manager& em) const {
+  if (!is_dict()) throw em.error_not_dict(v);
+  return py::rdict(robj(v));
 }
 
 

--- a/c/python/obj.cc
+++ b/c/python/obj.cc
@@ -318,16 +318,16 @@ double _obj::to_double(const error_manager& em) const {
 }
 
 
-ofloat _obj::to_pyfloat_force(const error_manager&) const noexcept {
+py::ofloat _obj::to_pyfloat_force(const error_manager&) const noexcept {
   if (PyFloat_Check(v) || v == Py_None) {
-    return py::ofloat(v);
+    return py::ofloat(robj(v));
   }
   PyObject* num = PyNumber_Float(v);  // new ref
   if (!num) {
     PyErr_Clear();
     num = nullptr;
   }
-  return py::ofloat::from_new_reference(num);
+  return py::ofloat(oobj::from_new_reference(num));
 }
 
 

--- a/c/python/obj.cc
+++ b/c/python/obj.cc
@@ -36,28 +36,28 @@ static void init_numpy();
 _obj::error_manager _obj::_em0;
 
 
-obj::obj(const PyObject* p) {
+robj::robj(const PyObject* p) {
   v = const_cast<PyObject*>(p);
 }
 
-obj::obj(const Arg& arg) {
+robj::robj(const Arg& arg) {
   v = arg.to_borrowed_ref();
 }
 
-obj::obj(const obj& other) {
+robj::robj(const robj& other) {
   v = other.v;
 }
 
-obj::obj(const oobj& other) {
+robj::robj(const oobj& other) {
   v = other.v;
 }
 
-obj& obj::operator=(const obj& other) {
+robj& robj::operator=(const robj& other) {
   v = other.v;
   return *this;
 }
 
-obj& obj::operator=(const _obj& other) {
+robj& robj::operator=(const _obj& other) {
   v = other.v;
   return *this;
 }
@@ -73,7 +73,7 @@ oobj::oobj(PyObject* p) {
 }
 
 oobj::oobj(const oobj& other) : oobj(other.v) {}
-oobj::oobj(const obj& other) : oobj(other.v) {}
+oobj::oobj(const robj& other) : oobj(other.v) {}
 
 oobj::oobj(oobj&& other) {
   v = other.v;
@@ -282,14 +282,14 @@ size_t _obj::to_size_t(const error_manager& em) const {
 
 py::oint _obj::to_pyint(const error_manager& em) const {
   if (v == Py_None) return py::oint();
-  if (PyLong_Check(v)) return py::oint(obj(v));
+  if (PyLong_Check(v)) return py::oint(robj(v));
   throw em.error_not_integer(v);
 }
 
 
 py::oint _obj::to_pyint_force(const error_manager&) const noexcept {
   if (v == Py_None) return py::oint();
-  if (PyLong_Check(v)) return py::oint(obj(v));
+  if (PyLong_Check(v)) return py::oint(robj(v));
   PyObject* num = PyNumber_Long(v);  // new ref
   if (!num) {
     PyErr_Clear();
@@ -686,7 +686,7 @@ oobj None()     { return oobj(Py_None); }
 oobj True()     { return oobj(Py_True); }
 oobj False()    { return oobj(Py_False); }
 oobj Ellipsis() { return oobj(Py_Ellipsis); }
-obj rnone()     { return obj(Py_None); }
+robj rnone()     { return robj(Py_None); }
 
 
 //------------------------------------------------------------------------------

--- a/c/python/obj.cc
+++ b/c/python/obj.cc
@@ -282,20 +282,20 @@ size_t _obj::to_size_t(const error_manager& em) const {
 
 py::oint _obj::to_pyint(const error_manager& em) const {
   if (v == Py_None) return py::oint();
-  if (PyLong_Check(v)) return py::oint(v);
+  if (PyLong_Check(v)) return py::oint(obj(v));
   throw em.error_not_integer(v);
 }
 
 
 py::oint _obj::to_pyint_force(const error_manager&) const noexcept {
   if (v == Py_None) return py::oint();
-  if (PyLong_Check(v)) return py::oint(v);
+  if (PyLong_Check(v)) return py::oint(obj(v));
   PyObject* num = PyNumber_Long(v);  // new ref
   if (!num) {
     PyErr_Clear();
     num = nullptr;
   }
-  return py::oint::from_new_reference(num);
+  return py::oint(oobj::from_new_reference(num));
 }
 
 

--- a/c/python/obj.cc
+++ b/c/python/obj.cc
@@ -692,7 +692,7 @@ oobj None()     { return oobj(Py_None); }
 oobj True()     { return oobj(Py_True); }
 oobj False()    { return oobj(Py_False); }
 oobj Ellipsis() { return oobj(Py_Ellipsis); }
-robj rnone()     { return robj(Py_None); }
+robj rnone()    { return robj(Py_None); }
 
 
 //------------------------------------------------------------------------------

--- a/c/python/obj.h
+++ b/c/python/obj.h
@@ -30,7 +30,7 @@ class olist;
 class ostring;
 class orange;
 class otuple;
-class obj;
+class robj;
 class oobj;
 using strvec = std::vector<std::string>;
 
@@ -42,13 +42,13 @@ using strvec = std::vector<std::string>;
  *
  * `py::_obj` by itself is not usable: instead, you should use one of the two
  * derived classes:
- *   - `py::obj` contains a *borrowed PyObject reference*. This class is used
+ *   - `py::robj` contains a *borrowed PyObject reference*. This class is used
  *     most commonly for objects that have a very small lifespan. DO NOT use
  *     this class to store `PyObject*`s for an extended period of time.
  *   - `py::oobj` contains an *owned PyObject reference*. The value that it
  *     wraps will not be garbage-collected as long as the `py::oobj` object
  *     remains alive. This class bears extra performance cost compared to
- *     `py::obj` (however this extra cost is very small).
+ *     `py::robj` (however this extra cost is very small).
  *
  *
  * Conversion methods
@@ -231,11 +231,11 @@ class _obj {
   protected:
     static error_manager _em0;
 
-    // `_obj` class is not directly constructible: create either `obj` or
+    // `_obj` class is not directly constructible: create either `robj` or
     // `oobj` objects instead.
     _obj() = default;
 
-    friend obj;
+    friend robj;
     friend oobj;
     friend Arg;
     friend oobj get_module(const char* name);
@@ -243,14 +243,14 @@ class _obj {
 
 
 
-class obj : public _obj {
+class robj : public _obj {
   public:
-    obj(const PyObject* p);
-    obj(const Arg&);
-    obj(const obj&);
-    obj(const oobj&);
-    obj& operator=(const obj&);
-    obj& operator=(const _obj&);
+    robj(const PyObject* p);
+    robj(const Arg&);
+    robj(const robj&);
+    robj(const oobj&);
+    robj& operator=(const robj&);
+    robj& operator=(const _obj&);
 };
 
 
@@ -260,7 +260,7 @@ class oobj : public _obj {
     oobj();
     oobj(PyObject* p);
     oobj(const oobj&);
-    oobj(const obj&);
+    oobj(const robj&);
     oobj(oobj&&);
     oobj& operator=(const oobj&);
     oobj& operator=(oobj&&);
@@ -283,7 +283,7 @@ oobj None();
 oobj True();
 oobj False();
 oobj Ellipsis();
-obj rnone();
+robj rnone();
 
 
 }  // namespace py

--- a/c/python/obj.h
+++ b/c/python/obj.h
@@ -31,6 +31,7 @@ class ostring;
 class orange;
 class otuple;
 class robj;
+class rdict;
 class oobj;
 using strvec = std::vector<std::string>;
 
@@ -188,6 +189,7 @@ class _obj {
     py::olist   to_pylist        (const error_manager& = _em0) const;
     py::otuple  to_pytuple       (const error_manager& = _em0) const;
     py::odict   to_pydict        (const error_manager& = _em0) const;
+    py::rdict   to_rdict         (const error_manager& = _em0) const;
     py::orange  to_pyrange       (const error_manager& = _em0) const;
     py::oiter   to_pyiter        (const error_manager& = _em0) const;
 
@@ -237,6 +239,8 @@ class _obj {
 
     friend robj;
     friend oobj;
+    friend odict;
+    friend rdict;
     friend Arg;
     friend oobj get_module(const char* name);
 };

--- a/c/python/oiter.cc
+++ b/c/python/oiter.cc
@@ -68,7 +68,7 @@ iter_iterator& iter_iterator::operator++() {
   return *this;
 }
 
-py::obj iter_iterator::operator*() const {
+py::robj iter_iterator::operator*() const {
   return next_value;
 }
 

--- a/c/python/oiter.h
+++ b/c/python/oiter.h
@@ -41,7 +41,7 @@ class oiter : public oobj {
 
 class iter_iterator {
   public:
-    using value_type = py::obj;
+    using value_type = py::robj;
     using category_type = std::input_iterator_tag;
 
   private:

--- a/c/python/tuple.cc
+++ b/c/python/tuple.cc
@@ -46,21 +46,21 @@ otuple& otuple::operator=(otuple&& other) {
 // Element accessors
 //------------------------------------------------------------------------------
 
-obj otuple::operator[](int64_t i) const {
+robj otuple::operator[](int64_t i) const {
   // PyTuple_GET_ITEM returns a borrowed reference
-  return obj(PyTuple_GET_ITEM(v, i));
+  return robj(PyTuple_GET_ITEM(v, i));
 }
 
-obj otuple::operator[](size_t i) const {
+robj otuple::operator[](size_t i) const {
   return this->operator[](static_cast<int64_t>(i));
 }
 
-obj otuple::operator[](int i) const {
+robj otuple::operator[](int i) const {
   return this->operator[](static_cast<int64_t>(i));
 }
 
-obj rtuple::operator[](size_t i) const {
-  return obj(PyTuple_GET_ITEM(v, static_cast<int64_t>(i)));
+robj rtuple::operator[](size_t i) const {
+  return robj(PyTuple_GET_ITEM(v, static_cast<int64_t>(i)));
 }
 
 

--- a/c/python/tuple.h
+++ b/c/python/tuple.h
@@ -34,9 +34,9 @@ class otuple : public oobj {
 
     size_t size() const noexcept;
 
-    obj operator[](int64_t i) const;
-    obj operator[](size_t i) const;
-    obj operator[](int i) const;
+    robj operator[](int64_t i) const;
+    robj operator[](size_t i) const;
+    robj operator[](int i) const;
 
     /**
      * `set(...)` methods should only be used to fill-in a new tuple object.
@@ -74,11 +74,11 @@ class otuple : public oobj {
  * or not -- the caller is expected to do that himself. Thus, this class
  * should be used judiciously.
  */
-class rtuple : public obj {
+class rtuple : public robj {
   public:
-    using obj::obj;
+    using robj::robj;
     size_t size() const noexcept;
-    obj operator[](size_t i) const;
+    robj operator[](size_t i) const;
 };
 
 

--- a/c/types.cc
+++ b/c/types.cc
@@ -243,7 +243,7 @@ int stype_from_pyobject(PyObject* s) {
     PyErr_Clear();
     return -1;
   }
-  int32_t value = py::obj(res).get_attr("value").to_int32();
+  int32_t value = py::robj(res).get_attr("value").to_int32();
   return value;
 }
 

--- a/c/utils/exceptions.cc
+++ b/c/utils/exceptions.cc
@@ -193,7 +193,7 @@ bool PyError::is_assertion_error() const {
 }
 
 std::string PyError::message() const {
-  return py::obj(exc_value).to_pystring_force().to_string();
+  return py::robj(exc_value).to_pystring_force().to_string();
 }
 
 

--- a/tests/munging/test_replace.py
+++ b/tests/munging/test_replace.py
@@ -311,8 +311,8 @@ def test_replace_bad1():
     with pytest.raises(TypeError) as e:
         df0 = dt.Frame(A=range(10))
         df0.replace({0: 500}, 17)
-    assert ("When the first argument to Frame.replace() is a dict, there "
-            "should be no second argument" == str(e.value))
+    assert ("When the first argument to Frame.replace() is a dictionary, there "
+            "should be no other arguments" == str(e.value))
 
 
 def test_replace_bad2():


### PR DESCRIPTION
This PR is a first attempt at normalizing the API of the functionality provided in `c/python/` directory. The overall goal is to ensure that different classes have consistent names/methods/constructors/etc.

Currently, only "int.h", "float.h" and "dict.h" were reviewed.

- Notably, `py::obj` was renamed to `py::robj` ("referenced" object), for consistency with other objects, and to avoid confusion with `py::_obj`;
- Added "python/_all.h", which will contain includes of all other python headers (currently, one needs to include "python/int.h", "python/oiter.h", "python/string.h", etc separately, which is tiresome);
- `py::odict` can no longer be initialized with `nullptr`;
- `py::rdict` can no longer perform unchecked construction from `py::robj`: use `.to_rdict()` method instead.
- improved internal documentation for `py::dict` and `py::oint`.