### PR TITLE
Add requirements_docs.txt

### DIFF
--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,0 +1,2 @@
+sphinx>=1.8
+nbsphinx>=0.3.5


### PR DESCRIPTION
Our build process requires `sphinx` of version 1.8 or higher. Adding a requirements file so that readthedocs site can be configured to use the correct version of the library.