### PR TITLE
The default format in Frame.save is now 'jay'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `DT[col]` syntax has been deprecated and now emits a warning. This
   will be converted to an error in version 0.8.0, and will be interpreted
   as row selector in 0.9.0.
+- default format for `Frame.save()` is now "jay".
 
 #### Fixed
 - bug in dt.cbind() where the first Frame in the list was ignored.

--- a/datatable/nff.py
+++ b/datatable/nff.py
@@ -24,7 +24,7 @@ def _stringify(x):
 
 
 @typed(dest=str, format=str, _strategy=str)
-def save(self, dest, format="nff", _strategy="auto"):
+def save(self, dest, format="jay", _strategy="auto"):
     """
     Save Frame in binary NFF/Jay format.
 

--- a/tests/munging/test_dt_append.py
+++ b/tests/munging/test_dt_append.py
@@ -5,8 +5,6 @@
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #-------------------------------------------------------------------------------
 import math
-import tempfile
-import shutil
 import pytest
 import types
 import datatable as dt
@@ -198,17 +196,15 @@ def test_rbind_self():
     assert_equals(dt0, dtr)
 
 
-def test_rbind_mmapped():
-    dir0 = tempfile.mkdtemp()
+def test_rbind_mmapped(tempfile):
     dt0 = dt.Frame({"A": [1, 5, 7], "B": ["one", "two", None]})
-    dt.save(dt0, dir0)
+    dt0.save(tempfile)
     del dt0
-    dt1 = dt.open(dir0)
+    dt1 = dt.open(tempfile)
     dt2 = dt.Frame({"A": [-1], "B": ["zero"]})
     dt1.rbind(dt2)
     dtr = dt.Frame({"A": [1, 5, 7, -1], "B": ["one", "two", None, "zero"]})
     assert_equals(dt1, dtr)
-    shutil.rmtree(dir0)
 
 
 def test_rbind_views0():

--- a/tests/munging/test_dt_rows.py
+++ b/tests/munging/test_dt_rows.py
@@ -746,13 +746,13 @@ def test_rows_bad_arguments(dt0):
                      "Boolean value cannot be used as a `rows` selector")
 
 
-def test_issue689(tempdir):
+def test_issue689(tempfile):
     n = 300000  # Must be > 65536
     data = [i % 8 for i in range(n)]
     d0 = dt.Frame(data, names=["A"])
-    dt.save(d0, tempdir)
+    d0.save(tempfile)
     del d0
-    d1 = dt.open(tempdir)
+    d1 = dt.open(tempfile)
     # Do not check d1! we want it to be lazy at this point
     d2 = d1(rows=lambda g: g[0] == 1)
     d2.internal.check()

--- a/tests/test_nff.py
+++ b/tests/test_nff.py
@@ -24,7 +24,7 @@ def test_save_and_load():
     dt0 = dt.Frame({"A": [1, 7, 100, 12],
                     "B": [True, None, False, None],
                     "C": ["alpha", "beta", None, "delta"]})
-    dt0.save(dir1)
+    dt0.save(dir1, format="nff")
     dt1 = dt.open(dir1)
     assert_equals(dt0, dt1)
     shutil.rmtree(dir1)
@@ -37,7 +37,7 @@ def test_empty_string_col():
     """
     dir1 = tempfile.mkdtemp()
     dt0 = dt.Frame([[1, 2, 3], ["", "", ""]])
-    dt0.save(dir1)
+    dt0.save(dir1, format="nff")
     dt1 = dt.open(dir1)
     assert_equals(dt0, dt1)
     shutil.rmtree(dir1)
@@ -48,7 +48,7 @@ def test_issue627():
     dir1 = tempfile.mkdtemp()
     dt0 = dt.Frame({"py": [1], "ру": [2], "рy": [3], "pу": [4]})
     assert dt0.shape == (1, 4)
-    dt0.save(dir1)
+    dt0.save(dir1, format="nff")
     dt1 = dt.open(dir1)
     assert_equals(dt0, dt1)
     shutil.rmtree(dir1)
@@ -62,7 +62,7 @@ def test_obj_columns(tempdir):
     assert d0.ltypes == (dt.ltype.int, dt.ltype.obj)
     assert d0.shape == (4, 2)
     with pytest.warns(DatatableWarning) as ws:
-        d0.save(tempdir)
+        d0.save(tempdir, format="nff")
     assert len(ws) == 1
     assert "Column 'B' of type obj64 was not saved" in ws[0].message.args[0]
     del d0
@@ -78,7 +78,7 @@ def test_save_view(tempdir):
     dt1 = dt0.sort(0)
     assert dt1.internal.isview
     dt1.internal.check()
-    dt1.save(tempdir)
+    dt1.save(tempdir, format="nff")
     dt2 = dt.open(tempdir)
     assert not dt2.internal.isview
     dt2.internal.check()
@@ -105,7 +105,7 @@ def test_jay_simple(tempfile):
 
 def test_jay_empty_string_col(tempfile):
     dt0 = dt.Frame([[1, 2, 3], ["", "", ""]], names=["hogs", "warts"])
-    dt0.save(tempfile, format="jay")
+    dt0.save(tempfile)
     assert os.path.isfile(tempfile)
     dt1 = dt.open(tempfile)
     assert_equals(dt0, dt1)
@@ -118,7 +118,7 @@ def test_jay_view(tempfile, seed):
     dt0 = dt.Frame({"values": src})
     dt1 = dt0.sort(0)
     assert dt1.internal.isview
-    dt1.save(tempfile, format="jay")
+    dt1.save(tempfile)
     assert os.path.isfile(tempfile)
     dt2 = dt.open(tempfile)
     assert not dt2.internal.isview
@@ -132,7 +132,7 @@ def test_jay_view(tempfile, seed):
 def test_jay_unicode_names(tempfile):
     dt0 = dt.Frame({"py": [1], "ру": [2], "рy": [3], "pу": [4]})
     assert len(set(dt0.names)) == 4
-    dt0.save(tempfile, format="jay")
+    dt0.save(tempfile)
     assert os.path.isfile(tempfile)
     dt1 = dt.open(tempfile)
     assert dt0.names == dt1.names
@@ -145,7 +145,7 @@ def test_jay_object_columns(tempfile):
     d0 = dt.Frame([src1, src2], names=["A", "B"])
     assert d0.stypes == (dt.int8, dt.obj64)
     with pytest.warns(DatatableWarning) as ws:
-        d0.save(tempfile, format="jay")
+        d0.save(tempfile)
     assert len(ws) == 1
     assert "Column `B` of type obj64 was not saved" in ws[0].message.args[0]
     d1 = dt.open(tempfile)
@@ -156,7 +156,7 @@ def test_jay_object_columns(tempfile):
 
 def test_jay_empty_frame(tempfile):
     d0 = dt.Frame()
-    d0.save(tempfile, format="jay")
+    d0.save(tempfile)
     assert os.path.isfile(tempfile)
     d1 = dt.open(tempfile)
     assert d1.shape == (0, 0)
@@ -181,7 +181,7 @@ def test_jay_all_types(tempfile):
     # Force calculation of mins and maxs, so that they get saved into Jay
     d0.min(), d0.max()
     assert len(set(d0.stypes)) == d0.ncols
-    d0.save(tempfile, format="jay")
+    d0.save(tempfile)
     assert os.path.isfile(tempfile)
     d1 = dt.open(tempfile)
     assert_equals(d0, d1)
@@ -194,7 +194,7 @@ def test_jay_keys(tempfile):
     assert len(d0.key) == 1
     assert d0.topython() == [["ab", "aop", "cd", "coo", "eee"],
                              [1, 5, 2, 4, 3]]
-    d0.save(tempfile, format="jay")
+    d0.save(tempfile)
     d1 = dt.open(tempfile)
     assert d1.key == ("x",)
     assert_equals(d0, d1)


### PR DESCRIPTION
This change is motivated by the fact that "NFF" format is now deprecated, so it makes no sense to keep it as the default. After this change, saving frames will be as easy as
```
frame.save("out.jay")
```

Closes #1422