### PR TITLE
Fix Frame rendering style in docs

### DIFF
--- a/c/frame/_repr_html_.cc
+++ b/c/frame/_repr_html_.cc
@@ -150,7 +150,9 @@ class HtmlWidget {
 
     void render_data_row(size_t i) {
       html << "    <tr>";
-      html << "<td class='row_index'>" << i << "</td>";
+      html << "<td class='row_index'>";
+      render_comma_separated(i);
+      html << "</td>";
       for (size_t j = 0; j < ncols; ++j) {
         if (j == cols0) {
           j = ncols - cols1;
@@ -178,18 +180,18 @@ class HtmlWidget {
 
 
     void render_table_footer() {
-      html << "  <div class='footer'>";
+      html << "  <div class='footer'>\n";
       render_frame_dimensions();
       html << "  </div>\n";
     }
 
     void render_frame_dimensions() {
-      html << "  <div class='frame_dimensions'>";
+      html << "    <div class='frame_dimensions'>";
       render_comma_separated(nrows);
       html << " row" << (nrows == 1? "" : "s") << " &times; ";
       render_comma_separated(ncols);
       html << " column" << (ncols == 1? "" : "s");
-      html << "  </div>\n";
+      html << "</div>\n";
     }
 
 
@@ -277,7 +279,7 @@ class HtmlWidget {
               "}\n";
       if (xd || vd) {
         html << ".datatable .frame thead { border-bottom: none; }\n"
-                ".datatable .frame tr {"
+                ".datatable .frame thead tr {"
                 "  background-image: " << (xd? imgx : imgv) <<
                 "  background-repeat: repeat-x;"
                 "  background-size: 14px;"
@@ -289,8 +291,9 @@ class HtmlWidget {
     }
 
     void render_comma_separated(size_t n) {
-      if (n == 0) {
-        html << '0';
+      // It is customary not to display commas in 4-digit numbers
+      if (n < 10000) {
+        html << n;
         return;
       }
       size_t n10 = n / 10;

--- a/docs/_static/code.css
+++ b/docs/_static/code.css
@@ -1,117 +1,119 @@
 
 body {
-    counter-reset: cc;
+  counter-reset: cc;
 }
 
 div.document div.notranslate {
-    border: none;
-    counter-increment: cc;
-    display: flex;
-    flex-direction: row;
-    padding: 0;
-    margin: 0 0 24px 0;
+  border: none;
+  counter-increment: cc;
+  display: flex;
+  flex-direction: row;
+  padding: 0;
+  margin: 0 0 24px 0;
 }
 
 div.document p + div.notranslate {
-    margin-top: -12px;
+  margin-top: -12px;
 }
 
 div.document div.notranslate + div.output-cell {
-    margin-top: -16px;
+  margin-top: -16px;
 }
 
 div.document div.notranslate:before {
-    color: #A6D2BB;
-    content: "[" counter(cc) "]:";
-    flex: 0 0 48px;
-    font-family: "Source Code Pro", monospace;
-    font-weight: bold;
-    font-size: 80%;
-    padding: .385em;
-    text-align: right;
+  color: #A6D2BB;
+  content: "[" counter(cc) "]:";
+  flex: 0 0 48px;
+  font-family: "Source Code Pro", monospace;
+  font-weight: bold;
+  font-size: 80%;
+  padding: .385em;
+  text-align: right;
 }
 
 div.document div.notranslate div.highlight {
-    background: #F5F5F5;
-    border: 1px solid #E0E0E0;
-    border-radius: 3px;
-    flex: 1 1 auto;
+  background: #F5F5F5;
+  border: 1px solid #E0E0E0;
+  border-radius: 3px;
+  flex: 1 1 auto;
 }
 
 div.document div.notranslate div.highlight pre {
-    padding: .5em 1em;
+  padding: .5em 1em;
 }
 
 
 div.document div.output-cell {
-    border: none;
-    display: flex;
-    flex-direction: row;
-    margin: 0 0 24px 0;
+  border: none;
+  display: flex;
+  flex-direction: row;
+  margin: 0 0 24px 0;
 }
 
 div.document div.output-cell:before {
-    color: #D9B1B2;
-    content: "[" counter(cc) "]:";
-    flex: 0 0 48px;
-    font-family: "Source Code Pro", monospace;
-    font-weight: bold;
-    font-size: 80%;
-    padding: .385em;
-    text-align: right;
+  color: #D9B1B2;
+  content: "[" counter(cc) "]:";
+  flex: 0 0 48px;
+  font-family: "Source Code Pro", monospace;
+  font-weight: bold;
+  font-size: 80%;
+  padding: .385em;
+  text-align: right;
 }
 
 .datatable table.frame {
-    border: none;
-    border-collapse: collapse;
-    border-spacing: 0;
-    color: #222;
-    font-size: 12px;
-    margin: 0 0 0 0;
+  border: none;
+  border-collapse: collapse;
+  border-spacing: 0;
+  color: #222;
+  font-size: 12px;
+  margin: 0 0 0 0;
 }
 .datatable .frame thead {
-    border-bottom: 1px solid #BDBDBD;
-    vertical-align: bottom;
+  border-bottom: 1px solid #BDBDBD;
+  vertical-align: bottom;
 }
 .datatable .frame td,
 .datatable .frame th,
 .datatable .frame tr {
-    border: none;
-    max-width: none;
-    padding: 0.5em 0.5em;
-    text-align: right;
-    vertical-align: middle;
+  border: none;
+  max-width: none;
+  padding: 0.5em 0.5em;
+  text-align: right;
+  vertical-align: middle;
+}
+.datatable .frame th:nth-child(2) {
+  padding-left: 12px;
+}
+.datatable .frame tr:nth-child(even) {
+  background-color: #F5F5F5;
 }
 
 .datatable .frame .row_index {
-  color: #CDE;
-  background: rgba(255,255,255,0.75);
-  font-size: 80%;
-  border-right: 1px solid #CCE6FF;
+  color: rgba(0, 0, 0, 0.38);
+  background: #EEEEEE;
+  font-size: 9px;
+  border-right: 1px solid #BDBDBD;
 }
 .datatable .frame .hellipsis {
-  background: linear-gradient(to bottom,
-    rgba(0,0,0,0.5) 0%, rgba(0,0,0,0.15) 7%,
-    rgba(0,0,0,0.0) 15%, rgba(0,0,0,0.0) 95%,
-    rgba(0,0,0,0.3) 100%);
-  padding: 0.1em 0.5em;
-  color: #DDD;
+  color: #E0E0E0;
 }
 .datatable .frame .vellipsis {
-  background: #FFF;
-  color: #DDD;
-  padding: 0.5em 1em;
-  border: 1px solid #EEE;
-  border-style: none solid;
+  background: #FFFFFF;
+  color: #E0E0E0;
 }
-.datatable .frame th.vellipsis { border: none; }
-.datatable .frame .na { color: #DDD; font-size: 80%; }
-.datatable .frame_dimensions {
-  background: #FAFAFA;
+.datatable .frame .na {
+  color: #E0E0E0;
+  font-size: 80%;
+}
+.datatable .footer {
+  font-size: 9px;
+}
+.datatable .footer .frame_dimensions {
+  background: #EEEEEE;
+  border-top: 1px solid #BDBDBD;
+  color: rgba(0, 0, 0, 0.38);
   display: inline-block;
-  font-size: 10px;
-  color: #AAA;
-  border: 1px solid #EEE;
-  padding: 0.1em .5em;
-  margin-left: 2em;
+  opacity: 0.6;
+  padding: 1px 10px 1px 5px;
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,6 +57,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.mathjax',
     'sphinx.ext.viewcode',
+    'sphinx.ext.napoleon'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/frame.rst
+++ b/docs/frame.rst
@@ -5,5 +5,6 @@ Python API
 ----------------
 .. autoclass:: datatable.Frame
     :members:
+    :inherited-members:
     :undoc-members:
 

--- a/docs/using-datatable.rst
+++ b/docs/using-datatable.rst
@@ -17,31 +17,33 @@ You can create a Frame from a variety of sources, including ``numpy`` arrays, ``
 
 .. raw:: html
 
-  <div class=output-cell><div class=datatable>
-    <table class=frame>
+  <div class=output-cell><div class='datatable'>
+    <table class='frame'>
     <thead>
-      <tr><td class=row_index></td><th>C0</th></tr>
+      <tr><td class='row_index'></td><th>C0</th></tr>
     </thead>
     <tbody>
-      <tr><td class=row_index>0</td><td>1.62435</td></tr>
-      <tr><td class=row_index>1</td><td>&minus;0.611756</td></tr>
-      <tr><td class=row_index>2</td><td>&minus;0.528172</td></tr>
-      <tr><td class=row_index>3</td><td>&minus;1.07297</td></tr>
-      <tr><td class=row_index>4</td><td>0.865408</td></tr>
-      <tr><td class=row_index>5</td><td>&minus;2.30154</td></tr>
-      <tr><td class=row_index>6</td><td>1.74481</td></tr>
-      <tr><td class=row_index>7</td><td>&minus;0.761207</td></tr>
-      <tr><td class=row_index>8</td><td>0.319039</td></tr>
-      <tr><td class=row_index>9</td><td>&minus;0.24937</td></tr>
-      <tr><td class=hellipsis>&middot;&middot;&middot;</td><td class=hellipsis>&middot;&middot;&middot;</td></tr>
-      <tr><td class=row_index>999995</td><td>0.0595784</td></tr>
-      <tr><td class=row_index>999996</td><td>0.140349</td></tr>
-      <tr><td class=row_index>999997</td><td>&minus;0.596161</td></tr>
-      <tr><td class=row_index>999998</td><td>1.18604</td></tr>
-      <tr><td class=row_index>999999</td><td>0.313398</td></tr>
+      <tr><td class='row_index'>0</td><td>1.62435</td></tr>
+      <tr><td class='row_index'>1</td><td>&minus;0.611756</td></tr>
+      <tr><td class='row_index'>2</td><td>&minus;0.528172</td></tr>
+      <tr><td class='row_index'>3</td><td>&minus;1.07297</td></tr>
+      <tr><td class='row_index'>4</td><td>0.865408</td></tr>
+      <tr><td class='row_index'>5</td><td>&minus;2.30154</td></tr>
+      <tr><td class='row_index'>6</td><td>1.74481</td></tr>
+      <tr><td class='row_index'>7</td><td>&minus;0.761207</td></tr>
+      <tr><td class='row_index'>8</td><td>0.319039</td></tr>
+      <tr><td class='row_index'>9</td><td>&minus;0.24937</td></tr>
+      <tr><td class='row_index'>&#x22EE;</td><td class='hellipsis'>&#x22EE;</td></tr>
+      <tr><td class='row_index'>999,995</td><td>0.0595784</td></tr>
+      <tr><td class='row_index'>999,996</td><td>0.140349</td></tr>
+      <tr><td class='row_index'>999,997</td><td>&minus;0.596161</td></tr>
+      <tr><td class='row_index'>999,998</td><td>1.18604</td></tr>
+      <tr><td class='row_index'>999,999</td><td>0.313398</td></tr>
     </tbody>
     </table>
-    <div class=frame_dimensions>1,000,000 rows &times; 1 column</div>
+    <div class='footer'>
+      <div class='frame_dimensions'>1,000,000 rows &times; 1 column</div>
+    </div>
   </div></div>
 
 ::
@@ -51,32 +53,33 @@ You can create a Frame from a variety of sources, including ``numpy`` arrays, ``
 
 .. raw:: html
 
-  <div class=output-cell><div class=datatable>
-    <table class=frame>
+  <div class=output-cell><div class='datatable'>
+    <table class='frame'>
     <thead>
-      <tr><td class=row_index></td><th>A</th></tr>
+      <tr><td class='row_index'></td><th>A</th></tr>
     </thead>
     <tbody>
-      <tr><td class=row_index>0</td><td>0</td></tr>
-      <tr><td class=row_index>1</td><td>1</td></tr>
-      <tr><td class=row_index>2</td><td>2</td></tr>
-      <tr><td class=row_index>3</td><td>3</td></tr>
-      <tr><td class=row_index>4</td><td>4</td></tr>
-      <tr><td class=row_index>5</td><td>5</td></tr>
-      <tr><td class=row_index>6</td><td>6</td></tr>
-      <tr><td class=row_index>7</td><td>7</td></tr>
-      <tr><td class=row_index>8</td><td>8</td></tr>
-      <tr><td class=row_index>9</td><td>9</td></tr>
-      <tr><td class=row_index>10</td><td>10</td></tr>
-      <tr><td class=hellipsis>&middot;&middot;&middot;</td><td class=hellipsis>&middot;&middot;&middot;</td></tr>
-      <tr><td class=row_index>995</td><td>995</td></tr>
-      <tr><td class=row_index>996</td><td>996</td></tr>
-      <tr><td class=row_index>997</td><td>997</td></tr>
-      <tr><td class=row_index>998</td><td>998</td></tr>
-      <tr><td class=row_index>999</td><td>999</td></tr>
+      <tr><td class='row_index'>0</td><td>0</td></tr>
+      <tr><td class='row_index'>1</td><td>1</td></tr>
+      <tr><td class='row_index'>2</td><td>2</td></tr>
+      <tr><td class='row_index'>3</td><td>3</td></tr>
+      <tr><td class='row_index'>4</td><td>4</td></tr>
+      <tr><td class='row_index'>5</td><td>5</td></tr>
+      <tr><td class='row_index'>6</td><td>6</td></tr>
+      <tr><td class='row_index'>7</td><td>7</td></tr>
+      <tr><td class='row_index'>8</td><td>8</td></tr>
+      <tr><td class='row_index'>9</td><td>9</td></tr>
+      <tr><td class='row_index'>&#x22EE;</td><td class='hellipsis'>&#x22EE;</td></tr>
+      <tr><td class='row_index'>995</td><td>995</td></tr>
+      <tr><td class='row_index'>996</td><td>996</td></tr>
+      <tr><td class='row_index'>997</td><td>997</td></tr>
+      <tr><td class='row_index'>998</td><td>998</td></tr>
+      <tr><td class='row_index'>999</td><td>999</td></tr>
     </tbody>
     </table>
-    <div class=frame_dimensions>1,000 rows &times; 1 column</div>
+    <div class='footer'>
+      <div class='frame_dimensions'>1000 rows &times; 1 column</div>
+    </div>
   </div></div>
 
 ::
@@ -85,17 +88,19 @@ You can create a Frame from a variety of sources, including ``numpy`` arrays, ``
 
 .. raw:: html
 
-  <div class=output-cell><div class=datatable>
-    <table class=frame>
+  <div class=output-cell><div class='datatable'>
+    <table class='frame'>
     <thead>
-      <tr><td class=row_index></td><th>n</th><th>s</th></tr>
+      <tr><td class='row_index'></td><th>n</th><th>s</th></tr>
     </thead>
     <tbody>
-      <tr><td class=row_index>0</td><td>1</td><td>foo</td></tr>
-      <tr><td class=row_index>1</td><td>3</td><td>bar</td></tr>
+      <tr><td class='row_index'>0</td><td>1</td><td>foo</td></tr>
+      <tr><td class='row_index'>1</td><td>3</td><td>bar</td></tr>
     </tbody>
     </table>
-    <div class=frame_dimensions>2 rows &times; 2 columns</div>
+    <div class='footer'>
+      <div class='frame_dimensions'>2 rows &times; 2 columns</div>
+    </div>
   </div></div>
 
 


### PR DESCRIPTION
- The styling of Frame display in docs is now the same as in Jupyter;
- Row numbers are now displayed comma-separated;
- Comma-separation is not applied to numbers in the range 1000-9999.

Closes #1426