### PR TITLE
Add column type indicators in Jupyter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+#### Added
+- In Jupyter notebook columns now have visual indicators of their types.
+  The logical types are color-coded, and the size of each element is
+  given by the number of dots (#1428).
+
+
 ### [Unreleased](https://github.com/h2oai/datatable/compare/HEAD...v0.6.0)
 #### Added
 - Frame can now be created from a list/dict of numpy arrays.

--- a/c/frame/_repr_html_.cc
+++ b/c/frame/_repr_html_.cc
@@ -106,9 +106,15 @@ class HtmlWidget {
     }
 
     void render_table_header() {
+      html << "  <thead>\n";
+      render_column_names();
+      render_column_types();
+      html << "  </thead>\n";
+    }
+
+    void render_column_names() {
       const std::vector<std::string>& colnames = dt->get_names();
-      html << "  <thead>\n"
-              "    <tr>";
+      html << "    <tr class='colnames'>";
       html << "<td class='row_index'></td>";
       for (size_t j = 0; j < ncols; ++j) {
         if (j == cols0) {
@@ -119,8 +125,25 @@ class HtmlWidget {
         render_escaped_string(colnames[j].data(), colnames[j].size());
         html << "</th>";
       }
-      html << "</tr>\n"
-              "  </thead>\n";
+      html << "</tr>\n";
+    }
+
+    void render_column_types() {
+      html << "    <tr class='coltypes'>";
+      html << "<td class='row_index'></td>";
+      for (size_t j = 0; j < ncols; ++j) {
+        if (j == cols0) {
+          j = ncols - cols1;
+          html << "<th class='vellipsis'>&hellip;</th>";
+        }
+        SType stype = dt->columns[j]->stype();
+        size_t elemsize = info(stype).elemsize();
+        html << "<td class='" << info(stype).ltype_name()
+             << "' title='" << info(stype).name() << "'>";
+        for (size_t k = 0; k < elemsize; ++k) html << "&#x25AA;";
+        html << "</td>";
+      }
+      html << "</tr>\n";
     }
 
     void render_table_body() {
@@ -170,6 +193,7 @@ class HtmlWidget {
           case SType::FLOAT64: render_fw_value<double>(col, i); break;
           case SType::STR32:   render_str_value<uint32_t>(col, i); break;
           case SType::STR64:   render_str_value<uint64_t>(col, i); break;
+          case SType::OBJ:     render_obj_value(col, i); break;
           default:
             html << "(unknown stype)";
         }
@@ -236,6 +260,18 @@ class HtmlWidget {
       }
     }
 
+    void render_obj_value(const Column* col, size_t row) {
+      auto scol = static_cast<const PyObjectColumn*>(col);
+      PyObject* val = scol->get_elem(static_cast<int64_t>(row));
+      if (ISNA<PyObject*>(val)) render_na();
+      else {
+        // Should we use repr() here instead?
+        py::ostring strval = py::robj(val).to_pystring_force();
+        CString cstr = strval.to_cstring();
+        render_escaped_string(cstr.ch, static_cast<size_t>(cstr.size));
+      }
+    }
+
     void render_na() {
       html << "<span class=na>NA</span>";
     }
@@ -250,11 +286,25 @@ class HtmlWidget {
 
       html << "<style type='text/css'>\n";
       html << ".datatable table.frame { margin-bottom: 0; }\n"
+              ".datatable table.frame thead { border-bottom: none; }\n"
+              ".datatable table.frame tr.coltypes td {"
+              "  color: #FFFFFF;"
+              "  line-height: 6px;"
+              "  padding: 0 0.5em;"
+              "}\n"
+              ".datatable .bool { background: #DDDD99; }\n"
+              ".datatable .obj  { background: #565656; }\n"
+              ".datatable .int  { background: #5D9E5D; }\n"
+              ".datatable .real { background: #4040CC; }\n"
+              ".datatable .str  { background: #CC4040; }\n"
               ".datatable .row_index {"
               "  background: var(--jp-border-color3);"
               "  border-right: 1px solid var(--jp-border-color0);"
               "  color: var(--jp-ui-font-color3);"
               "  font-size: 9px;"
+              "}\n"
+              ".datatable .frame tr.coltypes .row_index {"
+              "  background: var(--jp-border-color0);"
               "}\n"
               ".datatable th:nth-child(2) { padding-left: 12px; }\n"
               ".datatable .hellipsis {"
@@ -278,8 +328,7 @@ class HtmlWidget {
               "  padding: 1px 10px 1px 5px;"
               "}\n";
       if (xd || vd) {
-        html << ".datatable .frame thead { border-bottom: none; }\n"
-                ".datatable .frame thead tr {"
+        html << ".datatable .frame thead tr.colnames {"
                 "  background-image: " << (xd? imgx : imgv) <<
                 "  background-repeat: repeat-x;"
                 "  background-size: 14px;"

--- a/c/types.cc
+++ b/c/types.cc
@@ -300,6 +300,19 @@ LType info::ltype() const {
   return stype_info[stype].ltype;
 }
 
+const char* info::ltype_name() const {
+  switch (ltype()) {
+    case LType::MU:       return "void";
+    case LType::BOOL:     return "bool";
+    case LType::INT:      return "int";
+    case LType::REAL:     return "real";
+    case LType::STRING:   return "str";
+    case LType::DATETIME: return "time";
+    case LType::DURATION: return "duration";
+    case LType::OBJECT:   return "obj";
+  }
+}
+
 py::oobj info::py_ltype() const {
   return py::oobj(py_ltype_objs[static_cast<uint8_t>(ltype())]);
 }

--- a/c/types.h
+++ b/c/types.h
@@ -328,6 +328,7 @@ class info {
   public:
     info(SType s);
     const char* name() const;
+    const char* ltype_name() const;
     size_t elemsize() const;
     bool is_varwidth() const;
     LType ltype() const;

--- a/docs/_static/code.css
+++ b/docs/_static/code.css
@@ -66,13 +66,24 @@ div.document div.output-cell:before {
   border-collapse: collapse;
   border-spacing: 0;
   color: #222;
+  cursor: default;
   font-size: 12px;
   margin: 0 0 0 0;
 }
 .datatable .frame thead {
-  border-bottom: 1px solid #BDBDBD;
+  border-bottom: none;
   vertical-align: bottom;
 }
+.datatable table.frame tr.coltypes td {
+  color: #FFFFFF;
+  line-height: 6px;
+  padding: 0 0.5em;
+}
+.datatable .bool { background: #DDDD99; }
+.datatable .obj  { background: #565656; }
+.datatable .int  { background: #5D9E5D; }
+.datatable .real { background: #4040CC; }
+.datatable .str  { background: #CC4040; }
 .datatable .frame td,
 .datatable .frame th,
 .datatable .frame tr {
@@ -94,6 +105,9 @@ div.document div.output-cell:before {
   background: #EEEEEE;
   font-size: 9px;
   border-right: 1px solid #BDBDBD;
+}
+.datatable .frame tr.coltypes .row_index {
+  background: #BDBDBD;
 }
 .datatable .frame .hellipsis {
   color: #E0E0E0;

--- a/docs/using-datatable.rst
+++ b/docs/using-datatable.rst
@@ -20,7 +20,8 @@ You can create a Frame from a variety of sources, including ``numpy`` arrays, ``
   <div class=output-cell><div class='datatable'>
     <table class='frame'>
     <thead>
-      <tr><td class='row_index'></td><th>C0</th></tr>
+      <tr class='colnames'><td class='row_index'></td><th>C0</th></tr>
+      <tr class='coltypes'><td class='row_index'></td><td class='real' title='float64'>&#x25AA;&#x25AA;&#x25AA;&#x25AA;&#x25AA;&#x25AA;&#x25AA;&#x25AA;</td></tr>
     </thead>
     <tbody>
       <tr><td class='row_index'>0</td><td>1.62435</td></tr>
@@ -56,7 +57,8 @@ You can create a Frame from a variety of sources, including ``numpy`` arrays, ``
   <div class=output-cell><div class='datatable'>
     <table class='frame'>
     <thead>
-      <tr><td class='row_index'></td><th>A</th></tr>
+      <tr class='colnames'><td class='row_index'></td><th>A</th></tr>
+      <tr class='coltypes'><td class='row_index'></td><td class='int' title='int64'>&#x25AA;&#x25AA;&#x25AA;&#x25AA;&#x25AA;&#x25AA;&#x25AA;&#x25AA;</td></tr>
     </thead>
     <tbody>
       <tr><td class='row_index'>0</td><td>0</td></tr>
@@ -91,7 +93,8 @@ You can create a Frame from a variety of sources, including ``numpy`` arrays, ``
   <div class=output-cell><div class='datatable'>
     <table class='frame'>
     <thead>
-      <tr><td class='row_index'></td><th>n</th><th>s</th></tr>
+      <tr class='colnames'><td class='row_index'></td><th>n</th><th>s</th></tr>
+      <tr class='coltypes'><td class='row_index'></td><td class='int' title='int8'>&#x25AA;</td><td class='str' title='str32'>&#x25AA;&#x25AA;&#x25AA;&#x25AA;</td></tr>
     </thead>
     <tbody>
       <tr><td class='row_index'>0</td><td>1</td><td>foo</td></tr>


### PR DESCRIPTION
In Jupyter, we now display an extra row under the column names, carrying indicators of column types. This row is designed to be unobtrusive: only 6px in height, the color of each cell corresponds to the logical type of the column (int -> green, float -> blue, string -> red, bool -> yellow, object -> black), and the number of dots in the cell shows the element size (1 dot = 8 bit, 2 dots = 16 bits, 4 dots = 32 bits, 8 dots = 64 bits).

In addition, this PR fixes display of "obj" columns (previously they were not rendering at all).

This is how it now looks like:

<img width="612" alt="screen shot 2018-11-19 at 3 11 49 pm" src="https://user-images.githubusercontent.com/4231472/48741065-b67ad280-ec0e-11e8-8137-fabfff497f5e.png">


Closes #1428
Closes #1430