### PR TITLE
update using-datatable docs

### DIFF
--- a/docs/using-datatable.rst
+++ b/docs/using-datatable.rst
@@ -191,7 +191,7 @@ Select subsets of rows and/or columns using:
 
 ::
 
-   df["A"]            # select 1 column
+   df[:, "A"]         # select 1 column
    df[:10, :]         # first 10 rows
    df[::-1, "A":"D"]  # reverse rows order, columns from A to D
    df[27, 3]          # single element in row 27, column 3 (0-based)
@@ -203,7 +203,7 @@ Delete rows and or columns using:
 
 ::
 
-   del df["D"]        # delete column D
+   del df[:, "D"]     # delete column D
    del df[f.A < 0, :] # delete rows where column A has negative values
 
 Filter Rows


### PR DESCRIPTION
update using-datatable docs

Updates the documentation to use the preferred `DT[:, col]` syntax.
As of the 0.7.0 release, single-item selectors `DT[col]` are deprecated.
