### PR TITLE
Fixed installation from source distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   had another row filter applied (#1437).
 - Frame.copy() now retains the key (#1443).
 - rendering of "view" Frames in Jupyter notebook (#1448).
+- installation from source distribution (#1451).
 
 
 ### [v0.7.0](https://github.com/h2oai/datatable/compare/0.7.0...v0.6.0) — 2018-11-16

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include README.md
 include CHANGELOG.md
 include setup.py
 include setup.cfg
+include ci/setup_utils.py
 recursive-include c         *.c *.cc *.h
 recursive-include datatable *.py
 recursive-include tests     *.py


### PR DESCRIPTION
- File `ci/setup_utils.py` is no longer omitted from the sdist;
- Installing from sdist no longer requires generating the `__git__.py` file.

Closes #1451