### PR TITLE
Initial implementation of core.base_expr class

### DIFF
--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -11,6 +11,7 @@
 #include "capi.h"
 #include "csv/py_csv.h"
 #include "csv/writer.h"
+#include "expr/base_expr.h"
 #include "expr/py_expr.h"
 #include "extras/aggregator.h"
 #include "extras/py_ftrl.h"
@@ -236,6 +237,7 @@ PyInit__datatable()
 
     py::Frame::Type::init(m);
     py::Ftrl::Type::init(m);
+    py::base_expr::Type::init(m);
 
   } catch (const std::exception& e) {
     exception_to_python(e);

--- a/c/expr/base_expr.cc
+++ b/c/expr/base_expr.cc
@@ -237,7 +237,7 @@ class expr_literal : public base_expr {
     Column* col;
 
   public:
-    expr_literal(const py::robj&);
+    explicit expr_literal(const py::robj&);
     ~expr_literal() override;
     SType resolve(const workframe&) override;
     Column* evaluate_eager(const workframe&) override;

--- a/c/expr/base_expr.cc
+++ b/c/expr/base_expr.cc
@@ -1,0 +1,345 @@
+//------------------------------------------------------------------------------
+// Copyright 2018 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#include <memory>             // std::unique_ptr
+#include "datatable.h"
+#include "expr/base_expr.h"
+#include "expr/py_expr.h"
+#include "stdlib.h"
+
+
+namespace dt {
+
+
+
+//------------------------------------------------------------------------------
+// workframe
+//------------------------------------------------------------------------------
+
+class workframe {
+  private:
+    std::vector<DataTable*> dts;
+    std::vector<RowIndex> rowindexes;
+
+  public:
+    workframe() = default;
+    workframe(const workframe&) = delete;
+    workframe(workframe&&) = delete;
+
+    DataTable* get_datatable(size_t id) const {
+      return dts[id];
+    }
+
+    const RowIndex& get_rowindex(size_t id) const {
+      return rowindexes[id];
+    }
+};
+
+
+
+//------------------------------------------------------------------------------
+// base_expr
+//------------------------------------------------------------------------------
+
+class base_expr {
+  public:
+    virtual ~base_expr();
+    virtual SType resolve(const workframe&) = 0;
+    virtual Column* evaluate_eager(const workframe&) = 0;
+};
+
+using base_expr_ptr = std::unique_ptr<base_expr>;
+
+base_expr::~base_expr() {}
+
+
+
+//------------------------------------------------------------------------------
+// expr_column
+//------------------------------------------------------------------------------
+
+
+class expr_column : public base_expr {
+  private:
+    size_t frame_id;
+    size_t col_id;
+    py::oobj col_selector;
+
+  public:
+    expr_column(size_t dfid, const py::robj& col);
+    SType resolve(const workframe&) override;
+    Column* evaluate_eager(const workframe&) override;
+};
+
+
+expr_column::expr_column(size_t dfid, const py::robj& col)
+  : frame_id(dfid), col_id(size_t(-1)), col_selector(col) {}
+
+
+SType expr_column::resolve(const workframe& wf) {
+  DataTable* dt = wf.get_datatable(frame_id);
+  if (col_selector.is_int()) {
+    int64_t icolid = col_selector.to_int64_strict();
+    int64_t incols = static_cast<int64_t>(dt->ncols);
+    if (icolid < -incols || icolid >= incols) {
+      throw ValueError() << "Column index " << icolid << " is invalid for "
+          "a Frame with " << incols << " column" << (incols == 1? "" : "s");
+    }
+    if (icolid < 0) icolid += incols;
+    col_id = static_cast<size_t>(icolid);
+  }
+  else if (col_selector.is_string()) {
+    col_id = dt->xcolindex(col_selector);
+  }
+  xassert(col_id < dt->ncols);
+  return dt->columns[col_id]->stype();
+}
+
+
+Column* expr_column::evaluate_eager(const workframe& wf) {
+  DataTable* dt = wf.get_datatable(frame_id);
+  Column* rcol = dt->columns[col_id];
+  const RowIndex& dt_ri = wf.get_rowindex(frame_id);
+  const RowIndex& col_ri = rcol->rowindex();
+
+  if (dt_ri && col_ri) {
+    // TODO: implement rowindex cache in the workframe
+    return rcol->shallowcopy(dt_ri * col_ri);
+  }
+  else if (dt_ri /* && !col_ri */) {
+    return rcol->shallowcopy(dt_ri);
+  }
+  else {
+    return rcol->shallowcopy();
+  }
+}
+
+
+
+//------------------------------------------------------------------------------
+// expr_binaryop
+//------------------------------------------------------------------------------
+
+static std::vector<std::string> binop_names;
+static std::unordered_map<size_t, SType> binop_rules;
+
+static size_t bin_id(binopCode opcode, SType st1, SType st2) {
+  return (static_cast<size_t>(opcode) << 16) +
+         (static_cast<size_t>(st1) << 8) +
+         static_cast<size_t>(st2);
+}
+
+static void init_binops() {
+  constexpr SType bool8 = SType::BOOL;
+  std::vector<SType> integer_stypes = {
+    SType::INT8, SType::INT16, SType::INT32, SType::INT64};
+  std::vector<SType> numeric_stypes = {
+    SType::BOOL, SType::INT8, SType::INT16, SType::INT32, SType::INT64,
+    SType::FLOAT32, SType::FLOAT64};
+
+  for (SType st1 : numeric_stypes) {
+    for (SType st2 : numeric_stypes) {
+      SType stm = std::max(st1, st2);
+      binop_rules[bin_id(binopCode::PLUS, st1, st2)] = stm;
+      binop_rules[bin_id(binopCode::MINUS, st1, st2)] = stm;
+      binop_rules[bin_id(binopCode::MULTIPLY, st1, st2)] = stm;
+      binop_rules[bin_id(binopCode::POWER, st1, st2)] = stm;
+      binop_rules[bin_id(binopCode::DIVIDE, st1, st2)] = SType::FLOAT64;
+      binop_rules[bin_id(binopCode::REL_EQ, st1, st2)] = bool8;
+      binop_rules[bin_id(binopCode::REL_NE, st1, st2)] = bool8;
+      binop_rules[bin_id(binopCode::REL_LT, st1, st2)] = bool8;
+      binop_rules[bin_id(binopCode::REL_GT, st1, st2)] = bool8;
+      binop_rules[bin_id(binopCode::REL_LE, st1, st2)] = bool8;
+      binop_rules[bin_id(binopCode::REL_GE, st1, st2)] = bool8;
+    }
+  }
+  for (SType st1 : integer_stypes) {
+    for (SType st2 : integer_stypes) {
+      SType stm = std::max(st1, st2);
+      binop_rules[bin_id(binopCode::INT_DIVIDE, st1, st2)] = stm;
+      binop_rules[bin_id(binopCode::MODULO, st1, st2)] = stm;
+      binop_rules[bin_id(binopCode::LEFT_SHIFT, st1, st2)] = stm;
+      binop_rules[bin_id(binopCode::RIGHT_SHIFT, st1, st2)] = stm;
+    }
+  }
+  binop_rules[bin_id(binopCode::LOGICAL_AND, bool8, bool8)] = bool8;
+  binop_rules[bin_id(binopCode::LOGICAL_OR, bool8, bool8)] = bool8;
+
+  binop_names.resize(18);
+  binop_names[size_t(binopCode::PLUS)] = "+";
+  binop_names[size_t(binopCode::MINUS)] = "-";
+}
+
+
+class expr_binaryop : public base_expr {
+  private:
+    base_expr* lhs;
+    base_expr* rhs;
+    size_t binop_code;
+
+  public:
+    expr_binaryop(size_t opcode, base_expr* l, base_expr* r);
+    SType resolve(const workframe& wf) override;
+    Column* evaluate_eager(const workframe& wf) override;
+};
+
+
+expr_binaryop::expr_binaryop(size_t opcode, base_expr* l, base_expr* r)
+  : lhs(l), rhs(r), binop_code(opcode) {}
+
+
+SType expr_binaryop::resolve(const workframe& wf) {
+  SType lhs_stype = lhs->resolve(wf);
+  SType rhs_stype = rhs->resolve(wf);
+  size_t triple = bin_id(static_cast<binopCode>(binop_code),
+                         lhs_stype, rhs_stype);
+  if (binop_rules.count(triple)) {
+    throw TypeError() << "Binary operator `" << binop_names[binop_code]
+        << "` cannot be applied to column with stypes `" << lhs_stype
+        << "` and `" << rhs_stype << "`";
+  }
+  return binop_rules.at(triple);
+}
+
+
+Column* expr_binaryop::evaluate_eager(const workframe& wf) {
+  Column* lhs_res = lhs->evaluate_eager(wf);
+  Column* rhs_res = rhs->evaluate_eager(wf);
+  return expr::binaryop(binop_code, lhs_res, rhs_res);
+}
+
+
+
+//------------------------------------------------------------------------------
+// expr_literal
+//------------------------------------------------------------------------------
+
+class expr_literal : public base_expr {
+  private:
+    Column* col;
+
+  public:
+    expr_literal(const py::robj&);
+    ~expr_literal() override;
+    SType resolve(const workframe&) override;
+    Column* evaluate_eager(const workframe&) override;
+};
+
+
+expr_literal::expr_literal(const py::robj& v) {
+  py::olist lst(1);
+  lst.set(0, v);
+  col = Column::from_pylist(lst, 0);
+}
+
+expr_literal::~expr_literal() {
+  delete col;
+}
+
+
+SType expr_literal::resolve(const workframe&) {
+  return col->stype();
+}
+
+
+Column* expr_literal::evaluate_eager(const workframe&) {
+  return col->shallowcopy();
+}
+
+
+
+
+};
+
+
+//------------------------------------------------------------------------------
+// py::base_expr
+//------------------------------------------------------------------------------
+
+py::PKArgs py::base_expr::Type::args___init__(
+    1, 0, 0, true, false, {"opcode"}, "__init__", nullptr);
+
+const char* py::base_expr::Type::classname() {
+  return "base_expr";
+}
+
+const char* py::base_expr::Type::classdoc() {
+  return "Internal expression object";
+}
+
+
+static void check_args_count(const std::vector<py::robj>& va, size_t n) {
+  if (va.size() == n) return;
+  throw TypeError() << "Expected " << n << " additional arguments, but "
+      "received " << va.size();
+}
+
+static dt::base_expr* to_base_expr(const py::robj& arg) {
+  PyObject* v = arg.to_borrowed_ref();
+  if (Py_TYPE(v) == &py::base_expr::Type::type) {
+    auto vv = reinterpret_cast<py::base_expr*>(v);
+    return vv->expr;
+  }
+  throw TypeError() << "Expected a base_expr object, but got " << arg.typeobj();
+}
+
+
+void py::base_expr::m__init__(py::PKArgs& args) {
+  expr = nullptr;
+
+  size_t opcode = args[0].to_size_t();
+  std::vector<py::robj> va;
+  va.reserve(args.num_vararg_args());
+  for (auto item : args.varargs()) va.push_back(std::move(item));
+
+  switch (opcode) {
+    case dt::exprCode::COL: {
+      check_args_count(va, 2);
+      expr = new dt::expr_column(va[0].to_size_t(), va[1]);
+      break;
+    }
+    case dt::exprCode::BINOP: {
+      check_args_count(va, 3);
+      size_t binop_code = va[0].to_size_t();
+      dt::base_expr* lhs = to_base_expr(va[1]);
+      dt::base_expr* rhs = to_base_expr(va[2]);
+      expr = new dt::expr_binaryop(binop_code, lhs, rhs);
+      break;
+    }
+    case dt::exprCode::LITERAL: {
+      check_args_count(va, 1);
+      expr = new dt::expr_literal(va[0]);
+      break;
+    }
+  }
+}
+
+void py::base_expr::m__dealloc__() {
+  delete expr;
+}
+
+
+void py::base_expr::Type::init_methods_and_getsets(
+    py::ExtType<py::base_expr>::Methods&,
+    py::ExtType<py::base_expr>::GetSetters&)
+{
+  dt::init_binops();
+}

--- a/c/expr/base_expr.h
+++ b/c/expr/base_expr.h
@@ -1,0 +1,85 @@
+//------------------------------------------------------------------------------
+// Copyright 2018 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#ifndef dt_EXPR_BASE_EXPR_h
+#define dt_EXPR_BASE_EXPR_h
+#include "column.h"
+#include "python/ext_type.h"
+
+
+namespace dt {
+  class base_expr;
+
+  enum exprCode : size_t {
+    COL = 1,
+    BINOP = 2,
+    LITERAL = 3,
+  };
+
+  enum class binopCode : size_t {
+    PLUS           = 1,
+    MINUS          = 2,
+    MULTIPLY       = 3,
+    DIVIDE         = 4,
+    INT_DIVIDE     = 5,
+    POWER          = 6,
+    MODULO         = 7,
+    LOGICAL_AND    = 8,
+    LOGICAL_OR     = 9,
+    LEFT_SHIFT     = 10,
+    RIGHT_SHIFT    = 11,
+    REL_EQ         = 12,  // ==
+    REL_NE         = 13,  // !=
+    REL_GT         = 14,  // >
+    REL_LT         = 15,  // <
+    REL_GE         = 16,  // >=
+    REL_LE         = 17,  // <=
+  };
+
+}
+
+
+namespace py {
+
+
+class base_expr : public PyObject {
+  public:
+    dt::base_expr* expr;
+
+  public:
+    class Type : public ExtType<base_expr> {
+      public:
+        static PKArgs args___init__;
+        static const char* classname();
+        static const char* classdoc();
+        static bool is_subclassable() { return false; }
+        static void init_methods_and_getsets(Methods&, GetSetters&);
+    };
+
+    void m__init__(PKArgs&);
+    void m__dealloc__();
+
+};
+
+
+}
+
+#endif

--- a/c/expr/binaryop.cc
+++ b/c/expr/binaryop.cc
@@ -1,9 +1,23 @@
 //------------------------------------------------------------------------------
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright 2018 H2O.ai
 //
-// © H2O.ai 2018
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 // This file implements binary operations between columbs, such as Plus, Minus,
 // Multiply, etc. That is, if `x` and `y` are two columns of compatible
@@ -351,7 +365,7 @@ static mapperfn resolve2str(OpMode mode) {
 
 
 template<typename LT, typename RT, typename VT>
-static mapperfn resolve1(int opcode, SType stype, void** params, size_t nrows, OpMode mode) {
+static mapperfn resolve1(size_t opcode, SType stype, void** params, size_t nrows, OpMode mode) {
   if (opcode >= OpCode::Equal) {
     // override stype for relational operators
     stype = SType::BOOL;
@@ -385,7 +399,7 @@ static mapperfn resolve1(int opcode, SType stype, void** params, size_t nrows, O
 
 
 template<typename T0, typename T1>
-static mapperfn resolve1str(int opcode, void** params, size_t nrows, OpMode mode) {
+static mapperfn resolve1str(size_t opcode, void** params, size_t nrows, OpMode mode) {
   if (mode == OpMode::One_to_N) {
     mode = OpMode::N_to_One;
     std::swap(params[0], params[1]);
@@ -400,7 +414,7 @@ static mapperfn resolve1str(int opcode, void** params, size_t nrows, OpMode mode
 }
 
 
-static mapperfn resolve0(SType lhs_type, SType rhs_type, int opcode, void** params, size_t nrows, OpMode mode) {
+static mapperfn resolve0(SType lhs_type, SType rhs_type, size_t opcode, void** params, size_t nrows, OpMode mode) {
   if (mode == OpMode::Error) return nullptr;
   switch (lhs_type) {
     case SType::BOOL:
@@ -509,7 +523,7 @@ static mapperfn resolve0(SType lhs_type, SType rhs_type, int opcode, void** para
 // Exported binaryop function
 //------------------------------------------------------------------------------
 
-Column* binaryop(int opcode, Column* lhs, Column* rhs)
+Column* binaryop(size_t opcode, Column* lhs, Column* rhs)
 {
   lhs->reify();
   rhs->reify();

--- a/c/expr/py_expr.cc
+++ b/c/expr/py_expr.cc
@@ -24,7 +24,7 @@ PyObject* expr_binaryop(PyObject*, PyObject* args)
 
   Column* lhs = py_lhs.to_column();
   Column* rhs = py_rhs.to_column();
-  Column* res = expr::binaryop(opcode, lhs, rhs);
+  Column* res = expr::binaryop(static_cast<size_t>(opcode), lhs, rhs);
   return pycolumn::from_column(res, nullptr, 0);
 }
 

--- a/c/expr/py_expr.h
+++ b/c/expr/py_expr.h
@@ -59,7 +59,7 @@ typedef void (*mapperfn)(int64_t row0, int64_t row1, void** params);
 typedef void (*gmapperfn)(const int32_t* groups, int32_t grp, void** params);
 
 Column* unaryop(int opcode, Column* arg);
-Column* binaryop(int opcode, Column* lhs, Column* rhs);
+Column* binaryop(size_t opcode, Column* lhs, Column* rhs);
 Column* reduceop(int opcode, Column* arg, const Groupby& groupby);
 Column* reduce_first(const Column* col, const Groupby& groupby);
 

--- a/c/python/ext_type.h
+++ b/c/python/ext_type.h
@@ -48,8 +48,8 @@ namespace py {
  *    Please::Type::init(module);
  *
  * Note that unlike standard Python C extension types, this initialization
- * method does not return a status code. Instead, should an error occur, it
- * will be thrown as an exception.
+ * method does not return a status code. Instead, should an error occur,
+ * an exception will be thrown.
  *
  * Thus, in order to declare a python extension type, you should create a
  * class derived from `PyObject`, and containing a public internal class

--- a/datatable/expr/base_expr.py
+++ b/datatable/expr/base_expr.py
@@ -4,7 +4,6 @@
 #   License, v. 2.0. If a copy of the MPL was not distributed with this
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #-------------------------------------------------------------------------------
-
 import datatable
 from .consts import ctypes_map, nas_map
 
@@ -98,6 +97,13 @@ class BaseExpr:
         """
         Returns True iff this expression is a reducer (i.e. produces as many
         rows as there are groups in the groupby).
+        """
+        raise NotImplementedError
+
+
+    def _core(self):
+        """
+        Converts this object into a ``_datatable.base_expr``.
         """
         raise NotImplementedError
 

--- a/datatable/expr/binary_expr.py
+++ b/datatable/expr/binary_expr.py
@@ -7,7 +7,7 @@
 
 from .base_expr import BaseExpr
 from .literal_expr import LiteralExpr
-from .consts import ops_rules, division_ops
+from .consts import ops_rules, division_ops, baseexpr_opcodes
 from datatable.utils.typechecks import TTypeError, TValueError
 from datatable.lib import core
 
@@ -44,6 +44,12 @@ class BinaryOpExpr(BaseExpr):
 
     def is_reduce_expr(self, ee):
         return self._lhs.is_reduce_expr(ee) and self._rhs.is_reduce_expr(ee)
+
+    def _core(self):
+        return core.base_expr(baseexpr_opcodes["binop"],
+                              binary_op_codes[self._op],
+                              self._lhs._core(),
+                              self._rhs._core())
 
 
     #---------------------------------------------------------------------------

--- a/datatable/expr/column_expr.py
+++ b/datatable/expr/column_expr.py
@@ -6,7 +6,7 @@
 #-------------------------------------------------------------------------------
 
 from .base_expr import BaseExpr
-from .consts import nas_map
+from .consts import nas_map, baseexpr_opcodes
 from ..types import stype
 from datatable.lib import core
 from datatable.utils.typechecks import TTypeError
@@ -43,6 +43,10 @@ class ColSelectorExpr(BaseExpr):
     @property
     def col_index(self):
         return self._colid
+
+    def _core(self):
+        opcode = baseexpr_opcodes["col"]
+        return core.base_expr(opcode, self._dtexpr._id, self._colexpr)
 
     def __str__(self):
         strf = str(self._dtexpr)

--- a/datatable/expr/consts.py
+++ b/datatable/expr/consts.py
@@ -157,3 +157,10 @@ reduce_opcodes = {
     "sum": 6,
     "count": 7,
 }
+
+
+baseexpr_opcodes = {
+    "col": 1,
+    "binop": 2,
+    "literal": 3,
+}

--- a/datatable/expr/literal_expr.py
+++ b/datatable/expr/literal_expr.py
@@ -5,7 +5,7 @@
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #-------------------------------------------------------------------------------
 from .base_expr import BaseExpr
-from .consts import nas_map
+from .consts import nas_map, baseexpr_opcodes
 from ..types import stype
 from datatable.lib import core
 
@@ -50,6 +50,9 @@ class LiteralExpr(BaseExpr):
 
     def evaluate_eager(self, ee):
         return core.column_from_list([self.arg])
+
+    def _core(self):
+        return core.base_expr(baseexpr_opcodes["literal"], self.arg)
 
     def _isna(self, key, inode):
         return self.arg is None

--- a/datatable/expr/relop_expr.py
+++ b/datatable/expr/relop_expr.py
@@ -7,6 +7,7 @@
 
 from .base_expr import BaseExpr
 from .binary_expr import binary_op_codes
+from .consts import baseexpr_opcodes
 from .literal_expr import LiteralExpr
 from ..types import stype
 from datatable.utils.typechecks import TValueError
@@ -36,6 +37,12 @@ class RelationalOpExpr(BaseExpr):
         self._lhs.resolve()
         self._rhs.resolve()
         self._stype = stype.bool8
+
+    def _core(self):
+        return core.base_expr(baseexpr_opcodes["binop"],
+                              binary_op_codes[self._op],
+                              self._lhs._core(),
+                              self._rhs._core())
 
 
     #---------------------------------------------------------------------------

--- a/datatable/graph/dtproxy.py
+++ b/datatable/graph/dtproxy.py
@@ -57,7 +57,7 @@ class DatatableProxy(object):
     >>> d3 = d0[:, expr]
     >>> d4 = d0[expr > 0, expr]
     """
-    __slots__ = ["_datatable", "_rowindex", "_name"]
+    __slots__ = ["_datatable", "_rowindex", "_name", "_id"]
 
     # Developer notes:
     # This class uses dynamic name resolution to convert arbitrary attribute
@@ -65,10 +65,11 @@ class DatatableProxy(object):
     # internal attributes or method names that have a chance of clashing with
     # user's column names.
 
-    def __init__(self, name):
+    def __init__(self, name, id_):
         self._datatable = None
         self._rowindex = None
         self._name = name
+        self._id = id_
 
 
     def get_datatable(self):
@@ -156,5 +157,5 @@ class DatatableProxy(object):
             return self._datatable.stypes
 
 
-f = DatatableProxy("f")
-g = DatatableProxy("g")
+f = DatatableProxy("f", 0)
+g = DatatableProxy("g", 1)


### PR DESCRIPTION
This class will allow us to evaluate `DT[i, j, ...]` expressions from C++.
This is mostly work-in-progress for now, we'll need the rest of the evaluation infrastructure to make use of this new class.