### PR TITLE
namedtuple API adjustments

### DIFF
--- a/c/extras/dt_ftrl.h
+++ b/c/extras/dt_ftrl.h
@@ -25,9 +25,9 @@
 #include "extras/hash.h"
 
 
-typedef std::unique_ptr<Hash> hashptr;
-typedef std::unique_ptr<double[]> doubleptr;
-typedef std::unique_ptr<uint64_t[]> uint64ptr;
+using hashptr = std::unique_ptr<Hash>;
+using doubleptr = std::unique_ptr<double[]>;
+using uint64ptr = std::unique_ptr<uint64_t[]>;
 #define REPORT_FREQUENCY 1000
 
 namespace dt {
@@ -49,7 +49,7 @@ class Ftrl {
     dtptr dt_model;
     double* z;
     double* n;
-    
+
     // Input to the model.
     FtrlParams params;
 

--- a/c/extras/py_ftrl.cc
+++ b/c/extras/py_ftrl.cc
@@ -32,7 +32,7 @@ PKArgs Ftrl::Type::args___init__(1, 0, 7, false, false,
                                  "lambda2", "d", "n_epochs", "inter"},
                                  "__init__", nullptr);
 
-std::vector<strpair> Ftrl::params_fields_info = {
+static std::vector<strpair> params_fields_info = {
   strpair("alpha", "`alpha` in per-coordinate FTRL-Proximal algorithm"),
   strpair("beta", "`beta` in per-coordinate FTRL-Proximal algorithm"),
   strpair("lambda1", "L1 regularization parameter"),
@@ -42,9 +42,13 @@ std::vector<strpair> Ftrl::params_fields_info = {
   strpair("inter", "Parameter that controls if feature interactions to be used "
                    "or not")
 };
-strpair Ftrl::params_info = strpair("Params", "FTRL model parameters");
-onamedtupletype Ftrl::params_nttype(Ftrl::params_info,
-                                    Ftrl::params_fields_info);
+
+static onamedtupletype& _get_params_namedtupletype() {
+  static onamedtupletype ntt(
+    strpair("FtrlParams", "FTRL model parameters"),
+    params_fields_info);
+  return ntt;
+}
 
 
 void Ftrl::m__init__(PKArgs& args) {
@@ -124,7 +128,7 @@ const char* Ftrl::Type::classname() {
 
 const char* Ftrl::Type::classdoc() {
   return R"(Follow the Regularized Leader (FTRL) model with hashing trick.
-    
+
 See this reference for more details:
 https://www.eecs.tufts.edu/~dsculley/papers/ad-click-prediction.pdf
 
@@ -139,7 +143,7 @@ lambda1 : float
 lambda2 : float
     L2 regularization parameter.
 d : int
-    Number of bins to be used after the hashing trick. 
+    Number of bins to be used after the hashing trick.
 n_epochs : int
     Number of epochs to train for.
 inter : bool
@@ -217,11 +221,11 @@ Train an FTRL model on a dataset.
 Parameters
 ----------
 X: Frame
-    Datatable frame of shape (nrows, ncols) to be trained on. 
+    Datatable frame of shape (nrows, ncols) to be trained on.
 
 y: Frame
-    Datatable frame of shape (nrows, 1), i.e. the target column. 
-    This column must have a `bool` type. 
+    Datatable frame of shape (nrows, 1), i.e. the target column.
+    This column must have a `bool` type.
 
 Returns
 ----------
@@ -278,12 +282,12 @@ Make predictions for a dataset.
 Parameters
 ----------
 X: Frame
-    Datatable frame of shape (nrows, ncols) to make predictions for. 
+    Datatable frame of shape (nrows, ncols) to make predictions for.
     It must have the same number of columns as the training frame.
 
 Returns
 ----------
-    A new datatable frame of shape (nrows, 1) with a prediction 
+    A new datatable frame of shape (nrows, 1) with a prediction
     for each row of frame X.
 )");
 
@@ -356,7 +360,7 @@ oobj Ftrl::get_model() const {
 
 
 oobj Ftrl::get_params() const {
-  py::onamedtuple params(params_nttype);
+  py::onamedtuple params(_get_params_namedtupletype());
   params.set(0, get_alpha());
   params.set(1, get_beta());
   params.set(2, get_lambda1());

--- a/c/extras/py_ftrl.cc
+++ b/c/extras/py_ftrl.cc
@@ -42,9 +42,16 @@ static const char* doc_inter    = "Parameter that controls if feature interactio
 
 static onamedtupletype& _get_params_namedtupletype() {
   static onamedtupletype ntt(
-    "FtrlParams", "FTRL model parameters",
-    {"alpha", "beta", "lambda1", "lambda2", "d", "n_epochs", "inter"},
-    {doc_alpha, doc_beta, doc_lambda1, doc_lambda2, doc_d, doc_n_epochs, doc_inter});
+    "FtrlParams",
+    "FTRL model parameters",
+    {{"alpha",    doc_alpha},
+     {"beta",     doc_beta},
+     {"lambda1",  doc_lambda1},
+     {"lambda2",  doc_lambda2},
+     {"d",        doc_d},
+     {"n_epochs", doc_n_epochs},
+     {"inter",    doc_inter}}
+  );
   return ntt;
 }
 

--- a/c/extras/py_ftrl.cc
+++ b/c/extras/py_ftrl.cc
@@ -24,29 +24,27 @@
 #include "python/int.h"
 #include "python/tuple.h"
 #include "extras/py_ftrl.h"
-
 namespace py {
+
 
 PKArgs Ftrl::Type::args___init__(1, 0, 7, false, false,
                                  {"params", "alpha", "beta", "lambda1",
                                  "lambda2", "d", "n_epochs", "inter"},
                                  "__init__", nullptr);
 
-static std::vector<strpair> params_fields_info = {
-  strpair("alpha", "`alpha` in per-coordinate FTRL-Proximal algorithm"),
-  strpair("beta", "`beta` in per-coordinate FTRL-Proximal algorithm"),
-  strpair("lambda1", "L1 regularization parameter"),
-  strpair("lambda2", "L1 regularization parameter"),
-  strpair("d", "Number of bins to be used for the hashing trick"),
-  strpair("n_epochs", "Number of epochs to train a model for"),
-  strpair("inter", "Parameter that controls if feature interactions to be used "
-                   "or not")
-};
+static const char* doc_alpha    = "`alpha` in per-coordinate FTRL-Proximal algorithm";
+static const char* doc_beta     = "`beta` in per-coordinate FTRL-Proximal algorithm";
+static const char* doc_lambda1  = "L1 regularization parameter";
+static const char* doc_lambda2  = "L2 regularization parameter";
+static const char* doc_d        = "Number of bins to be used for the hashing trick";
+static const char* doc_n_epochs = "Number of epochs to train a model";
+static const char* doc_inter    = "Parameter that controls if feature interactions to be used or not";
 
 static onamedtupletype& _get_params_namedtupletype() {
   static onamedtupletype ntt(
-    strpair("FtrlParams", "FTRL model parameters"),
-    params_fields_info);
+    "FtrlParams", "FTRL model parameters",
+    {"alpha", "beta", "lambda1", "lambda2", "d", "n_epochs", "inter"},
+    {doc_alpha, doc_beta, doc_lambda1, doc_lambda2, doc_d, doc_n_epochs, doc_inter});
   return ntt;
 }
 
@@ -54,34 +52,32 @@ static onamedtupletype& _get_params_namedtupletype() {
 void Ftrl::m__init__(PKArgs& args) {
   dt::FtrlParams fp = dt::Ftrl::params_default;
 
-  bool defined_params = !args[0].is_none_or_undefined();
-  bool defined_alpha = !args[1].is_none_or_undefined();
-  bool defined_beta = !args[2].is_none_or_undefined();
-  bool defined_lambda1 = !args[3].is_none_or_undefined();
-  bool defined_lambda2 = !args[4].is_none_or_undefined();
-  bool defined_d = !args[5].is_none_or_undefined();
-  bool defined_n_epochs= !args[6].is_none_or_undefined();
-  bool defined_inter = !args[7].is_none_or_undefined();
+  bool defined_params   = !args[0].is_none_or_undefined();
+  bool defined_alpha    = !args[1].is_none_or_undefined();
+  bool defined_beta     = !args[2].is_none_or_undefined();
+  bool defined_lambda1  = !args[3].is_none_or_undefined();
+  bool defined_lambda2  = !args[4].is_none_or_undefined();
+  bool defined_d        = !args[5].is_none_or_undefined();
+  bool defined_n_epochs = !args[6].is_none_or_undefined();
+  bool defined_inter    = !args[7].is_none_or_undefined();
 
   if (defined_params) {
-    if (!(defined_alpha || defined_beta || defined_lambda1 || defined_lambda2
-        || defined_d || defined_n_epochs || defined_inter)) {
-
-      py::otuple arg0_tuple = args[0].to_otuple();
-      fp.alpha = arg0_tuple.get_attr("alpha").to_double_positive();
-      fp.beta = arg0_tuple.get_attr("beta").to_double_not_negative();
-      fp.lambda1 = arg0_tuple.get_attr("lambda1").to_double_not_negative();
-      fp.lambda2 = arg0_tuple.get_attr("lambda2").to_double_not_negative();
-      fp.d = static_cast<uint64_t>(arg0_tuple.get_attr("d").to_size_t_positive());
-      fp.n_epochs = arg0_tuple.get_attr("n_epochs").to_size_t();
-      fp.inter = arg0_tuple.get_attr("inter").to_bool_strict();
-
-    } else {
+    if (defined_alpha || defined_beta || defined_lambda1 || defined_lambda2 ||
+        defined_d || defined_n_epochs || defined_inter) {
       throw TypeError() << "You can either pass all the parameters with "
             << "`params` or any of the individual parameters with `alpha`, "
             << "`beta`, `lambda1`, `lambda2`, `d`, `n_epochs` or `inter` to "
             << "Ftrl constructor, but not both at the same time";
     }
+    py::otuple arg0_tuple = args[0].to_otuple();
+    fp.alpha = arg0_tuple.get_attr("alpha").to_double_positive();
+    fp.beta = arg0_tuple.get_attr("beta").to_double_not_negative();
+    fp.lambda1 = arg0_tuple.get_attr("lambda1").to_double_not_negative();
+    fp.lambda2 = arg0_tuple.get_attr("lambda2").to_double_not_negative();
+    fp.d = static_cast<uint64_t>(arg0_tuple.get_attr("d").to_size_t_positive());
+    fp.n_epochs = arg0_tuple.get_attr("n_epochs").to_size_t();
+    fp.inter = arg0_tuple.get_attr("inter").to_bool_strict();
+
   } else {
     if (defined_alpha) {
       fp.alpha = args[1].to_double_positive();
@@ -157,7 +153,7 @@ void Ftrl::Type::init_methods_and_getsets(Methods& mm, GetSetters& gs) {
     "model",
     "Frame having two columns, i.e. `z` and `n`, and `d` rows,\n"
     "where `d` is a number of bins set for modeling. Both column types\n"
-    "must be `FLOAT64`"
+    "must be `float64`"
   );
 
   gs.add<&Ftrl::get_params, &Ftrl::set_params>(
@@ -170,41 +166,13 @@ void Ftrl::Type::init_methods_and_getsets(Methods& mm, GetSetters& gs) {
     "Column name hashes.\n"
   );
 
-  gs.add<&Ftrl::get_alpha, &Ftrl::set_alpha>(
-    params_fields_info[0].first,
-    params_fields_info[0].second
-  );
-
-  gs.add<&Ftrl::get_beta, &Ftrl::set_beta>(
-    params_fields_info[1].first,
-    params_fields_info[1].second
-  );
-
-  gs.add<&Ftrl::get_lambda1, &Ftrl::set_lambda1>(
-    params_fields_info[2].first,
-    params_fields_info[2].second
-  );
-
-  gs.add<&Ftrl::get_lambda2, &Ftrl::set_lambda2>(
-    params_fields_info[3].first,
-    params_fields_info[3].second
-  );
-
-  gs.add<&Ftrl::get_d, &Ftrl::set_d>(
-    params_fields_info[4].first,
-    params_fields_info[4].second
-  );
-
-  gs.add<&Ftrl::get_n_epochs, &Ftrl::set_n_epochs>(
-    params_fields_info[5].first,
-    params_fields_info[5].second
-  );
-
-
-  gs.add<&Ftrl::get_inter, &Ftrl::set_inter>(
-    params_fields_info[6].first,
-    params_fields_info[6].second
-  );
+  gs.add<&Ftrl::get_alpha, &Ftrl::set_alpha>("alpha", doc_alpha);
+  gs.add<&Ftrl::get_beta, &Ftrl::set_beta>("beta", doc_beta);
+  gs.add<&Ftrl::get_lambda1, &Ftrl::set_lambda1>("lambda1", doc_lambda1);
+  gs.add<&Ftrl::get_lambda2, &Ftrl::set_lambda2>("lambda2", doc_lambda2);
+  gs.add<&Ftrl::get_d, &Ftrl::set_d>("d", doc_d);
+  gs.add<&Ftrl::get_n_epochs, &Ftrl::set_n_epochs>("n_epochs", doc_n_epochs);
+  gs.add<&Ftrl::get_inter, &Ftrl::set_inter>("inter", doc_inter);
 
   mm.add<&Ftrl::fit, args_fit>();
   mm.add<&Ftrl::predict, args_predict>();
@@ -286,8 +254,8 @@ X: Frame
     It must have the same number of columns as the training frame.
 
 Returns
-----------
-    A new datatable frame of shape (nrows, 1) with a prediction
+-------
+    A new Frame of shape (nrows, 1) with the predicted probability
     for each row of frame X.
 )");
 
@@ -308,9 +276,10 @@ oobj Ftrl::predict(const PKArgs& args) {
 
   size_t n_features = dtft->get_n_features();
   if (dt_X->ncols != n_features && n_features != 0) {
-    throw ValueError() << "Can only predict on a frame that has "<< n_features
-                       << " column(s), i.e. has the same number of features as "
-                       << "was used for model training";
+    throw ValueError() << "Can only predict on a Frame that has " << n_features
+                       << " column" << (n_features == 1? "" : "s")
+                       << ", i.e. has the same number of features as "
+                          "was used for model training";
   }
 
   DataTable* dt_y = dtft->predict(dt_X).release();
@@ -322,7 +291,7 @@ oobj Ftrl::predict(const PKArgs& args) {
 }
 
 
-PKArgs Ftrl::Type::args_reset(0, 0, 0, false, false, {}, "reset",
+NoArgs Ftrl::Type::args_reset("reset",
 R"(reset(self)
 --
 
@@ -333,12 +302,12 @@ Parameters
     None
 
 Returns
-----------
+-------
     None
 )");
 
 
-void Ftrl::reset(const PKArgs&) {
+void Ftrl::reset(const NoArgs&) {
   dtft->reset_model();
 }
 
@@ -529,5 +498,6 @@ void Ftrl::set_inter(robj inter) {
   bool inter_in = inter.to_bool_strict();
   dtft->set_inter(inter_in);
 }
+
 
 } // namespace py

--- a/c/extras/py_ftrl.h
+++ b/c/extras/py_ftrl.h
@@ -35,7 +35,7 @@ class Ftrl : public PyObject {
         static PKArgs args___init__;
         static PKArgs args_fit;
         static PKArgs args_predict;
-        static PKArgs args_reset;
+        static NoArgs args_reset;
         static const char* classname();
         static const char* classdoc();
         static bool is_subclassable() { return true; }
@@ -46,7 +46,7 @@ class Ftrl : public PyObject {
     void m__dealloc__();
     void fit(const PKArgs&);
     oobj predict(const PKArgs&);
-    void reset(const PKArgs&);
+    void reset(const NoArgs&);
 
     // Getters and setters.
     oobj get_model() const;

--- a/c/extras/py_ftrl.h
+++ b/c/extras/py_ftrl.h
@@ -71,11 +71,6 @@ class Ftrl : public PyObject {
 
     // Helper validation functions
     bool has_negative_n(DataTable*);
-
-    // Info for a namedtuple of parameters
-    static strpair params_info;
-    static std::vector<strpair> params_fields_info;
-    static onamedtupletype params_nttype;
 };
 
 } // namespece py

--- a/c/python/_all.h
+++ b/c/python/_all.h
@@ -22,5 +22,6 @@
 #include "python/dict.h"
 #include "python/float.h"
 #include "python/int.h"
+#include "python/namedtuple.h"
 #include "python/slice.h"
 #include "python/tuple.h"

--- a/c/python/namedtuple.cc
+++ b/c/python/namedtuple.cc
@@ -69,22 +69,26 @@ onamedtupletype::onamedtupletype(const std::string& cls_name,
   auto res = std::move(type).release();
 
   // Set namedtuple doc
-  py::ostring docstr = py::ostring(cls_doc);
-  PyObject_SetAttrString(res, "__doc__",
-                         docstr.to_borrowed_ref());
+  if (!cls_doc.empty()) {
+    py::ostring docstr = py::ostring(cls_doc);
+    PyObject_SetAttrString(res, "__doc__",
+                           docstr.to_borrowed_ref());
+  }
 
   // Set field docs
-  py::otuple args_prop(4);
-  py::otuple args_itemgetter(1);
-  args_prop.set(1, py::None());
-  args_prop.set(2, py::None());
-  for (size_t i = 0; i < field_docs.size(); ++i) {
-    args_itemgetter.set(0, py::oint(i));
-    args_prop.set(0, itemgetter.call(args_itemgetter));
-    args_prop.set(3, py::ostring(field_docs[i]));
-    auto prop = property.call(args_prop);
-    PyObject_SetAttrString(res, field_names[i].c_str(),
-                           prop.to_borrowed_ref());
+  if (!field_docs.empty()) {
+    py::otuple args_prop(4);
+    py::otuple args_itemgetter(1);
+    args_prop.set(1, py::None());
+    args_prop.set(2, py::None());
+    for (size_t i = 0; i < field_docs.size(); ++i) {
+      args_itemgetter.set(0, py::oint(i));
+      args_prop.set(0, itemgetter.call(args_itemgetter));
+      args_prop.set(3, py::ostring(field_docs[i]));
+      auto prop = property.call(args_prop);
+      PyObject_SetAttrString(res, field_names[i].c_str(),
+                             prop.to_borrowed_ref());
+    }
   }
 
   // Convert `PyObject*` to `PyTypeObject*`, so that it can be passed to

--- a/c/python/namedtuple.cc
+++ b/c/python/namedtuple.cc
@@ -28,18 +28,23 @@
 namespace py {
 
 
+//------------------------------------------------------------------------------
+// onamedtupletype
+//------------------------------------------------------------------------------
+
 onamedtupletype::onamedtupletype(
   const std::string& cls_name, const strvec& field_names
 ) : onamedtupletype(cls_name, "", field_names, {}) {}
 
 
 /**
-*  Create a namedtuple type based on the collections.namedtuple datatype.
-*  An alternative is to use `Struct Sequence Objects` as outlined here
-*  https://docs.python.org/3/c-api/tuple.html
-*  However, objects created with `PyStructSequence_New` are not standard
-*  Python namedtuples, but rather a simpler version of the latter.
-*/
+ * Create a namedtuple using python function `collections.namedtuple()`.
+ *
+ * Note: we do not use PyStructSequence objects from Python C API, because
+ * they are not standard namedtuples and do not provide the same API (for
+ * example, there is no `_replace()` method).
+ * https://docs.python.org/3/c-api/tuple.html
+ */
 onamedtupletype::onamedtupletype(const std::string& cls_name,
                                  const std::string& cls_doc,
                                  const strvec& field_names,
@@ -88,10 +93,30 @@ onamedtupletype::onamedtupletype(const std::string& cls_name,
 }
 
 
+onamedtupletype::onamedtupletype(const onamedtupletype& o) {
+  v = o.v;
+  nfields = o.nfields;
+  Py_XINCREF(v);
+}
+
+
+onamedtupletype::onamedtupletype(onamedtupletype&& o) {
+  v = o.v;
+  nfields = o.nfields;
+  o.v = nullptr;
+  o.nfields = 0;
+}
+
+
 onamedtupletype::~onamedtupletype() {
   Py_XDECREF(v);
 }
 
+
+
+//------------------------------------------------------------------------------
+// onamedtuple
+//------------------------------------------------------------------------------
 
 onamedtuple::onamedtuple(const onamedtupletype& type) {
   v = PyTuple_New(static_cast<Py_ssize_t>(type.nfields));

--- a/c/python/namedtuple.cc
+++ b/c/python/namedtuple.cc
@@ -24,6 +24,7 @@
 #include "python/tuple.h"
 #include "python/string.h"
 #include "python/int.h"
+#include "utils/assert.h"
 
 namespace py {
 
@@ -77,11 +78,12 @@ onamedtupletype::onamedtupletype(const std::string& cls_name,
 
   // Set field docs
   if (!field_docs.empty()) {
+    xassert(field_docs.size() == nfields);
     py::otuple args_prop(4);
     py::otuple args_itemgetter(1);
     args_prop.set(1, py::None());
     args_prop.set(2, py::None());
-    for (size_t i = 0; i < field_docs.size(); ++i) {
+    for (size_t i = 0; i < nfields; ++i) {
       args_itemgetter.set(0, py::oint(i));
       args_prop.set(0, itemgetter.call(args_itemgetter));
       args_prop.set(3, py::ostring(field_docs[i]));

--- a/c/python/namedtuple.cc
+++ b/c/python/namedtuple.cc
@@ -27,6 +27,7 @@
 
 namespace py {
 
+
 /**
 *  Create a namedtuple type based on the collections.namedtuple datatype.
 *  An alternative is to use `Struct Sequence Objects` as outlined here

--- a/c/python/namedtuple.h
+++ b/c/python/namedtuple.h
@@ -46,9 +46,22 @@ class onamedtupletype {
     size_t nfields;
 
   public:
-    onamedtupletype(const std::string& cls_name, const strvec& field_names);
-    onamedtupletype(const std::string& cls_name, const std::string& cls_doc,
-                    const strvec& field_names, const strvec& field_docs);
+    struct field {
+      std::string name;
+      std::string doc;
+
+      field(const char* n) : name(n) {}
+      field(const char* n, const char* d) : name(n), doc(d) {}
+      field(const std::string& n) : name(n) {}
+      field(const std::string& n, const std::string& d) : name(n), doc(d) {}
+    };
+
+  public:
+    onamedtupletype(const std::string& cls_name,
+                    const std::vector<std::string>& field_names);
+    onamedtupletype(const std::string& cls_name,
+                    const std::string& cls_doc,
+                    const std::vector<field> fields);
     onamedtupletype(const onamedtupletype&);
     onamedtupletype(onamedtupletype&&);
     ~onamedtupletype();

--- a/c/python/namedtuple.h
+++ b/c/python/namedtuple.h
@@ -49,6 +49,8 @@ class onamedtupletype {
     onamedtupletype(const std::string& cls_name, const strvec& field_names);
     onamedtupletype(const std::string& cls_name, const std::string& cls_doc,
                     const strvec& field_names, const strvec& field_docs);
+    onamedtuple(const onamedtuple&);
+    onamedtuple(onamedtuple&&);
     ~onamedtupletype();
 
     friend class onamedtuple;
@@ -56,9 +58,21 @@ class onamedtupletype {
 
 
 
+/**
+ * This class inherits the API from `py::otuple`. The primary difference is
+ * that the constructor takes an `onamedtupletype` argument rather than the
+ * number of fields.
+ */
 class onamedtuple : public otuple {
   public:
-    onamedtuple(const py::onamedtupletype& type);
+    explicit onamedtuple(const py::onamedtupletype& type);
+    onamedtuple() = default;
+    onamedtuple(const onamedtuple&) = default;
+    onamedtuple(onamedtuple&&) = default;
+    onamedtuple& operator=(const onamedtuple&) = default;
+    onamedtuple& operator=(onamedtuple&&) = default;
+
+    // TODO: create from an existing namedtuple PyObject, extract fields, etc.
 };
 
 

--- a/c/python/namedtuple.h
+++ b/c/python/namedtuple.h
@@ -49,8 +49,8 @@ class onamedtupletype {
     onamedtupletype(const std::string& cls_name, const strvec& field_names);
     onamedtupletype(const std::string& cls_name, const std::string& cls_doc,
                     const strvec& field_names, const strvec& field_docs);
-    onamedtuple(const onamedtuple&);
-    onamedtuple(onamedtuple&&);
+    onamedtupletype(const onamedtupletype&);
+    onamedtupletype(onamedtupletype&&);
     ~onamedtupletype();
 
     friend class onamedtuple;

--- a/c/python/namedtuple.h
+++ b/c/python/namedtuple.h
@@ -27,25 +27,41 @@
 
 namespace py {
 
-typedef std::pair<const char*, const char*> strpair;
 
+/**
+ * In Python, before a `namedtuple` can be created, its class must be
+ * instantiated. This class allows you to create new "namedtuple" classes
+ * dynamically and then use them when creating namedtuple objects.
+ *
+ * Example:
+ *
+ *     onamedtupletype cls("Point", {"x", "y"});
+ *     onamedtuple tup(cls);
+ *     tup.set(0, ofloat(1.0));
+ *     tup.set(1, ofloat(2.0));
+ */
 class onamedtupletype {
   private:
     PyTypeObject* v;
     size_t nfields;
 
   public:
-    onamedtupletype(strpair, std::vector<strpair>);
+    onamedtupletype(const std::string& cls_name, const strvec& field_names);
+    onamedtupletype(const std::string& cls_name, const std::string& cls_doc,
+                    const strvec& field_names, const strvec& field_docs);
     ~onamedtupletype();
 
     friend class onamedtuple;
 };
 
 
+
 class onamedtuple : public otuple {
   public:
     onamedtuple(const py::onamedtupletype& type);
 };
+
+
 
 }  // namespace py
 

--- a/tests/extras/test_ftrl.py
+++ b/tests/extras/test_ftrl.py
@@ -510,9 +510,9 @@ def test_ftrl_predict_wrong_frame():
     ft.fit(df_train, df_target)
     with pytest.raises(ValueError) as e:
         ft.predict(df_predict)
-    assert ("Can only predict on a frame that has %d column(s), i.e. has the "
+    assert ("Can only predict on a Frame that has 1 column, i.e. has the "
             "same number of features as was used for model training"
-            % (df_train.ncols) == str(e.value))
+            == str(e.value))
 
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
- prefer C++ `using` instead of `typedef`;
- fixed docstring of parameter `lambda2`;
- use `std::string`s instead of `const char*` for namedtuple construction;
- rename `Params` -> `FtrlParams`;
- defer creation of `FtrlParams` named tuple type until it is actually needed;
- add another constructor for `onamedtuple`, without the docstrings;
- add copy/move constructor for `onamedtuple` and `onamedtupletype`.