### PR TITLE
Deprecate methods .topython(), .tonumpy(), .topandas()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Improved the performance of setting `frame.nrows`. Now if the frame has
   multiple columns, a view will be created.
 
+- Single-item Frame selectors are prohibited: `DT[col]` is now an error. In
+  0.9.0 this will be interpreted as a row selector instead.
+
+- Frame methods `.topython()`, `.topandas()` and `.tonumpy()` are now
+  deprecated, they will be removed in 0.9.0. Please use `.to_list()`,
+  `.to_pandas()` and `.to_numpy()` instead.
 
 
 

--- a/c/frame/replace.cc
+++ b/c/frame/replace.cc
@@ -73,11 +73,11 @@ Examples
 --------
 >>> df = dt.Frame([1, 2, 3] * 3)
 >>> df.replace(1, -1)
->>> df.topython()
+>>> df.to_list()
 [[-1, 2, 3, -1, 2, 3, -1, 2, 3]]
 
 >>> df.replace({-1: 100, 2: 200, "foo": None})
->>> df.topython()
+>>> df.to_list()
 [[100, 200, 3, 100, 200, 3, 100, 200, 3]]
 )");
 

--- a/c/py_column.cc
+++ b/c/py_column.cc
@@ -166,7 +166,7 @@ PyObject* replace_rowindex(pycolumn::obj* self, PyObject* args) {
 }
 
 
-PyObject* topython(pycolumn::obj* self, PyObject*) {
+PyObject* to_list(pycolumn::obj* self, PyObject*) {
   Column* col = self->ref;
 
   int itype = static_cast<int>(col->stype());
@@ -215,7 +215,7 @@ static PyMethodDef column_methods[] = {
   METHODv(save_to_disk),
   METHODv(ungroup),
   METHODv(replace_rowindex),
-  METHOD0(topython),
+  METHOD0(to_list),
   {nullptr, nullptr, 0, nullptr}
 };
 

--- a/c/py_column.h
+++ b/c/py_column.h
@@ -110,8 +110,8 @@ DECLARE_METHOD(
   "does not affect the Frame from which this Column was extracted.\n")
 
 DECLARE_METHOD(
-  topython,
-  "topython()\n\n"
+  to_list,
+  "to_list()\n\n"
   "Return the contents of the Column as a plain Python list.\n")
 
 

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -6,6 +6,7 @@
 #-------------------------------------------------------------------------------
 import collections
 import time
+import warnings
 
 from datatable.lib import core
 import datatable
@@ -339,6 +340,10 @@ class Frame(core.Frame):
 
 
     def topython(self):  # DEPRECATED
+        warnings.warn(
+            "Method `Frame.topython()` is deprecated (will be removed in "
+            "0.9.0), please use `Frame.to_list()` instead",
+            category=FutureWarning)
         return self.to_list()
 
     # Old names

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -346,9 +346,19 @@ class Frame(core.Frame):
             category=FutureWarning)
         return self.to_list()
 
-    # Old names
-    topandas = to_pandas
-    tonumpy = to_numpy
+    def topandas(self):
+        warnings.warn(
+            "Method `Frame.topandas()` is deprecated (will be removed in "
+            "0.9.0), please use `Frame.to_pandas()` instead",
+            category=FutureWarning)
+        return self.to_pandas()
+
+    def tonumpy(self, stype=None):
+        warnings.warn(
+            "Method `Frame.tonumpy()` is deprecated (will be removed in "
+            "0.9.0), please use `Frame.to_numpy()` instead",
+            category=FutureWarning)
+        return self.to_numpy(stype)
 
 
     def scalar(self):

--- a/datatable/nff.py
+++ b/datatable/nff.py
@@ -50,8 +50,8 @@ def save(self, dest=None, format="jay", _strategy="auto"):
         return
 
     self.materialize()
-    mins = self.min().topython()
-    maxs = self.max().topython()
+    mins = self.min().to_list()
+    maxs = self.max().to_list()
 
     metafile = os.path.join(dest, "_meta.nff")
     with _builtin_open(metafile, "w", encoding="utf-8") as out:

--- a/docs/using-datatable.rst
+++ b/docs/using-datatable.rst
@@ -115,9 +115,9 @@ Convert an existing Frame into a ``numpy`` array, a ``pandas`` DataFrame, or a p
 
 ::
 
-   nparr = df1.tonumpy()
-   pddfr = df1.topandas()
-   pyobj = df1.topython()
+   nparr = df1.to_numpy()
+   pddfr = df1.to_pandas()
+   pyobj = df1.to_list()
 
 Parse Text (csv) Files
 ----------------------

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -107,7 +107,7 @@ def assert_equals(datatable1, datatable2):
     assert datatable1.shape == datatable2.shape
     assert same_iterables(datatable1.names, datatable2.names)
     assert same_iterables(datatable1.stypes, datatable2.stypes)
-    assert same_iterables(datatable1.topython(), datatable2.topython())
+    assert same_iterables(datatable1.to_list(), datatable2.to_list())
 
 
 

--- a/tests/extras/test_aggregate.py
+++ b/tests/extras/test_aggregate.py
@@ -66,12 +66,12 @@ def test_aggregate_0d_continuous_integer_random():
     d_members.internal.check()
     assert d_members.shape == (13, 1)
     assert d_members.ltypes == (ltype.int,)
-    assert d_members.topython() == [[0, 12, 10, 1, 5, 6, 7, 3, 8, 9, 11, 4, 2]]
+    assert d_members.to_list() == [[0, 12, 10, 1, 5, 6, 7, 3, 8, 9, 11, 4, 2]]
     d_in.internal.check()
     assert d_in.shape == (13, 2)
     assert d_in.ltypes == (ltype.int, ltype.int)
-    assert d_in.topython() == [[None, None, None, 0, 1, 2, 3, 3, 5, 5, 8, 8, 9],
-                               [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]]
+    assert d_in.to_list() == [[None, None, None, 0, 1, 2, 3, 3, 5, 5, 8, 8, 9],
+                              [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]]
 
 #-------------------------------------------------------------------------------
 # Aggregate 1D
@@ -85,11 +85,11 @@ def test_aggregate_1d_empty():
     d_members.internal.check()
     assert d_members.shape == (0, 1)
     assert d_members.ltypes == (ltype.int,)
-    assert d_members.topython() == [[]]
+    assert d_members.to_list() == [[]]
     d_in.internal.check()
     assert d_in.shape == (0, 1)
     assert d_in.ltypes == (ltype.int,)
-    assert d_in.topython() == [[]]
+    assert d_in.to_list() == [[]]
 
 
 def test_aggregate_1d_continuous_integer_tiny():
@@ -100,12 +100,11 @@ def test_aggregate_1d_continuous_integer_tiny():
     d_members.internal.check()
     assert d_members.shape == (1, 1)
     assert d_members.ltypes == (ltype.int,)
-    assert d_members.topython() == [[0]]
+    assert d_members.to_list() == [[0]]
     d_in.internal.check()
     assert d_in.shape == (1, 2)
     assert d_in.ltypes == (ltype.int, ltype.int)
-    assert d_in.topython() == [[5],
-                               [1]]
+    assert d_in.to_list() == [[5], [1]]
 
 
 def test_aggregate_1d_continuous_integer_equal():
@@ -116,12 +115,11 @@ def test_aggregate_1d_continuous_integer_equal():
     d_members.internal.check()
     assert d_members.shape == (10, 1)
     assert d_members.ltypes == (ltype.int,)
-    assert d_members.topython() == [[1, 1, 0, 1, 0, 1, 1, 1, 1, 1]]
+    assert d_members.to_list() == [[1, 1, 0, 1, 0, 1, 1, 1, 1, 1]]
     d_in.internal.check()
     assert d_in.shape == (2, 2)
     assert d_in.ltypes == (ltype.bool, ltype.int)
-    assert d_in.topython() == [[None, 0],
-                               [2, 8]]
+    assert d_in.to_list() == [[None, 0], [2, 8]]
 
 
 def test_aggregate_1d_continuous_integer_sorted():
@@ -132,12 +130,12 @@ def test_aggregate_1d_continuous_integer_sorted():
     d_members.internal.check()
     assert d_members.shape == (12, 1)
     assert d_members.ltypes == (ltype.int,)
-    assert d_members.topython() == [[1, 1, 0, 1, 1, 2, 2, 2, 3, 0, 3, 3]]
+    assert d_members.to_list() == [[1, 1, 0, 1, 1, 2, 2, 2, 3, 0, 3, 3]]
     d_in.internal.check()
     assert d_in.shape == (4, 2)
     assert d_in.ltypes == (ltype.int, ltype.int)
-    assert d_in.topython() == [[None, 0, 4, 7],
-                               [2, 4, 3, 3]]
+    assert d_in.to_list() == [[None, 0, 4, 7],
+                              [2, 4, 3, 3]]
 
 
 def test_aggregate_1d_continuous_integer_random():
@@ -148,12 +146,12 @@ def test_aggregate_1d_continuous_integer_random():
     d_members.internal.check()
     assert d_members.shape == (13, 1)
     assert d_members.ltypes == (ltype.int,)
-    assert d_members.topython() == [[0, 3, 3, 0, 1, 1, 1, 1, 2, 2, 3, 1, 0]]
+    assert d_members.to_list() == [[0, 3, 3, 0, 1, 1, 1, 1, 2, 2, 3, 1, 0]]
     d_in.internal.check()
     assert d_in.shape == (4, 2)
     assert d_in.ltypes == (ltype.int, ltype.int)
-    assert d_in.topython() == [[None, 2, 5, 9],
-                               [3, 5, 2, 3]]
+    assert d_in.to_list() == [[None, 2, 5, 9],
+                              [3, 5, 2, 3]]
 
 
 def test_aggregate_1d_continuous_real_sorted():
@@ -164,12 +162,12 @@ def test_aggregate_1d_continuous_real_sorted():
     d_members.internal.check()
     assert d_members.shape == (11, 1)
     assert d_members.ltypes == (ltype.int,)
-    assert d_members.topython() == [[1, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3]]
+    assert d_members.to_list() == [[1, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3]]
     d_in.internal.check()
     assert d_in.shape == (4, 2)
     assert d_in.ltypes == (ltype.real, ltype.int)
-    assert d_in.topython() == [[None, 0.0, 0.4, 0.7],
-                               [1, 4, 3, 3]]
+    assert d_in.to_list() == [[None, 0.0, 0.4, 0.7],
+                              [1, 4, 3, 3]]
 
 
 def test_aggregate_1d_continuous_real_random():
@@ -181,12 +179,12 @@ def test_aggregate_1d_continuous_real_random():
     d_members.internal.check()
     assert d_members.shape == (13, 1)
     assert d_members.ltypes == (ltype.int,)
-    assert d_members.topython() == [[3, 3, 2, 1, 1, 3, 1, 1, 2, 1, 0, 0, 0]]
+    assert d_members.to_list() == [[3, 3, 2, 1, 1, 3, 1, 1, 2, 1, 0, 0, 0]]
     d_in.internal.check()
     assert d_in.shape == (4, 2)
     assert d_in.ltypes == (ltype.real, ltype.int)
-    assert d_in.topython() == [[None, 0.1, 0.5, 0.7],
-                               [3, 5, 2, 3]]
+    assert d_in.to_list() == [[None, 0.1, 0.5, 0.7],
+                              [3, 5, 2, 3]]
 
 
 def test_aggregate_1d_categorical_sorted():
@@ -196,13 +194,13 @@ def test_aggregate_1d_categorical_sorted():
     d_members.internal.check()
     assert d_members.shape == (8, 1)
     assert d_members.ltypes == (ltype.int,)
-    assert d_members.topython() == [[0, 1, 2, 3, 4, 5, 6, 7]]
+    assert d_members.to_list() == [[0, 1, 2, 3, 4, 5, 6, 7]]
     d_in.internal.check()
     assert d_in.shape == (8, 2)
     assert d_in.ltypes == (ltype.str, ltype.int)
-    assert d_in.topython() == [[None, "blue", "green", "indigo", "orange",
-                                "red", "violet", "yellow"],
-                               [1, 1, 1, 1, 1, 1, 1, 1]]
+    assert d_in.to_list() == [[None, "blue", "green", "indigo", "orange",
+                               "red", "violet", "yellow"],
+                              [1, 1, 1, 1, 1, 1, 1, 1]]
 
 
 def test_aggregate_1d_categorical_unsorted():
@@ -212,13 +210,13 @@ def test_aggregate_1d_categorical_unsorted():
     d_members.internal.check()
     assert d_members.shape == (9, 1)
     assert d_members.ltypes == (ltype.int,)
-    assert d_members.topython() == [[1, 4, 6, 0, 2, 1, 3, 0, 5]]
+    assert d_members.to_list() == [[1, 4, 6, 0, 2, 1, 3, 0, 5]]
     d_in.internal.check()
     assert d_in.shape == (7, 2)
     assert d_in.ltypes == (ltype.str, ltype.int)
-    assert d_in.topython() == [[None, "blue", "green", "indigo", "orange",
-                                "violet", "yellow"],
-                               [2, 2, 1, 1, 1, 1, 1]]
+    assert d_in.to_list() == [[None, "blue", "green", "indigo", "orange",
+                               "violet", "yellow"],
+                              [2, 2, 1, 1, 1, 1, 1]]
 
 
 # Disable some of the checks for the moment, as even with the same seed
@@ -231,12 +229,12 @@ def test_aggregate_1d_categorical_sampling():
     d_members.internal.check()
     assert d_members.shape == (9, 1)
     assert d_members.ltypes == (ltype.int,)
-    # assert d_members.topython() == [[3, None, 2, 0, 1, 3, None, 0, None]]
+    # assert d_members.to_list() == [[3, None, 2, 0, 1, 3, None, 0, None]]
     d_in.internal.check()
     assert d_in.shape == (3, 2)
     assert d_in.ltypes == (ltype.str, ltype.int)
-    # assert d_in.topython() == [[None, 'green', 'yellow', 'blue'],
-    #                            [2, 1, 1, 2]]
+    # assert d_in.to_list() == [[None, 'green', 'yellow', 'blue'],
+    #                           [2, 1, 1, 2]]
 
 
 #-------------------------------------------------------------------------------
@@ -253,13 +251,13 @@ def test_aggregate_2d_continuous_integer_sorted():
     d_members.internal.check()
     assert d_members.shape == (12, 1)
     assert d_members.ltypes == (ltype.int,)
-    assert d_members.topython() == [[1, 0, 2, 2, 2, 2, 3, 3, 3, 4, 4, 4]]
+    assert d_members.to_list() == [[1, 0, 2, 2, 2, 2, 3, 3, 3, 4, 4, 4]]
     d_in.internal.check()
     assert d_in.shape == (5, 3)
     assert d_in.ltypes == (ltype.int, ltype.int, ltype.int)
-    assert d_in.topython() == [[0, None, 0, 4, 7],
-                               [None, 0, 0, 4, 7],
-                               [1, 1, 4, 3, 3]]
+    assert d_in.to_list() == [[0, None, 0, 4, 7],
+                              [None, 0, 0, 4, 7],
+                              [1, 1, 4, 3, 3]]
 
 
 def test_aggregate_2d_continuous_integer_random():
@@ -272,13 +270,13 @@ def test_aggregate_2d_continuous_integer_random():
     d_members.internal.check()
     assert d_members.shape == (11, 1)
     assert d_members.ltypes == (ltype.int,)
-    assert d_members.topython() == [[2, 0, 4, 5, 1, 3, 3, 6, 6, 7, 1]]
+    assert d_members.to_list() == [[2, 0, 4, 5, 1, 3, 3, 6, 6, 7, 1]]
     d_in.internal.check()
     assert d_in.shape == (8, 3)
     assert d_in.ltypes == (ltype.int, ltype.int, ltype.int)
-    assert d_in.topython() == [[None, 3, 9, 3, 8, 2, 5, 8],
-                               [None, 1, 3, 4, 5, 8, 8, 6],
-                               [1, 2, 1, 2, 1, 1, 2, 1]]
+    assert d_in.to_list() == [[None, 3, 9, 3, 8, 2, 5, 8],
+                              [None, 1, 3, 4, 5, 8, 8, 6],
+                              [1, 2, 1, 2, 1, 1, 2, 1]]
 
 
 def test_aggregate_2d_continuous_real_sorted():
@@ -293,13 +291,13 @@ def test_aggregate_2d_continuous_real_sorted():
     d_members.internal.check()
     assert d_members.shape == (13, 1)
     assert d_members.ltypes == (ltype.int,)
-    assert d_members.topython() == [[1, 3, 3, 3, 0, 3, 4, 4, 4, 5, 5, 5, 2]]
+    assert d_members.to_list() == [[1, 3, 3, 3, 0, 3, 4, 4, 4, 5, 5, 5, 2]]
     d_in.internal.check()
     assert d_in.shape == (6, 3)
     assert d_in.ltypes == (ltype.real, ltype.real, ltype.int)
-    assert d_in.topython() == [[None, 0.0, None, 0.0, 0.4, 0.7],
-                               [None, None, 0.0, 0.0, 0.4, 0.7],
-                               [1, 1, 1, 4, 3, 3]]
+    assert d_in.to_list() == [[None, 0.0, None, 0.0, 0.4, 0.7],
+                              [None, None, 0.0, 0.0, 0.4, 0.7],
+                              [1, 1, 1, 4, 3, 3]]
 
 
 def test_aggregate_2d_continuous_real_random():
@@ -314,13 +312,13 @@ def test_aggregate_2d_continuous_real_random():
     d_members.internal.check()
     assert d_members.shape == (12, 1)
     assert d_members.ltypes == (ltype.int,)
-    assert d_members.topython() == [[0, 2, 4, 5, 1, 0, 3, 3, 6, 6, 7, 1]]
+    assert d_members.to_list() == [[0, 2, 4, 5, 1, 0, 3, 3, 6, 6, 7, 1]]
     d_in.internal.check()
     assert d_in.shape == (8, 3)
     assert d_in.ltypes == (ltype.real, ltype.real, ltype.int)
-    assert d_in.topython() == [[None, 0.3, 0.9, 0.3, 0.8, 0.2, 0.5, 0.8],
-                               [None, 0.1, 0.3, 0.4, 0.5, 0.8, 0.8, 0.6],
-                               [2, 2, 1, 2, 1, 1, 2, 1]]
+    assert d_in.to_list() == [[None, 0.3, 0.9, 0.3, 0.8, 0.2, 0.5, 0.8],
+                              [None, 0.1, 0.3, 0.4, 0.5, 0.8, 0.8, 0.6],
+                              [2, 2, 1, 2, 1, 1, 2, 1]]
 
 
 def test_aggregate_2d_categorical_sorted():
@@ -332,16 +330,16 @@ def test_aggregate_2d_categorical_sorted():
     d_members.internal.check()
     assert d_members.shape == (10, 1)
     assert d_members.ltypes == (ltype.int,)
-    assert d_members.topython() == [[0, 2, 1, 3, 4, 5, 6, 7, 8, 9]]
+    assert d_members.to_list() == [[0, 2, 1, 3, 4, 5, 6, 7, 8, 9]]
     d_in.internal.check()
     assert d_in.shape == (10, 3)
     assert d_in.ltypes == (ltype.str, ltype.str, ltype.int)
-    assert d_in.topython() == [[None, "abc", None, "blue", "green", "indigo",
-                                "orange", "red", "violet", "yellow"],
-                               [None, None, "abc", "Friday", "Monday",
-                                "Saturday", "Sunday", "Thursday", "Tuesday",
-                                "Wednesday"],
-                               [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]]
+    assert d_in.to_list() == [[None, "abc", None, "blue", "green", "indigo",
+                               "orange", "red", "violet", "yellow"],
+                              [None, None, "abc", "Friday", "Monday",
+                               "Saturday", "Sunday", "Thursday", "Tuesday",
+                               "Wednesday"],
+                              [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]]
 
 
 def test_aggregate_2d_categorical_unsorted():
@@ -354,15 +352,15 @@ def test_aggregate_2d_categorical_unsorted():
     d_members.internal.check()
     assert d_members.shape == (7, 1)
     assert d_members.ltypes == (ltype.int,)
-    assert d_members.topython() == [[1, 2, 5, 3, 4, 0, 5]]
+    assert d_members.to_list() == [[1, 2, 5, 3, 4, 0, 5]]
     d_in.internal.check()
     assert d_in.shape == (6, 3)
     assert d_in.ltypes == (ltype.str, ltype.str, ltype.int)
-    assert d_in.topython() == [['violet', 'blue', 'indigo', 'violet', 'yellow',
-                                'red'],
-                               ['Friday', 'Monday', 'Monday', 'Saturday',
-                                'Thursday', 'Wednesday'],
-                               [1, 1, 1, 1, 1, 2]]
+    assert d_in.to_list() == [['violet', 'blue', 'indigo', 'violet', 'yellow',
+                               'red'],
+                              ['Friday', 'Monday', 'Monday', 'Saturday',
+                               'Thursday', 'Wednesday'],
+                              [1, 1, 1, 1, 1, 2]]
 
 
 # Disable some of the checks for the moment, as even with the same seed
@@ -378,13 +376,13 @@ def test_aggregate_2d_categorical_sampling():
     d_members.internal.check()
     assert d_members.shape == (10, 1)
     assert d_members.ltypes == (ltype.int,)
-    # assert d_members.topython() == [[...]]
+    # assert d_members.to_list() == [[...]]
     d_in.internal.check()
     assert d_in.shape == (4, 3)
     assert d_in.ltypes == (ltype.str, ltype.str, ltype.int)
-    # assert d_in.topython() == [[...],
-    #                            [...],
-    #                            [...]]
+    # assert d_in.to_list() == [[...],
+    #                           [...],
+    #                           [...]]
 
 
 def test_aggregate_2d_mixed_sorted():
@@ -397,14 +395,14 @@ def test_aggregate_2d_mixed_sorted():
     d_members.internal.check()
     assert d_members.shape == (10, 1)
     assert d_members.ltypes == (ltype.int,)
-    assert d_members.topython() == [[0, 2, 1, 3, 4, 5, 6, 7, 8, 9]]
+    assert d_members.to_list() == [[0, 2, 1, 3, 4, 5, 6, 7, 8, 9]]
     d_in.internal.check()
     assert d_in.shape == (10, 3)
     assert d_in.ltypes == (ltype.int, ltype.str, ltype.int)
-    assert d_in.topython() == [[None, 0, None, 0, 1, 2, 3, 4, 5, 6],
-                               [None, None, "a", "blue", "green", "indigo",
-                                "orange", "red", "violet", "yellow"],
-                               [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]]
+    assert d_in.to_list() == [[None, 0, None, 0, 1, 2, 3, 4, 5, 6],
+                              [None, None, "a", "blue", "green", "indigo",
+                               "orange", "red", "violet", "yellow"],
+                              [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]]
 
 
 def test_aggregate_2d_mixed_random():
@@ -417,14 +415,14 @@ def test_aggregate_2d_mixed_random():
     d_members.internal.check()
     assert d_members.shape == (11, 1)
     assert d_members.ltypes == (ltype.int,)
-    assert d_members.topython() == [[0, 2, 3, 1, 1, 5, 7, 1, 8, 6, 4]]
+    assert d_members.to_list() == [[0, 2, 3, 1, 1, 5, 7, 1, 8, 6, 4]]
     d_in.internal.check()
     assert d_in.shape == (9, 3)
     assert d_in.ltypes == (ltype.int, ltype.str, ltype.int)
-    assert d_in.topython() == [[1, None, 3, 0, 4, 6, 2, 6, 1],
-                               [None, 'abc', 'blue', 'indigo', 'red', 'red',
-                                'violet', 'violet', 'yellow'],
-                               [1, 3, 1, 1, 1, 1, 1, 1, 1]]
+    assert d_in.to_list() == [[1, None, 3, 0, 4, 6, 2, 6, 1],
+                              [None, 'abc', 'blue', 'indigo', 'red', 'red',
+                               'violet', 'violet', 'yellow'],
+                              [1, 3, 1, 1, 1, 1, 1, 1, 1]]
 
 
 #-------------------------------------------------------------------------------
@@ -444,11 +442,11 @@ def test_aggregate_3d_categorical():
                           progress_fn=report_progress)
     assert d_members.shape == (rows, 1)
     assert d_members.ltypes == (ltype.int,)
-    assert d_members.topython() == [exemplar_id]
+    assert d_members.to_list() == [exemplar_id]
     d_in.internal.check()
     assert d_in.shape == (rows, 4)
     assert d_in.ltypes == (ltype.str, ltype.str, ltype.str, ltype.int)
-    assert d_in.topython() == a_in + members_count
+    assert d_in.to_list() == a_in + members_count
 
 
 def test_aggregate_3d_real():
@@ -459,7 +457,7 @@ def test_aggregate_3d_real():
     ])
     d_members = aggregate(d_in, min_rows=0, nd_max_bins=3,
                           progress_fn=report_progress)
-    a_members = d_members.topython()[0]
+    a_members = d_members.to_list()[0]
     d = d_in.sort("C0")
     ri = d.internal.rowindex.tolist()
     for i, member in enumerate(a_members):
@@ -474,10 +472,10 @@ def test_aggregate_3d_real():
     assert d_in.shape == (3, 4)
     assert d_in.ltypes == (ltype.real, ltype.real, ltype.real, ltype.int)
 
-    assert d.topython() == [[0.10, 0.50, 0.95],
-                            [0.05, 0.55, 1.00],
-                            [0.00, 0.50, 0.90],
-                            [1, 4, 5]]
+    assert d.to_list() == [[0.10, 0.50, 0.95],
+                           [0.05, 0.55, 1.00],
+                           [0.00, 0.50, 0.90],
+                           [1, 4, 5]]
 
 
 def test_aggregate_nd_direct():
@@ -503,7 +501,7 @@ def aggregate_nd(nd):
     d_members = aggregate(d_in, min_rows=0, nd_max_bins=div, seed=1,
                           progress_fn=report_progress)
 
-    a_members = d_members.topython()[0]
+    a_members = d_members.to_list()[0]
     d = d_in.sort("C0")
     ri = d.internal.rowindex.tolist()
     for i, member in enumerate(a_members):
@@ -516,4 +514,4 @@ def aggregate_nd(nd):
     d_in.internal.check()
     assert d_in.shape == (div, nd + 1)
     assert d_in.ltypes == tuple(out_types)
-    assert d.topython() == out_value
+    assert d.to_list() == out_value

--- a/tests/extras/test_ftrl.py
+++ b/tests/extras/test_ftrl.py
@@ -525,7 +525,7 @@ def test_ftrl_fit_unique():
     df_target = dt.Frame([[True for i in range(ft.d)]])
     ft.fit(df_train, df_target)
     model = [[-0.5 for i in range(ft.d)], [0.25 for i in range(ft.d)]]
-    assert ft.model.topython() == model
+    assert ft.model.to_list() == model
 
 
 def test_ftrl_fit_predict_bool():

--- a/tests/fread/test_fread_api.py
+++ b/tests/fread/test_fread_api.py
@@ -26,7 +26,7 @@ def test_fread_from_file1(tempfile):
     d0 = dt.fread(tempfile)
     d0.internal.check()
     assert d0.names == ("A", "B")
-    assert d0.topython() == [[1], [2]]
+    assert d0.to_list() == [[1], [2]]
 
 
 def test_fread_from_file2():
@@ -62,7 +62,7 @@ def test_fread_from_cmd3(tempfile):
     with open(tempfile, "w") as o:
         o.write("A,B\n1,2\n3,4\n5,6\n7,3\n8,9\n")
     assert dt.fread(cmd="grep -v 3 %s" % tempfile) \
-             .topython() == [[1, 5, 8], [2, 6, 9]]
+             .to_list() == [[1, 5, 8], [2, 6, 9]]
 
 
 def test_fread_from_url1():
@@ -105,7 +105,7 @@ def test_fread_from_anysource_as_text3(capsys):
     out, err = capsys.readouterr()
     d0.internal.check()
     assert not err
-    assert d0.topython() == [[1, 5], [2, 4], [3, 3]]
+    assert d0.to_list() == [[1, 5], [2, 4], [3, 3]]
     assert "Input contains '\\x0A', treating it as raw text" in out
 
 
@@ -130,7 +130,7 @@ def test_fread_from_anysource_as_file2(tempfile, py36):
     d0.internal.check()
     d1.internal.check()
     d2.internal.check()
-    assert d0.topython() == d1.topython() == d2.topython()
+    assert d0.to_list() == d1.to_list() == d2.to_list()
 
 
 def test_fread_from_anysource_filelike():
@@ -147,7 +147,7 @@ def test_fread_from_anysource_filelike():
     d0 = dt.fread(MyFile())
     d0.internal.check()
     assert d0.names == ("A", "B", "C")
-    assert d0.topython() == [["a"], ["b"], ["c"]]
+    assert d0.to_list() == [["a"], ["b"], ["c"]]
 
 
 def test_fread_from_anysource_as_url(tempfile, capsys):
@@ -167,7 +167,7 @@ def test_fread_from_stringbuf():
     d0 = dt.fread(s)
     d0.internal.check()
     assert d0.names == ("A", "B", "C")
-    assert d0.topython() == [[1, 4], [2, 5], [3, 6]]
+    assert d0.to_list() == [[1, 4], [2, 5], [3, 6]]
 
 
 def test_fread_from_fileobj(tempfile):
@@ -178,7 +178,7 @@ def test_fread_from_fileobj(tempfile):
         d0 = dt.fread(f)
         d0.internal.check()
         assert d0.names == ("A", "B", "C")
-        assert d0.topython() == [["foo"], ["bar"], ["baz"]]
+        assert d0.to_list() == [["foo"], ["bar"], ["baz"]]
 
 
 def test_fread_file_not_exists():
@@ -204,7 +204,7 @@ def test_fread_xz_file(tempfile, capsys):
     d0 = dt.fread(xzfile, verbose=True)
     out, err = capsys.readouterr()
     d0.internal.check()
-    assert d0.topython() == [[1, 2, 3]]
+    assert d0.to_list() == [[1, 2, 3]]
     assert not err
     assert ("Extracting %s into memory" % xzfile) in out
     os.unlink(xzfile)
@@ -218,7 +218,7 @@ def test_fread_gz_file(tempfile, capsys):
     d0 = dt.fread(gzfile, verbose=True)
     out, err = capsys.readouterr()
     d0.internal.check()
-    assert d0.topython() == [[10, 20, 30]]
+    assert d0.to_list() == [[10, 20, 30]]
     assert not err
     assert ("Extracting %s into memory" % gzfile) in out
     os.unlink(gzfile)
@@ -233,7 +233,7 @@ def test_fread_bz2_file(tempfile, capsys):
         d0 = dt.fread(bzfile, verbose=True)
         out, err = capsys.readouterr()
         d0.internal.check()
-        assert d0.topython() == [[11, 22, 33]]
+        assert d0.to_list() == [[11, 22, 33]]
         assert not err
         assert ("Extracting %s into memory" % bzfile) in out
     finally:
@@ -249,7 +249,7 @@ def test_fread_zip_file_1(tempfile, capsys):
     out, err = capsys.readouterr()
     d0.internal.check()
     assert d0.names == ("a", "b", "c")
-    assert d0.topython() == [[10, 5], [20, 7], [30, 12]]
+    assert d0.to_list() == [[10, 5], [20, 7], [30, 12]]
     assert not err
     assert ("Extracting %s to temporary directory" % zfname) in out
     os.unlink(zfname)
@@ -272,9 +272,9 @@ def test_fread_zip_file_multi(tempfile):
     assert d0.names == ("a", "b", "c")
     assert d1.names == ("A", "B", "C")
     assert d2.names == ("Aa", "Bb", "Cc")
-    assert d0.topython() == [["foo", "gee"], ["bar", "jou"], ["baz", "sha"]]
-    assert d1.topython() == [[3, 6], [4, 7], [5, 8]]
-    assert d2.topython() == [[True, False], [1.5, 1e20], ["", "yay"]]
+    assert d0.to_list() == [["foo", "gee"], ["bar", "jou"], ["baz", "sha"]]
+    assert d1.to_list() == [[3, 6], [4, 7], [5, 8]]
+    assert d2.to_list() == [[True, False], [1.5, 1e20], ["", "yay"]]
     assert len(ws) == 1
     assert ("Zip file %s contains multiple compressed files"
             % zfname) in ws[0].message.args[0]
@@ -371,7 +371,7 @@ def test_fread_from_glob(tempfile):
         df.internal.check()
         assert df.names == ("A", "B", "C")
         assert df.shape == (20, 3)
-        assert df.topython() == [
+        assert df.to_list() == [
             [0, 0, 0, 1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0, 7, 0, 8, 0, 9],
             [0, 1, 0, 3, 0, 5, 0, 7, 0, 9, 0, 11, 0, 13, 0, 15, 0, 17, 0, 19],
             [0, 5, 0, 22, 0, 16, 0, 10, 0, 4, 0, 21, 0, 15, 0, 9, 0, 3, 0, 20]
@@ -391,14 +391,14 @@ def test_fread_columns_slice():
     d0 = dt.fread(text="A,B,C,D,E\n1,2,3,4,5", columns=slice(None, None, 2))
     d0.internal.check()
     assert d0.names == ("A", "C", "E")
-    assert d0.topython() == [[1], [3], [5]]
+    assert d0.to_list() == [[1], [3], [5]]
 
 
 def test_fread_columns_range():
     d0 = dt.fread(text="A,B,C,D,E\n1,2,3,4,5", columns=range(3))
     d0.internal.check()
     assert d0.names == ("A", "B", "C")
-    assert d0.topython() == [[1], [2], [3]]
+    assert d0.to_list() == [[1], [2], [3]]
 
 
 def test_fread_columns_range_bad1():
@@ -417,21 +417,21 @@ def test_fread_columns_list1():
     d0 = dt.fread(text="A,B,C\n1,2,3", columns=["foo", "bar", "baz"])
     d0.internal.check()
     assert d0.names == ("foo", "bar", "baz")
-    assert d0.topython() == [[1], [2], [3]]
+    assert d0.to_list() == [[1], [2], [3]]
 
 
 def test_fread_columns_list2():
     d0 = dt.fread(text="A,B,C\n1,2,3", columns=["foo", None, "baz"])
     d0.internal.check()
     assert d0.names == ("foo", "baz")
-    assert d0.topython() == [[1], [3]]
+    assert d0.to_list() == [[1], [3]]
 
 
 def test_fread_columns_list3():
     d0 = dt.fread(text="A,B,C\n1,2,3", columns=[("foo", str), None, None])
     d0.internal.check()
     assert d0.names == ("foo", )
-    assert d0.topython() == [["1"]]
+    assert d0.to_list() == [["1"]]
 
 
 def test_fread_columns_list_of_types():
@@ -440,7 +440,7 @@ def test_fread_columns_list_of_types():
     d0.internal.check()
     assert d0.names == ("A", "B", "C")
     assert d0.stypes == (stype.int32, stype.float64, stype.str32)
-    assert d0.topython() == [[1], [2.0], ["3"]]
+    assert d0.to_list() == [[1], [2.0], ["3"]]
 
 
 def test_fread_columns_list_bad1():
@@ -466,7 +466,7 @@ def test_fread_columns_list_bad4():
     src = 'A,B,C\n01,foo,3.140\n002,bar,6.28000\n'
     d0 = dt.fread(src, columns=[stype.str32, None, stype.float64])
     assert d0.names == ("A", "C")
-    assert d0.topython() == [["01", "002"], [3.14, 6.28]]
+    assert d0.to_list() == [["01", "002"], [3.14, 6.28]]
     with pytest.raises(RuntimeError) as e:
         dt.fread(src, columns=[str, float, float])
     assert "Attempt to override column 2 \"B\" with detected type 'Str32' " \
@@ -491,14 +491,14 @@ def test_fread_columns_set1():
     d0 = dt.fread(text=text, columns={"C1", "C3"})
     d0.internal.check()
     assert d0.names == ("C1", "C3")
-    assert d0.topython() == [[1, 2], [7, None]]
+    assert d0.to_list() == [[1, 2], [7, None]]
 
 
 def test_fread_columns_set2():
     with pytest.warns(DatatableWarning) as ws:
         d0 = dt.fread(text="A,B,A\n1,2,3\n", columns={"A"})
     assert d0.names == ("A", "A.1")
-    assert d0.topython() == [[1], [3]]
+    assert d0.to_list() == [[1], [3]]
     assert len(ws) == 1
     assert ("Duplicate column name 'A' found, and was assigned a unique name"
             in ws[0].message.args[0])
@@ -514,13 +514,13 @@ def test_fread_columns_set_bad():
 def test_fread_columns_dict1():
     d0 = dt.fread(text="C1,C2,C3\n1,2,3\n4,5,6", columns={"C3": "A", "C1": "B"})
     assert d0.names == ("B", "C2", "A")
-    assert d0.topython() == [[1, 4], [2, 5], [3, 6]]
+    assert d0.to_list() == [[1, 4], [2, 5], [3, 6]]
 
 
 def test_fread_columns_dict2():
     d0 = dt.fread(text="A,B,C,D\n1,2,3,4", columns={"A": "a", ...: None})
     assert d0.names == ("a", )
-    assert d0.topython() == [[1]]
+    assert d0.to_list() == [[1]]
 
 
 def test_fread_columns_dict3():
@@ -528,7 +528,7 @@ def test_fread_columns_dict3():
                   columns={"A": ("foo", float), "B": str, "C": None})
     assert d0.names == ("foo", "B")
     assert d0.ltypes == (ltype.real, ltype.str)
-    assert d0.topython() == [[1.0], ["2"]]
+    assert d0.to_list() == [[1.0], ["2"]]
 
 
 def test_fread_columns_dict4():
@@ -536,35 +536,35 @@ def test_fread_columns_dict4():
     d0 = dt.fread(src, columns={"C": str})
     assert d0.names == ("A", "B", "C")
     assert d0.ltypes == (ltype.int, ltype.str, ltype.str)
-    assert d0.topython() == [[1, 2], ["foo", "bar"], ["3.140", "6.28000"]]
+    assert d0.to_list() == [[1, 2], ["foo", "bar"], ["3.140", "6.28000"]]
     d1 = dt.fread(src, columns={"C": str, "A": float})
     assert d1.ltypes == (ltype.real, ltype.str, ltype.str)
-    assert d1.topython() == [[1, 2], ["foo", "bar"], ["3.140", "6.28000"]]
+    assert d1.to_list() == [[1, 2], ["foo", "bar"], ["3.140", "6.28000"]]
     d2 = dt.fread(src, columns={"C": str, "A": ltype.real})
     assert d2.ltypes == (ltype.real, ltype.str, ltype.str)
-    assert d2.topython() == [[1, 2], ["foo", "bar"], ["3.140", "6.28000"]]
+    assert d2.to_list() == [[1, 2], ["foo", "bar"], ["3.140", "6.28000"]]
 
 
 def test_fread_columns_dict_reverse():
     src = 'A,B,C\n01,foo,3.140\n002,bar,6.28000\n'
     d0 = dt.fread(src, columns={str: "C", ltype.real: ["A"]})
     assert d0.ltypes == (ltype.real, ltype.str, ltype.str)
-    assert d0.topython() == [[1, 2], ["foo", "bar"], ["3.140", "6.28000"]]
+    assert d0.to_list() == [[1, 2], ["foo", "bar"], ["3.140", "6.28000"]]
     d1 = dt.fread(src, columns={str: slice(2, None), ltype.real: ["A"]})
     assert d1.ltypes == (ltype.real, ltype.str, ltype.str)
-    assert d1.topython() == [[1, 2], ["foo", "bar"], ["3.140", "6.28000"]]
+    assert d1.to_list() == [[1, 2], ["foo", "bar"], ["3.140", "6.28000"]]
     d2 = dt.fread(src, columns={str: slice(None)})
     assert d2.ltypes == (ltype.str, ltype.str, ltype.str)
-    assert d2.topython() == [["01", "002"], ["foo", "bar"],
-                             ["3.140", "6.28000"]]
+    assert d2.to_list() == [["01", "002"], ["foo", "bar"],
+                            ["3.140", "6.28000"]]
 
 
 def test_fread_columns_type():
     src = 'A,B,C\n01,foo,3.140\n002,bar,6.28000\n'
     d0 = dt.fread(src, columns=str)
     assert d0.ltypes == (ltype.str, ltype.str, ltype.str)
-    assert d0.topython() == [["01", "002"], ["foo", "bar"],
-                             ["3.140", "6.28000"]]
+    assert d0.to_list() == [["01", "002"], ["foo", "bar"],
+                            ["3.140", "6.28000"]]
 
 
 def test_fread_columns_fn1():
@@ -574,7 +574,7 @@ def test_fread_columns_fn1():
                                                    for col in cols])
     d0.internal.check()
     assert d0.names == ("A2", "A4", "x16")
-    assert d0.topython() == [[4], [2], [0]]
+    assert d0.to_list() == [[4], [2], [0]]
 
 
 def test_fread_columns_fn3():
@@ -587,9 +587,9 @@ def test_fread_columns_fn3():
     assert d0.ltypes == (ltype.int, ltype.int)
     assert d1.ltypes == (ltype.real, ltype.real)
     assert d2.ltypes == (ltype.str, ltype.str)
-    assert d0.topython() == [[1], [2]]
-    assert d1.topython() == [[1.0], [2.0]]
-    assert d2.topython() == [["1"], ["2"]]
+    assert d0.to_list() == [[1], [2]]
+    assert d1.to_list() == [[1.0], [2.0]]
+    assert d2.to_list() == [["1"], ["2"]]
 
 
 @pytest.mark.parametrize("columns", [None, list(), set(), dict()])
@@ -598,7 +598,7 @@ def test_fread_columns_empty(columns):
     d0 = dt.fread("A,B,C\n1,2,3", columns=columns)
     assert d0.shape == (1, 3)
     assert d0.names == ("A", "B", "C")
-    assert d0.topython() == [[1], [2], [3]]
+    assert d0.to_list() == [[1], [2], [3]]
 
 
 
@@ -623,7 +623,7 @@ def test_sep_newline():
     d1.internal.check()
     assert d0.shape == d1.shape == (1, 1)
     assert d0.names == d1.names == ("A,B,C",)
-    assert d0.topython() == d1.topython() == [["1,2;3 ,5"]]
+    assert d0.to_list() == d1.to_list() == [["1,2;3 ,5"]]
 
 
 @pytest.mark.parametrize("sep", [None, ";", ",", "|", "\n", "*"])
@@ -666,7 +666,7 @@ def test_fread_skip_blank_lines_true():
     d0.internal.check()
     assert d0.shape == (2, 2)
     assert d0.ltypes == (ltype.int, ltype.int)
-    assert d0.topython() == [[1, 3], [2, 4]]
+    assert d0.to_list() == [[1, 3], [2, 4]]
 
 
 @pytest.mark.skip("Issue #838")
@@ -677,7 +677,7 @@ def test_fread_skip_blank_lines_false():
         d1.internal.check()
         assert d1.shape == (1, 2)
         assert d1.ltypes == (ltype.bool, ltype.int)
-        assert d1.topython() == [[True], [2]]
+        assert d1.to_list() == [[True], [2]]
     assert len(ws) == 1
     assert ("Found the last consistent line but text exists afterwards"
             in ws[0].message.args[0])
@@ -696,12 +696,12 @@ def test_fread_strip_whitespace():
     d0.internal.check()
     assert d0.shape == (2, 2)
     assert d0.ltypes == (ltype.int, ltype.str)
-    assert d0.topython() == [[1, 3], ["c", "d"]]
+    assert d0.to_list() == [[1, 3], ["c", "d"]]
     d1 = dt.fread(text=inp, strip_whitespace=False)
     d1.internal.check()
     assert d1.shape == (2, 2)
     assert d1.ltypes == (ltype.int, ltype.str)
-    assert d1.topython() == [[1, 3], ["  c  ", " d"]]
+    assert d1.to_list() == [[1, 3], ["  c  ", " d"]]
 
 
 
@@ -713,19 +713,19 @@ def test_fread_quotechar():
     inp = "A,B\n'foo',1\n\"bar\",2\n`baz`,3\n"
     d0 = dt.fread(inp)  # default is quotechar='"'
     d0.internal.check()
-    assert d0.topython() == [["'foo'", "bar", "`baz`"], [1, 2, 3]]
+    assert d0.to_list() == [["'foo'", "bar", "`baz`"], [1, 2, 3]]
     d1 = dt.fread(inp, quotechar="'")
     d1.internal.check()
-    assert d1.topython() == [["foo", '"bar"', "`baz`"], [1, 2, 3]]
+    assert d1.to_list() == [["foo", '"bar"', "`baz`"], [1, 2, 3]]
     d2 = dt.fread(inp, quotechar="`")
     d2.internal.check()
-    assert d2.topython() == [["'foo'", '"bar"', "baz"], [1, 2, 3]]
+    assert d2.to_list() == [["'foo'", '"bar"', "baz"], [1, 2, 3]]
     d3 = dt.fread(inp, quotechar="")
     d3.internal.check()
-    assert d3.topython() == [["'foo'", '"bar"', "`baz`"], [1, 2, 3]]
+    assert d3.to_list() == [["'foo'", '"bar"', "`baz`"], [1, 2, 3]]
     d4 = dt.fread(inp, quotechar=None)
     d4.internal.check()
-    assert d4.topython() == [["'foo'", "bar", "`baz`"], [1, 2, 3]]
+    assert d4.to_list() == [["'foo'", "bar", "`baz`"], [1, 2, 3]]
 
 
 def test_fread_quotechar_bad():
@@ -750,11 +750,11 @@ def test_fread_dec():
     d0 = dt.fread(inp)  # default is dec='.'
     d0.internal.check()
     assert d0.ltypes == (ltype.real, ltype.str)
-    assert d0.topython() == [[1.0, 2.345], ["1,000", "5,432e+10"]]
+    assert d0.to_list() == [[1.0, 2.345], ["1,000", "5,432e+10"]]
     d1 = dt.fread(inp, dec=",")
     d1.internal.check()
     assert d1.ltypes == (ltype.str, ltype.real)
-    assert d1.topython() == [["1.000", "2.345"], [1.0, 5.432e+10]]
+    assert d1.to_list() == [["1.000", "2.345"], [1.0, 5.432e+10]]
 
 
 def test_fread_dec_bad():
@@ -781,8 +781,8 @@ def test_fread_header():
     d1 = dt.fread(inp, header=False)
     d0.internal.check()
     d1.internal.check()
-    assert d0.topython() == [[1], [2]]
-    assert d1.topython() == [["A", "1"], ["B", "2"]]
+    assert d0.to_list() == [[1], [2]]
+    assert d1.to_list() == [["A", "1"], ["B", "2"]]
 
 
 
@@ -794,7 +794,7 @@ def test_fread_skip_to_line():
     d0 = dt.fread("a,z\nv,1\nC,D\n1,2\n", skip_to_line=3)
     d0.internal.check()
     assert d0.names == ("C", "D")
-    assert d0.topython() == [[1], [2]]
+    assert d0.to_list() == [[1], [2]]
 
 
 def test_fread_skip_to_line_large():
@@ -811,7 +811,7 @@ def test_fread_skip_to_string():
                   "1,2,3\n", skip_to_string=",B,")
     d0.internal.check()
     assert d0.names == ("A", "B", "C")
-    assert d0.topython() == [[1], [2], [3]]
+    assert d0.to_list() == [[1], [2], [3]]
 
 
 def test_skip_to_string_bad():
@@ -834,7 +834,7 @@ def test_fread_max_nrows(capsys):
     out, err = capsys.readouterr()
     d0.internal.check()
     assert d0.names == ("A", "B", "C")
-    assert d0.topython() == [[1, 3], ["foo", "bar"], [True, False]]
+    assert d0.to_list() == [[1, 3], ["foo", "bar"], [True, False]]
     assert "Allocating 3 column slots with 2 rows" in out
     assert "Too few rows allocated" not in out
     assert "converting input string into bytes" in out
@@ -858,7 +858,7 @@ def test_fread_max_nrows_correct_types():
     assert d0.names == ("A", "B")
     assert d0.shape == (3, 2)
     assert d0.ltypes == (ltype.int, ltype.int)
-    assert d0.topython() == [[1, 3, 5], [2, 4, 6]]
+    assert d0.to_list() == [[1, 3, 5], [2, 4, 6]]
 
 
 
@@ -905,9 +905,9 @@ def test_fillna0():
                   "2,baz\n"
                   "3", fill=True)
     d0.internal.check()
-    assert d0.topython() == [[1, 2, 3],
-                             ['foo', 'baz', None],
-                             ['bar', None, None]]
+    assert d0.to_list() == [[1, 2, 3],
+                            ['foo', 'baz', None],
+                            ['bar', None, None]]
 
 
 def test_fillna1():
@@ -920,7 +920,7 @@ def test_fillna1():
            "5\n")
     d = dt.fread(text=src, fill=True)
     d.internal.check()
-    p = d[1:, 1:].topython()
+    p = d[1:, 1:].to_list()
     assert p == [[None] * 4] * 8
 
 
@@ -931,7 +931,7 @@ def test_fillna_and_skipblanklines():
                   "baz\n"
                   "bar,3\n", fill=True, skip_blank_lines=True)
     d0.internal.check()
-    assert d0.topython() == [["foo", "baz", "bar"], [2, None, 3]]
+    assert d0.to_list() == [["foo", "baz", "bar"], [2, None, 3]]
 
 
 

--- a/tests/fread/test_fread_detect.py
+++ b/tests/fread/test_fread_detect.py
@@ -20,14 +20,14 @@ def test_fread_headers_less1():
     f0 = dt.fread("A\n10,5,foo,1\n11,-3,bar,2\n")
     f0.internal.check()
     assert f0.names == ("A", "C0", "C1", "C2")
-    assert f0.topython() == [[10, 11], [5, -3], ["foo", "bar"], [1, 2]]
+    assert f0.to_list() == [[10, 11], [5, -3], ["foo", "bar"], [1, 2]]
 
 
 def test_fread_headers_less2():
     f0 = dt.fread("A,B\n10,5,foo,1\n11,-3,bar,2\n")
     f0.internal.check()
     assert f0.names == ("A", "B", "C0", "C1")
-    assert f0.topython() == [[10, 11], [5, -3], ["foo", "bar"], [1, 2]]
+    assert f0.to_list() == [[10, 11], [5, -3], ["foo", "bar"], [1, 2]]
 
 
 def test_fread_headers_against_mu():
@@ -38,7 +38,7 @@ def test_fread_headers_against_mu():
     f0 = dt.fread("A,100,2\n,300,4\n,500,6\n")
     f0.internal.check()
     assert f0.names == ("C0", "C1", "C2")
-    assert f0.topython() == [["A", "", ""], [100, 300, 500], [2, 4, 6]]
+    assert f0.to_list() == [["A", "", ""], [100, 300, 500], [2, 4, 6]]
 
 
 def test_fread_headers_with_blanks():
@@ -49,7 +49,7 @@ def test_fread_headers_with_blanks():
         """)
     f0.internal.check()
     assert f0.names == ("C0", "C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8")
-    assert f0[:, -2:].topython() == [[None] * 3, [2865] * 3]
+    assert f0[:, -2:].to_list() == [[None] * 3, [2865] * 3]
 
 
 

--- a/tests/fread/test_fread_issues.py
+++ b/tests/fread/test_fread_issues.py
@@ -27,7 +27,7 @@ def test_issue_R1113():
     assert d0.names == ("ITER", "THETA1", "THETA2", "MCMC")
     assert d0.ltypes == (dt.ltype.int, dt.ltype.real, dt.ltype.real,
                          dt.ltype.real)
-    assert d0.topython() == [[-11000, -10999, -10998],
+    assert d0.to_list() == [[-11000, -10999, -10998],
                              [-2.5, -24.9853, 0.195957],
                              [2.3, 379.270, 4.16522],
                              [345678.20255, -195780.43911, 7937.13048]]
@@ -35,7 +35,7 @@ def test_issue_R1113():
     d1 = dt.fread(txt, strip_whitespace=False)
     d1.internal.check()
     assert d1.names == d0.names
-    assert d1.topython() == d0.topython()
+    assert d1.to_list() == d0.to_list()
     # Check that whitespace is not removed from column names either
     d2 = dt.fread(text=" ITER,    THETA1,       THETA2", strip_whitespace=False)
     d3 = dt.fread(text=" ITER  ,  THETA1   ,    THETA2", strip_whitespace=False)
@@ -61,11 +61,11 @@ def test_issue_R2106():
     d2.internal.check()
     d3.internal.check()
     d4.internal.check()
-    assert d0.topython() == [[1, 5, None, 12, 18, None]]
-    assert d1.topython() == [[1, 5, 12, 18]]
-    assert d2.topython() == [[1, 5, 12, 18]]
-    assert d3.topython() == [["1", "5", "NA", "12", "18", "NA"]]
-    assert d4.topython() == [[1, 5, None, 12, 18, None]]
+    assert d0.to_list() == [[1, 5, None, 12, 18, None]]
+    assert d1.to_list() == [[1, 5, 12, 18]]
+    assert d2.to_list() == [[1, 5, 12, 18]]
+    assert d3.to_list() == [["1", "5", "NA", "12", "18", "NA"]]
+    assert d4.to_list() == [[1, 5, None, 12, 18, None]]
 
 
 def test_issue_R2196():
@@ -75,7 +75,7 @@ def test_issue_R2196():
     d0 = dt.fread('1,2,"3,a"\n4,5,"6,b"')
     d0.internal.check()
     assert d0.shape == (2, 3)
-    assert d0.topython() == [[1, 4], [2, 5], ["3,a", "6,b"]]
+    assert d0.to_list() == [[1, 4], [2, 5], ["3,a", "6,b"]]
 
 
 def test_issue_R2222():
@@ -84,10 +84,10 @@ def test_issue_R2222():
     d2 = dt.fread("A,B\n999,5\n999,999\n", na_strings=["999", "NA"])
     d3 = dt.fread("A,B\n999,1\n999,2\n", na_strings=["99", "NA"])
     d0.internal.check()
-    assert d0.topython() == [[None, None], [1, 2]]
-    assert d1.topython() == [[None, 4], [1, 2]]
-    assert d2.topython() == [[None, None], [5, None]]
-    assert d3.topython() == [[999, 999], [1, 2]]
+    assert d0.to_list() == [[None, None], [1, 2]]
+    assert d1.to_list() == [[None, 4], [1, 2]]
+    assert d2.to_list() == [[None, None], [5, None]]
+    assert d3.to_list() == [[999, 999], [1, 2]]
 
 
 @pytest.mark.parametrize("v", ["%", "%d", "%s", "%.*s"])
@@ -122,13 +122,13 @@ def test_issue_R2351(tempfile):
         o.write(text)
     d0 = dt.fread(tempfile)
     d0.internal.check()
-    assert d0[:2, :].topython() == [["id0", "id1"], [0, 38]]
-    assert d0[-2:, :].topython() == [["id99998", "id99999"], [92, 130]]
+    assert d0[:2, :].to_list() == [["id0", "id1"], [0, 38]]
+    assert d0[-2:, :].to_list() == [["id99998", "id99999"], [92, 130]]
     with open(tempfile, "ab") as o:
         o.write(b"foo,1000")
     d0 = dt.fread(tempfile)
     d0.internal.check()
-    assert d0[-2:, :].topython() == [["id99999", "foo"], [130, 1000]]
+    assert d0[-2:, :].to_list() == [["id99999", "foo"], [130, 1000]]
 
 
 def test_issue_R2404():
@@ -140,10 +140,10 @@ def test_issue_R2404():
     assert d0.names == ("A", "B", "C", "D")
     assert d0.shape == (1000, 4)
     inp[111][2] = '"a"'
-    assert d0.topython() == [[row[0] for row in inp],
-                             [row[1] for row in inp],
-                             [row[2][1:-1] for row in inp],  # unescape
-                             [row[3] for row in inp]]
+    assert d0.to_list() == [[row[0] for row in inp],
+                            [row[1] for row in inp],
+                            [row[2][1:-1] for row in inp],  # unescape
+                            [row[3] for row in inp]]
 
 
 @pytest.mark.parametrize("sep", [" ", ",", ";"])
@@ -157,7 +157,7 @@ def test_issue_R2322(sep):
     d0.internal.check()
     assert d0.shape == (3, 1)
     assert d0.names == (name, )
-    assert d0.topython() == [[2, 3, 4]]
+    assert d0.to_list() == [[2, 3, 4]]
 
 
 def test_issue_R2464():
@@ -167,7 +167,7 @@ def test_issue_R2464():
     f = dt.fread('A,B,C\n1,2,"a,b"', columns={'A', 'B'})
     f.internal.check()
     assert f.names == ("A", "B")
-    assert f.topython() == [[1], [2]]
+    assert f.to_list() == [[1], [2]]
 
 
 def test_issue_R2535():
@@ -180,11 +180,11 @@ def test_issue_R2535():
     d0.internal.check()
     d1.internal.check()
     d2.internal.check()
-    assert d0.topython() == [list("ace"), list("bdf"), [2, 3, 4]]
-    assert d1.topython() == [list("ace"), list("bdf"), [2, 3, 4]]
-    assert d2.topython() == [["a", "c", None, "e"],
-                             ["b", "d", None, "f"],
-                             [2, 3, None, 4]]
+    assert d0.to_list() == [list("ace"), list("bdf"), [2, 3, 4]]
+    assert d1.to_list() == [list("ace"), list("bdf"), [2, 3, 4]]
+    assert d2.to_list() == [["a", "c", None, "e"],
+                            ["b", "d", None, "f"],
+                            [2, 3, None, 4]]
 
 
 @pytest.mark.skip(reason="Issue #804")
@@ -194,13 +194,13 @@ def test_issue_R2535x():
     # passing explicitly `fill=False` value.
     src = "a b 2\nc d 3\n\ne f 4\n"
     d3 = dt.fread(src, skip_blank_lines=False, fill=False)
-    assert d3.topython() == [list("ac"), list("bd"), [2, 3]]
+    assert d3.to_list() == [list("ac"), list("bd"), [2, 3]]
 
 
 def test_issue_R2542():
     d0 = dt.fread("A\r1\r\r\r2\r")
     d0.internal.check()
-    assert d0.topython() == [[1, None, None, 2]]
+    assert d0.to_list() == [[1, None, None, 2]]
 
 
 def test_issue_R2666():
@@ -209,10 +209,10 @@ def test_issue_R2666():
     d1 = dt.fread("1;2;3\n4\n5",   sep=";", fill=True)
     d2 = dt.fread("1;2;3\n;4\n5",  sep=";", fill=True)
     d3 = dt.fread("1;2;3\n4\n;5",  sep=";", fill=True)
-    assert d0.topython() == [[1, 4, 5],    [2, None, 6],    [3, None, None]]
-    assert d1.topython() == [[1, 4, 5],    [2, None, None], [3, None, None]]
-    assert d2.topython() == [[1, None, 5], [2, 4, None],    [3, None, None]]
-    assert d3.topython() == [[1, 4, None], [2, None, 5],    [3, None, None]]
+    assert d0.to_list() == [[1, 4, 5],    [2, None, 6],    [3, None, None]]
+    assert d1.to_list() == [[1, 4, 5],    [2, None, None], [3, None, None]]
+    assert d2.to_list() == [[1, None, 5], [2, 4, None],    [3, None, None]]
+    assert d3.to_list() == [[1, 4, None], [2, None, 5],    [3, None, None]]
 
 
 
@@ -227,7 +227,7 @@ def test_issue_527():
     d0 = dt.fread(text=inp)
     d0.internal.check()
     assert d0.names == ("A", "Bÿ", "C")
-    assert d0.topython() == [[1], [2], ["3ª"]]
+    assert d0.to_list() == [[1], [2], ["3ª"]]
 
 
 def test_issue_594():
@@ -259,17 +259,17 @@ def test_issue_606():
     d0 = dt.fread(text="A\n23     ")
     d0.internal.check()
     assert d0.names == ("A",)
-    assert d0.topython() == [[23]]
+    assert d0.to_list() == [[23]]
     d1 = dt.fread("A B C \n10 11 12 \n")
     d1.internal.check()
     assert d1.names == ("A", "B", "C")
-    assert d1.topython() == [[10], [11], [12]]
+    assert d1.to_list() == [[10], [11], [12]]
     d2 = dt.fread("a  b  c\nfoo  bar  baz\noof  bam  \nnah  aye  l8r")
     d2.internal.check()
     assert d2.names == ("a", "b", "c")
-    assert d2.topython() == [["foo", "oof", "nah"],
-                             ["bar", "bam", "aye"],
-                             ["baz", None,  "l8r"]]  # should this be ""?
+    assert d2.to_list() == [["foo", "oof", "nah"],
+                            ["bar", "bam", "aye"],
+                            ["baz", None,  "l8r"]]  # should this be ""?
 
 
 def test_issue_615():
@@ -277,16 +277,16 @@ def test_issue_615():
                   "NaNaNa,Infinity-3,nanny,0x1.5p+12@boo,23ba,2.5e-4q,"
                   "Truely,Falsely,1\n")
     d0.internal.check()
-    assert d0.topython() == [["NaNaNa"], ["Infinity-3"], ["nanny"],
-                             ["0x1.5p+12@boo"], ["23ba"], ["2.5e-4q"],
-                             ["Truely"], ["Falsely"], [1]]
+    assert d0.to_list() == [["NaNaNa"], ["Infinity-3"], ["nanny"],
+                            ["0x1.5p+12@boo"], ["23ba"], ["2.5e-4q"],
+                            ["Truely"], ["Falsely"], [1]]
 
 
 def test_issue_628():
     """Similar to #594 but read in verbose mode."""
     d0 = dt.fread(b"a,\x80\n11,2\n", verbose=True)
     d0.internal.check()
-    assert d0.topython() == [[11], [2]]
+    assert d0.to_list() == [[11], [2]]
     # The interpretation of byte \x80 as symbol € is not set in stone: we may
     # alter it in the future, or make it platform-dependent?
     assert d0.names == ("a", "€")
@@ -300,7 +300,7 @@ def test_issue_641():
     f.internal.check()
     assert f.names == ("A", "B", "C")
     assert f.ltypes == (dt.ltype.int, dt.ltype.str, dt.ltype.str)
-    assert f.topython() == [[5, 6, 7], ["", "foo\rbar", "bah"], ["", "z", ""]]
+    assert f.to_list() == [[5, 6, 7], ["", "foo\rbar", "bah"], ["", "z", ""]]
 
 
 def test_issue_643():
@@ -308,7 +308,7 @@ def test_issue_643():
     d0.internal.check()
     assert d0.names == ("A", "B")
     assert d0.ltypes == (dt.ltype.int, dt.ltype.int)
-    assert d0.topython() == [[1, 3, 5, 6], [2, 4, 6, 7]]
+    assert d0.to_list() == [[1, 3, 5, 6], [2, 4, 6, 7]]
 
 
 def test_issue_664(capsys):
@@ -320,7 +320,7 @@ def test_issue_664(capsys):
     assert "we know nrows=3 exactly" in out
     f.internal.check()
     assert f.shape == (3, 3)
-    assert f.topython() == [["x", "A", "y"],
+    assert f.to_list() == [["x", "A", "y"],
                             [None, "B", None],
                             [None, 2, None]]
 
@@ -329,7 +329,7 @@ def test_issue_670():
     d0 = dt.fread("A\n1\n\n\n2\n", skip_blank_lines=True)
     d0.internal.check()
     assert d0.shape == (2, 1)
-    assert d0.topython() == [[1, 2]]
+    assert d0.to_list() == [[1, 2]]
 
 
 @pytest.mark.parametrize("seed", [random.randint(0, 2**31)])
@@ -404,7 +404,7 @@ def test_issue720(seed):
     d0.internal.check()
     assert d0.names == ("A", "B")
     assert d0.ltypes == (dt.ltype.str, dt.ltype.str)
-    assert d0.topython() == [src0, src1]
+    assert d0.to_list() == [src0, src1]
 
 
 def test_issuee786():
@@ -412,7 +412,7 @@ def test_issuee786():
     df.internal.check()
     assert df.shape == (0, 1)
     assert df.names == ('"A","B"',)
-    assert df.topython() == [[]]
+    assert df.to_list() == [[]]
 
 
 def test_issue939(capsys):
@@ -460,7 +460,7 @@ def test_issue998():
     assert f0.names == tuple("C%d" % i for i in range(f0.ncols))
     assert f0.stypes == (dt.stype.float64,) * f0.ncols
     assert same_iterables(
-        f0.sum().topython(),
+        f0.sum().to_list(),
         [[1058818.0], [1981919.6107614636], [701.7858121241807],
          [-195.48500674014213], [1996390.3476011853], [-1759.5364254778178],
          [1980743.446578741], [-1108.7512905876065], [1712.947751407064],
@@ -489,4 +489,4 @@ def test_issue1233():
     # strictly linear, we end up type-bumping the column more than once,
     # which means the re-read has to happen more than once too...
     d0 = dt.fread("NaN\n2\n")
-    assert d0.topython() == [[None, 2.0]]
+    assert d0.to_list() == [[None, 2.0]]

--- a/tests/fread/test_fread_issues.py
+++ b/tests/fread/test_fread_issues.py
@@ -28,9 +28,9 @@ def test_issue_R1113():
     assert d0.ltypes == (dt.ltype.int, dt.ltype.real, dt.ltype.real,
                          dt.ltype.real)
     assert d0.to_list() == [[-11000, -10999, -10998],
-                             [-2.5, -24.9853, 0.195957],
-                             [2.3, 379.270, 4.16522],
-                             [345678.20255, -195780.43911, 7937.13048]]
+                            [-2.5, -24.9853, 0.195957],
+                            [2.3, 379.270, 4.16522],
+                            [345678.20255, -195780.43911, 7937.13048]]
     # `strip_whitespace` has no effect when `sep == ' '`
     d1 = dt.fread(txt, strip_whitespace=False)
     d1.internal.check()
@@ -321,8 +321,8 @@ def test_issue_664(capsys):
     f.internal.check()
     assert f.shape == (3, 3)
     assert f.to_list() == [["x", "A", "y"],
-                            [None, "B", None],
-                            [None, 2, None]]
+                           [None, "B", None],
+                           [None, 2, None]]
 
 
 def test_issue_670():

--- a/tests/fread/test_fread_large.py
+++ b/tests/fread/test_fread_large.py
@@ -212,8 +212,8 @@ def test_fread_1206FUT():
     assert d0.shape == d1.shape == (308, 21)
     assert d0.names == d1.names
     assert d0.stypes == d1.stypes
-    p0 = d0.topython()
-    p1 = d1.topython()
+    p0 = d0.to_list()
+    p1 = d1.to_list()
     assert p0[:-1] == p1[:-1]
     assert p0[-1] == [""] * 10 + ["A"] * 298
     assert p1[-1] == [" "] * 10 + ["A"] * 298

--- a/tests/fread/test_fread_small.py
+++ b/tests/fread/test_fread_small.py
@@ -31,7 +31,7 @@ def test_bool1():
     d0.internal.check()
     assert d0.shape == (3, 4)
     assert d0.ltypes == (ltype.bool,) * 4
-    assert d0.topython() == [[True, False, None]] * 4
+    assert d0.to_list() == [[True, False, None]] * 4
 
 
 def test_bool_nas():
@@ -40,15 +40,15 @@ def test_bool_nas():
                   "false,FALSE,10\n"
                   "NA,NA,100\n")
     assert d0.ltypes == (ltype.bool, ltype.bool, ltype.int)
-    assert d0.topython() == [[True, False, None], [True, False, None],
-                             [5, 10, 100]]
+    assert d0.to_list() == [[True, False, None], [True, False, None],
+                            [5, 10, 100]]
 
 
 def test_bool_truncated():
     d0 = dt.fread("A\nTrue\nFalse\nFal")
     d0.internal.check()
     assert d0.ltypes == (ltype.str,)
-    assert d0.topython() == [["True", "False", "Fal"]]
+    assert d0.to_list() == [["True", "False", "Fal"]]
 
 
 def test_incompatible_bools():
@@ -59,10 +59,10 @@ def test_incompatible_bools():
                   "TRUE,true,True,TRUE\n")
     d0.internal.check()
     assert d0.ltypes == (ltype.str,) * 4
-    assert d0.topython() == [["True", "False", "TRUE"],
-                             ["TRUE", "FALSE", "true"],
-                             ["true", "false", "True"],
-                             ["1", "0", "TRUE"]]
+    assert d0.to_list() == [["True", "False", "TRUE"],
+                            ["TRUE", "FALSE", "true"],
+                            ["true", "false", "True"],
+                            ["1", "0", "TRUE"]]
 
 
 def test_float_hex_random():
@@ -72,7 +72,7 @@ def test_float_hex_random():
     d0 = dt.fread(text=inp)
     d0.internal.check()
     assert d0.ltypes == (ltype.real, )
-    assert d0.topython() == [arr]
+    assert d0.to_list() == [arr]
 
 
 def test_float_hex_formats():
@@ -86,7 +86,7 @@ def test_float_hex_formats():
                   "Infinity\n"
                   "-Infinity")
     d0.internal.check()
-    assert d0.topython() == [[1, -2, 8, 10, 100, None, math.inf, -math.inf]]
+    assert d0.to_list() == [[1, -2, 8, 10, 100, None, math.inf, -math.inf]]
 
 
 def test_float_hex0():
@@ -94,8 +94,8 @@ def test_float_hex0():
                   "0x0.0p+0\n"
                   "0x0p0\n"
                   "-0x0p-0\n")
-    assert d0.topython() == [[0.0] * 3]
-    assert math.copysign(1.0, d0.topython()[0][2]) == -1.0
+    assert d0.to_list() == [[0.0] * 3]
+    assert math.copysign(1.0, d0.to_list()[0][2]) == -1.0
 
 
 def test_float_hex1():
@@ -106,7 +106,7 @@ def test_float_hex1():
                        "0x1.2AAAAAp+22")
     d0.internal.check()
     assert d0.stypes == (stype.float32, )
-    assert d0.topython() == [[0, 1.3125, 0.65625, 4893354.5]]
+    assert d0.to_list() == [[0, 1.3125, 0.65625, 4893354.5]]
 
 
 def test_float_hex2():
@@ -120,10 +120,10 @@ def test_float_hex2():
                   "0x1.FFFFFFFFFFFFFp+1023\n"  # largest normal
                   "0x1.0000000000000p-1022")   # smallest normal
     d0.internal.check()
-    assert d0.topython()[0] == [0.9380760727005495, 0.06192392729945053,
-                                0.9884021124759415, 0.011597887524058551,
-                                2.225073858507201e-308, 4.940656458412e-324,
-                                1.7976931348623157e308, 2.2250738585072014e-308]
+    assert d0.to_list()[0] == [0.9380760727005495, 0.06192392729945053,
+                               0.9884021124759415, 0.011597887524058551,
+                               2.225073858507201e-308, 4.940656458412e-324,
+                               1.7976931348623157e308, 2.2250738585072014e-308]
 
 
 def test_float_hex_invalid():
@@ -135,7 +135,7 @@ def test_float_hex_invalid():
               "0x0.1p1"]        # exponent too small for a subnormal number
     d0 = dt.fread("A,B,C,D,E,F\n" + ",".join(fields))
     d0.internal.check()
-    assert d0.topython() == [[f] for f in fields]
+    assert d0.to_list() == [[f] for f in fields]
 
 
 def test_float_decimal0(noppc64):
@@ -175,7 +175,7 @@ def test_float_precision():
     d0 = dt.fread(text)
     d0.internal.check()
     assert d0.ltypes == (ltype.real, )
-    assert list_equals(d0.topython()[0], src)
+    assert list_equals(d0.to_list()[0], src)
 
 
 def test_float_overflow():
@@ -189,7 +189,7 @@ def test_float_overflow():
     d0.internal.check()
     assert d0.shape == (1, len(fields))
     assert d0.ltypes == (ltype.str,) * len(fields)
-    assert d0.topython() == [[x] for x in fields]
+    assert d0.to_list() == [[x] for x in fields]
 
 
 def test_int():
@@ -202,9 +202,9 @@ def test_int():
     i64max = 9223372036854775807
     d0.internal.check()
     assert d0.stypes == (stype.int32, stype.int64, stype.int32)
-    assert d0.topython() == [[0, 99, 100, 2147483647, -2147483647],
-                             [0, 999, 2587, i64max, -i64max],
-                             [0, 9999, -1000, 99, None]]
+    assert d0.to_list() == [[0, 99, 100, 2147483647, -2147483647],
+                            [0, 999, 2587, i64max, -i64max],
+                            [0, 9999, -1000, 99, None]]
 
 
 def test_leading0s():
@@ -212,7 +212,7 @@ def test_leading0s():
     d0 = dt.fread(src)
     d0.internal.check()
     assert d0.shape == (1000, 1)
-    assert d0.topython() == [list(range(1000))]
+    assert d0.to_list() == [list(range(1000))]
 
 
 def test_int_toolong1():
@@ -224,8 +224,8 @@ def test_int_toolong1():
     d1.internal.check()
     assert d0.stypes == (stype.int64, )
     assert d1.stypes == (stype.str32, )
-    assert d0.topython() == [[int(x) for x in src[1:-1]]]
-    assert d1.topython() == [src[1:]]
+    assert d0.to_list() == [[int(x) for x in src[1:-1]]]
+    assert d1.to_list() == [src[1:]]
 
 
 def test_int_toolong2():
@@ -234,15 +234,15 @@ def test_int_toolong2():
                   "9223372036854775808,-9223372036854775808\n")
     d0.internal.check()
     assert d0.ltypes == (ltype.str, ltype.str)
-    assert d0.topython() == [["9223372036854775807", "9223372036854775808"],
-                             ["9223372036854775806", "-9223372036854775808"]]
+    assert d0.to_list() == [["9223372036854775807", "9223372036854775808"],
+                            ["9223372036854775806", "-9223372036854775808"]]
 
 
 def test_int_toolong3():
     # from R issue #2250
     d0 = dt.fread("A,B\n2,384325987234905827340958734572934\n")
     d0.internal.check()
-    assert d0.topython() == [[2], ["384325987234905827340958734572934"]]
+    assert d0.to_list() == [[2], ["384325987234905827340958734572934"]]
 
 
 def test_int_even_longer():
@@ -256,9 +256,9 @@ def test_int_even_longer():
     text = "A,B,C,D\n%s,%s,1.%s,%s.99" % (src1, src2, src2, src2)
     d0 = dt.fread(text)
     d0.internal.check()
-    assert d0.topython() == [[src1], [src2],
-                             [float("1." + src2)],
-                             [float(src2)]]
+    assert d0.to_list() == [[src1], [src2],
+                            [float("1." + src2)],
+                            [float(src2)]]
 
 
 def test_int_with_thousand_sep():
@@ -269,9 +269,9 @@ def test_int_with_thousand_sep():
     d0.internal.check()
     assert d0.shape == (3, 3)
     assert d0.names == ("A", "B", "C")
-    assert d0.topython() == [[5, 0, 295],
-                             [100, 1234, 500005],
-                             [3378149, 1999, 7134930]]
+    assert d0.to_list() == [[5, 0, 295],
+                            [100, 1234, 500005],
+                            [3378149, 1999, 7134930]]
 
 
 def test_int_with_thousand_sep2():
@@ -282,9 +282,9 @@ def test_int_with_thousand_sep2():
                   ',"1,549,048,733,295,668",5354\n')
     d0.internal.check()
     assert d0.stypes == (dt.int32, dt.int64, dt.int32)
-    assert d0.topython() == [[3, 4785, 17, None],
-                             [200, 11, 835, 1549048733295668],
-                             [998, 9560293, 0, 5354]]
+    assert d0.to_list() == [[3, 4785, 17, None],
+                            [200, 11, 835, 1549048733295668],
+                            [998, 9560293, 0, 5354]]
 
 
 def test_int_with_thousand_sep_not_really():
@@ -305,7 +305,7 @@ def test_int_with_thousand_sep_not_really():
     d0 = dt.fread(src)
     assert d0.names == names
     assert d0.stypes == (dt.str32,) * len(bad_ints)
-    assert d0.topython() == [[x] for x in bad_ints]
+    assert d0.to_list() == [[x] for x in bad_ints]
 
 
 
@@ -314,7 +314,7 @@ def test_float_ext_literals1():
     d0 = dt.fread("A\n+Inf\nINF\n-inf\n-Infinity\n1.3e2")
     d0.internal.check()
     assert d0.ltypes == (ltype.real, )
-    assert d0.topython() == [[inf, inf, -inf, -inf, 130]]
+    assert d0.to_list() == [[inf, inf, -inf, -inf, 130]]
 
 
 def test_float_ext_literals2():
@@ -322,22 +322,22 @@ def test_float_ext_literals2():
                   "sNaN\nNaNQ\nNaNS\n-.999e-1")
     d0.internal.check()
     assert d0.ltypes == (ltype.real, )
-    assert d0.topython() == [[0.2, None, None, None, None, None,
-                              None, None, None, -0.0999]]
+    assert d0.to_list() == [[0.2, None, None, None, None, None,
+                             None, None, None, -0.0999]]
 
 
 def test_float_ext_literals3():
     d0 = dt.fread("C\n1.0\nNaN3490\n-qNaN9\n+sNaN99999\nNaN000000\nNaN000")
     d0.internal.check()
     assert d0.ltypes == (ltype.real, )
-    assert d0.topython() == [[1, None, None, None, None, None]]
+    assert d0.to_list() == [[1, None, None, None, None, None]]
 
 
 def test_float_ext_literals4():
     d0 = dt.fread("D\n1.\n1.#SNAN\n1.#QNAN\n1.#IND\n1.#INF\n")
     d0.internal.check()
     assert d0.ltypes == (ltype.real, )
-    assert d0.topython() == [[1, None, None, None, math.inf]]
+    assert d0.to_list() == [[1, None, None, None, math.inf]]
 
 
 def test_float_ext_literals5():
@@ -345,34 +345,34 @@ def test_float_ext_literals5():
                   "#REF!\n#N/A\n1e0\n")
     d0.internal.check()
     assert d0.ltypes == (ltype.real, )
-    assert d0.topython() == [[0, None, None, None, None, None, None, None, 1]]
+    assert d0.to_list() == [[0, None, None, None, None, None, None, None, 1]]
 
 
 def test_float_ext_literals6():
     d0 = dt.fread("F\n1.1\n+1.3333333333333\n5.9e320\n45609E11\n-0890.e-03\n")
     d0.internal.check()
     assert d0.ltypes == (ltype.real, )
-    assert d0.topython() == [[1.1, 1.3333333333333, 5.9e320, 45609e11, -0.890]]
+    assert d0.to_list() == [[1.1, 1.3333333333333, 5.9e320, 45609e11, -0.890]]
 
 
 def test_float_many_zeros():
     d0 = dt.fread("G\n0.0000000000000000000000000000000000000000000000449548\n")
     d0.internal.check()
     assert d0.ltypes == (ltype.real, )
-    assert d0.topython() == [[4.49548e-47]]
+    assert d0.to_list() == [[4.49548e-47]]
 
 
 def test_invalid_int_numbers():
     d0 = dt.fread('A,B,C\n1,+,4\n2,-,5\n3,-,6\n')
     d0.internal.check()
     assert d0.names == ("A", "B", "C")
-    assert d0.topython() == [[1, 2, 3], ["+", "-", "-"], [4, 5, 6]]
+    assert d0.to_list() == [[1, 2, 3], ["+", "-", "-"], [4, 5, 6]]
 
 
 def test_invalid_float_numbers():
     d0 = dt.fread("A,B,C,D,E,F\n.,+.,.e,.e+,0e,e-3\n")
     d0.internal.check()
-    assert d0.topython() == [["."], ["+."], [".e"], [".e+"], ["0e"], ["e-3"]]
+    assert d0.to_list() == [["."], ["+."], [".e"], [".e+"], ["0e"], ["e-3"]]
 
 
 
@@ -382,8 +382,8 @@ def test_invalid_float_numbers():
 
 @pytest.mark.parametrize(
     "src", ["", " ", "\n", " \n" * 3, "\t\n  \n\n        \t  ", "\uFEFF",
-            "\uFEFF\n", "\uFEFF  \t\n \n\n", "\n\x1A\x1A", "\0", "\0\0\0\0",
-            "\n\0", "\uFEFF  \n  \n\t\0\x1A\0\x1A"])
+            "\uFEFF\n", "\uFEFF  \t\n \n\n", "\n\x1A\x1A", "\x00", "\x00" * 4,
+            "\n\x00", "\uFEFF  \n  \n\t\x00\x1A\x00\x1A"])
 def test_input_empty(tempfile, src):
     with open(tempfile, "w", encoding="utf-8") as o:
         o.write(src)
@@ -446,21 +446,21 @@ def test_fread_single_number1():
     f.internal.check()
     assert f.shape == (1, 1)
     assert f.names == ("C", )
-    assert f.topython() == [[12.345]]
+    assert f.to_list() == [[12.345]]
 
 
 def test_fread_single_number2():
     f = dt.fread("345.12\n")
     f.internal.check()
     assert f.shape == (1, 1)
-    assert f.topython() == [[345.12]]
+    assert f.to_list() == [[345.12]]
 
 
 def test_fread_two_numbers():
     f = dt.fread("12.34\n56.78")
     f.internal.check()
     assert f.shape == (2, 1)
-    assert f.topython() == [[12.34, 56.78]]
+    assert f.to_list() == [[12.34, 56.78]]
 
 
 def test_1x1_na():
@@ -469,7 +469,7 @@ def test_1x1_na():
     assert d0.shape == (1, 1)
     assert d0.names == ("A", )
     assert d0.ltypes == (ltype.bool, )
-    assert d0.topython() == [[None]]
+    assert d0.to_list() == [[None]]
 
 
 def test_0x2_na():
@@ -479,7 +479,7 @@ def test_0x2_na():
     assert d0.shape == (0, 2)
     assert d0.names == ("A", "B")
     assert d0.ltypes == (ltype.bool, ltype.bool)
-    assert d0.topython() == [[], []]
+    assert d0.to_list() == [[], []]
 
 
 def test_0x3_with_whitespace():
@@ -495,7 +495,7 @@ def test_1line_not_header():
     d0.internal.check()
     assert d0.shape == (1, 3)
     assert d0.ltypes == (ltype.str, ltype.str, ltype.int)
-    assert d0.topython() == [["C1"], ["C2"], [3]]
+    assert d0.to_list() == [["C1"], ["C2"], [3]]
 
 
 def test_input_htmlfile():
@@ -517,7 +517,7 @@ def test_fread1():
                  "100.3")
     assert f.shape == (3, 1)
     assert f.names == ("hello", )
-    assert f.topython() == [[1.1, 200000.0, 100.3]]
+    assert f.to_list() == [[1.1, 200000.0, 100.3]]
 
 
 def test_fread2():
@@ -536,50 +536,50 @@ def test_runaway_quote():
     d0 = dt.fread('"A,B,C\n1,2,3\n4,5,6')
     assert d0.shape == (2, 3)
     assert d0.names == ('"A', 'B', 'C')
-    assert d0.topython() == [[1, 4], [2, 5], [3, 6]]
+    assert d0.to_list() == [[1, 4], [2, 5], [3, 6]]
 
 
 def test_unmatched_quotes():
     # Should instead all quotes remain around 'aa', 'bb' and 'cc' ?
     assert dt.fread('A,B\n"aa",1\n"bb,2\n"cc",3\n') \
-             .topython() == [['aa', '"bb', 'cc'], [1, 2, 3]]
+             .to_list() == [['aa', '"bb', 'cc'], [1, 2, 3]]
     assert dt.fread('A,B\n"aa",1\n""bb",2\n"cc",3\n') \
-             .topython() == [['aa', '"bb', 'cc'], [1, 2, 3]]
+             .to_list() == [['aa', '"bb', 'cc'], [1, 2, 3]]
     assert dt.fread('A,B\n"aa",1\nbb",2\n"cc",3\n') \
-             .topython() == [['aa', 'bb"', 'cc'], [1, 2, 3]]
+             .to_list() == [['aa', 'bb"', 'cc'], [1, 2, 3]]
     assert dt.fread('A,B\n"aa",1\n"bb"",2\n"cc",3\n') \
-             .topython() == [['aa', 'bb"', 'cc'], [1, 2, 3]]
+             .to_list() == [['aa', 'bb"', 'cc'], [1, 2, 3]]
 
 
 def test_unescaped_quotes():
     d0 = dt.fread('key\tvalue\tcheck\n'
                   '8591\t{"item":12,"content":"TABLE"}\tok')
     assert d0.names == ("key", "value", "check")
-    assert d0.topython() == [[8591], ['{"item":12,"content":"TABLE"}'], ["ok"]]
+    assert d0.to_list() == [[8591], ['{"item":12,"content":"TABLE"}'], ["ok"]]
 
 
 def test_unescaped_quotes2():
     d0 = dt.fread('A,B,C\n1.2,Foo"Bar,"a"b\"c"d"\nfo"o,bar,"b,az""\n')
-    assert d0.topython() == [["1.2", 'fo"o'], ['Foo"Bar', 'bar'],
-                             ['a"b"c"d', 'b,az"']]
+    assert d0.to_list() == [["1.2", 'fo"o'], ['Foo"Bar', 'bar'],
+                            ['a"b"c"d', 'b,az"']]
     d1 = dt.fread('A,B,C\n1.2,Foo"Bar,"a"b\"c"d""\nfo"o,bar,"b,az""\n')
-    assert d1.topython() == [["1.2", 'fo"o'], ['Foo"Bar', 'bar'],
-                             ['a"b"c"d"', 'b,az"']]
+    assert d1.to_list() == [["1.2", 'fo"o'], ['Foo"Bar', 'bar'],
+                            ['a"b"c"d"', 'b,az"']]
     d2 = dt.fread('A,B,C\n1.2,Foo"Bar,"a"b\"c"d""\nfo"o,bar,"b,"az""\n')
-    assert d2.topython() == [["1.2", 'fo"o'], ['Foo"Bar', 'bar'],
-                             ['a"b"c"d"', 'b,"az"']]
+    assert d2.to_list() == [["1.2", 'fo"o'], ['Foo"Bar', 'bar'],
+                            ['a"b"c"d"', 'b,"az"']]
 
 
 def test_quoted_headers():
     d0 = dt.fread('"One,Two","Three",Four\n12,3,4\n56,7,8\n')
     assert d0.names == ("One,Two", "Three", "Four")
-    assert d0.topython() == [[12, 56], [3, 7], [4, 8]]
+    assert d0.to_list() == [[12, 56], [3, 7], [4, 8]]
 
 
 def test_trailing_backslash():
     d0 = dt.fread('dir,size\n"C:\\",123\n')
     assert d0.names == ("dir", "size")
-    assert d0.topython() == [["C:\\"], [123]]
+    assert d0.to_list() == [["C:\\"], [123]]
 
 
 def test_space_separated_numbers():
@@ -614,7 +614,7 @@ def test_utf16(tempfile):
         d0 = dt.fread(tempfile)
         d0.internal.check()
         assert d0.names == names
-        assert d0.topython() == [col1, col2, col3]
+        assert d0.to_list() == [col1, col2, col3]
 
 
 def test_fread_CtrlZ():
@@ -623,15 +623,15 @@ def test_fread_CtrlZ():
     d0 = dt.fread(text=src)
     d0.internal.check()
     assert d0.ltypes == (dt.ltype.int, dt.ltype.int, dt.ltype.int)
-    assert d0.topython() == [[-1], [2], [3]]
+    assert d0.to_list() == [[-1], [2], [3]]
 
 
 def test_fread_NUL():
     """Check that NUL characters at the end of the file are removed"""
-    d0 = dt.fread(text=b"A,B\n2.3,5\0\0\0\0\0\0\0\0\0\0")
+    d0 = dt.fread(text=b"A,B\n2.3,5\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")
     d0.internal.check()
     assert d0.ltypes == (dt.ltype.real, dt.ltype.int)
-    assert d0.topython() == [[2.3], [5]]
+    assert d0.to_list() == [[2.3], [5]]
 
 
 def test_fread_1col_a():
@@ -648,7 +648,7 @@ def test_fread_1col_a():
                        "\n")
     d0.internal.check()
     assert d0.names == ("A",)
-    assert d0.topython() == [[1, 2, None, 4, None, 5, None]]
+    assert d0.to_list() == [[1, 2, None, 4, None, 5, None]]
 
 
 def test_fread_1col_b():
@@ -658,8 +658,8 @@ def test_fread_1col_b():
                   "you can.\n\n", sep="\n")
     d1.internal.check()
     assert d1.names == ("QUOTE",)
-    assert d1.topython() == [["If you think", "you can do it,", "",
-                              "you can.", ""]]
+    assert d1.to_list() == [["If you think", "you can do it,", "",
+                             "you can.", ""]]
 
 
 @pytest.mark.parametrize("eol", ["\n", "\r", "\n\r", "\r\n", "\r\r\n"])
@@ -668,7 +668,7 @@ def test_fread_1col_c(eol):
     d0 = dt.fread(eol.join(data))
     d0.internal.check()
     assert d0.names == ("A", )
-    assert d0.topython() == [[100, 200, None, 400, None, 600]]
+    assert d0.to_list() == [[100, 200, None, 400, None, 600]]
 
 
 @pytest.mark.parametrize("eol", ["\n", "\r", "\n\r", "\r\n", "\r\r\n"])
@@ -678,26 +678,26 @@ def test_different_line_endings(eol):
     d0 = dt.fread(text=text)
     d0.internal.check()
     assert d0.names == ("A", "B")
-    assert d0.topython() == [[None, 1, 2, 3], ["koo", "vi", "mu", "yay"]]
+    assert d0.to_list() == [[None, 1, 2, 3], ["koo", "vi", "mu", "yay"]]
 
 
 def test_fread_quoting():
     d0 = dt.fread("A,B,C,D\n1,3,ghu,5\n2,4,zifuh,667")
     d0.internal.check()
     assert d0.names == ("A", "B", "C", "D")
-    assert d0.topython() == [[1, 2], [3, 4], ["ghu", "zifuh"], [5, 667]]
+    assert d0.to_list() == [[1, 2], [3, 4], ["ghu", "zifuh"], [5, 667]]
     d1 = dt.fread('A,B,C,D\n1,3,pq[q,5\n2,4,"dflb",6')
     d1.internal.check()
     assert d1.names == ("A", "B", "C", "D")
-    assert d1.topython() == [[1, 2], [3, 4], ["pq[q", "dflb"], [5, 6]]
+    assert d1.to_list() == [[1, 2], [3, 4], ["pq[q", "dflb"], [5, 6]]
     d2 = dt.fread('A,B,C,D\n1,3,nib,5\n2,4,"la,la,la,la",6')
     d2.internal.check()
     assert d2.names == ("A", "B", "C", "D")
-    assert d2.topython() == [[1, 2], [3, 4], ["nib", "la,la,la,la"], [5, 6]]
+    assert d2.to_list() == [[1, 2], [3, 4], ["nib", "la,la,la,la"], [5, 6]]
     d3 = dt.fread('A,B,C,D\n1,3,foo,5\n2,4,"ba,\\"r,",6')
     d3.internal.check()
     assert d3.names == ("A", "B", "C", "D")
-    assert d3.topython() == [[1, 2], [3, 4], ["foo", "ba,\"r,"], [5, 6]]
+    assert d3.to_list() == [[1, 2], [3, 4], ["foo", "ba,\"r,"], [5, 6]]
 
 
 def test_fread_default_colnames():
@@ -724,7 +724,7 @@ def test_fread_na_field():
     d0.internal.check()
     assert d0.names == ("A", "B", "C")
     assert d0.stypes == (stype.int32, stype.int32, stype.bool8)
-    assert d0.topython() == [[1, 2], [3, 4], [None, None]]
+    assert d0.to_list() == [[1, 2], [3, 4], [None, None]]
 
 
 def test_last_quoted_field():
@@ -734,7 +734,7 @@ def test_last_quoted_field():
     d0.internal.check()
     assert d0.shape == (2, 3)
     assert d0.ltypes == (dt.ltype.int, dt.ltype.int, dt.ltype.int)
-    assert d0.topython() == [[1, 3], [5, 9], [17, 1000]]
+    assert d0.to_list() == [[1, 3], [5, 9], [17, 1000]]
 
 
 def test_numbers_with_quotes1():
@@ -746,7 +746,7 @@ def test_numbers_with_quotes1():
     assert d0.shape == (3, 2)
     assert d0.ltypes == (dt.ltype.int, dt.ltype.int)
     assert d0.names == ("B", "C")
-    assert d0.topython() == [[12, 13, 14], [15, 18, 3]]
+    assert d0.to_list() == [[12, 13, 14], [15, 18, 3]]
 
 
 def test_numbers_with_quotes2():
@@ -757,7 +757,7 @@ def test_numbers_with_quotes2():
     assert d0.shape == (2, 2)
     assert d0.ltypes == (dt.ltype.int, dt.ltype.int)
     assert d0.names == ("A", "B")
-    assert d0.topython() == [[83, 55], [23948, 20487203497]]
+    assert d0.to_list() == [[83, 55], [23948, 20487203497]]
 
 
 def test_unquoting1():
@@ -767,7 +767,7 @@ def test_unquoting1():
                   '"goodbye"\n')
     d0.internal.check()
     assert d0.names == ('"A"',)
-    assert d0.topython() == [['hello, "world"', '"', 'goodbye']]
+    assert d0.to_list() == [['hello, "world"', '"', 'goodbye']]
 
 
 def test_unquoting2():
@@ -779,7 +779,7 @@ def test_unquoting2():
                   quotechar="'")
     d0.internal.check()
     assert d0.names == ("B",)
-    assert d0.topython() == [["morning", "'night'", "day", "even'ing"]]
+    assert d0.to_list() == [["morning", "'night'", "day", "even'ing"]]
 
 
 def test_unescaping1():
@@ -789,9 +789,9 @@ def test_unescaping1():
                   '"\\r\\t\\v\\a\\b\\071\\uABCD"\n')
     d0.internal.check()
     assert d0.names == ("C\\D",)
-    assert d0.topython() == [["AB CD\n",
-                              "\"one\", 'two', three",
-                              "\r\t\v\a\b\071\uABCD"]]
+    assert d0.to_list() == [["AB CD\n",
+                             "\"one\", 'two', three",
+                             "\r\t\v\a\b\071\uABCD"]]
 
 
 def test_whitespace_nas():
@@ -803,9 +803,9 @@ def test_whitespace_nas():
     d0.internal.check()
     assert d0.names == ("A", "B", "C")
     assert d0.ltypes == (dt.ltype.real,) * 3
-    assert d0.topython() == [[17, 3, None, 0],
-                             [34, None, 2, 0.1],
-                             [2.3, 1, None, 0]]
+    assert d0.to_list() == [[17, 3, None, 0],
+                            [34, None, 2, 0.1],
+                            [2.3, 1, None, 0]]
 
 
 def test_quoted_na_strings():
@@ -817,7 +817,7 @@ def test_quoted_na_strings():
     d0.internal.check()
     assert d0.names == ("A", "B", "C")
     assert d0.ltypes == (dt.ltype.str,) * 3
-    assert d0.topython() == [["foo", None], ["bar", None], ["caw", None]]
+    assert d0.to_list() == [["foo", None], ["bar", None], ["caw", None]]
 
 
 def test_clashing_column_names():
@@ -841,32 +841,32 @@ def test_clashing_column_names2():
 
 
 def test_nuls1():
-    d0 = dt.fread("A,B\0\n1,2\n")
+    d0 = dt.fread("A,B\x00\n1,2\n")
     d0.internal.check()
     # Special characters are replaced in column names
     assert d0.names == ("A", "B.")
     assert d0.shape == (1, 2)
-    assert d0.topython() == [[1], [2]]
+    assert d0.to_list() == [[1], [2]]
 
 
 def test_nuls2():
-    d0 = dt.fread("A,B\nfoo,ba\0r\nalpha,beta\0\ngamma\0,delta\n")
+    d0 = dt.fread("A,B\nfoo,ba\x00r\nalpha,beta\x00\ngamma\x00,delta\n")
     d0.internal.check()
     assert d0.names == ("A", "B")
     assert d0.shape == (3, 2)
-    assert d0.topython() == [["foo", "alpha", "gamma\0"],
-                             ["ba\0r", "beta\0", "delta"]]
+    assert d0.to_list() == [["foo", "alpha", "gamma\x00"],
+                            ["ba\x00r", "beta\x00", "delta"]]
 
 def test_nuls3():
-    lines = ["%02d,%d,%d\0" % (i, i % 3, 20 - i) for i in range(10)]
+    lines = ["%02d,%d,%d\x00" % (i, i % 3, 20 - i) for i in range(10)]
     src = "\n".join(["a,b,c"] + lines + [""])
     d0 = dt.fread(src, verbose=True)
     d0.internal.check()
     assert d0.shape == (10, 3)
     assert d0.names == ("a", "b", "c")
-    assert d0.topython() == [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-                             [0, 1, 2, 0, 1, 2, 0, 1, 2, 0],
-                             ["%d\0" % i for i in range(20, 10, -1)]]
+    assert d0.to_list() == [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+                            [0, 1, 2, 0, 1, 2, 0, 1, 2, 0],
+                            ["%d\x00" % i for i in range(20, 10, -1)]]
 
 
 def test_headers_with_na():
@@ -876,7 +876,7 @@ def test_headers_with_na():
                  "1,2,3\n")
     d.internal.check()
     assert d.names == ("A", "B", "C0")
-    assert d.topython() == [[1], [2], [3]]
+    assert d.to_list() == [[1], [2], [3]]
 
 
 def test_file_nolock(tempfile):
@@ -893,14 +893,14 @@ def test_file_nolock(tempfile):
     assert os.stat(tempfile).st_size == 32
     # Try reading the file again
     d0 = dt.fread(tempfile, fill=True)
-    assert d0.topython() == [[1, 4, 5, 8, 10],
-                             [2, None, 6, 9, 11],
-                             [3, None, 7, None, 1]]
+    assert d0.to_list() == [[1, 4, 5, 8, 10],
+                            [2, None, 6, 9, 11],
+                            [3, None, 7, None, 1]]
     # Try overwriting the file
     with open(tempfile, "wb") as o:
         o.write(b"A,B\n1\n2,3\n")
     d0 = dt.fread(tempfile, fill=True)
-    assert d0.topython() == [[1, 2], [None, 3]]
+    assert d0.to_list() == [[1, 2], [None, 3]]
     # Try removing the file
     os.unlink(tempfile)
     assert not os.path.exists(tempfile)
@@ -939,7 +939,7 @@ def test_empty_strings(seed, repl):
     d1.internal.check()
     assert d1.names == d0.names
     assert d1.stypes == d0.stypes
-    assert d1.topython() == src
+    assert d1.to_list() == src
 
 
 @pytest.mark.parametrize("seed", [random.randint(0, 2**31)])
@@ -973,8 +973,8 @@ def test_random_data(seed, tempfile):
     src[1][1] = None
     src[2][2] = None
     src[3][3] = ""    # FIXME
-    src[4][4] = None  # .topython() below converts `nan`s into None
-    res = d1.topython()
+    src[4][4] = None  # .to_list() below converts `nan`s into None
+    res = d1.to_list()
     assert res[0] == src[0]
     assert res[1] == src[1]
     assert list_equals(res[2], src[2])
@@ -1041,7 +1041,7 @@ def test_almost_nodata(capsys):
     d0.internal.check()
     assert d0.shape == (n, 3)
     assert d0.ltypes == (ltype.int, ltype.str, ltype.str)
-    assert d0.topython() == [[2017] * n, m, ["foo"] * n]
+    assert d0.to_list() == [[2017] * n, m, ["foo"] * n]
     print(out)
     assert not err
     assert ("Column 2 (B) bumped from Unknown to Str32 "
@@ -1070,7 +1070,7 @@ def test_under_allocation(capsys):
     assert d0.names == ("A", "B")
     sum1 = 1234567 * 200 * 101 + 7 * 2000 * 100
     sum2 = 45789123 * 200 * 101 + 3 * 2000 * 100
-    assert d0.sum().topython() == [[sum1], [sum2]]
+    assert d0.sum().to_list() == [[sum1], [sum2]]
 
 
 @pytest.mark.parametrize("mul", [16, 128, 256, 512, 1024, 2048])
@@ -1094,7 +1094,7 @@ def test_round_filesize(tempfile, mul, eol):
     d0 = dt.fread(tempfile)
     d0.internal.check()
     assert d0.shape == (mul, 7)
-    assert d0.topython() == data
+    assert d0.to_list() == data
 
 
 def test_maxnrows_on_large_dataset():
@@ -1107,7 +1107,7 @@ def test_maxnrows_on_large_dataset():
     t0 = time.time() - t0
     d0.internal.check()
     assert d0.shape == (5, 3)
-    assert d0.topython() == [[0, 1, 2, 3, 4], ["x"] * 5, [True] * 5]
+    assert d0.to_list() == [[0, 1, 2, 3, 4], ["x"] * 5, [True] * 5]
     t1 = time.time()
     d1 = dt.fread(src, nthreads=4, verbose=True)
     t1 = time.time() - t1
@@ -1176,4 +1176,4 @@ def test_qr_bump_out_of_sample(capsys):
     pysrc = [[123] * 3000, ["abcd"] * 3000]
     pysrc[0][137] = -1
     pysrc[1][137] = '"This" is not funny'
-    assert d0.topython() == pysrc
+    assert d0.to_list() == pysrc

--- a/tests/munging/test_assign.py
+++ b/tests/munging/test_assign.py
@@ -15,7 +15,7 @@ def test_assign_column_slice():
     assert f0.ltypes == (dt.ltype.int, dt.ltype.real, dt.ltype.str)
     f0[:, 1:] = -1
     assert f0.shape == (4, 3)
-    assert f0.topython() == [src[0], [-1] * 4, [-1] * 4]
+    assert f0.to_list() == [src[0], [-1] * 4, [-1] * 4]
     assert f0.ltypes == (dt.ltype.int, ) * 3
 
 
@@ -28,10 +28,10 @@ def test_assign_column_array():
     assert f0.shape == (10, 2)
     f0[:, "C"] = "foo"
     assert f0.ltypes == (dt.ltype.int, dt.ltype.real, dt.ltype.str)
-    assert f0.topython() == [list(range(10)), [3.5] * 10, ["foo"] * 10]
+    assert f0.to_list() == [list(range(10)), [3.5] * 10, ["foo"] * 10]
     f0[:, ["B", "C"]] = False
     assert f0.ltypes == (dt.ltype.int, dt.ltype.bool, dt.ltype.bool)
-    assert f0.topython() == [list(range(10)), [False] * 10, [False] * 10]
+    assert f0.to_list() == [list(range(10)), [False] * 10, [False] * 10]
     f0[:, "A"] = None
     assert f0.ltypes == (dt.ltype.bool,) * 3
 
@@ -43,15 +43,15 @@ def test_assign_single_cell():
             f0[i, j] = i + j
     f0.internal.check()
     assert f0.ltypes == (dt.ltype.int, ) * 2
-    assert f0.topython() == [[0, 1, 2, 3], [1, 2, 3, 4]]
+    assert f0.to_list() == [[0, 1, 2, 3], [1, 2, 3, 4]]
 
 
 def test_assign_filtered():
     f0 = dt.Frame({"A": range(10)})
     f0[f.A < 5, :] = -1
-    assert f0.topython() == [[-1, -1, -1, -1, -1, 5, 6, 7, 8, 9]]
+    assert f0.to_list() == [[-1, -1, -1, -1, -1, 5, 6, 7, 8, 9]]
     f0[f.A < 0, :] = None
-    assert f0.topython() == [[None, None, None, None, None, 5, 6, 7, 8, 9]]
+    assert f0.to_list() == [[None, None, None, None, None, 5, 6, 7, 8, 9]]
 
 
 def test_assign_to_view():
@@ -60,8 +60,8 @@ def test_assign_to_view():
     f1[:, "AA"] = "test"
     assert f1.names == ("A", "AA")
     assert f1.ltypes == (dt.ltype.int, dt.ltype.str)
-    assert f1.topython() == [list(range(0, 10, 2)), ["test"] * 5]
-    assert f0.topython() == [list(range(10))]
+    assert f1.to_list() == [list(range(0, 10, 2)), ["test"] * 5]
+    assert f0.to_list() == [list(range(10))]
 
 
 def test_assign_frame():

--- a/tests/munging/test_dt_append.py
+++ b/tests/munging/test_dt_append.py
@@ -185,7 +185,7 @@ def test_rbind_strings5():
     f0 = dt.Frame([1, 2, 3])
     f1 = dt.Frame(["foo", "bra"])
     f1.rbind(f0)
-    assert f1.topython() == [["foo", "bra", "1", "2", "3"]]
+    assert f1.to_list() == [["foo", "bra", "1", "2", "3"]]
 
 
 
@@ -291,7 +291,7 @@ def test_rbind_different_stypes3():
     assert dt1.stypes == (stype.str32,) * 4
     dt0.rbind(dt1)
     assert dt0.stypes == (stype.str32,) * 4
-    assert dt0.topython() == [
+    assert dt0.to_list() == [
         ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "alpha"],
         ["100", "110", "120", "130", "140", "150", "160", "170", "180", "190",
          "beta"],
@@ -315,7 +315,7 @@ def test_rbind_different_stypes4():
     assert dt1.stypes == (stype.str32, ) * 3
     dt0.rbind(dt1)
     assert dt0.stypes == (stype.str32, ) * 3
-    assert dt0.topython() == [
+    assert dt0.to_list() == [
         ["1", "0", "0", None, "1", "vega", "altair", None],
         ["0.0", "-12.34", None, "70000000.0", "1499.0", None, "wren", "crow"],
         [None, "4.998", "5.14", "-340000.0", "1.333333", "f", None, None]
@@ -347,7 +347,7 @@ def test_rbind_all_stypes():
             f3.internal.check()
             assert f1.nrows == len(sources[st1]) + len(sources[st2])
             assert f3.shape == f1.shape
-            assert f1.topython() == f3.topython()
+            assert f1.to_list() == f3.to_list()
             del f1
             del f2
             del f3
@@ -358,7 +358,7 @@ def test_rbind_modulefn():
     f1 = dt.Frame([109813, None, 9385])
     f3 = dt.rbind(f0, f1)
     f3.internal.check()
-    assert f3.topython()[0] == f0.topython()[0] + f1.topython()[0]
+    assert f3.to_list()[0] == f0.to_list()[0] + f1.to_list()[0]
 
 
 def test_issue1292():
@@ -366,5 +366,5 @@ def test_issue1292():
     f0.nrows = 2
     f0.rbind(f0)
     f0.internal.check()
-    assert f0.topython() == [[None] * 4]
+    assert f0.to_list() == [[None] * 4]
     assert f0.stypes == (stype.str32,)

--- a/tests/munging/test_dt_cbind.py
+++ b/tests/munging/test_dt_cbind.py
@@ -217,7 +217,7 @@ def test_cbind_array():
     d0.internal.check()
     assert d0.shape == (5, 11)
     assert d0.names == ("A",) + tuple("A.%d" % (i + 1) for i in range(10))
-    assert d0.topython() == [[0, 1, 2, 3, 4]] * 11
+    assert d0.to_list() == [[0, 1, 2, 3, 4]] * 11
 
 
 def test_cbind_bad_things():

--- a/tests/munging/test_dt_cols.py
+++ b/tests/munging/test_dt_cols.py
@@ -178,7 +178,7 @@ def test_cols_select_by_type(dt0):
     assert dt2.names == ("C", )
     dt3 = dt0[:, dt.ltype.str]
     assert dt3.shape == (0, 0)
-    assert dt3.topython() == []
+    assert dt3.to_list() == []
     dt4 = dt0[:, dt.stype.bool8]
     assert dt4.shape == (6, 1)
     assert dt4.stypes == (dt.stype.bool8, )
@@ -267,13 +267,13 @@ def test_cols_expression2():
     f1.internal.check()
     assert f1.names == ("foo", "bar")
     assert f1.stypes == f0.stypes * 2
-    assert f1.topython() == [list(range(10)), list(range(0, -10, -1))]
+    assert f1.to_list() == [list(range(10)), list(range(0, -10, -1))]
     if has_llvm():
         f2 = f0(select=selector, engine="llvm")
         f2.internal.check()
         assert f2.stypes == f1.stypes
         assert f2.names == f1.names
-        assert f2.topython() == f1.topython()
+        assert f2.to_list() == f1.to_list()
 
 
 def test_cols_bad_arguments(dt0):
@@ -294,7 +294,7 @@ def test_cols_from_view(dt0):
     assert d1.internal.isview
     d2 = d1[:, "B"]
     d2.internal.check()
-    assert d2.topython() == [[2, 3, 2]]
+    assert d2.to_list() == [[2, 3, 2]]
 
 
 def test_cols_on_empty_frame():

--- a/tests/munging/test_dt_combo.py
+++ b/tests/munging/test_dt_combo.py
@@ -18,14 +18,14 @@ def test_columns_rows():
     df2 = df0[::2, :][:, f.A + f.B]
     df1.internal.check()
     df2.internal.check()
-    assert df1.topython() == [[0, 6, 12, 18, 24]]
-    assert df2.topython() == [[0, 6, 12, 18, 24]]
+    assert df1.to_list() == [[0, 6, 12, 18, 24]]
+    assert df2.to_list() == [[0, 6, 12, 18, 24]]
 
     df3 = df0[::-2, {"res": f.A * f.B}]
     df4 = df0[::2, :][::-1, :][:, f.A * f.B]
     df3.internal.check()
     df4.internal.check()
-    assert df3.topython() == [[162, 98, 50, 18, 2]]
+    assert df3.to_list() == [[162, 98, 50, 18, 2]]
 
 
 def test_issue1225():
@@ -35,4 +35,4 @@ def test_issue1225():
     # assert f1.internal.isview
     f1.materialize()
     assert f1.stypes == (stype.float64, stype.int8)
-    assert f1.topython() == [[3.0, 2.0, 1.0], [8, 6, 5]]
+    assert f1.to_list() == [[3.0, 2.0, 1.0], [8, 6, 5]]

--- a/tests/munging/test_dt_rows.py
+++ b/tests/munging/test_dt_rows.py
@@ -39,7 +39,7 @@ def assert_typeerror(df, rows, error_message):
 
 
 def as_list(df):
-    return df.topython()
+    return df.to_list()
 
 
 def is_slice(df):
@@ -100,16 +100,16 @@ def test_rows_integer1(dt0, i):
     assert dt1.names == dt0.names
     assert dt1.ltypes == dt0.ltypes
     assert is_slice(dt1)
-    assert dt1.topython() == [[col[i]] for col in dt0.topython()]
+    assert dt1.to_list() == [[col[i]] for col in dt0.to_list()]
 
 
 def test_rows_integer2(dt0):
-    assert dt0(0).topython() == [[0], [7], [5]]
-    assert dt0(-2).topython()[:2] == [[1], [1]]
-    assert dt0(-2).topython()[2][0] is None  # nan turns into None
-    assert dt0(2).topython() == [[1], [9], [1.3]]
-    assert dt0(4).topython() == [[0], [None], [100000]]
-    assert dt0[1, :].topython() == [[1], [-11], [1]]
+    assert dt0(0).to_list() == [[0], [7], [5]]
+    assert dt0(-2).to_list()[:2] == [[1], [1]]
+    assert dt0(-2).to_list()[2][0] is None  # nan turns into None
+    assert dt0(2).to_list() == [[1], [9], [1.3]]
+    assert dt0(4).to_list() == [[0], [None], [100000]]
+    assert dt0[1, :].to_list() == [[1], [-11], [1]]
 
 
 def test_rows_integer3(dt0):
@@ -153,17 +153,17 @@ def test_rows_slice1(dt0, sliceobj, nrows):
     assert dt1.names == dt0.names
     assert dt1.ltypes == dt0.ltypes
     assert nrows == 0 or is_slice(dt1)
-    assert dt1.topython() == [col[sliceobj] for col in dt0.topython()]
+    assert dt1.to_list() == [col[sliceobj] for col in dt0.to_list()]
 
 
 def test_rows_slice2(dt0):
-    assert dt0[:5, :].topython()[0] == [0, 1, 1, None, 0]
-    assert dt0[::-1, :].topython()[1] == \
+    assert dt0[:5, :].to_list()[0] == [0, 1, 1, None, 0]
+    assert dt0[::-1, :].to_list()[1] == \
         [None, 1, -1, 0, 0, None, 1e4, 9, -11, 7]
-    assert dt0[::3, :].topython()[1] == [7, 10000, 0, None]
-    assert dt0[:3:2, :].topython()[1] == [7, 9]
-    assert dt0[4:-2, :].topython()[1] == [None, 0, 0, -1]
-    assert dt0[20:, :].topython()[2] == []
+    assert dt0[::3, :].to_list()[1] == [7, 10000, 0, None]
+    assert dt0[:3:2, :].to_list()[1] == [7, 9]
+    assert dt0[4:-2, :].to_list()[1] == [None, 0, 0, -1]
+    assert dt0[20:, :].to_list()[2] == []
 
 
 def test_rows_slice3(dt0):
@@ -201,8 +201,8 @@ def test_rows_range1(dt0, rangeobj):
     assert dt1.names == dt0.names
     assert dt1.ltypes == dt0.ltypes
     assert len(rangeobj) == 0 or is_slice(dt1)
-    assert dt1.topython() == [[col[i] for i in rangeobj]
-                              for col in dt0.topython()]
+    assert dt1.to_list() == [[col[i] for i in rangeobj]
+                             for col in dt0.to_list()]
 
 
 def test_rows_range2(dt0):
@@ -344,9 +344,9 @@ def test_rows_int_column(dt0):
     assert dt1.shape == (4, 3)
     assert dt1.names == dt0.names
     assert dt1.ltypes == dt0.ltypes
-    assert dt1.topython() == [[0, None, 0, 1],
-                              [7, 10000, 7, -11],
-                              [5, 0.1, 5, 1]]
+    assert dt1.to_list() == [[0, None, 0, 1],
+                             [7, 10000, 7, -11],
+                             [5, 0.1, 5, 1]]
 
 
 def test_rows_int_numpy_array(dt0, numpy):
@@ -355,18 +355,18 @@ def test_rows_int_numpy_array(dt0, numpy):
     dt1.internal.check()
     assert dt1.shape == (4, 3)
     assert dt1.ltypes == dt0.ltypes
-    assert dt1.topython() == [[None, 1, 0, None],
+    assert dt1.to_list() == [[None, 1, 0, None],
                               [-1, -11, 7, 10000],
                               [-14, 1, 5, 0.1]]
     arr2 = numpy.array([[7, 1, 0, 3]])
     dt2 = dt0(rows=arr2)
     dt2.internal.check()
     assert dt1.shape == dt2.shape
-    assert dt1.topython() == dt2.topython()
+    assert dt1.to_list() == dt2.to_list()
     dt3 = dt0(rows=numpy.array([[7], [1], [0], [3]]))
     dt3.internal.check()
     assert dt3.shape == dt2.shape
-    assert dt3.topython() == dt2.topython()
+    assert dt3.to_list() == dt2.to_list()
 
 
 def test_rows_int_numpy_array_errors(dt0, numpy):
@@ -412,7 +412,7 @@ def test_rows_function1(dt0):
     assert dt1.shape == dt2.shape == (5, 3)
     assert is_arr(dt1)
     assert as_list(dt1)[1] == [-11, 9, 0, 1, None]
-    assert dt1.topython() == dt2.topython()
+    assert dt1.to_list() == dt2.to_list()
 
 
 def test_rows_function2(dt0):
@@ -428,7 +428,7 @@ def test_rows_function3(dt0):
     dt1.internal.check()
     dt2.internal.check()
     assert dt1.shape == dt2.shape == (2, 3)
-    assert dt1.topython() == dt2.topython() == [[0, 1], [7, 9], [5, 1.3]]
+    assert dt1.to_list() == dt2.to_list() == [[0, 1], [7, 9], [5, 1.3]]
 
 
 def test_rows_function4(dt0):
@@ -437,7 +437,7 @@ def test_rows_function4(dt0):
     dt1.internal.check()
     dt2.internal.check()
     assert dt1.shape == dt2.shape == (2, 3)
-    assert dt1.topython() == dt2.topython() == [[0, 1], [0, 0], [0, -2.6]]
+    assert dt1.to_list() == dt2.to_list() == [[0, 1], [0, 0], [0, -2.6]]
 
 
 def test_rows_function_invalid(dt0):
@@ -478,98 +478,98 @@ def test_rows_equal(df1):
     dt1 = df1(f.A == f.B, engine="eager")
     dt1.internal.check()
     assert dt1.names == df1.names
-    assert dt1.topython() == [[3, 4, None, 9], [3, 4, None, 9]]
+    assert dt1.to_list() == [[3, 4, None, 9], [3, 4, None, 9]]
     if has_llvm():
         dt2 = df1(f.A == f.B, engine="llvm")
         dt2.internal.check()
         assert dt1.names == dt2.names
-        assert dt1.topython() == dt2.topython()
+        assert dt1.to_list() == dt2.to_list()
 
 
 def test_rows_not_equal(df1):
     dt1 = df1(f.A != f.B, engine="eager")
     dt1.internal.check()
     assert dt1.names == df1.names
-    assert dt1.topython() == [[0, 1, 2, 5, 6, 7, None],
-                              [3, 2, 1, 0, 2, None, 8]]
+    assert dt1.to_list() == [[0, 1, 2, 5, 6, 7, None],
+                             [3, 2, 1, 0, 2, None, 8]]
     if has_llvm():
         dt2 = df1(f.A != f.B, engine="llvm")
         dt2.internal.check()
         assert dt1.names == dt2.names
-        assert dt1.topython() == dt2.topython()
+        assert dt1.to_list() == dt2.to_list()
 
 
 def test_rows_less_than(df1):
     dt1 = df1(f.A < f.B, engine="eager")
     dt1.internal.check()
     assert dt1.names == df1.names
-    assert dt1.topython() == [[0, 1], [3, 2]]
+    assert dt1.to_list() == [[0, 1], [3, 2]]
     if has_llvm():
         dt2 = df1(f.A < f.B, engine="llvm")
         dt2.internal.check()
         assert dt1.names == dt2.names
-        assert dt1.topython() == dt2.topython()
+        assert dt1.to_list() == dt2.to_list()
 
 
 def test_rows_greater_than(df1):
     dt1 = df1(f.A > f.B, engine="eager")
     dt1.internal.check()
     assert dt1.names == df1.names
-    assert dt1.topython() == [[2, 5, 6], [1, 0, 2]]
+    assert dt1.to_list() == [[2, 5, 6], [1, 0, 2]]
     if has_llvm():
         dt2 = df1(f.A > f.B, engine="llvm")
         dt2.internal.check()
         assert dt1.names == dt2.names
-        assert dt1.topython() == dt2.topython()
+        assert dt1.to_list() == dt2.to_list()
 
 
 def test_rows_less_than_or_equal(df1):
     dt1 = df1(f.A <= f.B, engine="eager")
     dt1.internal.check()
     assert dt1.names == df1.names
-    assert dt1.topython() == [[0, 1, 3, 4, None, 9], [3, 2, 3, 4, None, 9]]
+    assert dt1.to_list() == [[0, 1, 3, 4, None, 9], [3, 2, 3, 4, None, 9]]
     if has_llvm():
         dt2 = df1(f.A <= f.B, engine="llvm")
         dt2.internal.check()
         assert dt1.names == dt2.names
-        assert dt1.topython() == dt2.topython()
+        assert dt1.to_list() == dt2.to_list()
 
 
 def test_rows_greater_than_or_equal(df1):
     dt1 = df1(f.A >= f.B, engine="eager")
     dt1.internal.check()
     assert dt1.names == df1.names
-    assert dt1.topython() == [[2, 3, 4, 5, 6, None, 9],
-                              [1, 3, 4, 0, 2, None, 9]]
+    assert dt1.to_list() == [[2, 3, 4, 5, 6, None, 9],
+                             [1, 3, 4, 0, 2, None, 9]]
     if has_llvm():
         dt2 = df1(f.A >= f.B, engine="llvm")
         dt2.internal.check()
         assert dt1.names == dt2.names
-        assert dt1.topython() == dt2.topython()
+        assert dt1.to_list() == dt2.to_list()
 
 
 def test_rows_compare_to_scalar_gt(df1):
     dt1 = df1(f.A > 3, engine="eager")
     dt1.internal.check()
     assert dt1.names == df1.names
-    assert dt1.topython() == [[4, 5, 6, 7, 9], [4, 0, 2, None, 9]]
+    assert dt1.to_list() == [[4, 5, 6, 7, 9], [4, 0, 2, None, 9]]
     if has_llvm():
         dt2 = df1(f.A > 3, engine="llvm")
         dt2.internal.check()
         assert dt1.names == dt2.names
-        assert dt1.topython() == dt2.topython()
+        assert dt1.to_list() == dt2.to_list()
 
 
 def test_rows_compare_to_scalar_lt(df1):
     dt1 = df1(f.A < 3, engine="eager")
     dt1.internal.check()
     assert dt1.names == df1.names
-    assert dt1.topython() == [[0, 1, 2], [3, 2, 1]]
+    assert dt1.to_list() == [[0, 1, 2], [3, 2, 1]]
     if has_llvm():
         dt2 = df1(f.A < 3, engine="llvm")
         dt2.internal.check()
         assert dt1.names == dt2.names
-        assert dt1.topython() == dt2.topython()
+        assert dt1.to_list() == dt2.to_list()
 
 
 # noinspection PyComparisonWithNone
@@ -577,24 +577,24 @@ def test_rows_compare_to_scalar_eq(df1):
     dt1 = df1(f.A == None, engine="eager")
     dt1.internal.check()
     assert dt1.names == df1.names
-    assert dt1.topython() == [[None, None], [None, 8]]
+    assert dt1.to_list() == [[None, None], [None, 8]]
     if has_llvm():
         dt2 = df1(f.A == None, engine="llvm")
         dt2.internal.check()
         assert dt1.names == dt2.names
-        assert dt1.topython() == dt2.topython()
+        assert dt1.to_list() == dt2.to_list()
 
 
 def test_rows_unary_minus(df1):
     dt1 = df1(-f.A < -3, engine="eager")
     dt1.internal.check()
     assert dt1.names == df1.names
-    assert dt1.topython() == [[4, 5, 6, 7, 9], [4, 0, 2, None, 9]]
+    assert dt1.to_list() == [[4, 5, 6, 7, 9], [4, 0, 2, None, 9]]
     if has_llvm():
         dt2 = df1(-f.A < -3, engine="llvm")
         dt2.internal.check()
         assert dt1.names == dt2.names
-        assert dt1.topython() == dt2.topython()
+        assert dt1.to_list() == dt2.to_list()
 
 
 def test_rows_isna(df1):
@@ -602,12 +602,12 @@ def test_rows_isna(df1):
     dt1 = df1(isna(f.A), engine="eager")
     dt1.internal.check()
     assert dt1.names == df1.names
-    assert dt1.topython() == [[None, None], [None, 8]]
+    assert dt1.to_list() == [[None, None], [None, 8]]
     if has_llvm():
         dt2 = df1(isna(f.A), engine="llvm")
         dt2.internal.check()
         assert dt1.names == dt2.names
-        assert dt1.topython() == dt2.topython()
+        assert dt1.to_list() == dt2.to_list()
 
 
 def test_rows_mean():
@@ -615,7 +615,7 @@ def test_rows_mean():
     df0 = dt.Frame(range(10), names=["A"])
     df1 = df0(f.A > mean(f.A), engine="eager")
     df1.internal.check()
-    assert df1.topython() == [[5, 6, 7, 8, 9]]
+    assert df1.to_list() == [[5, 6, 7, 8, 9]]
 
 
 def test_rows_min_max():
@@ -624,7 +624,7 @@ def test_rows_min_max():
     # min = 0, max = 9
     df1 = df0(f.A > (min(f.A) + max(f.A)) / 2, engine="eager")
     df1.internal.check()
-    assert df1.topython() == [[5, 6, 7, 8, 9]]
+    assert df1.to_list() == [[5, 6, 7, 8, 9]]
 
 
 def test_rows_stdev():
@@ -633,7 +633,7 @@ def test_rows_stdev():
     # stdev = 3.0276
     df1 = df0(f.A > sd(f.A), engine="eager")
     df1.internal.check()
-    assert df1.topython() == [[4, 5, 6, 7, 8, 9]]
+    assert df1.to_list() == [[4, 5, 6, 7, 8, 9]]
 
 
 def test_rows_strequal():
@@ -646,11 +646,11 @@ def test_rows_strequal():
     df4 = df0("bcD" == f.B, engine="eager")
     df1.internal.check()
     df2.internal.check()
-    assert df1.topython() == [["a", None, "xia"]] * 2
-    assert df2.topython() == [["bcd", "foo", "bee", "good"],
-                              ["bcD", "fooo", None, "evil"]]
-    assert df3.topython() == [["foo"], ["fooo"]]
-    assert df4.topython() == [["bcd"], ["bcD"]]
+    assert df1.to_list() == [["a", None, "xia"]] * 2
+    assert df2.to_list() == [["bcd", "foo", "bee", "good"],
+                             ["bcD", "fooo", None, "evil"]]
+    assert df3.to_list() == [["foo"], ["fooo"]]
+    assert df4.to_list() == [["bcd"], ["bcD"]]
 
 
 
@@ -666,7 +666,7 @@ def test_filter_on_view1():
     df2 = df1(f.A < 10)
     df2.internal.check()
     assert df2.internal.isview
-    assert df2.topython() == [[0, 2, 4, 6, 8]]
+    assert df2.to_list() == [[0, 2, 4, 6, 8]]
 
 
 def test_filter_on_view2():
@@ -675,7 +675,7 @@ def test_filter_on_view2():
     df2 = df1(rows=lambda g: g.A < 10)
     df2.internal.check()
     assert df2.internal.isview
-    assert df2.topython() == [[5, 7, 9, 3, 1, 4, 8]]
+    assert df2.to_list() == [[5, 7, 9, 3, 1, 4, 8]]
 
 
 def test_filter_on_view3():
@@ -683,11 +683,11 @@ def test_filter_on_view3():
     df1 = df0[::5, :]
     df2 = df1(f.A <= 10, engine="eager")
     df2.internal.check()
-    assert df2.topython() == [[0, 5, 10]]
+    assert df2.to_list() == [[0, 5, 10]]
     if has_llvm():
         df3 = df1(f.A <= 10, engine="llvm")
         df3.internal.check()
-        assert df3.topython() == [[0, 5, 10]]
+        assert df3.to_list() == [[0, 5, 10]]
 
 
 def test_chained_slice(dt0):

--- a/tests/munging/test_dt_rows.py
+++ b/tests/munging/test_dt_rows.py
@@ -356,8 +356,8 @@ def test_rows_int_numpy_array(dt0, numpy):
     assert dt1.shape == (4, 3)
     assert dt1.ltypes == dt0.ltypes
     assert dt1.to_list() == [[None, 1, 0, None],
-                              [-1, -11, 7, 10000],
-                              [-14, 1, 5, 0.1]]
+                             [-1, -11, 7, 10000],
+                             [-14, 1, 5, 0.1]]
     arr2 = numpy.array([[7, 1, 0, 3]])
     dt2 = dt0(rows=arr2)
     dt2.internal.check()

--- a/tests/munging/test_replace.py
+++ b/tests/munging/test_replace.py
@@ -35,37 +35,37 @@ from tests import list_equals
 def test_replace_scalar_scalar():
     df = dt.Frame([1, 2, 3])
     df.replace(1, 5)
-    assert df.topython() == [[5, 2, 3]]
+    assert df.to_list() == [[5, 2, 3]]
 
 
 def test_replace_list_scalar():
     df = dt.Frame([1, 2, 3])
     df.replace([1, 2, 7], 5)
-    assert df.topython() == [[5, 5, 3]]
+    assert df.to_list() == [[5, 5, 3]]
 
 
 def test_replace_none_list():
     df = dt.Frame([1, 2, 3, None])
     df.replace(None, [0, 0.0, ""])
-    assert df.topython() == [[1, 2, 3, 0]]
+    assert df.to_list() == [[1, 2, 3, 0]]
 
 
 def test_replace_list_list():
     df = dt.Frame([1, 2, 3])
     df.replace([1, 2, 7], [6, 2, 5])
-    assert df.topython() == [[6, 2, 3]]
+    assert df.to_list() == [[6, 2, 3]]
 
 
 def test_replace_emptylist():
     df = dt.Frame([1, 2, 3])
     df.replace([], 0)
-    assert df.topython() == [[1, 2, 3]]
+    assert df.to_list() == [[1, 2, 3]]
 
 
 def test_replace_dict():
     df = dt.Frame([1, 2, 3])
     df.replace({3: 1, 1: 3})
-    assert df.topython() == [[3, 2, 1]]
+    assert df.to_list() == [[3, 2, 1]]
 
 
 
@@ -79,14 +79,14 @@ def test_replace_bool_simple():
     df.replace({True: False, False: True})
     df.internal.check()
     assert df.stypes == (dt.bool8,) * 3
-    assert df.topython() == [[False, True, None], [False] * 3, [True] * 3]
+    assert df.to_list() == [[False, True, None], [False] * 3, [True] * 3]
 
 
 def test_replace_bool_na():
     df = dt.Frame([True, False, None])
     df.replace(None, False)
     df.internal.check()
-    assert df.topython() == [[True, False, False]]
+    assert df.to_list() == [[True, False, False]]
 
 
 
@@ -99,7 +99,7 @@ def test_replace_int_simple():
     df = dt.Frame(range(5))
     df.replace(0, -1)
     df.internal.check()
-    assert df.topython() == [[-1, 1, 2, 3, 4]]
+    assert df.to_list() == [[-1, 1, 2, 3, 4]]
 
 
 @pytest.mark.parametrize("st", dt.ltype.int.stypes)
@@ -118,17 +118,17 @@ def test_replace_int_with_upcast():
     df.replace(5, 1000)
     df.internal.check()
     assert df.stypes == (dt.stype.int32,)
-    assert df.topython() == [[0, 1, 2, 3, 4, 1000, 6, 7, 8, 9]]
+    assert df.to_list() == [[0, 1, 2, 3, 4, 1000, 6, 7, 8, 9]]
     df.replace(9, 10**10)
     assert df.stypes == (dt.stype.int64,)
-    assert df.topython() == [[0, 1, 2, 3, 4, 1000, 6, 7, 8, 10**10]]
+    assert df.to_list() == [[0, 1, 2, 3, 4, 1000, 6, 7, 8, 10**10]]
 
 
 @pytest.mark.parametrize("st", dt.ltype.int.stypes)
 def test_replace_into_int(st):
     df = dt.Frame(A=[0, 5, 9, 0, 3, 1], stype=st)
     df.replace([0, 1], None)
-    assert df.topython() == [[None, 5, 9, None, 3, None]]
+    assert df.to_list() == [[None, 5, 9, None, 3, None]]
 
 
 @pytest.mark.parametrize("seed", [random.getrandbits(32)])
@@ -145,7 +145,7 @@ def test_replace_large(seed):
     for i in range(n):
         src[i] = replacements.get(src[i], src[i])
     df.internal.check()
-    assert df.topython() == [src]
+    assert df.to_list() == [src]
     assert df.stypes == (st,)
     assert df.names == ("A",)
     assert df.sum1() == sum(src)
@@ -166,7 +166,7 @@ def test_replace_floats(st):
     assert df.stypes == (st, st)
     res = [[1.1, 0.0, 5e10, -1.0, -2.0],
            [-inf, -2.0, -2.0, 3.99, 7.0]]
-    pydt = df.topython()
+    pydt = df.to_list()
     if st == dt.stype.float64:
         assert pydt == res
     else:
@@ -180,7 +180,7 @@ def test_replace_infs():
     assert df.stypes == (dt.float32, dt.float64)
     df.replace([inf, -inf], None)
     df.internal.check()
-    assert df.topython() == [[1.0, None, None]] * 2
+    assert df.to_list() == [[1.0, None, None]] * 2
     assert df.stypes == (dt.float32, dt.float64)
 
 
@@ -189,7 +189,7 @@ def test_replace_float_with_upcast():
     assert df.stypes == (dt.float32,)
     df.replace(2.0, 1.5e100)
     assert df.stypes == (dt.float64,)
-    assert df.topython() == [[1.5, 1.5e100, 3.5, 4.0]]
+    assert df.to_list() == [[1.5, 1.5e100, 3.5, 4.0]]
 
 
 
@@ -201,13 +201,13 @@ def test_replace_float_with_upcast():
 def test_replace_str_simple():
     df = dt.Frame(["foo", "bar", "buzz"])
     df.replace("bar", "oomph")
-    assert df.topython() == [["foo", "oomph", "buzz"]]
+    assert df.to_list() == [["foo", "oomph", "buzz"]]
 
 
 def test_replace_str_none():
     df = dt.Frame(["A", "BC", None, "DEF", None, "G"])
     df.replace(["A", None], [None, "??"])
-    assert df.topython() == [[None, "BC", "??", "DEF", "??", "G"]]
+    assert df.to_list() == [[None, "BC", "??", "DEF", "??", "G"]]
 
 
 @pytest.mark.parametrize("seed", [random.getrandbits(32)])
@@ -223,7 +223,7 @@ def test_replace_str_large(seed):
             src[i] = "2"
         elif word == "five":
             src[i] = "1+1+1+1+1"
-    assert df.topython() == [src]
+    assert df.to_list() == [src]
 
 
 
@@ -236,7 +236,7 @@ def test_replace_nothing():
     df = dt.Frame(range(5))
     df.replace([], [])
     df.replace({})
-    assert df.topython() == [list(range(5))]
+    assert df.to_list() == [list(range(5))]
 
 
 def test_replace_nas():
@@ -245,9 +245,9 @@ def test_replace_nas():
                    [True, False, None, None]])
     df.replace(None, [77, 9.999, True])
     df.internal.check()
-    assert df.topython() == [[1, 77, 5, 10],
-                             [2.7, 9.999, 9.999, 1e5],
-                             [True, False, True, True]]
+    assert df.to_list() == [[1, 77, 5, 10],
+                            [2.7, 9.999, 9.999, 1e5],
+                            [True, False, True, True]]
 
 
 @pytest.mark.parametrize("st", [dt.float32, dt.float64])
@@ -258,7 +258,7 @@ def test_replace_nas2(st):
     df.replace(nan, 0.0)
     df.internal.check()
     assert df.stypes == (st,)
-    assert df.topython() == [[1.0, 0.0, 2.5, 0.0, 0.0]]
+    assert df.to_list() == [[1.0, 0.0, 2.5, 0.0, 0.0]]
 
 
 @pytest.mark.parametrize("nn", [0, 1, 2, 3, 5, 8])
@@ -281,15 +281,15 @@ def test_replace_multiple(nn, st):
     df.replace(replacements)
     df.internal.check()
     assert df.stypes == (st,)
-    assert df.topython()[0] == res
+    assert df.to_list()[0] == res
 
 
 def test_replace_in_copy():
     df1 = dt.Frame([[1, 2, 3], [5.5, 6.6, 7.7], ["A", "B", "C"]])
     df2 = df1.copy()
     df2.replace({3: 9, 5.5: 0.0, "B": "-"})
-    assert df1.topython() == [[1, 2, 3], [5.5, 6.6, 7.7], ["A", "B", "C"]]
-    assert df2.topython() == [[1, 2, 9], [0.0, 6.6, 7.7], ["A", "-", "C"]]
+    assert df1.to_list() == [[1, 2, 3], [5.5, 6.6, 7.7], ["A", "B", "C"]]
+    assert df2.to_list() == [[1, 2, 9], [0.0, 6.6, 7.7], ["A", "-", "C"]]
 
 
 def test_replace_do_nothing():
@@ -297,7 +297,7 @@ def test_replace_do_nothing():
     df1 = dt.Frame([[1, 2], [3, 4], [5.0, 6.6], [-inf, inf]])
     df1.replace([-99, -inf, inf], None)
     df1.internal.check()
-    assert df1.topython() == [[1, 2], [3, 4], [5.0, 6.6], [None, None]]
+    assert df1.to_list() == [[1, 2], [3, 4], [5.0, 6.6], [None, None]]
 
 
 def test_replace_do_nothing2(numpy):
@@ -306,7 +306,7 @@ def test_replace_do_nothing2(numpy):
     df = dt.Frame(a)
     df.replace([-np.inf, np.inf], [np.nan, np.nan])
     df.internal.check()
-    assert df.topython() == [[1., 1.], [2., None], [3., 4.], [None, 5.]]
+    assert df.to_list() == [[1., 1.], [2., None], [3., 4.], [None, 5.]]
 
 
 

--- a/tests/munging/test_str.py
+++ b/tests/munging/test_str.py
@@ -47,7 +47,7 @@ def test_split_into_nhot0():
     assert f1.names == fr.names
     assert f1.stypes == (dt.stype.bool8, ) * f1.ncols
     assert f1.shape == fr.shape
-    assert f1.topython() == fr.topython()
+    assert f1.to_list() == fr.to_list()
 
 
 def test_split_into_nhot1():
@@ -63,7 +63,7 @@ def test_split_into_nhot1():
     fr = fr[..., f1.names]
     assert f1.shape == fr.shape == (5, 2)
     assert f1.stypes == (dt.stype.bool8, dt.stype.bool8)
-    assert f1.topython() == fr.topython()
+    assert f1.to_list() == fr.to_list()
 
 
 def test_split_into_nhot_sep():
@@ -72,7 +72,7 @@ def test_split_into_nhot_sep():
     assert set(f1.names) == {"a", "b", "c"}
     fr = dt.Frame(a=[1, 1, 1], b=[1, 1, 0], c=[1, 0, 1])
     assert set(f1.names) == set(fr.names)
-    assert f1.topython() == fr[:, f1.names].topython()
+    assert f1.to_list() == fr[:, f1.names].to_list()
 
 
 def test_split_into_nhot_quotes():
@@ -125,4 +125,4 @@ def test_split_into_nhot_long(seed, st):
     fr = dt.Frame(liberty=col1, equality=col2, justice=col3, freedom=col4)
     assert set(f1.names) == set(fr.names)
     f1 = f1[..., fr.names]
-    assert f1.topython() == fr.topython()
+    assert f1.to_list() == fr.to_list()

--- a/tests/random_attack.py
+++ b/tests/random_attack.py
@@ -292,7 +292,7 @@ class Frame0:
         assert self.df.ncols == len(self.data)
         assert self.df.names == tuple(self.names)
         self.check_types()
-        assert self.df.topython() == self.data
+        assert self.df.to_list() == self.data
 
     def check_shape(self):
         df_nrows = self.df.nrows

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -854,7 +854,7 @@ def test_to_dict():
 @pytest.mark.usefixtures("pandas")
 def test_topandas():
     d0 = dt.Frame({"A": [1, 5], "B": ["hello", "you"], "C": [True, False]})
-    p0 = d0.topandas()
+    p0 = d0.to_pandas()
     assert p0.shape == (2, 3)
     assert same_iterables(p0.columns.tolist(), ["A", "B", "C"])
     assert p0["A"].values.tolist() == [1, 5]
@@ -868,7 +868,7 @@ def test_topandas_view():
                    ["alpha", "beta", None, "delta", "epsilon", "zeta"],
                    [.3, 1e2, -.5, 1.9, 2.2, 7.9]], names=["A", "b", "c"])
     d1 = d0[::-2, :]
-    p1 = d1.topandas()
+    p1 = d1.to_pandas()
     assert p1.shape == d1.shape
     assert p1.columns.tolist() == ["A", "b", "c"]
     assert p1.values.T.tolist() == d1.to_list()
@@ -884,7 +884,7 @@ def test_topandas_nas():
     d0.internal.check()
     assert d0.stypes == (dt.stype.bool8, dt.stype.int8, dt.stype.int16,
                          dt.stype.int32, dt.stype.int64)
-    p0 = d0.topandas()
+    p0 = d0.to_pandas()
     # Check that each column in Pandas DataFrame has the correct number of NAs
     assert p0.count().tolist() == [2, 4, 3, 4, 1]
 
@@ -892,7 +892,7 @@ def test_topandas_nas():
 def test_tonumpy0(numpy):
     d0 = dt.Frame([1, 3, 5, 7, 9])
     assert d0.stypes == (stype.int8, )
-    a0 = d0.tonumpy()
+    a0 = d0.to_numpy()
     assert a0.shape == d0.shape
     assert a0.dtype == numpy.dtype("int8")
     assert a0.tolist() == [[1], [3], [5], [7], [9]]
@@ -903,7 +903,7 @@ def test_tonumpy0(numpy):
 def test_tonumpy1(numpy):
     d0 = dt.Frame({"A": [1, 5], "B": ["helo", "you"],
                    "C": [True, False], "D": [3.4, None]})
-    a0 = d0.tonumpy()
+    a0 = d0.to_numpy()
     assert a0.shape == d0.shape
     assert a0.dtype == numpy.dtype("object")
     assert same_iterables(a0.T.tolist(), d0.to_list())
@@ -945,7 +945,7 @@ def test_numpy_constructor_multi_types(numpy):
                              [1.0, 0, 0],
                              [30498, 1349810, -134308],
                              [1.454, 4.9e-23, 1e7]]
-    assert (d0.tonumpy() == n0).all()
+    assert (d0.to_numpy() == n0).all()
 
 
 def test_numpy_constructor_view(numpy):
@@ -956,7 +956,7 @@ def test_numpy_constructor_view(numpy):
     assert n1.dtype == numpy.dtype("int32")
     assert n1.T.tolist() == [list(range(99, 0, -2)),
                              list(range(990000, 0, -20000))]
-    assert (d1.tonumpy() == n1).all()
+    assert (d1.to_numpy() == n1).all()
 
 
 def test_numpy_constructor_single_col(numpy):
@@ -965,7 +965,7 @@ def test_numpy_constructor_single_col(numpy):
     n0 = numpy.array(d0)
     assert n0.shape == d0.shape
     assert n0.dtype == numpy.dtype("int8")
-    assert (n0 == d0.tonumpy()).all()
+    assert (n0 == d0.to_numpy()).all()
 
 
 def test_numpy_constructor_single_string_col(numpy):
@@ -976,26 +976,26 @@ def test_numpy_constructor_single_string_col(numpy):
     assert a.shape == d.shape
     assert a.dtype == numpy.dtype("object")
     assert a.T.tolist() == d.to_list()
-    assert (a == d.tonumpy()).all()
+    assert (a == d.to_numpy()).all()
 
 
 def test_numpy_constructor_view_1col(numpy):
     d0 = dt.Frame({"A": [1, 2, 3, 4], "B": [True, False, True, False]})
     d2 = d0[::2, "B"]
-    a = d2.tonumpy()
+    a = d2.to_numpy()
     assert a.T.tolist() == [[True, True]]
     assert (a == numpy.array(d2)).all()
 
 
 def test_tonumpy_with_stype(numpy):
     """
-    Test using dt.tonumpy() with explicit `stype` argument.
+    Test using dt.to_numpy() with explicit `stype` argument.
     """
     src = [[1.5, 2.6, 5.4], [3, 7, 10]]
     d0 = dt.Frame(src)
     assert d0.stypes == (stype.float64, stype.int8)
-    a1 = d0.tonumpy("float32")
-    a2 = d0.tonumpy()
+    a1 = d0.to_numpy("float32")
+    a2 = d0.to_numpy()
     del d0
     # Check using list_equals(), which allows a tolerance of 1e-6, because
     # conversion to float32 resulted in loss of precision

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -304,14 +304,14 @@ def test_del_0cols():
     del d0[:, []]
     d0.internal.check()
     assert d0.shape == (1, 16)
-    assert d0.topython() == smalldt().topython()
+    assert d0.to_list() == smalldt().to_list()
 
 def test_del_1col_str_1():
     d0 = smalldt()
     del d0[:, "A"]
     d0.internal.check()
     assert d0.shape == (1, 15)
-    assert d0.topython() == [[i] for i in range(1, 16)]
+    assert d0.to_list() == [[i] for i in range(1, 16)]
     assert d0.names == tuple("BCDEFGHIJKLMNOP")
     assert len(d0.ltypes) == d0.ncols
 
@@ -320,7 +320,7 @@ def test_del_1col_str_2():
     del d0[:, "B"]
     d0.internal.check()
     assert d0.shape == (1, 15)
-    assert d0.topython() == [[i] for i in range(16) if i != 1]
+    assert d0.to_list() == [[i] for i in range(16) if i != 1]
     assert d0.names == tuple("ACDEFGHIJKLMNOP")
 
 def test_del_1col_str_3():
@@ -328,7 +328,7 @@ def test_del_1col_str_3():
     del d0[:, "P"]
     d0.internal.check()
     assert d0.shape == (1, 15)
-    assert d0.topython() == [[i] for i in range(16) if i != 15]
+    assert d0.to_list() == [[i] for i in range(16) if i != 15]
     assert d0.names == tuple("ABCDEFGHIJKLMNO")
 
 def test_del_1col_int():
@@ -344,7 +344,7 @@ def test_del_cols_strslice():
     d0.internal.check()
     assert d0.shape == (1, 9)
     assert d0.names == tuple("ABCDLMNOP")
-    assert d0.topython() == [[0], [1], [2], [3], [11], [12], [13], [14], [15]]
+    assert d0.to_list() == [[0], [1], [2], [3], [11], [12], [13], [14], [15]]
 
 def test_del_cols_intslice1():
     d0 = smalldt()
@@ -352,7 +352,7 @@ def test_del_cols_intslice1():
     d0.internal.check()
     assert d0.shape == (1, 8)
     assert d0.names == tuple("BDFHJLNP")
-    assert d0.topython() == [[i] for i in range(1, 16, 2)]
+    assert d0.to_list() == [[i] for i in range(1, 16, 2)]
 
 def test_del_cols_intslice2():
     d0 = smalldt()
@@ -360,7 +360,7 @@ def test_del_cols_intslice2():
     d0.internal.check()
     assert d0.shape == (1, 8)
     assert d0.names == tuple("ACEGIKMO")
-    assert d0.topython() == [[i] for i in range(0, 16, 2)]
+    assert d0.to_list() == [[i] for i in range(0, 16, 2)]
 
 def test_del_cols_all():
     d0 = smalldt()
@@ -421,7 +421,7 @@ def test_del_rows_single():
     d0 = dt.Frame(range(10))
     del d0[3, :]
     d0.internal.check()
-    assert d0.topython() == [[0, 1, 2, 4, 5, 6, 7, 8, 9]]
+    assert d0.to_list() == [[0, 1, 2, 4, 5, 6, 7, 8, 9]]
 
 
 def test_del_rows_slice0():
@@ -429,7 +429,7 @@ def test_del_rows_slice0():
     del d0[:3, :]
     d0.internal.check()
     assert d0.shape == (7, 1)
-    assert d0.topython() == [list(range(3, 10))]
+    assert d0.to_list() == [list(range(3, 10))]
 
 
 def test_del_rows_slice1():
@@ -437,7 +437,7 @@ def test_del_rows_slice1():
     del d0[-4:, :]
     d0.internal.check()
     assert d0.shape == (6, 1)
-    assert d0.topython() == [list(range(10 - 4))]
+    assert d0.to_list() == [list(range(10 - 4))]
 
 
 def test_del_rows_slice2():
@@ -445,7 +445,7 @@ def test_del_rows_slice2():
     del d0[2:6, :]
     d0.internal.check()
     assert d0.shape == (6, 1)
-    assert d0.topython() == [[0, 1, 6, 7, 8, 9]]
+    assert d0.to_list() == [[0, 1, 6, 7, 8, 9]]
 
 
 def test_del_rows_slice_empty():
@@ -453,7 +453,7 @@ def test_del_rows_slice_empty():
     del d0[4:4, :]
     d0.internal.check()
     assert d0.shape == (10, 1)
-    assert d0.topython() == [list(range(10))]
+    assert d0.to_list() == [list(range(10))]
 
 
 def test_del_rows_slice_reverse():
@@ -462,7 +462,7 @@ def test_del_rows_slice_reverse():
     del d0[:4:-1, :]
     del s0[:4:-1]
     d0.internal.check()
-    assert d0.topython() == [s0]
+    assert d0.to_list() == [s0]
 
 
 def test_del_rows_slice_all():
@@ -483,14 +483,14 @@ def test_del_rows_slice_step():
     d0 = dt.Frame(range(10))
     del d0[::3, :]
     d0.internal.check()
-    assert d0.topython() == [[1, 2, 4, 5, 7, 8]]
+    assert d0.to_list() == [[1, 2, 4, 5, 7, 8]]
 
 
 def test_del_rows_array():
     d0 = dt.Frame(range(10))
     del d0[[0, 7, 8], :]
     d0.internal.check()
-    assert d0.topython() == [[1, 2, 3, 4, 5, 6, 9]]
+    assert d0.to_list() == [[1, 2, 3, 4, 5, 6, 9]]
 
 
 @pytest.mark.skip("Issue #805")
@@ -498,37 +498,37 @@ def test_del_rows_array_unordered():
     d0 = dt.Frame(range(10))
     del d0[[3, 1, 5, 2, 2, 0, -1], :]
     d0.internal.check()
-    assert d0.topython() == [[4, 6, 7, 8]]
+    assert d0.to_list() == [[4, 6, 7, 8]]
 
 
 def test_del_rows_filter():
     d0 = dt.Frame(range(10), names=["A"], stype="int32")
     del d0[f.A < 4, :]
     d0.internal.check()
-    assert d0.topython() == [[4, 5, 6, 7, 8, 9]]
+    assert d0.to_list() == [[4, 5, 6, 7, 8, 9]]
 
 
 def test_del_rows_nas():
     d0 = dt.Frame({"A": [1, 5, None, 12, 7, None, -3]})
     del d0[isna(f.A), :]
     d0.internal.check()
-    assert d0.topython() == [[1, 5, 12, 7, -3]]
+    assert d0.to_list() == [[1, 5, 12, 7, -3]]
 
 
 def test_del_rows_from_view1():
     d0 = dt.Frame(range(10))
     d1 = d0[::2, :]  # 0 2 4 6 8
     del d1[3, :]
-    assert d1.topython() == [[0, 2, 4, 8]]
+    assert d1.to_list() == [[0, 2, 4, 8]]
     del d1[[0, 3], :]
-    assert d1.topython() == [[2, 4]]
+    assert d1.to_list() == [[2, 4]]
 
 
 def test_del_rows_from_view2():
     f0 = dt.Frame([1, 3, None, 4, 5, None, None, 2, None, None, None])
     f1 = f0[5:, :]
     del f1[isna(f[0]), :]
-    assert f1.topython() == [[2]]
+    assert f1.to_list() == [[2]]
 
 
 
@@ -541,7 +541,7 @@ def test_resize_rows_api():
     f0.nrows = 3
     f0.nrows = 5
     f0.internal.check()
-    assert f0.topython() == [[20, None, None, None, None]]
+    assert f0.to_list() == [[20, None, None, None, None]]
 
 
 def test_resize_rows0():
@@ -550,12 +550,12 @@ def test_resize_rows0():
     f0.internal.check()
     assert f0.shape == (6, 1)
     assert f0.stypes == (dt.int32,)
-    assert f0.topython() == [[0, 1, 2, 3, 4, 5]]
+    assert f0.to_list() == [[0, 1, 2, 3, 4, 5]]
     f0.nrows = 12
     f0.internal.check()
     assert f0.shape == (12, 1)
     assert f0.stypes == (dt.int32,)
-    assert f0.topython() == [[0, 1, 2, 3, 4, 5] + [None] * 6]
+    assert f0.to_list() == [[0, 1, 2, 3, 4, 5] + [None] * 6]
     f0.nrows = 1
     f0.internal.check()
     assert f0.shape == (1, 1)
@@ -565,7 +565,7 @@ def test_resize_rows0():
     f0.internal.check()
     assert f0.shape == (20, 1)
     assert f0.stypes == (dt.int32,)
-    assert f0.topython() == [[0] + [None] * 19]
+    assert f0.to_list() == [[0] + [None] * 19]
 
 
 def test_resize_rows1():
@@ -579,26 +579,26 @@ def test_resize_rows1():
     f0.internal.check()
     assert f0.shape == (7, 5)
     assert f0.stypes == stypes
-    assert f0.topython() == [src + [None] * 6 for src in srcs]
+    assert f0.to_list() == [src + [None] * 6 for src in srcs]
     f0.nrows = 20
     f0.internal.check()
     assert f0.shape == (20, 5)
     assert f0.stypes == stypes
-    assert f0.topython() == [src + [None] * 19 for src in srcs]
+    assert f0.to_list() == [src + [None] * 19 for src in srcs]
     f0.nrows = 0
     f0.internal.check()
     assert f0.shape == (0, 5)
     assert f0.stypes == stypes
-    assert f0.topython() == [[]] * 5
+    assert f0.to_list() == [[]] * 5
 
 
 def test_resize_rows_nastrs():
     f0 = dt.Frame(["foo", None, None, None, "gar"])
     f0.nrows = 3
-    assert f0.topython() == [["foo", None, None]]
+    assert f0.to_list() == [["foo", None, None]]
     f0.nrows = 10
     f0.internal.check()
-    assert f0.topython() == [["foo"] + [None] * 9]
+    assert f0.to_list() == [["foo"] + [None] * 9]
 
 
 def test_resize_view_slice():
@@ -611,12 +611,12 @@ def test_resize_view_slice():
     f1.internal.check()
     assert f1.shape == (10, 1)
     assert f1.internal.isview
-    assert f1.topython()[0] == list(range(8, 28, 2))
+    assert f1.to_list()[0] == list(range(8, 28, 2))
     f1.nrows = 15
     f1.internal.check()
     assert f1.shape == (15, 1)
     assert f1.internal.isview
-    assert f1.topython()[0] == list(range(8, 28, 2)) + [None] * 5
+    assert f1.to_list()[0] == list(range(8, 28, 2)) + [None] * 5
 
 
 def test_resize_view_array():
@@ -625,17 +625,17 @@ def test_resize_view_array():
     f1.internal.check()
     assert f1.shape == (8, 1)
     assert f1.internal.isview
-    assert f1.topython() == [[1, 1, 2, 3, 5, 8, 13, 0]]
+    assert f1.to_list() == [[1, 1, 2, 3, 5, 8, 13, 0]]
     f1.nrows = 4
     f1.internal.check()
     assert f1.shape == (4, 1)
     assert f1.internal.isview
-    assert f1.topython() == [[1, 1, 2, 3]]
+    assert f1.to_list() == [[1, 1, 2, 3]]
     f1.nrows = 5
     f1.internal.check()
     assert f1.shape == (5, 1)
     assert f1.internal.isview
-    assert f1.topython() == [[1, 1, 2, 3, None]]
+    assert f1.to_list() == [[1, 1, 2, 3, None]]
 
 
 def test_resize_bad():
@@ -810,7 +810,7 @@ def test_to_list():
            [False, True, None, True]]
     d0 = dt.Frame(src, names=["A", "B", "C"])
     assert d0.ltypes == (ltype.int, ltype.str, ltype.bool)
-    a0 = d0.topython()
+    a0 = d0.to_list()
     assert len(a0) == 3
     assert len(a0[0]) == 4
     assert a0 == src
@@ -822,7 +822,7 @@ def test_to_list2():
     src = [[1.0, None, float("nan"), 3.3]]
     d0 = dt.Frame(src)
     assert d0.ltypes == (ltype.real, )
-    a0 = d0.topython()[0]
+    a0 = d0.to_list()[0]
     assert a0 == [1.0, None, None, 3.3]
 
 
@@ -871,7 +871,7 @@ def test_topandas_view():
     p1 = d1.topandas()
     assert p1.shape == d1.shape
     assert p1.columns.tolist() == ["A", "b", "c"]
-    assert p1.values.T.tolist() == d1.topython()
+    assert p1.values.T.tolist() == d1.to_list()
 
 
 @pytest.mark.usefixtures("pandas")
@@ -906,7 +906,7 @@ def test_tonumpy1(numpy):
     a0 = d0.tonumpy()
     assert a0.shape == d0.shape
     assert a0.dtype == numpy.dtype("object")
-    assert same_iterables(a0.T.tolist(), d0.topython())
+    assert same_iterables(a0.T.tolist(), d0.to_list())
     a1 = numpy.array(d0)
     assert (a0 == a1).all()
 
@@ -916,7 +916,7 @@ def test_numpy_constructor_simple(numpy):
     d0 = dt.Frame(tbl)
     assert d0.shape == (5, 3)
     assert d0.stypes == (stype.int8, stype.int8, stype.int8)
-    assert d0.topython() == tbl
+    assert d0.to_list() == tbl
     n0 = numpy.array(d0)
     assert n0.shape == d0.shape
     assert n0.dtype == numpy.dtype("int8")
@@ -975,7 +975,7 @@ def test_numpy_constructor_single_string_col(numpy):
     a = numpy.array(d)
     assert a.shape == d.shape
     assert a.dtype == numpy.dtype("object")
-    assert a.T.tolist() == d.topython()
+    assert a.T.tolist() == d.to_list()
     assert (a == d.tonumpy()).all()
 
 
@@ -1114,9 +1114,9 @@ def test_copy_frame():
     d1.internal.check()
     assert d0.names == d1.names
     assert d0.stypes == d1.stypes
-    assert d0.topython() == d1.topython()
+    assert d0.to_list() == d1.to_list()
     d0[1, "A"] = 100
-    assert d0.topython() != d1.topython()
+    assert d0.to_list() != d1.to_list()
     d0.names = ("w", "x", "y", "z")
     assert d1.names != d0.names
 
@@ -1274,5 +1274,5 @@ def test_issue898():
     f1 = f0[:-1, :]
     del f0
     f1.materialize()
-    res = f1.topython()
+    res = f1.to_list()
     del res

--- a/tests/test_dt_create.py
+++ b/tests/test_dt_create.py
@@ -192,7 +192,7 @@ def test_create_from_range():
     d0 = dt.Frame(range(8))
     d0.internal.check()
     assert d0.shape == (8, 1)
-    assert d0.topython() == [list(range(8))]
+    assert d0.to_list() == [list(range(8))]
 
 
 
@@ -213,7 +213,7 @@ def test_create_from_list_of_lists_with_stypes_dict():
     d0.internal.check()
     assert d0.names == ("a", "b", "c")
     assert d0.ltypes == (ltype.int, ltype.int, ltype.real)
-    assert d0.topython() == [[4], [9], [3.0]]
+    assert d0.to_list() == [[4], [9], [3.0]]
 
 
 def test_create_from_list_of_lists_with_stypes_dict_bad():
@@ -227,7 +227,7 @@ def test_create_from_list_of_ranges():
     d0 = dt.Frame([range(6), range(0, 12, 2)])
     d0.internal.check()
     assert d0.shape == (6, 2)
-    assert d0.topython() == [list(range(6)), list(range(0, 12, 2))]
+    assert d0.to_list() == [list(range(6)), list(range(0, 12, 2))]
 
 
 def test_create_from_empty_list_of_lists():
@@ -269,16 +269,16 @@ def test_create_from_kwargs0():
     d0 = dt.Frame(varname=[1])
     d0.internal.check()
     assert d0.names == ("varname",)
-    assert d0.topython() == [[1]]
+    assert d0.to_list() == [[1]]
 
 
 def test_create_from_kwargs1():
     d0 = dt.Frame(A=[1, 2, 3], B=[True, None, False], C=["a", "b", "c"])
     d0.internal.check()
     assert same_iterables(d0.names, ("A", "B", "C"))
-    assert same_iterables(d0.topython(), [[1, 2, 3],
-                                          [True, None, False],
-                                          ["a", "b", "c"]])
+    assert same_iterables(d0.to_list(), [[1, 2, 3],
+                                         [True, None, False],
+                                         ["a", "b", "c"]])
 
 
 def test_create_from_kwargs2():
@@ -287,7 +287,7 @@ def test_create_from_kwargs2():
     assert d0.shape == (4, 2)
     assert same_iterables(d0.names, ("x", "y"))
     assert same_iterables(d0.stypes, (dt.int64, dt.float32))
-    assert same_iterables(d0.topython(), [[0, 1, 2, 3], [1, 3, 8, 0]])
+    assert same_iterables(d0.to_list(), [[0, 1, 2, 3], [1, 3, 8, 0]])
 
 
 def test_create_from_kwargs_error():
@@ -324,7 +324,7 @@ def test_create_from_frame2():
     d0 = dt.Frame([range(5), [7] * 5, list("owbke")])
     d1 = dt.Frame(d0, names=["A", "B", "C"])
     d1.internal.check()
-    assert d1.topython() == d0.topython()
+    assert d1.to_list() == d0.to_list()
     assert d1.stypes == d0.stypes
     assert d1.names != d0.names
     assert d1.names == ("A", "B", "C")
@@ -358,8 +358,8 @@ def test_create_from_string():
     assert d0.names == ("A", "B", "C", "D")
     assert d0.ltypes == (dt.ltype.bool, dt.ltype.real, dt.ltype.int,
                          dt.ltype.str)
-    assert d0.topython() == [[True, False, None], [2.0, 5.5, None],
-                             [3, None, 1000], ["boo", "bar", ""]]
+    assert d0.to_list() == [[True, False, None], [2.0, 5.5, None],
+                            [3, None, 1000], ["boo", "bar", ""]]
 
 
 def test_cannot_create_from_multiple_files(tempfile):
@@ -397,9 +397,9 @@ def test_create_from_list_of_tuples1():
     d0.internal.check()
     assert d0.shape == (4, 3)
     assert d0.ltypes == (ltype.int, ltype.real, ltype.str)
-    assert d0.topython() == [[1, 3, 9, 0],
-                             [2.0, 1.5, 0.1, -10.0],
-                             ["foo", "zee", "xyx", None]]
+    assert d0.to_list() == [[1, 3, 9, 0],
+                            [2.0, 1.5, 0.1, -10.0],
+                            ["foo", "zee", "xyx", None]]
 
 
 def test_create_from_list_of_tuples2():
@@ -408,7 +408,7 @@ def test_create_from_list_of_tuples2():
     assert d0.shape == (1, 3)
     assert d0.ltypes == (ltype.int, ltype.real, ltype.str)
     assert d0.names == ("a", "b", "c")
-    assert d0.topython() == [[1], [3.0], ["5"]]
+    assert d0.to_list() == [[1], [3.0], ["5"]]
 
 
 def test_create_from_list_of_tuples_bad():
@@ -443,8 +443,8 @@ def test_create_from_list_of_namedtuples():
     assert d0.shape == (3, 3)
     assert d0.names == ("name", "age", "sex")
     assert d0.ltypes == (ltype.str, ltype.int, ltype.str)
-    assert d0.topython() == [["Grogg", "Alexx", "Fiona"],
-                             [21, 14, 24], ["M", "M", "F"]]
+    assert d0.to_list() == [["Grogg", "Alexx", "Fiona"],
+                            [21, 14, 24], ["M", "M", "F"]]
 
 
 def test_create_from_list_of_namedtuples_names_override():
@@ -455,7 +455,7 @@ def test_create_from_list_of_namedtuples_names_override():
     assert d0.shape == (2, 3)
     assert d0.names == ("x", "y", "z")
     assert d0.ltypes == (ltype.int,) * 3
-    assert d0.topython() == [[5, 3], [6, 2], [7, 1]]
+    assert d0.to_list() == [[5, 3], [6, 2], [7, 1]]
 
 
 
@@ -473,10 +473,10 @@ def test_create_from_list_of_dicts1():
     assert d0.shape == (5, 4)
     assert d0.names == ("a", "b", "c", "d")
     assert d0.ltypes == (ltype.int, ltype.int, ltype.str, ltype.real)
-    assert d0.topython() == [[5, 99, -4, None, None],
-                             [7, None, None, None, None],
-                             ["Hey", None, "Yay", None, None],
-                             [None, None, 2.17, 1e10, None]]
+    assert d0.to_list() == [[5, 99, -4, None, None],
+                            [7, None, None, None, None],
+                            ["Hey", None, "Yay", None, None],
+                            [None, None, 2.17, 1e10, None]]
 
 
 @pytest.mark.usefixtures("py36")
@@ -485,8 +485,8 @@ def test_create_from_list_of_dicts2():
     d0.internal.check()
     assert d0.shape == (3, 4)
     assert d0.names == ("foo", "bar", "argh", "_")
-    assert d0.topython() == [[11, 4, None], [34, None, None],
-                             [None, 17, None], [None, None, 0]]
+    assert d0.to_list() == [[11, 4, None], [34, None, None],
+                            [None, 17, None], [None, None, 0]]
 
 
 def test_create_from_list_of_dicts_with_names1():
@@ -499,10 +499,10 @@ def test_create_from_list_of_dicts_with_names1():
     assert d0.shape == (5, 4)
     assert d0.names == ("c", "a", "d", "e")
     assert d0.ltypes == (ltype.str, ltype.int, ltype.real, ltype.bool)
-    assert d0.topython() == [["Rose", None, "Lily", None, None],
-                             [12, 37, 80, None, None],
-                             [None, None, 3.14159, 1.7e10, None],
-                             [None, None, None, None, None]]
+    assert d0.to_list() == [["Rose", None, "Lily", None, None],
+                            [12, 37, 80, None, None],
+                            [None, None, 3.14159, 1.7e10, None],
+                            [None, None, None, None, None]]
 
 
 def test_create_from_list_of_dicts_with_names2():
@@ -556,7 +556,7 @@ def test_create_as_int8():
     d0.internal.check()
     assert d0.stypes == (stype.int8, )
     assert d0.shape == (7, 1)
-    assert d0.topython() == [[1, None, -1, -24, 2, 123, None]]
+    assert d0.to_list() == [[1, None, -1, -24, 2, 123, None]]
 
 
 def test_create_as_int16():
@@ -565,7 +565,7 @@ def test_create_as_int16():
     assert d0.stypes == (stype.int16, )
     assert d0.shape == (6, 1)
     # int(1e50) = 2407412430484045 * 2**115, which is ≡0 (mod 2**16)
-    assert d0.topython() == [[0, 1000, None, 27, None, 1]]
+    assert d0.to_list() == [[0, 1000, None, 27, None, 1]]
 
 
 def test_create_as_int32():
@@ -573,7 +573,7 @@ def test_create_as_int32():
     d0.internal.check()
     assert d0.stypes == (stype.int32, )
     assert d0.shape == (5, 1)
-    assert d0.topython() == [[1, 2, 5, 3, None]]
+    assert d0.to_list() == [[1, 2, 5, 3, None]]
 
 
 def test_create_as_float32():
@@ -583,7 +583,7 @@ def test_create_as_float32():
     assert d0.stypes == (stype.float32, )
     assert d0.shape == (6, 1)
     # Apparently, float "inf" converts into double "inf" when cast. Good!
-    assert list_equals(d0.topython(), [[1, 5, 2.6, 7.7777, -math.inf, 0]])
+    assert list_equals(d0.to_list(), [[1, 5, 2.6, 7.7777, -math.inf, 0]])
 
 
 def test_create_as_float64():
@@ -593,8 +593,8 @@ def test_create_as_float64():
     d0.internal.check()
     assert d0.stypes == (stype.float64, stype.float64)
     assert d0.shape == (6, 2)
-    assert d0.topython() == [[1.0, 2.0, 3.0, 4.0, 5.0, None],
-                             [2.7, 3.1, 0, None, math.inf, -math.inf]]
+    assert d0.to_list() == [[1.0, 2.0, 3.0, 4.0, 5.0, None],
+                            [2.7, 3.1, 0, None, math.inf, -math.inf]]
 
 
 def test_create_as_str32():
@@ -602,7 +602,7 @@ def test_create_as_str32():
     d0.internal.check()
     assert d0.stypes == (stype.str32, )
     assert d0.shape == (5, 1)
-    assert d0.topython() == [["1", "2.7", "foo", None, "(3, 4)"]]
+    assert d0.to_list() == [["1", "2.7", "foo", None, "(3, 4)"]]
 
 
 def test_create_as_str64():
@@ -610,7 +610,7 @@ def test_create_as_str64():
     d0.internal.check()
     assert d0.stypes == (stype.str64, )
     assert d0.shape == (10, 1)
-    assert d0.topython() == [[str(n) for n in range(10)]]
+    assert d0.to_list() == [[str(n) for n in range(10)]]
 
 
 @pytest.mark.parametrize("st", [stype.int8, stype.int16, stype.int64,
@@ -620,9 +620,9 @@ def test_create_range_as_stype(st):
     d0.internal.check()
     assert d0.stypes == (st,)
     if st == stype.str32:
-        assert d0.topython()[0] == [str(x) for x in range(10)]
+        assert d0.to_list()[0] == [str(x) for x in range(10)]
     else:
-        assert d0.topython()[0] == list(range(10))
+        assert d0.to_list()[0] == list(range(10))
 
 
 
@@ -693,7 +693,7 @@ def test_create_from_pandas_series(pandas):
     d = dt.Frame(p)
     d.internal.check()
     assert d.shape == (4, 1)
-    assert d.topython() == [[1, 5, 9, -12]]
+    assert d.to_list() == [[1, 5, 9, -12]]
 
 
 def test_create_from_pandas_with_names(pandas):
@@ -710,7 +710,7 @@ def test_create_from_pandas_series_with_names(pandas):
     d.internal.check()
     assert d.shape == (4, 1)
     assert d.names == ("ha!", )
-    assert d.topython() == [[10000, 5, 19, -12]]
+    assert d.to_list() == [[10000, 5, 19, -12]]
 
 
 def test_create_from_pandas_float16_series(pandas):
@@ -721,7 +721,7 @@ def test_create_from_pandas_float16_series(pandas):
     assert d.stypes == (stype.float32, )
     assert d.shape == (3, 1)
     # The precision of `float16`s is too low for `list_equals()` method.
-    res = d.topython()[0]
+    res = d.to_list()[0]
     assert all(abs(src[i] - res[i]) < 1e-3 for i in range(3))
 
 
@@ -768,7 +768,7 @@ def test_create_from_0d_numpy_array(numpy):
     d.internal.check()
     assert d.shape == (1, 1)
     assert d.names == ("C0", )
-    assert d.topython() == [[100]]
+    assert d.to_list() == [[100]]
 
 
 def test_create_from_1d_numpy_array(numpy):
@@ -777,7 +777,7 @@ def test_create_from_1d_numpy_array(numpy):
     d.internal.check()
     assert d.shape == (3, 1)
     assert d.names == ("C0", )
-    assert d.topython() == [[1, 2, 3]]
+    assert d.to_list() == [[1, 2, 3]]
 
 
 def test_create_from_2d_numpy_array(numpy):
@@ -786,7 +786,7 @@ def test_create_from_2d_numpy_array(numpy):
     d.internal.check()
     assert d.shape == a.shape
     assert d.names == ("C0", "C1", "C2", "C3", "C4")
-    assert d.topython() == a.T.tolist()
+    assert d.to_list() == a.T.tolist()
 
 
 def test_create_from_3d_numpy_array(numpy):
@@ -802,7 +802,7 @@ def test_create_from_string_numpy_array(numpy):
     d.internal.check()
     assert d.shape == (6, 1)
     assert d.names == ("C0", )
-    assert d.topython() == [a.tolist()]
+    assert d.to_list() == [a.tolist()]
 
 
 def test_create_from_masked_numpy_array1(numpy):
@@ -813,7 +813,7 @@ def test_create_from_masked_numpy_array1(numpy):
     d.internal.check()
     assert d.shape == (5, 1)
     assert d.stypes == (stype.bool8, )
-    assert d.topython() == [[True, None, True, False, None]]
+    assert d.to_list() == [[True, None, True, False, None]]
 
 
 def test_create_from_masked_numpy_array2(numpy):
@@ -825,7 +825,7 @@ def test_create_from_masked_numpy_array2(numpy):
     d.internal.check()
     assert d.shape == (n, 1)
     assert d.stypes == (stype.int16, )
-    assert d.topython() == [arr.tolist()]
+    assert d.to_list() == [arr.tolist()]
 
 
 def test_create_from_masked_numpy_array3(numpy):
@@ -837,7 +837,7 @@ def test_create_from_masked_numpy_array3(numpy):
     d.internal.check()
     assert d.shape == (n, 1)
     assert d.stypes == (stype.int32, )
-    assert d.topython() == [arr.tolist()]
+    assert d.to_list() == [arr.tolist()]
 
 
 def test_create_from_masked_numpy_array4(numpy):
@@ -849,7 +849,7 @@ def test_create_from_masked_numpy_array4(numpy):
     d.internal.check()
     assert d.shape == (n, 1)
     assert d.stypes == (stype.float64, )
-    assert list_equals(d.topython(), [arr.tolist()])
+    assert list_equals(d.to_list(), [arr.tolist()])
 
 
 def test_create_from_numpy_array_with_names(numpy):
@@ -858,7 +858,7 @@ def test_create_from_numpy_array_with_names(numpy):
     d.internal.check()
     assert d.shape == (3, 1)
     assert d.names == ("gargantuan", )
-    assert d.topython() == [[1, 2, 3]]
+    assert d.to_list() == [[1, 2, 3]]
 
 
 def test_create_from_numpy_float16(numpy):
@@ -869,7 +869,7 @@ def test_create_from_numpy_float16(numpy):
     assert d.stypes == (stype.float32, )
     assert d.shape == (len(src), 1)
     # The precision of `float16`s is too low for `list_equals()` method.
-    res = d.topython()[0]
+    res = d.to_list()[0]
     assert all(abs(src[i] - res[i]) < 1e-3 for i in range(3))
 
 
@@ -910,7 +910,7 @@ def test_create_from_datetime_array(numpy):
     df.internal.check()
     assert df.shape == (10, 1)
     assert df.stypes == (stype.str32,)
-    assert df.topython() == [["1970-01-01T00:00:00"] * 10]
+    assert df.to_list() == [["1970-01-01T00:00:00"] * 10]
 
 
 
@@ -956,7 +956,7 @@ def test_issue_409():
     d = dt.Frame([10**333, -10**333, 10**-333, -10**-333])
     d.internal.check()
     assert d.ltypes == (ltype.real, )
-    p = d.topython()
+    p = d.to_list()
     assert p == [[inf, -inf, 0.0, -0.0]]
     assert copysign(1, p[0][-1]) == -1
 
@@ -997,4 +997,4 @@ def test_create_datatable():
     d = dt.DataTable([1, 2, 3])
     d.internal.check()
     assert d.__class__.__name__ == "Frame"
-    assert d.topython() == [[1, 2, 3]]
+    assert d.to_list() == [[1, 2, 3]]

--- a/tests/test_dt_create.py
+++ b/tests/test_dt_create.py
@@ -734,7 +734,7 @@ def test_create_from_pandas_float16_dataframe(pandas):
 
 
 def test_create_from_pandas_issue1235(pandas):
-    df = dt.fread("A\n" + "\U00010000" * 50).topandas()
+    df = dt.fread("A\n" + "\U00010000" * 50).to_pandas()
     table = dt.Frame(df)
     table.internal.check()
     assert table.shape == (1, 1)

--- a/tests/test_dt_expr.py
+++ b/tests/test_dt_expr.py
@@ -140,12 +140,12 @@ def test_dt_invert(src):
     df2 = dt0(select=~f[0], engine="eager")
     df2.internal.check()
     assert df2.stypes == dt0.stypes
-    assert df2.topython() == [[inv(x) for x in src]]
+    assert df2.to_list() == [[inv(x) for x in src]]
     if has_llvm():
         df1 = dt0(select=~f[0], engine="llvm")
         df1.internal.check()
         assert df1.stypes == dt0.stypes
-        assert df1.topython() == [[inv(x) for x in src]]
+        assert df1.to_list() == [[inv(x) for x in src]]
 
 
 @pytest.mark.parametrize("src", dt_float)
@@ -176,7 +176,7 @@ def test_dt_neg(src):
     dtr = dt0(select=lambda f: -f[0])
     dtr.internal.check()
     assert dtr.stypes == dt0.stypes
-    assert list_equals(dtr.topython()[0], [neg(x) for x in src])
+    assert list_equals(dtr.to_list()[0], [neg(x) for x in src])
 
 
 @pytest.mark.parametrize("src", dt_bool)
@@ -199,7 +199,7 @@ def test_dt_pos(src):
     dtr = dt0(select=lambda f: +f[0])
     dtr.internal.check()
     assert dtr.stypes == dt0.stypes
-    assert list_equals(dtr.topython()[0], list(src))
+    assert list_equals(dtr.to_list()[0], list(src))
 
 
 @pytest.mark.parametrize("src", dt_bool)
@@ -223,12 +223,12 @@ def test_dt_isna(src):
     dt1.internal.check()
     assert dt1.stypes == (stype.bool8,)
     pyans = [x is None for x in src]
-    assert dt1.topython()[0] == pyans
+    assert dt1.to_list()[0] == pyans
     if has_llvm():
         dt2 = dt0(select=lambda f: dt.isna(f[0]), engine="llvm")
         dt2.internal.check()
         assert dt2.stypes == (stype.bool8,)
-        assert dt2.topython()[0] == pyans
+        assert dt2.to_list()[0] == pyans
 
 
 
@@ -251,7 +251,7 @@ def test_abs_srcs(src):
     dt1.internal.check()
     assert dt0.stypes == dt1.stypes
     pyans = [None if x is None else abs(x) for x in src]
-    assert dt1.topython()[0] == pyans
+    assert dt1.to_list()[0] == pyans
 
 
 def test_abs_all_stypes():
@@ -263,7 +263,7 @@ def test_abs_all_stypes():
     dt0 = dt.Frame(src, stypes=[dt.int8, dt.int16, dt.int32, dt.int64])
     dt1 = dt0[:, [abs(f[i]) for i in range(4)]]
     dt1.internal.check()
-    assert dt1.topython() == [[abs(x) for x in col] for col in src]
+    assert dt1.to_list() == [[abs(x) for x in col] for col in src]
 
 
 
@@ -297,7 +297,7 @@ def test_exp_srcs(src):
                 pyans.append(exp(x))
             except OverflowError:
                 pyans.append(inf)
-    assert dt1.topython()[0] == pyans
+    assert dt1.to_list()[0] == pyans
 
 
 def test_exp_all_stypes():
@@ -322,7 +322,7 @@ def test_exp_all_stypes():
                 except OverflowError:
                     l.append(math.inf)
         pyans.append(l)
-    assert dt1.topython() == pyans
+    assert dt1.to_list() == pyans
 
 
 
@@ -337,7 +337,7 @@ def test_cast_to_float32(src):
     dt1.internal.check()
     assert dt1.stypes == (dt.float32,) * dt0.ncols
     pyans = [float(x) if x is not None else None for x in src]
-    assert list_equals(dt1.topython()[0], pyans)
+    assert list_equals(dt1.to_list()[0], pyans)
 
 
 @pytest.mark.parametrize("stype0", ltype.int.stypes)
@@ -349,8 +349,8 @@ def test_cast_int_to_str(stype0):
     assert dt1.stypes == (dt.str32, dt.str64)
     assert dt1.shape == (dt0.nrows, 2)
     ans = [None if v is None else str(v)
-           for v in dt0.topython()[0]]
-    assert dt1.topython()[0] == ans
+           for v in dt0.to_list()[0]]
+    assert dt1.to_list()[0] == ans
 
 
 @pytest.mark.parametrize("src", dt_bool + dt_int + dt_float + dt_obj)
@@ -368,7 +368,7 @@ def test_cast_to_str(src):
     dt2.internal.check()
     assert dt1.stypes == (dt.str32,) * dt0.ncols
     assert dt2.stypes == (dt.str64,) * dt0.ncols
-    assert dt1.topython()[0] == [to_str(x) for x in src]
+    assert dt1.to_list()[0] == [to_str(x) for x in src]
 
 
 def test_cast_view():
@@ -376,7 +376,7 @@ def test_cast_view():
     df1 = df0[::-1, :][:, dt.float32(f.A)]
     df1.internal.check()
     assert df1.stypes == (dt.float32,)
-    assert df1.topython() == [[3.0, 2.0, 1.0]]
+    assert df1.to_list() == [[3.0, 2.0, 1.0]]
 
 
 
@@ -392,8 +392,8 @@ def test_logical_and1():
 
     df0 = dt.Frame(A=src1, B=src2)
     df1 = df0[(f.A < 10) & (f.B == 1), [f.A, f.B]]
-    assert df1.topython() == [[src1[i] for i in ans],
-                              [src2[i] for i in ans]]
+    assert df1.to_list() == [[src1[i] for i in ans],
+                             [src2[i] for i in ans]]
 
 
 def test_logical_or1():
@@ -404,8 +404,8 @@ def test_logical_or1():
 
     df0 = dt.Frame(A=src1, B=src2)
     df1 = df0[(f.A < 10) | (f.B == 1), [f.A, f.B]]
-    assert df1.topython() == [[src1[i] for i in ans],
-                              [src2[i] for i in ans]]
+    assert df1.to_list() == [[src1[i] for i in ans],
+                             [src2[i] for i in ans]]
 
 
 @pytest.mark.parametrize("seed", [random.getrandbits(63)])
@@ -417,7 +417,7 @@ def test_logical_and2(seed):
 
     df0 = dt.Frame(A=src1, B=src2)
     df1 = df0[:, f.A & f.B]
-    assert df1.topython()[0] == \
+    assert df1.to_list()[0] == \
         [None if (src1[i] is None or src2[i] is None) else
          src1[i] and src2[i]
          for i in range(n)]
@@ -432,7 +432,7 @@ def test_logical_or2(seed):
 
     df0 = dt.Frame(A=src1, B=src2)
     df1 = df0[:, f.A | f.B]
-    assert df1.topython()[0] == \
+    assert df1.to_list()[0] == \
         [None if (src1[i] is None or src2[i] is None) else
          src1[i] or src2[i]
          for i in range(n)]
@@ -452,7 +452,7 @@ def test_div_mod(seed):
 
     df0 = dt.Frame(x=src1, y=src2)
     df1 = df0[:, [f.x // f.y, f.x % f.y]]
-    assert df1.topython() == [
+    assert df1.to_list() == [
         [None if src2[i] == 0 else src1[i] // src2[i] for i in range(n)],
         [None if src2[i] == 0 else src1[i] % src2[i] for i in range(n)]
     ]
@@ -475,7 +475,7 @@ def test_expr_reuse():
     df1.internal.check()
     assert df1.names == ("A", )
     assert df1.stypes == (stype.bool8, )
-    assert df1.topython() == [[True, False, False, False, False]]
+    assert df1.to_list() == [[True, False, False, False, False]]
     df2 = df1[:, expr]
     df2.internal.check()
-    assert df2.topython() == [[False, True, True, True, True]]
+    assert df2.to_list() == [[False, True, True, True, True]]

--- a/tests/test_dt_sort.py
+++ b/tests/test_dt_sort.py
@@ -29,30 +29,30 @@ def test_sort_len1():
     assert d0.shape == (1, 1)
     d1 = d0.sort(0)
     d1.internal.check()
-    assert d1.topython() == [[10**6]]
+    assert d1.to_list() == [[10**6]]
 
 
 def test_sort_len1_view():
     d0 = dt.Frame([range(10), range(10, 0, -1)])
     d1 = d0[6, :].sort(0)
-    assert d1.topython() == [[6], [4]]
+    assert d1.to_list() == [[6], [4]]
     d2 = d0[[7], :].sort(0)
-    assert d2.topython() == [[7], [3]]
+    assert d2.to_list() == [[7], [3]]
     d3 = d0[2:3, :].sort(0)
-    assert d3.topython() == [[2], [8]]
+    assert d3.to_list() == [[2], [8]]
     d4 = d0[4::2, :].sort(1, 0)
     assert d4.shape == (3, 2)
-    assert d4.topython() == [[8, 6, 4], [2, 4, 6]]
+    assert d4.to_list() == [[8, 6, 4], [2, 4, 6]]
 
 
 def test_sort_len2():
     d0 = dt.Frame([None, 10000000])
     d1 = d0.sort(0)
     d1.internal.check()
-    assert d1.topython() == [[None, 10000000]]
+    assert d1.to_list() == [[None, 10000000]]
     d0 = dt.Frame([10000000, None])
     d2 = d0.sort(0)
-    assert d1.topython() == d2.topython()
+    assert d1.to_list() == d2.to_list()
 
 
 def test_sort_with_engine():
@@ -62,7 +62,7 @@ def test_sort_with_engine():
     d1.internal.check()
     d2.internal.check()
     assert d1.shape == d2.shape == d0.shape
-    assert d1.topython() == d2.topython() == [sorted(d0.topython()[0])]
+    assert d1.to_list() == d2.to_list() == [sorted(d0.to_list()[0])]
 
 
 def test_nonfirst_column():
@@ -76,7 +76,7 @@ def test_nonfirst_column():
     assert d1.internal.isview
     assert d0.shape == d1.shape == (100, 2)
     assert d0.names == d1.names == ("A", "B")
-    a0, a1 = d1.topython()
+    a0, a1 = d1.to_list()
     assert sorted(a0) == list(range(100))
     assert a0 != list(range(100))
     assert a1 == sorted(a1)
@@ -94,7 +94,7 @@ def test_int32_small():
     assert d1.stypes == d0.stypes
     assert d1.internal.isview
     d1.internal.check()
-    assert d1.topython() == [[None, -45, 1, 2, 17, 34, 96, 245, 847569]]
+    assert d1.to_list() == [[None, -45, 1, 2, 17, 34, 96, 245, 847569]]
 
 
 def test_int32_small_stable():
@@ -104,7 +104,7 @@ def test_int32_small_stable():
     ], names=["A", "B"])
     d1 = d0.sort("A")
     d1.internal.check()
-    assert d1.topython() == [
+    assert d1.to_list() == [
         [None, None, None, 3, 3, 5, 5, 1000000],
         [20, 100, 500, 5, 200, 1, 10, 50],
     ]
@@ -120,7 +120,7 @@ def test_int32_large():
     d0 = dt.Frame(src)
     assert d0.stypes == (stype.int32, )
     d1 = d0.sort(0)
-    assert d1.topython() == [list(range(p1))]
+    assert d1.to_list() == [list(range(p1))]
 
 
 @pytest.mark.parametrize("n", [30, 300, 3000, 30000, 60000, 120000])
@@ -129,9 +129,9 @@ def test_int32_large_stable(n):
     d0 = dt.Frame([src, range(n)], names=["A", "B"])
     assert d0.stypes[0] == stype.int32
     d1 = d0(sort="A", select="B")
-    assert d1.topython() == [list(range(0, n, 3)) +
-                             list(range(1, n, 3)) +
-                             list(range(2, n, 3))]
+    assert d1.to_list() == [list(range(0, n, 3)) +
+                            list(range(1, n, 3)) +
+                            list(range(2, n, 3))]
 
 
 @pytest.mark.parametrize("n", [5, 100, 500, 2500, 32767, 32768, 32769, 200000])
@@ -141,7 +141,7 @@ def test_int32_constant(n):
     assert d0.stypes[0] == stype.int32
     d1 = d0.sort(0)
     assert d1.stypes == d0.stypes
-    assert d1.topython() == tbl0
+    assert d1.to_list() == tbl0
 
 
 def test_int32_reverse():
@@ -150,7 +150,7 @@ def test_int32_reverse():
     assert d0.stypes[0] == stype.int32
     d1 = d0.sort(0)
     assert d1.stypes == d0.stypes
-    assert d1.topython() == [list(range(step, 1000000 + step, step))]
+    assert d1.to_list() == [list(range(step, 1000000 + step, step))]
 
 
 @pytest.mark.parametrize("b", [32767, 1000000])
@@ -161,7 +161,7 @@ def test_int32_upper_range(b):
     d0 = dt.Frame([b, b - 1, b + 1] * 1000)
     assert d0.stypes[0] == stype.int32
     d1 = d0.sort(0)
-    assert d1.topython() == [[b - 1] * 1000 + [b] * 1000 + [b + 1] * 1000]
+    assert d1.to_list() == [[b - 1] * 1000 + [b] * 1000 + [b + 1] * 1000]
 
 
 @pytest.mark.parametrize("dc", [32765, 32766, 32767, 32768,
@@ -175,7 +175,7 @@ def test_int32_u2range(dc):
     d0 = dt.Frame([c, b, a] * 1000)
     assert d0.stypes[0] == stype.int32
     d1 = d0.sort(0)
-    assert d1.topython() == [[a] * 1000 + [b] * 1000 + [c] * 1000]
+    assert d1.to_list() == [[a] * 1000 + [b] * 1000 + [c] * 1000]
 
 
 def test_int32_unsigned():
@@ -190,13 +190,13 @@ def test_int32_unsigned():
     assert d0.stypes == (stype.int32, )
     d1 = d0.sort(0)
     d1.internal.check()
-    assert d1.topython() == [tbl]
+    assert d1.to_list() == [tbl]
 
 
 def test_int32_issue220():
     d0 = dt.Frame([None] + [1000000] * 200 + [None])
     d1 = d0.sort(0)
-    assert d1.topython() == [[None, None] + [1000000] * 200]
+    assert d1.to_list() == [[None, None] + [1000000] * 200]
 
 
 
@@ -209,7 +209,7 @@ def test_int8_small():
     assert d1.stypes == d0.stypes
     assert d1.internal.isview
     d1.internal.check()
-    assert d1.topython() == [[None, -45, 1, 2, 17, 34, 45, 69, 75, 84, 96]]
+    assert d1.to_list() == [[None, -45, 1, 2, 17, 34, 45, 69, 75, 84, 96]]
 
 
 def test_int8_small_stable():
@@ -219,7 +219,7 @@ def test_int8_small_stable():
     ], names=["A", "B"])
     d1 = d0(sort="A")
     d1.internal.check()
-    assert d1.topython() == [
+    assert d1.to_list() == [
         [None, None, None, 3, 3, 5, 5, 100],
         [20, 100, 500, 5, 200, 1, 10, 50],
     ]
@@ -230,7 +230,7 @@ def test_int8_large():
     d1 = d0.sort(0)
     assert d1.stypes == (stype.int8, )
     d1.internal.check()
-    assert d1.topython() == [sum(([i] * 10 for i in range(-50, 51)), [])]
+    assert d1.to_list() == [sum(([i] * 10 for i in range(-50, 51)), [])]
 
 
 @pytest.mark.parametrize("n", [30, 303, 3333, 30000, 60009, 120000])
@@ -239,7 +239,7 @@ def test_int8_large_stable(n):
     d0 = dt.Frame([src, range(n)], names=("A", "B"))
     assert d0.stypes[0] == stype.int8
     d1 = d0(sort="A", select="B")
-    assert d1.topython() == [list(range(0, n, 3)) +
+    assert d1.to_list() == [list(range(0, n, 3)) +
                              list(range(2, n, 3)) +
                              list(range(1, n, 3))]
 
@@ -254,7 +254,7 @@ def test_bool8_small():
     assert d1.stypes == d0.stypes
     assert d1.internal.isview
     d1.internal.check()
-    assert d1.topython() == [[None, None, False, False, True, True, True]]
+    assert d1.to_list() == [[None, None, False, False, True, True, True]]
 
 
 def test_bool8_small_stable():
@@ -266,8 +266,8 @@ def test_bool8_small_stable():
     assert d1.names == d0.names
     assert d1.internal.isview
     d1.internal.check()
-    assert d1.topython() == [[None, None, False, False, True, True, True],
-                             [4, 7, 2, 3, 1, 5, 6]]
+    assert d1.to_list() == [[None, None, False, False, True, True, True],
+                            [4, 7, 2, 3, 1, 5, 6]]
 
 
 @pytest.mark.parametrize("n", [100, 512, 1000, 5000, 100000])
@@ -281,7 +281,7 @@ def test_bool8_large(n):
     d0.internal.check()
     d1.internal.check()
     nn = 2 * n
-    assert d1.topython() == [[None] * nn + [False] * nn + [True] * nn]
+    assert d1.to_list() == [[None] * nn + [False] * nn + [True] * nn]
 
 
 @pytest.mark.parametrize("n", [254, 255, 256, 257, 258, 1000, 10000])
@@ -291,9 +291,9 @@ def test_bool8_large_stable(n):
     d1 = d0(sort="A", select="B")
     assert d1.internal.isview
     d1.internal.check()
-    assert d1.topython() == [list(range(2, 3 * n, 3)) +
-                             list(range(1, 3 * n, 3)) +
-                             list(range(0, 3 * n, 3))]
+    assert d1.to_list() == [list(range(2, 3 * n, 3)) +
+                            list(range(1, 3 * n, 3)) +
+                            list(range(0, 3 * n, 3))]
 
 
 
@@ -304,7 +304,7 @@ def test_int16_small():
     assert d0.stypes[0] == stype.int16
     d1 = d0.sort(0)
     d1.internal.check()
-    assert d1.topython() == [[None, -1000, -10, 0, 2, 100, 999, 10000]]
+    assert d1.to_list() == [[None, -1000, -10, 0, 2, 100, 999, 10000]]
 
 
 def test_int16_small_stable():
@@ -313,8 +313,8 @@ def test_int16_small_stable():
     assert d0.stypes[0] == stype.int16
     d1 = d0.sort(0)
     d1.internal.check()
-    assert d1.topython() == [[0, 0, 0, 0, 0, 0, 1000, 1000, 1000],
-                             [1, 3, 4, 6, 7, 9, 2, 5, 8]]
+    assert d1.to_list() == [[0, 0, 0, 0, 0, 0, 1000, 1000, 1000],
+                            [1, 3, 4, 6, 7, 9, 2, 5, 8]]
 
 
 def test_int16_large():
@@ -322,7 +322,7 @@ def test_int16_large():
     d1 = d0.sort(0)
     assert d1.stypes == (stype.int16, )
     d1.internal.check()
-    assert d1.topython() == [list(range(-5003, 5004))]
+    assert d1.to_list() == [list(range(-5003, 5004))]
 
 
 @pytest.mark.parametrize("n", [100, 150, 200, 500, 1000, 200000])
@@ -332,11 +332,11 @@ def test_int16_large_stable(n):
     assert d0.stypes[0] == stype.int16
     d1 = d0(sort="A", select="B")
     d1.internal.check()
-    assert d1.topython() == [list(range(1, 5 * n, 5)) +
-                             list(range(3, 5 * n, 5)) +
-                             list(range(0, 5 * n, 5)) +
-                             list(range(2, 5 * n, 5)) +
-                             list(range(4, 5 * n, 5))]
+    assert d1.to_list() == [list(range(1, 5 * n, 5)) +
+                            list(range(3, 5 * n, 5)) +
+                            list(range(0, 5 * n, 5)) +
+                            list(range(2, 5 * n, 5)) +
+                            list(range(4, 5 * n, 5))]
 
 
 
@@ -348,7 +348,7 @@ def test_int64_small():
     d1 = d0.sort(0)
     assert d1.stypes == d0.stypes
     d1.internal.check()
-    assert d1.topython() == [[None] + [10**i for i in range(13)]]
+    assert d1.to_list() == [[None] + [10**i for i in range(13)]]
 
 
 def test_int64_small_stable():
@@ -356,7 +356,7 @@ def test_int64_small_stable():
     assert d0.stypes == (stype.int64, stype.int32)
     d1 = d0(sort=0, select=1)
     d1.internal.check()
-    assert d1.topython() == [[1, 5, 9, 2, 6, 10, 0, 4, 8, 3, 7, 11]]
+    assert d1.to_list() == [[1, 5, 9, 2, 6, 10, 0, 4, 8, 3, 7, 11]]
 
 
 @pytest.mark.parametrize("n", [16, 20, 30, 40, 50, 100, 500, 1000])
@@ -371,8 +371,8 @@ def test_int64_large0(n):
     d1.internal.check()
     assert d1.internal.isview
     assert b < a < d < c
-    assert d0.topython() == [[c, d, a, b] * n]
-    assert d1.topython() == [[b] * n + [a] * n + [d] * n + [c] * n]
+    assert d0.to_list() == [[c, d, a, b] * n]
+    assert d1.to_list() == [[b] * n + [a] * n + [d] * n + [c] * n]
 
 
 @pytest.mark.parametrize("seed", [random.getrandbits(63) for i in range(10)])
@@ -383,7 +383,7 @@ def test_int64_large_random(seed):
     d0 = dt.Frame(tbl)
     assert d0.stypes == (stype.int64, )
     d1 = d0.sort(0)
-    assert d1.topython() == [sorted(tbl)]
+    assert d1.to_list() == [sorted(tbl)]
 
 
 
@@ -396,7 +396,7 @@ def test_float32_small():
     assert d0.stypes == (stype.float32, )
     d1 = d0.sort(0)
     dr = dt.Frame([None, -inf, -5, 0, .1, .2, .4, .9, 3, 5.2, 11, inf])
-    assert list_equals(d1.topython(), dr.topython())
+    assert list_equals(d1.to_list(), dr.to_list())
 
 
 def test_float32_nans():
@@ -404,7 +404,7 @@ def test_float32_nans():
     d0 = dt.Frame([nan, 0.5, nan, nan, -3, nan, 0.2, nan, nan, 1],
                   stype="float32")
     d1 = d0.sort(0)
-    assert list_equals(d1.topython(),
+    assert list_equals(d1.to_list(),
                        [[None, None, None, None, None, None, -3, 0.2, 0.5, 1]])
 
 
@@ -415,7 +415,7 @@ def test_float32_large():
     d1.internal.check()
     dr = dt.Frame([-1000] * 100 + [0] * 100 + [7.2] * 100 +
                   [1.5e10] * 100 + [math.inf] * 100)
-    assert list_equals(d1.topython(), dr.topython())
+    assert list_equals(d1.to_list(), dr.to_list())
 
 
 @pytest.mark.parametrize("n", [15, 16, 17, 20, 50, 100, 1000, 100000])
@@ -424,7 +424,7 @@ def test_float32_random(numpy, n):
     d0 = dt.Frame(a)
     assert d0.stypes == (stype.float32, )
     d1 = d0.sort(0)
-    assert list_equals(d1.topython()[0], sorted(a.tolist()))
+    assert list_equals(d1.to_list()[0], sorted(a.tolist()))
 
 
 
@@ -437,7 +437,7 @@ def test_float64_small():
     d1 = d0.sort(0)
     d1.internal.check()
     dr = dt.Frame([None, -inf, -0.5, 0, 0.1, 1.6, 3.3, 1e100, inf])
-    assert list_equals(d1.topython(), dr.topython())
+    assert list_equals(d1.to_list(), dr.to_list())
 
 
 def test_float64_zeros():
@@ -447,7 +447,7 @@ def test_float64_zeros():
     d1 = d0.sort(0)
     d1.internal.check()
     dr = dt.Frame([-z] * 100 + [z] * 100 + [0.5])
-    assert str(d1.topython()) == str(dr.topython())
+    assert str(d1.to_list()) == str(dr.to_list())
 
 
 @pytest.mark.parametrize("n", [20, 100, 500, 2500, 20000])
@@ -459,7 +459,7 @@ def test_float64_large(n):
     d1.internal.check()
     dr = dt.Frame([None] * n + [-inf] * n + [-5.1] * n +
                   [0] * n + [.3] * n + [12.6] * n + [inf] * n)
-    assert list_equals(d1.topython(), dr.topython())
+    assert list_equals(d1.to_list(), dr.to_list())
 
 
 @pytest.mark.parametrize("n", [15, 16, 17, 20, 50, 100, 1000, 100000])
@@ -468,7 +468,7 @@ def test_float64_random(numpy, n):
     d0 = dt.Frame(a)
     assert d0.stypes == (stype.float64, )
     d1 = d0.sort(0)
-    assert list_equals(d1.topython()[0], sorted(a.tolist()))
+    assert list_equals(d1.to_list()[0], sorted(a.tolist()))
 
 
 
@@ -486,7 +486,7 @@ def test_sort_view1():
     assert d2.shape == d1.shape
     d2.internal.check()
     assert d2.internal.isview
-    assert d2.topython() == [[5] * 5 + [10] * 5]
+    assert d2.to_list() == [[5] * 5 + [10] * 5]
 
 
 def test_sort_view2():
@@ -494,7 +494,7 @@ def test_sort_view2():
     d1 = d0.sort(0)
     d2 = d1(sort=0)
     d2.internal.check()
-    assert d2.topython() == d1.topython()
+    assert d2.to_list() == d1.to_list()
 
 
 def test_sort_view3():
@@ -503,7 +503,7 @@ def test_sort_view3():
     d2 = d1(sort=0)
     d2.internal.check()
     assert d2.shape == (200, 1)
-    assert d2.topython() == [list(range(4, 1000, 5))]
+    assert d2.to_list() == [list(range(4, 1000, 5))]
 
 
 def test_sort_view4():
@@ -514,15 +514,15 @@ def test_sort_view4():
     d1.internal.check()
     d2.internal.check()
     assert d1.shape == d2.shape == (5, 1)
-    assert d1.topython() == [[None, "bar", "lalala", "nay", "rem"]]
-    assert d2.topython() == [["", "aye", "baz", "foo", "quo"]]
+    assert d1.to_list() == [[None, "bar", "lalala", "nay", "rem"]]
+    assert d2.to_list() == [["", "aye", "baz", "foo", "quo"]]
 
 
 def test_sort_view_large_strs():
     d0 = dt.Frame(list("abcbpeiuqenvkjqperufhqperofin;d") * 100)
     d1 = d0[:, ::2].sort(0)
     d1.internal.check()
-    elems = d1.topython()[0]
+    elems = d1.to_list()[0]
     assert elems == sorted(elems)
 
 
@@ -561,13 +561,13 @@ def test_sort_view_all_stypes(st):
     src = [fn() for _ in range(n)]
     d0 = dt.Frame(src, stype=st)
     if st in (stype.int8, stype.int16, stype.float32):
-        src = d0.topython()[0]
+        src = d0.to_list()[0]
     d1 = d0[::3, :].sort(0)
     d0.internal.check()
     d1.internal.check()
     assert d1.shape == ((n + 2) // 3, 1)
     assert d1.stypes == (st, )
-    assert d1.topython()[0] == sorted(src[::3], key=sortkey)
+    assert d1.to_list()[0] == sorted(src[::3], key=sortkey)
 
 
 
@@ -590,7 +590,7 @@ def test_strXX_small1(st):
     assert d0.stypes == (st, )
     d1 = d0.sort(0)
     d1.internal.check()
-    assert d1.topython() == [sorted(src)]
+    assert d1.to_list() == [sorted(src)]
 
 
 @pytest.mark.parametrize("st", [dt.str32, dt.str64])
@@ -601,7 +601,7 @@ def test_strXX_small2(st):
     d1 = d0.sort(0)
     d1.internal.check()
     src.remove(None)
-    assert d1.topython() == [[None] + sorted(src)]
+    assert d1.to_list() == [[None] + sorted(src)]
 
 
 @pytest.mark.parametrize("st", [dt.str32, dt.str64])
@@ -612,7 +612,7 @@ def test_strXX_large1(st):
     assert d0.stypes == (st, )
     d1 = d0.sort(0)
     d1.internal.check()
-    assert d1.topython() == [sorted(src)]
+    assert d1.to_list() == [sorted(src)]
 
 
 @pytest.mark.parametrize("st", [dt.str32, dt.str64])
@@ -622,7 +622,7 @@ def test_strXX_large2(st):
     assert d0.stypes == (st, )
     d1 = d0.sort(0)
     d1.internal.check()
-    assert d1.topython() == [sorted(src)]
+    assert d1.to_list() == [sorted(src)]
 
 
 @pytest.mark.parametrize("st", [dt.str32, dt.str64])
@@ -632,7 +632,7 @@ def test_strXX_large3(st):
     assert d0.stypes == (st, )
     d1 = d0.sort(0)
     d1.internal.check()
-    assert d1.topython() == [sorted(src)]
+    assert d1.to_list() == [sorted(src)]
 
 
 @pytest.mark.parametrize("st", [dt.str32, dt.str64])
@@ -644,7 +644,7 @@ def test_strXX_large4(st):
     assert d0.stypes == (st, )
     d1 = d0.sort(0)
     d1.internal.check()
-    assert d1.topython() == [sorted(src)]
+    assert d1.to_list() == [sorted(src)]
 
 
 @pytest.mark.parametrize("st", [dt.str32, dt.str64])
@@ -657,7 +657,7 @@ def test_strXX_large5(st):
     assert dt0.stypes == (st, )
     dt1 = dt0(sort=0)
     dt1.internal.check()
-    assert dt1.topython()[0] == sorted(src)
+    assert dt1.to_list()[0] == sorted(src)
 
 
 @pytest.mark.parametrize("st", [dt.str32, dt.str64])
@@ -674,7 +674,7 @@ def test_strXX_large6(st):
     assert dt0.stypes == (st, )
     dt1 = dt0(sort=0)
     dt1.internal.check()
-    assert dt1.topython()[0] == sorted(words)
+    assert dt1.to_list()[0] == sorted(words)
 
 
 
@@ -698,7 +698,7 @@ def test_sort_len1_multi():
     d1.internal.check()
     assert d1.shape == (1, 3)
     assert d1.names == d0.names
-    assert d1.topython() == d0.topython()
+    assert d1.to_list() == d0.to_list()
 
 
 def test_int32_small_multi():
@@ -711,8 +711,8 @@ def test_int32_small_multi():
     order = sorted(range(len(src[0])), key=lambda i: (src[0][i], src[1][i]))
     d1.internal.check()
     assert d1.names == d0.names
-    assert d1.topython() == [[src[0][i] for i in order],
-                             [src[1][i] for i in order]]
+    assert d1.to_list() == [[src[0][i] for i in order],
+                            [src[1][i] for i in order]]
 
 
 @pytest.mark.parametrize("seed", [random.getrandbits(32)])
@@ -725,9 +725,9 @@ def test_bool8_2cols_multi(seed):
     n11 = sum(data[1][i] for i in range(n) if data[0][i] is True)
     d0 = dt.Frame(data)
     d1 = d0.sort(0, 1)
-    assert d1.topython() == [[False] * (n - n0) + [True] * n0,
-                             [False] * (n - n0 - n10) + [True] * n10 +
-                             [False] * (n0 - n11) + [True] * n11]
+    assert d1.to_list() == [[False] * (n - n0) + [True] * n0,
+                            [False] * (n - n0 - n10) + [True] * n10 +
+                            [False] * (n0 - n11) + [True] * n11]
 
 
 @pytest.mark.parametrize("seed", [random.getrandbits(32)])
@@ -754,7 +754,7 @@ def test_multisort_bool_real(seed):
     d1 = d0.sort(0, 1)
     d1.internal.check()
     n0 = sum(col0)
-    assert d1.topython() == [
+    assert d1.to_list() == [
         [False] * (n - n0) + [True] * n0,
         sorted([col1[i] for i in range(n) if col0[i] is False]) +
         sorted([col1[i] for i in range(n) if col0[i] is True])]
@@ -790,7 +790,7 @@ def test_sort_random_multi(seed):
     # d0.save("multi.jay", format="jay")
     # dt.Frame(sorted_data).save("test.jay", format="jay")
     d1 = d0.sort("B", "C", "D")
-    assert d1.topython() == sorted_data
+    assert d1.to_list() == sorted_data
 
 
 

--- a/tests/test_dt_sort.py
+++ b/tests/test_dt_sort.py
@@ -240,8 +240,8 @@ def test_int8_large_stable(n):
     assert d0.stypes[0] == stype.int8
     d1 = d0(sort="A", select="B")
     assert d1.to_list() == [list(range(0, n, 3)) +
-                             list(range(2, n, 3)) +
-                             list(range(1, n, 3))]
+                            list(range(2, n, 3)) +
+                            list(range(1, n, 3))]
 
 
 

--- a/tests/test_dt_stats.py
+++ b/tests/test_dt_stats.py
@@ -64,7 +64,7 @@ def test_min(src):
     assert dtr.names == dt0.names
     assert dtr.stypes == dt0.stypes
     assert dtr.shape == (1, 1)
-    assert dtr.topython() == [[t_min(src)]]
+    assert dtr.to_list() == [[t_min(src)]]
     assert dtr.scalar() == dt0.min1()
 
 
@@ -72,7 +72,7 @@ def test_dt_str():
     dt0 = dt.Frame([[1, 5, 3, 9, -2], list("abcde")])
     dtr = dt0.min()
     dtr.internal.check()
-    assert dtr.topython() == [[-2], [None]]
+    assert dtr.to_list() == [[-2], [None]]
 
 
 
@@ -96,7 +96,7 @@ def test_max(src):
     assert dtr.names == dt0.names
     assert dtr.stypes == dt0.stypes
     assert dtr.shape == (1, 1)
-    assert dtr.topython() == [[t_max(src)]]
+    assert dtr.to_list() == [[t_max(src)]]
     assert dtr.scalar() == dt0.max1()
 
 
@@ -125,7 +125,7 @@ def test_sum(src):
     assert dtr.stypes == (sum_stype(dt0.stypes[0]), )
     assert dtr.shape == (1, dt0.ncols)
     assert dt0.names == dtr.names
-    assert list_equals(dtr.topython(), [[t_sum(src)]])
+    assert list_equals(dtr.to_list(), [[t_sum(src)]])
     assert list_equals([dtr.scalar()], [dt0.sum1()])
 
 
@@ -149,7 +149,7 @@ def test_dt_mean(src):
     assert dt0.names == dtr.names
     assert dtr.stypes == (stype.float64,)
     assert dtr.shape == (1, 1)
-    assert list_equals(dtr.topython(), [[t_mean(src)]])
+    assert list_equals(dtr.to_list(), [[t_mean(src)]])
     assert list_equals([dtr.scalar()], [dt0.mean1()])
 
 
@@ -173,7 +173,7 @@ def test_dt_mean_special_cases(src, res):
     assert dt0.names == dtr.names
     assert dtr.stypes == (stype.float64,)
     assert dtr.shape == (1, 1)
-    assert list_equals(dtr.topython(), [[res]])
+    assert list_equals(dtr.to_list(), [[res]])
 
 
 
@@ -200,7 +200,7 @@ def test_dt_sd(src):
     assert dtr.stypes == (stype.float64, )
     assert dtr.shape == (1, 1)
     assert dt0.names == dtr.names
-    assert list_equals(dtr.topython(), [[t_sd(src)]])
+    assert list_equals(dtr.to_list(), [[t_sd(src)]])
     assert list_equals([dtr.scalar()], [dt0.sd1()])
 
 
@@ -218,7 +218,7 @@ def test_dt_sd_special_cases(src, res):
     assert dtr.stypes == (stype.float64, )
     assert dtr.shape == (1, 1)
     assert dt0.names == dtr.names
-    assert list_equals(dtr.topython(), [[res]])
+    assert list_equals(dtr.to_list(), [[res]])
 
 
 
@@ -244,7 +244,7 @@ def test_dt_count_na(src):
     assert dtr.stypes == (stype.int64, )
     assert dtr.shape == (1, 1)
     assert dt0.names == dtr.names
-    assert dtr.topython() == [[ans]]
+    assert dtr.to_list() == [[ans]]
     assert dtr.scalar() == dt0.countna1()
 
 
@@ -427,34 +427,34 @@ def test_stats_bool_large(numpy):
     n = 12345678
     a = numpy.random.randint(2, size=n, dtype=numpy.bool8)
     dt0 = dt.Frame(a)
-    assert dt0.sum().topython() == [[a.sum()]]
-    assert dt0.countna().topython() == [[0]]
-    assert list_equals(dt0.mean().topython(), [[a.mean()]])
-    assert list_equals(dt0.sd().topython(), [[a.std(ddof=1)]])
+    assert dt0.sum().to_list() == [[a.sum()]]
+    assert dt0.countna().to_list() == [[0]]
+    assert list_equals(dt0.mean().to_list(), [[a.mean()]])
+    assert list_equals(dt0.sd().to_list(), [[a.std(ddof=1)]])
 
 
 def test_stats_int_large(numpy):
     n = 12345678
     a = numpy.random.randint(2**20, size=n, dtype=numpy.int32)
     dt0 = dt.Frame(a)
-    assert dt0.min().topython() == [[a.min()]]
-    assert dt0.max().topython() == [[a.max()]]
-    assert dt0.sum().topython() == [[a.sum()]]
-    assert dt0.countna().topython() == [[0]]
-    assert list_equals(dt0.mean().topython(), [[a.mean()]])
-    assert list_equals(dt0.sd().topython(), [[a.std(ddof=1)]])
+    assert dt0.min().to_list() == [[a.min()]]
+    assert dt0.max().to_list() == [[a.max()]]
+    assert dt0.sum().to_list() == [[a.sum()]]
+    assert dt0.countna().to_list() == [[0]]
+    assert list_equals(dt0.mean().to_list(), [[a.mean()]])
+    assert list_equals(dt0.sd().to_list(), [[a.std(ddof=1)]])
 
 
 def test_stats_float_large(numpy):
     n = 12345678
     a = numpy.random.random(size=n) * 1e6
     dt0 = dt.Frame(a)
-    assert dt0.min().topython() == [[a.min()]]
-    assert dt0.max().topython() == [[a.max()]]
-    assert dt0.countna().topython() == [[0]]
-    assert list_equals(dt0.sum().topython(), [[a.sum()]])
-    assert list_equals(dt0.mean().topython(), [[a.mean()]])
-    assert list_equals(dt0.sd().topython(), [[a.std(ddof=1)]])
+    assert dt0.min().to_list() == [[a.min()]]
+    assert dt0.max().to_list() == [[a.max()]]
+    assert dt0.countna().to_list() == [[0]]
+    assert list_equals(dt0.sum().to_list(), [[a.sum()]])
+    assert list_equals(dt0.mean().to_list(), [[a.mean()]])
+    assert list_equals(dt0.sd().to_list(), [[a.std(ddof=1)]])
 
 
 @pytest.mark.parametrize("seed", [random.getrandbits(32)])

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -35,24 +35,24 @@ def test_groups_internal2():
     gb = d1.internal.groupby
     assert gb.ngroups == 5
     assert gb.group_sizes == [1, 4, 1, 2, 1]
-    assert d1.topython() == [[None, 1, 1, 1, 1, 2, 3, 3, 5],
-                             ["d", "a", None, "b", "h", "a", "c", "f", "b"]]
+    assert d1.to_list() == [[None, 1, 1, 1, 1, 2, 3, 3, 5],
+                            ["d", "a", None, "b", "h", "a", "c", "f", "b"]]
     d2 = d0(groupby="B")
     d2.internal.check()
     gb = d2.internal.groupby
     assert gb.ngroups == 7
     assert gb.group_sizes == [1, 2, 2, 1, 1, 1, 1]
-    assert d2.topython() == [[1, 1, 2, 5, 1, 3, None, 3, 1],
-                             [None, "a", "a", "b", "b", "c", "d", "f", "h"]]
+    assert d2.to_list() == [[1, 1, 2, 5, 1, 3, None, 3, 1],
+                            [None, "a", "a", "b", "b", "c", "d", "f", "h"]]
 
 
 def test_groups_internal3():
     f0 = dt.Frame(A=[1, 2, 1, 3, 2, 2, 2, 1, 3, 1], B=range(10))
     f1 = f0(select=["B", f.A + f.B], groupby="A")
     f1.internal.check()
-    assert f1.topython() == [[1, 1, 1, 1, 2, 2, 2, 2, 3, 3],
-                             [0, 2, 7, 9, 1, 4, 5, 6, 3, 8],
-                             [1, 3, 8, 10, 3, 6, 7, 8, 6, 11]]
+    assert f1.to_list() == [[1, 1, 1, 1, 2, 2, 2, 2, 3, 3],
+                            [0, 2, 7, 9, 1, 4, 5, 6, 3, 8],
+                            [1, 3, 8, 10, 3, 6, 7, 8, 6, 11]]
     gb = f1.internal.groupby
     assert gb
     assert gb.ngroups == 3
@@ -93,7 +93,7 @@ def test_groups_internal5_strs(seed):
     assert gb
     grp_offsets = gb.group_offsets
     ssrc = sorted(src)
-    assert f1.topython() == [ssrc]
+    assert f1.to_list() == [ssrc]
     x_prev = None
     for i in range(gb.ngroups):
         s = set(ssrc[grp_offsets[i]:grp_offsets[i + 1]])
@@ -113,10 +113,10 @@ def test_groups1():
                    "B": [0, 1, 2, 3, 4, 5, 6, 7]})
     f1 = f0(select=mean(f.B), groupby=f.A)
     assert f1.stypes == (dt.int8, dt.float64,)
-    assert f1.topython() == [[1, 2, 3], [3.8, 2.0, 5.0]]
+    assert f1.to_list() == [[1, 2, 3], [3.8, 2.0, 5.0]]
     f2 = f0[:, mean(f.B), "A"]
     assert f2.stypes == f1.stypes
-    assert f2.topython() == f1.topython()
+    assert f2.to_list() == f1.to_list()
 
 
 def test_groups_multiple():
@@ -124,7 +124,7 @@ def test_groups_multiple():
                    "size": [5, 2, 7, 13, 0]})
     f1 = f0[:, [min(f.size), max(f.size)], "color"]
     f1.internal.check()
-    assert f1.topython() == [["blue", "green", "red"], [2, 0, 5], [2, 7, 13]]
+    assert f1.to_list() == [["blue", "green", "red"], [2, 0, 5], [2, 7, 13]]
 
 
 def test_groups_autoexpand():
@@ -132,15 +132,15 @@ def test_groups_autoexpand():
                    "size": [5, 2, 7, 13, 0]})
     f1 = f0[:, [mean(f.size), "size"], f.color]
     f1.internal.check()
-    assert f1.topython() == [["blue", "green", "green", "red", "red"],
-                             [2.0, 3.5, 3.5, 9.0, 9.0],
-                             [2, 7, 0, 5, 13]]
+    assert f1.to_list() == [["blue", "green", "green", "red", "red"],
+                            [2.0, 3.5, 3.5, 9.0, 9.0],
+                            [2, 7, 0, 5, 13]]
 
 
 def test_groupby_with_filter1():
     f0 = dt.Frame({"KEY": [1, 2, 1, 2, 1, 2], "X": [-10, 2, 3, 0, 1, -7]})
     f1 = f0[f.X > 0, sum(f.X), f.KEY]
-    assert f1.topython() == [[1, 2], [4, 2]]
+    assert f1.to_list() == [[1, 2], [4, 2]]
 
 
 def test_groupby_with_filter2():
@@ -154,7 +154,7 @@ def test_groupby_with_filter2():
     answer = [sum(src1[i] for i in range(n)
                   if src0[i] == key and 0 <= src1[i] <= 2)
               for key in range(4)]
-    assert f2.topython() == [[0, 1, 2, 3], answer]
+    assert f2.to_list() == [[0, 1, 2, 3], answer]
 
 
 
@@ -168,8 +168,8 @@ def test_reduce_sum():
                    "size": [5, 2, 7, 13, -1]})
     f1 = f0[:, sum(f.size), f.color]
     f1.internal.check()
-    assert f1.topython() == [["blue", "green", "red"],
-                             [2, 6, 18]]
+    assert f1.to_list() == [["blue", "green", "red"],
+                            [2, 6, 18]]
 
 
 
@@ -228,9 +228,9 @@ def test_groupby_large_random_integers(seed):
 def test_groupby_multi():
     DT = dt.Frame(A=[1, 2, 3] * 3, B=[1, 2] * 4 + [1], C=range(9))
     res = DT[:, sum(f.C), by("A", "B")]
-    assert res.topython() == [[1, 1, 2, 2, 3, 3],
-                              [1, 2, 1, 2, 1, 2],
-                              [6, 3, 4, 8, 10, 5]]
+    assert res.to_list() == [[1, 1, 2, 2, 3, 3],
+                             [1, 2, 1, 2, 1, 2],
+                             [6, 3, 4, 8, 10, 5]]
 
 
 @pytest.mark.parametrize("seed", [random.getrandbits(32)])
@@ -258,4 +258,4 @@ def test_groupby_multi_large(seed):
     DT0 = dt.Frame([col0, col1, col2, col3], names=["A", "B", "C", "D"])
     DT1 = DT0[:, sum(f.D), by(f.A, f.B, f.C)]
     DT2 = dt.Frame(grouped)
-    assert same_iterables(DT1.topython(), DT2.topython())
+    assert same_iterables(DT1.to_list(), DT2.to_list())

--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -38,7 +38,7 @@ def test_join_simple():
     res.internal.check()
     assert res.shape == (7, 3)
     assert res.names == ("A", "B", "V")
-    assert res.topython() == [
+    assert res.to_list() == [
         [1, 3, 2, 1, 1, 2, 0],
         ["a", "b", "c", "d", "e", "f", "g"],
         ["one", "three", "two", "one", "one", "two", "zero"]]
@@ -52,7 +52,7 @@ def test_join_strings():
     res.internal.check()
     assert res.shape == (7, 3)
     assert res.names == ("A", "B", "V")
-    assert res.topython() == [
+    assert res.to_list() == [
         [1, 3, 2, 1, 1, 2, 0],
         ["c", "a", "b", "d", "a", "b", "b"],
         [10, 0, 5, 15, 0, 5, 5]]
@@ -64,7 +64,7 @@ def test_join_missing_levels():
     d1.key = "A"
     res = d0[:, :, join(d1)]
     res.internal.check()
-    assert res.topython() == [[1, 2, 3], [True, False, None]]
+    assert res.to_list() == [[1, 2, 3], [True, False, None]]
 
 
 def test_join_errors():
@@ -103,7 +103,7 @@ def test_join_random(seed, lt):
     elif lt == ltype.real:
         keys = [random.random() for _ in range(nkeys)]
         if st == stype.float32:
-            keys = list(set(dt.Frame(keys, stype=st).topython()[0]))
+            keys = list(set(dt.Frame(keys, stype=st).to_list()[0]))
         else:
             keys = list(set(keys))
     else:
@@ -113,7 +113,7 @@ def test_join_random(seed, lt):
 
     dkey = dt.Frame(KEY=keys, VAL=range(nkeys), stypes={"KEY": st})
     dkey.key = "KEY"
-    keys, vals = dkey.topython()
+    keys, vals = dkey.to_list()
     main = [random.choice(keys) for i in range(ndata)]
     dmain = dt.Frame(KEY=main, stype=st)
     res = [vals[keys.index(main[i])] for i in range(ndata)]
@@ -122,7 +122,7 @@ def test_join_random(seed, lt):
     djoined.internal.check()
     assert djoined.shape == (ndata, 2)
     assert djoined.names == ("KEY", "VAL")
-    assert djoined.topython() == [main, res]
+    assert djoined.to_list() == [main, res]
 
 
 
@@ -134,9 +134,9 @@ def test_join_update():
     assert d0.names == ("A", "B", "AA")
     a = 4.75
     b = 14.0 / 3
-    assert d0.topython() == [[1, 2, 3, 2, 3, 1, 3, 2, 2, 1],
-                             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-                             [b, a, 4, a, 4, b, 4, a, a, b]]
+    assert d0.to_list() == [[1, 2, 3, 2, 3, 1, 3, 2, 2, 1],
+                            [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+                            [b, a, 4, a, 4, b, 4, a, a, b]]
 
 
 def test_join_and_select_g_col():
@@ -150,7 +150,7 @@ def test_join_and_select_g_col():
     assert R.shape == (3, 1)
     assert R.stypes == (stype.str32,)
     # assert R.names == ("c",)   # not working yet
-    assert R.topython() == [[None, "bar", "foo"]]
+    assert R.to_list() == [[None, "bar", "foo"]]
 
 
 def test_join_multi():

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -37,18 +37,18 @@ def test_keys_simple():
     assert dt0.key == ("name",)
     assert dt0.shape == (5, 3)
     assert dt0.names == ("name", "sex", "avg")
-    assert dt0.topython() == [["Adam", "Alice", "Joe", "Leslie", "Mary"],
-                              [12, 8, 1, 15, 5],
-                              [-4.23, 5.3819, 3.6, 2.01, 9.78]]
+    assert dt0.to_list() == [["Adam", "Alice", "Joe", "Leslie", "Mary"],
+                             [12, 8, 1, 15, 5],
+                             [-4.23, 5.3819, 3.6, 2.01, 9.78]]
     dt0.key = "sex"
     dt0.internal.check()
     assert not dt0.internal.isview
     assert dt0.key == ("sex",)
     assert dt0.shape == (5, 3)
     assert dt0.names == ("sex", "name", "avg")
-    assert dt0.topython() == [[1, 5, 8, 12, 15],
-                              ["Joe", "Mary", "Alice", "Adam", "Leslie"],
-                              [3.6, 9.78, 5.3819, -4.23, 2.01]]
+    assert dt0.to_list() == [[1, 5, 8, 12, 15],
+                             ["Joe", "Mary", "Alice", "Adam", "Leslie"],
+                             [3.6, 9.78, 5.3819, -4.23, 2.01]]
     dt0.key = None
     assert dt0.key == tuple()
 

--- a/tests/test_nff.py
+++ b/tests/test_nff.py
@@ -89,7 +89,7 @@ def test_obj_columns(tempdir):
     d1.internal.check()
     assert d1.shape == (4, 1)
     assert d1.names == ("A", )
-    assert d1.topython() == [src1]
+    assert d1.to_list() == [src1]
 
 
 def test_save_view(tempdir):
@@ -102,7 +102,7 @@ def test_save_view(tempdir):
     assert not dt2.internal.isview
     dt2.internal.check()
     assert dt2.names == dt1.names
-    assert dt2.topython() == dt1.topython()
+    assert dt2.to_list() == dt1.to_list()
 
 
 
@@ -145,7 +145,7 @@ def test_jay_view(tempfile, seed):
     dt2.internal.check()
     assert dt1.names == dt2.names
     assert dt1.stypes == dt2.stypes
-    assert dt1.topython() == dt2.topython()
+    assert dt1.to_list() == dt2.to_list()
 
 
 def test_jay_unicode_names(tempfile):
@@ -170,7 +170,7 @@ def test_jay_object_columns(tempfile):
     d1 = dt.open(tempfile)
     d1.internal.check()
     assert d1.names == ("A",)
-    assert d1.topython() == [src1]
+    assert d1.to_list() == [src1]
 
 
 def test_jay_empty_frame(tempfile):
@@ -212,8 +212,8 @@ def test_jay_keys(tempfile):
                    [1, 2, 3, 4, 5]], names=("x", "y"))
     d0.key = "x"
     assert len(d0.key) == 1
-    assert d0.topython() == [["ab", "aop", "cd", "coo", "eee"],
-                             [1, 5, 2, 4, 3]]
+    assert d0.to_list() == [["ab", "aop", "cd", "coo", "eee"],
+                            [1, 5, 2, 4, 3]]
     d0.save(tempfile)
     d1 = dt.open(tempfile)
     assert d1.key == ("x",)

--- a/tests/test_tocsv.py
+++ b/tests/test_tocsv.py
@@ -54,7 +54,7 @@ def test_issue365():
     assert d1.shape == d0.shape
     assert d1.names == d0.names
     assert d1.ltypes == d0.ltypes
-    assert d1.topython() == d0.topython()
+    assert d1.to_list() == d0.to_list()
 
 
 def test_write_spacestrs():
@@ -62,7 +62,7 @@ def test_write_spacestrs():
     d = dt.Frame([" hello ", "world  ", " !", "!", ""])
     assert d.to_csv() == 'C0\n" hello "\n"world  "\n" !"\n!\n""\n'
     dd = dt.fread(text=d.to_csv(), sep='\n')
-    assert d.topython() == dd.topython()
+    assert d.to_list() == dd.to_list()
 
 
 def test_write_spacenames():
@@ -70,7 +70,7 @@ def test_write_spacenames():
                  names=["  foo", "bar ", " "])
     assert d.to_csv() == '"  foo","bar "," "\n1,1,0\n2,2,0\n3,3,0\n'
     dd = dt.fread(text=d.to_csv())
-    assert d.topython() == dd.topython()
+    assert d.to_list() == dd.to_list()
 
 
 def test_strategy(capsys, tempfile):
@@ -169,7 +169,7 @@ def test_save_double():
            [10**p for p in range(320) if p != 126])
     d = dt.Frame(src)
     dd = dt.fread(text=d.to_csv())
-    assert d.topython()[0] == dd.topython()[0]
+    assert d.to_list()[0] == dd.to_list()[0]
     # .split() in order to produce better error messages
     assert d.to_csv(hex=True).split("\n") == dd.to_csv(hex=True).split("\n")
 


### PR DESCRIPTION
These methods were scheduled for deprecation in 0.7.0, and now they are actually deprecated: using any of them still works but emits a warning.

The `.topython()` method is replaced with `.to_list()`. Name change is due to the fact that "python" is ambiguous: we also have `.to_dict()` and `.to_tuples()`.

Names `.tonumpy()`, `.topandas()` are changed into `.to_numpy()` and `.to_pandas()` for consistency with other similarly-called methods: `.to_list()`, `.to_dict()`, `.to_tuples()`, `.to_csv()`, etc.