### PR TITLE
Add support for pickling Ftrl objects

### DIFF
--- a/c/extras/dt_ftrl.cc
+++ b/c/extras/dt_ftrl.cc
@@ -43,17 +43,17 @@ Ftrl::Ftrl(FtrlParams params_in) :
   params(params_in),
   n_features(0),
   n_inter_features(0),
+  w(nullptr),
   model_trained(false)
 {
 }
 
 
 void Ftrl::create_model() {
-  w = doubleptr(new double[params.d]());
   Column* col_z = Column::new_data_column(SType::FLOAT64, params.d);
   Column* col_n = Column::new_data_column(SType::FLOAT64, params.d);
   dt_model = dtptr(new DataTable({col_z, col_n}, model_cols));
-  init_zn();
+  init_weights();
   reset_model();
 }
 
@@ -65,9 +65,10 @@ void Ftrl::reset_model() {
 }
 
 
-void Ftrl::init_zn() {
+void Ftrl::init_weights() {
   z = static_cast<double*>(dt_model->columns[0]->data_w());
   n = static_cast<double*>(dt_model->columns[1]->data_w());
+  w = doubleptr(new double[params.d]());
 }
 
 
@@ -383,7 +384,7 @@ size_t Ftrl::get_n_epochs() {
 void Ftrl::set_model(DataTable* dt_model_in) {
   dt_model = dtptr(dt_model_in->copy());
   set_d(dt_model->nrows);
-  init_zn();
+  init_weights();
   n_features = 0;
   model_trained = true;
 }

--- a/c/extras/dt_ftrl.cc
+++ b/c/extras/dt_ftrl.cc
@@ -37,13 +37,11 @@ const FtrlParams Ftrl::params_default = {0.005, 1.0, 0.0, 1.0,
 *  Set up FTRL parameters and initialize weights.
 */
 Ftrl::Ftrl(FtrlParams params_in) :
-  dt_model(nullptr),
   z(nullptr),
   n(nullptr),
   params(params_in),
   n_features(0),
   n_inter_features(0),
-  w(nullptr),
   model_trained(false)
 {
 }

--- a/c/extras/dt_ftrl.h
+++ b/c/extras/dt_ftrl.h
@@ -80,7 +80,7 @@ class Ftrl {
     bool is_trained();
     void create_model();
     void reset_model();
-    void init_zn();
+    void init_weights();
 
     // Learning helper methods.
     static double logloss(double, bool);

--- a/c/extras/py_ftrl.h
+++ b/c/extras/py_ftrl.h
@@ -46,6 +46,8 @@ class Ftrl : public PyObject {
 
     void m__init__(PKArgs&);
     void m__dealloc__();
+    oobj m__getstate__(const NoArgs&);  // pickling support
+    void m__setstate__(const PKArgs&);
 
    // Learning and predicting methods.
     void fit(const PKArgs&);
@@ -55,7 +57,8 @@ class Ftrl : public PyObject {
     // Getters and setters.
     oobj get_model() const;
     oobj get_colnames_hashes() const;
-    oobj get_params() const;
+    oobj get_params_namedtuple() const;
+    oobj get_params_tuple() const;
     oobj get_alpha() const;
     oobj get_beta() const;
     oobj get_lambda1() const;
@@ -64,7 +67,8 @@ class Ftrl : public PyObject {
     oobj get_inter() const;
     oobj get_n_epochs() const;
     void set_model(robj);
-    void set_params(robj);
+    void set_params_namedtuple(robj);
+    void set_params_tuple(robj);
     void set_alpha(robj);
     void set_beta(robj);
     void set_lambda1(robj);

--- a/datatable/models.py
+++ b/datatable/models.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+#-------------------------------------------------------------------------------
+# Copyright 2018 H2O.ai
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#-------------------------------------------------------------------------------
+from datatable.lib._datatable import Ftrl

--- a/tests/extras/test_aggregate.py
+++ b/tests/extras/test_aggregate.py
@@ -435,7 +435,7 @@ def test_aggregate_3d_categorical():
     nd_max_bins_in = rows
     a_in = [["blue"] * rows, ["orange"] * rows, ["yellow"] * rows]
     members_count = [[1] * rows]
-    exemplar_id = [i for i in range(rows)]
+    exemplar_id = list(range(rows))
     d_in = dt.Frame(a_in)
 
     d_members = aggregate(d_in, nd_max_bins=nd_max_bins_in,
@@ -492,9 +492,9 @@ def aggregate_nd(nd):
     nrows = 1000
     div = 50
     column = [i % div for i in range(nrows)]
-    matrix = [column for i in range(nd)]
+    matrix = [column] * nd
     out_types = [ltype.int] * nd + [ltype.int]
-    out_value = [[i for i in range(div)]] * nd + \
+    out_value = [list(range(div))] * nd + \
                 [[nrows // div for i in range(div)]]
 
     d_in = dt.Frame(matrix)

--- a/tests/extras/test_aggregate.py
+++ b/tests/extras/test_aggregate.py
@@ -495,7 +495,7 @@ def aggregate_nd(nd):
     matrix = [column] * nd
     out_types = [ltype.int] * nd + [ltype.int]
     out_value = [list(range(div))] * nd + \
-                [[nrows // div for i in range(div)]]
+                [[nrows // div] * div]
 
     d_in = dt.Frame(matrix)
     d_members = aggregate(d_in, min_rows=0, nd_max_bins=div, seed=1,

--- a/tests/extras/test_ftrl.py
+++ b/tests/extras/test_ftrl.py
@@ -25,9 +25,10 @@
 # Test FTRL modeling capabilities
 #
 #-------------------------------------------------------------------------------
+import pickle
 import datatable as dt
-from datatable.lib import core
-from datatable import f
+from datatable.models import Ftrl
+from datatable import f, stype
 import pytest
 import collections
 import random
@@ -59,56 +60,56 @@ epsilon = 0.01
 
 def test_ftrl_construct_wrong_alpha_type():
     with pytest.raises(TypeError) as e:
-        noop(core.Ftrl(alpha = "1.0"))
+        noop(Ftrl(alpha = "1.0"))
     assert ("Argument `alpha` in Ftrl() constructor should be a float, instead "
             "got <class 'str'>" == str(e.value))
 
 
 def test_ftrl_construct_wrong_beta_type():
     with pytest.raises(TypeError) as e:
-        noop(core.Ftrl(beta = "1.0"))
+        noop(Ftrl(beta = "1.0"))
     assert ("Argument `beta` in Ftrl() constructor should be a float, instead "
             "got <class 'str'>" == str(e.value))
 
 
 def test_ftrl_construct_wrong_lambda1_type():
     with pytest.raises(TypeError) as e:
-        noop(core.Ftrl(lambda1 = "1.0"))
+        noop(Ftrl(lambda1 = "1.0"))
     assert ("Argument `lambda1` in Ftrl() constructor should be a float, "
             "instead got <class 'str'>" == str(e.value))
 
 
 def test_ftrl_construct_wrong_lambda2_type():
     with pytest.raises(TypeError) as e:
-        noop(core.Ftrl(lambda2 = "1.0"))
+        noop(Ftrl(lambda2 = "1.0"))
     assert ("Argument `lambda2` in Ftrl() constructor should be a float, "
             "instead got <class 'str'>" == str(e.value))
 
 
 def test_ftrl_construct_wrong_d_type():
     with pytest.raises(TypeError) as e:
-        noop(core.Ftrl(d = 1000000.0))
+        noop(Ftrl(d = 1000000.0))
     assert ("Argument `d` in Ftrl() constructor should be an integer, instead "
             "got <class 'float'>" == str(e.value))
 
 
 def test_ftrl_construct_wrong_n_epochs_type():
     with pytest.raises(TypeError) as e:
-        noop(core.Ftrl(n_epochs = 10.0))
+        noop(Ftrl(n_epochs = 10.0))
     assert ("Argument `n_epochs` in Ftrl() constructor should be an integer, "
             "instead got <class 'float'>" == str(e.value))
 
 
 def test_ftrl_construct_wrong_inter_type():
     with pytest.raises(TypeError) as e:
-        noop(core.Ftrl(inter = 2))
+        noop(Ftrl(inter = 2))
     assert ("Argument `inter` in Ftrl() constructor should be a boolean, "
             "instead got <class 'int'>" == str(e.value))
 
 
 def test_ftrl_construct_wrong_combination():
     with pytest.raises(TypeError) as e:
-        noop(core.Ftrl(params=tparams, alpha = tparams.alpha))
+        noop(Ftrl(params=tparams, alpha = tparams.alpha))
     assert ("You can either pass all the parameters with `params` or any of "
             "the individual parameters with `alpha`, `beta`, `lambda1`, "
             "`lambda2`, `d`, `n_epochs` or `inter` to Ftrl constructor, "
@@ -117,7 +118,7 @@ def test_ftrl_construct_wrong_combination():
 
 def test_ftrl_construct_unknown_arg():
     with pytest.raises(TypeError) as e:
-        noop(core.Ftrl(c = 1.0))
+        noop(Ftrl(c = 1.0))
     assert ("Ftrl() constructor got an unexpected keyword argument `c`" ==
             str(e.value))
 
@@ -129,42 +130,42 @@ def test_ftrl_construct_unknown_arg():
 
 def test_ftrl_construct_wrong_alpha_value():
     with pytest.raises(ValueError) as e:
-        noop(core.Ftrl(alpha = 0.0))
+        noop(Ftrl(alpha = 0.0))
     assert ("Argument `alpha` in Ftrl() constructor should be positive: 0.0"
             == str(e.value))
 
 
 def test_ftrl_construct_wrong_beta_value():
     with pytest.raises(ValueError) as e:
-        noop(core.Ftrl(beta = -1.0))
+        noop(Ftrl(beta = -1.0))
     assert ("Argument `beta` in Ftrl() constructor cannot be negative: -1.0"
             == str(e.value))
 
 
 def test_ftrl_construct_wrong_lambda1_value():
     with pytest.raises(ValueError) as e:
-        noop(core.Ftrl(lambda1 = -1.0))
+        noop(Ftrl(lambda1 = -1.0))
     assert ("Argument `lambda1` in Ftrl() constructor cannot be negative: -1.0"
             == str(e.value))
 
 
 def test_ftrl_construct_wrong_lambda2_value():
     with pytest.raises(ValueError) as e:
-        noop(core.Ftrl(lambda2 = -1.0))
+        noop(Ftrl(lambda2 = -1.0))
     assert ("Argument `lambda2` in Ftrl() constructor cannot be negative: -1.0"
             == str(e.value))
 
 
 def test_ftrl_construct_wrong_d_value():
     with pytest.raises(ValueError) as e:
-        noop(core.Ftrl(d = 0))
+        noop(Ftrl(d = 0))
     assert ("Argument `d` in Ftrl() constructor should be positive: 0"
             == str(e.value))
 
 
 def test_ftrl_construct_wrong_n_epochs_value():
     with pytest.raises(ValueError) as e:
-        noop(core.Ftrl(n_epochs = -1))
+        noop(Ftrl(n_epochs = -1))
     assert ("Argument `n_epochs` in Ftrl() constructor cannot be negative: -1"
             == str(e.value))
 
@@ -174,17 +175,17 @@ def test_ftrl_construct_wrong_n_epochs_value():
 #-------------------------------------------------------------------------------
 
 def test_ftrl_create_default():
-    ft = core.Ftrl()
+    ft = Ftrl()
     assert ft.params == default_params
 
 
 def test_ftrl_create_params():
-    ft = core.Ftrl(tparams)
+    ft = Ftrl(tparams)
     assert ft.params == tparams
 
 
 def test_ftrl_create_individual():
-    ft = core.Ftrl(alpha = tparams.alpha, beta = tparams.beta,
+    ft = Ftrl(alpha = tparams.alpha, beta = tparams.beta,
                    lambda1 = tparams.lambda1, lambda2 = tparams.lambda2,
                    d = tparams.d, n_epochs = tparams.n_epochs,
                    inter = tparams.inter)
@@ -198,14 +199,14 @@ def test_ftrl_create_individual():
 #-------------------------------------------------------------------------------
 
 def test_ftrl_get_parameters():
-    ft = core.Ftrl(tparams)
+    ft = Ftrl(tparams)
     assert ft.params == tparams
     assert (ft.alpha, ft.beta, ft.lambda1, ft.lambda2,
             ft.d, ft.n_epochs, ft.inter) == tparams
 
 
 def test_ftrl_set_individual():
-    ft = core.Ftrl()
+    ft = Ftrl()
     ft.alpha = tparams.alpha
     ft.beta = tparams.beta
     ft.lambda1 = tparams.lambda1
@@ -217,7 +218,7 @@ def test_ftrl_set_individual():
 
 
 def test_ftrl_set_params():
-    ft = core.Ftrl()
+    ft = Ftrl()
     ft.params = tparams
     assert ft.params == tparams
 
@@ -227,7 +228,7 @@ def test_ftrl_set_params():
 #-------------------------------------------------------------------------------
 
 def test_ftrl_set_wrong_params_type():
-    ft = core.Ftrl()
+    ft = Ftrl()
     params = tparams._replace(alpha = "1.0")
     with pytest.raises(TypeError) as e:
         ft.params = params
@@ -235,7 +236,7 @@ def test_ftrl_set_wrong_params_type():
 
 
 def test_ftrl_set_wrong_params_name():
-    ft = core.Ftrl()
+    ft = Ftrl()
     WrongParams = collections.namedtuple("WrongParams",["alpha", "inter"])
     wrong_params = WrongParams(alpha = 1, inter = True)
     with pytest.raises(AttributeError) as e:
@@ -244,49 +245,49 @@ def test_ftrl_set_wrong_params_name():
 
 
 def test_ftrl_set_wrong_alpha_type():
-    ft = core.Ftrl()
+    ft = Ftrl()
     with pytest.raises(TypeError) as e:
         ft.alpha = "0.0"
     assert ("Expected a float, instead got <class 'str'>" == str(e.value))
 
 
 def test_ftrl_set_wrong_beta_type():
-    ft = core.Ftrl()
+    ft = Ftrl()
     with pytest.raises(TypeError) as e:
         ft.beta = "-1.0"
     assert ("Expected a float, instead got <class 'str'>" == str(e.value))
 
 
 def test_ftrl_set_wrong_lambda1_type():
-    ft = core.Ftrl()
+    ft = Ftrl()
     with pytest.raises(TypeError) as e:
         ft.lambda1 = "-1.0"
     assert ("Expected a float, instead got <class 'str'>" == str(e.value))
 
 
 def test_ftrl_set_wrong_lambda2_type():
-    ft = core.Ftrl()
+    ft = Ftrl()
     with pytest.raises(TypeError) as e:
         ft.lambda2 = "-1.0"
     assert ("Expected a float, instead got <class 'str'>" == str(e.value))
 
 
 def test_ftrl_set_wrong_d_type():
-    ft = core.Ftrl()
+    ft = Ftrl()
     with pytest.raises(TypeError) as e:
         ft.d = "0"
     assert ("Expected an integer, instead got <class 'str'>" == str(e.value))
 
 
 def test_ftrl_set_wrong_n_epochs_type():
-    ft = core.Ftrl()
+    ft = Ftrl()
     with pytest.raises(TypeError) as e:
         ft.n_epochs = "-10.0"
     assert ("Expected an integer, instead got <class 'str'>" == str(e.value))
 
 
 def test_ftrl_set_wrong_inter_type():
-    ft = core.Ftrl()
+    ft = Ftrl()
     with pytest.raises(TypeError) as e:
         ft.inter = 2
     assert ("Expected a boolean, instead got <class 'int'>" == str(e.value))
@@ -297,42 +298,42 @@ def test_ftrl_set_wrong_inter_type():
 #-------------------------------------------------------------------------------
 
 def test_ftrl_set_wrong_alpha_value():
-    ft = core.Ftrl()
+    ft = Ftrl()
     with pytest.raises(ValueError) as e:
         ft.alpha = 0.0
     assert ("Value should be positive: 0.0" == str(e.value))
 
 
 def test_ftrl_set_wrong_beta_value():
-    ft = core.Ftrl()
+    ft = Ftrl()
     with pytest.raises(ValueError) as e:
         ft.beta = -1.0
     assert ("Value cannot be negative: -1.0" == str(e.value))
 
 
 def test_ftrl_set_wrong_lambda1_value():
-    ft = core.Ftrl()
+    ft = Ftrl()
     with pytest.raises(ValueError) as e:
         ft.lambda1 = -1.0
     assert ("Value cannot be negative: -1.0" == str(e.value))
 
 
 def test_ftrl_set_wrong_lambda2_value():
-    ft = core.Ftrl()
+    ft = Ftrl()
     with pytest.raises(ValueError) as e:
         ft.lambda2 = -1.0
     assert ("Value cannot be negative: -1.0" == str(e.value))
 
 
 def test_ftrl_set_wrong_d_value():
-    ft = core.Ftrl()
+    ft = Ftrl()
     with pytest.raises(ValueError) as e:
         ft.d = 0
     assert ("Value should be positive: 0" == str(e.value))
 
 
 def test_ftrl_set_wrong_n_epochs_value():
-    ft = core.Ftrl()
+    ft = Ftrl()
     with pytest.raises(ValueError) as e:
         ft.n_epochs = -10
     assert ("Integer value cannot be negative" == str(e.value))
@@ -342,19 +343,19 @@ def test_ftrl_set_wrong_n_epochs_value():
 #-------------------------------------------------------------------------------
 
 def test_ftrl_model_untrained():
-    ft = core.Ftrl()
+    ft = Ftrl()
     assert ft.model == None
 
 
 def test_ftrl_set_negative_n_model():
-    ft = core.Ftrl(tparams)
+    ft = Ftrl(tparams)
     with pytest.raises(ValueError) as e:
         ft.model = tmodel[:, {'z' : f.z, 'n' : -f.n}][:, ['z', 'n']]
     assert ("Values in column `n` cannot be negative" == str(e.value))
 
 
 def test_ftrl_set_wrong_shape_model():
-    ft = core.Ftrl(tparams)
+    ft = Ftrl(tparams)
     with pytest.raises(ValueError) as e:
         ft.model = tmodel[:, 'n']
     assert ("FTRL model frame must have %d rows, and 2 columns, whereas your "
@@ -363,7 +364,7 @@ def test_ftrl_set_wrong_shape_model():
 
 
 def test_ftrl_set_wrong_type_model():
-    ft = core.Ftrl(tparams)
+    ft = Ftrl(tparams)
     model = dt.Frame([["foo" for i in range(tparams.d)],
                       [random.random() for i in range(tparams.d)]],
                       names=['z', 'n'])
@@ -375,20 +376,20 @@ def test_ftrl_set_wrong_type_model():
 
 
 def test_ftrl_get_set_model():
-    ft = core.Ftrl(tparams)
+    ft = Ftrl(tparams)
     ft.model = tmodel
     assert_equals(ft.model, tmodel)
 
 
 def test_ftrl_reset_model():
-    ft = core.Ftrl(tparams)
+    ft = Ftrl(tparams)
     ft.model = tmodel
     ft.reset()
     assert ft.model == None
 
 
 def test_ftrl_none_model():
-    ft = core.Ftrl(tparams)
+    ft = Ftrl(tparams)
     ft.model = None
     assert ft.model == None
 
@@ -398,7 +399,7 @@ def test_ftrl_none_model():
 #-------------------------------------------------------------------------------
 
 def test_ftrl_fit_wrong_empty_training():
-    ft = core.Ftrl()
+    ft = Ftrl()
     df_train = dt.Frame()
     df_target = dt.Frame([True])
     with pytest.raises(ValueError) as e:
@@ -408,7 +409,7 @@ def test_ftrl_fit_wrong_empty_training():
 
 
 def test_ftrl_fit_wrong_empty_target():
-    ft = core.Ftrl()
+    ft = Ftrl()
     df_train = dt.Frame([1.0, 2.0])
     df_target = dt.Frame()
     with pytest.raises(ValueError) as e:
@@ -418,7 +419,7 @@ def test_ftrl_fit_wrong_empty_target():
 
 
 def test_ftrl_fit_wrong_target_integer():
-    ft = core.Ftrl()
+    ft = Ftrl()
     df_train = dt.Frame([1, 2, 3])
     df_target = dt.Frame([4, 5, 6])
     with pytest.raises(ValueError) as e:
@@ -428,7 +429,7 @@ def test_ftrl_fit_wrong_target_integer():
 
 
 def test_ftrl_fit_wrong_target_real():
-    ft = core.Ftrl()
+    ft = Ftrl()
     df_train = dt.Frame([1, 2, 3])
     df_target = dt.Frame([4.0, 5.0, 6.0])
     with pytest.raises(ValueError) as e:
@@ -438,7 +439,7 @@ def test_ftrl_fit_wrong_target_real():
 
 
 def test_ftrl_fit_wrong_target_string():
-    ft = core.Ftrl()
+    ft = Ftrl()
     df_train = dt.Frame([1, 2, 3])
     df_target = dt.Frame(["Monday", "Tuesday", "Wedenesday"])
     with pytest.raises(ValueError) as e:
@@ -458,7 +459,7 @@ def test_ftrl_col_hashes():
                           10071734010655191393,  6063711047550005084,
                            4309007444360962581,  4517980897659475069,
                           17871586791652695964, 15779814813469047786)
-    ft = core.Ftrl()
+    ft = Ftrl()
     df_train = dt.Frame([[0]] * ncols)
     df_target = dt.Frame([[True]])
     ft.fit(df_train, df_target)
@@ -471,7 +472,7 @@ def test_ftrl_col_hashes():
 
 
 def test_ftrl_fit_no_frame():
-    ft = core.Ftrl()
+    ft = Ftrl()
     with pytest.raises(ValueError) as e:
         ft.fit()
     assert ("Training frame parameter is missing"
@@ -479,7 +480,7 @@ def test_ftrl_fit_no_frame():
 
 
 def test_ftrl_fit_no_target():
-    ft = core.Ftrl()
+    ft = Ftrl()
     with pytest.raises(ValueError) as e:
         ft.fit(None)
     assert ("Target frame parameter is missing"
@@ -487,14 +488,14 @@ def test_ftrl_fit_no_target():
 
 
 def test_ftrl_fit_predict_nones():
-    ft = core.Ftrl()
+    ft = Ftrl()
     ft.fit(None, None)
     df_target = ft.predict(None)
     assert df_target == None
 
 
 def test_ftrl_predict_not_trained():
-    ft = core.Ftrl()
+    ft = Ftrl()
     df_train = dt.Frame([[1, 2, 3], [True, False, True]])
     with pytest.raises(ValueError) as e:
         ft.predict(df_train)
@@ -503,7 +504,7 @@ def test_ftrl_predict_not_trained():
 
 
 def test_ftrl_predict_wrong_frame():
-    ft = core.Ftrl()
+    ft = Ftrl()
     df_train = dt.Frame([[1, 2, 3]])
     df_target = dt.Frame([[True, False, True]])
     df_predict = dt.Frame([[1, 2, 3], [4, 5, 6]])
@@ -520,7 +521,7 @@ def test_ftrl_predict_wrong_frame():
 #-------------------------------------------------------------------------------
 
 def test_ftrl_fit_unique():
-    ft = core.Ftrl(d = 10)
+    ft = Ftrl(d = 10)
     df_train = dt.Frame([[i for i in range(ft.d)]])
     df_target = dt.Frame([[True for i in range(ft.d)]])
     ft.fit(df_train, df_target)
@@ -529,7 +530,7 @@ def test_ftrl_fit_unique():
 
 
 def test_ftrl_fit_predict_bool():
-    ft = core.Ftrl(alpha = 0.1, n_epochs = 10000)
+    ft = Ftrl(alpha = 0.1, n_epochs = 10000)
     df_train = dt.Frame([[True, False]])
     df_target = dt.Frame([[True, False]])
     ft.fit(df_train, df_target)
@@ -541,7 +542,7 @@ def test_ftrl_fit_predict_bool():
 
 
 def test_ftrl_fit_predict_int():
-    ft = core.Ftrl(alpha = 0.1, n_epochs = 10000)
+    ft = Ftrl(alpha = 0.1, n_epochs = 10000)
     df_train = dt.Frame([[0, 1]])
     df_target = dt.Frame([[True, False]])
     ft.fit(df_train, df_target)
@@ -553,7 +554,7 @@ def test_ftrl_fit_predict_int():
 
 
 def test_ftrl_fit_predict_float():
-    ft = core.Ftrl(alpha = 0.1, n_epochs = 10000)
+    ft = Ftrl(alpha = 0.1, n_epochs = 10000)
     df_train = dt.Frame([[0.0, 1.0]])
     df_target = dt.Frame([[True, False]])
     ft.fit(df_train, df_target)
@@ -565,7 +566,7 @@ def test_ftrl_fit_predict_float():
 
 
 def test_ftrl_fit_predict_string():
-    ft = core.Ftrl(alpha = 0.1, n_epochs = 10000)
+    ft = Ftrl(alpha = 0.1, n_epochs = 10000)
     df_train = dt.Frame([["Monday", "Tuesday"]])
     df_target = dt.Frame([[True, False]])
     ft.fit(df_train, df_target)
@@ -574,3 +575,40 @@ def test_ftrl_fit_predict_string():
     assert df_target[0, 0] >= 1 - epsilon
     assert df_target[1, 0] >= 0
     assert df_target[1, 0] < epsilon
+
+
+def test_ftrl_fit_predict_from_setters():
+    ft = Ftrl(d = 10)
+    df_train = dt.Frame([[i for i in range(ft.d)]])
+    df_target = dt.Frame([[True for i in range(ft.d)]])
+    # Train `ft` to get a model
+    ft.fit(df_train, df_target)
+    # Set this model and parameters to `ft2`
+    ft2 = Ftrl()
+    ft2.params = ft.params
+    ft2.model = ft.model
+    # Train `ft2` and make predictions
+    ft2.fit(df_train, df_target)
+    target2 = ft2.predict(df_train)
+    # Train `ft` and make predictions
+    ft.fit(df_train, df_target)
+    target1 = ft.predict(df_train)
+    assert_equals(ft.model, ft2.model)
+    assert_equals(target1, target2)
+
+#-------------------------------------------------------------------------------
+# Test pickling
+#-------------------------------------------------------------------------------
+
+def test_ftrl_pickling():
+    ft = Ftrl(d = 10)
+    df_train = dt.Frame([[i for i in range(ft.d)]])
+    df_target = dt.Frame([[True for i in range(ft.d)]])
+    ft.fit(df_train, df_target)
+    ft_pickled = pickle.dumps(ft)
+    ft_unpickled = pickle.loads(ft_pickled)  
+    ft_unpickled.model.internal.check()
+    assert ft_unpickled.model.names == ('z', 'n')
+    assert ft_unpickled.model.stypes == (stype.float64, stype.float64)
+    assert_equals(ft.model, ft_unpickled.model)
+    assert ft.params == ft_unpickled.params

--- a/tests/extras/test_ftrl.py
+++ b/tests/extras/test_ftrl.py
@@ -43,8 +43,8 @@ Params = collections.namedtuple("Params",["alpha", "beta", "lambda1", "lambda2",
 tparams = Params(alpha = 1, beta = 2, lambda1 = 3, lambda2 = 4, d = 5,
                      n_epochs = 6, inter = True)
 
-tmodel = dt.Frame([[random.random()] * tparams.d,
-                   [random.random()] * tparams.d],
+tmodel = dt.Frame([[random.random() for _ in range(tparams.d)],
+                   [random.random() for _ in range(tparams.d)]],
                    names=['z', 'n'])
 
 default_params = Params(alpha = 0.005, beta = 1, lambda1 = 0, lambda2 = 1,
@@ -366,7 +366,7 @@ def test_ftrl_set_wrong_shape_model():
 def test_ftrl_set_wrong_type_model():
     ft = Ftrl(tparams)
     model = dt.Frame([["foo"] * tparams.d,
-                      [random.random()] * tparams.d],
+                      [random.random() for _ in range(tparams.d)]],
                       names=['z', 'n'])
     with pytest.raises(ValueError) as e:
         ft.model = model

--- a/tests/extras/test_ftrl.py
+++ b/tests/extras/test_ftrl.py
@@ -43,9 +43,9 @@ Params = collections.namedtuple("Params",["alpha", "beta", "lambda1", "lambda2",
 tparams = Params(alpha = 1, beta = 2, lambda1 = 3, lambda2 = 4, d = 5,
                      n_epochs = 6, inter = True)
 
-tmodel = dt.Frame([[random.random() for i in range(tparams.d)],
-                      [random.random() for i in range(tparams.d)]],
-                      names=['z', 'n'])
+tmodel = dt.Frame([[random.random()] * tparams.d,
+                   [random.random()] * tparams.d],
+                   names=['z', 'n'])
 
 default_params = Params(alpha = 0.005, beta = 1, lambda1 = 0, lambda2 = 1,
                         d = 1000000, n_epochs = 1, inter = False)
@@ -365,8 +365,8 @@ def test_ftrl_set_wrong_shape_model():
 
 def test_ftrl_set_wrong_type_model():
     ft = Ftrl(tparams)
-    model = dt.Frame([["foo" for i in range(tparams.d)],
-                      [random.random() for i in range(tparams.d)]],
+    model = dt.Frame([["foo"] * tparams.d,
+                      [random.random()] * tparams.d],
                       names=['z', 'n'])
     with pytest.raises(ValueError) as e:
         ft.model = model
@@ -522,10 +522,10 @@ def test_ftrl_predict_wrong_frame():
 
 def test_ftrl_fit_unique():
     ft = Ftrl(d = 10)
-    df_train = dt.Frame([[i for i in range(ft.d)]])
-    df_target = dt.Frame([[True for i in range(ft.d)]])
+    df_train = dt.Frame(range(ft.d))
+    df_target = dt.Frame([True] * ft.d)
     ft.fit(df_train, df_target)
-    model = [[-0.5 for i in range(ft.d)], [0.25 for i in range(ft.d)]]
+    model = [[-0.5] * ft.d, [0.25] * ft.d]
     assert ft.model.to_list() == model
 
 
@@ -579,8 +579,8 @@ def test_ftrl_fit_predict_string():
 
 def test_ftrl_fit_predict_from_setters():
     ft = Ftrl(d = 10)
-    df_train = dt.Frame([[i for i in range(ft.d)]])
-    df_target = dt.Frame([[True for i in range(ft.d)]])
+    df_train = dt.Frame(range(ft.d))
+    df_target = dt.Frame([True] * ft.d)
     # Train `ft` to get a model
     ft.fit(df_train, df_target)
     # Set this model and parameters to `ft2`
@@ -603,8 +603,8 @@ def test_ftrl_fit_predict_from_setters():
 
 def test_ftrl_pickling():
     ft = Ftrl(d = 10)
-    df_train = dt.Frame([[i for i in range(ft.d)]])
-    df_target = dt.Frame([[True for i in range(ft.d)]])
+    df_train = dt.Frame(range(ft.d))
+    df_target = dt.Frame([True] * ft.d)
     ft.fit(df_train, df_target)
     ft_pickled = pickle.dumps(ft)
     ft_unpickled = pickle.loads(ft_pickled)

--- a/tests/extras/test_ftrl.py
+++ b/tests/extras/test_ftrl.py
@@ -596,6 +596,7 @@ def test_ftrl_fit_predict_from_setters():
     assert_equals(ft.model, ft2.model)
     assert_equals(target1, target2)
 
+
 #-------------------------------------------------------------------------------
 # Test pickling
 #-------------------------------------------------------------------------------
@@ -606,7 +607,7 @@ def test_ftrl_pickling():
     df_target = dt.Frame([[True for i in range(ft.d)]])
     ft.fit(df_train, df_target)
     ft_pickled = pickle.dumps(ft)
-    ft_unpickled = pickle.loads(ft_pickled)  
+    ft_unpickled = pickle.loads(ft_pickled)
     ft_unpickled.model.internal.check()
     assert ft_unpickled.model.names == ('z', 'n')
     assert ft_unpickled.model.stypes == (stype.float64, stype.float64)


### PR DESCRIPTION
- make `Ftrl` class to be a part of `datatable.models`;
- add support for pickling `Ftrl` objects that contain the both parameters and the model. Since namedtuples cannot be easily pickled, we pickle parameters as a normal tuple adding internal methods to get/set a normal tuple of parameters. These getters and setters are not exposed to the user;
- add `w` weight initialization in the model setter, otherwise it would not possible to fit / predict after unpickling;
- add the corresponding tests;
- minor cleaning and refactoring.

Closes #1476