### PR TITLE
Adjust feature importance test for FTRL

### DIFF
--- a/tests/extras/test_ftrl.py
+++ b/tests/extras/test_ftrl.py
@@ -610,7 +610,6 @@ def test_ftrl_feature_importance():
     df_target = dt.Frame([False, True] * (ft.d // 2))
     ft.fit(df_train, df_target)
     fi = ft.fi
-    print(ft.fi.to_list())
     assert fi[0, 0] < fi[2, 0]
     assert fi[2, 0] < fi[1, 0]
 

--- a/tests/extras/test_ftrl.py
+++ b/tests/extras/test_ftrl.py
@@ -602,14 +602,15 @@ def test_ftrl_fit_predict_from_setters():
 #-------------------------------------------------------------------------------
 
 def test_ftrl_feature_importance():
-    ft = Ftrl(d = 100)
+    ft = Ftrl(d = 200)
     df_train = dt.Frame([range(ft.d),
                          [i % 2 for i in range(ft.d)],
-                         [i % 3 for i in range(ft.d)]
+                         [i % 20 for i in range(ft.d)]
                         ])
     df_target = dt.Frame([False, True] * (ft.d // 2))
     ft.fit(df_train, df_target)
     fi = ft.fi
+    print(ft.fi.to_list())
     assert fi[0, 0] < fi[2, 0]
     assert fi[2, 0] < fi[1, 0]
 


### PR DESCRIPTION
Adjust feature importance test to make importance difference more significant, so that there is less chances this test is affected by hogwild.