### PR TITLE
Improve test coverage for i_node.cc

### DIFF
--- a/c/expr/i_node.cc
+++ b/c/expr/i_node.cc
@@ -167,7 +167,7 @@ expr_in::~expr_in() {
 void expr_in::execute(workframe& wf) {
   SType st = expr->resolve(wf);
   if (st != SType::BOOL) {
-    throw TypeError() << "Filter expression must be of `bool8` type, instead it "
+    throw TypeError() << "Filter expression must be boolean, instead it "
         "was of type " << st;
   }
   Column* col = expr->evaluate_eager(wf);
@@ -226,7 +226,7 @@ void frame_in::post_init_check(workframe& wf) {
     int64_t max = col->max_int64();
     if (min < -1) {
       throw ValueError() << "An integer column used as an `i` selector "
-          "contains invalid negative indices: " << min;
+          "contains an invalid negative index: " << min;
     }
     if (max >= static_cast<int64_t>(nrows)) {
       throw ValueError() << "An integer column used as an `i` selector "
@@ -268,8 +268,8 @@ static i_node* _from_nparray(py::oobj src) {
   }
   py::ostring dtype = src.get_attr("dtype").to_pystring_force();
   std::string dtype_str { PyUnicode_AsUTF8(dtype.to_borrowed_ref()) };
-  bool is_bool = dtype_str.compare(0, 4, "bool");
-  bool is_int = dtype_str.compare(0, 3, "int");
+  bool is_bool = dtype_str.compare(0, 4, "bool") == 0;
+  bool is_int = dtype_str.compare(0, 3, "int") == 0;
   if (!(is_bool || is_int)) {
     throw TypeError() << "Either a boolean or an integer numpy array expected "
         "for an `i` selector, got array of dtype `" << dtype_str << "`";

--- a/c/expr/i_node.cc
+++ b/c/expr/i_node.cc
@@ -488,6 +488,10 @@ static i_node* _make(py::robj src) {
     auto ss = src.to_orange();
     return new slice_in(ss.start(), ss.stop(), ss.step(), false);
   }
+  // String is iterable, therefore this check must come before .is_iterable()
+  if (src.is_string()) {
+    throw TypeError() << "String value cannot be used as an `i` expression";
+  }
   // "iterable" is a very generic interface, so it must come close to last
   // in the resolution sequence
   if (src.is_iterable()) {

--- a/c/expr/i_node.cc
+++ b/c/expr/i_node.cc
@@ -394,27 +394,33 @@ void multislice_in::execute(workframe& wf) {
         break;
       }
       case item_kind::RANGE: {
-        if (item.start < 0) item.start += inrows;
-        if (item.stop < 0) item.stop += inrows;
+        if (item.start < 0) {
+          item.start += inrows;
+          item.stop += inrows;
+        }
         int64_t icount = (item.stop - item.start) / item.step;
         total_count += static_cast<size_t>(icount);
         break;
       }
       case item_kind::SLICE: {
-        if (item.start < 0) item.start += inrows;
-        if (item.start < 0) item.start = 0;
-        if (item.start > inrows) continue;
-        if (item.stop < 0) item.stop += inrows;
-        if (item.stop < 0) item.stop = -1;
-        if (item.stop > inrows) item.stop = inrows;
-        int64_t icount = 0;
-        if (item.step > 0 && item.stop > item.start) {
-          icount = (item.stop - item.start + item.step - 1) / item.step;
+        if (item.step != 0) {
+          if (item.start < 0) item.start += inrows;
+          if (item.start < 0) item.start = 0;
+          if (item.start > inrows) continue;
+          if (item.stop < 0) item.stop += inrows;
+          if (item.stop < 0) item.stop = -1;
+          if (item.stop > inrows) item.stop = inrows;
+          int64_t icount = 0;
+          if (item.step > 0 && item.stop > item.start) {
+            icount = (item.stop - item.start + item.step - 1) / item.step;
+          }
+          if (item.step < 0 && item.stop < item.start) {
+            icount = (item.start - item.stop - item.step - 1) / (-item.step);
+          }
+          total_count += static_cast<size_t>(icount);
+        } else {
+          total_count += static_cast<size_t>(item.stop);
         }
-        if (item.step < 0 && item.stop < item.start) {
-          icount = (item.start - item.stop - item.step - 1) / (-item.step);
-        }
-        total_count += static_cast<size_t>(icount);
         break;
       }
     }
@@ -442,6 +448,7 @@ void multislice_in::execute(workframe& wf) {
       }
     }
   }
+  xassert(j == total_count);
   RowIndex ri(std::move(indices), false);
   wf.apply_rowindex(ri);
 }

--- a/c/expr/i_node.cc
+++ b/c/expr/i_node.cc
@@ -376,8 +376,8 @@ multislice_in::multislice_in(py::robj src) {
 
 void multislice_in::post_init_check(workframe& wf) {
   if (wf.nrows() < min_nrows) {
-    throw ValueError() << "`i` selector is valid for a Frame with at least "
-        << min_nrows << " row" << (min_nrows == 1? "" : "s");
+    throw ValueError() << "`i` selector is not valid for a Frame with "
+        << wf.nrows() << " row" << (wf.nrows() == 1? "" : "s");
   }
 }
 

--- a/c/expr/j_node.cc
+++ b/c/expr/j_node.cc
@@ -359,6 +359,12 @@ jptr j_node::make(py::robj src, workframe& wf) {
 
 j_node::~j_node() {}
 
+void j_node::delete_(workframe&) {}
+
+void j_node::update(workframe&) {}
+
+
+
 
 /*******************************
 

--- a/c/expr/j_node.h
+++ b/c/expr/j_node.h
@@ -36,7 +36,9 @@ class j_node {
     static jptr make(py::robj src, workframe& wf);
 
     virtual ~j_node();
-    virtual DataTable* select(workframe& wf) = 0;
+    virtual DataTable* select(workframe&) = 0;
+    virtual void delete_(workframe&);
+    virtual void update(workframe&);
 };
 
 

--- a/c/rowindex_array.cc
+++ b/c/rowindex_array.cc
@@ -403,7 +403,7 @@ void ArrayRowIndexImpl::init_from_integer_column(const Column* col) {
   }
   int64_t imin = col->min_int64();
   int64_t imax = col->max_int64();
-  if (imin < 0) {
+  if (imin < -1) {
     throw ValueError() << "Row indices in integer column cannot be negative";
   }
   min = static_cast<size_t>(imin);

--- a/ci/llvm-gcov.sh
+++ b/ci/llvm-gcov.sh
@@ -1,2 +1,21 @@
 #!/bin/bash
-exec "$LLVM4$LLVM5$LLVM6/bin/llvm-cov" gcov "$@"
+
+if [ -n "$LLVM7" ]; then
+	exec "$LLVM7/bin/llvm-cov" gcov "$@"
+
+elif [ -n "$LLVM6" ]; then
+	exec "$LLVM6/bin/llvm-cov" gcov "$@"
+
+elif [ -n "$LLVM5" ]; then
+	exec "$LLVM5/bin/llvm-cov" gcov "$@"
+
+elif [ -n "$LLVM4" ]; then
+	exec "$LLVM4/bin/llvm-cov" gcov "$@"
+
+elif [ -f "/usr/local/opt/llvm/bin/llvm-cov" ]; then
+	exec "/usr/local/opt/llvm/bin/llvm-cov" gcov "$@"
+
+else
+	exec gcov "$@"
+
+fi

--- a/datatable/expr/mean_expr.py
+++ b/datatable/expr/mean_expr.py
@@ -1,12 +1,29 @@
-#!/usr/bin/env python3
-# © H2O.ai 2018; -*- encoding: utf-8 -*-
-#   This Source Code Form is subject to the terms of the Mozilla Public
-#   License, v. 2.0. If a copy of the MPL was not distributed with this
-#   file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 #-------------------------------------------------------------------------------
-
+# Copyright 2018 H2O.ai
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#-------------------------------------------------------------------------------
 from .base_expr import BaseExpr
-from .consts import ops_rules, ctypes_map, nas_map, reduce_opcodes
+from .consts import (ops_rules, ctypes_map, nas_map, reduce_opcodes,
+                     baseexpr_opcodes)
 from datatable.lib import core
 
 
@@ -43,6 +60,12 @@ class MeanReducer(BaseExpr):
 
     def __str__(self):
         return "mean%d(%s)" % (self.skipna, self.expr)
+
+
+    def _core(self):
+        return core.base_expr(baseexpr_opcodes["unreduce"],
+                              reduce_opcodes["mean"],
+                              self.expr._core())
 
 
     def _value(self, key, inode):

--- a/datatable/expr/minmax_expr.py
+++ b/datatable/expr/minmax_expr.py
@@ -1,12 +1,28 @@
-#!/usr/bin/env python3
-# © H2O.ai 2018; -*- encoding: utf-8 -*-
-#   This Source Code Form is subject to the terms of the Mozilla Public
-#   License, v. 2.0. If a copy of the MPL was not distributed with this
-#   file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 #-------------------------------------------------------------------------------
-
+# Copyright 2018 H2O.ai
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#-------------------------------------------------------------------------------
 from .base_expr import BaseExpr
-from .consts import ctypes_map, nas_map, reduce_opcodes
+from .consts import ctypes_map, nas_map, reduce_opcodes, baseexpr_opcodes
 from ..utils.typechecks import Frame_t, is_type
 from ..types import stype
 from datatable.lib import core
@@ -65,6 +81,12 @@ class MinMaxReducer(BaseExpr):
 
     def __str__(self):
         return "%s%d(%s)" % (self._name, self._skipna, self._arg)
+
+
+    def _core(self):
+        return core.base_expr(baseexpr_opcodes["unreduce"],
+                              reduce_opcodes[self._name],
+                              self._arg._core())
 
 
     def _value(self, key, inode):

--- a/datatable/expr/sd_expr.py
+++ b/datatable/expr/sd_expr.py
@@ -1,16 +1,34 @@
-#!/usr/bin/env python3
-# © H2O.ai 2018; -*- encoding: utf-8 -*-
-#   This Source Code Form is subject to the terms of the Mozilla Public
-#   License, v. 2.0. If a copy of the MPL was not distributed with this
-#   file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 #-------------------------------------------------------------------------------
-
+# Copyright 2018 H2O.ai
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#-------------------------------------------------------------------------------
 from .base_expr import BaseExpr
-from .consts import ops_rules, ctypes_map, reduce_opcodes
+from .consts import ops_rules, ctypes_map, reduce_opcodes, baseexpr_opcodes
 from datatable.lib import core
+
 
 def sd(expr, skipna=True):
     return StdevReducer(expr, skipna)
+
 
 
 class StdevReducer(BaseExpr):
@@ -39,6 +57,12 @@ class StdevReducer(BaseExpr):
 
     def __str__(self):
         return "sd%d(%s)" % (self.skipna, self.expr)
+
+
+    def _core(self):
+        return core.base_expr(baseexpr_opcodes["unreduce"],
+                              reduce_opcodes["stdev"],
+                              self.expr._core())
 
 
     def _value(self, key, inode):

--- a/tests/munging/test_dt_rows.py
+++ b/tests/munging/test_dt_rows.py
@@ -26,14 +26,14 @@ def _dt0():
 
 def assert_valueerror(df, rows, error_message):
     with pytest.raises(ValueError) as e:
-        df[rows, :]
+        noop(df[rows, :])
     assert str(e.type) == "<class 'datatable.ValueError'>"
     assert error_message in str(e.value)
 
 
 def assert_typeerror(df, rows, error_message):
     with pytest.raises(TypeError) as e:
-        df[rows, :]
+        noop(df[rows, :])
     assert str(e.type) == "<class 'datatable.TypeError'>"
     assert error_message in str(e.value)
 
@@ -439,9 +439,10 @@ def test_rows_int_column_large(dt0):
 
 def test_rows_int_column_nas(dt0):
     col = dt.Frame([3, None, 2, 4])
-    with pytest.raises(ValueError) as e:
-        dt0[col, :]
-    assert "RowIndex source column contains NA values" in str(e.value)
+    assert_valueerror(
+        dt0, col,
+        "RowIndex source column contains NA values")
+
 
 
 
@@ -461,10 +462,10 @@ def test_rows_numpy_array(numpy):
 def test_rows_numpy_array_big(numpy):
     DT = dt.Frame(range(1000))
     idx = numpy.arange(900, 1200, 5)
-    with pytest.raises(ValueError) as e:
-        noop(DT[idx, :])
-    assert ("An integer column used as an `i` selector contains index 1195 "
-            "which is not valid for a Frame with 1000 rows" in str(e.value))
+    assert_valueerror(
+        DT, idx,
+        "An integer column used as an `i` selector contains index 1195 "
+        "which is not valid for a Frame with 1000 rows")
 
 
 def test_rows_int_numpy_array_shapes(dt0, numpy):

--- a/tests/munging/test_dt_rows.py
+++ b/tests/munging/test_dt_rows.py
@@ -155,6 +155,13 @@ def test_rows_slice1(dt0, sliceobj, nrows):
     assert dt1.to_list() == [col[sliceobj] for col in dt0.to_list()]
 
 
+def test_rows_0step_slice():
+    DT = dt.Frame(range(5))
+    res = DT[3:100:0, :]
+    res.internal.check()
+    assert res.to_list() == [[3] * 100]
+
+
 def test_rows_slice2(dt0):
     assert dt0[:5, :].to_list()[0] == [0, 1, 1, None, 0]
     assert dt0[::-1, :].to_list()[1] == \
@@ -275,13 +282,44 @@ def test_rows_multislice2(dt0):
             [0.1, 1, 5, 1, 1.3, 0.1, 100000, 0, -2.6, 2, 2, 2])
 
 
-def test_rows_multislice3(dt0):
+def test_rows_multislice4():
+    DT = dt.Frame(range(20))
+    res = DT[[range(5), 3, -1, range(8, -2, -2)], :]
+    res.internal.check()
+    assert res.ncols == 1
+    assert res.to_list()[0] == [0, 1, 2, 3, 4, 3, 19, 8, 6, 4, 2, 0]
+
+
+def test_rows_multislice5():
+    DT = dt.Frame(range(20))
+    res = DT[[range(3), slice(4, 105, 0)], :]
+    res.internal.check()
+    assert res.ncols == 1
+    assert res.to_list()[0] == [0, 1, 2] + [4] * 105
+
+
+def test_rows_multislice_invalid1(dt0):
     assert_typeerror(
         dt0, [1, "hey"],
         "Invalid item 'hey' at index 1 in the `i` selector list")
+
+
+def test_rows_multislice_invalid2(dt0):
     assert_valueerror(
         dt0, [1, -1, 5, -11],
         "`i` selector is not valid for a Frame with 10 rows")
+
+
+def test_rows_multislice_invalid3(dt0):
+    assert_valueerror(
+        dt0, [0, range(4, -4, -1)],
+        "Invalid wrap-around range(4, -4, -1) for an `i` selector")
+
+
+def test_rows_multislice_invalid4(dt0):
+    assert_typeerror(
+        dt0, [slice("A", "Z")],
+        "Only integer-valued slices are allowed")
 
 
 

--- a/tests/munging/test_dt_rows.py
+++ b/tests/munging/test_dt_rows.py
@@ -16,7 +16,7 @@ from tests import same_iterables, has_llvm, noop
 
 @pytest.fixture(name="dt0")
 def _dt0():
-    nan = float("nan")
+    from math import nan
     return dt.Frame([
         [0,   1,   1,  None,    0,  0,    1, None,   1,    1],  # bool
         [7, -11,   9, 10000, None,  0,    0,   -1,   1, None],  # int
@@ -26,14 +26,14 @@ def _dt0():
 
 def assert_valueerror(df, rows, error_message):
     with pytest.raises(ValueError) as e:
-        df(rows=rows)
+        df[rows, :]
     assert str(e.type) == "<class 'datatable.ValueError'>"
     assert error_message in str(e.value)
 
 
 def assert_typeerror(df, rows, error_message):
     with pytest.raises(TypeError) as e:
-        df(rows=rows)
+        df[rows, :]
     assert str(e.type) == "<class 'datatable.TypeError'>"
     assert error_message in str(e.value)
 
@@ -72,11 +72,11 @@ def test_dt0_properties(dt0):
 
 def test_rows_ellipsis(dt0):
     """Both dt(...) and dt() should select all rows and all columns."""
-    dt1 = dt0()
+    dt1 = dt0[None, :]
     dt1.internal.check()
     assert dt1.shape == (10, 3)
     assert not dt1.internal.isview
-    dt1 = dt0(...)
+    dt1 = dt0[..., :]
     dt1.internal.check()
     assert dt1.shape == (10, 3)
     assert not dt1.internal.isview
@@ -87,14 +87,14 @@ def test_rows_ellipsis(dt0):
 # Integer selector tests
 #
 # Test row selectors which are simple integers, e.g.:
-#     dt(5)
-# should select the 6-th row of the datatable. Negative integers are also
-# allowed, and should count from the end of the datatable.
+#     dt[5, :]
+# should select the 6-th row of the Frame. Negative integers are also
+# allowed, and should count from the end of the Frame.
 #-------------------------------------------------------------------------------
 
 @pytest.mark.parametrize("i", range(-10, 10))
 def test_rows_integer1(dt0, i):
-    dt1 = dt0(i)
+    dt1 = dt0[i, :]
     dt1.internal.check()
     assert dt1.shape == (1, 3)
     assert dt1.names == dt0.names
@@ -104,30 +104,30 @@ def test_rows_integer1(dt0, i):
 
 
 def test_rows_integer2(dt0):
-    assert dt0(0).to_list() == [[0], [7], [5]]
-    assert dt0(-2).to_list()[:2] == [[1], [1]]
-    assert dt0(-2).to_list()[2][0] is None  # nan turns into None
-    assert dt0(2).to_list() == [[1], [9], [1.3]]
-    assert dt0(4).to_list() == [[0], [None], [100000]]
+    assert dt0[0, :].to_list() == [[0], [7], [5]]
+    assert dt0[-2, :].to_list()[:2] == [[1], [1]]
+    assert dt0[-2, :].to_list()[2][0] is None  # nan turns into None
+    assert dt0[2, :].to_list() == [[1], [9], [1.3]]
+    assert dt0[4, :].to_list() == [[0], [None], [100000]]
     assert dt0[1, :].to_list() == [[1], [-11], [1]]
 
 
 def test_rows_integer3(dt0):
     assert_valueerror(dt0, 10,
-                      "Row `10` is invalid for datatable with 10 rows")
+                      "Row `10` is invalid for a frame with 10 rows")
     assert_valueerror(dt0, -11,
-                      "Row `-11` is invalid for datatable with 10 rows")
+                      "Row `-11` is invalid for a frame with 10 rows")
     assert_valueerror(dt0, -20,
-                      "Row `-20` is invalid for datatable with 10 rows")
-    assert_valueerror(dt0, 10**19,
-                      "Row `10000000000000000000` is invalid for datatable "
+                      "Row `-20` is invalid for a frame with 10 rows")
+    assert_valueerror(dt0, 10**18,
+                      "Row `1000000000000000000` is invalid for a frame "
                       "with 10 rows")
 
 
 def test_rows_integer_empty_dt():
     df = dt.Frame()
-    assert_valueerror(df, 0, "Row `0` is invalid for datatable with 0 rows")
-    assert_valueerror(df, -1, "Row `-1` is invalid for datatable with 0 rows")
+    assert_valueerror(df, 0, "Row `0` is invalid for a frame with 0 rows")
+    assert_valueerror(df, -1, "Row `-1` is invalid for a frame with 0 rows")
 
 
 
@@ -138,7 +138,6 @@ def test_rows_integer_empty_dt():
 #     dt[:5, :]
 #     dt[3:-2, :]
 #     dt[::-1, :]
-#     dt(rows=slice(None, None, -1))
 #-------------------------------------------------------------------------------
 
 @pytest.mark.parametrize("sliceobj, nrows", [(slice(None, -2), 8),
@@ -148,7 +147,7 @@ def test_rows_integer_empty_dt():
                                              (slice(None, None, 100), 1),
                                              (slice(None, None, -1), 10)])
 def test_rows_slice1(dt0, sliceobj, nrows):
-    dt1 = dt0(sliceobj)
+    dt1 = dt0[sliceobj, :]
     dt1.internal.check()
     assert dt1.names == dt0.names
     assert dt1.ltypes == dt0.ltypes
@@ -173,11 +172,11 @@ def test_rows_slice3(dt0):
 
 def test_rows_slice_errors(dt0):
     # noinspection PyTypeChecker
-    assert_valueerror(dt0, slice(3, 5.7),
-                      "slice(3, 5.7, None) is not integer-valued")
+    assert_typeerror(dt0, slice(3, 5.7),
+                     "slice(3, 5.7, None) is not integer-valued")
     # noinspection PyTypeChecker
-    assert_valueerror(dt0, slice("colA", "colC"),
-                      "slice('colA', 'colC', None) is not integer-valued")
+    assert_typeerror(dt0, slice("colA", "colC"),
+                     "slice('colA', 'colC', None) is not integer-valued")
 
 
 
@@ -185,8 +184,8 @@ def test_rows_slice_errors(dt0):
 # Range selector
 #
 # Test that a range object can be used as a row selector, for example:
-#     dt(range(5))
-#     dt(range(3, -1, -1))
+#     dt[range(5), :]
+#     dt[range(3, -1, -1), :]
 #-------------------------------------------------------------------------------
 
 @pytest.mark.parametrize("rangeobj", [range(5),
@@ -195,7 +194,7 @@ def test_rows_slice_errors(dt0):
                                       range(7, -1),
                                       range(9, -1, -1)])
 def test_rows_range1(dt0, rangeobj):
-    dt1 = dt0(rangeobj)
+    dt1 = dt0[rangeobj, :]
     dt1.internal.check()
     assert dt1.shape == (len(rangeobj), 3)
     assert dt1.names == dt0.names
@@ -206,10 +205,15 @@ def test_rows_range1(dt0, rangeobj):
 
 
 def test_rows_range2(dt0):
-    assert_valueerror(dt0, range(15),
-                      "Invalid range(0, 15) for a datatable with 10 rows")
-    assert_valueerror(dt0, range(-5, 5),
-                      "Invalid range(-5, 5) for a datatable with 10 rows")
+    assert_valueerror(
+        dt.Frame(range(1)), range(5),
+        "range(0, 5, 1) cannot be applied to a Frame with 1 row")
+    assert_valueerror(
+        dt0, range(15),
+        "range(0, 15, 1) cannot be applied to a Frame with 10 rows")
+    assert_valueerror(
+        dt0, range(-5, 5),
+        "range(-5, 5, 1) cannot be applied to a Frame with 10 rows")
 
 
 
@@ -223,12 +227,17 @@ def test_rows_range2(dt0):
 def test_rows_generator(dt0):
     g = (i * 2 for i in range(4))
     assert type(g).__name__ == "generator"
-    dt1 = dt0(g)
+    dt1 = dt0[g, :]
     dt1.internal.check()
     assert dt1.shape == (4, 3)
     assert is_arr(dt1)
-    assert_valueerror(dt0, (i if i % 3 < 2 else str(-i) for i in range(10)),
-                      "Invalid row selector '-2' generated at position 2")
+
+
+def test_rows_generator_bad(dt0):
+    assert_valueerror(
+        dt0, (i if i % 3 < 2 else str(-i) for i in range(10)),
+        "Invalid row selector '-2' generated at position 2")
+
 
 
 
@@ -249,7 +258,7 @@ def test_rows_generator(dt0):
                           ([0, 2, range(4), -1], 7),
                           ([4, 9, 3, slice(7), range(10)], 20)])
 def test_rows_multislice(dt0, selector, nrows):
-    dt1 = dt0(selector)
+    dt1 = dt0[selector, :]
     dt1.internal.check()
     assert dt1.shape == (nrows, 3)
     assert dt1.names == ("colA", "colB", "colC")
@@ -258,11 +267,11 @@ def test_rows_multislice(dt0, selector, nrows):
 
 
 def test_rows_multislice2(dt0):
-    assert as_list(dt0([3, 9, 1, 0]))[0] == [None, 1, 1, 0]
-    assert as_list(dt0((2, 5, 5, -1)))[1] == [9, 0, 0, None]
-    assert (as_list(dt0([slice(5, None), slice(None, 5)]))[1] ==
+    assert as_list(dt0[[3, 9, 1, 0], :])[0] == [None, 1, 1, 0]
+    assert as_list(dt0[(2, 5, 5, -1), :])[1] == [9, 0, 0, None]
+    assert (as_list(dt0[[slice(5, None), slice(None, 5)], :])[1] ==
             [0, 0, -1, 1, None, 7, -11, 9, 10000, None])
-    assert (as_list(dt0([3, 1, slice(-3), 9, 9, 9]))[2] ==
+    assert (as_list(dt0[[3, 1, slice(-3), 9, 9, 9], :])[2] ==
             [0.1, 1, 5, 1, 1.3, 0.1, 100000, 0, -2.6, 2, 2, 2])
 
 
@@ -286,7 +295,7 @@ def test_rows_multislice3(dt0):
 
 def test_rows_bool_column(dt0):
     col = dt.Frame([1, 0, 1, 1, None, 0, None, 1, 1, 0])
-    dt1 = dt0(col)
+    dt1 = dt0[col, :]
     dt1.internal.check()
     assert dt1.shape == (5, 3)
     assert dt1.names == ("colA", "colB", "colC")
@@ -296,15 +305,15 @@ def test_rows_bool_column(dt0):
 
 
 def test_rows_bool_column_error(dt0):
-    assert_valueerror(dt0, dt.Frame(list(i % 2 for i in range(20))),
-                      "`rows` datatable has 20 rows, but applied to a "
-                      "datatable with 10 rows")
+    assert_valueerror(
+        dt0, dt.Frame(list(i % 2 for i in range(20))),
+        "`i` selector has 20 rows, but applied to a Frame with 10 rows")
 
 
 def test_rows_bool_numpy_array(dt0, numpy):
     arr = numpy.array([True, False, True, True, False,
                        False, True, False, False, True])
-    dt1 = dt0(arr)
+    dt1 = dt0[arr, :]
     dt1.internal.check()
     assert dt1.shape == (5, 3)
     assert dt1.names == ("colA", "colB", "colC")
@@ -313,17 +322,19 @@ def test_rows_bool_numpy_array(dt0, numpy):
 
 
 def test_rows_bool_numpy_array_error(dt0, numpy):
-    assert_valueerror(dt0, numpy.array([True, False, False]),
-                      "Cannot apply a boolean numpy array of length 3 "
-                      "to a datatable with 10 rows")
+    assert_valueerror(
+        dt0, numpy.array([True, False, False]),
+        "Cannot apply a boolean numpy array of length 3 to a Frame with "
+        "10 rows")
 
 
 def test_rows_bad_column(dt0):
-    assert_valueerror(dt0, dt0,
-                      "`rows` argument should be a single-column datatable")
-    assert_typeerror(dt0, dt.Frame([0.3, 1, 1.5]),
-                     "`rows` datatable should be either a boolean or an "
-                     "integer column")
+    assert_valueerror(
+        dt0, dt0,
+        "`i` selector should be a single-column Frame")
+    assert_typeerror(
+        dt0, dt.Frame([0.3, 1, 1.5]),
+        "`i` selector should be either a boolean or an integer column")
 
 
 
@@ -331,15 +342,15 @@ def test_rows_bad_column(dt0):
 # Integer column selector
 #
 # Test the use of an integer column as a filter:
-#     dt(rows=dt.Frame([0, 5, 10]))
+#     dt[dt.Frame([0, 5, 10]), :]
 #
 # which should produce the same result as
-#     dt(rows=[0, 5, 10])
+#     dt[[0, 5, 10], :]
 #-------------------------------------------------------------------------------
 
 def test_rows_int_column(dt0):
     col = dt.Frame([0, 3, 0, 1])
-    dt1 = dt0(rows=col)
+    dt1 = dt0[col, :]
     dt1.internal.check()
     assert dt1.shape == (4, 3)
     assert dt1.names == dt0.names
@@ -349,50 +360,17 @@ def test_rows_int_column(dt0):
                              [5, 0.1, 5, 1]]
 
 
-def test_rows_int_numpy_array(dt0, numpy):
-    arr = numpy.array([7, 1, 0, 3])
-    dt1 = dt0(rows=arr)
-    dt1.internal.check()
-    assert dt1.shape == (4, 3)
-    assert dt1.ltypes == dt0.ltypes
-    assert dt1.to_list() == [[None, 1, 0, None],
-                             [-1, -11, 7, 10000],
-                             [-14, 1, 5, 0.1]]
-    arr2 = numpy.array([[7, 1, 0, 3]])
-    dt2 = dt0(rows=arr2)
-    dt2.internal.check()
-    assert dt1.shape == dt2.shape
-    assert dt1.to_list() == dt2.to_list()
-    dt3 = dt0(rows=numpy.array([[7], [1], [0], [3]]))
-    dt3.internal.check()
-    assert dt3.shape == dt2.shape
-    assert dt3.to_list() == dt2.to_list()
-
-
-def test_rows_int_numpy_array_errors(dt0, numpy):
-    assert_valueerror(dt0, numpy.array([[1, 2], [2, 1], [3, 3]]),
-                      "Only a single-dimensional numpy.array is allowed as a "
-                      "`rows` argument")
-    assert_valueerror(dt0, numpy.array([[[4, 0, 1]]]),
-                      "Only a single-dimensional numpy.array is allowed as a "
-                      "`rows` argument")
-    with pytest.raises(ValueError) as e:
-        dt0(rows=numpy.array([5, 11, 3]))
-    assert ("The data column contains index 11 which is not allowed for a "
-            "Frame with 10 rows" in str(e.value))
-
-
 def test_rows_int_column_negative(dt0):
     col = dt.Frame([3, 7, -1, 4])
     with pytest.raises(ValueError) as e:
-        dt0(rows=col)
+        dt0[col, :]
     assert "Row indices in integer column cannot be negative" in str(e.value)
 
 
 def test_rows_int_column_nas(dt0):
     col = dt.Frame([3, None, 2, 4])
     with pytest.raises(ValueError) as e:
-        dt0(rows=col)
+        dt0[col, :]
     assert "RowIndex source column contains NA values" in str(e.value)
 
 
@@ -419,48 +397,73 @@ def test_rows_numpy_array_big(numpy):
             "which is not valid for a Frame with 1000 rows" in str(e.value))
 
 
+def test_rows_int_numpy_array1(dt0, numpy):
+    arr = numpy.array([7, 1, 0, 3])
+    dt1 = dt0[arr, :]
+    dt1.internal.check()
+    assert dt1.shape == (4, 3)
+    assert dt1.ltypes == dt0.ltypes
+    assert dt1.to_list() == [[None, 1, 0, None],
+                             [-1, -11, 7, 10000],
+                             [-14, 1, 5, 0.1]]
+
+
+def test_rows_int_numpy_array2(dt0, numpy):
+    arr2 = numpy.array([[7, 1, 0, 3]])
+    dt2 = dt0[arr2, :]
+    dt2.internal.check()
+    assert dt1.shape == dt2.shape
+    assert dt1.to_list() == dt2.to_list()
+
+
+def test_rows_int_numpy_array3(dt0, numpy):
+    dt3 = dt0[numpy.array([[7], [1], [0], [3]]), :]
+    dt3.internal.check()
+    assert dt3.shape == dt2.shape
+    assert dt3.to_list() == dt2.to_list()
+
+
+def test_rows_int_numpy_array_errors(dt0, numpy):
+    assert_valueerror(
+        dt0, numpy.array([[1, 2], [2, 1], [3, 3]]),
+        "Only a single-dimensional numpy array is allowed as `i` selector")
+    assert_valueerror(
+        dt0, numpy.array([[[4, 0, 1]]]),
+        "Only a single-dimensional numpy array is allowed as `i` selector")
+    assert_valueerror(
+        dt0, numpy.array([5, 11, 3]),
+        "An integer column used as an `i` selector contains index 11 which is "
+        "not valid for a Frame with 10 rows")
+
+
+
 
 #-------------------------------------------------------------------------------
 # Expression-based selectors
 #
 # Test that it is possible to use a lambda-expression as a filter:
-#     dt(lambda f: f.colA < f.colB)
+#     dt[f.colA < f.colB, :]
 #-------------------------------------------------------------------------------
 
 def test_rows_function1(dt0):
-    dt1 = dt0(lambda g: g.colA)
-    dt2 = dt0(f.colA)
-    dt1.internal.check()
+    dt2 = dt0[f.colA, :]
     dt2.internal.check()
-    assert dt1.shape == dt2.shape == (5, 3)
-    assert is_arr(dt1)
-    assert as_list(dt1)[1] == [-11, 9, 0, 1, None]
-    assert dt1.to_list() == dt2.to_list()
-
-
-def test_rows_function2(dt0):
-    dt1 = dt0(lambda g: [5, 7, 9])
-    dt1.internal.check()
-    assert dt1.shape == (3, 3)
-    assert as_list(dt1)[1] == [0, -1, None]
+    assert dt2.shape == (5, 3)
+    assert dt2.to_list()[1] == [-11, 9, 0, 1, None]
 
 
 def test_rows_function3(dt0):
-    dt1 = dt0(lambda g: g.colA < g.colB)
     dt2 = dt0[f.colA < f.colB, :]
-    dt1.internal.check()
     dt2.internal.check()
-    assert dt1.shape == dt2.shape == (2, 3)
-    assert dt1.to_list() == dt2.to_list() == [[0, 1], [7, 9], [5, 1.3]]
+    assert dt2.shape == (2, 3)
+    assert dt2.to_list() == [[0, 1], [7, 9], [5, 1.3]]
 
 
 def test_rows_function4(dt0):
-    dt1 = dt0(lambda g: g.colB == 0)
-    dt2 = dt0(f.colB == 0)
+    dt1 = dt0[f.colB == 0, :]
     dt1.internal.check()
-    dt2.internal.check()
-    assert dt1.shape == dt2.shape == (2, 3)
-    assert dt1.to_list() == dt2.to_list() == [[0, 1], [0, 0], [0, -2.6]]
+    assert dt1.shape == (2, 3)
+    assert dt1.to_list() == [[0, 1], [0, 0], [0, -2.6]]
 
 
 def test_rows_function_invalid(dt0):
@@ -498,163 +501,163 @@ def _fixture2():
 
 
 def test_rows_equal(df1):
-    dt1 = df1(f.A == f.B, engine="eager")
+    dt1 = df1[f.A == f.B, :]
     dt1.internal.check()
     assert dt1.names == df1.names
     assert dt1.to_list() == [[3, 4, None, 9], [3, 4, None, 9]]
-    if has_llvm():
-        dt2 = df1(f.A == f.B, engine="llvm")
-        dt2.internal.check()
-        assert dt1.names == dt2.names
-        assert dt1.to_list() == dt2.to_list()
+    # if has_llvm():
+    #     dt2 = df1(f.A == f.B, engine="llvm")
+    #     dt2.internal.check()
+    #     assert dt1.names == dt2.names
+    #     assert dt1.to_list() == dt2.to_list()
 
 
 def test_rows_not_equal(df1):
-    dt1 = df1(f.A != f.B, engine="eager")
+    dt1 = df1[f.A != f.B, :]
     dt1.internal.check()
     assert dt1.names == df1.names
     assert dt1.to_list() == [[0, 1, 2, 5, 6, 7, None],
                              [3, 2, 1, 0, 2, None, 8]]
-    if has_llvm():
-        dt2 = df1(f.A != f.B, engine="llvm")
-        dt2.internal.check()
-        assert dt1.names == dt2.names
-        assert dt1.to_list() == dt2.to_list()
+    # if has_llvm():
+    #     dt2 = df1(f.A != f.B, engine="llvm")
+    #     dt2.internal.check()
+    #     assert dt1.names == dt2.names
+    #     assert dt1.to_list() == dt2.to_list()
 
 
 def test_rows_less_than(df1):
-    dt1 = df1(f.A < f.B, engine="eager")
+    dt1 = df1[f.A < f.B, :]
     dt1.internal.check()
     assert dt1.names == df1.names
     assert dt1.to_list() == [[0, 1], [3, 2]]
-    if has_llvm():
-        dt2 = df1(f.A < f.B, engine="llvm")
-        dt2.internal.check()
-        assert dt1.names == dt2.names
-        assert dt1.to_list() == dt2.to_list()
+    # if has_llvm():
+    #     dt2 = df1(f.A < f.B, engine="llvm")
+    #     dt2.internal.check()
+    #     assert dt1.names == dt2.names
+    #     assert dt1.to_list() == dt2.to_list()
 
 
 def test_rows_greater_than(df1):
-    dt1 = df1(f.A > f.B, engine="eager")
+    dt1 = df1[f.A > f.B, :]
     dt1.internal.check()
     assert dt1.names == df1.names
     assert dt1.to_list() == [[2, 5, 6], [1, 0, 2]]
-    if has_llvm():
-        dt2 = df1(f.A > f.B, engine="llvm")
-        dt2.internal.check()
-        assert dt1.names == dt2.names
-        assert dt1.to_list() == dt2.to_list()
+    # if has_llvm():
+    #     dt2 = df1(f.A > f.B, engine="llvm")
+    #     dt2.internal.check()
+    #     assert dt1.names == dt2.names
+    #     assert dt1.to_list() == dt2.to_list()
 
 
 def test_rows_less_than_or_equal(df1):
-    dt1 = df1(f.A <= f.B, engine="eager")
+    dt1 = df1[f.A <= f.B, :]
     dt1.internal.check()
     assert dt1.names == df1.names
     assert dt1.to_list() == [[0, 1, 3, 4, None, 9], [3, 2, 3, 4, None, 9]]
-    if has_llvm():
-        dt2 = df1(f.A <= f.B, engine="llvm")
-        dt2.internal.check()
-        assert dt1.names == dt2.names
-        assert dt1.to_list() == dt2.to_list()
+    # if has_llvm():
+    #     dt2 = df1(f.A <= f.B, engine="llvm")
+    #     dt2.internal.check()
+    #     assert dt1.names == dt2.names
+    #     assert dt1.to_list() == dt2.to_list()
 
 
 def test_rows_greater_than_or_equal(df1):
-    dt1 = df1(f.A >= f.B, engine="eager")
+    dt1 = df1[f.A >= f.B, :]
     dt1.internal.check()
     assert dt1.names == df1.names
     assert dt1.to_list() == [[2, 3, 4, 5, 6, None, 9],
                              [1, 3, 4, 0, 2, None, 9]]
-    if has_llvm():
-        dt2 = df1(f.A >= f.B, engine="llvm")
-        dt2.internal.check()
-        assert dt1.names == dt2.names
-        assert dt1.to_list() == dt2.to_list()
+    # if has_llvm():
+    #     dt2 = df1(f.A >= f.B, engine="llvm")
+    #     dt2.internal.check()
+    #     assert dt1.names == dt2.names
+    #     assert dt1.to_list() == dt2.to_list()
 
 
 def test_rows_compare_to_scalar_gt(df1):
-    dt1 = df1(f.A > 3, engine="eager")
+    dt1 = df1[f.A > 3, :]
     dt1.internal.check()
     assert dt1.names == df1.names
     assert dt1.to_list() == [[4, 5, 6, 7, 9], [4, 0, 2, None, 9]]
-    if has_llvm():
-        dt2 = df1(f.A > 3, engine="llvm")
-        dt2.internal.check()
-        assert dt1.names == dt2.names
-        assert dt1.to_list() == dt2.to_list()
+    # if has_llvm():
+    #     dt2 = df1(f.A > 3, engine="llvm")
+    #     dt2.internal.check()
+    #     assert dt1.names == dt2.names
+    #     assert dt1.to_list() == dt2.to_list()
 
 
 def test_rows_compare_to_scalar_lt(df1):
-    dt1 = df1(f.A < 3, engine="eager")
+    dt1 = df1[f.A < 3, :]
     dt1.internal.check()
     assert dt1.names == df1.names
     assert dt1.to_list() == [[0, 1, 2], [3, 2, 1]]
-    if has_llvm():
-        dt2 = df1(f.A < 3, engine="llvm")
-        dt2.internal.check()
-        assert dt1.names == dt2.names
-        assert dt1.to_list() == dt2.to_list()
+    # if has_llvm():
+    #     dt2 = df1(f.A < 3, engine="llvm")
+    #     dt2.internal.check()
+    #     assert dt1.names == dt2.names
+    #     assert dt1.to_list() == dt2.to_list()
 
 
 # noinspection PyComparisonWithNone
 def test_rows_compare_to_scalar_eq(df1):
-    dt1 = df1(f.A == None, engine="eager")
+    dt1 = df1[f.A == None, :]
     dt1.internal.check()
     assert dt1.names == df1.names
     assert dt1.to_list() == [[None, None], [None, 8]]
-    if has_llvm():
-        dt2 = df1(f.A == None, engine="llvm")
-        dt2.internal.check()
-        assert dt1.names == dt2.names
-        assert dt1.to_list() == dt2.to_list()
+    # if has_llvm():
+    #     dt2 = df1(f.A == None, engine="llvm")
+    #     dt2.internal.check()
+    #     assert dt1.names == dt2.names
+    #     assert dt1.to_list() == dt2.to_list()
 
 
 def test_rows_unary_minus(df1):
-    dt1 = df1(-f.A < -3, engine="eager")
+    dt1 = df1[-f.A < -3, :]
     dt1.internal.check()
     assert dt1.names == df1.names
     assert dt1.to_list() == [[4, 5, 6, 7, 9], [4, 0, 2, None, 9]]
-    if has_llvm():
-        dt2 = df1(-f.A < -3, engine="llvm")
-        dt2.internal.check()
-        assert dt1.names == dt2.names
-        assert dt1.to_list() == dt2.to_list()
+    # if has_llvm():
+    #     dt2 = df1(-f.A < -3, engine="llvm")
+    #     dt2.internal.check()
+    #     assert dt1.names == dt2.names
+    #     assert dt1.to_list() == dt2.to_list()
 
 
 def test_rows_isna(df1):
     from datatable import isna
-    dt1 = df1(isna(f.A), engine="eager")
+    dt1 = df1[isna(f.A), :]
     dt1.internal.check()
     assert dt1.names == df1.names
     assert dt1.to_list() == [[None, None], [None, 8]]
-    if has_llvm():
-        dt2 = df1(isna(f.A), engine="llvm")
-        dt2.internal.check()
-        assert dt1.names == dt2.names
-        assert dt1.to_list() == dt2.to_list()
+    # if has_llvm():
+    #     dt2 = df1(isna(f.A), engine="llvm")
+    #     dt2.internal.check()
+    #     assert dt1.names == dt2.names
+    #     assert dt1.to_list() == dt2.to_list()
 
 
 def test_rows_mean():
     from datatable import mean
-    df0 = dt.Frame(range(10), names=["A"])
-    df1 = df0(f.A > mean(f.A), engine="eager")
+    df0 = dt.Frame(A=range(10))
+    df1 = df0[f.A > mean(f.A), :]
     df1.internal.check()
     assert df1.to_list() == [[5, 6, 7, 8, 9]]
 
 
 def test_rows_min_max():
     from datatable import min, max
-    df0 = dt.Frame(range(10), names=["A"])
+    df0 = dt.Frame(A=range(10))
     # min = 0, max = 9
-    df1 = df0(f.A > (min(f.A) + max(f.A)) / 2, engine="eager")
+    df1 = df0[f.A > (min(f.A) + max(f.A)) / 2, :]
     df1.internal.check()
     assert df1.to_list() == [[5, 6, 7, 8, 9]]
 
 
 def test_rows_stdev():
     from datatable import sd
-    df0 = dt.Frame(range(10), names=["A"])
+    df0 = dt.Frame(A=range(10))
     # stdev = 3.0276
-    df1 = df0(f.A > sd(f.A), engine="eager")
+    df1 = df0[f.A > sd(f.A), :]
     df1.internal.check()
     assert df1.to_list() == [[4, 5, 6, 7, 8, 9]]
 
@@ -663,10 +666,10 @@ def test_rows_strequal():
     df0 = dt.Frame([["a", "bcd", "foo", None, "bee", "xia", "good"],
                     ["a", "bcD", "fooo", None, None, "xia", "evil"]],
                    names=["A", "B"])
-    df1 = df0(f.A == f.B, engine="eager")
-    df2 = df0(f.A != f.B, engine="eager")
-    df3 = df0(f.A == "foo", engine="eager")
-    df4 = df0("bcD" == f.B, engine="eager")
+    df1 = df0[f.A == f.B, :]
+    df2 = df0[f.A != f.B, :]
+    df3 = df0[f.A == "foo", :]
+    df4 = df0["bcD" == f.B, :]
     df1.internal.check()
     df2.internal.check()
     assert df1.to_list() == [["a", None, "xia"]] * 2
@@ -686,71 +689,89 @@ def test_filter_on_view1():
     df0 = dt.Frame({"A": range(50)})
     df1 = df0[::2, :]
     assert df1.shape == (25, 1)
-    df2 = df1(f.A < 10)
+    df2 = df1[f.A < 10, :]
     df2.internal.check()
     assert df2.internal.isview
     assert df2.to_list() == [[0, 2, 4, 6, 8]]
 
 
 def test_filter_on_view2():
-    df0 = dt.Frame({"A": range(50)})
+    df0 = dt.Frame(A=range(50))
     df1 = df0[[5, 7, 9, 3, 1, 4, 12, 8, 11, -3], :]
-    df2 = df1(rows=lambda g: g.A < 10)
+    df2 = df1[f.A < 10, :]
     df2.internal.check()
     assert df2.internal.isview
     assert df2.to_list() == [[5, 7, 9, 3, 1, 4, 8]]
 
 
 def test_filter_on_view3():
-    df0 = dt.Frame({"A": range(20)})
+    df0 = dt.Frame(A=range(20))
     df1 = df0[::5, :]
-    df2 = df1(f.A <= 10, engine="eager")
+    df2 = df1[f.A <= 10, :]
     df2.internal.check()
     assert df2.to_list() == [[0, 5, 10]]
-    if has_llvm():
-        df3 = df1(f.A <= 10, engine="llvm")
-        df3.internal.check()
-        assert df3.to_list() == [[0, 5, 10]]
+    # if has_llvm():
+    #     df3 = df1(f.A <= 10, engine="llvm")
+    #     df3.internal.check()
+    #     assert df3.to_list() == [[0, 5, 10]]
 
 
-def test_chained_slice(dt0):
+def test_chained_slice0(dt0):
     dt1 = dt0[::2, :]
     dt1.internal.check()
     assert dt1.shape == (5, 3)
     assert dt1.internal.rowindex_type == "slice"
-    dt2 = dt1[::-1, :]
+
+
+def test_chained_slice1(dt0):
+    dt2 = dt0[::2, :][::-1, :]
     dt2.internal.check()
     assert dt2.shape == (5, 3)
     assert dt2.internal.rowindex_type == "slice"
-    assert as_list(dt2)[1] == [1, 0, None, 9, 7]
-    dt3 = dt1[2:4, :]
+    assert dt2.to_list()[1] == [1, 0, None, 9, 7]
+
+
+def test_chained_slice2(dt0):
+    dt3 = dt0[::2, :][2:4, :]
     dt3.internal.check()
     assert dt3.shape == (2, 3)
     assert dt3.internal.rowindex_type == "slice"
-    assert as_list(dt3) == [[0, 1], [None, 0], [100000, -2.6]]
-    dt4 = dt1[(1, 0, 3, 2), :]
+    assert dt3.to_list() == [[0, 1], [None, 0], [100000, -2.6]]
+
+
+def test_chained_slice3(dt0):
+    dt4 = dt0[::2, :][[1, 0, 3, 2], :]
     dt4.internal.check()
     assert dt4.shape == (4, 3)
     assert dt4.internal.rowindex_type == "arr32"
-    assert as_list(dt4) == [[1, 0, 1, 0], [9, 7, 0, None], [1.3, 5, -2.6, 1e5]]
+    assert dt4.to_list() == [[1, 0, 1, 0], [9, 7, 0, None], [1.3, 5, -2.6, 1e5]]
 
 
-def test_chained_array(dt0):
-    dt1 = dt0[(2, 5, 1, 1, 1, 0), :]
+def test_chained_array0(dt0):
+    dt1 = dt0[[2, 5, 1, 1, 1, 0], :]
     dt1.internal.check()
     assert dt1.shape == (6, 3)
     assert dt1.internal.rowindex_type == "arr32"
-    dt2 = dt1[::2, :]
+
+
+def test_chained_array1(dt0):
+    dt2 = dt0[[2, 5, 1, 1, 1, 0], :][::2, :]
     dt2.internal.check()
     assert dt2.shape == (3, 3)
     assert dt2.internal.rowindex_type == "arr32"
     assert as_list(dt2) == [[1, 1, 1], [9, -11, -11], [1.3, 1, 1]]
-    dt3 = dt1[::-1, :]
+
+
+def test_chained_array2(dt0):
+    dt3 = dt0[[2, 5, 1, 1, 1, 0], :][::-1, :]
     dt3.internal.check()
     assert dt3.shape == (6, 3)
     assert dt3.internal.rowindex_type == "arr32"
     assert as_list(dt3)[:2] == [[0, 1, 1, 1, 0, 1], [7, -11, -11, -11, 0, 9]]
-    dt4 = dt1[(2, 3, 0), :]
+
+
+def test_chained_array3(dt0):
+    dt4 = dt0[[2, 5, 1, 1, 1, 0], :][(2, 3, 0), :]
     dt4.internal.check()
     assert dt4.shape == (3, 3)
     assert as_list(dt4) == [[1, 1, 1], [-11, -11, 9], [1, 1, 1.3]]
@@ -765,12 +786,14 @@ def test_rows_bad_arguments(dt0):
     """
     Test row selectors that are invalid (i.e. not of the types listed above).
     """
-    assert_typeerror(dt0, 0.5, "Unexpected `rows` argument: 0.5")
-    assert_typeerror(dt0, "5", "Unexpected `rows` argument: '5'")
-    assert_typeerror(dt0, True,
-                     "Boolean value cannot be used as a `rows` selector")
-    assert_typeerror(dt0, False,
-                     "Boolean value cannot be used as a `rows` selector")
+    assert_typeerror(
+        dt0, 0.5, "Unexpected `rows` argument: 0.5")
+    assert_typeerror(
+        dt0, "59", "String value cannot be used as an `i` expression")
+    assert_typeerror(
+        dt0, True, "Boolean value cannot be used as an `i` expression")
+    assert_typeerror(
+        dt0, False, "Boolean value cannot be used as an `i` expression")
 
 
 def test_issue689(tempfile):
@@ -781,7 +804,7 @@ def test_issue689(tempfile):
     del d0
     d1 = dt.open(tempfile)
     # Do not check d1! we want it to be lazy at this point
-    d2 = d1(rows=lambda g: g[0] == 1)
+    d2 = d1[f[0] == 1, :]
     d2.internal.check()
     assert d2.shape == (n / 8, 1)
 

--- a/tests/munging/test_dt_rows.py
+++ b/tests/munging/test_dt_rows.py
@@ -298,6 +298,21 @@ def test_rows_multislice5():
     assert res.to_list()[0] == [0, 1, 2] + [4] * 105
 
 
+def test_rows_multislice6():
+    DT = dt.Frame(range(20))
+    res = DT[[slice(100), slice(4, None, -2)], :]
+    res.internal.check()
+    assert res.ncols == 1
+    assert res.to_list()[0] == list(range(20)) + [4, 2, 0]
+
+
+def test_rows_multislice7():
+    DT = dt.Frame(range(20))
+    res = DT[[range(-5, 0, 2)], :]
+    res.internal.check()
+    assert res.to_list() == [[15, 17, 19]]
+
+
 def test_rows_multislice_invalid1(dt0):
     assert_typeerror(
         dt0, [1, "hey"],
@@ -320,6 +335,18 @@ def test_rows_multislice_invalid4(dt0):
     assert_typeerror(
         dt0, [slice("A", "Z")],
         "Only integer-valued slices are allowed")
+
+
+def test_rows_multislice_invalid5(dt0):
+    s = "when step is 0, both start and stop must " \
+        "be present, and stop must be non-negative"
+    assert_valueerror(
+        dt0, [slice(3, -1, 0)], "Invalid slice(3, -1, 0): " + s)
+    assert_valueerror(
+        dt0, [slice(3, None, 0)], "Invalid slice(3, None, 0): " + s)
+    assert_valueerror(
+        dt0, [slice(None, 6, 0)], "Invalid slice(None, 6, 0): " + s)
+
 
 
 


### PR DESCRIPTION
- Many tests in `test_dt_rows.py` used old-fashioned style `DT(rows=...)` of selecting elements from a Frame. Consequently, those tests were not running for the new-style selectors `DT[i, j]` expressions. As a result, several bugs were inadvertently introduced during the latest round of refactoring, as the tests effectively ignored the new code. This PR addresses this issue, and transforms all tests in `test_dt_rows.py` into the "new-style" selectors of the form `DT[i, j]`. Eventually the old-style calling method `DT(...)` will be deprecated and later removed.

- After the tests were enabled, few more bugs were discovered and fixed, in particular bugs involving "multislice" `i` selectors;

- Fixed coverage script `llvm-gcov.sh`;

- Handle correctly all reducer nodes, including sd, min, max and mean;

- Several tests were added in order to achieve 100% coverage of `i_node.cc`;

- In some tests error messages were improved.