### PR TITLE
Do not train FTRL model on rows where target is None

### DIFF
--- a/c/extras/dt_ftrl.cc
+++ b/c/extras/dt_ftrl.cc
@@ -76,6 +76,7 @@ void Ftrl::fit(const DataTable* dt_X, const DataTable* dt_y) {
       size_t nth = static_cast<size_t>(omp_get_num_threads());
 
       for (size_t j = ith; j < dt_X->nrows; j += nth) {
+        if (ISNA<int8_t>(d_y[j])) continue;
         bool y = d_y[j];
         hash_row(x, j);
         double p = predict_row(x);

--- a/tests/extras/test_ftrl.py
+++ b/tests/extras/test_ftrl.py
@@ -529,6 +529,15 @@ def test_ftrl_fit_unique():
     assert ft.model.to_list() == model
 
 
+def test_ftrl_fit_unique_ignore_none():
+    ft = Ftrl(d = 10)
+    df_train = dt.Frame(range(2 * ft.d))
+    df_target = dt.Frame([True] * ft.d + [None] * ft.d)
+    ft.fit(df_train, df_target)
+    model = [[-0.5] * ft.d, [0.25] * ft.d]
+    assert ft.model.to_list() == model
+
+
 def test_ftrl_fit_predict_bool():
     ft = Ftrl(alpha = 0.1, nepochs = 10000)
     df_train = dt.Frame([[True, False]])


### PR DESCRIPTION
It seems that `None` targets were automatically converted to `True`, due to the fact we never tested  if they're `None` or not. For datasets having a lot of `None` targets, this results in the model being trained on the possibly wrong data.

Fix it, so that we simply do not train our model if a target is `None`. Add a relevant test.