### PR TITLE
Fix split_into_nhot() when applied to a view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - installation from source distribution (#1451).
 
+- Function `dt.split_into_nhot()` now works correctly with view Frames (#1507).
+
 
 ### Changed
 

--- a/tests/munging/test_str.py
+++ b/tests/munging/test_str.py
@@ -126,3 +126,14 @@ def test_split_into_nhot_long(seed, st):
     assert set(f1.names) == set(fr.names)
     f1 = f1[..., fr.names]
     assert f1.to_list() == fr.to_list()
+
+
+def test_split_into_nhot_view():
+  f0 = dt.Frame(A=["cat,dog,mouse", "mouse", None, "dog, cat"])
+  f1 = dt.split_into_nhot(f0[::-1, :])
+  f2 = dt.split_into_nhot(f0[3, :])
+  assert set(f1.names) == {"cat", "dog", "mouse"}
+  assert f1[:, ["cat", "dog", "mouse"]].to_list() == \
+         [[1, 0, 0, 1], [1, 0, 0, 1], [0, 0, 1, 1]]
+  assert set(f2.names) == {"cat", "dog"}
+  assert f2[:, ["cat", "dog"]].to_list() == [[1], [1]]


### PR DESCRIPTION
Function `dt.split_into_nhot(frame)` now works correctly when `frame` is a view.

Closes #1507