### PR TITLE
Joins refactor

### DIFF
--- a/c/datatable.h
+++ b/c/datatable.h
@@ -162,6 +162,8 @@ DataTable* open_jay_from_mbuf(const MemoryRange&);
 
 DataTable* apply_rowindex(const DataTable*, const RowIndex& ri);
 
+RowIndex natural_join(const DataTable* xdt, const DataTable* jdt);
+
 
 //==============================================================================
 

--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -12,6 +12,7 @@
 #include "csv/py_csv.h"
 #include "csv/writer.h"
 #include "expr/base_expr.h"
+#include "expr/by_node.h"
 #include "expr/join_node.h"
 #include "expr/py_expr.h"
 #include "extras/aggregator.h"
@@ -239,6 +240,7 @@ PyInit__datatable()
     py::Frame::Type::init(m);
     py::Ftrl::Type::init(m);
     py::base_expr::Type::init(m);
+    py::oby::init(m);
     py::ojoin::init(m);
 
   } catch (const std::exception& e) {

--- a/c/expr/by_node.cc
+++ b/c/expr/by_node.cc
@@ -1,0 +1,104 @@
+//------------------------------------------------------------------------------
+// Copyright 2018 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#include "expr/by_node.h"
+#include "python/arg.h"
+namespace py {
+
+
+
+//------------------------------------------------------------------------------
+// oby::pyobj::Type
+//------------------------------------------------------------------------------
+
+PKArgs oby::pyobj::Type::args___init__(
+    0, 0, 0, true, false, {}, "__init__", nullptr);
+
+const char* oby::pyobj::Type::classname() {
+  return "datatable.by";
+}
+
+const char* oby::pyobj::Type::classdoc() {
+  return "by() clause for use in DT[i, j, ...]";
+}
+
+bool oby::pyobj::Type::is_subclassable() {
+  return true;  // TODO: make false
+}
+
+void oby::pyobj::Type::init_methods_and_getsets(Methods&, GetSetters& gs) {
+  gs.add<&pyobj::get_cols>("_cols");
+}
+
+
+
+
+//------------------------------------------------------------------------------
+// oby::pyobj
+//------------------------------------------------------------------------------
+
+void oby::pyobj::m__init__(PKArgs& args) {
+  olist colslist(args.num_vararg_args());
+  size_t i = 0;
+  for (robj arg : args.varargs()) {
+    colslist.set(i++, arg);
+  }
+  cols = std::move(colslist);
+}
+
+
+void oby::pyobj::m__dealloc__() {
+  cols = nullptr;  // Releases the stored oobj
+}
+
+
+oobj oby::pyobj::get_cols() const {
+  return cols;
+}
+
+
+
+
+//------------------------------------------------------------------------------
+// oby
+//------------------------------------------------------------------------------
+
+oby::oby(const robj& src) : oobj(src) {}
+
+
+bool oby::check(PyObject* v) {
+  if (!v) return false;
+  auto typeptr = reinterpret_cast<PyObject*>(&pyobj::Type::type);
+  int ret = PyObject_IsInstance(v, typeptr);
+  if (ret == -1) PyErr_Clear();
+  return (ret == 1);
+}
+
+
+void oby::init(PyObject* m) {
+  pyobj::Type::init(m);
+}
+
+
+
+
+
+}

--- a/c/expr/by_node.cc
+++ b/c/expr/by_node.cc
@@ -21,6 +21,7 @@
 //------------------------------------------------------------------------------
 #include "expr/by_node.h"
 #include "python/arg.h"
+#include "python/tuple.h"
 namespace py {
 
 
@@ -82,6 +83,15 @@ oobj oby::pyobj::get_cols() const {
 //------------------------------------------------------------------------------
 
 oby::oby(const robj& src) : oobj(src) {}
+oby::oby(const oobj& src) : oobj(src) {}
+
+
+oby oby::make(const robj& r) {
+  robj oby_type(reinterpret_cast<PyObject*>(&pyobj::Type::type));
+  otuple args(1);
+  args.set(0, r);
+  return oby(oby_type.call(args));
+}
 
 
 bool oby::check(PyObject* v) {

--- a/c/expr/by_node.h
+++ b/c/expr/by_node.h
@@ -55,14 +55,20 @@ class oby : public oobj
     oby& operator=(const oby&) = default;
     oby& operator=(oby&&) = default;
 
-    // DataTable* get_datatable() const;
+    // This static constructor is the equivalent of python call `by(r)`.
+    // It creates a new `by` object from the column descriptor `r`.
+    static oby make(const robj& r);
 
     static bool check(PyObject* v);
     static void init(PyObject* m);
 
   private:
+    // This private constructor will reinterpret the object `r` as an
+    // `oby` object. This constructor does not create any new python objects,
+    // as opposed to the static `oby::make(r)` constructor.
+    oby(const robj& r);
+    oby(const oobj&);
     friend class _obj;
-    oby(const robj&);
 };
 
 

--- a/c/expr/by_node.h
+++ b/c/expr/by_node.h
@@ -19,8 +19,8 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
-#ifndef dt_EXPR_JOIN_NODE_h
-#define dt_EXPR_JOIN_NODE_h
+#ifndef dt_EXPR_BY_NODE_h
+#define dt_EXPR_BY_NODE_h
 #include "python/ext_type.h"
 #include "python/obj.h"
 
@@ -28,11 +28,11 @@ namespace py {
 
 
 
-class ojoin : public oobj
+class oby : public oobj
 {
   class pyobj : public PyObject {
     public:
-      oobj join_frame;
+      oobj cols;
 
       class Type : public ExtType<pyobj> {
         public:
@@ -45,30 +45,24 @@ class ojoin : public oobj
 
       void m__init__(PKArgs&);
       void m__dealloc__();
-      oobj get_joinframe() const;
-
-    private:
-      // The class does not use traditional constructor/destructor mechanism.
-      // Instead, the objects are created/deleted by Python C backend.
-      pyobj();
-      ~pyobj();
+      oobj get_cols() const;
   };
 
   public:
-    ojoin() = default;
-    ojoin(const ojoin&) = default;
-    ojoin(ojoin&&) = default;
-    ojoin& operator=(const ojoin&) = default;
-    ojoin& operator=(ojoin&&) = default;
+    oby() = default;
+    oby(const oby&) = default;
+    oby(oby&&) = default;
+    oby& operator=(const oby&) = default;
+    oby& operator=(oby&&) = default;
 
-    DataTable* get_datatable() const;
+    // DataTable* get_datatable() const;
 
     static bool check(PyObject* v);
     static void init(PyObject* m);
 
   private:
     friend class _obj;
-    ojoin(const robj&);
+    oby(const robj&);
 };
 
 

--- a/c/expr/i_node.cc
+++ b/c/expr/i_node.cc
@@ -512,8 +512,10 @@ static i_node* _make(py::robj src) {
 }
 
 
-iptr i_node::make(py::robj src) {
-  return iptr(_make(src));
+iptr i_node::make(py::robj src, workframe& wf) {
+  iptr res(_make(src));
+  res->post_init_check(wf);
+  return res;
 }
 
 

--- a/c/expr/i_node.cc
+++ b/c/expr/i_node.cc
@@ -508,7 +508,7 @@ static i_node* _make(py::robj src) {
   if (src.is_bool()) {
     throw TypeError() << "Boolean value cannot be used as an `i` expression";
   }
-  return nullptr;  // for now
+  throw TypeError() << "Unsupported `i` selector of type " << src.typeobj();
 }
 
 

--- a/c/expr/i_node.h
+++ b/c/expr/i_node.h
@@ -39,7 +39,7 @@ using iptr = std::unique_ptr<dt::i_node>;
  */
 class i_node {
   public:
-    static iptr make(py::robj src);
+    static iptr make(py::robj src, workframe& wf);
 
     virtual ~i_node();
     virtual void post_init_check(workframe& wf);

--- a/c/expr/j_node.cc
+++ b/c/expr/j_node.cc
@@ -47,11 +47,11 @@ class col_set {
   private:
     RowIndex& rowindex_product(const RowIndex& ra, const RowIndex& rb) {
       for (auto it = all_ri.rbegin(); it != all_ri.rend(); ++it) {
-        if (it->first == rb) {
+        if (it->first == ra) {
           return it->second;
         }
       }
-      all_ri.push_back(std::make_pair(rb, ra * rb));
+      all_ri.push_back(std::make_pair(ra, ra * rb));
       return all_ri.back().second;
     }
 };
@@ -106,7 +106,7 @@ DataTable* allcols_jn::select(workframe& wf) {
     cols.reserve_extra(dti->ncols - j0);
     if (wf.nframes() > 1) {
       const strvec& dti_names = dti->get_names();
-      names.insert(names.end(), dti_names.begin(), dti_names.end());
+      names.insert(names.end(), dti_names.begin() + j0, dti_names.end());
     }
 
     for (size_t j = j0; j < dti->ncols; ++j) {

--- a/c/expr/join_node.cc
+++ b/c/expr/join_node.cc
@@ -55,6 +55,9 @@ void ojoin::pyobj::Type::init_methods_and_getsets(Methods&, GetSetters& gs) {
 //------------------------------------------------------------------------------
 
 void ojoin::pyobj::m__init__(PKArgs& args) {
+  if (!args[0]) {
+    throw TypeError() << "join() is missing the required parameter `frame`";
+  }
   join_frame = args[0].to_oobj();
   if (!join_frame.is_frame()) {
     throw TypeError() << "The argument to join() must be a Frame";

--- a/c/expr/workframe.cc
+++ b/c/expr/workframe.cc
@@ -41,9 +41,26 @@ EvalMode workframe::get_mode() const {
 }
 
 
-void workframe::add_subframe(DataTable* dt) {
+void workframe::add_join(py::ojoin oj) {
+  DataTable* dt = oj.get_datatable();
   frames.push_back(subframe {dt, RowIndex(), true});
 }
+
+
+void workframe::add_groupby(py::oby og) {
+  by_node = og;
+}
+
+
+void workframe::compute_joins() {
+  if (frames.size() <= 1) return;
+  DataTable* xdt = frames[0].dt;
+  for (size_t i = 1; i < frames.size(); ++i) {
+    DataTable* jdt = frames[i].dt;
+    frames[i].ri = natural_join(xdt, jdt);
+  }
+}
+
 
 
 DataTable* workframe::get_datatable(size_t i) const {

--- a/c/expr/workframe.cc
+++ b/c/expr/workframe.cc
@@ -82,6 +82,10 @@ bool workframe::is_naturally_joined(size_t i) const {
   return frames[i].natural;
 }
 
+bool workframe::has_groupby() const {
+  return bool(by_node);
+}
+
 
 size_t workframe::nframes() const {
   return frames.size();

--- a/c/expr/workframe.h
+++ b/c/expr/workframe.h
@@ -90,6 +90,7 @@ class workframe {
     const RowIndex& get_rowindex(size_t i) const;
     const Groupby& get_groupby() const;
     bool is_naturally_joined(size_t i) const;
+    bool has_groupby() const;
     size_t nframes() const;
     size_t nrows() const;
 

--- a/c/expr/workframe.h
+++ b/c/expr/workframe.h
@@ -78,7 +78,9 @@ class workframe {
     explicit workframe(DataTable*);
     void set_mode(EvalMode);
     EvalMode get_mode() const;
+
     void add_subframe(DataTable*);
+    void add_groupby(py::oby);
 
     DataTable* get_datatable(size_t i) const;
     const RowIndex& get_rowindex(size_t i) const;

--- a/c/expr/workframe.h
+++ b/c/expr/workframe.h
@@ -21,10 +21,12 @@
 //------------------------------------------------------------------------------
 #ifndef dt_EXPR_WORKFRAME_h
 #define dt_EXPR_WORKFRAME_h
-#include <vector>        // std::vector
-#include "datatable.h"   // DataTable
-#include "groupby.h"     // Groupby
-#include "rowindex.h"    // RowIndex
+#include <vector>            // std::vector
+#include "expr/by_node.h"    // py::oby
+#include "expr/join_node.h"  // py::ojoin
+#include "datatable.h"       // DataTable
+#include "groupby.h"         // Groupby
+#include "rowindex.h"        // RowIndex
 namespace dt {
 
 
@@ -67,6 +69,7 @@ class workframe {
   private:
     std::vector<subframe> frames;
     Groupby gb;
+    py::oby by_node;
     EvalMode mode;
     size_t : 64 - sizeof(EvalMode) * 8;
 
@@ -79,8 +82,9 @@ class workframe {
     void set_mode(EvalMode);
     EvalMode get_mode() const;
 
-    void add_subframe(DataTable*);
+    void add_join(py::ojoin);
     void add_groupby(py::oby);
+    void compute_joins();
 
     DataTable* get_datatable(size_t i) const;
     const RowIndex& get_rowindex(size_t i) const;

--- a/c/frame/__getitem__.cc
+++ b/c/frame/__getitem__.cc
@@ -19,6 +19,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
+#include "expr/by_node.h"
 #include "expr/i_node.h"
 #include "expr/j_node.h"
 #include "expr/join_node.h"

--- a/c/frame/__getitem__.cc
+++ b/c/frame/__getitem__.cc
@@ -19,6 +19,44 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
+//
+// This is a main file dedicated to computing the pythonic expression
+//
+//     DT[i, j, by(), join(), ...]
+//
+// Here `i` can be either an int, a slice, a range, a list of ints, a generator
+// expression, a boolean or integer Frame, a numpy array, etc. We convert all
+// of these various forms into an `i_node` object.
+//
+// Similarly, the `j` item can also be an int, a string, a slice, a range,
+// an expression, a type, an stype, a list/tuple/iterator of any of these, etc.
+// We build a `j_node` object out of the `j` expression.
+//
+// On the contrary, the python `by()` function already creates a "by_node"
+// object, so there is no need to instantiate anything. The only thing remaining
+// is to verify the correctness of columns / column expressions used in this
+// `by_node`.
+//
+// Likewise, each `join()` call in python creates a "join_node" object, and we
+// only need to collect these objects into the workframe.
+//
+//
+// The "workframe" object gathers all the information necessary to evaluate the
+// expression `DT[i, j, ...]` above.
+//
+// We begin evaluation with checking the by- and join- nodes and inserting them
+// into the workframe. This has to be done first, because `i` and `j` nodes can
+// refer to columns from the join frames, and therefore in order to check their
+// correctness we need to know which frames are joined.
+//
+// Next, we construct `i_node` and `j_node` from arguments `i` and `j`.
+//
+// Once all nodes of the evaluation graph are initialized, we compute all joins
+// (if any). After this step all subframes within the evaluation frame will
+// become conformant, i.e. they'll have the same number of rows (after applying
+// each subframe's RowIndex).
+//
+//------------------------------------------------------------------------------
 #include "expr/by_node.h"
 #include "expr/i_node.h"
 #include "expr/j_node.h"
@@ -104,7 +142,7 @@ oobj Frame::_main_getset(robj item, robj value) {
   for (size_t k = 2; k < nargs; ++k) {
     auto arg_join = targs[k].to_ojoin_lax();
     if (arg_join) {
-      wf.add_subframe(arg_join.get_datatable());
+      wf.add_join(arg_join);
       continue;
     }
     auto arg_by = targs[k].to_oby_lax();
@@ -113,11 +151,16 @@ oobj Frame::_main_getset(robj item, robj value) {
       continue;
     }
   }
-  auto iexpr = dt::i_node::make(targs[0]);
+
+  // 3. Instantiate `i_node` and `j_node`.
+  auto iexpr = dt::i_node::make(targs[0], wf);
   auto jexpr = dt::j_node::make(targs[1], wf);
   xassert(iexpr && jexpr);
+
+  // 4. Perform joins.
+  wf.compute_joins();
+
   if (nargs == 2) {
-    iexpr->post_init_check(wf);
     iexpr->execute(wf);
     if (value == GETITEM) {
       DataTable* res = jexpr->select(wf);

--- a/c/frame/__getitem__.cc
+++ b/c/frame/__getitem__.cc
@@ -98,13 +98,19 @@ oobj Frame::_main_getset(robj item, robj value) {
   wf.set_mode(value == GETITEM? dt::EvalMode::SELECT :
               value == DELITEM? dt::EvalMode::DELETE :
                                 dt::EvalMode::UPDATE);
-  // 2. TODO: Check if `j` is an `update()` and if so change the mode.
-  // 3. Search for join nodes in order to bind all aliases and
-  //    to know which frames participate in DT[...]
+
+  // 2. Search for join nodes in order to bind all aliases and
+  //    to know which frames participate in `DT[...]`.
   for (size_t k = 2; k < nargs; ++k) {
-    auto oj = targs[k].to_ojoin_lax();
-    if (oj) {
-      wf.add_subframe(oj.get_datatable());
+    auto arg_join = targs[k].to_ojoin_lax();
+    if (arg_join) {
+      wf.add_subframe(arg_join.get_datatable());
+      continue;
+    }
+    auto arg_by = targs[k].to_oby_lax();
+    if (arg_by) {
+      wf.add_groupby(arg_by);
+      continue;
     }
   }
   auto iexpr = dt::i_node::make(targs[0]);

--- a/c/frame/__getitem__.cc
+++ b/c/frame/__getitem__.cc
@@ -92,45 +92,43 @@ oobj Frame::_fast_getset(robj item, robj value) {
 
 oobj Frame::_main_getset(robj item, robj value) {
   rtuple targs = item.to_rtuple_lax();
-  if (targs) {
-    size_t nargs = targs.size();
-    // 1. Create the workframe
-    dt::workframe wf(dt);
-    wf.set_mode(value == GETITEM? dt::EvalMode::SELECT :
-                value == DELITEM? dt::EvalMode::DELETE :
-                                  dt::EvalMode::UPDATE);
-    // 2. Check if `j` is an `update()` and if so change the mode.
-    // 3. Search for join nodes in order to bind all aliases and
-    //    to know which frames participate in DT[...]
-    for (size_t k = 2; k < nargs; ++k) {
-      auto oj = targs[k].to_ojoin_lax();
-      if (oj) {
-        wf.add_subframe(oj.get_datatable());
-      }
-    }
-    if (nargs == 2) {
-      auto iexpr = dt::i_node::make(targs[0]);
-      auto jexpr = dt::j_node::make(targs[1], wf);
-      if (iexpr && jexpr) {
-        iexpr->post_init_check(wf);
-        iexpr->execute(wf);
-        if (value == GETITEM) {
-          DataTable* res = jexpr->select(wf);
-          return oobj::from_new_reference(py::Frame::from_datatable(res));
-        }
-        if (value == DELITEM) {
-          jexpr->delete_(wf);
-          _clear_types();
-          return py::None();
-        }
-      }
-    }
-
-  } else {
+  if (!(targs && targs.size() >= 2)) {
     throw ValueError() << "Single-item selectors `DT[col]` are prohibited "
         "since 0.8.0; please use `DT[:, col]`. In 0.9.0 this expression "
         "will be interpreted as a row selector instead.";
   }
+
+  size_t nargs = targs.size();
+  // 1. Create the workframe
+  dt::workframe wf(dt);
+  wf.set_mode(value == GETITEM? dt::EvalMode::SELECT :
+              value == DELITEM? dt::EvalMode::DELETE :
+                                dt::EvalMode::UPDATE);
+  // 2. Check if `j` is an `update()` and if so change the mode.
+  // 3. Search for join nodes in order to bind all aliases and
+  //    to know which frames participate in DT[...]
+  for (size_t k = 2; k < nargs; ++k) {
+    auto oj = targs[k].to_ojoin_lax();
+    if (oj) {
+      wf.add_subframe(oj.get_datatable());
+    }
+  }
+  auto iexpr = dt::i_node::make(targs[0]);
+  auto jexpr = dt::j_node::make(targs[1], wf);
+  if (iexpr && jexpr && nargs == 2) {
+    iexpr->post_init_check(wf);
+    iexpr->execute(wf);
+    if (value == GETITEM) {
+      DataTable* res = jexpr->select(wf);
+      return oobj::from_new_reference(py::Frame::from_datatable(res));
+    }
+    if (value == DELITEM) {
+      jexpr->delete_(wf);
+      _clear_types();
+      return py::None();
+    }
+  }
+
   return _fallback_getset(item, value);
 }
 

--- a/c/frame/py_frame.h
+++ b/c/frame/py_frame.h
@@ -119,7 +119,6 @@ class Frame : public PyObject {
     void _replace_names_from_map(py::odict);
 
     // getitem / setitem support
-    oobj _fast_getset(robj item, robj value);
     oobj _main_getset(robj item, robj value);
     oobj _fallback_getset(robj item, robj value);
 

--- a/c/python/obj.cc
+++ b/c/python/obj.cc
@@ -1,12 +1,27 @@
 //------------------------------------------------------------------------------
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright 2018 H2O.ai
 //
-// © H2O.ai 2018
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #include "python/obj.h"
 #include <cstdint>         // INT32_MAX
+#include "expr/by_node.h"
 #include "expr/join_node.h"
 #include "frame/py_frame.h"
 #include "py_column.h"
@@ -159,6 +174,10 @@ bool _obj::is_frame() const noexcept {
 
 bool _obj::is_join_node() const noexcept {
   return py::ojoin::check(v);
+}
+
+bool _obj::is_by_node() const noexcept {
+  return py::oby::check(v);
 }
 
 bool _obj::is_pandas_frame() const noexcept {
@@ -552,6 +571,14 @@ py::ojoin _obj::to_ojoin_lax() const {
     return ojoin(robj(v));
   }
   return ojoin();
+}
+
+
+py::oby _obj::to_oby_lax() const {
+  if (is_by_node()) {
+    return oby(robj(v));
+  }
+  return oby();
 }
 
 

--- a/c/python/obj.h
+++ b/c/python/obj.h
@@ -22,6 +22,7 @@ namespace py {
 
 // Forward declarations
 class Arg;
+class oby;
 class odict;
 class ofloat;
 class oint;
@@ -170,6 +171,7 @@ class _obj {
     bool is_range()         const noexcept;
     bool is_slice()         const noexcept;
     bool is_frame()         const noexcept;
+    bool is_by_node()       const noexcept;
     bool is_join_node()     const noexcept;
     bool is_pandas_frame()  const noexcept;
     bool is_pandas_series() const noexcept;
@@ -214,6 +216,7 @@ class _obj {
     DataTable*  to_frame          (const error_manager& = _em0) const;
     SType       to_stype          (const error_manager& = _em0) const;
     py::ojoin   to_ojoin_lax      () const;
+    py::oby     to_oby_lax        () const;
 
     PyObject*   to_pyobject_newref() const noexcept;
     PyObject*   to_borrowed_ref() const { return v; }

--- a/datatable/graph/__init__.py
+++ b/datatable/graph/__init__.py
@@ -84,7 +84,7 @@ def make_datatable(dt, rows, select, groupby=None, join=None, sort=None,
 
         rowsnode.execute()
         if grbynode:
-            grbynode.execute()
+            grbynode.execute(ee)
 
         colsnode.execute()
         res_dt = ee.columns.to_frame(colsnode.column_names)

--- a/datatable/graph/groupby_node.py
+++ b/datatable/graph/groupby_node.py
@@ -13,11 +13,9 @@ from datatable.graph.dtproxy import f
 class SimpleGroupbyNode:
 
     def __init__(self, ee, col):
-        self._engine = ee
         self._col = col
 
-    def execute(self):
-        ee = self._engine
+    def execute(self, ee):
         df = ee.dt.internal
         col = self._col
         if ee.rowindex:
@@ -56,16 +54,12 @@ def make_groupby(grby, ee):
 class by:
     def __init__(self, *args):
         self._cols = list(args)
-        self._engine = None
 
     def resolve_columns(self, ee):
-        self._engine = ee
-        dt = self._engine.dt
         for i, col in enumerate(self._cols):
-            self._cols[i] = process_column(col, dt)
+            self._cols[i] = process_column(col, ee.dt)
 
-    def execute(self):
-        ee = self._engine
+    def execute(self, ee):
         df = ee.dt.internal
         rowindex, groupby = df.sort(*self._cols, True)
         f.set_rowindex(rowindex)

--- a/datatable/graph/groupby_node.py
+++ b/datatable/graph/groupby_node.py
@@ -21,9 +21,7 @@ def make_groupby(grby, ee):
 
 
 
-class by:
-    def __init__(self, *args):
-        self._cols = list(args)
+class by(core.by):
 
     def resolve_columns(self, ee):
         for i, col in enumerate(self._cols):

--- a/datatable/graph/groupby_node.py
+++ b/datatable/graph/groupby_node.py
@@ -10,44 +10,14 @@ from datatable.utils.typechecks import TTypeError
 from datatable.graph.dtproxy import f
 
 
-class SimpleGroupbyNode:
-
-    def __init__(self, ee, col):
-        self._col = col
-
-    def execute(self, ee):
-        df = ee.dt.internal
-        col = self._col
-        if ee.rowindex:
-            cf = core.columns_from_slice(df, ee.rowindex, col, 1, 1)
-            df = cf.to_frame(None).internal
-            col = 0
-        rowindex, groupby = df.sort(col, True)
-        f.set_rowindex(rowindex)
-        ee.set_source_rowindex(rowindex)
-        ee.clear_final_rowindex()
-        if ee.rowindex:
-            ee.set_final_rowindex(rowindex, ee.rowindex)
-        ee.rowindex = rowindex
-        ee.groupby = groupby
-        ee.groupby_cols = [self._col]
-
-
-
 def make_groupby(grby, ee):
     if grby is None:
         return None
-    if isinstance(grby, by):
-        grby.resolve_columns(ee)
-        return grby
+    if not isinstance(grby, by):
+        grby = by(grby)
 
-    # TODO: change to ee.make_columnset() when we can do multi-col sorts
-    grbycol = process_column(grby, ee.dt)
-    if not isinstance(grbycol, int):
-        raise TTypeError("Currently only single-column group-bys are "
-                         "supported")
-
-    return SimpleGroupbyNode(ee, grbycol)
+    grby.resolve_columns(ee)
+    return grby
 
 
 

--- a/tests/munging/test_dt_rows.py
+++ b/tests/munging/test_dt_rows.py
@@ -872,7 +872,7 @@ def test_rows_bad_arguments(dt0):
     Test row selectors that are invalid (i.e. not of the types listed above).
     """
     assert_typeerror(
-        dt0, 0.5, "Unexpected `rows` argument: 0.5")
+        dt0, 0.5, "Unsupported `i` selector of type <class 'float'>")
     assert_typeerror(
         dt0, "59", "String value cannot be used as an `i` expression")
     assert_typeerror(

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -59,9 +59,9 @@ def patched_terminal(monkeypatch):
     dt.utils.terminal.term.disable_styling()
 
 
-def assert_valueerror(datatable, rows, error_message):
+def assert_valueerror(frame, rows, error_message):
     with pytest.raises(ValueError) as e:
-        datatable(rows=rows)
+        noop(frame[rows, :])
     assert str(e.type) == "<class 'dt.ValueError'>"
     assert error_message in str(e.value)
 
@@ -219,10 +219,10 @@ def test_dt_getitem(dt0):
 def test_issue1406(dt0):
     with pytest.raises(ValueError) as e:
         dt0[tuple()]
-    assert "Invalid selector ()" == str(e.value)
+    assert "Single-item selectors `DT[col]` are prohibited" in str(e.value)
     with pytest.raises(ValueError) as e:
         dt0[(None,)]
-    assert "Invalid selector (None,)" == str(e.value)
+    assert "Single-item selectors `DT[col]` are prohibited" in str(e.value)
 
 
 

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -207,9 +207,9 @@ def test_dt_getitem(dt0):
     assert dt1.names == ("E", )
     elem2 = dt0[0, 1]
     assert elem2 is True
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(TypeError) as e:
         dt0[0, 1, 2, 3]
-    assert "Selector (0, 1, 2, 3) is not supported" in str(e.value)
+    assert "Invalid item at position 2 in DT[i, j, ...] call" == str(e.value)
     with pytest.raises(ValueError) as e:
         dt0["A"]
     assert ("Single-item selectors `DT[col]` are prohibited"

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -137,12 +137,14 @@ def test_groups_autoexpand():
                             [2, 7, 0, 5, 13]]
 
 
+@pytest.mark.skip(reason="Issue #1348")
 def test_groupby_with_filter1():
     f0 = dt.Frame({"KEY": [1, 2, 1, 2, 1, 2], "X": [-10, 2, 3, 0, 1, -7]})
     f1 = f0[f.X > 0, sum(f.X), f.KEY]
     assert f1.to_list() == [[1, 2], [4, 2]]
 
 
+@pytest.mark.skip(reason="Issue #1348")
 def test_groupby_with_filter2():
     # Check that rowindex works even when applied to a view
     n = 10000

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -130,7 +130,7 @@ def test_groups_multiple():
 def test_groups_autoexpand():
     f0 = dt.Frame({"color": ["red", "blue", "green", "red", "green"],
                    "size": [5, 2, 7, 13, 0]})
-    f1 = f0[:, [mean(f.size), "size"], f.color]
+    f1 = f0[:, [mean(f.size), f.size], f.color]
     f1.internal.check()
     assert f1.to_list() == [["blue", "green", "green", "red", "red"],
                             [2.0, 3.5, 3.5, 9.0, 9.0],

--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -69,7 +69,7 @@ def test_join_missing_levels():
 
 def test_join_errors():
     d0 = dt.Frame(A=[1, 2, 3])
-    d1 = dt.Frame(B=range(10), stype=dt.float64)
+    d1 = dt.Frame(B=[str(x) for x in range(10)])
     with pytest.raises(ValueError) as e:
         d0[:, :, join(d1)]
     assert "The join frame is not keyed" in str(e.value)
@@ -80,8 +80,9 @@ def test_join_errors():
     d1.names = ("A",)
     with pytest.raises(TypeError) as e:
         d0[:, :, join(d1)]
-    assert ("Join column `A` has type int in the left Frame, and type real "
-            "in the right Frame" in str(e.value))
+    assert ("Column `A` of type int8 in the left Frame cannot be joined to "
+            "column `A` of incompatible type str32 in the right Frame"
+            in str(e.value))
 
 
 @pytest.mark.parametrize("seed,lt", [(random.getrandbits(32), ltype.bool),


### PR DESCRIPTION
- (Select) joins are now computed in C++ entirely;
- Error message from invalid joins now includes the names of the mismatched columns;
- Fix bug in joins where bool columns could not be joined to others;
- `i_node` is now constructed in C++ always, without fall-back into python;
- The `by()` function is now declared in C++, in preparation for moving this functionality away from python into the core;
- class `SimpleGroupbyNode` in python removed;

WIP for #1477