### PR TITLE
Fix #1481

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `DT.replace()` now works correctly when the replacement list is `[+inf]` or
   `[1.7976931348623157e+308]` (#1510).
 
+- When a `g.`-column is used but there is no join frame, an appropriate
+  error message is now emitted (#1481).
+
 
 ### Changed
 

--- a/c/expr/base_expr.cc
+++ b/c/expr/base_expr.cc
@@ -56,6 +56,10 @@ size_t expr_column::get_frame_id() const noexcept {
 
 size_t expr_column::get_col_index(const workframe& wf) {
   if (col_id == size_t(-1)) {
+    if (frame_id >= wf.nframes()) {
+      throw ValueError()
+          << "Column expression references a non-existing join frame";
+    }
     const DataTable* dt = wf.get_datatable(frame_id);
     if (col_selector.is_int()) {
       int64_t icolid = col_selector.to_int64_strict();

--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -24,7 +24,7 @@
 import datatable as dt
 import pytest
 import random
-from tests import random_string
+from tests import random_string, noop
 from datatable import join, ltype, stype, f, g, mean
 
 
@@ -67,19 +67,29 @@ def test_join_missing_levels():
     assert res.to_list() == [[1, 2, 3], [True, False, None]]
 
 
-def test_join_errors():
+def test_join_error_nokey():
     d0 = dt.Frame(A=[1, 2, 3])
-    d1 = dt.Frame(B=[str(x) for x in range(10)])
+    d1 = dt.Frame(A=range(10))
     with pytest.raises(ValueError) as e:
-        d0[:, :, join(d1)]
+        noop(d0[:, :, join(d1)])
     assert "The join frame is not keyed" in str(e.value)
+
+
+def test_join_error_no_left_column():
+    d0 = dt.Frame(A=[1, 2, 3])
+    d1 = dt.Frame(B=range(10))
     d1.key = "B"
     with pytest.raises(ValueError) as e:
-        d0[:, :, join(d1)]
+        noop(d0[:, :, join(d1)])
     assert "Key column `B` does not exist in the left Frame" in str(e.value)
-    d1.names = ("A",)
+
+
+def test_join_error_type_mismatch():
+    d0 = dt.Frame(A=[1, 2, 3])
+    d1 = dt.Frame(A=[str(x) for x in range(10)])
+    d1.key = "A"
     with pytest.raises(TypeError) as e:
-        d0[:, :, join(d1)]
+        noop(d0[:, :, join(d1)])
     assert ("Column `A` of type int8 in the left Frame cannot be joined to "
             "column `A` of incompatible type str32 in the right Frame"
             in str(e.value))
@@ -206,3 +216,27 @@ def test_join_multi_random(seed):
 
     joinframe = xframe[:, :, join(jframe)]
     assert joinframe[:, "V"].to_list()[0] == rescol
+
+
+def test_issue1481():
+    DT = dt.Frame(A=range(5))
+    with pytest.raises(ValueError) as e:
+        noop(DT[:, [f.A, g.A]])
+    assert ("Item 1 of the `j` selector list references a non-existing "
+            "join frame" == str(e.value))
+
+
+def test_issue1481_2():
+    DT = dt.Frame(A=range(5))
+    with pytest.raises(ValueError) as e:
+        noop(DT[g.X > 0, :])
+    assert ("Column expression references a non-existing join frame"
+            == str(e.value))
+
+
+def test_issue1481_3():
+    DT = dt.Frame(A=range(5))
+    with pytest.raises(ValueError) as e:
+        noop(DT[:, g.A + 1])
+    assert ("Column expression references a non-existing join frame"
+            == str(e.value))


### PR DESCRIPTION
When a `g.`-column is used but there is no join frame, an appropriate
  error message is now emitted.