### PR TITLE
Disable llvmlite dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,16 +61,17 @@ def get_main_dependencies():
     deps = ["typesentry>=0.2.6", "blessed"]
     # If there is an active LLVM installation, then also require the
     # `llvmlite` module.
-    llvmdir, llvmver = get_llvm(True)
-    if llvmdir:
-        llvmlite_req = (">=0.20.0,<0.21.0" if llvmver == "LLVM4" else
-                        ">=0.21.0,<0.23.0" if llvmver == "LLVM5" else
-                        ">=0.23.0")
-        deps += ["llvmlite" + llvmlite_req]
-        # If we need to install llvmlite, this can help
-        if not os.environ.get("LLVM_CONFIG"):
-            os.environ["LLVM_CONFIG"] = \
-                os.path.join(llvmdir, "bin", "llvm-config")
+    # llvmdir, llvmver = get_llvm(True)
+    # if llvmdir:
+    #     llvmlite_req = (">=0.20.0,<0.21.0" if llvmver == "LLVM4" else
+    #                     ">=0.21.0,<0.23.0" if llvmver == "LLVM5" else
+    #                     ">=0.23.0,<0.27.0" if llvmver == "LLVM6" else
+    #                     ">=0.27.0")
+    #     deps += ["llvmlite" + llvmlite_req]
+    #     # If we need to install llvmlite, this can help
+    #     if not os.environ.get("LLVM_CONFIG"):
+    #         os.environ["LLVM_CONFIG"] = \
+    #             os.path.join(llvmdir, "bin", "llvm-config")
     return deps
 
 


### PR DESCRIPTION
Llvmlite is now an optional dependency, so it shouldn't be listed as required.

This change should help resolve recent errors with PPC64le build.