### PR TITLE
Avoid crashing when getting less than 2 arguments in Frame.replace()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Partial column update (i.e. expression of the form `DT[i, j] = R`) now works
   for string columns as well (#1523).
 
+- `DT.replace()` now throws an error if called with 0 or 1 argument (#1525).
+  Thanks to [Arno Candel][] for discovering this issue.
+
 
 ### Changed
 

--- a/c/frame/replace.cc
+++ b/c/frame/replace.cc
@@ -136,6 +136,10 @@ class ReplaceAgent {
 void Frame::replace(const PKArgs& args) {
   const Arg& x = args[0];  // replace what
   const Arg& y = args[1];  // replace with
+  if (!x) {
+    throw TypeError() << "Missing the required argument `replace_what` in "
+        "method Frame.replace()";
+  }
 
   ReplaceAgent ra(dt);
   ra.parse_x_y(x, y);
@@ -183,6 +187,10 @@ void ReplaceAgent::parse_x_y(const Arg& x, const Arg& y) {
     return;
   }
   else {
+    if (!y) {
+      throw TypeError() << "Missing the required argument `replace_with` in "
+          "method Frame.replace()";
+    }
     if (x.is_list_or_tuple()) {
       olist xl = x.to_pylist();
       for (size_t i = 0; i < xl.size(); ++i) {

--- a/tests/munging/test_replace.py
+++ b/tests/munging/test_replace.py
@@ -386,3 +386,19 @@ def test_replace_nonunique():
         df0.replace([0, 9, 11, 0], -1)
     assert ("Replacement target `0` was specified more than once in "
             "Frame.replace()" == str(e.value))
+
+
+def test_issue1525_1():
+    with pytest.raises(TypeError) as e:
+        df0 = dt.Frame(["foo"])
+        df0.replace()
+    assert ("Missing the required argument `replace_what` in method "
+            "Frame.replace()" == str(e.value))
+
+
+def test_issue1525_2():
+    with pytest.raises(TypeError) as e:
+        df0 = dt.Frame(["foo"])
+        df0.replace("foo")
+    assert ("Missing the required argument `replace_with` in method "
+            "Frame.replace()" == str(e.value))


### PR DESCRIPTION
Closes #1525