### PR TITLE
Fix count() when used with non-trivial i in DT[i,j]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed crash when viewing a frame obtained by resizing a 0-row frame (#1527).
   Thanks to [Nishant Kalonia][] for reporting.
 
+- Function `count()` now returns correct result within the `DT[i, j]` expression
+  with non-trivial `i` (#1316).
+
 
 ### Changed
 

--- a/tests/test_reduce.py
+++ b/tests/test_reduce.py
@@ -125,6 +125,15 @@ def test_count_dt_integer_large(numpy):
     assert df_reduce.to_list() == [[n]]
 
 
+def test_count_with_i():
+    # See issue 1316
+    DT = dt.Frame(A=range(100))
+    assert DT[:5, count()][0, 0] == 5
+    assert DT[-12:, count()][0, 0] == 12
+    assert DT[::3, count()][0, 0] == 34
+
+
+
 
 #-------------------------------------------------------------------------------
 # First


### PR DESCRIPTION
This issue was actually resolved as a by-product of  #1534, this PR merely adds a test to verify.

Closes #1316