### PR TITLE
Fix groupby when applied to a view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Function `count()` now returns correct result within the `DT[i, j]` expression
   with non-trivial `i` (#1316).
 
+- Fixed groupby when it is applied to a Frame with view columns (#1542).
+
 
 ### Changed
 

--- a/c/expr/by_node.cc
+++ b/c/expr/by_node.cc
@@ -64,8 +64,13 @@ void collist_bn::execute(workframe& wf) {
   if (ri0) {
     throw NotImplError();
   }
-  RowIndex ri = dt0->sortby(indices, &gb);
-  wf.apply_rowindex(ri);
+  std::vector<sort_spec> spec;
+  for (size_t i : indices) {
+    spec.push_back(sort_spec(i));
+  }
+  auto res = dt0->group(spec);
+  gb = std::move(res.second);
+  wf.apply_rowindex(res.first);
 }
 
 

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -261,3 +261,22 @@ def test_groupby_multi_large(seed):
     DT1 = DT0[:, sum(f.D), by(f.A, f.B, f.C)]
     DT2 = dt.Frame(grouped)
     assert same_iterables(DT1.to_list(), DT2.to_list())
+
+
+def test_groupby_on_view():
+    # See issue #1542
+    DT = dt.Frame(A=[1, 2, 3, 1, 2, 3],
+                  B=[3, 6, 2, 4, 3, 1],
+                  C=['b', 'd', 'b', 'b', 'd', 'b'])
+    V = DT[f.A != 1, :]
+    assert V.internal.isview
+    assert V.shape == (4, 3)
+    assert V.to_dict() == {'A': [2, 3, 2, 3],
+                           'B': [6, 2, 3, 1],
+                           'C': ['d', 'b', 'd', 'b']}
+    RES = V[:, max(f.B), by(f.C)]
+    assert RES.shape == (2, 2)
+    assert RES.to_dict() == {'C': ['b', 'd'],
+                             'C0': [2, 6]}
+
+


### PR DESCRIPTION
Added new internal method `DataTable::group(spec, as_view) -> pair<RowIndex, Groupby>`, as a replacement for `DataTable::sortby()`. The new method has more predictable return value: the returned rowindex either applies to the column, or to its source (for a view column), depending on the value of the parameter `as_view`.

Closes #1542 