### PR TITLE
Fix selecting and assigning to a 0-column subset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed groupby when it is applied to a Frame with view columns (#1542).
 
+- When replacing an empty set of columns, the replacement frame can now be
+  also empty (i.e. have shape [0 x 0]) (#1544).
+
 
 ### Changed
 
@@ -117,6 +120,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Improved the performance of setting `frame.nrows`. Now if the frame has
   multiple columns, a view will be created.
+
+- When no columns are selected in `DT[i, j]`, the returned frame will now
+  have the same number of rows as if at least 1 column was selected. Previously
+  an empty [0 x 0] frame was returned.
 
 
 ### Deprecated

--- a/c/expr/workframe.cc
+++ b/c/expr/workframe.cc
@@ -138,6 +138,12 @@ void workframe::fix_columns() {
 py::oobj workframe::get_result() {
   if (mode == EvalMode::SELECT) {
     DataTable* result = new DataTable(std::move(columns), std::move(colnames));
+    if (result->ncols == 0) {
+      // When selecting a 0-column subset, make sure the number of rows is the
+      // same as if some of the columns were selected.
+      result->nrows = frames[0].ri? frames[0].ri.size()
+                                  : frames[0].dt->nrows;
+    }
     return py::oobj::from_new_reference(py::Frame::from_datatable(result));
   }
   return py::None();

--- a/c/py_datatable.cc
+++ b/c/py_datatable.cc
@@ -315,17 +315,19 @@ PyObject* replace_column_slice(obj* self, PyObject* args) {
   DataTable* repl = py::robj(arg5).to_frame();
   size_t rrows = repl->nrows;
   size_t rcols = repl->ncols;
-  size_t rrows2 = rows_ri? rows_ri.size() : dt->nrows;
+  size_t lrows = rows_ri? rows_ri.size() : dt->nrows;
+  size_t lcols = count;
 
   if (!check_slice_triple(start, count, step, dt->ncols - 1)) {
     throw ValueError() << "Invalid slice " << start << "/" << count
                        << "/" << step << " for a Frame with " << dt->ncols
                        << " columns";
   }
-  bool ok = (rrows == rrows2 || rrows == 1) && (rcols == count || rcols == 1);
+  bool ok = ((rrows == lrows || rrows == 1) && (rcols == lcols || rcols == 1))
+            || (rrows == 0 && rcols == 0 && lcols == 0);
   if (!ok) {
     throw ValueError() << "Invalid replacement Frame: expected [" <<
-      rrows2 << " x " << count << "], but received [" << rrows <<
+      lrows << " x " << lcols << "], but received [" << rrows <<
       " x " << rcols << "]";
   }
 
@@ -357,13 +359,14 @@ PyObject* replace_column_array(obj* self, PyObject* args) {
   DataTable* repl = py::robj(arg3).to_frame();
   size_t rrows = repl->nrows;
   size_t rcols = repl->ncols;
-  size_t rrows2 = rows_ri? rows_ri.size() : dt->nrows;
+  size_t lrows = rows_ri? rows_ri.size() : dt->nrows;
+  size_t lcols = cols.size();
 
-  bool ok = (rrows == rrows2 || rrows == 1) &&
-            (rcols == cols.size() || rcols == 1);
+  bool ok = ((rrows == lrows || rrows == 1) && (rcols == lcols || rcols == 1))
+            || (rrows == 0 && rcols == 0 && lcols == 0);
   if (!ok) {
     throw ValueError() << "Invalid replacement Frame: expected [" <<
-      rrows2 << " x " << cols.size() << "], but received [" << rrows <<
+      lrows << " x " << cols.size() << "], but received [" << rrows <<
       " x " << rcols << "]";
   }
 

--- a/tests/munging/test_assign.py
+++ b/tests/munging/test_assign.py
@@ -6,6 +6,7 @@
 #-------------------------------------------------------------------------------
 import datatable as dt
 from datatable import f
+from tests import assert_equals
 
 
 
@@ -87,3 +88,13 @@ def test_assign_string_columns2():
     assert f0.names == ("A", )
     assert f0.stypes == (dt.stype.str32,)
     assert f0.to_list() == [["Oh my!", None, None, None, "infinity"]]
+
+
+def test_assign_empty_frame():
+    # See issue #1544
+    X = dt.Frame(A=range(10))
+    X[:, []] = X[:, []]
+    X.internal.check()
+    X[:, []] = dt.Frame()
+    X.internal.check()
+    assert_equals(X, dt.Frame(A=range(10)))

--- a/tests/munging/test_dt_cols.py
+++ b/tests/munging/test_dt_cols.py
@@ -248,7 +248,7 @@ def test_j_select_by_type2(dt0):
 
 def test_j_select_by_type3(dt0):
     dt3 = dt0[:, dt.ltype.str]
-    assert dt3.shape == (0, 0)
+    assert dt3.shape == (6, 0)
     assert dt3.to_list() == []
 
 
@@ -525,6 +525,12 @@ def test_j_expression2():
     #     assert f2.to_list() == f1.to_list()
 
 
+
+
+#-------------------------------------------------------------------------------
+# Special cases
+#-------------------------------------------------------------------------------
+
 def test_j_bad_arguments(dt0):
     """
     Check certain arguments that would be invalid as column selectors
@@ -562,3 +568,17 @@ def test_j_on_empty_frame():
     d2.internal.check()
     assert d1.shape == (0, 0)
     assert d2.shape == (0, 0)
+
+
+def test_empty_selector1(dt0):
+    d1 = dt0[:, []]
+    d1.internal.check()
+    assert d1.nrows == dt0.nrows
+    assert d1.ncols == 0
+
+
+def test_empty_selector2(dt0):
+    d1 = dt0[-3:, []]
+    d1.internal.check()
+    assert d1.nrows == 3
+    assert d1.ncols == 0


### PR DESCRIPTION
- When 0 columns are selected from a Frame, we now return the result with same number of rows as if some columns were selected;
- During assignment to a 0 column selection, the replacement Frame can now be 0x0.

Closes #1544 