### PR TITLE
Fix join applied to a view frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,40 +67,34 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fixed rendering of "view" Frames in a Jupyter notebook (#1448). This bug
-  caused the frame to display wrong data when viewed in a notebook. Thanks to
-  [Michael Frasco][] and [CarlosThinkBig][] for reporting.
+  caused the frame to display wrong data when viewed in a notebook.
 
 - Fixed crash when an int-column `i` selector is applied to a Frame which
-  already had another row filter applied (#1437). Thanks to [Arno Candel][] for
-  reporting.
+  already had another row filter applied (#1437).
 
 - `Frame.copy()` now retains the frame's key, if any (#1443).
 
-- Installation from source distribution now works as expected (#1451). Thanks to
-  [Jonathan McKinney][] for reporting.
+- Installation from source distribution now works as expected (#1451).
 
 - When a `g.`-column is used but there is no join frame, an appropriate
   error message is now emitted (#1481).
 
 - The equality operators `==` / `!=` can now be applied to string columns too
-  (#1491). Thanks to [Arno Candel][] for reporting.
+  (#1491).
 
 - Function `dt.split_into_nhot()` now works correctly with view Frames (#1507).
 
 - `DT.replace()` now works correctly when the replacement list is `[+inf]` or
-  `[1.7976931348623157e+308]` (#1510). Thanks to [Arno Candel][] for reporting.
+  `[1.7976931348623157e+308]` (#1510).
 
-- FTRL algorithm now works correctly with view frames (#1502). Thanks to
-  [Olivier][] for reporting this issue.
+- FTRL algorithm now works correctly with view frames (#1502).
 
 - Partial column update (i.e. expression of the form `DT[i, j] = R`) now works
   for string columns as well (#1523).
 
 - `DT.replace()` now throws an error if called with 0 or 1 argument (#1525).
-  Thanks to [Arno Candel][] for discovering this issue.
 
 - Fixed crash when viewing a frame obtained by resizing a 0-row frame (#1527).
-  Thanks to [Nishant Kalonia][] for reporting.
 
 - Function `count()` now returns correct result within the `DT[i, j]` expression
   with non-trivial `i` (#1316).
@@ -109,6 +103,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - When replacing an empty set of columns, the replacement frame can now be
   also empty (i.e. have shape [0 x 0]) (#1544).
+
+- Fixed join results when join is applied to a view frame (#1540).
 
 
 ### Changed
@@ -154,6 +150,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   - [Michael Frasco][] - documentation fixes;
 
   - [Michal Raška][] - build system maintenance.
+
+- Additional thanks to people who helped make `datatable` more stable by
+  discovering and reporting bugs that were fixed in this release:
+
+  [Pasha Stetsenko][] (#1316, #1443, #1481, #1542),
+  [Arno Candel][] (#1437, #1491, #1510, #1525),
+  [Michael Frasco][] (#1448),
+  [Jonathan McKinney][] (#1451),
+  [CarlosThinkBig][] (#1475),
+  [Olivier][] (#1502),
+  [Oleksiy Kononenko][] (#1507),
+  [Nishant Kalonia][] (#1527, #1540),
+  [Megan Kurka][] (#1544).
 
 
 
@@ -841,6 +850,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [arno candel]: https://github.com/arnocandel
 [carlosthinkbig]: https://github.com/CarlosThinkBig
 [jonathan mckinney]: https://github.com/pseudotensor
+[megan kurka]: https://github.com/meganjkurka
 [michael frasco]: https://github.com/mfrasco
 [michal raška]: https://github.com/michal-raska
 [nishant kalonia]: https://github.com/nkalonia1

--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -240,3 +240,15 @@ def test_issue1481_3():
         noop(DT[:, g.A + 1])
     assert ("Column expression references a non-existing join frame"
             == str(e.value))
+
+
+def test_join_view():
+    # See issue #1540
+    x = dt.Frame(A=[1,2,3,1,2,3], B=[3,6,2,4,3,1], C=list("bdbbdb"))
+    a = x[f.A == 1, ['A', 'B', 'C']]
+    r = dt.Frame(C=['b', 'z'], BB=[2, 1000])
+    r.key = 'C'
+    res = a[:, :, join(r)]
+    assert res.shape == (2, 4)
+    assert res.names == ("A", "B", "C", "BB")
+    assert res.to_list() == [[1, 1], [3, 4], ['b', 'b'], [2, 2]]


### PR DESCRIPTION
The fix is currently partial: we materialize the left frame before join. In the future (after #1188) we could do better and work with view frame directly.

Closes #1540 