### PR TITLE
Traverse exemplars in a quasi-random order in ND aggregator

### DIFF
--- a/c/extras/aggregator.cc
+++ b/c/extras/aggregator.cc
@@ -583,7 +583,6 @@ void Aggregator::group_nd(const dtptr& dt, dtptr& dt_members) {
   // some new exemplars were added (and may be even `delta` was adjusted)
   // meanwhile, so restart is needed for the `test_member` procedure.
   size_t ecounter = 0;
-//  srand(seed);
 
   #pragma omp parallel num_threads(nth0)
   {

--- a/c/extras/aggregator.cc
+++ b/c/extras/aggregator.cc
@@ -600,11 +600,14 @@ void Aggregator::group_nd(const dtptr& dt, dtptr& dt_members) {
           dt::shared_lock<dt::shared_bmutex> lock(shmutex, /* exclusive = */ false);
           ecounter_local = ecounter;
           size_t nexemplars = exemplars.size();
-          // direct-order-search, may result in larger first and tiny last exemplars
-          // for (size_t j = 0; j < nexemplars; ++j) {
 
-          // reverse-order-search, better in terms of balance in the `member_counts`
-          for (size_t j = nexemplars - 1; j < nexemplars; --j) {
+          std::vector<size_t> sample;
+          sample.reserve(nexemplars);
+          for (size_t k = 0; k < nexemplars; ++k) sample.push_back(k);
+          std::random_shuffle(sample.begin(), sample.end());
+
+          for (size_t k = 0; k < nexemplars; ++k) {
+            size_t j = sample[k];
             // Note, this distance will depend on delta, because
             // `early_exit = true` by default
             distance = calculate_distance(member, exemplars[j]->coords, ndims, delta);

--- a/c/extras/aggregator.cc
+++ b/c/extras/aggregator.cc
@@ -599,7 +599,12 @@ void Aggregator::group_nd(const dtptr& dt, dtptr& dt_members) {
         test_member: {
           dt::shared_lock<dt::shared_bmutex> lock(shmutex, /* exclusive = */ false);
           ecounter_local = ecounter;
-          for (size_t j = 0; j < exemplars.size(); ++j) {
+          size_t nexemplars = exemplars.size();
+          // direct-order-search, may result in larger first and tiny last exemplars
+          // for (size_t j = 0; j < nexemplars; ++j) {
+
+          // reverse-order-search, better in terms of balance in the `member_counts`
+          for (size_t j = nexemplars - 1; j < nexemplars; --j) {
             // Note, this distance will depend on delta, because
             // `early_exit = true` by default
             distance = calculate_distance(member, exemplars[j]->coords, ndims, delta);

--- a/c/extras/aggregator.cc
+++ b/c/extras/aggregator.cc
@@ -609,9 +609,9 @@ void Aggregator::group_nd(const dtptr& dt, dtptr& dt_members) {
           size_t ncoprimes = coprimes.size();
 
           // Generate random exemplar and coprime vector indices.
-          // When `nexemplars` is zero, this may generate any `size_t` number,
-          // however, since we do not do any testing in this case, this is
-          // not an issue.
+          // When `nexemplars` is zero, this may be any `size_t` number,
+          // however, since we do not do any member testing in this case,
+          // this is not an issue.
           std::uniform_int_distribution<size_t> exemplars_dist(0, nexemplars - 1);
           std::uniform_int_distribution<size_t> coprimes_dist(0, ncoprimes - 1);
           size_t exemplar_index = exemplars_dist(generator);

--- a/c/extras/aggregator.cc
+++ b/c/extras/aggregator.cc
@@ -669,20 +669,28 @@ void Aggregator::group_nd(const dtptr& dt, dtptr& dt_members) {
 
 void Aggregator::fill_coprimes(size_t n, std::vector<size_t>& coprimes) {
   coprimes.clear();
-  for (size_t i = 1; i <= n; ++i) {
-    if (gcd(i, n) == 1) coprimes.push_back(i);
+  if (n == 1) {
+    coprimes.push_back(1);
+    return;
   }
-}
 
-
-size_t Aggregator::gcd(size_t a, size_t b) {
-  size_t x;
-  while (b) {
-    x = a % b;
-    a = b;
-    b = x;
+  std::vector<bool> mask(n - 1, false);
+  for (size_t i = 2; i <= n / 2; ++i) {
+    if (mask[i - 1]) continue;
+    if (n % i == 0) {
+      size_t j = 1;
+      while (j * i < n) {
+        mask[j * i - 1] = true;
+        j++;
+      }
+    }
   }
-  return a;
+
+  for (size_t i = 1; i < n; ++i) {
+    if (mask[i - 1] == 0) {
+      coprimes.push_back(i);
+    }
+  }
 }
 
 

--- a/c/extras/aggregator.h
+++ b/c/extras/aggregator.h
@@ -75,4 +75,8 @@ class Aggregator {
     void adjust_members(std::vector<size_t>&, dtptr&);
     size_t calculate_map(std::vector<size_t>&, size_t);
     void progress(double, int status_code=0);
+
+    // Randomization methods
+    static void calc_coprimes(std::vector<size_t>&, size_t);
+    static size_t gcd(size_t, size_t);
 };

--- a/c/extras/aggregator.h
+++ b/c/extras/aggregator.h
@@ -63,6 +63,10 @@ class Aggregator {
     bool random_sampling(dtptr&, size_t, size_t);
     void aggregate_exemplars(DataTable*, dtptr&, bool);
 
+    // Methods for modular quasi-random generator
+    static void fill_coprimes(size_t, std::vector<size_t>&);
+    static size_t gcd(size_t, size_t);
+
     // Helper methods
     size_t get_nthreads(const dtptr&);
     doubleptr generate_pmatrix(const dtptr&);
@@ -75,8 +79,4 @@ class Aggregator {
     void adjust_members(std::vector<size_t>&, dtptr&);
     size_t calculate_map(std::vector<size_t>&, size_t);
     void progress(double, int status_code=0);
-
-    // Randomization methods
-    static void calc_coprimes(std::vector<size_t>&, size_t);
-    static size_t gcd(size_t, size_t);
 };

--- a/c/extras/aggregator.h
+++ b/c/extras/aggregator.h
@@ -65,7 +65,6 @@ class Aggregator {
 
     // Methods for modular quasi-random generator
     static void fill_coprimes(size_t, std::vector<size_t>&);
-    static size_t gcd(size_t, size_t);
 
     // Helper methods
     size_t get_nthreads(const dtptr&);


### PR DESCRIPTION
When exemplars are traversed in the order they appear in the `exemplars` vector, first exemplars will always have a priority over the last ones, hence, first exemplars "absorb" most of the members. In this case one can not distinguish real outliers with the exemplars (the last ones) that just had no chances to get some members.

One of the ways to fix it is to traverse exemplars in a random order, so that each exemplar gets the "same" chances to "absorb" a particular member. Here we use modular arithmetic to traverse exemplars in quasi-random order, as this approach seems to have negligible overhead, when comparing to `std::random_shuffle`, and we do not really need to be fully random, but just different enough to not inflate some particular exemplars.