### PR TITLE
Implement `m__dealloc__` to delete models and labels

### DIFF
--- a/c/extras/py_ftrl.cc
+++ b/c/extras/py_ftrl.cc
@@ -65,8 +65,8 @@ static onamedtupletype& _get_params_namedtupletype() {
 
 
 void Ftrl::m__init__(PKArgs& args) {
-  dt::FtrlParams dt_params = dt::Ftrl::default_params;
   dtft = nullptr;
+  dt::FtrlParams dt_params = dt::Ftrl::default_params;
 
   bool defined_params   = !args[0].is_none_or_undefined();
   bool defined_labels   = !args[1].is_none_or_undefined();
@@ -153,8 +153,8 @@ void Ftrl::m__init__(PKArgs& args) {
   }
 
   dtft = new std::vector<dtftptr>;
-  reg_type = RegType::NONE;
   init_dtft(dt_params);
+  reg_type = RegType::NONE;
 }
 
 

--- a/c/extras/py_ftrl.cc
+++ b/c/extras/py_ftrl.cc
@@ -177,6 +177,7 @@ void Ftrl::m__dealloc__() {
   Py_XDECREF(py_labels);
   if (dtft != nullptr) {
     delete dtft;
+    dtft = nullptr;
   }
 }
 

--- a/c/extras/py_ftrl.h
+++ b/c/extras/py_ftrl.h
@@ -39,7 +39,7 @@ enum class RegType : uint8_t {
 
 class Ftrl : public PyObject {
   private:
-    std::vector<dtftptr> dtft;
+    std::vector<dtftptr>* dtft;
     py::olist labels;
     RegType reg_type;
     size_t : 56;


### PR DESCRIPTION
As `py::Ftrl` class is managed by Python, `m__dealloc` should deallocate all the resources. Implement it to prevent memory leaks.

Could help to fix https://github.com/h2oai/h2oai/issues/6633 and https://github.com/h2oai/h2oai/issues/6514