### PR TITLE
Fix a bug in true division of integers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - A string column produced from a partial join now materializes correctly
   (#1556).
 
+- Fixed incorrect result during "true division" of integer columns, when one
+  of the values was negative and the other positive (#1562).
+
 
 ### Changed
 
@@ -171,7 +174,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   discovering and reporting bugs that were fixed in this release:
 
   [Pasha Stetsenko][] (#1316, #1443, #1481, #1542, #1551),
-  [Arno Candel][] (#1437, #1491, #1510, #1525, #1549, #1556),
+  [Arno Candel][] (#1437, #1491, #1510, #1525, #1549, #1556, #1562),
   [Michael Frasco][] (#1448),
   [Jonathan McKinney][] (#1451),
   [CarlosThinkBig][] (#1475),

--- a/c/expr/binaryop.cc
+++ b/c/expr/binaryop.cc
@@ -195,7 +195,7 @@ inline static VT op_div(LT x, RT y) {
   VT vx = static_cast<VT>(x);
   VT vy = static_cast<VT>(y);
   VT res = vx / vy;
-  if ((vx < 0) != (vy < 0) && vx != res * vy) {
+  if (std::is_integral<VT>::value && (vx < 0) != (vy < 0) && vx != res * vy) {
     --res;
   }
   return res;

--- a/tests/test_dt_expr.py
+++ b/tests/test_dt_expr.py
@@ -503,11 +503,17 @@ def test_div_mod(seed):
     src2 = [random.randint(-10, 10) for _ in range(n)]
 
     df0 = dt.Frame(x=src1, y=src2)
-    df1 = df0[:, [f.x // f.y, f.x % f.y]]
+    df1 = df0[:, [f.x // f.y, f.x % f.y, f.x / f.y]]
     assert df1.to_list() == [
         [None if src2[i] == 0 else src1[i] // src2[i] for i in range(n)],
-        [None if src2[i] == 0 else src1[i] % src2[i] for i in range(n)]
+        [None if src2[i] == 0 else src1[i] % src2[i] for i in range(n)],
+        [None if src2[i] == 0 else src1[i] / src2[i] for i in range(n)]
     ]
+
+
+def test_issue1562():
+    DT = dt.Frame(A=[-8], B=[1677])
+    assert DT[:, f.A / f.B][0, 0] == -(8.0 / 1677.0)
 
 
 


### PR DESCRIPTION
The issue was that the logic for correcting integer division (offsetting by -1 when dividing a negative number by a positive) was incorrectly applied for true division as well.

Closes #1562 