### PR TITLE
Implement post-link fix-up of the built executable on MacOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,7 +105,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed groupby when it is applied to a Frame with view columns (#1542).
 
 - When replacing an empty set of columns, the replacement frame can now be
-  also empty (i.e. have shape [0 x 0]) (#1544).
+  also empty (i.e. have shape `[0 x 0]`) (#1544).
 
 - Fixed join results when join is applied to a view frame (#1540).
 
@@ -121,6 +121,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - `Frame.to_csv()` no longer crashes on Unix when writing an empty frame
   (#1565).
+
+- The build process on MacOS now ensures that the `libomp.dylib` is properly
+  referenced via `@rpath`. This prevents installation problems caused by the
+  dynamic dependencies referenced by their absolute paths which are not valid
+  outside of the build machine (#1559).
 
 
 ### Changed
@@ -138,7 +143,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - When no columns are selected in `DT[i, j]`, the returned frame will now
   have the same number of rows as if at least 1 column was selected. Previously
-  an empty [0 x 0] frame was returned.
+  an empty `[0 x 0]` frame was returned.
 
 - Assigning a value to a column `DT[:, 'A'] = x` will attempt to preserve the
   column's stype; or if not possible, the column will be upcasted within its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,7 +195,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   [Olivier][] (#1502),
   [Oleksiy Kononenko][] (#1507),
   [Nishant Kalonia][] (#1527, #1540),
-  [Megan Kurka][] (#1544).
+  [Megan Kurka][] (#1544),
+  [Joseph Granados][] (#1559).
 
 
 
@@ -883,6 +884,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [arno candel]: https://github.com/arnocandel
 [carlosthinkbig]: https://github.com/CarlosThinkBig
 [jonathan mckinney]: https://github.com/pseudotensor
+[joseph granados]: https://github.com/g-eoj
 [megan kurka]: https://github.com/meganjkurka
 [michael frasco]: https://github.com/mfrasco
 [michal raška]: https://github.com/michal-raska

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,25 @@
-#!/usr/bin/env python3
-# © H2O.ai 2018; -*- encoding: utf-8 -*-
-#   This Source Code Form is subject to the terms of the Mozilla Public
-#   License, v. 2.0. If a copy of the MPL was not distributed with this
-#   file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#-------------------------------------------------------------------------------
+# Copyright 2018 H2O.ai
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
 #-------------------------------------------------------------------------------
 """
 Build script for the `datatable` module.
@@ -16,9 +33,10 @@ import shutil
 import sys
 from setuptools import setup, find_packages, Extension
 from ci.setup_utils import (get_datatable_version, make_git_version_file,
-                            get_llvm, get_compiler, get_extra_compile_flags,
+                            get_compiler, get_extra_compile_flags,
                             get_extra_link_args, find_linked_dynamic_libraries,
-                            TaskContext, islinux, ismacos, iswindows)
+                            TaskContext, islinux, ismacos, iswindows,
+                            monkey_patch_compiler)
 
 print()
 cmd = ""
@@ -135,6 +153,9 @@ if cmd in ("build", "bdist_wheel", "build_ext", "install"):
             else:
                 log.info("Copying %s to %s" % (libpath, trgfile))
                 shutil.copy(libpath, trgfile)
+
+    if ismacos():
+        monkey_patch_compiler()
 
 
 # Create the git version file


### PR DESCRIPTION
This PR augments the existing `CCompiler` class used by `setup.py`, such that after the usual link stage a "post-link" action is executed. In this post-link step we do the following:
- Check the LOAD_DYLIB entries in the _datatable.so library, using `otool -L`;
- Verify that only standard system entries (`/usr/lib/*`) or local dynamic libraries (`@rpath/*`) are present;
- If not, the entries are fixed up using the `name_install_tool -change`;
- Verify that all referenced local dylibs (`@rpath/*`) are actually present in the `datatable/lib/` directory.

This change affects MacOS only. In principle, similar process can be applied on Linux platform as well.

Here's the output example from this process:
```
Post-link processing
  Output file: build/lib.macosx-10.9-x86_64-3.6/datatable/lib/_datatable.cpython-36m-darwin.so
  Checking dependencies of _datatable.cpython-36m-darwin.so
    $ otool -L build/lib.macosx-10.9-x86_64-3.6/datatable/lib/_datatable.cpython-36m-darwin.so
      /usr/local/opt/llvm/lib/libomp.dylib
      /usr/lib/libc++.1.dylib
      /usr/lib/libSystem.B.dylib
  Relocating dependency libomp.dylib
    $ install_name_tool -change /usr/local/opt/llvm/lib/libomp.dylib @rpath/libomp.dylib build/lib.macosx-10.9-x86_64-3.6/datatable/lib/_datatable.cpython-36m-darwin.so
  Checking dependencies of _datatable.cpython-36m-darwin.so
    $ otool -L build/lib.macosx-10.9-x86_64-3.6/datatable/lib/_datatable.cpython-36m-darwin.so
      @rpath/libomp.dylib
      /usr/lib/libc++.1.dylib
      /usr/lib/libSystem.B.dylib
  Checking dependencies of libomp.dylib
    $ otool -L datatable/lib/libomp.dylib
      /usr/lib/libSystem.B.dylib
  Resolved list of dependencies:
    /usr/lib/libSystem.B.dylib
    /usr/lib/libc++.1.dylib
    @rpath/libomp.dylib
```

Closes #1559 