### PR TITLE
Fix assignment DT[i,j] = list-of-exprs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   dynamic dependencies referenced by their absolute paths which are not valid
   outside of the build machine (#1559).
 
+- Fixed crash when the RHS of assignment `DT[i, j] = ...` was a list of
+  expressions (#1539).
+
 
 ### Changed
 
@@ -187,7 +190,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Additional thanks to people who helped make `datatable` more stable by
   discovering and reporting bugs that were fixed in this release:
 
-  [Pasha Stetsenko][] (#1316, #1443, #1481, #1542, #1551),
+  [Pasha Stetsenko][] (#1316, #1443, #1481, #1539, #1542, #1551),
   [Arno Candel][] (#1437, #1491, #1510, #1525, #1549, #1556, #1562),
   [Michael Frasco][] (#1448),
   [Jonathan McKinney][] (#1451, #1565),


### PR DESCRIPTION
The fix itself was introduced in #1561, this merely adds the relevant tests.

Closes #1539.