### PR TITLE
Added many tests for DT[i,j]=... assignment

### DIFF
--- a/c/column.cc
+++ b/c/column.cc
@@ -40,6 +40,7 @@ Column* Column::new_column(SType stype) {
 
 
 Column* Column::new_data_column(SType stype, size_t nrows) {
+  xassert(stype != SType::VOID);
   Column* col = new_column(stype);
   col->nrows = nrows;
   col->init_data();

--- a/c/expr/repl_node.cc
+++ b/c/expr/repl_node.cc
@@ -171,8 +171,15 @@ void scalar_rn::replace_values(workframe& wf, const intvec& indices) const {
     Column* col = dt0->columns[j];
     SType st = col? col->stype() : SType::VOID;
     colptr replcol = make_column(st, 1);
-    if (!col) {
-      col = Column::new_na_column(st, dt0->nrows);
+    if (col) {
+      SType res_stype = replcol->stype();
+      if (col->stype() != res_stype) {
+        dt0->columns[j] = col->cast(res_stype);
+        delete col;
+        col = dt0->columns[j];
+      }
+    } else {
+      col = Column::new_na_column(replcol->stype(), dt0->nrows);
       dt0->columns[j] = col;
     }
     col->replace_values(ri0, replcol.get());
@@ -194,7 +201,7 @@ class scalar_na_rn : public scalar_rn {
 };
 
 const char* scalar_na_rn::value_type() const noexcept {
-  return "None";
+  return "None";  // LCOV_EXCL_LINE
 }
 
 

--- a/c/frame/repeat.cc
+++ b/c/frame/repeat.cc
@@ -64,6 +64,9 @@ Column* Column::repeat(size_t nreps) {
   size_t new_nrows = nrows * nreps;
 
   Column* newcol = Column::new_data_column(stype(), new_nrows);
+  if (!new_nrows) {
+    return newcol;
+  }
   const void* olddata = data();
   void* newdata = newcol->data_w();
 

--- a/tests/munging/test_assign.py
+++ b/tests/munging/test_assign.py
@@ -170,3 +170,138 @@ def test_assign_list_duplicates():
     assert DT.to_list() == [[0, 1, 2, 3, 4], [1, 2, 3, 4, 5], [2, 3, 4, 5, 6]]
     assert len(ws) == 1
     assert "Duplicate column name 'B' found" in ws[0].message.args[0]
+
+
+def test_stats_after_assign():
+    DT = dt.Frame(A=[0, 1, None, 4, 7])
+    assert DT.min1() == 0
+    assert DT.max1() == 7
+    assert DT.countna1() == 1
+    DT[:, "A"] = 100
+    assert DT.min1() == DT.max1() == 100
+    assert DT.countna1() == 0
+
+
+
+
+#-------------------------------------------------------------------------------
+# Assign a scalar
+#-------------------------------------------------------------------------------
+
+def test_assign_scalar_to_one_column():
+    DT = dt.Frame([range(5), [4, 3, 9, 11, -1]], names=("A", "B"))
+    DT[:, "B"] = 100
+    DT.internal.check()
+    assert DT.names == ("A", "B")
+    assert DT.stypes == (dt.int32, dt.int8)
+    assert DT.to_list() == [[0, 1, 2, 3, 4], [100] * 5]
+
+
+def test_assign_scalar_to_all():
+    DT = dt.Frame([range(5), [4, 3, 9, 11, -1]], names=("A", "B"))
+    DT[:, :] = 12
+    DT.internal.check()
+    assert DT.names == ("A", "B")
+    assert DT.stypes == (dt.int32, dt.int8)
+    assert DT.to_list() == [[12] * 5] * 2
+
+
+def test_assign_scalar_to_list_of_columns():
+    DT = dt.Frame([[1, 3, 4], [2.5, 17.3, None], [4.99, -12, 2.22]],
+                  names=("A", "B", "C"))
+    DT[:, ["A", "C"]] = 35
+    DT.internal.check()
+    assert DT.names == ("A", "B", "C")
+    assert DT.stypes == (dt.int8, dt.float64, dt.float64)
+    assert DT.to_list() == [[35] * 3, [2.5, 17.3, None], [35.0] * 3]
+
+
+def test_assign_scalar_to_subset_of_rows():
+    DT = dt.Frame(A=range(8))
+    DT[::2, "A"] = 100
+    assert_equals(DT, dt.Frame(A=[100, 1, 100, 3, 100, 5, 100, 7],
+                               stype=dt.int32))
+
+
+def test_assign_scalar_to_empty_frame_0x0():
+    DT = dt.Frame()
+    DT[:, "A"] = 'foo!'
+    assert_equals(DT, dt.Frame(A=[], stype=dt.str32))
+
+
+def test_assign_scalar_to_empty_frame_3x0():
+    DT = dt.Frame()
+    DT.nrows = 3
+    DT[:, "A"] = 'foo!'
+    assert_equals(DT, dt.Frame(A=['foo!'] * 3, stype=dt.str32))
+
+
+def test_assign_scalar_to_empty_frame_0x3():
+    DT = dt.Frame(A=[], B=[], C=[])
+    DT[:, "A":"C"] = 0
+    assert_equals(DT, dt.Frame(A=[], B=[], C=[]))
+
+
+def test_assign_scalar_out_of_range():
+    DT = dt.Frame(A=[1, 2, 3])
+    assert DT.stypes == (dt.int8,)
+    DT[:, "A"] = 5000000
+    assert_equals(DT, dt.Frame(A=[5000000] * 3))
+
+
+def test_assign_scalar_out_of_range_to_subset():
+    DT = dt.Frame(A=list(range(10)))
+    assert DT.stypes == (dt.int8,)
+    DT[:3, "A"] = 999
+    assert_equals(DT, dt.Frame(A=[999, 999, 999, 3, 4, 5, 6, 7, 8, 9]))
+
+
+def test_assign_scalar_to_newcolumn_subset():
+    DT = dt.Frame(A=range(5))
+    DT[[1, 4], "B"] = 3.7
+    assert_equals(DT, dt.Frame(A=range(5), B=[None, 3.7, None, None, 3.7]))
+
+
+def test_assign_scalar_wrong_type():
+    DT = dt.Frame(A=range(5))
+    with pytest.raises(TypeError) as e:
+        DT[:, "A"] = 'what?'
+    assert ("Cannot assign string value to column `A` of type int32"
+            == str(e.value))
+
+
+@pytest.mark.parametrize("x", [3.9, 995])
+def test_assign_scalar_wrong_type2(x):
+    DT = dt.Frame(A=["hello"])
+    with pytest.raises(TypeError) as e:
+        DT[:, "A"] = x
+    name = "integer" if isinstance(x, int) else "float"
+    assert ("Cannot assign %s value to column `A` of type str32" % name
+            == str(e.value))
+
+
+def test_assign_scalar_int_overflow():
+    # When integer overflows, it becomes a max int64
+    # (not sure this is desired behavior...)
+    DT = dt.Frame(A=range(5))
+    DT[:, "A"] = 10**100
+    assert_equals(DT, dt.Frame(A=[2**63 - 1] * 5))
+
+
+def test_assign_scalar_float_upcast():
+    # When float32 overflows, it is converted to float64
+    DT = dt.Frame(A=[1.3, 2.7], stype=dt.float32)
+    DT[:, "A"] = 1.5e+100
+    assert_equals(DT, dt.Frame(A=[1.5e100, 1.5e100]))
+
+
+def test_assign_scalar_to_float32_column():
+    DT = dt.Frame(A=range(5), stype=dt.float32)
+    DT[:, "A"] = 3.14159
+    assert_equals(DT, dt.Frame(A=[3.14159] * 5, stype=dt.float32))
+
+
+def test_assign_scalar_to_str64_column():
+    DT = dt.Frame(A=["wonder", None, "ful", None], stype=dt.str64)
+    DT[:, "A"] = "beep"
+    assert_equals(DT, dt.Frame(A=["beep"] * 4, stype=dt.str64))


### PR DESCRIPTION
Implement column upcasting when assigning a value which would otherwise not fit into the given stype.

This also fixes a couple of other bugs:
- `repeat(0)` was causing a crash;
- partial column assignment was creating a column of VOID stype;

Closes #1554 