### PR TITLE
Fix a bug when mixing computed & regular columns (with groupby)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Expression `DT[:, :, by(...)]` no longer produces duplicates of columns used
   in the by-clause (#1576).
 
+- In certain circumstances mixing computed and plain columns under groupby
+  caused incorrect result (#1578).
+
 
 ### Changed
 
@@ -204,7 +207,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Additional thanks to people who helped make `datatable` more stable by
   discovering and reporting bugs that were fixed in this release:
 
-  [Pasha Stetsenko][] (#1316, #1443, #1481, #1539, #1542, #1551, #1572, #1576),
+  [Pasha Stetsenko][] (#1316, #1443, #1481, #1539, #1542, #1551, #1572, #1576,
+    #1578),
   [Arno Candel][] (#1437, #1491, #1510, #1525, #1549, #1556, #1562),
   [Michael Frasco][] (#1448),
   [Jonathan McKinney][] (#1451, #1565),

--- a/c/expr/base_expr.h
+++ b/c/expr/base_expr.h
@@ -80,7 +80,7 @@ class base_expr {
     virtual ~base_expr();
     virtual SType resolve(const workframe&) = 0;
     virtual GroupbyMode get_groupby_mode(const workframe&) const = 0;
-    virtual Column* evaluate_eager(const workframe&) = 0;
+    virtual Column* evaluate_eager(workframe&) = 0;
 };
 
 
@@ -97,7 +97,7 @@ class expr_column : public base_expr {
     size_t get_col_index(const workframe&);
     SType resolve(const workframe&) override;
     GroupbyMode get_groupby_mode(const workframe&) const override;
-    Column* evaluate_eager(const workframe&) override;
+    Column* evaluate_eager(workframe&) override;
 };
 
 

--- a/c/expr/workframe.cc
+++ b/c/expr/workframe.cc
@@ -238,12 +238,12 @@ void workframe::add_column(
 
 RowIndex& workframe::_product(const RowIndex& ra, const RowIndex& rb) {
   for (auto it = all_ri.rbegin(); it != all_ri.rend(); ++it) {
-    if (it->first == ra) {
-      return it->second;
+    if (it->ab == ra && it->bc == rb) {
+      return it->ac;
     }
   }
-  all_ri.push_back(std::make_pair(ra, ra * rb));
-  return all_ri.back().second;
+  all_ri.push_back({ra, rb, ra * rb});
+  return all_ri.back().ac;
 }
 
 

--- a/c/expr/workframe.h
+++ b/c/expr/workframe.h
@@ -88,7 +88,7 @@ class workframe {
     // Result
     colvec columns;
     strvec colnames;
-    using ripair = std::pair<RowIndex, RowIndex>;
+    struct ripair { RowIndex ab, bc, ac; };
     std::vector<ripair> all_ri;
 
   public:
@@ -130,6 +130,7 @@ class workframe {
     RowIndex& _product(const RowIndex& ra, const RowIndex& rb);
     void fix_columns();
 
+    friend class expr_column;  // Use _product
     friend class by_node;  // Allow access to `gb`
 };
 

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -63,7 +63,6 @@ def test_groups_internal2():
                      A=[1, 1, 2, 5, 1, 3, None, 3, 1]))
 
 
-@pytest.mark.xfail(reason="Issue #1578")
 def test_groups_internal3():
     f0 = dt.Frame(A=[1, 2, 1, 3, 2, 2, 2, 1, 3, 1], B=range(10))
     f1 = f0[:, [f.B, f.A + f.B], by(f.A)]


### PR DESCRIPTION
The products of rowindexes were memoized incorrectly, this is now fixed.
In addition, implemented a TODO note in `expr_column` class, which now uses rowindex product memoization too.

Closes #1578 