### PR TITLE
slice-valued i expression, combined with a groupby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   the function `sort()`. If sorting is specified alongside a groupby, the
   values will be sorted within each group (#1531).
 
+- A slice-valued `i` expression can now be combined with a `by()` operator
+  in `DT[i, j, by()]`. The result is that the slice `i` is applied to each
+  group produced by `by()`, before the `j` is evaluated (#1585).
+
 
 ### Fixed
 

--- a/c/expr/i_node.cc
+++ b/c/expr/i_node.cc
@@ -185,21 +185,25 @@ void slice_in::execute_grouped(workframe& wf) {
     }
   }
   else if (step < 0) {
-    if (istart == py::oslice::NA) istart = static_cast<int64_t>(wf.nrows());
+    int32_t start, stop;
     for (size_t g = 0; g < ng; ++g) {
       int32_t off0 = group_offsets[g - 1];
       int32_t off1 = group_offsets[g];
       int32_t n = off1 - off0;
-      int32_t start = istart == py::oslice::NA || istart >= n
-                      ? n - 1 : static_cast<int32_t>(istart);
+      start = istart == py::oslice::NA || istart >= n
+              ? n - 1 : static_cast<int32_t>(istart);
       if (start < 0) start += n;
-      int32_t stop = -1;  // if istop==NA
-      if (istop != py::oslice::NA) {
+      start += off0;
+      if (istop == py::oslice::NA) {
+        stop = off0 - 1;
+      } else {
         stop = static_cast<int32_t>(istop);
         if (stop < 0) stop += n;
+        if (stop < 0) stop = -1;
+        stop += off0;
       }
       if (start > stop) {
-        for (int32_t i = start; i > stop; ++i) {
+        for (int32_t i = start; i > stop; i += step) {
           out_rowindices[j++] = i;
         }
         out_offsets[k++] = static_cast<int32_t>(j);

--- a/c/expr/i_node.h
+++ b/c/expr/i_node.h
@@ -44,6 +44,7 @@ class i_node {
     virtual ~i_node();
     virtual void post_init_check(workframe&);
     virtual void execute(workframe&) = 0;
+    virtual void execute_grouped(workframe&) = 0;
 };
 
 

--- a/c/expr/workframe.h
+++ b/c/expr/workframe.h
@@ -113,7 +113,7 @@ class workframe {
 
     DataTable* get_datatable(size_t i) const;
     const RowIndex& get_rowindex(size_t i) const;
-    const Groupby& get_groupby() const;
+    const Groupby& get_groupby();
     const by_node& get_by_node() const;
     bool is_naturally_joined(size_t i) const;
     bool has_groupby() const;
@@ -121,6 +121,7 @@ class workframe {
     size_t nrows() const;
 
     void apply_rowindex(const RowIndex& ri);
+    void apply_groupby(const Groupby& gb_);
 
     size_t size() const noexcept;
     void reserve(size_t n);

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -115,7 +115,9 @@ def assert_equals(frame1, frame2):
         assert frame1.stypes == frame2.stypes, (
             "The left frame has stypes %r, while the right has stypes %r"
             % (frame1.stypes, frame2.stypes))
-        assert frame1.to_list() == frame2.to_list()
+        assert frame1.to_list() == frame2.to_list(), (
+            "The frames have different data:\n"
+            "LHS = %r\nRHS = %r" % (frame1.to_list(), frame2.to_list()))
     else:
         assert frame1.shape == frame2.shape
         assert same_iterables(frame1.names, frame2.names)

--- a/tests/munging/test_dt_rows.py
+++ b/tests/munging/test_dt_rows.py
@@ -23,8 +23,8 @@
 #-------------------------------------------------------------------------------
 import pytest
 import datatable as dt
-from datatable import stype, ltype, f
-from tests import same_iterables, noop
+from datatable import stype, ltype, f, by
+from tests import same_iterables, noop, assert_equals
 
 
 #-------------------------------------------------------------------------------
@@ -869,3 +869,18 @@ def test_issue1437(st):
     d2.internal.check()
     assert d2.to_list() == [list(range(10))]
 
+
+
+
+#-------------------------------------------------------------------------------
+# (i=slice) + by
+#-------------------------------------------------------------------------------
+
+def test_grouped_slice_simple():
+    DT = dt.Frame(A=[1,2,3,1,2,3], B=[3,4,3,4,3,4])
+    res1 = DT[1:, :, by("B")]
+    res2 = DT[:2, :, by("B")]
+    res3 = DT[::-1, :, by("B")]
+    assert_equals(res1, dt.Frame(B=[3, 3, 4, 4], A=[3, 2, 1, 3]))
+    assert_equals(res2, dt.Frame(B=[3, 3, 4, 4], A=[1, 3, 2, 1]))
+    assert_equals(res3, dt.Frame(B=[3, 3, 3, 4, 4, 4], A=[2, 3, 1, 3, 1, 2]))

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -154,14 +154,14 @@ def test_groups_autoexpand():
                             [2, 7, 0, 5, 13]]
 
 
-@pytest.mark.skip(reason="Issue #1348")
+@pytest.mark.skip(reason="Issue #1586")
 def test_groupby_with_filter1():
     f0 = dt.Frame({"KEY": [1, 2, 1, 2, 1, 2], "X": [-10, 2, 3, 0, 1, -7]})
     f1 = f0[f.X > 0, sum(f.X), f.KEY]
     assert f1.to_list() == [[1, 2], [4, 2]]
 
 
-@pytest.mark.skip(reason="Issue #1348")
+@pytest.mark.skip(reason="Issue #1586")
 def test_groupby_with_filter2():
     # Check that rowindex works even when applied to a view
     n = 10000


### PR DESCRIPTION
This PR allows the syntax such as
```
DT[:5, :, by("id")]
```
to select the first 5 rows for each group when the frame is grouped by the "id" column.

Slices with positive, negative, and zero step are supported.

Closes #1585