### PR TITLE
Adjust FTRL feature importance tests

### DIFF
--- a/c/extras/py_ftrl.cc
+++ b/c/extras/py_ftrl.cc
@@ -209,7 +209,7 @@ lambda1 : float
     L1 regularization parameter.
 lambda2 : float
     L2 regularization parameter.
-d : int
+nbins : int
     Number of bins to be used after the hashing trick.
 nepochs : int
     Number of epochs to train for.

--- a/tests/extras/test_ftrl.py
+++ b/tests/extras/test_ftrl.py
@@ -728,7 +728,7 @@ def test_ftrl_feature_importances():
     ft = Ftrl(nbins = 200)
     df_train = dt.Frame([range(ft.nbins),
                          [i % 2 for i in range(ft.nbins)],
-                         [i % 20 for i in range(ft.nbins)]
+                         [i % 10 for i in range(ft.nbins)]
                         ], names = feature_names)
     df_target = dt.Frame([False, True] * (ft.nbins // 2))
     ft.fit(df_train, df_target)
@@ -763,7 +763,7 @@ def test_ftrl_interactions():
     ft = Ftrl(nbins = 200, interactions = True)
     df_train = dt.Frame([range(ft.nbins),
                          [i % 2 for i in range(ft.nbins)],
-                         [i % 20 for i in range(ft.nbins)]
+                         [i % 10 for i in range(ft.nbins)]
                         ], names = feature_names)
     df_target = dt.Frame([False, True] * (ft.nbins // 2))
     ft.fit(df_train, df_target)

--- a/tests/extras/test_ftrl.py
+++ b/tests/extras/test_ftrl.py
@@ -770,7 +770,6 @@ def test_ftrl_interactions():
     df_target = dt.Frame([False, True] * (nrows // 2))
     ft.fit(df_train, df_target)
     fi = ft.feature_importances
-    print(fi.to_list())
     assert fi.stypes == (stype.str32, stype.float64)
     assert fi.names == ("feature_name", "feature_importance")
     assert fi[:, 0].to_list() == [feature_names + feature_interactions]

--- a/tests/extras/test_ftrl.py
+++ b/tests/extras/test_ftrl.py
@@ -724,13 +724,14 @@ def test_ftrl_regression():
 #-------------------------------------------------------------------------------
 
 def test_ftrl_feature_importances():
-    feature_names = ['f1', 'f2', 'f3']
-    ft = Ftrl(nbins = 200)
-    df_train = dt.Frame([range(ft.nbins),
-                         [i % 2 for i in range(ft.nbins)],
-                         [i % 10 for i in range(ft.nbins)]
+    nrows = 200
+    feature_names = ['unique', 'boolean', 'mod10']
+    ft = Ftrl()
+    df_train = dt.Frame([range(nrows),
+                         [i % 2 for i in range(nrows)],
+                         [i % 10 for i in range(nrows)]
                         ], names = feature_names)
-    df_target = dt.Frame([False, True] * (ft.nbins // 2))
+    df_target = dt.Frame([False, True] * (nrows // 2))
     ft.fit(df_train, df_target)
     fi = ft.feature_importances
     assert fi.stypes == (stype.str32, stype.float64)
@@ -758,16 +759,18 @@ def test_ftrl_fi_shallowcopy():
 #-------------------------------------------------------------------------------
 
 def test_ftrl_interactions():
-    feature_names = ['f1', 'f2', 'f3']
-    feature_interactions = ['f1:f2', 'f1:f3', 'f2:f3']
-    ft = Ftrl(nbins = 200, interactions = True)
-    df_train = dt.Frame([range(ft.nbins),
-                         [i % 2 for i in range(ft.nbins)],
-                         [i % 10 for i in range(ft.nbins)]
+    nrows = 200
+    feature_names = ['unique', 'boolean', 'mod10']
+    feature_interactions = ['unique:boolean', 'unique:mod10', 'boolean:mod10']
+    ft = Ftrl(interactions = True)
+    df_train = dt.Frame([range(nrows),
+                         [i % 2 for i in range(nrows)],
+                         [i % 10 for i in range(nrows)]
                         ], names = feature_names)
-    df_target = dt.Frame([False, True] * (ft.nbins // 2))
+    df_target = dt.Frame([False, True] * (nrows // 2))
     ft.fit(df_train, df_target)
     fi = ft.feature_importances
+    print(fi.to_list())
     assert fi.stypes == (stype.str32, stype.float64)
     assert fi.names == ("feature_name", "feature_importance")
     assert fi[:, 0].to_list() == [feature_names + feature_interactions]


### PR DESCRIPTION
Due to Hogwild approach some of the FTRL tests may fail for a given thread competition scenario. Trying to adjust number of bins, feature names and values to make their importances order of magnitude different, so that tests are less prone to Hogwild.