### PR TITLE
Sort in reverse order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -217,7 +217,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   discovering and reporting bugs that were fixed in this release:
 
   [Pasha Stetsenko][] (#1316, #1443, #1481, #1539, #1542, #1551, #1572, #1576,
-    #1578),
+  #1578),
   [Arno Candel][] (#1437, #1491, #1510, #1525, #1549, #1556, #1562),
   [Michael Frasco][] (#1448),
   [Jonathan McKinney][] (#1451, #1565),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   in `DT[i, j, by()]`. The result is that the slice `i` is applied to each
   group produced by `by()`, before the `j` is evaluated (#1585).
 
+- Implemented sorting in reverse direction, via `sort(-col)`, where `col` is
+  any regular column selector such as `f.A` or `f[column]`. The `-` sign is
+  symbolic, no actual negation occurs. As such, this works even for string
+  columns (#792).
+
 
 ### Fixed
 

--- a/c/expr/base_expr.h
+++ b/c/expr/base_expr.h
@@ -69,6 +69,8 @@ enum class unop : size_t {
   LOG10  = 8,
 };
 
+class base_expr;
+using pexpr = std::unique_ptr<base_expr>;
 
 
 //------------------------------------------------------------------------------
@@ -81,6 +83,11 @@ class base_expr {
     virtual SType resolve(const workframe&) = 0;
     virtual GroupbyMode get_groupby_mode(const workframe&) const = 0;
     virtual Column* evaluate_eager(workframe&) = 0;
+
+    virtual bool is_column_expr() const;
+    virtual bool is_negated_expr() const;
+    virtual pexpr get_negated_expr();
+    virtual size_t get_col_index(const workframe&);
 };
 
 
@@ -94,7 +101,8 @@ class expr_column : public base_expr {
     expr_column(size_t dfid, const py::robj& col);
 
     size_t get_frame_id() const noexcept;
-    size_t get_col_index(const workframe&);
+    size_t get_col_index(const workframe&) override;
+    bool is_column_expr() const override;
     SType resolve(const workframe&) override;
     GroupbyMode get_groupby_mode(const workframe&) const override;
     Column* evaluate_eager(workframe&) override;

--- a/c/expr/by_node.h
+++ b/c/expr/by_node.h
@@ -68,8 +68,8 @@ class by_node {
 
   public:
     by_node();
-    void add_groupby_columns(collist_ptr&&);
-    void add_sortby_columns(collist_ptr&&);
+    void add_groupby_columns(workframe&, collist_ptr&&);
+    void add_sortby_columns(workframe&, collist_ptr&&);
 
     explicit operator bool() const;
     bool has_group_column(size_t i) const;
@@ -77,7 +77,7 @@ class by_node {
     void execute(workframe&) const;
 
   private:
-    void _add_columns(collist_ptr&& cl, bool group_columns);
+    void _add_columns(workframe& wf, collist_ptr&& cl, bool isgrp);
 };
 
 

--- a/c/expr/workframe.cc
+++ b/c/expr/workframe.cc
@@ -61,12 +61,12 @@ void workframe::add_join(py::ojoin oj) {
 
 
 void workframe::add_groupby(py::oby og) {
-  byexpr.add_groupby_columns(og.cols(*this));
+  byexpr.add_groupby_columns(*this, og.cols(*this));
 }
 
 
 void workframe::add_sortby(py::osort obj) {
-  byexpr.add_sortby_columns(obj.cols(*this));
+  byexpr.add_sortby_columns(*this, obj.cols(*this));
 }
 
 

--- a/c/sort.h
+++ b/c/sort.h
@@ -86,9 +86,15 @@ class GroupGatherer {
     operator bool() const { return !!groups; }
 
     void push(size_t grp);
-    template <typename T, typename V> void from_data(const T*, V*, size_t);
-    template <typename T, typename V> void from_data(const uint8_t*, const T*, T, V*, size_t);
+
+    template <typename T, typename V>
+    void from_data(const T*, V*, size_t);
+
+    template <typename T, typename V>
+    void from_data(const uint8_t*, const T*, T, V*, size_t, bool descending);
+
     void from_chunks(radix_range* rrmap, size_t nradixes);
+
     void from_histogram(size_t* histogram, size_t nchunks, size_t nradixes);
 };
 
@@ -105,12 +111,12 @@ template <typename T, typename V>
 void insert_sort_values(const T* x, V* o, int n, GroupGatherer& gg);
 
 template <typename T, typename V>
-void insert_sort_keys_str(const uint8_t*, const T*, T, V*, V*, int, GroupGatherer&);
+void insert_sort_keys_str(const uint8_t*, const T*, T, V*, V*, int, GroupGatherer&, bool);
 
 template <typename T, typename V>
-void insert_sort_values_str(const uint8_t*, const T*, T, V*, int, GroupGatherer&);
+void insert_sort_values_str(const uint8_t*, const T*, T, V*, int, GroupGatherer&, bool);
 
-template <typename T>
+template <int R, typename T>
 int compare_offstrings(const uint8_t*, T, T, T, T);
 
 
@@ -125,20 +131,22 @@ extern template void insert_sort_values(const uint16_t*, int32_t*, int, GroupGat
 extern template void insert_sort_values(const uint32_t*, int32_t*, int, GroupGatherer&);
 extern template void insert_sort_values(const uint64_t*, int32_t*, int, GroupGatherer&);
 
-extern template void insert_sort_keys_str(  const uint8_t*, const uint32_t*, uint32_t, int32_t*, int32_t*, int, GroupGatherer&);
-extern template void insert_sort_values_str(const uint8_t*, const uint32_t*, uint32_t, int32_t*, int, GroupGatherer&);
-extern template void insert_sort_keys_str(  const uint8_t*, const uint64_t*, uint64_t, int32_t*, int32_t*, int, GroupGatherer&);
-extern template void insert_sort_values_str(const uint8_t*, const uint64_t*, uint64_t, int32_t*, int, GroupGatherer&);
+extern template void insert_sort_keys_str(  const uint8_t*, const uint32_t*, uint32_t, int32_t*, int32_t*, int, GroupGatherer&, bool);
+extern template void insert_sort_values_str(const uint8_t*, const uint32_t*, uint32_t, int32_t*, int, GroupGatherer&, bool);
+extern template void insert_sort_keys_str(  const uint8_t*, const uint64_t*, uint64_t, int32_t*, int32_t*, int, GroupGatherer&, bool);
+extern template void insert_sort_values_str(const uint8_t*, const uint64_t*, uint64_t, int32_t*, int, GroupGatherer&, bool);
 
-extern template int compare_offstrings(const uint8_t*, uint32_t, uint32_t, uint32_t, uint32_t);
-extern template int compare_offstrings(const uint8_t*, uint64_t, uint64_t, uint64_t, uint64_t);
+extern template int compare_offstrings<1>(const uint8_t*, uint32_t, uint32_t, uint32_t, uint32_t);
+extern template int compare_offstrings<1>(const uint8_t*, uint64_t, uint64_t, uint64_t, uint64_t);
+extern template int compare_offstrings<-1>(const uint8_t*, uint32_t, uint32_t, uint32_t, uint32_t);
+extern template int compare_offstrings<-1>(const uint8_t*, uint64_t, uint64_t, uint64_t, uint64_t);
 
 extern template void GroupGatherer::from_data(const uint8_t*,  int32_t*, size_t);
 extern template void GroupGatherer::from_data(const uint16_t*, int32_t*, size_t);
 extern template void GroupGatherer::from_data(const uint32_t*, int32_t*, size_t);
 extern template void GroupGatherer::from_data(const uint64_t*, int32_t*, size_t);
-extern template void GroupGatherer::from_data(const uint8_t*, const uint32_t*, uint32_t, int32_t*, size_t);
-extern template void GroupGatherer::from_data(const uint8_t*, const uint64_t*, uint64_t, int32_t*, size_t);
+extern template void GroupGatherer::from_data(const uint8_t*, const uint32_t*, uint32_t, int32_t*, size_t, bool);
+extern template void GroupGatherer::from_data(const uint8_t*, const uint64_t*, uint64_t, int32_t*, size_t, bool);
 
 
 #endif

--- a/c/sort_groups.cc
+++ b/c/sort_groups.cc
@@ -47,16 +47,19 @@ void GroupGatherer::from_data(const T* data, V* o, size_t n) {
 
 template <typename T, typename V>
 void GroupGatherer::from_data(
-  const uint8_t* strdata, const T* stroffs, T start, V* o, size_t n)
-{
+  const uint8_t* strdata, const T* stroffs, T start, V* o, size_t n,
+  bool descending
+) {
   if (n == 0) return;
+  auto compfn = descending? compare_offstrings<-1, T>
+                          : compare_offstrings<1, T>;
   T olast0 = (stroffs[o[0] - 1] & ~GETNA<T>()) + start;
   T olast1 = stroffs[o[0]];
   size_t lasti = 0;
   for (size_t i = 1; i < n; ++i) {
     T ocurr0 = (stroffs[o[i] - 1] & ~GETNA<T>()) + start;
     T ocurr1 = stroffs[o[i]];
-    if (compare_offstrings(strdata, olast0, olast1, ocurr0, ocurr1)) {
+    if (compfn(strdata, olast0, olast1, ocurr0, ocurr1)) {
       push(i - lasti);
       olast0 = ocurr0;
       olast1 = ocurr1;
@@ -107,5 +110,5 @@ template void GroupGatherer::from_data(const uint8_t*,  int32_t*, size_t);
 template void GroupGatherer::from_data(const uint16_t*, int32_t*, size_t);
 template void GroupGatherer::from_data(const uint32_t*, int32_t*, size_t);
 template void GroupGatherer::from_data(const uint64_t*, int32_t*, size_t);
-template void GroupGatherer::from_data(const uint8_t*, const uint32_t*, uint32_t, int32_t*, size_t);
-template void GroupGatherer::from_data(const uint8_t*, const uint64_t*, uint64_t, int32_t*, size_t);
+template void GroupGatherer::from_data(const uint8_t*, const uint32_t*, uint32_t, int32_t*, size_t, bool);
+template void GroupGatherer::from_data(const uint8_t*, const uint64_t*, uint64_t, int32_t*, size_t, bool);

--- a/c/sort_insert.cc
+++ b/c/sort_insert.cc
@@ -1,9 +1,23 @@
 //------------------------------------------------------------------------------
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright 2018 H2O.ai
 //
-// © H2O.ai 2018
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 // Insertion sort functions
 //
@@ -35,26 +49,26 @@
  *
  * Type T can be either `int32_t` or `int64_t`.
  */
-template <typename T>
+template <int R, typename T>
 int compare_offstrings(
     const uint8_t* strdata, T aoff0, T aoff1, T boff0, T boff1)
 {
   // Handle NAs and empty strings
   if (ISNA<T>(boff1)) return ISNA<T>(aoff1)? 0 : -1;
   if (ISNA<T>(aoff1)) return 1;
-  if (boff1 <= boff0) return aoff1 <= aoff0? 0 : -1;
-  if (aoff1 <= aoff0) return 1;
+  if (boff1 <= boff0) return aoff1 <= aoff0? 0 : -R;
+  if (aoff1 <= aoff0) return R;
 
   T lena = aoff1 - aoff0;
   T lenb = boff1 - boff0;
   for (T t = 0; t < lena; ++t) {
-    if (t == lenb) return -1;  // b is shorter than a
+    if (t == lenb) return -R;  // b is shorter than a
     uint8_t ca = strdata[aoff0 + t];
     uint8_t cb = strdata[boff0 + t];
     if (ca == cb) continue;
-    return (ca < cb)? 1 : -1;  // a and b differ at character t
+    return (ca < cb)? R : -R;  // a and b differ at character t
   }
-  return lena == lenb? 0 : 1;
+  return lena == lenb? 0 : R;
 }
 
 
@@ -141,8 +155,10 @@ void insert_sort_keys(const T* x, V* o, V* tmp, int n, GroupGatherer& gg)
 template <typename T, typename V>
 void insert_sort_keys_str(
     const uint8_t* strdata, const T* stroffs, T strstart, V* o, V* tmp, int n,
-    GroupGatherer& gg)
+    GroupGatherer& gg, bool descending)
 {
+  auto compfn = descending? compare_offstrings<-1, T>
+                          : compare_offstrings<1, T>;
   int j;
   tmp[0] = 0;
   for (int i = 1; i < n; ++i) {
@@ -152,7 +168,7 @@ void insert_sort_keys_str(
       V k = tmp[j - 1];
       T off0k = (stroffs[o[k] - 1] + strstart) & ~GETNA<T>();
       T off1k = stroffs[o[k]];
-      int cmp = compare_offstrings(strdata, off0i, off1i, off0k, off1k);
+      int cmp = compfn(strdata, off0i, off1i, off0k, off1k);
       if (cmp != 1) break;
       tmp[j] = tmp[j-1];
     }
@@ -162,7 +178,8 @@ void insert_sort_keys_str(
     tmp[i] = o[tmp[i]];
   }
   if (gg) {
-    gg.from_data(strdata, stroffs, strstart, tmp, static_cast<size_t>(n));
+    gg.from_data(strdata, stroffs, strstart, tmp,
+                 static_cast<size_t>(n), descending);
   }
   std::memcpy(o, tmp, static_cast<size_t>(n) * sizeof(V));
 }
@@ -171,8 +188,10 @@ void insert_sort_keys_str(
 template <typename T, typename V>
 void insert_sort_values_str(
     const uint8_t* strdata, const T* stroffs, T strstart, V* o, int n,
-    GroupGatherer& gg)
+    GroupGatherer& gg, bool descending)
 {
+  auto compfn = descending? compare_offstrings<-1, T>
+                          : compare_offstrings<1, T>;
   int j;
   o[0] = 0;
   for (int i = 1; i < n; ++i) {
@@ -182,14 +201,15 @@ void insert_sort_values_str(
       V k = o[j - 1];
       T off0k = (stroffs[k - 1] + strstart) & ~GETNA<T>();
       T off1k = stroffs[k];
-      int cmp = compare_offstrings(strdata, off0i, off1i, off0k, off1k);
+      int cmp = compfn(strdata, off0i, off1i, off0k, off1k);
       if (cmp != 1) break;
       o[j] = o[j-1];
     }
     o[j] = static_cast<V>(i);
   }
   if (gg) {
-    gg.from_data(strdata, stroffs, strstart, o, static_cast<size_t>(n));
+    gg.from_data(strdata, stroffs, strstart, o,
+                 static_cast<size_t>(n), descending);
   }
 }
 
@@ -209,9 +229,12 @@ template void insert_sort_values(const uint16_t*, int32_t*, int, GroupGatherer&)
 template void insert_sort_values(const uint32_t*, int32_t*, int, GroupGatherer&);
 template void insert_sort_values(const uint64_t*, int32_t*, int, GroupGatherer&);
 
-template void insert_sort_keys_str(  const uint8_t*, const uint32_t*, uint32_t, int32_t*, int32_t*, int, GroupGatherer&);
-template void insert_sort_values_str(const uint8_t*, const uint32_t*, uint32_t, int32_t*, int, GroupGatherer&);
-template void insert_sort_keys_str(  const uint8_t*, const uint64_t*, uint64_t, int32_t*, int32_t*, int, GroupGatherer&);
-template void insert_sort_values_str(const uint8_t*, const uint64_t*, uint64_t, int32_t*, int, GroupGatherer&);
-template int compare_offstrings(const uint8_t*, uint32_t, uint32_t, uint32_t, uint32_t);
-template int compare_offstrings(const uint8_t*, uint64_t, uint64_t, uint64_t, uint64_t);
+template void insert_sort_keys_str(  const uint8_t*, const uint32_t*, uint32_t, int32_t*, int32_t*, int, GroupGatherer&, bool);
+template void insert_sort_values_str(const uint8_t*, const uint32_t*, uint32_t, int32_t*, int, GroupGatherer&, bool);
+template void insert_sort_keys_str(  const uint8_t*, const uint64_t*, uint64_t, int32_t*, int32_t*, int, GroupGatherer&, bool);
+template void insert_sort_values_str(const uint8_t*, const uint64_t*, uint64_t, int32_t*, int, GroupGatherer&, bool);
+
+template int compare_offstrings<1>(const uint8_t*, uint32_t, uint32_t, uint32_t, uint32_t);
+template int compare_offstrings<1>(const uint8_t*, uint64_t, uint64_t, uint64_t, uint64_t);
+template int compare_offstrings<-1>(const uint8_t*, uint32_t, uint32_t, uint32_t, uint32_t);
+template int compare_offstrings<-1>(const uint8_t*, uint64_t, uint64_t, uint64_t, uint64_t);

--- a/tests/test_dt_sort.py
+++ b/tests/test_dt_sort.py
@@ -823,11 +823,11 @@ def test_sort_bools_reverse():
 @pytest.mark.parametrize("st", dt.ltype.int.stypes)
 def test_sort_ints_reverse(st):
     DT = dt.Frame(A=[5, 17, 9, -12, 0, 111, 3, 5], B=list('abcdefgh'),
-                  stypes=[st, dt.str32])
+                  stypes={"A": st, "B": dt.str32})
     assert_equals(DT[:, :, sort(-f.A)],
                   dt.Frame(A=[111, 17, 9, 5, 5, 3, 0, -12],
                            B=list('fbcahged'),
-                           stypes=[st, dt.str32]))
+                           stypes={"A": st, "B": dt.str32}))
 
 
 def test_sort_doubles_reverse():

--- a/tests/test_dt_sort.py
+++ b/tests/test_dt_sort.py
@@ -26,10 +26,13 @@ import pytest
 import random
 import datatable as dt
 from datatable import stype, ltype, sort, by, f
+from math import inf, nan
 from tests import list_equals, random_string, assert_equals
 
 
 
+#-------------------------------------------------------------------------------
+# Simple sort
 #-------------------------------------------------------------------------------
 
 def test_sort_len0():
@@ -126,7 +129,7 @@ def test_int32_small_stable():
 
 def test_int32_large():
     # p1, p2 should both be prime, with p1 < p2. Here we rely on the fact that
-    # a multiplicative group of integers module n is cyclic with order n-1 when
+    # a multiplicative group of integers modulo n is cyclic with order n-1 when
     # n is prime.
     p1 = 1000003
     p2 = 2000003
@@ -158,7 +161,7 @@ def test_int32_constant(n):
     assert d1.to_list() == tbl0
 
 
-def test_int32_reverse():
+def test_int32_reverse_list():
     step = 10
     d0 = dt.Frame(range(1000000, 0, -step))
     assert d0.stypes[0] == stype.int32
@@ -214,6 +217,8 @@ def test_int32_issue220():
 
 
 
+#-------------------------------------------------------------------------------
+# Int8
 #-------------------------------------------------------------------------------
 
 def test_int8_small():
@@ -404,7 +409,6 @@ def test_int64_large_random(seed):
 #-------------------------------------------------------------------------------
 
 def test_float32_small():
-    from math import inf, nan
     d0 = dt.Frame([0, .4, .9, .2, .1, nan, -inf, -5, 3, 11, inf, 5.2],
                   stype="float32")
     assert d0.stypes == (stype.float32, )
@@ -414,7 +418,6 @@ def test_float32_small():
 
 
 def test_float32_nans():
-    from math import nan
     d0 = dt.Frame([nan, 0.5, nan, nan, -3, nan, 0.2, nan, nan, 1],
                   stype="float32")
     d1 = d0.sort(0)
@@ -445,7 +448,6 @@ def test_float32_random(numpy, n):
 #-------------------------------------------------------------------------------
 
 def test_float64_small():
-    from math import inf
     d0 = dt.Frame([0.1, -0.5, 1.6, 0, None, -inf, inf, 3.3, 1e100])
     assert d0.stypes == (stype.float64, )
     d1 = d0.sort(0)
@@ -466,7 +468,6 @@ def test_float64_zeros():
 
 @pytest.mark.parametrize("n", [20, 100, 500, 2500, 20000])
 def test_float64_large(n):
-    from math import inf
     d0 = dt.Frame([12.6, .3, inf, -5.1, 0, -inf, None] * n)
     assert d0.stypes == (stype.float64, )
     d1 = d0.sort(0)
@@ -806,6 +807,51 @@ def test_sort_random_multi(seed):
     d1 = d0.sort("B", "C", "D")
     assert d1.to_list() == sorted_data
 
+
+
+#-------------------------------------------------------------------------------
+# Sort in reverse order
+#-------------------------------------------------------------------------------
+
+def test_sort_bools_reverse():
+    DT = dt.Frame(A=[True, None, False, None, True, None], B=list('abcdef'))
+    assert_equals(DT[:, :, sort(-f.A)],
+                  dt.Frame(A=[None, None, None, True, True, False],
+                           B=['b', 'd', 'f', 'a', 'e', 'c']))
+
+
+@pytest.mark.parametrize("st", dt.ltype.int.stypes)
+def test_sort_ints_reverse(st):
+    DT = dt.Frame(A=[5, 17, 9, -12, 0, 111, 3, 5], B=list('abcdefgh'),
+                  stypes=[st, dt.str32])
+    assert_equals(DT[:, :, sort(-f.A)],
+                  dt.Frame(A=[111, 17, 9, 5, 5, 3, 0, -12],
+                           B=list('fbcahged'),
+                           stypes=[st, dt.str32]))
+
+
+def test_sort_doubles_reverse():
+    DT = dt.Frame(A=[0.0, 0.1, -0.5, 1.6, -0.0, None, -inf, inf, 3.3, 1e100])
+    assert_equals(DT[:, :, sort(-f.A)],
+                  dt.Frame(A=[None, inf, 1e100, 3.3, 1.6, 0.1, 0.0, -0.0,
+                              -0.5, -inf]))
+
+
+def test_sort_double_stable_nans():
+    DT = dt.Frame(A=[nan, -nan, nan, -inf, None, inf, 9.99, None],
+                  B=list('abcdefgh'))
+    assert_equals(DT[:, :, sort(-f.A)],
+                  dt.Frame(A=[None] * 5 + [inf, 9.99, -inf],
+                           B=list('abcehfgd')))
+
+
+@pytest.mark.parametrize("st", [dt.str32, dt.str64])
+def test_sort_strings_reverse(st):
+    DT = dt.Frame(A=['aye', '', 'zebra', 'zulu', 'nautilus', None, 'oxen'],
+                  stype=st)
+    RES = dt.Frame(A=[None, 'zulu', 'zebra', 'oxen', 'nautilus', 'aye', ''],
+                   stype=st)
+    assert_equals(DT[:, :, sort(-f.A)], RES)
 
 
 

--- a/tests/test_dt_sort.py
+++ b/tests/test_dt_sort.py
@@ -854,6 +854,18 @@ def test_sort_strings_reverse(st):
     assert_equals(DT[:, :, sort(-f.A)], RES)
 
 
+def test_sort_strings_reverse_large():
+    src = ['klein', 'nim', 'toapr', 'f', '', 'zleu', '?34', '.............']
+    src *= 10
+    src += ['adferg', 'reneeas', 'ldodls', 'qu', 'zleuss', 'ni'] * 7
+    src *= 25
+    src += ['shoo!', 'zzZzzZ' * 5]
+    DT = dt.Frame(A=src)
+    RES = dt.Frame(A=sorted(src, reverse=True))
+    assert_equals(DT[:, :, sort(-f.A)], RES)
+
+
+
 
 #-------------------------------------------------------------------------------
 # Misc issues


### PR DESCRIPTION
This PR implements sorting in reverse order. The functionality is achieved by adjusting the procedure for data extraction (i.e. conversion of source data into unsigned ints needed by the radix sort algorithm). As such, there should be no difference in run time of ascending / descending sorting.

The API is the following:
```
DT[:, :, sort(-f.A)]
```

Closes #792 