### PR TITLE
Fix min/max calculation in ArrayRowIndex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - In certain circumstances mixing computed and plain columns under groupby
   caused incorrect result (#1578).
 
+- Fixed an internal error which was occurring when multiple row filters were
+  applied to a Frame in sequence (#1592).
+
 
 ### Changed
 
@@ -217,7 +220,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   discovering and reporting bugs that were fixed in this release:
 
   [Pasha Stetsenko][] (#1316, #1443, #1481, #1539, #1542, #1551, #1572, #1576,
-  #1578),
+  #1578, #1592),
   [Arno Candel][] (#1437, #1491, #1510, #1525, #1549, #1556, #1562),
   [Michael Frasco][] (#1448),
   [Jonathan McKinney][] (#1451, #1565),

--- a/c/expr/i_node.cc
+++ b/c/expr/i_node.cc
@@ -243,7 +243,7 @@ void slice_in::execute_grouped(workframe& wf) {
   xassert(j <= ri_size);
   out_ri_array.resize(j);
   out_groups.resize((k + 1) * sizeof(int32_t));
-  RowIndex newri(std::move(out_ri_array), /* sorted = */ true);
+  RowIndex newri(std::move(out_ri_array), /* sorted = */ (step >= 0));
   Groupby newgb(k, std::move(out_groups));
   wf.apply_rowindex(newri);
   wf.apply_groupby(newgb);

--- a/c/rowindex_impl.h
+++ b/c/rowindex_impl.h
@@ -36,7 +36,9 @@ class RowIndexImpl {
      *     The number of elements in the RowIndex.
      *
      * min, max
-     *     Smallest / largest entry in the RowIndex.
+     *     Smallest / largest entry in the RowIndex. If the RowIndex is empty
+     *     (length 0), or if all entries in the RowIndex are NAs, then
+     *     min = max = RowIndex::NA.
      *
      * refcount
      *     Ref-counter for this RowIndexImpl object. A RowIndexImpl* object
@@ -72,7 +74,7 @@ class RowIndexImpl {
     void release();
 
     virtual size_t nth(size_t i) const = 0;
-    virtual RowIndexImpl* uplift_from(const RowIndexImpl*) = 0;
+    virtual RowIndexImpl* uplift_from(const RowIndexImpl*) const = 0;
     virtual RowIndexImpl* negate(size_t nrows) const = 0;
 
     virtual void resize(size_t n) = 0;
@@ -97,7 +99,7 @@ class SliceRowIndexImpl : public RowIndexImpl {
     SliceRowIndexImpl(size_t start, size_t count, size_t step);
 
     size_t nth(size_t i) const override;
-    RowIndexImpl* uplift_from(const RowIndexImpl*) override;
+    RowIndexImpl* uplift_from(const RowIndexImpl*) const override;
     RowIndexImpl* negate(size_t nrows) const override;
 
     void resize(size_t n) override;
@@ -145,7 +147,7 @@ class ArrayRowIndexImpl : public RowIndexImpl {
     const int64_t* indices64() const noexcept;
 
     size_t nth(size_t i) const override;
-    RowIndexImpl* uplift_from(const RowIndexImpl*) override;
+    RowIndexImpl* uplift_from(const RowIndexImpl*) const override;
     RowIndexImpl* negate(size_t nrows) const override;
 
     void resize(size_t n) override;

--- a/c/rowindex_slice.cc
+++ b/c/rowindex_slice.cc
@@ -81,7 +81,7 @@ size_t SliceRowIndexImpl::nth(size_t i) const {
 
 
 
-RowIndexImpl* SliceRowIndexImpl::uplift_from(const RowIndexImpl* rii) {
+RowIndexImpl* SliceRowIndexImpl::uplift_from(const RowIndexImpl* rii) const {
   RowIndexType uptype = rii->type;
 
   // Product of 2 slices is again a slice.

--- a/c/set_funcs.cc
+++ b/c/set_funcs.cc
@@ -50,10 +50,10 @@ struct sort_result {
 // helper functions
 //------------------------------------------------------------------------------
 
-static py::oobj make_pyframe(
-    sort_result& sr, arr32_t&& arr, bool arr_sorted = true
-) {
-  RowIndex out_ri = RowIndex(std::move(arr), arr_sorted);
+static py::oobj make_pyframe(sort_result& sr, arr32_t&& arr) {
+  // The array of rowindices `arr` is typically shuffled because the values
+  // in the input are sorted before they are compared.
+  RowIndex out_ri = RowIndex(std::move(arr), false);
   Column* out_col = sr.col->shallowcopy(out_ri);
   out_col->reify();
   DataTable* dt = new DataTable({out_col}, {sr.colname});
@@ -420,8 +420,7 @@ static py::oobj _symdiff(ccolvec&& cc) {
     }
   }
   arr.resize(j);
-  // symdiff() is the only method that can produce potentially unsorted `arr`.
-  return make_pyframe(sr, std::move(arr), false);
+  return make_pyframe(sr, std::move(arr));
 }
 
 

--- a/tests/munging/test_dt_rows.py
+++ b/tests/munging/test_dt_rows.py
@@ -219,6 +219,16 @@ def test_slice_errors2(dt0):
                       "must be positive")
 
 
+def test_slice_after_resize():
+    """Issue #1592"""
+    DT = dt.Frame(A=['cat'])
+    DT.nrows = 3
+    RES = DT[2:, :]
+    RES.internal.check()
+    assert RES.to_list() == [[None]]
+
+
+
 
 #-------------------------------------------------------------------------------
 # Range selector

--- a/tests/random_attack.py
+++ b/tests/random_attack.py
@@ -313,10 +313,7 @@ class Frame0:
     def resize_rows(self, nrows):
         curr_nrows = self.nrows
         self.df.nrows = nrows
-        if curr_nrows == 1:
-            for i, elem in enumerate(self.data):
-                self.data[i] = elem * nrows
-        elif curr_nrows < nrows:
+        if curr_nrows < nrows:
             append = [None] * (nrows - curr_nrows)
             for i, elem in enumerate(self.data):
                 self.data[i] = elem + append


### PR DESCRIPTION
- Clarify calculation of min/max in `ArrayRowIndexImpl` for the case when all entries are NAs;
- Run `verify_integrity` on ArrayRowIndexImpl upon construction (but only in debug mode);
- Fixed an issue with set_funcs where they created `ArrayRowIndex`es incorrectly marked as sorted.
- Fixed "grouped slice" operation which created an `ArrayRowIndex` incorrectly marked as sorted if the step was negative.

Closes #1592