### PR TITLE
Do not segfault when pickling an empty FTRL model

### DIFF
--- a/c/extras/py_ftrl.cc
+++ b/c/extras/py_ftrl.cc
@@ -1051,7 +1051,7 @@ void Ftrl::m__setstate__(const PKArgs& args) {
   if (pickle[2].is_tuple()) {
     py::otuple fi_tuple = pickle[2].to_otuple();
     for (size_t i = 0; i < fi_tuple.size(); ++i) {
-      (*dtft)[i]->set_fi(fi_tuple[i].to_frame());
+      (*dtft)[i]->set_fi(fi_tuple[i].to_frame()->copy());
     }
   }
 

--- a/tests/extras/test_ftrl.py
+++ b/tests/extras/test_ftrl.py
@@ -784,6 +784,28 @@ def test_ftrl_interactions():
 # Test pickling
 #-------------------------------------------------------------------------------
 
+def test_ftrl_pickling_empty_model():
+    ft_pickled = pickle.dumps(Ftrl())
+    ft_unpickled = pickle.loads(ft_pickled)
+    assert ft_unpickled.model == None
+    assert ft_unpickled.feature_importances == None
+    assert ft_unpickled.params == Ftrl().params
+
+
+def test_ftrl_reuse_pickled_empty_model():
+    ft_pickled = pickle.dumps(Ftrl())
+    ft_unpickled = pickle.loads(ft_pickled)
+    ft_unpickled.nbins = 10
+    df_train = dt.Frame({"id" : range(ft_unpickled.nbins)})
+    df_target = dt.Frame([True] * ft_unpickled.nbins)
+    ft_unpickled.fit(df_train, df_target)
+    model = [[-0.5] * ft_unpickled.nbins, [0.25] * ft_unpickled.nbins]
+    fi = dt.Frame([["id"], [0.0]], names = ["feature_name", "feature_importance"])
+    print(ft_unpickled.feature_importances.to_dict())
+    assert ft_unpickled.model[0].to_list() == model
+    assert_equals(ft_unpickled.feature_importances, fi)
+
+
 def test_ftrl_pickling():
     ft = Ftrl(nbins = 10)
     df_train = dt.Frame(range(ft.nbins), names = ["f1"])

--- a/tests/extras/test_ftrl.py
+++ b/tests/extras/test_ftrl.py
@@ -801,7 +801,6 @@ def test_ftrl_reuse_pickled_empty_model():
     ft_unpickled.fit(df_train, df_target)
     model = [[-0.5] * ft_unpickled.nbins, [0.25] * ft_unpickled.nbins]
     fi = dt.Frame([["id"], [0.0]], names = ["feature_name", "feature_importance"])
-    print(ft_unpickled.feature_importances.to_dict())
     assert ft_unpickled.model[0].to_list() == model
     assert_equals(ft_unpickled.feature_importances, fi)
 


### PR DESCRIPTION
`Ftrl()` object has an empty model, feature importances and feature names fields. This is now properly checked during pickling/unpickling to prevent segfaults. Several relevant tests have also been added.

Closes #1597 