### PR TITLE
Fixed crash with pandas 0.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed rbinding of frames if one of them is a negative step slice (#1594).
 
+- Fixed a crash that occurred with the latest `pandas` 0.24.0 (#1600).
+
 
 ### Changed
 
@@ -228,7 +230,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   [Jonathan McKinney][] (#1451, #1565),
   [CarlosThinkBig][] (#1475),
   [Olivier][] (#1502),
-  [Oleksiy Kononenko][] (#1507),
+  [Oleksiy Kononenko][] (#1507, #1600),
   [Nishant Kalonia][] (#1527, #1540),
   [Megan Kurka][] (#1544),
   [Joseph Granados][] (#1559).

--- a/c/frame/__init__.cc
+++ b/c/frame/__init__.cc
@@ -407,6 +407,9 @@ class FrameInitializationManager {
           py::oobj colsrc = pdsrc.get_item(col).get_attr("values");
           make_column(colsrc, SType::VOID);
         }
+        if (ncols == size_t(-1)) {
+          check_names_count(cols.size());
+        }
       } else {
         xassert(src.is_pandas_series());
         check_names_count(1);

--- a/c/python/iter.cc
+++ b/c/python/iter.cc
@@ -42,16 +42,21 @@ iter_iterator oiter::end() const noexcept {
 
 
 size_t oiter::size() const noexcept {
-  oobj method = get_attr("__length_hint__");
-  PyObject* mptr = method.to_borrowed_ref();
-  PyObject* res = PyObject_CallObject(mptr, nullptr);  // new ref
-  if (!res) {
-    PyErr_Clear();
-    return static_cast<size_t>(-1);
-  }
-  long long len = PyLong_AsLongLong(res);
-  Py_XDECREF(res);
-  return static_cast<size_t>(len);
+  size_t len = static_cast<size_t>(-1);
+  try {
+    // get_attr() may throw an exception if there is no such attribute
+    oobj method = get_attr("__length_hint__");
+    PyObject* mptr = method.to_borrowed_ref();
+    PyObject* res = PyObject_CallObject(mptr, nullptr);  // new ref
+    if (res) {
+      long long t = PyLong_AsLongLong(res);
+      Py_XDECREF(res);
+      len = static_cast<size_t>(t);
+    } else {
+      PyErr_Clear();
+    }
+  } catch (...) {}
+  return len;
 }
 
 


### PR DESCRIPTION
The latest version of pandas (0.24.0, released Jan 25) removed `__length_hint__` property from its `DataFrame.columns` iterator. Unfortunately, our code did not account for this method being missing, and was throwing an exception inside a "noexcept" function. This has now been fixed.

Closes #1600 