### PR TITLE
Multiple rowindexes per Frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,8 +212,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Notes
 
-- `datatable` now uses integration with [Codacy](https://app.codacy.com/project/st-pasha/datatable/dashboard)
+- `datatable` now uses integration with
+  [Codacy](https://app.codacy.com/project/st-pasha/datatable/dashboard)
   to keep track of code quality and potential errors.
+
+- Internally, we now allow each Column in a Frame to have its own separate
+  RowIndex. This will improve the performance, especially in join/cbind
+  operations. Applications that use the `datatable`'s C API may need to be
+  updated to account for this (#1188).
 
 - This release was prepared by:
 

--- a/c/api.cc
+++ b/c/api.cc
@@ -201,27 +201,4 @@ const void* DtRowindex_ArrayData(PyObject* pyri) {
 
 
 
-//------------------------------------------------------------------------------
-// Deprecated
-//------------------------------------------------------------------------------
-
-void* datatable_get_column_data(void* dt_, size_t column) {
-  DataTable *dt = static_cast<DataTable*>(dt_);
-  return dt->columns[column]->data_w();
-}
-
-void datatable_unpack_slicerowindex(void* dt_, size_t* start, size_t* step) {
-  DataTable *dt = static_cast<DataTable*>(dt_);
-  RowIndex ri(dt->rowindex);
-  *start = ri.slice_start();
-  *step  = ri.slice_step();
-}
-
-void datatable_unpack_arrayrowindex(void *dt_, void **indices) {
-  DataTable *dt = static_cast<DataTable*>(dt_);
-  RowIndex ri(dt->rowindex);
-  *indices = const_cast<int32_t*>(ri.indices32());
-}
-
-
 } // extern "C"

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -84,7 +84,6 @@ class DataTable {
     colvec   columns;
 
   private:
-    RowIndex rowindex;  // DEPRECATED (see #1188)
     size_t   nkeys;
     strvec   names;
     mutable py::otuple py_names;   // memoized tuple of column names

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -80,11 +80,11 @@ class DataTable {
   public:
     size_t   nrows;
     size_t   ncols;
-    RowIndex rowindex;  // DEPRECATED (see #1188)
     Groupby  groupby;
     colvec   columns;
 
   private:
+    RowIndex rowindex;  // DEPRECATED (see #1188)
     size_t   nkeys;
     strvec   names;
     mutable py::otuple py_names;   // memoized tuple of column names

--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -147,8 +147,14 @@ PyObject* has_omp_support(PyObject*, PyObject*) {
 
 
 static py::PKArgs fn_get_rowindex(
-    2, 0, 0, false, false, {"frame", "col"},
-    "get_rowindex", nullptr,
+    2, 0, 0, false, false, {"frame", "i"},
+    "get_rowindex",
+R"(get_rowindex(frame, i)
+--
+
+Retrieve the RowIndex object of the `i`th column of the `frame`, or None
+if that column has no RowIndex.
+)",
 
 [](const py::PKArgs& args) -> py::oobj {
   if (!args[0] || !args[1]) throw ValueError() << "Expected 2 arguments";

--- a/c/frame/cbind.cc
+++ b/c/frame/cbind.cc
@@ -141,10 +141,6 @@ DataTable* DataTable::cbind(std::vector<DataTable*> dts)
     if (t_nrows < dts[i]->nrows) t_nrows = dts[i]->nrows;
   }
 
-  // First, materialize the "main" datatable if it is a view
-  // TODO: remove after #1188
-  reify();
-
   // Fix up the main datatable if it has too few rows
   if (nrows < t_nrows) {
     for (size_t i = 0; i < ncols; ++i) {

--- a/c/frame/join.cc
+++ b/c/frame/join.cc
@@ -406,8 +406,6 @@ RowIndex natural_join(const DataTable* xdt, const DataTable* jdt) {
   for (size_t j : xcols) {
     xdt->columns[j]->reify();
   }
-  // TODO: remove in #1188
-  for (auto col : xdt->columns) col->reify();
 
   arr32_t arr_result_indices(xdt->nrows);
   int32_t* result_indices = arr_result_indices.data();

--- a/c/frame/key.cc
+++ b/c/frame/key.cc
@@ -131,7 +131,7 @@ void DataTable::set_key(std::vector<size_t>& col_indices) {
   reorder_names(col_indices);
 
   // Apply sort key
-  replace_rowindex(ri * rowindex);
+  apply_rowindex(ri);
   reify();
 
   nkeys = K;

--- a/c/py_buffers.cc
+++ b/c/py_buffers.cc
@@ -425,7 +425,7 @@ static int getbuffer_DataTable(
   // Check whether we have a single-column DataTable that doesn't need to be
   // copied -- in which case it should be possible to return the buffer
   // by-reference instead of copying the data into an intermediate buffer.
-  if (ncols == 1 && dt->rowindex.isabsent() && !REQ_WRITABLE(flags) &&
+  if (ncols == 1 && !dt->columns[0]->rowindex() && !REQ_WRITABLE(flags) &&
       dt->columns[0]->is_fixedwidth()) {
     return dt_getbuffer_1_col(self, view, flags);
   }

--- a/c/py_columnset.cc
+++ b/c/py_columnset.cc
@@ -148,10 +148,6 @@ PyObject* append_columns(obj* self, PyObject* args) {
     throw TypeError() << "Expected argument of type Columnset";
   }
   obj* other = static_cast<obj*>(arg1);
-  // TODO: remove in #1188
-  for (size_t i = 0; i < other->ncols; ++i) {
-    other->columns[i]->reify();
-  }
 
   size_t newncols = self->ncols + other->ncols;
   Column** columns = self->columns;

--- a/c/py_datatable.h
+++ b/c/py_datatable.h
@@ -67,14 +67,6 @@ DECLARE_GETTER(
   isview,
   "Is the datatable view or now?")
 
-DECLARE_GETTER(
-  rowindex_type,
-  "Type of the row index: 'slice' or 'array'")
-
-DECLARE_GETTER(
-  rowindex,
-  "Row index of the view Frame, or None if this is not a view Frame")
-
 DECLARE_GETSET(
   groupby,
   "Groupby applied to the Frame, or None if no groupby was applied")

--- a/c/py_rowindex.cc
+++ b/c/py_rowindex.cc
@@ -173,10 +173,10 @@ PyObject* get_type(obj* self) {
   static PyObject* tSlice = PyUnicode_FromString("slice");
   static PyObject* tArr32 = PyUnicode_FromString("arr32");
   static PyObject* tArr64 = PyUnicode_FromString("arr64");
-  RowIndexType type = self->ref->type();
-  return incref(type == RowIndexType::SLICE? tSlice :
-                type == RowIndexType::ARR32? tArr32 :
-                type == RowIndexType::ARR64? tArr64 : Py_None);
+  RowIndexType rt = self->ref->type();
+  return incref(rt == RowIndexType::SLICE? tSlice :
+                rt == RowIndexType::ARR32? tArr32 :
+                rt == RowIndexType::ARR64? tArr64 : Py_None);
 }
 
 PyObject* get_nrows(obj* self) {

--- a/c/py_rowindex.cc
+++ b/c/py_rowindex.cc
@@ -169,6 +169,16 @@ PyObject* rowindex_from_filterfn(PyObject*, PyObject* args)
 // Getters/setters
 //==============================================================================
 
+PyObject* get_type(obj* self) {
+  static PyObject* tSlice = PyUnicode_FromString("slice");
+  static PyObject* tArr32 = PyUnicode_FromString("arr32");
+  static PyObject* tArr64 = PyUnicode_FromString("arr64");
+  RowIndexType type = self->ref->type();
+  return incref(type == RowIndexType::SLICE? tSlice :
+                type == RowIndexType::ARR32? tArr32 :
+                type == RowIndexType::ARR64? tArr64 : Py_None);
+}
+
 PyObject* get_nrows(obj* self) {
   return PyLong_FromSize_t(self->ref->size());
 }
@@ -239,6 +249,7 @@ PyObject* tolist(obj* self, PyObject*)
 //==============================================================================
 
 static PyGetSetDef rowindex_getsetters[] = {
+  GETTER(type),
   GETTER(nrows),
   GETTER(min),
   GETTER(max),

--- a/c/py_rowindex.h
+++ b/c/py_rowindex.h
@@ -65,6 +65,10 @@ DECLARE_DESTRUCTOR()
 //---- Getters/setters ---------------------------------------------------------
 
 DECLARE_GETTER(
+  type,
+  "The type of the rowindex: 'slice', 'arr32' or 'arr64'.")
+
+DECLARE_GETTER(
   nrows,
   "Number of rows in the rowindex")
 

--- a/c/sort.cc
+++ b/c/sort.cc
@@ -1244,8 +1244,7 @@ RiGb DataTable::group(const std::vector<sort_spec>& spec, bool as_view) const
   if (nrows <= 1) {
     arr32_t indices(nrows);
     if (nrows) {
-      size_t i = col0->rowindex()[0];
-      indices[0] = static_cast<int32_t>(i);
+      indices[0] = as_view? static_cast<int32_t>(col0->rowindex()[0]) : 0;
     }
     result.first = RowIndex(std::move(indices), true);
     if (!spec[0].sort_only) {

--- a/c/sort.cc
+++ b/c/sort.cc
@@ -1303,11 +1303,6 @@ RowIndex DataTable::sortby(const std::vector<size_t>& colindices,
   if (nrows > INT32_MAX) {
     throw NotImplError() << "Cannot sort a Frame with " << nrows << " rows";
   }
-  if (rowindex.isarr64() || rowindex.size() > INT32_MAX ||
-      (rowindex.max() > INT32_MAX && rowindex.max() != RowIndex::NA)) {
-    throw NotImplError() << "Cannot sort a Frame which is a view on another "
-                            "Frame with more than 2**31 rows";
-  }
   // TODO: fix for the multi-rowindex case (#1188)
   // A frame can be sorted by columns col1, ..., colN if and only if all these
   // columns have the same rowindex. The resulting RowIndex can be applied to

--- a/c/sort.cc
+++ b/c/sort.cc
@@ -1303,7 +1303,6 @@ RowIndex DataTable::sortby(const std::vector<size_t>& colindices,
   if (nrows > INT32_MAX) {
     throw NotImplError() << "Cannot sort a Frame with " << nrows << " rows";
   }
-  // TODO: fix for the multi-rowindex case (#1188)
   // A frame can be sorted by columns col1, ..., colN if and only if all these
   // columns have the same rowindex. The resulting RowIndex can be applied to
   // to all columns in the frame iff one of the following holds: (1) all

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -127,7 +127,7 @@ class Frame(core.Frame):
 
     def sort(self, *cols):
         """
-        Sort datatable by the specified column(s).
+        Sort Frame by the specified column(s).
 
         Parameters
         ----------
@@ -137,18 +137,16 @@ class Frame(core.Frame):
 
         Returns
         -------
-        New datatable sorted by the provided column(s). The target datatable
+        New Frame sorted by the provided column(s). The target Frame
         remains unmodified.
         """
         if not cols:
-            indexes = list(range(self.ncols))
+            cols = list(range(self.ncols))
         elif len(cols) == 1 and isinstance(cols[0], list):
-            indexes = [self.colindex(col) for col in cols[0]]
+            cols = cols[0]
         else:
-            indexes = [self.colindex(col) for col in cols]
-        ri = self._dt.sort(*indexes)[0]
-        cs = core.columns_from_slice(self._dt, ri, 0, self.ncols, 1)
-        return cs.to_frame(self.names)
+            cols = list(cols)
+        return self[:, :, datatable.sort(*cols)]
 
 
     #---------------------------------------------------------------------------

--- a/datatable/include/datatable.h
+++ b/datatable/include/datatable.h
@@ -169,12 +169,6 @@ const void* DtRowindex_ArrayData(PyObject* pyri);
 
 
 
-//-------- DEPRECATED ----------------------------------------------------------
-
-void* datatable_get_column_data(void* dt, size_t column);
-void  datatable_unpack_slicerowindex(void* dt, size_t* start, size_t* step);
-void  datatable_unpack_arrayrowindex(void* dt, void** indices);
-
 #ifdef __cplusplus
 }
 #endif

--- a/datatable/internal.py
+++ b/datatable/internal.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+#-------------------------------------------------------------------------------
+# Copyright 2018 H2O.ai
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#-------------------------------------------------------------------------------
+
+from .lib._datatable import (
+	get_rowindex
+)

--- a/tests/extras/test_aggregate.py
+++ b/tests/extras/test_aggregate.py
@@ -452,7 +452,6 @@ def test_aggregate_3d_categorical():
     assert d_in.to_list() == a_in + members_count
 
 
-@pytest.mark.xfail()
 def test_aggregate_3d_real():
     d_in = dt.Frame([
         [0.95, 0.50, 0.55, 0.10, 0.90, 0.50, 0.90, 0.50, 0.90, 1.00],
@@ -482,13 +481,11 @@ def test_aggregate_3d_real():
                            [1, 4, 5]]
 
 
-@pytest.mark.xfail()
 def test_aggregate_nd_direct():
     args = get_default_args(aggregate)
     aggregate_nd(args["max_dimensions"] // 2)
 
 
-@pytest.mark.xfail()
 def test_aggregate_nd_projection():
     args = get_default_args(aggregate)
     aggregate_nd(args["max_dimensions"] * 2)

--- a/tests/extras/test_aggregate.py
+++ b/tests/extras/test_aggregate.py
@@ -28,6 +28,7 @@
 import datatable as dt
 from datatable import ltype
 from datatable.extras.aggregate import aggregate
+from datatable.internal import get_rowindex
 import inspect
 
 #-------------------------------------------------------------------------------
@@ -459,7 +460,7 @@ def test_aggregate_3d_real():
                           progress_fn=report_progress)
     a_members = d_members.to_list()[0]
     d = d_in.sort("C0")
-    ri = d.internal.rowindex.tolist()
+    ri = get_rowindex(d, 0).tolist()
     for i, member in enumerate(a_members):
         a_members[i] = ri.index(member)
 
@@ -503,7 +504,7 @@ def aggregate_nd(nd):
 
     a_members = d_members.to_list()[0]
     d = d_in.sort("C0")
-    ri = d.internal.rowindex.tolist()
+    ri = get_rowindex(d, 0).tolist()
     for i, member in enumerate(a_members):
         a_members[i] = ri.index(member)
 

--- a/tests/extras/test_aggregate.py
+++ b/tests/extras/test_aggregate.py
@@ -30,6 +30,8 @@ from datatable import ltype
 from datatable.extras.aggregate import aggregate
 from datatable.internal import get_rowindex
 import inspect
+import pytest
+
 
 #-------------------------------------------------------------------------------
 # Get default arguments of a function
@@ -450,6 +452,7 @@ def test_aggregate_3d_categorical():
     assert d_in.to_list() == a_in + members_count
 
 
+@pytest.mark.xfail()
 def test_aggregate_3d_real():
     d_in = dt.Frame([
         [0.95, 0.50, 0.55, 0.10, 0.90, 0.50, 0.90, 0.50, 0.90, 1.00],
@@ -479,11 +482,13 @@ def test_aggregate_3d_real():
                            [1, 4, 5]]
 
 
+@pytest.mark.xfail()
 def test_aggregate_nd_direct():
     args = get_default_args(aggregate)
     aggregate_nd(args["max_dimensions"] // 2)
 
 
+@pytest.mark.xfail()
 def test_aggregate_nd_projection():
     args = get_default_args(aggregate)
     aggregate_nd(args["max_dimensions"] * 2)

--- a/tests/munging/test_dt_cbind.py
+++ b/tests/munging/test_dt_cbind.py
@@ -151,10 +151,8 @@ def test_bad_arguments():
 def test_cbind_views1():
     d0 = dt.Frame({"A": range(100)})
     d1 = d0[:5, :]
-    assert d1.internal.isview
     d2 = dt.Frame({"B": [3, 6, 9, 12, 15]}, stype=stype.int32)
     d1.cbind(d2)
-    assert not d1.internal.isview
     dr = dt.Frame({"A": range(5), "B": range(3, 18, 3)})
     assert_equals(d1, dr)
 
@@ -162,12 +160,9 @@ def test_cbind_views1():
 def test_cbind_views2():
     d0 = dt.Frame({"A": range(10)}, stype=stype.int8)
     d1 = d0[2:5, :]
-    assert d1.internal.isview
     d2 = dt.Frame({"B": list("abcdefghij")})
     d3 = d2[-3:, :]
-    assert d3.internal.isview
     d1.cbind(d3)
-    assert not d1.internal.isview
     dr = dt.Frame({"A": [2, 3, 4], "B": ["h", "i", "j"]})
     assert_equals(d1, dr)
 

--- a/tests/munging/test_dt_combo.py
+++ b/tests/munging/test_dt_combo.py
@@ -6,6 +6,7 @@
 #-------------------------------------------------------------------------------
 import datatable as dt
 from datatable import stype, f
+from datatable.internal import get_rowindex
 
 
 
@@ -31,8 +32,8 @@ def test_columns_rows():
 def test_issue1225():
     f0 = dt.Frame(A=[1, 2, 3], B=[5, 6, 8])
     f1 = f0[::-1, :][:, [dt.float64(f.A), f.B]]
-    # TODO: restore this check after #1188
-    # assert f1.internal.isview
+    assert get_rowindex(f1, 0) is None
+    assert get_rowindex(f1, 1).type == "slice"
     f1.materialize()
     assert f1.stypes == (stype.float64, stype.int8)
     assert f1.to_list() == [[3.0, 2.0, 1.0], [8, 6, 5]]

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -29,6 +29,7 @@ import time
 import datatable as dt
 from collections import namedtuple
 from datatable import stype, ltype, f, isna
+from datatable.internal import get_rowindex
 from tests import same_iterables, list_equals, noop
 
 
@@ -1018,8 +1019,8 @@ def test_html_repr_slice():
 def test_internal_rowindex():
     d0 = dt.Frame(range(100))
     d1 = d0[:20, :]
-    assert d0.internal.rowindex is None
-    assert repr(d1.internal.rowindex) == "_RowIndex(0/20/1)"
+    assert get_rowindex(d0, 0) is None
+    assert repr(get_rowindex(d1, 0)) == "_RowIndex(0/20/1)"
 
 
 def test_issue898():


### PR DESCRIPTION
This PR is the final step in implementing #1188: to allow each Column in a Frame to have its own distinct RowIndex. This allows us to: 
- cbind frames that have different rowindices without materializing individual columns;
- perform joins without materializing the resulting frame;
- Select filtered columns alongside the computed ones in `DT[i, j, ...]` expression.

Additional changes:
- Removed deprecated C API functions `datatable_get_column_data`, `datatable_unpack_slicerowindex`, `datatable_unpack_arrayrowindex` which are no longer used;
- `DataTable::rowindex` property was removed;
- Removed obsolete function `_datatable.get_internal_function_ptrs()`;
- Added function `datatable.internal.get_rowindex(frame, i)`;
- Removed `Frame.internal.rowindex` and `Frame.internal.rowindex_type`;
- Fixed sort function when applied to a 1-row view Frame.

Closes #1188