### PR TITLE
Refactor sorting/grouping and RowIndex usage in Aggregator

### DIFF
--- a/c/extras/aggregator.h
+++ b/c/extras/aggregator.h
@@ -47,23 +47,23 @@ class Aggregator {
     py::oobj progress_fn;
 
     // Grouping and aggregating methods
-    void group_0d(const DataTable*, dtptr&);
+    void aggregate_exemplars(DataTable*, dtptr&, bool);
+    void group_0d(DataTable*, dtptr&);
     void group_1d(const dtptr&, dtptr&);
-    void group_2d(const dtptr&, dtptr&);
-    void group_nd(const dtptr&, dtptr&);
     void group_1d_continuous(const dtptr&, dtptr&);
-    void group_2d_continuous(const dtptr&, dtptr&);
     void group_1d_categorical(const dtptr&, dtptr&);
+    void group_2d(const dtptr&, dtptr&);
+    void group_2d_continuous(const dtptr&, dtptr&);
     void group_2d_categorical(const dtptr&, dtptr&);
     template<typename T1, typename T2>
     void group_2d_categorical_str(const dtptr&, dtptr&);
     void group_2d_mixed(bool, const dtptr&, dtptr&);
     template<typename T>
     void group_2d_mixed_str(bool, const dtptr&, dtptr&);
-    bool random_sampling(dtptr&, size_t, size_t);
-    void aggregate_exemplars(DataTable*, dtptr&, bool);
+    void group_nd(const dtptr&, dtptr&);
 
-    // Methods for modular quasi-random generator
+    // Random sampling and modular quasi-random generator
+    bool random_sampling(dtptr&, size_t, size_t);
     static void fill_coprimes(size_t, std::vector<size_t>&);
 
     // Helper methods

--- a/c/extras/aggregator.h
+++ b/c/extras/aggregator.h
@@ -48,7 +48,7 @@ class Aggregator {
 
     // Grouping and aggregating methods
     void aggregate_exemplars(DataTable*, dtptr&, bool);
-    void group_0d(DataTable*, dtptr&);
+    void group_0d(const DataTable*, dtptr&);
     void group_1d(const dtptr&, dtptr&);
     void group_1d_continuous(const dtptr&, dtptr&);
     void group_1d_categorical(const dtptr&, dtptr&);

--- a/docs/ftrl.rst
+++ b/docs/ftrl.rst
@@ -40,13 +40,13 @@ FTRL Model Parameters
 The FTRL model requires a list of parameters for training and making predictions,
 namely:
 
--  ``alpha`` — Learning rate, defaults to ``0.005``.
--  ``beta`` — Beta parameter, defaults to ``1.0``.
--  ``lambda1`` — L1 regularization parameter, defaults to ``0.0``.
--  ``lambda2`` — L2 regularization parameter, defaults to ``1.0``.
--  ``nbins`` — The number of bins for the hashing trick, defaults to ``1000000``.
--  ``nepochs`` — The number of epochs to train the model for, defaults to ``1``.
--  ``interactions`` — Whether to enable second order feature interactions, defaults to ``False``.
+-  ``alpha`` – learning rate, defaults to ``0.005``.
+-  ``beta`` – beta parameter, defaults to ``1.0``.
+-  ``lambda1`` – L1 regularization parameter, defaults to ``0.0``.
+-  ``lambda2`` – L2 regularization parameter, defaults to ``1.0``.
+-  ``nbins`` – the number of bins for the hashing trick, defaults to ``1000000``.
+-  ``nepochs`` – the number of epochs to train the model for, defaults to ``1``.
+-  ``interactions`` – whether to enable second order feature interactions, defaults to ``False``.
 
 If some parameters need to be changed, this can be done either
 when creating the model, as

--- a/docs/ftrl.rst
+++ b/docs/ftrl.rst
@@ -53,7 +53,7 @@ when creating the model, as
 
 ::
 
-  ftrl_model = Ftrl(alpha = 0.1, nbins = 100, inter = False)
+  ftrl_model = Ftrl(alpha = 0.1, nbins = 100, interactions = False)
   
 or, if the model already exists, as
 
@@ -61,7 +61,7 @@ or, if the model already exists, as
 
   ftrl_model.alpha = 0.1
   ftrl_model.nbins = 100
-  ftrl_model.inter = False
+  ftrl_model.interactions = False
 
 If some parameters were not set explicitely, they will be assigned the default
 values.

--- a/tests/extras/test_aggregate.py
+++ b/tests/extras/test_aggregate.py
@@ -346,24 +346,22 @@ def test_aggregate_2d_categorical_sorted():
 
 
 def test_aggregate_2d_categorical_unsorted():
-    d_in = dt.Frame([["blue", "indigo", "red", "violet", "yellow", "violet",
-                      "red"],
-                     ["Monday", "Monday", "Wednesday", "Saturday", "Thursday",
-                      "Friday", "Wednesday"]])
+    d_in = dt.Frame([["blue", "indigo", "red", "violet", "yellow", "violet", "red"],
+                     ["Monday", "Monday", "Wednesday", "Saturday", "Thursday", "Friday", "Wednesday"]])
 
     d_members = aggregate(d_in, min_rows=0, progress_fn=report_progress)
     d_members.internal.check()
     assert d_members.shape == (7, 1)
     assert d_members.ltypes == (ltype.int,)
-    assert d_members.to_list() == [[1, 2, 5, 3, 4, 0, 5]]
+    assert d_members.to_list() == [[0, 1, 2, 4, 5, 3, 2]]
     d_in.internal.check()
     assert d_in.shape == (6, 3)
     assert d_in.ltypes == (ltype.str, ltype.str, ltype.int)
-    assert d_in.to_list() == [['violet', 'blue', 'indigo', 'violet', 'yellow',
-                               'red'],
-                              ['Friday', 'Monday', 'Monday', 'Saturday',
-                               'Thursday', 'Wednesday'],
-                              [1, 1, 1, 1, 1, 2]]
+    assert d_in.to_list() == [['blue', 'indigo', 'red', 'violet', 'violet',
+                               'yellow'],
+                              ['Monday', 'Monday', 'Wednesday', 'Friday',
+                               'Saturday', 'Thursday'],
+                              [1, 1, 2, 1, 1, 1]]
 
 
 # Disable some of the checks for the moment, as even with the same seed


### PR DESCRIPTION
- use `group` instead of `sortby` for sorting/grouping;
- make use of two-column grouping in `group_2d_categorical_str`;
- adjust `test_aggregate_2d_categorical_unsorted` test as we now sort by the first column first, then by the second one;
- use RowIndex `operator[]`, instead of RowIndex indices;
- minor changes to FTRL documentation.

Closes #1434