### PR TITLE
max/min for an empty column now returns None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   the frame in-place, so it was confusing to both update in-place and return the
   original frame (#1610).
 
+- `min()` / `max()` over an empty or all-NA column now returns `None` instead of
+  +Inf / -Inf respectively (#1624).
+
 
 ### Deprecated
 

--- a/c/expr/reduceop.cc
+++ b/c/expr/reduceop.cc
@@ -184,15 +184,16 @@ static void min_skipna(const int32_t* groups, int32_t grp, void** params) {
   T res = infinity<T>();
   size_t row0 = static_cast<size_t>(groups[grp]);
   size_t row1 = static_cast<size_t>(groups[grp + 1]);
+  bool valid = false;
   col0->rowindex().iterate(row0, row1, 1,
     [&](size_t, size_t j) {
       if (j == RowIndex::NA) return;
       T x = inputs[j];
-      if (!ISNA<T>(x) && x < res) {
-        res = x;
-      }
+      if (ISNA<T>(x)) return;
+      if (x < res) res = x;
+      valid = true;
     });
-  outputs[grp] = res;
+  outputs[grp] = valid? res : GETNA<T>();
 }
 
 
@@ -208,17 +209,18 @@ static void max_skipna(const int32_t* groups, int32_t grp, void** params) {
   const T* inputs = static_cast<const T*>(col0->data());
   T* outputs = static_cast<T*>(col1->data_w());
   T res = -infinity<T>();
+  bool valid = false;
   size_t row0 = static_cast<size_t>(groups[grp]);
   size_t row1 = static_cast<size_t>(groups[grp + 1]);
   col0->rowindex().iterate(row0, row1, 1,
     [&](size_t, size_t j) {
       if (j == RowIndex::NA) return;
       T x = inputs[j];
-      if (!ISNA<T>(x) && x > res) {
-        res = x;
-      }
+      if (ISNA<T>(x)) return;
+      if (x > res) res = x;
+      valid = true;
     });
-  outputs[grp] = res;
+  outputs[grp] = valid? res : GETNA<T>();
 }
 
 

--- a/datatable/expr/minmax_expr.py
+++ b/datatable/expr/minmax_expr.py
@@ -55,6 +55,9 @@ def max(*args, **kwds):
         return _builtin_max(*args, **kwds)
 
 
+min.__doc__ = _builtin_min.__doc__
+max.__doc__ = _builtin_max.__doc__
+
 
 class MinMaxReducer(BaseExpr):
 

--- a/tests/test_reduce.py
+++ b/tests/test_reduce.py
@@ -22,6 +22,8 @@
 # IN THE SOFTWARE.
 #-------------------------------------------------------------------------------
 import datatable as dt
+import math
+import pytest
 from datatable import f, ltype, first, count
 
 
@@ -200,3 +202,46 @@ def test_first_2d_array():
             [0, 1, 0, 5, 3, 8, 1, 0, 2, 5, 8, None, 1]]
     a_reduce = first(a_in)
     assert a_reduce == [9, 8, 2, 3, None, None, 3, 0, 5, 5, 8, None, 1]
+
+
+
+
+#-------------------------------------------------------------------------------
+# min/max
+#-------------------------------------------------------------------------------
+
+@pytest.mark.parametrize("mm", [dt.min, dt.max])
+@pytest.mark.parametrize("st", dt.ltype.int.stypes)
+def test_minmax_integer(mm, st):
+    src = [0, 23, 100, 99, -11, 24, -1]
+    DT = dt.Frame(A=src, stype=st)
+    assert DT[:, mm(f.A)].to_list() == [[mm(src)]]
+
+
+@pytest.mark.parametrize("mm", [dt.min, dt.max])
+def test_minmax_real(mm):
+    src = [5.6, 12.99, 1e+12, -3.4e-22, math.nan, 0.0]
+    DT = dt.Frame(A=src)
+    assert DT[:, mm(f.A)].to_list() == [[mm(src)]]
+
+
+@pytest.mark.parametrize("mm", [dt.min, dt.max])
+def test_minmax_infs(mm):
+    src = [math.nan, 1.0, 2.5, -math.inf, 3e199, math.inf]
+    answer = -math.inf if mm == dt.min else +math.inf
+    DT = dt.Frame(A=src)
+    assert DT[:, mm(f.A)].to_list() == [[answer]]
+
+
+@pytest.mark.parametrize("mm", [dt.min, dt.max])
+@pytest.mark.parametrize("st", dt.ltype.int.stypes + dt.ltype.real.stypes)
+def test_minmax_empty(mm, st):
+    DT1 = dt.Frame(A=[], stype=st)
+    assert DT1[:, mm(f.A)].to_list() == [[None]]
+
+
+@pytest.mark.parametrize("mm", [dt.min, dt.max])
+@pytest.mark.parametrize("st", dt.ltype.int.stypes + dt.ltype.real.stypes)
+def test_minmax_nas(mm, st):
+    DT2 = dt.Frame(B=[None]*3, stype=st)
+    assert DT2[:, mm(f.B)].to_list() == [[None]]


### PR DESCRIPTION
This PR changes the behavior of functions `max()` and `min()` when they are applied to empty or all-NA columns. Previously those functions returned `-Inf` and `+Inf` respectively (or, for integer columns, `-MAX` and `+MAX`). Now these functions will return `None`.

The reasons for the change are discussed in #1624, but in summary they are:
- in mathematics max and min of an empty set do not exist, only supremum and infimum;
- for integers returning a large integer looks like a bug, and we prefer the behavior of floats to match the behavior of integers;
- numpy returns nan for max/min of array of nans (with a warning);
- R returns NA for max/min of a vector of NAs (however, it returns ±∞ if option `na.rm=TRUE` is used).

Closes #1624