### PR TITLE
Move hashing functionality from header to source file, fix `nbins` setter bug, add a test

### DIFF
--- a/c/extras/hash.cc
+++ b/c/extras/hash.cc
@@ -21,9 +21,17 @@
 //------------------------------------------------------------------------------
 #include "extras/hash.h"
 
+
+/*
+* Abstract Hash class constructor and destructor.
+*/
 Hash::Hash(const Column* col) : ri(col->rowindex()) {}
 Hash::~Hash() {}
 
+
+/*
+* Hash booleans by casting them to `uint64_t`.
+*/
 HashBool::HashBool(const Column* col) : Hash(col) {
   values = dynamic_cast<const BoolColumn*>(col)->elements_r();
 }
@@ -35,3 +43,78 @@ uint64_t HashBool::hash(size_t row) const {
   uint64_t h = static_cast<uint64_t>(value);
   return h;
 }
+
+
+/*
+* Hash integers by casting them to `uint64_t`.
+*/
+template <typename T>
+HashInt<T>::HashInt(const Column* col) : Hash(col) {
+  values = dynamic_cast<const IntColumn<T>*>(col)->elements_r();
+}
+
+
+template <typename T>
+uint64_t HashInt<T>::hash(size_t row) const {
+  size_t i = ri[row];
+  T value = (i == RowIndex::NA)? GETNA<T>() : values[i];
+  uint64_t h = static_cast<uint64_t>(value);
+  return h;
+}
+
+
+/*
+* Hash floats by reinterpreting their bit representation as `uint64_t`.
+* TODO: also support some binning here.
+*/
+template <typename T>
+HashFloat<T>::HashFloat(const Column* col) : Hash(col){
+  values = dynamic_cast<const RealColumn<T>*>(col)->elements_r();
+}
+
+
+template <typename T>
+uint64_t HashFloat<T>::hash(size_t row) const {
+  size_t i = ri[row];
+  T value = (i == RowIndex::NA)? GETNA<T>() : values[i];
+  auto x = static_cast<double>(value);
+  uint64_t* h = reinterpret_cast<uint64_t*>(&x);
+  return *h;
+}
+
+
+/*
+* Hash strings using Murmur hash function.
+*/
+template <typename T>
+HashString<T>::HashString(const Column* col) : Hash(col){
+  auto scol = dynamic_cast<const StringColumn<T>*>(col);
+  strdata = scol->strdata();
+  offsets = scol->offsets();
+}
+
+
+template <typename T>
+uint64_t HashString<T>::hash(size_t row) const {
+  size_t i = ri[row];
+  if (i == RowIndex::NA) {
+    return static_cast<uint64_t>(GETNA<T>());
+  } else {
+    if (ISNA<T>(offsets[i])) {
+      return static_cast<uint64_t>(GETNA<T>());
+    }
+    const T strstart = offsets[i - 1] & ~GETNA<T>();
+    const char* c_str = strdata + strstart;
+    T len = offsets[i] - strstart;
+    return hash_murmur2(c_str, len * sizeof(char), 0);
+  }
+}
+
+template class HashInt<int8_t>;
+template class HashInt<int16_t>;
+template class HashInt<int32_t>;
+template class HashInt<int64_t>;
+template class HashFloat<float>;
+template class HashFloat<double>;
+template class HashString<uint32_t>;
+template class HashString<uint64_t>;

--- a/c/extras/py_ftrl.cc
+++ b/c/extras/py_ftrl.cc
@@ -971,6 +971,11 @@ void Ftrl::set_lambda2(robj py_lambda2) {
 
 
 void Ftrl::set_nbins(robj py_nbins) {
+  if ((*dtft)[0]->is_trained()) {
+    throw ValueError() << "Cannot set `nbins` for a trained model, "
+                       << "reset this model or create a new one";
+  }
+
   uint64_t nbins = static_cast<uint64_t>(py_nbins.to_size_t());
   py::Validator::check_positive(nbins, py_nbins);
   for (size_t i = 0; i < dtft->size(); ++i) {

--- a/c/sort_insert.cc
+++ b/c/sort_insert.cc
@@ -216,7 +216,7 @@ void insert_sort_values_str(
 
 
 //==============================================================================
-// Explicitly instantate template functions
+// Explicitly instantiate template functions
 //==============================================================================
 
 template void insert_sort_keys(const uint8_t*,  int32_t*, int32_t*, int, GroupGatherer&);

--- a/docs/ftrl.rst
+++ b/docs/ftrl.rst
@@ -1,12 +1,12 @@
 FTRL
 ====
 
-This section describes the FTRL (Follow the Regularized Leader) model as implemented in DataTable.
+This section describes the FTRL (Follow the Regularized Leader) model as implemented in datatable.
 
 FTRL Model Information
 ----------------------
 
-The Follow the Regularized Leader (FTRL) model is a DataTable implementation of 
+The Follow the Regularized Leader (FTRL) model is a datatable implementation of 
 the FTRL-Proximal online learning 
 `algorithm <https://research.google.com/pubs/archive/41159.pdf>`__
 for binomial logistic regression. It uses a
@@ -78,7 +78,7 @@ Use the ``fit()`` method to train a model for a binomial logistic regression pro
   
 where ``X`` is a frame of shape ``(nrows, ncols)`` to be trained on,
 and ``y`` is a frame of shape ``(nrows, 1)`` having a ``bool`` type
-of the target column. The following DataTable column types are supported 
+of the target column. The following datatable column types are supported 
 for the ``X`` frame: ``bool``, ``int``, ``real`` and ``str``.
 
 

--- a/docs/ftrl.rst
+++ b/docs/ftrl.rst
@@ -78,7 +78,8 @@ Use the ``fit()`` method to train a model for a binomial logistic regression pro
   
 where ``X`` is a frame of shape ``(nrows, ncols)`` to be trained on,
 and ``y`` is a frame of shape ``(nrows, 1)`` having a ``bool`` type
-of the target column.
+of the target column. The following DataTable column types are supported 
+for the ``X`` frame: ``bool``, ``int``, ``real`` and ``str``.
 
 
 Resetting a Model

--- a/tests/extras/test_ftrl.py
+++ b/tests/extras/test_ftrl.py
@@ -631,6 +631,20 @@ def test_ftrl_fit_predict_view():
     assert_equals(predictions, predictions_range)
 
 
+def test_ftrl_disable_nbins_setter_after_fit():
+    ft = Ftrl(nbins = 10)
+    df_train = dt.Frame(range(ft.nbins))
+    df_target = dt.Frame([True] * ft.nbins)
+    ft.fit(df_train, df_target)
+    with pytest.raises(ValueError) as e:
+        ft.nbins = 100
+    assert ("Cannot set `nbins` for a trained model, "
+            "reset this model or create a new one"
+            == str(e.value))
+    ft.reset()
+    ft.nbins = 100
+
+
 #-------------------------------------------------------------------------------
 # Test multinomial regression
 #-------------------------------------------------------------------------------

--- a/tests/extras/test_ftrl.py
+++ b/tests/extras/test_ftrl.py
@@ -643,6 +643,9 @@ def test_ftrl_disable_nbins_setter_after_fit():
             == str(e.value))
     ft.reset()
     ft.nbins = 100
+    ft.fit(df_train, df_target)
+    assert ft.model[0].nrows == 100
+    assert ft.model[0].ncols == 2
 
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
- move hashing functionality from `hash.h` to `hash.cc`;
- fix `nbins` setter bug that lead to segfault, when the model was already trained;
- add a relevant test to ensure that only untrained models allow for `nbins` change;
- update docs to explicitly say what datatypes are supported by FTRL algo. 

Closes #1631