### PR TITLE
Minor fix to rendered HTML table

### DIFF
--- a/c/frame/_repr_html_.cc
+++ b/c/frame/_repr_html_.cc
@@ -134,7 +134,7 @@ class HtmlWidget {
       for (size_t j = 0; j < ncols; ++j) {
         if (j == cols0) {
           j = ncols - cols1;
-          html << "<th class='vellipsis'>&hellip;</th>";
+          html << "<td></td>";
         }
         SType stype = dt->columns[j]->stype();
         size_t elemsize = info(stype).elemsize();


### PR DESCRIPTION
The style for `tr.coltypes` expects only `<TD>` elements, so the presence of a `<TH>` was making the row rendered incorrectly.