### PR TITLE
Fix feature importance FTRL tests

### DIFF
--- a/tests/extras/test_ftrl.py
+++ b/tests/extras/test_ftrl.py
@@ -741,16 +741,17 @@ def test_ftrl_regression():
 #-------------------------------------------------------------------------------
 
 def test_ftrl_feature_importances():
-    nrows = 200
+    nrows = 10**4
     feature_names = ['unique', 'boolean', 'mod10']
     ft = Ftrl()
     df_train = dt.Frame([range(nrows),
                          [i % 2 for i in range(nrows)],
-                         [i % 10 for i in range(nrows)]
+                         [i % 100 for i in range(nrows)]
                         ], names = feature_names)
     df_target = dt.Frame([False, True] * (nrows // 2))
     ft.fit(df_train, df_target)
     fi = ft.feature_importances
+    print(fi.to_list())
     assert fi.stypes == (stype.str32, stype.float64)
     assert fi.names == ("feature_name", "feature_importance")
     assert fi[:, 0].to_list() == [feature_names]
@@ -776,17 +777,18 @@ def test_ftrl_fi_shallowcopy():
 #-------------------------------------------------------------------------------
 
 def test_ftrl_interactions():
-    nrows = 200
+    nrows = 10**4
     feature_names = ['unique', 'boolean', 'mod10']
     feature_interactions = ['unique:boolean', 'unique:mod10', 'boolean:mod10']
     ft = Ftrl(interactions = True)
     df_train = dt.Frame([range(nrows),
                          [i % 2 for i in range(nrows)],
-                         [i % 10 for i in range(nrows)]
+                         [i % 100 for i in range(nrows)]
                         ], names = feature_names)
     df_target = dt.Frame([False, True] * (nrows // 2))
     ft.fit(df_train, df_target)
     fi = ft.feature_importances
+    print(fi.to_list())
     assert fi.stypes == (stype.str32, stype.float64)
     assert fi.names == ("feature_name", "feature_importance")
     assert fi[:, 0].to_list() == [feature_names + feature_interactions]

--- a/tests/extras/test_ftrl.py
+++ b/tests/extras/test_ftrl.py
@@ -751,7 +751,6 @@ def test_ftrl_feature_importances():
     df_target = dt.Frame([False, True] * (nrows // 2))
     ft.fit(df_train, df_target)
     fi = ft.feature_importances
-    print(fi.to_list())
     assert fi.stypes == (stype.str32, stype.float64)
     assert fi.names == ("feature_name", "feature_importance")
     assert fi[:, 0].to_list() == [feature_names]
@@ -788,7 +787,6 @@ def test_ftrl_interactions():
     df_target = dt.Frame([False, True] * (nrows // 2))
     ft.fit(df_train, df_target)
     fi = ft.feature_importances
-    print(fi.to_list())
     assert fi.stypes == (stype.str32, stype.float64)
     assert fi.names == ("feature_name", "feature_importance")
     assert fi[:, 0].to_list() == [feature_names + feature_interactions]


### PR DESCRIPTION
With the hogwild approach some of the tests may become unstable, when there are many threads modifying the same model weights. Here we Increase number of rows and adjust data to have a larger spread in the feature importances. 