### PR TITLE
Convert pyRowindex class into new-style (based on ExtType)

### DIFF
--- a/c/api.cc
+++ b/c/api.cc
@@ -43,7 +43,7 @@ static DataTable* _extract_dt(PyObject* pydt) {
 
 static RowIndex* _extract_ri(PyObject* pyri) {
   if (pyri == Py_None) return nullptr;
-  return static_cast<pyrowindex::obj*>(pyri)->ref;
+  return static_cast<py::orowindex::pyobject*>(pyri)->ri;
 }
 
 
@@ -91,7 +91,7 @@ PyObject* DtFrame_ColumnRowindex(PyObject* pydt, size_t i) {
   auto dt = _extract_dt(pydt);
   if (_column_index_oob(dt, i)) return nullptr;
   const RowIndex& ri = dt->columns[i]->rowindex();  // rowindex() is noexcept
-  return ri? pyrowindex::wrap(ri) : py::None().release();
+  return (ri? py::orowindex(ri) : py::None()).release();
 }
 
 
@@ -146,15 +146,8 @@ const char* DtFrame_ColumnStringDataR(PyObject* pydt, size_t i) {
 //------------------------------------------------------------------------------
 
 int DtRowindex_Check(PyObject* ob) {
-  if (ob == nullptr) return 0;
   if (ob == Py_None) return 1;
-  auto typeptr = reinterpret_cast<PyObject*>(&pyrowindex::type);
-  int ret = PyObject_IsInstance(ob, typeptr);
-  if (ret == -1) {
-    PyErr_Clear();
-    ret = 0;
-  }
-  return ret;
+  return py::orowindex::check(ob);
 }
 
 

--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -163,8 +163,7 @@ if that column has no RowIndex.
   if (col >= dt->ncols) throw ValueError() << "Index out of bounds";
 
   RowIndex ri = dt->columns[col]->rowindex();
-  return ri? py::oobj::from_new_reference(pyrowindex::wrap(ri))
-           : py::None();
+  return ri? py::orowindex(ri) : py::None();
 });
 
 
@@ -175,11 +174,6 @@ if that column has no RowIndex.
 
 void DatatableModule::init_methods() {
   add(METHODv(pycolumn::column_from_list));
-  add(METHODv(pyrowindex::rowindex_from_slice));
-  add(METHODv(pyrowindex::rowindex_from_slicelist));
-  add(METHODv(pyrowindex::rowindex_from_array));
-  add(METHODv(pyrowindex::rowindex_from_column));
-  add(METHODv(pyrowindex::rowindex_from_filterfn));
   add(METHODv(pydatatable::datatable_load));
   add(METHODv(pydatatable::open_jay));
   add(METHODv(pydatatable::install_buffer_hooks));
@@ -220,13 +214,13 @@ PyInit__datatable()
     if (!init_py_types(m)) return nullptr;
     if (!pycolumn::static_init(m)) return nullptr;
     if (!pydatatable::static_init(m)) return nullptr;
-    if (!pyrowindex::static_init(m)) return nullptr;
     if (!init_py_encodings(m)) return nullptr;
     init_jay();
 
     py::Frame::Type::init(m);
     py::Ftrl::Type::init(m);
     py::base_expr::Type::init(m);
+    py::orowindex::pyobject::Type::init(m);
     py::oby::init(m);
     py::ojoin::init(m);
     py::osort::init(m);

--- a/c/frame/join.cc
+++ b/c/frame/join.cc
@@ -443,30 +443,6 @@ RowIndex natural_join(const DataTable* xdt, const DataTable* jdt) {
 
 
 
-
-// TODO: remove these functions
-
-static py::PKArgs fn_natural_join(
-    2, 0, 0,
-    false, false,
-    {"xdt", "jdt"},
-    "natural_join",
-R"(natural_join(xdt, jdt)
---
-
-Join two Frames `xdt` and `jdt` on the keys of `jdt`.
-)",
-
-[](const py::PKArgs& args) -> py::oobj {
-  DataTable* xdt = args[0].to_frame();
-  DataTable* jdt = args[1].to_frame();
-  return py::oobj::from_new_reference(pyrowindex::wrap(
-           natural_join(xdt, jdt)
-         ));
-});
-
-
 void DatatableModule::init_methods_join() {
   _init_comparators();
-  ADDFN(fn_natural_join);
 }

--- a/c/py_column.cc
+++ b/c/py_column.cc
@@ -89,7 +89,7 @@ PyObject* get_data_pointer(pycolumn::obj* self) {
 PyObject* get_rowindex(pycolumn::obj* self) {
   Column* col = self->ref;
   const RowIndex& ri = col->rowindex();
-  return ri? pyrowindex::wrap(ri) : none();
+  return (ri? py::orowindex(ri) : py::None()).release();
 }
 
 
@@ -128,21 +128,6 @@ PyObject* save_to_disk(pycolumn::obj* self, PyObject* args) {
                                            WritableBuffer::Strategy::Auto;
 
   col->save_to_disk(filename, sstrategy);
-  Py_RETURN_NONE;
-}
-
-
-PyObject* replace_rowindex(pycolumn::obj* self, PyObject* args) {
-  PyObject* arg1;
-  if (!PyArg_ParseTuple(args, "O:replace_rowindex", &arg1)) return nullptr;
-  RowIndex newri = py::robj(arg1).to_rowindex();
-
-  Column* col = self->ref;
-  self->ref = col->shallowcopy(newri);
-  delete col;
-  self->pydt = nullptr;
-  self->colidx = GETNA<int64_t>();
-
   Py_RETURN_NONE;
 }
 
@@ -194,7 +179,6 @@ static PyGetSetDef column_getseters[] = {
 
 static PyMethodDef column_methods[] = {
   METHODv(save_to_disk),
-  METHODv(replace_rowindex),
   METHOD0(to_list),
   {nullptr, nullptr, 0, nullptr}
 };

--- a/c/py_column.h
+++ b/c/py_column.h
@@ -96,13 +96,6 @@ DECLARE_METHOD(
   "writing strategy.\n")
 
 DECLARE_METHOD(
-  replace_rowindex,
-  "replace_rowindex(new_rowindex)\n\n"
-  "Replaces rowindex of the current Column with the provided one. The new\n"
-  "rowindex should be compatible with the Column's data source. This method\n"
-  "does not affect the Frame from which this Column was extracted.\n")
-
-DECLARE_METHOD(
   to_list,
   "to_list()\n\n"
   "Return the contents of the Column as a plain Python list.\n")

--- a/c/python/obj.cc
+++ b/c/python/obj.cc
@@ -520,18 +520,6 @@ strvec _obj::to_stringlist(const error_manager&) const {
 // Object conversions
 //------------------------------------------------------------------------------
 
-RowIndex _obj::to_rowindex(const error_manager& em) const {
-  if (v == Py_None) {
-    return RowIndex();
-  }
-  if (!PyObject_TypeCheck(v, &pyrowindex::type)) {
-    throw em.error_not_rowindex(v);
-  }
-  RowIndex* ref = static_cast<pyrowindex::obj*>(v)->ref;
-  return ref ? RowIndex(*ref) : RowIndex();  // copy-constructor is called here
-}
-
-
 DataTable* _obj::to_frame(const error_manager& em) const {
   if (v == Py_None) return nullptr;
   if (is_frame()) {

--- a/c/python/obj.h
+++ b/c/python/obj.h
@@ -212,7 +212,6 @@ class _obj {
     py::rtuple  to_rtuple_lax     () const;
 
     Column*     to_column         (const error_manager& = _em0) const;
-    RowIndex    to_rowindex       (const error_manager& = _em0) const;
     DataTable*  to_frame          (const error_manager& = _em0) const;
     SType       to_stype          (const error_manager& = _em0) const;
     py::ojoin   to_ojoin_lax      () const;

--- a/tests/extras/test_aggregate.py
+++ b/tests/extras/test_aggregate.py
@@ -459,7 +459,7 @@ def test_aggregate_3d_real():
                           progress_fn=report_progress)
     a_members = d_members.to_list()[0]
     d = d_in.sort("C0")
-    ri = get_rowindex(d, 0).tolist()
+    ri = get_rowindex(d, 0).to_list()
     for i, member in enumerate(a_members):
         a_members[i] = ri.index(member)
 
@@ -503,7 +503,7 @@ def aggregate_nd(nd):
 
     a_members = d_members.to_list()[0]
     d = d_in.sort("C0")
-    ri = get_rowindex(d, 0).tolist()
+    ri = get_rowindex(d, 0).to_list()
     for i, member in enumerate(a_members):
         a_members[i] = ri.index(member)
 

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -1009,11 +1009,11 @@ def test_html_repr_slice():
 # Misc
 #-------------------------------------------------------------------------------
 
-def test_internal_rowindex():
-    d0 = dt.Frame(range(100))
-    d1 = d0[:20, :]
-    assert get_rowindex(d0, 0) is None
-    assert repr(get_rowindex(d1, 0)) == "_RowIndex(0/20/1)"
+# def test_internal_rowindex():
+#     d0 = dt.Frame(range(100))
+#     d1 = d0[:20, :]
+#     assert get_rowindex(d0, 0) is None
+#     assert repr(get_rowindex(d1, 0)) == "_RowIndex(0/20/1)"
 
 
 def test_issue898():


### PR DESCRIPTION
- `py::RowIndex` class was converted into the new format based on `ExtType`. This makes the code cleaner, and also helps to eventually remove "py_utils.h" (which is a blocker for #1369).
- Remove methods `core.rowindex_from_*()`
- Remove method `core.natural_join()`

WIP for #1066
WIP for #1369