### PR TITLE
Disable parallelization `Aggregator::generate_pmatrix`

### DIFF
--- a/c/extras/aggregator.cc
+++ b/c/extras/aggregator.cc
@@ -849,7 +849,6 @@ doubleptr Aggregator::generate_pmatrix(const dtptr& dt_exemplars) {
   generator.seed(seed);
   std::normal_distribution<double> distribution(0.0, 1.0);
 
-  #pragma omp parallel for schedule(static)
   for (size_t i = 0; i < dt_exemplars->ncols * max_dimensions; ++i) {
     pmatrix[i] = distribution(generator);
   }


### PR DESCRIPTION
Since `std::default_random_engine` may not be thread safe, and projection matrix is normally pretty small in terms of dimensions, it may have no sense to parallelize `Aggregator::generate_pmatrix`  method. Disable parallelization as it could be one of the reasons why `test_aggregate_nd_projection` test segfaults on machines with many cores.