### PR TITLE
.to_numpy() for frames with NA values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed crash in certain circumstances when a key was applied after a
   groupby (#1639).
 
+- `Frame.to_numpy()` now returns a numpy `masked_array` if the frame has
+  any NA values (#1619).
 
 
 ### Deprecated
@@ -47,7 +49,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   and reporting bugs that were fixed in this release:
 
   [antorsae][] (#1639),
-
+  [arno candel][] (#1619)
 
 
 

--- a/c/column.cc
+++ b/c/column.cc
@@ -442,3 +442,4 @@ Stats* VoidColumn::get_stats() const { return nullptr; }
 void VoidColumn::fill_na() {}
 RowIndex VoidColumn::join(const Column*) const { return RowIndex(); }
 py::oobj VoidColumn::get_value_at_index(size_t) const { return py::oobj(); }
+void VoidColumn::fill_na_mask(int8_t*, size_t, size_t) {}

--- a/c/column.h
+++ b/c/column.h
@@ -296,6 +296,8 @@ public:
   virtual Stats* get_stats() const = 0;
   Stats* get_stats_if_exist() const { return stats; }
 
+  virtual void fill_na_mask(int8_t* outmask, size_t row0, size_t row1) = 0;
+
 protected:
   Column(size_t nrows = 0);
   virtual void init_data() = 0;
@@ -369,6 +371,7 @@ public:
   virtual void replace_values(RowIndex at, const Column* with) override;
   void replace_values(const RowIndex& at, T with);
   virtual RowIndex join(const Column* keycol) const override;
+  void fill_na_mask(int8_t* outmask, size_t row0, size_t row1) override;
 
 protected:
   void init_data() override;
@@ -676,6 +679,7 @@ public:
   void verify_integrity(const std::string& name) const override;
 
   py::oobj get_value_at_index(size_t i) const override;
+  void fill_na_mask(int8_t* outmask, size_t row0, size_t row1) override;
 
 protected:
   StringColumn();
@@ -732,6 +736,7 @@ class VoidColumn : public Column {
     RowIndex join(const Column* keycol) const override;
     Stats* get_stats() const override;
     py::oobj get_value_at_index(size_t i) const override;
+    void fill_na_mask(int8_t* outmask, size_t row0, size_t row1) override;
   protected:
     VoidColumn();
     void init_data() override;

--- a/c/column_fw.cc
+++ b/c/column_fw.cc
@@ -372,6 +372,14 @@ RowIndex FwColumn<T>::join(const Column* keycol) const {
 }
 
 
+template <typename T>
+void FwColumn<T>::fill_na_mask(int8_t* outmask, size_t row0, size_t row1) {
+  const T* tdata = elements_r();
+  for (size_t i = row0; i < row1; ++i) {
+    outmask[i] = ISNA<T>(tdata[i]);
+  }
+}
+
 
 // Explicit instantiations
 template class FwColumn<int8_t>;

--- a/c/column_string.cc
+++ b/c/column_string.cc
@@ -641,6 +641,15 @@ RowIndex StringColumn<T>::join(const Column* keycol) const {
 }
 
 
+template <typename T>
+void StringColumn<T>::fill_na_mask(int8_t* outmask, size_t row0, size_t row1) {
+  const T* offs = this->offsets();
+  for (size_t i = row0; i < row1; ++i) {
+    outmask[i] = ISNA<T>(offs[i]);
+  }
+}
+
+
 
 //------------------------------------------------------------------------------
 // Stats

--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -244,6 +244,8 @@ PyInit__datatable()
   init_csvwrite_constants();
   init_exceptions();
 
+  force_stype = SType::VOID;
+
   static DatatableModule dtmod;
   PyObject* m = dtmod.init();
 

--- a/c/datatablemodule.h
+++ b/c/datatablemodule.h
@@ -41,4 +41,7 @@ class DatatableModule : public py::ExtModule<DatatableModule> {
 };
 
 
+extern SType force_stype;  // Declared in py_buffers
+
+
 #endif

--- a/c/frame/py_frame.cc
+++ b/c/frame/py_frame.cc
@@ -66,21 +66,6 @@ R"(tail(self, n=10)
 Return the last `n` rows of the Frame, same as ``self[-n:, :]``.
 )");
 
-PKArgs Frame::Type::fn_to_numpy(
-    0, 1, 0, false, false,
-    {"stype"}, "to_numpy",
-R"(to_numpy(self, stype=None)
---
-
-Convert frame into a numpy array, optionally forcing it into a
-specific stype/dtype.
-
-Parameters
-----------
-stype: datatable.stype, numpy.dtype or str
-    Cast frame into this stype before converting it into a numpy array.
-)");
-
 
 
 const char* Frame::Type::classname() {
@@ -225,20 +210,6 @@ oobj Frame::tail(const PKArgs& args) {
   return m__getitem__(aa);
 }
 
-
-oobj Frame::to_numpy(const PKArgs& args) {
-  oobj numpy = oobj::import("numpy");
-  SType st = SType::VOID;
-  if (!args[0].is_undefined()) {
-    st = args[0].to_stype();
-  }
-  otuple call_args(1);
-  call_args.set(0, oobj(this));
-  force_stype = st;
-  oobj res = numpy.get_attr("array").call(call_args);
-  force_stype = SType::VOID;
-  return res;
-}
 
 
 

--- a/c/frame/py_frame.h
+++ b/c/frame/py_frame.h
@@ -61,6 +61,7 @@ class Frame : public PyObject {
         static NoArgs args_to_tuples;
         static PKArgs fn_head;
         static PKArgs fn_tail;
+        static PKArgs fn_to_numpy;
         static NoArgs fn___getstate__;
         static PKArgs fn___setstate__;
         static const char* classname();
@@ -107,6 +108,7 @@ class Frame : public PyObject {
     oobj to_dict(const NoArgs&);
     oobj to_list(const NoArgs&);
     oobj to_tuples(const NoArgs&);
+    oobj to_numpy(const PKArgs&);
     oobj head(const PKArgs&);
     oobj tail(const PKArgs&);
     void repeat(const PKArgs&);

--- a/c/frame/to_numpy.cc
+++ b/c/frame/to_numpy.cc
@@ -1,0 +1,146 @@
+//------------------------------------------------------------------------------
+// Copyright 2018 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#include "frame/py_frame.h"
+#include "python/_all.h"
+#include "python/args.h"
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+static bool datatable_has_nas(DataTable* dt) {
+  for (size_t i = 0; i < dt->ncols; ++i) {
+    if (dt->columns[i]->countna() > 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+
+
+//------------------------------------------------------------------------------
+// to_numpy()
+//------------------------------------------------------------------------------
+namespace py {
+
+
+PKArgs Frame::Type::fn_to_numpy(
+    0, 1, 0, false, false,
+    {"stype"}, "to_numpy",
+R"(to_numpy(self, stype=None)
+--
+
+Convert frame into a numpy array, optionally forcing it into the
+specified stype/dtype.
+
+In a limited set of circumstances the returned numpy array will be
+created as a data view, avoiding copying the data. This happens if
+all of these conditions are met:
+
+  - the frame is not a view;
+  - the frame has only 1 column;
+  - the column's type is not string;
+  - the `stype` argument was not used.
+
+In all other cases the returned numpy array will have a copy of the
+frame's data. If the frame has multiple columns of different stypes,
+then the values will be upcasted into the smallest common stype.
+
+If the frame has any NA values, then the returned numpy array will
+be an instance of `numpy.ma.masked_array`.
+
+Parameters
+----------
+stype: datatable.stype, numpy.dtype or str
+    Cast frame into this stype before converting it into a numpy array.
+)");
+
+
+oobj Frame::to_numpy(const PKArgs& args) {
+  oobj numpy = oobj::import("numpy");
+  oobj nparray = numpy.get_attr("array");
+  SType st = SType::VOID;
+  if (!args[0].is_undefined()) {
+    st = args[0].to_stype();
+  }
+  oobj res;
+  otuple call_args1(1);
+  call_args1.set(0, oobj(this));
+  force_stype = st;
+  res = nparray.call(call_args1);
+  force_stype = SType::VOID;
+
+  // If there are any columns with NAs, replace the numpy.array with
+  // numpy.ma.masked_array
+  bool has_nas = false;
+  for (size_t i = 0; i < dt->ncols; ++i) {
+    if (dt->columns[i]->countna() > 0) {
+      has_nas = true;
+      break;
+    }
+  }
+
+  if (has_nas) {
+    size_t dtsize = dt->ncols * dt->nrows;
+    Column* mask_col = Column::new_data_column(SType::BOOL, dtsize);
+    int8_t* mask_data = static_cast<int8_t*>(mask_col->data_w());
+
+    size_t n_row_chunks = std::max(dt->nrows / 100, size_t(1));
+    size_t rows_per_chunk = dt->nrows / n_row_chunks;
+    size_t n_chunks = dt->ncols * n_row_chunks;
+    #pragma omp parallel for
+    for (size_t j = 0; j < n_chunks; ++j) {
+      size_t icol = j / n_row_chunks;
+      size_t irow = j - (icol * n_row_chunks);
+      size_t row0 = irow * rows_per_chunk;
+      size_t row1 = irow == n_row_chunks-1? dt->nrows : row0 + rows_per_chunk;
+      int8_t* mask_ptr = mask_data + icol * dt->nrows;
+      Column* col = dt->columns[icol];
+      if (col->countna()) {
+        col->fill_na_mask(mask_ptr, row0, row1);
+      } else {
+        std::memset(mask_ptr, 0, row1 - row0);
+      }
+    }
+
+    DataTable* mask_dt = new DataTable({mask_col});
+    oobj mask_frame = oobj::from_new_reference(Frame::from_datatable(mask_dt));
+    call_args1.set(0, mask_frame);
+    oobj mask_array = nparray.call(call_args1);
+
+    otuple call_args2(2);
+    call_args2.set(0, oint(dt->ncols));
+    call_args2.set(1, oint(dt->nrows));
+    mask_array = mask_array.invoke("reshape", call_args2).get_attr("T");
+
+    call_args2.set(0, res);
+    call_args2.set(1, mask_array);
+    res = numpy.get_attr("ma").get_attr("masked_array").call(call_args2);
+  }
+
+  return res;
+}
+
+
+
+}  // namespace py

--- a/c/frame/to_numpy.cc
+++ b/c/frame/to_numpy.cc
@@ -92,15 +92,7 @@ oobj Frame::to_numpy(const PKArgs& args) {
 
   // If there are any columns with NAs, replace the numpy.array with
   // numpy.ma.masked_array
-  bool has_nas = false;
-  for (size_t i = 0; i < dt->ncols; ++i) {
-    if (dt->columns[i]->countna() > 0) {
-      has_nas = true;
-      break;
-    }
-  }
-
-  if (has_nas) {
+  if (datatable_has_nas(dt)) {
     size_t dtsize = dt->ncols * dt->nrows;
     Column* mask_col = Column::new_data_column(SType::BOOL, dtsize);
     int8_t* mask_data = static_cast<int8_t*>(mask_col->data_w());

--- a/c/py_buffers.cc
+++ b/c/py_buffers.cc
@@ -21,6 +21,8 @@
 #include "utils/assert.h"
 #include "utils/exceptions.h"
 
+SType force_stype;
+
 // Forward declarations
 static Column* try_to_resolve_object_column(Column* col);
 static SType stype_from_format(const char *format, int64_t itemsize);
@@ -426,7 +428,7 @@ static int getbuffer_DataTable(
   // copied -- in which case it should be possible to return the buffer
   // by-reference instead of copying the data into an intermediate buffer.
   if (ncols == 1 && !dt->columns[0]->rowindex() && !REQ_WRITABLE(flags) &&
-      dt->columns[0]->is_fixedwidth()) {
+      dt->columns[0]->is_fixedwidth() && force_stype == SType::VOID) {
     return dt_getbuffer_1_col(self, view, flags);
   }
 
@@ -436,7 +438,7 @@ static int getbuffer_DataTable(
   // "INDIRECT" buffer.
 
   // First, find the common stype for all columns in the DataTable.
-  SType stype = self->use_stype_for_buffers;
+  SType stype = force_stype;
   if (stype == SType::VOID) {
     // Auto-detect common stype
     uint64_t stypes_mask = 0;

--- a/c/py_datatable.cc
+++ b/c/py_datatable.cc
@@ -38,7 +38,6 @@ PyObject* wrap(DataTable* dt)
     auto pypydt = reinterpret_cast<pydatatable::obj*>(pydt);
     pypydt->ref = dt;
     pypydt->_frame = nullptr;
-    pypydt->use_stype_for_buffers = SType::VOID;
   }
   return pydt;
 }
@@ -310,11 +309,11 @@ PyObject* materialize(obj* self, PyObject*) {
 }
 
 
-PyObject* use_stype_for_buffers(obj* self, PyObject* args) {
+PyObject* use_stype_for_buffers(obj*, PyObject* args) {
   int st = 0;
   if (!PyArg_ParseTuple(args, "|i:use_stype_for_buffers", &st))
     return nullptr;
-  self->use_stype_for_buffers = static_cast<SType>(st);
+  force_stype = static_cast<SType>(st);
   Py_RETURN_NONE;
 }
 

--- a/c/py_datatable.h
+++ b/c/py_datatable.h
@@ -13,6 +13,8 @@
 #include "py_utils.h"
 namespace py { class Frame; }
 
+extern SType force_stype;
+
 #define BASECLS pydatatable::obj
 #define CLSNAME DataTable
 #define HOMEFLAG dt_PY_DATATABLE_cc
@@ -37,8 +39,6 @@ namespace pydatatable
 struct obj : public PyObject {
   DataTable* ref;
   py::Frame* _frame;
-  SType use_stype_for_buffers;
-  int64_t : 56;
 };
 
 extern PyTypeObject type;

--- a/c/python/obj.cc
+++ b/c/python/obj.cc
@@ -124,6 +124,20 @@ oobj oobj::import(const char* mod, const char* symbol) {
   return mod_obj.get_attr(symbol);
 }
 
+oobj oobj::import(const char* mod) {
+  PyObject* module = PyImport_ImportModule(mod);
+  if (!module) {
+    if (PyErr_ExceptionMatches(PyExc_ModuleNotFoundError)) {
+      PyErr_Clear();
+      throw ImportError() << "Module `" << mod << "` is not installed. "
+                             "It is required for running this function";
+    } else {
+      throw PyError();
+    }
+  }
+  return oobj::from_new_reference(module);
+}
+
 oobj::~oobj() {
   Py_XDECREF(v);
 }

--- a/c/python/obj.cc
+++ b/c/python/obj.cc
@@ -127,7 +127,7 @@ oobj oobj::import(const char* mod, const char* symbol) {
 oobj oobj::import(const char* mod) {
   PyObject* module = PyImport_ImportModule(mod);
   if (!module) {
-    if (PyErr_ExceptionMatches(PyExc_ModuleNotFoundError)) {
+    if (PyErr_ExceptionMatches(PyExc_ImportError)) {
       PyErr_Clear();
       throw ImportError() << "Module `" << mod << "` is not installed. "
                              "It is required for running this function";

--- a/c/python/obj.h
+++ b/c/python/obj.h
@@ -291,6 +291,7 @@ class oobj : public _obj {
     oobj& operator=(const oobj&);
     oobj& operator=(oobj&&);
     static oobj import(const char* module, const char* symbol);
+    static oobj import(const char* module);
     ~oobj();
 
     static oobj from_new_reference(PyObject* p);

--- a/c/utils/exceptions.cc
+++ b/c/utils/exceptions.cc
@@ -200,14 +200,15 @@ std::string PyError::message() const {
 
 //==============================================================================
 
+Error AssertionError() { return Error(PyExc_AssertionError); }
+Error ImportError()    { return Error(PyExc_ImportError); }
+Error IOError()        { return Error(PyExc_IOError); }
+Error MemoryError()    { return Error(PyExc_MemoryError); }
+Error NotImplError()   { return Error(PyExc_NotImplementedError); }
+Error OverflowError()  { return Error(PyExc_OverflowError); }
 Error RuntimeError()   { return Error(PyExc_RuntimeError); }
 Error TypeError()      { return Error(type_error_class); }
 Error ValueError()     { return Error(value_error_class); }
-Error OverflowError()  { return Error(PyExc_OverflowError); }
-Error MemoryError()    { return Error(PyExc_MemoryError); }
-Error NotImplError()   { return Error(PyExc_NotImplementedError); }
-Error IOError()        { return Error(PyExc_IOError); }
-Error AssertionError() { return Error(PyExc_AssertionError); }
 
 void replace_typeError(PyObject* obj) { type_error_class = obj; }
 void replace_valueError(PyObject* obj) { value_error_class = obj; }

--- a/c/utils/exceptions.h
+++ b/c/utils/exceptions.h
@@ -101,6 +101,7 @@ Error MemoryError();
 Error NotImplError();
 Error IOError();
 Error AssertionError();
+Error ImportError();
 
 void replace_typeError(PyObject* obj);
 void replace_valueError(PyObject* obj);

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -327,30 +327,6 @@ class Frame(core.Frame):
         return pd
 
 
-    def to_numpy(self, stype=None):
-        """
-        Convert Frame into a numpy array, optionally forcing it into a
-        specific stype/dtype.
-
-        Parameters
-        ----------
-        stype: datatable.stype, numpy.dtype or str
-            Cast datatable into this dtype before converting it into a numpy
-            array.
-        """
-        numpy = load_module("numpy")
-        if not hasattr(numpy, "array"):  # pragma: no cover
-            raise ImportError("Unsupported numpy version: `%s`"
-                              % (getattr(numpy, "__version__", "???"), ))
-        st = 0
-        if stype:
-            st = datatable.stype(stype).value
-        self.internal.use_stype_for_buffers(st)
-        res = numpy.array(self.internal)
-        self.internal.use_stype_for_buffers(0)
-        return res
-
-
     def topython(self):
         warnings.warn(
             "Method `Frame.topython()` is deprecated (will be removed in "


### PR DESCRIPTION
`Frame.to_numpy()` method now returns a `numpy.ma.masked_array` if the underlying frame had any NA values. This works for all stypes, not just boolean.

Closes #1619