### PR TITLE
Kfold splitting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][]
 
+### Added
+
+- Added function `dt.models.kfold(k, n)` to prepare indices for k-fold
+  splitting. This function will return `k` pairs of row selectors such that
+  when these selectors are applied to an `n`-rows frame, that frame will be
+  split into train and test part according to the K-fold splitting scheme.
+
+
 ### Fixed
 
 - Fixed crash in certain circumstances when a key was applied after a

--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -227,6 +227,7 @@ void DatatableModule::init_methods() {
 
   init_methods_aggregate();
   init_methods_join();
+  init_methods_kfold();
   init_methods_options();
   init_methods_repeat();
   init_methods_sets();

--- a/c/datatablemodule.h
+++ b/c/datatablemodule.h
@@ -28,12 +28,13 @@ class DatatableModule : public py::ExtModule<DatatableModule> {
     }
 
     void init_methods();
-    void init_methods_aggregate();// extra/aggergate.cc
-    void init_methods_join();     // frame/join.cc
-    void init_methods_options();  // options.cc
-    void init_methods_repeat();   // frame/repeat.cc
-    void init_methods_sets();     // set_funcs.cc
-    void init_methods_str();      // str/py_str.cc
+    void init_methods_aggregate(); // extras/aggregate.cc
+    void init_methods_kfold();     // extras/kfold.cc
+    void init_methods_join();      // frame/join.cc
+    void init_methods_options();   // options.cc
+    void init_methods_repeat();    // frame/repeat.cc
+    void init_methods_sets();      // set_funcs.cc
+    void init_methods_str();       // str/py_str.cc
 
     #ifdef DTTEST
       void init_tests();

--- a/c/extras/kfold.cc
+++ b/c/extras/kfold.cc
@@ -77,7 +77,7 @@ n: int
   }
   if (k > n) {
     throw ValueError() << "The number of splits `k` cannot exceed the number "
-        "of rows in the frame";
+        "of rows `n`";
   }
 
   int64_t ik = static_cast<int64_t>(k);

--- a/c/extras/kfold.cc
+++ b/c/extras/kfold.cc
@@ -1,0 +1,137 @@
+//------------------------------------------------------------------------------
+// Copyright 2018 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#include "frame/py_frame.h"
+#include "python/_all.h"
+#include "python/arg.h"
+#include "utils/exceptions.h"
+#include "column.h"
+#include "datatable.h"
+#include "datatablemodule.h"
+
+namespace py {
+
+
+//------------------------------------------------------------------------------
+// kfold()
+//------------------------------------------------------------------------------
+
+static PKArgs fn_kfold_simple(
+  0, 2, 0, false, false,
+  {"k", "n"}, "kfold",
+
+R"(kfold(k, n)
+--
+
+Perform k-fold split of data with `n` rows into `k` train / test subsets.
+
+This function will return a list of `k` tuples `(train_rows, test_rows)`, where
+each component of the tuple is a rows selector that can be applied to a frame
+with `n` rows. Some of these row selectors will be simple python ranges, others
+will be single-column Frame objects.
+
+The range `[0; n)` is split into `k` approximately equal parts (called "folds"),
+and then each `i`-th split will use the `i`-th fold as a test part, and all the
+remaining rows as the train part. Thus, `i`-th split is comprised of:
+
+  - train: rows [0; i*n/k) + [(i+1)*n/k; n)
+  - test:  rows [i*n/k; (i+1)*n/k)
+
+where integer division is assumed.
+
+Parameters
+----------
+k: int
+    Number of folds, must be at least 2.
+
+n: int
+    The number of rows in the frame that you want to split. This parameter
+    must be greater or equal to `k`.
+)",
+
+[](const py::PKArgs& args) -> py::oobj {
+  if (!args[0]) throw TypeError() << "Required parameter `k` is missing";
+  if (!args[1]) throw TypeError() << "Required parameter `n` is missing";
+  size_t k = args[0].to_size_t();
+  size_t n = args[1].to_size_t();
+  if (k < 2) {
+    throw ValueError() << "The number of splits `k` cannot be less than 2";
+  }
+  if (k > n) {
+    throw ValueError() << "The number of splits `k` cannot exceed the number "
+        "of rows in the frame";
+  }
+
+  int64_t ik = static_cast<int64_t>(k);
+  int64_t in = static_cast<int64_t>(n);
+
+  olist res(k);
+  otuple split_first(2);
+  split_first.set(0, orange(in/ik, in));
+  split_first.set(1, orange(0, in/ik));
+  otuple split_last(2);
+  split_last.set(0, orange(0, (ik-1)*in/ik));
+  split_last.set(1, orange((ik-1)*in/ik, in));
+  res.set(0, split_first);
+  res.set(k-1, split_last);
+
+  std::vector<int32_t*> data;
+
+  for (int64_t ii = 1; ii < ik-1; ++ii) {
+    int64_t b1 = ii*in/ik;
+    int64_t b2 = (ii+1)*in/ik;
+    size_t colsize = static_cast<size_t>(b1 + in - b2);
+    Column* col = Column::new_data_column(SType::INT32, colsize);
+    DataTable* dt = new DataTable({col});
+    data.push_back(static_cast<int32_t*>(col->data_w()));
+
+    otuple split_i(2);
+    split_i.set(0, oobj::from_new_reference(Frame::from_datatable(dt)));
+    split_i.set(1, orange(b1, b2));
+    res.set(static_cast<size_t>(ii), split_i);
+  }
+
+  for (int64_t t = 0; t < ik*(ik-2); ++t) {
+    int64_t j = t / ik;     // column index
+    int64_t i = t - j * ik; // block of rows
+    ++j;
+    if (i == j) continue;
+    int64_t row0 = i * in / ik;
+    int64_t row1 = (i+1) * in / ik;
+    int64_t delta = i < j? 0 : (j+1)*in/ik - j*in/ik;
+    int32_t* ptr = data[static_cast<size_t>(j) - 1] - delta;
+    for (int64_t row = row0; row < row1; ++row) {
+      ptr[row] = static_cast<int32_t>(row);
+    }
+  }
+
+  return std::move(res);
+});
+
+
+
+}  // namespace py
+
+
+
+void DatatableModule::init_methods_kfold() {
+  ADDFN(py::fn_kfold_simple);
+}

--- a/c/extras/kfold.cc
+++ b/c/extras/kfold.cc
@@ -35,70 +35,71 @@ namespace py {
 //------------------------------------------------------------------------------
 
 static PKArgs fn_kfold_simple(
-  0, 2, 0, false, false,
-  {"k", "n"}, "kfold",
+  0, 0, 2, false, false,
+  {"nrows", "nsplits"}, "kfold",
 
-R"(kfold(k, n)
+R"(kfold(nrows, nsplits)
 --
 
-Perform k-fold split of data with `n` rows into `k` train / test subsets.
+Perform k-fold split of data with `nrows` rows into `nsplits` train/test
+subsets.
 
-This function will return a list of `k` tuples `(train_rows, test_rows)`, where
-each component of the tuple is a rows selector that can be applied to a frame
-with `n` rows. Some of these row selectors will be simple python ranges, others
-will be single-column Frame objects.
+This function will return a list of `nsplits` tuples `(train_rows, test_rows)`,
+where each component of the tuple is a rows selector that can be applied to a
+frame with `nrows` rows. Some of these row selectors will be simple python
+ranges, others will be single-column Frame objects.
 
-The range `[0; n)` is split into `k` approximately equal parts (called "folds"),
-and then each `i`-th split will use the `i`-th fold as a test part, and all the
-remaining rows as the train part. Thus, `i`-th split is comprised of:
+The range `[0; nrows)` is split into `nsplits` approximately equal parts
+(called "folds"), and then each `i`-th split will use the `i`-th fold as a
+test part, and all the remaining rows as the train part. Thus, `i`-th split is
+comprised of:
 
-  - train: rows [0; i*n/k) + [(i+1)*n/k; n)
-  - test:  rows [i*n/k; (i+1)*n/k)
+  - train: rows [0; i*nrows/nsplits) + [(i+1)*nrows/nsplits; nrows)
+  - test:  rows [i*nrows/nsplits; (i+1)*nrows/nsplits)
 
 where integer division is assumed.
 
 Parameters
 ----------
-k: int
-    Number of folds, must be at least 2.
+nrows: int
+    The number of rows in the frame that you want to split.
 
-n: int
-    The number of rows in the frame that you want to split. This parameter
-    must be greater or equal to `k`.
+nsplits: int
+    Number of folds, must be at least 2, but not larger than `nrows`.
 )",
 
 [](const py::PKArgs& args) -> py::oobj {
-  if (!args[0]) throw TypeError() << "Required parameter `k` is missing";
-  if (!args[1]) throw TypeError() << "Required parameter `n` is missing";
-  size_t k = args[0].to_size_t();
-  size_t n = args[1].to_size_t();
-  if (k < 2) {
-    throw ValueError() << "The number of splits `k` cannot be less than 2";
+  if (!args[0]) throw TypeError() << "Required parameter `nrows` is missing";
+  if (!args[1]) throw TypeError() << "Required parameter `nsplits` is missing";
+  size_t nrows = args[0].to_size_t();
+  size_t nsplits = args[1].to_size_t();
+  if (nsplits < 2) {
+    throw ValueError() << "The number of splits cannot be less than two";
   }
-  if (k > n) {
-    throw ValueError() << "The number of splits `k` cannot exceed the number "
-        "of rows `n`";
+  if (nsplits > nrows) {
+    throw ValueError()
+      << "The number of splits cannot exceed the number of rows";
   }
 
-  int64_t ik = static_cast<int64_t>(k);
-  int64_t in = static_cast<int64_t>(n);
+  int64_t k = static_cast<int64_t>(nsplits);
+  int64_t n = static_cast<int64_t>(nrows);
 
-  olist res(k);
+  olist res(nsplits);
   otuple split_first(2);
-  split_first.set(0, orange(in/ik, in));
-  split_first.set(1, orange(0, in/ik));
+  split_first.set(0, orange(n/k, n));
+  split_first.set(1, orange(0, n/k));
   otuple split_last(2);
-  split_last.set(0, orange(0, (ik-1)*in/ik));
-  split_last.set(1, orange((ik-1)*in/ik, in));
+  split_last.set(0, orange(0, (k-1)*n/k));
+  split_last.set(1, orange((k-1)*n/k, n));
   res.set(0, split_first);
-  res.set(k-1, split_last);
+  res.set(nsplits-1, split_last);
 
   std::vector<int32_t*> data;
 
-  for (int64_t ii = 1; ii < ik-1; ++ii) {
-    int64_t b1 = ii*in/ik;
-    int64_t b2 = (ii+1)*in/ik;
-    size_t colsize = static_cast<size_t>(b1 + in - b2);
+  for (int64_t ii = 1; ii < k-1; ++ii) {
+    int64_t b1 = ii*n/k;
+    int64_t b2 = (ii+1)*n/k;
+    size_t colsize = static_cast<size_t>(b1 + n - b2);
     Column* col = Column::new_data_column(SType::INT32, colsize);
     DataTable* dt = new DataTable({col});
     data.push_back(static_cast<int32_t*>(col->data_w()));
@@ -109,14 +110,14 @@ n: int
     res.set(static_cast<size_t>(ii), split_i);
   }
 
-  for (int64_t t = 0; t < ik*(ik-2); ++t) {
-    int64_t j = t / ik;     // column index
-    int64_t i = t - j * ik; // block of rows
+  for (int64_t t = 0; t < k*(k-2); ++t) {
+    int64_t j = t / k;     // column index
+    int64_t i = t - j * k; // block of rows
     ++j;
     if (i == j) continue;
-    int64_t row0 = i * in / ik;
-    int64_t row1 = (i+1) * in / ik;
-    int64_t delta = i < j? 0 : (j+1)*in/ik - j*in/ik;
+    int64_t row0 = i * n / k;
+    int64_t row1 = (i+1) * n / k;
+    int64_t delta = i < j? 0 : (j+1)*n/k - j*n/k;
     int32_t* ptr = data[static_cast<size_t>(j) - 1] - delta;
     for (int64_t row = row0; row < row1; ++row) {
       ptr[row] = static_cast<int32_t>(row);

--- a/datatable/models.py
+++ b/datatable/models.py
@@ -20,6 +20,6 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 #-------------------------------------------------------------------------------
-from datatable.lib._datatable import Ftrl
+from datatable.lib._datatable import Ftrl, kfold
 
-__all__ = ("Ftrl",)
+__all__ = ("Ftrl", "kfold")

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -161,3 +161,15 @@ def noop(x):
     expression result.
     """
     pass
+
+
+def assert_type_error(f, msg):
+    with pytest.raises(TypeError) as e:
+        f()
+    assert msg in str(e.value)
+
+
+def assert_value_error(f, msg):
+    with pytest.raises(ValueError) as e:
+        f()
+    assert msg in str(e.value)

--- a/tests/models/test_kfold.py
+++ b/tests/models/test_kfold.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#-------------------------------------------------------------------------------
+# Copyright 2018 H2O.ai
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#-------------------------------------------------------------------------------
+import datatable as dt
+import pytest
+import random
+from datatable.models import kfold
+
+
+def assert_type_error(args, msg):
+    with pytest.raises(TypeError) as e:
+        kfold(*args)
+    assert msg in str(e.value)
+
+def assert_value_error(args, msg):
+    with pytest.raises(ValueError) as e:
+        kfold(*args)
+    assert msg in str(e.value)
+
+
+def test_bad_args1():
+    assert_type_error((), "Required parameter `k` is missing")
+    assert_type_error((5,), "Required parameter `n` is missing")
+    assert_type_error((5, 3.3), "Argument `n` in kfold() should be an integer")
+    assert_type_error((None, 7), "Argument `k` in kfold() should be an integer")
+    assert_type_error((1, 1, 1), "kfold() takes at most 2 positional arguments")
+
+
+def test_bad_args2():
+    assert_value_error((-1, 1), "Argument `k` in kfold() cannot be negative")
+    assert_value_error((3, -3), "Argument `n` in kfold() cannot be negative")
+    assert_value_error((0, 5), "The number of splits `k` cannot be less than 2")
+    assert_value_error((2, 1), "The number of splits `k` cannot exceed the "
+                               "number of rows `n`")
+
+def test_kfold_simple():
+    splits = kfold(2, 2)
+    assert splits == [(range(1, 2), range(0, 1)),
+                      (range(0, 1), range(1, 2))]
+
+
+def test_kfold_api():
+    splits1 = kfold(2, 3)
+    splits2 = kfold(2, n=3)
+    splits3 = kfold(k=2, n=3)
+    assert splits1 == splits2 == splits3
+
+
+@pytest.mark.parametrize("seed", [random.getrandbits(32)])
+def test_kfold_k_2(seed):
+    random.seed(seed)
+    n = 2 + int(random.expovariate(0.01))
+    h = n // 2
+    splits = kfold(2, n)
+    assert splits == [(range(h, n), range(0, h)),
+                      (range(0, h), range(h, n))]
+
+
+@pytest.mark.parametrize("seed", [random.getrandbits(32)])
+def test_kfold_k_3(seed):
+    random.seed(seed)
+    n = 3 + int(random.expovariate(0.01))
+    h1 = n // 3
+    h2 = 2 * n // 3
+    splits = kfold(3, n)
+    assert len(splits) == 3
+    assert splits[0] == (range(h1, n), range(0, h1))
+    assert splits[1][1] == range(h1, h2)
+    assert splits[2] == (range(0, h2), range(h2, n))
+    assert isinstance(splits[1][0], dt.Frame)
+    assert splits[1][0].nrows == h1 + n - h2
+    assert splits[1][0].to_list()[0] == list(range(0, h1)) + list(range(h2, n))
+
+
+@pytest.mark.parametrize("seed", [random.getrandbits(32)])
+def test_kfold_k_any(seed):
+    random.seed(seed)
+    k = 2 + int(random.expovariate(0.01))
+    n = k + int(random.expovariate(0.0001))
+    splits = kfold(k, n)
+    h1 = n // k
+    h2 = n * (k-1) // k
+    assert len(splits) == k
+    assert splits[0] == (range(h1, n), range(0, h1))
+    assert splits[-1] == (range(0, h2), range(h2, n))
+    for j, split in enumerate(splits[1:-1], 1):
+        hl = j * n // k
+        hu = (j + 1) * n // k
+        assert split[1] == range(hl, hu)
+        assert isinstance(split[0], dt.Frame)
+        assert split[0].nrows + len(split[1]) == n
+        assert split[0].ncols == 1
+        assert split[0].to_list()[0] == list(range(0, hl)) + list(range(hu, n))


### PR DESCRIPTION
Added function `dt.models.kfold(nrows, nsplits)` to prepare indices for k-fold splitting. This function will return `nsplits` pairs of row selectors such that when these selectors are applied to an `nrows` frame, that frame will be split into train and test part according to the K-fold splitting scheme.

More specifically, the documentation for method `kfold` is the following:
```
kfold(nrows, nsplits)
--

Perform k-fold split of data with `nrows` rows into `nsplits` train/test
subsets.

This function will return a list of `nsplits` tuples `(train_rows, test_rows)`,
where each component of the tuple is a rows selector that can be applied to a
frame with `nrows` rows. Some of these row selectors will be simple python
ranges, others will be single-column Frame objects.

The range `[0; nrows)` is split into `nsplits` approximately equal parts
(called "folds"), and then each `i`-th split will use the `i`-th fold as a
test part, and all the remaining rows as the train part. Thus, `i`-th split is
comprised of:

  - train: rows [0; i*nrows/nsplits) + [(i+1)*nrows/nsplits; nrows)
  - test:  rows [i*nrows/nsplits; (i+1)*nrows/nsplits)

where integer division is assumed.

Parameters
----------
nrows: int
    The number of rows in the frame that you want to split.

nsplits: int
    Number of folds, must be at least 2, but not larger than `nrows`.
```

Closes #1627