### PR TITLE
Create mechanism for defining python interface methods more robustly

### DIFF
--- a/c/frame/py_frame.h
+++ b/c/frame/py_frame.h
@@ -59,8 +59,6 @@ class Frame : public PyObject {
         static NoArgs args_to_dict;
         static NoArgs args_to_list;
         static NoArgs args_to_tuples;
-        static PKArgs fn_head;
-        static PKArgs fn_tail;
         static PKArgs fn_to_numpy;
         static NoArgs fn___getstate__;
         static PKArgs fn___setstate__;

--- a/c/python/arg.cc
+++ b/c/python/arg.cc
@@ -90,6 +90,10 @@ SType       Arg::to_stype()        const { return pyobj.to_stype(*this); }
 SType       Arg::to_stype(const error_manager& em) const { return pyobj.to_stype(em); }
 DataTable*  Arg::to_frame()        const { return pyobj.to_frame(*this); }
 
+Arg::operator int32_t() const { return to_int32_strict(); }
+Arg::operator int64_t() const { return to_int64_strict(); }
+Arg::operator size_t()  const { return to_size_t(); }
+
 
 
 //------------------------------------------------------------------------------

--- a/c/python/arg.h
+++ b/c/python/arg.h
@@ -97,8 +97,9 @@ class Arg : public _obj::error_manager {
      * too large.
      * This method must not be called if the argument is undefined.
      */
-    // operator int32_t() const;
-    // operator int64_t() const;
+    operator int32_t() const;
+    operator int64_t() const;
+    operator size_t() const;
 
     /**
      * Convert argument to different list objects.


### PR DESCRIPTION
Adding new macro `ADD_METHOD(mm, method, args);`, which should eventually replace all the existing template functions `mm.add<...>()`. I hope that the new approach will be more robust than the current (in particular, less chances of compiler errors). In addition, it is conceptually simpler and produces smaller code footprint than the current approach. Also, the `args` variable can now be declared statically in a file, there is no need to define it in the class.

This PR only converts 2 methods `Frame.head()` and `Frame.tail()` to the new approach, as a "test-drive". A subsequent PR will take care to convert all the existing usages.