### PR TITLE
Simplify ExtType<T>::Methods class

### DIFF
--- a/c/extras/py_ftrl.h
+++ b/c/extras/py_ftrl.h
@@ -49,11 +49,6 @@ class Ftrl : public PyObject {
     class Type : public ExtType<Ftrl> {
       public:
         static PKArgs args___init__;
-        static PKArgs args_fit;
-        static PKArgs args_predict;
-        static NoArgs args_reset;
-        static NoArgs fn___getstate__;
-        static PKArgs fn___setstate__;
         static const char* classname();
         static const char* classdoc();
         static bool is_subclassable() { return true; }
@@ -66,7 +61,7 @@ class Ftrl : public PyObject {
     void init_dtft(dt::FtrlParams);
 
     // Pickling support
-    oobj m__getstate__(const NoArgs&);
+    oobj m__getstate__(const PKArgs&);
     void m__setstate__(const PKArgs&);
 
     // Learning and predicting methods
@@ -76,7 +71,7 @@ class Ftrl : public PyObject {
     template <typename T>
     void fit_regression(DataTable*, DataTable*);
     oobj predict(const PKArgs&);
-    void reset(const NoArgs&);
+    void reset(const PKArgs&);
     void reset_feature_names();
 
     // Getters and setters

--- a/c/py_rowindex.cc
+++ b/c/py_rowindex.cc
@@ -28,44 +28,6 @@ namespace py {
 
 
 //------------------------------------------------------------------------------
-// orowindex::pyobject::Type
-//------------------------------------------------------------------------------
-
-const char* orowindex::pyobject::Type::classname() {
-  return "datatable.internal.RowIndex";
-}
-
-const char* orowindex::pyobject::Type::classdoc() {
-  return nullptr;
-}
-
-bool orowindex::pyobject::Type::is_subclassable() {
-  return false;
-}
-
-void orowindex::pyobject::Type::init_methods_and_getsets(
-    Methods& mm, GetSetters& gs) {
-  gs.add<&orowindex::pyobject::get_type>("type");
-  gs.add<&orowindex::pyobject::get_nrows>("nrows");
-  gs.add<&orowindex::pyobject::get_min>("min");
-  gs.add<&orowindex::pyobject::get_max>("max");
-  mm.add<&orowindex::pyobject::to_list, args_to_list>();
-}
-
-
-PKArgs orowindex::pyobject::Type::args___init__(
-  0, 0, 0, false, false, {}, "__init__", nullptr);
-
-
-NoArgs orowindex::pyobject::Type::args_to_list("to_list",
-"to_list(self)\n"
-"--\n\n"
-"Convert this RowIndex into a python list of indices.\n");
-
-
-
-
-//------------------------------------------------------------------------------
 // orowindex::pyobject
 //------------------------------------------------------------------------------
 
@@ -115,7 +77,16 @@ oobj orowindex::pyobject::get_max() const {
 }
 
 
-oobj orowindex::pyobject::to_list(const NoArgs&) {
+static PKArgs args_to_list(
+  0, 0, 0, false, false,
+  {}, "to_list",
+
+"to_list(self)\n"
+"--\n\n"
+"Convert this RowIndex into a python list of indices.\n"
+);
+
+oobj orowindex::pyobject::to_list(const PKArgs&) {
   size_t n = ri->size();
   olist res(n);
   ri->iterate(0, n, 1,
@@ -151,6 +122,38 @@ bool orowindex::check(PyObject* v) {
   }
   return true;
 }
+
+
+
+
+//------------------------------------------------------------------------------
+// orowindex::pyobject::Type
+//------------------------------------------------------------------------------
+
+const char* orowindex::pyobject::Type::classname() {
+  return "datatable.internal.RowIndex";
+}
+
+const char* orowindex::pyobject::Type::classdoc() {
+  return nullptr;
+}
+
+bool orowindex::pyobject::Type::is_subclassable() {
+  return false;
+}
+
+void orowindex::pyobject::Type::init_methods_and_getsets(
+    Methods& mm, GetSetters& gs) {
+  gs.add<&orowindex::pyobject::get_type>("type");
+  gs.add<&orowindex::pyobject::get_nrows>("nrows");
+  gs.add<&orowindex::pyobject::get_min>("min");
+  gs.add<&orowindex::pyobject::get_max>("max");
+  ADD_METHOD(mm, &orowindex::pyobject::to_list, args_to_list);
+}
+
+
+PKArgs orowindex::pyobject::Type::args___init__(
+  0, 0, 0, false, false, {}, "__init__", nullptr);
 
 
 

--- a/c/py_rowindex.h
+++ b/c/py_rowindex.h
@@ -50,7 +50,6 @@ struct orowindex::pyobject : public PyObject {
   class Type : public ExtType<pyobject> {
     public:
       static PKArgs args___init__;
-      static NoArgs args_to_list;
       static const char* classname();
       static const char* classdoc();
       static bool is_subclassable();
@@ -65,7 +64,7 @@ struct orowindex::pyobject : public PyObject {
   oobj get_min() const;
   oobj get_max() const;
 
-  oobj to_list(const NoArgs&);
+  oobj to_list(const PKArgs&);
 };
 
 


### PR DESCRIPTION
Convert all code to use new `ADD_METHOD` macro; remove old templates `Methods::add<...>`. As a consequence, the `ExtType<T>::Methods` class is now much simpler.

The purpose of this refactoring is that complicated templates are not always compiled reliably by all compilers, which causes problems such as #1369. By switching to much simpler macros, these problems should be largely alleviated.