### PR TITLE
Getters / setters revamp

### DIFF
--- a/c/expr/by_node.cc
+++ b/c/expr/by_node.cc
@@ -204,7 +204,8 @@ bool oby::pyobj::Type::is_subclassable() {
 }
 
 void oby::pyobj::Type::init_methods_and_getsets(Methods&, GetSetters& gs) {
-  gs.add<&pyobj::get_cols>("_cols");
+  static GSArgs args__cols("_cols");
+  ADD_GETTER(gs, &pyobj::get_cols, args__cols);
 }
 
 

--- a/c/expr/join_node.cc
+++ b/c/expr/join_node.cc
@@ -45,7 +45,8 @@ bool ojoin::pyobj::Type::is_subclassable() {
 }
 
 void ojoin::pyobj::Type::init_methods_and_getsets(Methods&, GetSetters& gs) {
-  gs.add<&pyobj::get_joinframe>("joinframe");
+  static GSArgs args_joinframe("joinframe");
+  ADD_GETTER(gs, &pyobj::get_joinframe, args_joinframe);
 }
 
 

--- a/c/expr/sort_node.cc
+++ b/c/expr/sort_node.cc
@@ -46,7 +46,8 @@ bool _sort::Type::is_subclassable() {
 }
 
 void _sort::Type::init_methods_and_getsets(Methods&, GetSetters& gs) {
-  gs.add<&_sort::get_cols>("_cols");
+  static GSArgs args__cols("_cols");
+  ADD_GETTER(gs, &_sort::get_cols, args__cols);
 }
 
 

--- a/c/extras/py_ftrl.cc
+++ b/c/extras/py_ftrl.cc
@@ -1082,6 +1082,7 @@ bool Ftrl::has_negative_n(DataTable* dt) const {
 static PKArgs args___getstate__(
     0, 0, 0, false, false, {}, "__getstate__", nullptr);
 
+
 oobj Ftrl::m__getstate__(const PKArgs&) {
   py::otuple pickle(6);
   py::oobj params = get_params_tuple();
@@ -1105,7 +1106,6 @@ oobj Ftrl::m__getstate__(const PKArgs&) {
   pickle.set(5, py_reg_type);
   return std::move(pickle);
 }
-
 
 
 static PKArgs args___setstate__(

--- a/c/frame/key.cc
+++ b/c/frame/key.cc
@@ -28,10 +28,23 @@
 //------------------------------------------------------------------------------
 // py::Frame API
 //------------------------------------------------------------------------------
+namespace py {
 
-py::oobj py::Frame::get_key() const {
-  py::otuple key(dt->get_nkeys());
-  py::otuple names = get_names().to_otuple();
+static GSArgs args_key(
+  "key",
+R"(Tuple of column names that serve as a primary key for this Frame.
+
+If the Frame is not keyed, this will return an empty tuple.
+
+Assigning to this property will make the Frame keyed by the specified
+column(s). The key columns will be moved to the front, and the Frame
+will be sorted. The values in the key columns must be unique.
+)");
+
+
+oobj Frame::get_key() const {
+  otuple key(dt->get_nkeys());
+  otuple names = get_names().to_otuple();
   for (size_t i = 0; i < key.size(); ++i) {
     key.set(i, names[i]);
   }
@@ -39,7 +52,7 @@ py::oobj py::Frame::get_key() const {
 }
 
 
-void py::Frame::set_key(py::robj val) {
+void Frame::set_key(robj val) {
   if (val.is_none()) {
     return dt->clear_key();
   }
@@ -49,9 +62,9 @@ void py::Frame::set_key(py::robj val) {
     col_indices.push_back(index);
   }
   else if (val.is_list_or_tuple()) {
-    py::olist vallist = val.to_pylist();
+    olist vallist = val.to_pylist();
     for (size_t i = 0; i < vallist.size(); ++i) {
-      py::robj item = vallist[i];
+      robj item = vallist[i];
       if (vallist[i].is_string()) {
         size_t index = dt->xcolindex(vallist[i]);
         col_indices.push_back(index);
@@ -71,6 +84,13 @@ void py::Frame::set_key(py::robj val) {
 
 
 
+void Frame::Type::_init_key(GetSetters& gs) {
+  ADD_GETSET(gs, &Frame::get_key, &Frame::set_key, args_key);
+}
+
+
+
+} // namespace py
 //------------------------------------------------------------------------------
 // DataTable API
 //------------------------------------------------------------------------------

--- a/c/frame/names.cc
+++ b/c/frame/names.cc
@@ -154,34 +154,31 @@ oobj Frame::colindex(const PKArgs& args) {
 
 
 
-void Frame::Type::_init_names(Methods& mm, GetSetters& gs) {
-  ADD_METHOD(mm, &Frame::colindex, args_colindex);
+static GSArgs args_names(
+  "names",
+R"(Tuple of column names.
 
-  gs.add<&Frame::get_names, &Frame::set_names>("names",
-    "Tuple of column names.\n"
-    "\n"
-    "You can rename the Frame's columns by assigning a new list/tuple of\n"
-    "names to this property. The length of the new list of names must be\n"
-    "the same as the number of columns in the Frame.\n"
-    "\n"
-    "It is also possible to rename just a few columns by assigning a\n"
-    "dictionary ``{oldname: newname, ...}``. Any column not listed in the\n"
-    "dictionary will retain its name.\n"
-    "\n"
-    "Examples\n"
-    "--------\n"
-    ">>> d0 = dt.Frame([[1], [2], [3]])\n"
-    ">>> d0.names = ['A', 'B', 'C']\n"
-    ">>> d0.names\n"
-    "('A', 'B', 'C')\n"
-    ">>> d0.names = {'B': 'middle'}\n"
-    ">>> d0.names\n"
-    "('A', 'middle', 'C')\n"
-    ">>> del d0.names\n"
-    ">>> d0.names\n"
-    "('C0', 'C1', 'C2')");
-}
+You can rename the Frame's columns by assigning a new list/tuple of
+names to this property. The length of the new list of names must be
+the same as the number of columns in the Frame.
 
+It is also possible to rename just a few columns by assigning a
+dictionary ``{oldname: newname, ...}``. Any column not listed in the
+dictionary will retain its name.
+
+Examples
+--------
+>>> d0 = dt.Frame([[1], [2], [3]])
+>>> d0.names = ['A', 'B', 'C']
+>>> d0.names
+('A', 'B', 'C')
+>>> d0.names = {'B': 'middle'}
+>>> d0.names
+('A', 'middle', 'C')
+>>> del d0.names
+>>> d0.names
+('C0', 'C1', 'C2)
+)");
 
 
 oobj Frame::get_names() const {
@@ -203,6 +200,13 @@ void Frame::set_names(robj arg)
   else {
     throw TypeError() << "Expected a list of strings, got " << arg.typeobj();
   }
+}
+
+
+
+void Frame::Type::_init_names(Methods& mm, GetSetters& gs) {
+  ADD_METHOD(mm, &Frame::colindex, args_colindex);
+  ADD_GETSET(gs, &Frame::get_names, &Frame::set_names, args_names);
 }
 
 

--- a/c/frame/py_frame.cc
+++ b/c/frame/py_frame.cc
@@ -181,7 +181,6 @@ oobj Frame::get_nrows() const {
   return py::oint(dt->nrows);
 }
 
-
 void Frame::set_nrows(py::robj nr) {
   if (!nr.is_int()) {
     throw TypeError() << "Number of rows must be an integer, not "
@@ -195,6 +194,10 @@ void Frame::set_nrows(py::robj nr) {
 }
 
 
+static GSArgs args_shape(
+  "shape",
+  "Tuple with (nrows, ncols) dimensions of the Frame\n");
+
 oobj Frame::get_shape() const {
   py::otuple shape(2);
   shape.set(0, get_nrows());
@@ -202,6 +205,10 @@ oobj Frame::get_shape() const {
   return std::move(shape);
 }
 
+
+static GSArgs args_stypes(
+  "stypes",
+  "The tuple of each column's stypes (\"storage types\")\n");
 
 oobj Frame::get_stypes() const {
   if (stypes == nullptr) {
@@ -216,6 +223,10 @@ oobj Frame::get_stypes() const {
 }
 
 
+static GSArgs args_ltypes(
+  "ltypes",
+  "The tuple of each column's ltypes (\"logical types\")\n");
+
 oobj Frame::get_ltypes() const {
   if (ltypes == nullptr) {
     py::otuple oltypes(dt->ncols);
@@ -228,6 +239,9 @@ oobj Frame::get_ltypes() const {
   return oobj(ltypes);
 }
 
+
+static GSArgs args_internal("internal", "[DEPRECATED]");
+static GSArgs args__dt("_dt", "[DEPRECATED]");
 
 oobj Frame::get_internal() const {
   return oobj(core_dt);
@@ -262,9 +276,9 @@ const char* Frame::Type::classdoc() {
 }
 
 
-void Frame::Type::init_methods_and_getsets(Methods& mm, GetSetters& gs)
-{
+void Frame::Type::init_methods_and_getsets(Methods& mm, GetSetters& gs) {
   _init_cbind(mm);
+  _init_key(gs);
   _init_init(mm);
   _init_names(mm, gs);
   _init_replace(mm);
@@ -274,27 +288,11 @@ void Frame::Type::init_methods_and_getsets(Methods& mm, GetSetters& gs)
 
   ADD_GETTER(gs, &Frame::get_ncols, args_ncols);
   ADD_GETSET(gs, &Frame::get_nrows, &Frame::set_nrows, args_nrows);
-
-  gs.add<&Frame::get_shape>("shape",
-    "Tuple with (nrows, ncols) dimensions of the Frame\n");
-
-  gs.add<&Frame::get_stypes>("stypes",
-    "The tuple of each column's stypes (\"storage types\")\n");
-
-  gs.add<&Frame::get_ltypes>("ltypes",
-    "The tuple of each column's ltypes (\"logical types\")\n");
-
-  gs.add<&Frame::get_key, &Frame::set_key>("key",
-    "Tuple of column names that serve as a primary key for this Frame.\n"
-    "\n"
-    "If the Frame is not keyed, this will return an empty tuple.\n"
-    "\n"
-    "Assigning to this property will make the Frame keyed by the specified\n"
-    "column(s). The key columns will be moved to the front, and the Frame\n"
-    "will be sorted. The values in the key columns must be unique.\n");
-
-  gs.add<&Frame::get_internal>("internal", "[DEPRECATED]");
-  gs.add<&Frame::get_internal>("_dt");
+  ADD_GETTER(gs, &Frame::get_shape, args_shape);
+  ADD_GETTER(gs, &Frame::get_stypes, args_stypes);
+  ADD_GETTER(gs, &Frame::get_ltypes, args_ltypes);
+  ADD_GETTER(gs, &Frame::get_internal, args_internal);
+  ADD_GETTER(gs, &Frame::get_internal, args__dt);
 
   ADD_METHOD(mm, &Frame::head, args_head);
   ADD_METHOD(mm, &Frame::tail, args_tail);

--- a/c/frame/py_frame.cc
+++ b/c/frame/py_frame.cc
@@ -106,82 +106,6 @@ oobj Frame::copy(const PKArgs&) {
 
 
 //------------------------------------------------------------------------------
-// Declare Frame's API
-//------------------------------------------------------------------------------
-
-PKArgs Frame::Type::args___init__(1, 0, 3, false, true,
-                                  {"src", "names", "stypes", "stype"},
-                                  "__init__", nullptr);
-
-
-const char* Frame::Type::classname() {
-  return "datatable.core.Frame";
-}
-
-const char* Frame::Type::classdoc() {
-  return
-    "Two-dimensional column-oriented table of data. Each column has its own\n"
-    "name and type. Types may vary across columns but cannot vary within\n"
-    "each column.\n"
-    "\n"
-    "Internally the data is stored as C primitives, and processed using\n"
-    "multithreaded native C++ code.\n"
-    "\n"
-    "This is a primary data structure for the `datatable` module.\n";
-}
-
-
-void Frame::Type::init_methods_and_getsets(Methods& mm, GetSetters& gs)
-{
-  _init_cbind(mm);
-  _init_init(mm);
-  _init_names(mm, gs);
-  _init_replace(mm);
-  _init_reprhtml(mm);
-  _init_tonumpy(mm);
-  _init_topython(mm);
-
-  gs.add<&Frame::get_ncols>("ncols",
-    "Number of columns in the Frame\n");
-
-  gs.add<&Frame::get_nrows, &Frame::set_nrows>("nrows",
-    "Number of rows in the Frame.\n"
-    "\n"
-    "Assigning to this property will change the height of the Frame,\n"
-    "either by truncating if the new number of rows is smaller than the\n"
-    "current, or filling with NAs if the new number of rows is greater.\n"
-    "\n"
-    "Increasing the number of rows of a keyed Frame is not allowed.\n");
-
-  gs.add<&Frame::get_shape>("shape",
-    "Tuple with (nrows, ncols) dimensions of the Frame\n");
-
-  gs.add<&Frame::get_stypes>("stypes",
-    "The tuple of each column's stypes (\"storage types\")\n");
-
-  gs.add<&Frame::get_ltypes>("ltypes",
-    "The tuple of each column's ltypes (\"logical types\")\n");
-
-  gs.add<&Frame::get_key, &Frame::set_key>("key",
-    "Tuple of column names that serve as a primary key for this Frame.\n"
-    "\n"
-    "If the Frame is not keyed, this will return an empty tuple.\n"
-    "\n"
-    "Assigning to this property will make the Frame keyed by the specified\n"
-    "column(s). The key columns will be moved to the front, and the Frame\n"
-    "will be sorted. The values in the key columns must be unique.\n");
-
-  gs.add<&Frame::get_internal>("internal", "[DEPRECATED]");
-  gs.add<&Frame::get_internal>("_dt");
-
-  ADD_METHOD(mm, &Frame::head, args_head);
-  ADD_METHOD(mm, &Frame::tail, args_tail);
-  ADD_METHOD(mm, &Frame::copy, args_copy);
-}
-
-
-
-//------------------------------------------------------------------------------
 // Misc
 //------------------------------------------------------------------------------
 bool Frame::internal_construction = false;
@@ -233,14 +157,30 @@ void Frame::_clear_types() const {
 // Getters / setters
 //------------------------------------------------------------------------------
 
+static GSArgs args_ncols(
+  "ncols",
+  "Number of columns in the Frame\n");
+
 oobj Frame::get_ncols() const {
   return py::oint(dt->ncols);
 }
 
 
+static GSArgs args_nrows(
+  "nrows",
+R"(Number of rows in the Frame.
+
+Assigning to this property will change the height of the Frame,
+either by truncating if the new number of rows is smaller than the
+current, or filling with NAs if the new number of rows is greater.
+
+Increasing the number of rows of a keyed Frame is not allowed.
+)");
+
 oobj Frame::get_nrows() const {
   return py::oint(dt->nrows);
 }
+
 
 void Frame::set_nrows(py::robj nr) {
   if (!nr.is_int()) {
@@ -292,6 +232,76 @@ oobj Frame::get_ltypes() const {
 oobj Frame::get_internal() const {
   return oobj(core_dt);
 }
+
+
+
+
+//------------------------------------------------------------------------------
+// Declare Frame's API
+//------------------------------------------------------------------------------
+
+PKArgs Frame::Type::args___init__(1, 0, 3, false, true,
+                                  {"src", "names", "stypes", "stype"},
+                                  "__init__", nullptr);
+
+
+const char* Frame::Type::classname() {
+  return "datatable.core.Frame";
+}
+
+const char* Frame::Type::classdoc() {
+  return
+    "Two-dimensional column-oriented table of data. Each column has its own\n"
+    "name and type. Types may vary across columns but cannot vary within\n"
+    "each column.\n"
+    "\n"
+    "Internally the data is stored as C primitives, and processed using\n"
+    "multithreaded native C++ code.\n"
+    "\n"
+    "This is a primary data structure for the `datatable` module.\n";
+}
+
+
+void Frame::Type::init_methods_and_getsets(Methods& mm, GetSetters& gs)
+{
+  _init_cbind(mm);
+  _init_init(mm);
+  _init_names(mm, gs);
+  _init_replace(mm);
+  _init_reprhtml(mm);
+  _init_tonumpy(mm);
+  _init_topython(mm);
+
+  ADD_GETTER(gs, &Frame::get_ncols, args_ncols);
+  ADD_GETSET(gs, &Frame::get_nrows, &Frame::set_nrows, args_nrows);
+
+  gs.add<&Frame::get_shape>("shape",
+    "Tuple with (nrows, ncols) dimensions of the Frame\n");
+
+  gs.add<&Frame::get_stypes>("stypes",
+    "The tuple of each column's stypes (\"storage types\")\n");
+
+  gs.add<&Frame::get_ltypes>("ltypes",
+    "The tuple of each column's ltypes (\"logical types\")\n");
+
+  gs.add<&Frame::get_key, &Frame::set_key>("key",
+    "Tuple of column names that serve as a primary key for this Frame.\n"
+    "\n"
+    "If the Frame is not keyed, this will return an empty tuple.\n"
+    "\n"
+    "Assigning to this property will make the Frame keyed by the specified\n"
+    "column(s). The key columns will be moved to the front, and the Frame\n"
+    "will be sorted. The values in the key columns must be unique.\n");
+
+  gs.add<&Frame::get_internal>("internal", "[DEPRECATED]");
+  gs.add<&Frame::get_internal>("_dt");
+
+  ADD_METHOD(mm, &Frame::head, args_head);
+  ADD_METHOD(mm, &Frame::tail, args_tail);
+  ADD_METHOD(mm, &Frame::copy, args_copy);
+}
+
+
 
 
 }  // namespace py

--- a/c/frame/py_frame.h
+++ b/c/frame/py_frame.h
@@ -58,6 +58,7 @@ class Frame : public PyObject {
       private:
         static void _init_cbind(Methods&);
         static void _init_init(Methods&);
+        static void _init_key(GetSetters&);
         static void _init_names(Methods&, GetSetters&);
         static void _init_replace(Methods&);
         static void _init_tonumpy(Methods&);

--- a/c/py_rowindex.cc
+++ b/c/py_rowindex.cc
@@ -54,6 +54,8 @@ oobj orowindex::pyobject::m__repr__() {
 
 
 
+static GSArgs args_type("type");
+
 oobj orowindex::pyobject::get_type() const {
   static oobj tSlice = ostring("slice");
   static oobj tArr32 = ostring("arr32");
@@ -64,13 +66,22 @@ oobj orowindex::pyobject::get_type() const {
          rt == RowIndexType::ARR64? tArr64 : None();
 }
 
+
+static GSArgs args_nrows("nrows");
+
 oobj orowindex::pyobject::get_nrows() const {
   return oint(ri->size());
 }
 
+
+static GSArgs args_min("min");
+
 oobj orowindex::pyobject::get_min() const {
   return oint(ri->min());
 }
+
+
+static GSArgs args_max("max");
 
 oobj orowindex::pyobject::get_max() const {
   return oint(ri->max());
@@ -143,11 +154,12 @@ bool orowindex::pyobject::Type::is_subclassable() {
 }
 
 void orowindex::pyobject::Type::init_methods_and_getsets(
-    Methods& mm, GetSetters& gs) {
-  gs.add<&orowindex::pyobject::get_type>("type");
-  gs.add<&orowindex::pyobject::get_nrows>("nrows");
-  gs.add<&orowindex::pyobject::get_min>("min");
-  gs.add<&orowindex::pyobject::get_max>("max");
+    Methods& mm, GetSetters& gs)
+{
+  ADD_GETTER(gs, &orowindex::pyobject::get_type, args_type);
+  ADD_GETTER(gs, &orowindex::pyobject::get_nrows, args_nrows);
+  ADD_GETTER(gs, &orowindex::pyobject::get_min, args_min);
+  ADD_GETTER(gs, &orowindex::pyobject::get_max, args_max);
   ADD_METHOD(mm, &orowindex::pyobject::to_list, args_to_list);
 }
 

--- a/c/python/args.h
+++ b/c/python/args.h
@@ -27,6 +27,48 @@ namespace py {
 
 
 //------------------------------------------------------------------------------
+// GSArgs
+//------------------------------------------------------------------------------
+
+/**
+ * Helper class for getters/setters in ExtType<T>::GetSetters.
+ */
+class GSArgs {
+  public:
+    const char* name;
+    const char* doc;
+
+    GSArgs(const char* name_, const char* doc_=nullptr)
+      : name(name_), doc(doc_) {}
+
+    template <typename T>
+    PyObject* exec_getter(PyObject* obj, oobj (T::*func)() const) noexcept {
+      try {
+        T* t = static_cast<T*>(obj);
+        oobj res = (t->*func)();
+        return std::move(res).release();
+      } catch (const std::exception& e) {
+        exception_to_python(e);
+        return nullptr;
+      }
+    }
+
+    template <typename T>
+    int exec_setter(PyObject* obj, PyObject* value, void (T::*func)(robj)) noexcept {
+      try {
+        T* t = static_cast<T*>(obj);
+        (t->*func)(robj(value));
+        return 0;
+      } catch (const std::exception& e) {
+        exception_to_python(e);
+        return -1;
+      }
+    }
+};
+
+
+
+//------------------------------------------------------------------------------
 // Args
 //------------------------------------------------------------------------------
 

--- a/c/python/ext_type.h
+++ b/c/python/ext_type.h
@@ -264,30 +264,6 @@ namespace _impl {
     }
   }
 
-  template <typename T, oobj (T::*F)() const>
-  PyObject* _safe_getter(PyObject* self, void*) {
-    try {
-      T* t = static_cast<T*>(self);
-      oobj res = (t->*F)();
-      return std::move(res).release();
-    } catch (const std::exception& e) {
-      exception_to_python(e);
-      return nullptr;
-    }
-  }
-
-  template <typename T, void (T::*F)(py::robj)>
-  int _safe_setter(PyObject* self, PyObject* value, void*) {
-    try {
-      T* t = static_cast<T*>(self);
-      (t->*F)(py::robj(value));
-      return 0;
-    } catch (const std::exception& e) {
-      exception_to_python(e);
-      return -1;
-    }
-  }
-
 
   /**
    * SFINAE checker for the presence of various methods:


### PR DESCRIPTION
This PR changes changes the way getters / setters are declared, similar to #1657.

Now in order to declare a getter [+setter], you have to create a static `GSArgs` variable (similar to `PKArgs` for methods). This variable only carries the name of the property and its docstring. The advantage of the new approach is that now the documentation for a property can be declared right next to the property itself, which is a big plus.
In addition, the amount of generated code is now smaller, and we don't use templates as heavily. Instead, there are now 2 macros:
```
ADD_GETTER(gs, &Class::getterfn, args);
ADD_GETSET(gs, &Class::getterfn, &Class::setterfn, args);
```

