### PR TITLE
Change license to Apache-v2

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -18,7 +18,7 @@ The `datatable` is an open-source Python library for manipulation of tabular
 data. It is primarily developed at H2O.ai, with the support of broader
 community.
 
-The `datatable` is a younger sibling of [R data.table][https://github.com/Rdatatable/data.table/wiki] project, and attempts
+The `datatable` is a younger sibling of [R data.table][] project, and attempts
 to mimic the core of its API. The R data.table project is primarily developed by
 [Matt Dowle][], who is its main author, and who blessed the development of
 Python `datatable` by allowing the use of name "data table" and providing the

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,254 +1,66 @@
+<!--
+  Copyright 2018 H2O.ai
 
-The `datatable` is an open-source library for tabular data manipulation.
-It is a younger sibling of [R `data.table`](https://github.com/Rdatatable/data.table),
-and attempts to mimic its API and some of the core algorithms. The development
-of `datatable` is sponsored by H2O.ai.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
 
-In the lists below each person is listed with their GitHub id in parentheses.
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+The `datatable` is an open-source Python library for manipulation of tabular
+data. It is primarily developed at H2O.ai, with the support of broader
+community.
+
+The `datatable` is a younger sibling of [R data.table][] project, and attempts
+to mimic the core of its API. The R data.table project is primarily developed by
+[Matt Dowle][], who is its main author, and who blessed the development of
+Python `datatable` by allowing the use of name "data table" and providing the
+initial advice and direction.
+
 
 ### Developers
 
-- Pasha Stetsenko (st-pasha)
-
-- Matt Dowle (mattdowle), the main author of R `data.table`, who
-  - built the library which paved path for this project,
-  - allowed to use the name "datatable",
-  - contributed the initial core fread functionality,
-  - implemented radix sort in R,
-  - provided general advice on the direction of project development, and
-  - supports the datatable community.
+- [Pasha Stetsenko][]
+- [Oleksiy Kononenko][]
 
 
 ### Contributors
 (with 10 commits or more, excluding merges)
-- Anmol Bal (abal5)
-- Michal Malohlava (mmalohlava)
-- Michal Raška (michal-raska)
-- Nishant Kalonia (nkalonia1)
-- Oleksiy Kononenko (oleksiyskononenko)
-- Tom Kraljevic (tomkraljevic)
+
+- [Anmol Bal][]
+- [Michal Malohlava][]
+- [Michal Raška][]
+- [Nishant Kalonia][]
+- [Tom Kraljevic][]
 
 
 ### Special thanks to
 
 - Jeff Fohl (jefffohl), for designing the datatable logo.
 
-- [Google Flatbuffers project](https://github.com/google/flatbuffers),
-  distributed under the terms of Apache License v2.
+- [Google Flatbuffers project][], distributed under the terms of
+  Apache License v2.
 
-- Milo Yip (miloyip), for his [`itoa`/`ltoa` functions](https://github.com/miloyip/itoa-benchmark/blob/master/src/branchlut2.cpp),
-  distributed under the terms of MIT license.
-
-
-### Addendum
-Some of the code in this project was borrowed from other open-source projects.
-The license terms of those other projects usually require that we also provide
-a copy of those license terms to the end user. Such copies are listed below:
-
-<details>
-    <summary>Apache License v2</summary>
-
-```text
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
-
-    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-    1. Definitions.
-
-       "License" shall mean the terms and conditions for use, reproduction,
-       and distribution as defined by Sections 1 through 9 of this document.
-
-       "Licensor" shall mean the copyright owner or entity authorized by
-       the copyright owner that is granting the License.
-
-       "Legal Entity" shall mean the union of the acting entity and all
-       other entities that control, are controlled by, or are under common
-       control with that entity. For the purposes of this definition,
-       "control" means (i) the power, direct or indirect, to cause the
-       direction or management of such entity, whether by contract or
-       otherwise, or (ii) ownership of fifty percent (50%) or more of the
-       outstanding shares, or (iii) beneficial ownership of such entity.
-
-       "You" (or "Your") shall mean an individual or Legal Entity
-       exercising permissions granted by this License.
-
-       "Source" form shall mean the preferred form for making modifications,
-       including but not limited to software source code, documentation
-       source, and configuration files.
-
-       "Object" form shall mean any form resulting from mechanical
-       transformation or translation of a Source form, including but
-       not limited to compiled object code, generated documentation,
-       and conversions to other media types.
-
-       "Work" shall mean the work of authorship, whether in Source or
-       Object form, made available under the License, as indicated by a
-       copyright notice that is included in or attached to the work
-       (an example is provided in the Appendix below).
-
-       "Derivative Works" shall mean any work, whether in Source or Object
-       form, that is based on (or derived from) the Work and for which the
-       editorial revisions, annotations, elaborations, or other modifications
-       represent, as a whole, an original work of authorship. For the purposes
-       of this License, Derivative Works shall not include works that remain
-       separable from, or merely link (or bind by name) to the interfaces of,
-       the Work and Derivative Works thereof.
-
-       "Contribution" shall mean any work of authorship, including
-       the original version of the Work and any modifications or additions
-       to that Work or Derivative Works thereof, that is intentionally
-       submitted to Licensor for inclusion in the Work by the copyright owner
-       or by an individual or Legal Entity authorized to submit on behalf of
-       the copyright owner. For the purposes of this definition, "submitted"
-       means any form of electronic, verbal, or written communication sent
-       to the Licensor or its representatives, including but not limited to
-       communication on electronic mailing lists, source code control systems,
-       and issue tracking systems that are managed by, or on behalf of, the
-       Licensor for the purpose of discussing and improving the Work, but
-       excluding communication that is conspicuously marked or otherwise
-       designated in writing by the copyright owner as "Not a Contribution."
-
-       "Contributor" shall mean Licensor and any individual or Legal Entity
-       on behalf of whom a Contribution has been received by Licensor and
-       subsequently incorporated within the Work.
-
-    2. Grant of Copyright License. Subject to the terms and conditions of
-       this License, each Contributor hereby grants to You a perpetual,
-       worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-       copyright license to reproduce, prepare Derivative Works of,
-       publicly display, publicly perform, sublicense, and distribute the
-       Work and such Derivative Works in Source or Object form.
-
-    3. Grant of Patent License. Subject to the terms and conditions of
-       this License, each Contributor hereby grants to You a perpetual,
-       worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-       (except as stated in this section) patent license to make, have made,
-       use, offer to sell, sell, import, and otherwise transfer the Work,
-       where such license applies only to those patent claims licensable
-       by such Contributor that are necessarily infringed by their
-       Contribution(s) alone or by combination of their Contribution(s)
-       with the Work to which such Contribution(s) was submitted. If You
-       institute patent litigation against any entity (including a
-       cross-claim or counterclaim in a lawsuit) alleging that the Work
-       or a Contribution incorporated within the Work constitutes direct
-       or contributory patent infringement, then any patent licenses
-       granted to You under this License for that Work shall terminate
-       as of the date such litigation is filed.
-
-    4. Redistribution. You may reproduce and distribute copies of the
-       Work or Derivative Works thereof in any medium, with or without
-       modifications, and in Source or Object form, provided that You
-       meet the following conditions:
-
-       (a) You must give any other recipients of the Work or
-           Derivative Works a copy of this License; and
-
-       (b) You must cause any modified files to carry prominent notices
-           stating that You changed the files; and
-
-       (c) You must retain, in the Source form of any Derivative Works
-           that You distribute, all copyright, patent, trademark, and
-           attribution notices from the Source form of the Work,
-           excluding those notices that do not pertain to any part of
-           the Derivative Works; and
-
-       (d) If the Work includes a "NOTICE" text file as part of its
-           distribution, then any Derivative Works that You distribute must
-           include a readable copy of the attribution notices contained
-           within such NOTICE file, excluding those notices that do not
-           pertain to any part of the Derivative Works, in at least one
-           of the following places: within a NOTICE text file distributed
-           as part of the Derivative Works; within the Source form or
-           documentation, if provided along with the Derivative Works; or,
-           within a display generated by the Derivative Works, if and
-           wherever such third-party notices normally appear. The contents
-           of the NOTICE file are for informational purposes only and
-           do not modify the License. You may add Your own attribution
-           notices within Derivative Works that You distribute, alongside
-           or as an addendum to the NOTICE text from the Work, provided
-           that such additional attribution notices cannot be construed
-           as modifying the License.
-
-       You may add Your own copyright statement to Your modifications and
-       may provide additional or different license terms and conditions
-       for use, reproduction, or distribution of Your modifications, or
-       for any such Derivative Works as a whole, provided Your use,
-       reproduction, and distribution of the Work otherwise complies with
-       the conditions stated in this License.
-
-    5. Submission of Contributions. Unless You explicitly state otherwise,
-       any Contribution intentionally submitted for inclusion in the Work
-       by You to the Licensor shall be under the terms and conditions of
-       this License, without any additional terms or conditions.
-       Notwithstanding the above, nothing herein shall supersede or modify
-       the terms of any separate license agreement you may have executed
-       with Licensor regarding such Contributions.
-
-    6. Trademarks. This License does not grant permission to use the trade
-       names, trademarks, service marks, or product names of the Licensor,
-       except as required for reasonable and customary use in describing the
-       origin of the Work and reproducing the content of the NOTICE file.
-
-    7. Disclaimer of Warranty. Unless required by applicable law or
-       agreed to in writing, Licensor provides the Work (and each
-       Contributor provides its Contributions) on an "AS IS" BASIS,
-       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-       implied, including, without limitation, any warranties or conditions
-       of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-       PARTICULAR PURPOSE. You are solely responsible for determining the
-       appropriateness of using or redistributing the Work and assume any
-       risks associated with Your exercise of permissions under this License.
-
-    8. Limitation of Liability. In no event and under no legal theory,
-       whether in tort (including negligence), contract, or otherwise,
-       unless required by applicable law (such as deliberate and grossly
-       negligent acts) or agreed to in writing, shall any Contributor be
-       liable to You for damages, including any direct, indirect, special,
-       incidental, or consequential damages of any character arising as a
-       result of this License or out of the use or inability to use the
-       Work (including but not limited to damages for loss of goodwill,
-       work stoppage, computer failure or malfunction, or any and all
-       other commercial damages or losses), even if such Contributor
-       has been advised of the possibility of such damages.
-
-    9. Accepting Warranty or Additional Liability. While redistributing
-       the Work or Derivative Works thereof, You may choose to offer,
-       and charge a fee for, acceptance of support, warranty, indemnity,
-       or other liability obligations and/or rights consistent with this
-       License. However, in accepting such obligations, You may act only
-       on Your own behalf and on Your sole responsibility, not on behalf
-       of any other Contributor, and only if You agree to indemnify,
-       defend, and hold each Contributor harmless for any liability
-       incurred by, or claims asserted against, such Contributor by reason
-       of your accepting any such warranty or additional liability.
-
-    END OF TERMS AND CONDITIONS
-```
-</details>
+- Milo Yip (miloyip), for his [itoa/ltoa functions][], distributed under the
+  terms of MIT license.
 
 
-<details>
-    <summary>MIT license</summary>
+[anmol bal]: https://github.com/abal5
+[matt dowle]: https://github.com/mattdowle
+[michal malohlava]: https://github.com/mmalohlava
+[michal raška]: https://github.com/michal-raska
+[nishant kalonia]: https://github.com/nkalonia1
+[oleksiy kononenko]: https://github.com/oleksiyskononenko
+[pasha stetsenko]: https://github.com/st-pasha
+[tom kraljevic]: https://github.com/tomkraljevic
 
-```text
-    Permission is hereby granted, free of charge, to any person obtaining a copy
-    of this software and associated documentation files (the "Software"), to deal
-    in the Software without restriction, including without limitation the rights
-    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-    copies of the Software, and to permit persons to whom the Software is
-    furnished to do so, subject to the following conditions:
-
-    The above copyright notice and this permission notice shall be included in
-    all copies or substantial portions of the Software.
-
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-    THE SOFTWARE.
-```
-</details>
+[google flatbuffers project]: https://github.com/google/flatbuffers
+[itoa/ltoa functions]: https://github.com/miloyip/itoa-benchmark/blob/master/src/branchlut2.cpp
+[r data.table]: https://github.com/Rdatatable/data.table

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -18,7 +18,7 @@ The `datatable` is an open-source Python library for manipulation of tabular
 data. It is primarily developed at H2O.ai, with the support of broader
 community.
 
-The `datatable` is a younger sibling of [R data.table][] project, and attempts
+The `datatable` is a younger sibling of [R data.table][https://github.com/Rdatatable/data.table/wiki] project, and attempts
 to mimic the core of its API. The R data.table project is primarily developed by
 [Matt Dowle][], who is its main author, and who blessed the development of
 Python `datatable` by allowing the use of name "data table" and providing the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,17 @@
 <!---
   Copyright 2018 H2O.ai
 
-  Permission is hereby granted, free of charge, to any person obtaining a
-  copy of this software and associated documentation files (the "Software"),
-  to deal in the Software without restriction, including without limitation
-  the rights to use, copy, modify, merge, publish, distribute, sublicense,
-  and/or sell copies of the Software, and to permit persons to whom the
-  Software is furnished to do so, subject to the following conditions:
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
 
-  The above copyright notice and this permission notice shall be included in
-  all copies or substantial portions of the Software.
+      http://www.apache.org/licenses/LICENSE-2.0
 
-  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
-  IN THE SOFTWARE.
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
 -->
 
 # Changelog
@@ -33,6 +27,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   splitting. This function will return `k` pairs of row selectors such that
   when these selectors are applied to an `n`-rows frame, that frame will be
   split into train and test part according to the K-fold splitting scheme.
+
+
+### Changed
+
+- Project's license has been changed from MPL-2 back to Apache License v2.0
+  (#1659).
 
 
 ### Fixed

--- a/LICENSE
+++ b/LICENSE
@@ -1,373 +1,202 @@
-Mozilla Public License Version 2.0
-==================================
-
-1. Definitions
---------------
-
-1.1. "Contributor"
-    means each individual or legal entity that creates, contributes to
-    the creation of, or owns Covered Software.
-
-1.2. "Contributor Version"
-    means the combination of the Contributions of others (if any) used
-    by a Contributor and that particular Contributor's Contribution.
-
-1.3. "Contribution"
-    means Covered Software of a particular Contributor.
-
-1.4. "Covered Software"
-    means Source Code Form to which the initial Contributor has attached
-    the notice in Exhibit A, the Executable Form of such Source Code
-    Form, and Modifications of such Source Code Form, in each case
-    including portions thereof.
-
-1.5. "Incompatible With Secondary Licenses"
-    means
-
-    (a) that the initial Contributor has attached the notice described
-        in Exhibit B to the Covered Software; or
 
-    (b) that the Covered Software was made available under the terms of
-        version 1.1 or earlier of the License, but not also under the
-        terms of a Secondary License.
-
-1.6. "Executable Form"
-    means any form of the work other than Source Code Form.
-
-1.7. "Larger Work"
-    means a work that combines Covered Software with other material, in
-    a separate file or files, that is not Covered Software.
-
-1.8. "License"
-    means this document.
-
-1.9. "Licensable"
-    means having the right to grant, to the maximum extent possible,
-    whether at the time of the initial grant or subsequently, any and
-    all of the rights conveyed by this License.
-
-1.10. "Modifications"
-    means any of the following:
-
-    (a) any file in Source Code Form that results from an addition to,
-        deletion from, or modification of the contents of Covered
-        Software; or
-
-    (b) any new file in Source Code Form that contains any Covered
-        Software.
-
-1.11. "Patent Claims" of a Contributor
-    means any patent claim(s), including without limitation, method,
-    process, and apparatus claims, in any patent Licensable by such
-    Contributor that would be infringed, but for the grant of the
-    License, by the making, using, selling, offering for sale, having
-    made, import, or transfer of either its Contributions or its
-    Contributor Version.
-
-1.12. "Secondary License"
-    means either the GNU General Public License, Version 2.0, the GNU
-    Lesser General Public License, Version 2.1, the GNU Affero General
-    Public License, Version 3.0, or any later versions of those
-    licenses.
-
-1.13. "Source Code Form"
-    means the form of the work preferred for making modifications.
-
-1.14. "You" (or "Your")
-    means an individual or a legal entity exercising rights under this
-    License. For legal entities, "You" includes any entity that
-    controls, is controlled by, or is under common control with You. For
-    purposes of this definition, "control" means (a) the power, direct
-    or indirect, to cause the direction or management of such entity,
-    whether by contract or otherwise, or (b) ownership of more than
-    fifty percent (50%) of the outstanding shares or beneficial
-    ownership of such entity.
-
-2. License Grants and Conditions
---------------------------------
-
-2.1. Grants
-
-Each Contributor hereby grants You a world-wide, royalty-free,
-non-exclusive license:
-
-(a) under intellectual property rights (other than patent or trademark)
-    Licensable by such Contributor to use, reproduce, make available,
-    modify, display, perform, distribute, and otherwise exploit its
-    Contributions, either on an unmodified basis, with Modifications, or
-    as part of a Larger Work; and
-
-(b) under Patent Claims of such Contributor to make, use, sell, offer
-    for sale, have made, import, and otherwise transfer either its
-    Contributions or its Contributor Version.
-
-2.2. Effective Date
-
-The licenses granted in Section 2.1 with respect to any Contribution
-become effective for each Contribution on the date the Contributor first
-distributes such Contribution.
-
-2.3. Limitations on Grant Scope
-
-The licenses granted in this Section 2 are the only rights granted under
-this License. No additional rights or licenses will be implied from the
-distribution or licensing of Covered Software under this License.
-Notwithstanding Section 2.1(b) above, no patent license is granted by a
-Contributor:
-
-(a) for any code that a Contributor has removed from Covered Software;
-    or
-
-(b) for infringements caused by: (i) Your and any other third party's
-    modifications of Covered Software, or (ii) the combination of its
-    Contributions with other software (except as part of its Contributor
-    Version); or
-
-(c) under Patent Claims infringed by Covered Software in the absence of
-    its Contributions.
-
-This License does not grant any rights in the trademarks, service marks,
-or logos of any Contributor (except as may be necessary to comply with
-the notice requirements in Section 3.4).
-
-2.4. Subsequent Licenses
-
-No Contributor makes additional grants as a result of Your choice to
-distribute the Covered Software under a subsequent version of this
-License (see Section 10.2) or under the terms of a Secondary License (if
-permitted under the terms of Section 3.3).
-
-2.5. Representation
-
-Each Contributor represents that the Contributor believes its
-Contributions are its original creation(s) or it has sufficient rights
-to grant the rights to its Contributions conveyed by this License.
-
-2.6. Fair Use
-
-This License is not intended to limit any rights You have under
-applicable copyright doctrines of fair use, fair dealing, or other
-equivalents.
-
-2.7. Conditions
-
-Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
-in Section 2.1.
-
-3. Responsibilities
--------------------
-
-3.1. Distribution of Source Form
-
-All distribution of Covered Software in Source Code Form, including any
-Modifications that You create or to which You contribute, must be under
-the terms of this License. You must inform recipients that the Source
-Code Form of the Covered Software is governed by the terms of this
-License, and how they can obtain a copy of this License. You may not
-attempt to alter or restrict the recipients' rights in the Source Code
-Form.
-
-3.2. Distribution of Executable Form
-
-If You distribute Covered Software in Executable Form then:
-
-(a) such Covered Software must also be made available in Source Code
-    Form, as described in Section 3.1, and You must inform recipients of
-    the Executable Form how they can obtain a copy of such Source Code
-    Form by reasonable means in a timely manner, at a charge no more
-    than the cost of distribution to the recipient; and
-
-(b) You may distribute such Executable Form under the terms of this
-    License, or sublicense it under different terms, provided that the
-    license for the Executable Form does not attempt to limit or alter
-    the recipients' rights in the Source Code Form under this License.
-
-3.3. Distribution of a Larger Work
-
-You may create and distribute a Larger Work under terms of Your choice,
-provided that You also comply with the requirements of this License for
-the Covered Software. If the Larger Work is a combination of Covered
-Software with a work governed by one or more Secondary Licenses, and the
-Covered Software is not Incompatible With Secondary Licenses, this
-License permits You to additionally distribute such Covered Software
-under the terms of such Secondary License(s), so that the recipient of
-the Larger Work may, at their option, further distribute the Covered
-Software under the terms of either this License or such Secondary
-License(s).
-
-3.4. Notices
-
-You may not remove or alter the substance of any license notices
-(including copyright notices, patent notices, disclaimers of warranty,
-or limitations of liability) contained within the Source Code Form of
-the Covered Software, except that You may alter any license notices to
-the extent required to remedy known factual inaccuracies.
-
-3.5. Application of Additional Terms
-
-You may choose to offer, and to charge a fee for, warranty, support,
-indemnity or liability obligations to one or more recipients of Covered
-Software. However, You may do so only on Your own behalf, and not on
-behalf of any Contributor. You must make it absolutely clear that any
-such warranty, support, indemnity, or liability obligation is offered by
-You alone, and You hereby agree to indemnify every Contributor for any
-liability incurred by such Contributor as a result of warranty, support,
-indemnity or liability terms You offer. You may include additional
-disclaimers of warranty and limitations of liability specific to any
-jurisdiction.
-
-4. Inability to Comply Due to Statute or Regulation
----------------------------------------------------
-
-If it is impossible for You to comply with any of the terms of this
-License with respect to some or all of the Covered Software due to
-statute, judicial order, or regulation then You must: (a) comply with
-the terms of this License to the maximum extent possible; and (b)
-describe the limitations and the code they affect. Such description must
-be placed in a text file included with all distributions of the Covered
-Software under this License. Except to the extent prohibited by statute
-or regulation, such description must be sufficiently detailed for a
-recipient of ordinary skill to be able to understand it.
-
-5. Termination
---------------
-
-5.1. The rights granted under this License will terminate automatically
-if You fail to comply with any of its terms. However, if You become
-compliant, then the rights granted under this License from a particular
-Contributor are reinstated (a) provisionally, unless and until such
-Contributor explicitly and finally terminates Your grants, and (b) on an
-ongoing basis, if such Contributor fails to notify You of the
-non-compliance by some reasonable means prior to 60 days after You have
-come back into compliance. Moreover, Your grants from a particular
-Contributor are reinstated on an ongoing basis if such Contributor
-notifies You of the non-compliance by some reasonable means, this is the
-first time You have received notice of non-compliance with this License
-from such Contributor, and You become compliant prior to 30 days after
-Your receipt of the notice.
-
-5.2. If You initiate litigation against any entity by asserting a patent
-infringement claim (excluding declaratory judgment actions,
-counter-claims, and cross-claims) alleging that a Contributor Version
-directly or indirectly infringes any patent, then the rights granted to
-You by any and all Contributors for the Covered Software under Section
-2.1 of this License shall terminate.
-
-5.3. In the event of termination under Sections 5.1 or 5.2 above, all
-end user license agreements (excluding distributors and resellers) which
-have been validly granted by You or Your distributors under this License
-prior to termination shall survive termination.
-
-************************************************************************
-*                                                                      *
-*  6. Disclaimer of Warranty                                           *
-*  -------------------------                                           *
-*                                                                      *
-*  Covered Software is provided under this License on an "as is"       *
-*  basis, without warranty of any kind, either expressed, implied, or  *
-*  statutory, including, without limitation, warranties that the       *
-*  Covered Software is free of defects, merchantable, fit for a        *
-*  particular purpose or non-infringing. The entire risk as to the     *
-*  quality and performance of the Covered Software is with You.        *
-*  Should any Covered Software prove defective in any respect, You     *
-*  (not any Contributor) assume the cost of any necessary servicing,   *
-*  repair, or correction. This disclaimer of warranty constitutes an   *
-*  essential part of this License. No use of any Covered Software is   *
-*  authorized under this License except under this disclaimer.         *
-*                                                                      *
-************************************************************************
-
-************************************************************************
-*                                                                      *
-*  7. Limitation of Liability                                          *
-*  --------------------------                                          *
-*                                                                      *
-*  Under no circumstances and under no legal theory, whether tort      *
-*  (including negligence), contract, or otherwise, shall any           *
-*  Contributor, or anyone who distributes Covered Software as          *
-*  permitted above, be liable to You for any direct, indirect,         *
-*  special, incidental, or consequential damages of any character      *
-*  including, without limitation, damages for lost profits, loss of    *
-*  goodwill, work stoppage, computer failure or malfunction, or any    *
-*  and all other commercial damages or losses, even if such party      *
-*  shall have been informed of the possibility of such damages. This   *
-*  limitation of liability shall not apply to liability for death or   *
-*  personal injury resulting from such party's negligence to the       *
-*  extent applicable law prohibits such limitation. Some               *
-*  jurisdictions do not allow the exclusion or limitation of           *
-*  incidental or consequential damages, so this exclusion and          *
-*  limitation may not apply to You.                                    *
-*                                                                      *
-************************************************************************
-
-8. Litigation
--------------
-
-Any litigation relating to this License may be brought only in the
-courts of a jurisdiction where the defendant maintains its principal
-place of business and such litigation shall be governed by laws of that
-jurisdiction, without reference to its conflict-of-law provisions.
-Nothing in this Section shall prevent a party's ability to bring
-cross-claims or counter-claims.
-
-9. Miscellaneous
-----------------
-
-This License represents the complete agreement concerning the subject
-matter hereof. If any provision of this License is held to be
-unenforceable, such provision shall be reformed only to the extent
-necessary to make it enforceable. Any law or regulation which provides
-that the language of a contract shall be construed against the drafter
-shall not be used to construe this License against a Contributor.
-
-10. Versions of the License
----------------------------
-
-10.1. New Versions
-
-Mozilla Foundation is the license steward. Except as provided in Section
-10.3, no one other than the license steward has the right to modify or
-publish new versions of this License. Each version will be given a
-distinguishing version number.
-
-10.2. Effect of New Versions
-
-You may distribute the Covered Software under the terms of the version
-of the License under which You originally received the Covered Software,
-or under the terms of any subsequent version published by the license
-steward.
-
-10.3. Modified Versions
-
-If you create software not governed by this License, and you want to
-create a new license for such software, you may create and use a
-modified version of this License if you rename the license and remove
-any references to the name of the license steward (except to note that
-such modified license differs from this License).
-
-10.4. Distributing Source Code Form that is Incompatible With Secondary
-Licenses
-
-If You choose to distribute Source Code Form that is Incompatible With
-Secondary Licenses under the terms of this version of the License, the
-notice described in Exhibit B of this License must be attached.
-
-Exhibit A - Source Code Form License Notice
--------------------------------------------
-
-  This Source Code Form is subject to the terms of the Mozilla Public
-  License, v. 2.0. If a copy of the MPL was not distributed with this
-  file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-If it is not possible or desirable to put the notice in a particular
-file, then You may include the notice in a location (such as a LICENSE
-file in a relevant directory) where a recipient would be likely to look
-for such a notice.
-
-You may add additional accurate notices of copyright ownership.
-
-Exhibit B - "Incompatible With Secondary Licenses" Notice
----------------------------------------------------------
-
-  This Source Code Form is "Incompatible With Secondary Licenses", as
-  defined by the Mozilla Public License, v. 2.0.
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,23 +1,17 @@
-<!---
+<!--
   Copyright 2018 H2O.ai
 
-  Permission is hereby granted, free of charge, to any person obtaining a
-  copy of this software and associated documentation files (the "Software"),
-  to deal in the Software without restriction, including without limitation
-  the rights to use, copy, modify, merge, publish, distribute, sublicense,
-  and/or sell copies of the Software, and to permit persons to whom the
-  Software is furnished to do so, subject to the following conditions:
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
 
-  The above copyright notice and this permission notice shall be included in
-  all copies or substantial portions of the Software.
+      http://www.apache.org/licenses/LICENSE-2.0
 
-  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
-  IN THE SOFTWARE.
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
 -->
 
 # datatable
@@ -114,6 +108,32 @@ On all other platforms a source distribution will be needed. For more
 information see [Build instructions](https://github.com/h2oai/datatable/wiki/Build-instructions).
 
 
+## License
+
+This project is licensed under the terms of [Apache License v2.0][]. The text
+of this license is also available in the [LICENSE][] file.
+
+All files in this repository that do not bear any boilerplate notices, should
+be presumed to have the following copyright/license notice attached (in
+satisfaction of the definition of "Work" from section 1 of the license):
+
+```text
+   Copyright 2018 H2O.ai
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+```
+
+
 ## See also
 
 * [Build instructions](https://github.com/h2oai/datatable/wiki/Build-instructions)
@@ -121,7 +141,9 @@ information see [Build instructions](https://github.com/h2oai/datatable/wiki/Bui
 * [Documentation](https://datatable.readthedocs.io/en/latest/?badge=latest)
 
 
-  [pandas]: https://github.com/pandas-dev/pandas
-  [sframe]: https://github.com/turi-code/SFrame
-  [data.table]: https://github.com/Rdatatable/data.table
-  [driverless.ai]: https://www.h2o.ai/driverless-ai/
+[apache license v2.0]: http://www.apache.org/licenses/LICENSE-2.0
+[license]: https://github.com/h2oai/datatable/LICENSE
+[pandas]: https://github.com/pandas-dev/pandas
+[sframe]: https://github.com/turi-code/SFrame
+[data.table]: https://github.com/Rdatatable/data.table
+[driverless.ai]: https://www.h2o.ai/driverless-ai/

--- a/ci/make_fast.py
+++ b/ci/make_fast.py
@@ -1,8 +1,19 @@
 #!/usr/bin/env python3
-# © H2O.ai 2018; -*- encoding: utf-8 -*-
-#   This Source Code Form is subject to the terms of the Mozilla Public
-#   License, v. 2.0. If a copy of the MPL was not distributed with this
-#   file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -*- coding: utf-8 -*-
+#-------------------------------------------------------------------------------
+# Copyright 2018 H2O.ai
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #-------------------------------------------------------------------------------
 import os
 import re

--- a/docs/contrib.rst
+++ b/docs/contrib.rst
@@ -2,15 +2,22 @@
 Contributing
 ------------
 
-``datatable`` is an open source project released under the Mozilla Public Licence v2. Open Source projects live by their user and developer communities. We welcome and encourage your contributions of any kind!
+``datatable`` is an open source project released under the Apache License v2.0.
+Open Source projects live by their user and developer communities. We welcome
+and encourage your contributions of any kind!
 
-No matter what your skill set or level of engagement is with ``datatable``, you can help others by improving the ecosystem of documentation, bug report and feature request tickets, and code.
+No matter what your skill set or level of engagement is with ``datatable``,
+you can help others by improving the ecosystem of documentation, bug report
+and feature request tickets, and code.
 
-We invite anyone who is interested to contribute, whether through pull requests, or tests, or GitHub issues, API suggestions, or generic discussion.
+We invite anyone who is interested to contribute, whether through pull requests,
+or tests, or GitHub issues, API suggestions, or generic discussion.
 
 
 
 Have Questions?
 ---------------
 
-If you have questions about using ``datatable``, post them on Stack Overflow using the ``[datatable] [python]`` tags at http://stackoverflow.com/questions/tagged/datatable+python.
+If you have questions about using ``datatable``, post them on Stack Overflow
+using the ``[datatable] [python]`` tags at
+http://stackoverflow.com/questions/tagged/datatable+python.

--- a/setup.py
+++ b/setup.py
@@ -3,23 +3,17 @@
 #-------------------------------------------------------------------------------
 # Copyright 2018 H2O.ai
 #
-# Permission is hereby granted, free of charge, to any person obtaining a
-# copy of this software and associated documentation files (the "Software"),
-# to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense,
-# and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions:
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
-# IN THE SOFTWARE.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #-------------------------------------------------------------------------------
 """
 Build script for the `datatable` module.
@@ -190,13 +184,13 @@ setup(
     author="Pasha Stetsenko",
     author_email="pasha@h2o.ai",
 
-    license="Mozilla Public License v2.0",
+    license="Apache License v2.0",
 
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
         "Intended Audience :: Science/Research",
-        "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
+        "License :: OSI Approved :: Apache Software License",
         "Operating System :: MacOS",
         "Operating System :: Unix",
         "Programming Language :: Python :: 3.5",

--- a/tests/fread/test_fread_api.py
+++ b/tests/fread/test_fread_api.py
@@ -55,7 +55,7 @@ def test_fread_from_cmd2():
     assert d0.nrows >= 12
     d1 = dt.fread(cmd="cat LICENSE", sep="\n")
     d1.internal.check()
-    assert d1.nrows == 372
+    assert d1.nrows == 200
 
 
 def test_fread_from_cmd3(tempfile):
@@ -75,7 +75,7 @@ def test_fread_from_url2():
     path = os.path.abspath("LICENSE")
     d0 = dt.fread("file://" + path, sep="\n")
     d0.internal.check()
-    assert d0.shape == (372, 1)
+    assert d0.shape == (200, 1)
 
 
 def test_fread_from_anysource_as_text1(capsys):


### PR DESCRIPTION
This project originally started under the Apache-v2 license (https://github.com/h2oai/datatable/commit/83f4b1efb19e5ceb456f64b5dafb312691ec2af0). We switched to MPL-2 approximately one year ago, but that change was done hastily without proper discussion or debate (#722). Since then we considered extensively the relative merits of MPL vs Apache, and found that MPL is not the right choice for us (#1310). The summary of the pro/con arguments is as follows:

* Apache (and likewise BSD/MIT) license is prevalent in the open source Python community, and therefore the preferred choice for a new python library;

* MPL-2 is not widely known among developers; thus potential users/developers may be cautious about using a product licensed under unfamiliar terms;

* MPL-2 license is a barrier from the point of view of legally-savvy organizations too: for example, ASF [in its guildelines](https://www.apache.org/legal/resolved.html#category-b) allows use of MPL-licensed binaries only, not the source files.

* Likewise, Google also [lists](https://opensource.google.com/docs/thirdparty/licenses/) MPL-2 as a `reciprocal` type of license, and allows its inclusion only in unmodified binary form but not in source form (in products that are distributed externally). At the same time, they classify Apache as `notice` license, so that it requires only a notice of inclusion;

* Historically, H2O.ai has released its open source software under Apache licenses, using a more restrictive license such as MPL will be a detraction from the open source ideals;

* Applying MPL-2 license is difficult and error-prone:
  - putting the text of MPL-2 license into the LICENSE file is not sufficient, and in fact serves no purpose other than to make GitHub display MPL-2 in the "license" field;
  - MPL-2 is a file-level license (as opposed to traditional repository-level licenses), meaning that it has to be affirmatively applied to each and every file that one wants to license. The application of the license consist of adding the Notice (see Exhibit A) into each licensed file, or by attaching this notice via a comment in a side-along file;
  - if an unaware contributor adds a file that has no Notice, that file is unlicensed;
  - if the repository does not use CLA and does not automatically assigns copyright to the repository owner, that single unlicensed file may legally "poison" the entire project since nobody other than the original author will have the ability to edit, use or remove that file (see [No License](https://choosealicense.com/no-permission/));
  - if a file contains the Notice, it does not automatically mean that the file is licensed under MPL. This is because the license defines _covered software_ as "Source Code Form to which the **initial** Contributor has attached the notice in Exhibit A". If the Notice was put into a file by someone else other than the initial contributor, it has no effect;
  - adding a "binary" file (any file that cannot have comments, such as config file, data, image, etc) requires attaching the Notice to that file via a separate side-along file. It is **not enough** to have a readme.txt saying "all files in this repository have the following Notice attached: ...", since the Notice must be attached by the initial contributor. This means that it is even easier to accidentally commit an unlicensed binary file than it is to commit an unlicensed source code file;
  - due to the factors listed above, verifying the compliance of a repository to the terms of MPL-2 is an extremely difficult task, which probably requires specialized tools;
  - in addition to all the above, the binary form of the library must "inform the recipients how they can obtain the copy of the source code". This is not as easy to implement as it seems. If, say, we distribute library of version 0.6, the recipient must be informed how to obtain the source code for version 0.6. Which means we have to be very careful about providing URL to the specific point in git history (pointing to a branch is not enough, because multiple bug-fix releases may be hosted on the same branch);
  - the documentation pages that are rendered in html and hosted on an external website are also considered binary form of the underlying source .rst files. As such, we are required within the documentation to inform the reader where the source of each documentation file is;
  - logos present an additional challenge if we decide to use them anywhere, because this too becomes distribution. For example, if you were to put a datatable logo on a t-shirt, that t-shirt should bear a notice of the URL where the Source Code Form of the logo can be found;
  - MPL is a file-level license, which means every file in the repository is a separate entity, independently licensed under MPL-2. It can be argued then that the requirement to "inform the recipient of the executable form how they can obtain the source code form" pertains to each file independently. This would mean the executable form should inform the user about each and every file that it is comprised of, giving the exact URLs of each file at the correct point in git history.

* It has been claimed that one decisive advantage of MPL over Apache is that the former prevents a third party from creating an enhanced closed-source version of the library (so-called "datatablePRO") that would compete with ours. Unfortunately, this claim is inaccurate: a closed-source library based on `data.table` can be created, provided that any new "pro" features will be added in separate files. The C/C++ language makes this process particularly simple through the `#include` pre-processor directive.

We also briefly considered whether we should switch to MIT instead of Apache. The summary of arguments is as follows:

* MIT license is much shorter and easier to understand;
* Apache-v2 is more precise and strict in its definitions/language, and therefore provides better legal protection;
* The term "MIT license" it itself slightly ambiguous, there are actually 2 flavors: the "Expat License" and "X11 License";
* The boilerplate for Apache-v2 is better designed: it clearly states that the software is licensed under Apache-v2, whereas with MIT the boilerplate contains the text of the license, making it hard to understand what kind of license it is;
* Apache-v2 includes a patent license clause, whereas MIT doesn't;
* Apache-v2 is much newer license than MIT, and incorporates decades of legal research;
* Apache-v2 is backed by the Apache Software Foundation;
* Apache-v2 was used originally for this project, making it a more natural choice compared to MIT;
* Apache-v2 is used in most other H2O open source projects;
* As of 2018, MIT is the most popular open source license on GitHub (26%), closely followed by Apache (22%).
* MIT is easier to apply compared to Apache: for MIT the single LICENSE file in the repository is sufficient, whereas for Apache the boilerplate has to be "attached" to the "Work". Superficially, this makes Apache similar to MPL, however there are significant differences: Apache requires that the notice be applied to the "Work", and we can always consider the entire repository as a single "Work" (in MPL the notice had to be applied to each and every file). In addition, Apache only requires the notice to be attached (by whatever means), whereas MPL requires that the notice is attached by the "original contributor". Thus, in order to satisfy the Apache requirement it is sufficient to add a notice in the README file that the entire repository is licensed under Apache-v2; it is impossible to do the same with the MPL-2 license.

--------

Given all the above, I believe the Apache license to be a superior choice for this project compared to the MPL-2 or MIT licenses. Thus, switching back to Apache will be a step that will be met positively by the community, and at the same time eliminate significant legal hurdles.

This PR only updates meta-information associated with the project. Individual boilerplate notices can be updated later, so as not to create unnecessary merge conflict due to changes in too many files.

Closes #1310 