### PR TITLE
Leak-proofing

### DIFF
--- a/c/column.cc
+++ b/c/column.cc
@@ -5,8 +5,9 @@
 //
 // © H2O.ai 2018
 //------------------------------------------------------------------------------
-#include "column.h"
 #include <cstdlib>     // atoll
+#include "column.h"
+#include "datatablemodule.h"
 #include "py_utils.h"
 #include "rowindex.h"
 #include "sort.h"
@@ -17,7 +18,16 @@
 
 Column::Column(size_t nrows_)
     : stats(nullptr),
-      nrows(nrows_) {}
+      nrows(nrows_)
+{
+  TRACK(this, sizeof(*this), "Column");
+}
+
+Column::~Column() {
+  delete stats;
+  UNTRACK(this);
+}
+
 
 
 Column* Column::new_column(SType stype) {
@@ -222,11 +232,6 @@ void Column::replace_rowindex(const RowIndex& newri) {
   nrows = ri.size();
 }
 
-
-
-Column::~Column() {
-  delete stats;
-}
 
 
 /**

--- a/c/column_bool.cc
+++ b/c/column_bool.cc
@@ -5,8 +5,9 @@
 //
 // © H2O.ai 2018
 //------------------------------------------------------------------------------
-#include "column.h"
 #include <Python.h>
+#include "column.h"
+#include "datatablemodule.h"
 #include "utils/parallel.h"
 
 
@@ -109,6 +110,7 @@ inline static MemoryRange cast_str_helper(
   size_t exp_size = src->nrows;
   auto wb = MWBPtr(new MemoryWritableBuffer(exp_size));
   char* tmpbuf = new char[1024];
+  TRACK(tmpbuf, sizeof(tmpbuf), "cast_str_helper::tmpbuf");
   char* tmpend = tmpbuf + 1000;  // Leave at least 24 spare chars in buffer
   char* ch = tmpbuf;
   T offset = 0;
@@ -130,6 +132,7 @@ inline static MemoryRange cast_str_helper(
   wb->write(static_cast<size_t>(ch - tmpbuf), tmpbuf);
   wb->finalize();
   delete[] tmpbuf;
+  UNTRACK(tmpbuf);
   return wb->get_mbuf();
 }
 

--- a/c/column_bool.cc
+++ b/c/column_bool.cc
@@ -110,7 +110,7 @@ inline static MemoryRange cast_str_helper(
   size_t exp_size = src->nrows;
   auto wb = MWBPtr(new MemoryWritableBuffer(exp_size));
   char* tmpbuf = new char[1024];
-  TRACK(tmpbuf, sizeof(tmpbuf), "cast_str_helper::tmpbuf");
+  TRACK(tmpbuf, sizeof(tmpbuf), "BoolColumn::tmpbuf");
   char* tmpend = tmpbuf + 1000;  // Leave at least 24 spare chars in buffer
   char* ch = tmpbuf;
   T offset = 0;

--- a/c/column_int.cc
+++ b/c/column_int.cc
@@ -154,7 +154,7 @@ inline static MemoryRange cast_str_helper(
   size_t exp_size = nrows * sizeof(IT);
   auto wb = MWBPtr(new MemoryWritableBuffer(exp_size));
   char* tmpbuf = new char[1024];
-  TRACK(tmpbuf, sizeof(tmpbuf), "cast_str_helper::tmpbuf");
+  TRACK(tmpbuf, sizeof(tmpbuf), "IntColumn::tmpbuf");
   char* tmpend = tmpbuf + 1000;  // Leave at least 24 spare chars in buffer
   char* ch = tmpbuf;
   OT offset = 0;

--- a/c/column_int.cc
+++ b/c/column_int.cc
@@ -7,6 +7,7 @@
 //------------------------------------------------------------------------------
 #include "column.h"
 #include "csv/toa.h"
+#include "datatablemodule.h"
 #include "python/int.h"
 #include "py_types.h"
 #include "py_utils.h"
@@ -153,6 +154,7 @@ inline static MemoryRange cast_str_helper(
   size_t exp_size = nrows * sizeof(IT);
   auto wb = MWBPtr(new MemoryWritableBuffer(exp_size));
   char* tmpbuf = new char[1024];
+  TRACK(tmpbuf, sizeof(tmpbuf), "cast_str_helper::tmpbuf");
   char* tmpend = tmpbuf + 1000;  // Leave at least 24 spare chars in buffer
   char* ch = tmpbuf;
   OT offset = 0;
@@ -175,6 +177,7 @@ inline static MemoryRange cast_str_helper(
   wb->write(static_cast<size_t>(ch - tmpbuf), tmpbuf);
   wb->finalize();
   delete[] tmpbuf;
+  UNTRACK(tmpbuf);
   return wb->get_mbuf();
 }
 

--- a/c/column_real.cc
+++ b/c/column_real.cc
@@ -138,7 +138,7 @@ inline static MemoryRange cast_str_helper(
   size_t exp_size = src->nrows * sizeof(IT) * 2;
   auto wb = MWBPtr(new MemoryWritableBuffer(exp_size));
   char* tmpbuf = new char[1024];
-  TRACK(tmpbuf, sizeof(tmpbuf), "cast_str_helper::tmpbuf");
+  TRACK(tmpbuf, sizeof(tmpbuf), "RealColumn::tmpbuf");
   char* tmpend = tmpbuf + 1000;  // Leave at least 24 spare chars in buffer
   char* ch = tmpbuf;
   OT offset = 0;

--- a/c/column_real.cc
+++ b/c/column_real.cc
@@ -7,6 +7,7 @@
 //------------------------------------------------------------------------------
 #include "column.h"
 #include "csv/toa.h"
+#include "datatablemodule.h"
 #include "utils/parallel.h"
 #include "python/float.h"
 #include "py_utils.h"
@@ -40,12 +41,12 @@ RealStats<T>* RealColumn<T>::get_stats() const {
 
 template <typename T> T      RealColumn<T>::min() const  { return get_stats()->min(this); }
 template <typename T> T      RealColumn<T>::max() const  { return get_stats()->max(this); }
-template <typename T> T      RealColumn<T>::mode() const  { return get_stats()->mode(this); }
+template <typename T> T      RealColumn<T>::mode() const { return get_stats()->mode(this); }
 template <typename T> double RealColumn<T>::sum() const  { return get_stats()->sum(this); }
 template <typename T> double RealColumn<T>::mean() const { return get_stats()->mean(this); }
 template <typename T> double RealColumn<T>::sd() const   { return get_stats()->stdev(this); }
 template <typename T> double RealColumn<T>::skew() const { return get_stats()->skew(this); }
-template <typename T> double RealColumn<T>::kurt() const   { return get_stats()->kurt(this); }
+template <typename T> double RealColumn<T>::kurt() const { return get_stats()->kurt(this); }
 
 // Retrieve stat value as a column
 template <typename T>
@@ -137,6 +138,7 @@ inline static MemoryRange cast_str_helper(
   size_t exp_size = src->nrows * sizeof(IT) * 2;
   auto wb = MWBPtr(new MemoryWritableBuffer(exp_size));
   char* tmpbuf = new char[1024];
+  TRACK(tmpbuf, sizeof(tmpbuf), "cast_str_helper::tmpbuf");
   char* tmpend = tmpbuf + 1000;  // Leave at least 24 spare chars in buffer
   char* ch = tmpbuf;
   OT offset = 0;
@@ -159,6 +161,7 @@ inline static MemoryRange cast_str_helper(
   wb->write(static_cast<size_t>(ch - tmpbuf), tmpbuf);
   wb->finalize();
   delete[] tmpbuf;
+  UNTRACK(tmpbuf);
   return wb->get_mbuf();
 }
 

--- a/c/csv/dtoa.h
+++ b/c/csv/dtoa.h
@@ -168,6 +168,7 @@
 //------------------------------------------------------------------------------
 #ifndef dt_csv_DTOA_H
 #define dt_csv_DTOA_H
+#include <cstring>   // std::memcpy
 #include <stdint.h>
 
 #ifndef _WIN32

--- a/c/csv/reader.cc
+++ b/c/csv/reader.cc
@@ -208,6 +208,7 @@ void GenericReader::init_header() {
 }
 
 void GenericReader::init_nastrings() {
+  // TODO: `na_strings` should be properly destroyed in the end
   na_strings = freader.get_attr("na_strings").to_cstringlist();
   blank_is_na = false;
   number_is_na = false;

--- a/c/csv/writer.cc
+++ b/c/csv/writer.cc
@@ -16,6 +16,7 @@
 #include "utils/parallel.h"
 #include "column.h"
 #include "datatable.h"
+#include "datatablemodule.h"
 #include "memrange.h"
 #include "types.h"
 #include "utils.h"
@@ -53,6 +54,11 @@ public:
       strbuf = static_cast<StringColumn<uint64_t>*>(col)->strdata();
       data = static_cast<StringColumn<uint64_t>*>(col)->offsets();
     }
+    TRACK(this, sizeof(*this), "write::CsvColumn");
+  }
+
+  ~CsvColumn() {
+    UNTRACK(this);
   }
 
   void write(char** pch, size_t row) {
@@ -536,6 +542,7 @@ void CsvWriter::write_column_names()
       maxsize += column_names[i].size()*2 + 2 + 1;
     }
     char *ch0 = new char[maxsize];
+    TRACK(ch0, maxsize, "CsvWriter.ch0");
     char *ch = ch0;
     for (size_t i = 0; i < ncolnames; i++) {
       write_string(&ch, column_names[i].data());
@@ -547,6 +554,7 @@ void CsvWriter::write_column_names()
     // Write this string buffer into the target.
     wb->write(static_cast<size_t>(ch - ch0), ch0);
     delete[] ch0;
+    UNTRACK(ch0);
   }
 }
 

--- a/c/csv/writer.cc
+++ b/c/csv/writer.cc
@@ -385,7 +385,7 @@ void CsvWriter::write()
         reqsize *= 2;
         reqsize += fixed_size_per_row * static_cast<size_t>(row1 - row0);
         if (thbufsize < reqsize) {
-          thbuf = static_cast<char*>(realloc(thbuf, reqsize));
+          thbuf = dt::realloc<char>(thbuf, reqsize);
           thbufsize = reqsize;
           if (!thbuf) {
             throw RuntimeError() << "Unable to allocate " << thbufsize

--- a/c/datatable.cc
+++ b/c/datatable.cc
@@ -182,7 +182,8 @@ void DataTable::resize_rows(size_t new_nrows) {
   }
 
   for (size_t j = 0; j < rowindices.size(); ++j) {
-    RowIndex& r = rowindices[j];
+    RowIndex r = std::move(rowindices[j]);
+    xassert(!rowindices[j]);
     if (!r) r = RowIndex(size_t(0), nrows, size_t(1));
     r.resize(new_nrows);
     for (size_t i : colindices[j]) {

--- a/c/datatable.cc
+++ b/c/datatable.cc
@@ -5,10 +5,11 @@
 //
 // © H2O.ai 2018
 //------------------------------------------------------------------------------
-#include "datatable.h"
 #include <algorithm>
 #include <limits>
 #include "utils/parallel.h"
+#include "datatable.h"
+#include "datatablemodule.h"
 #include "py_utils.h"
 #include "rowindex.h"
 #include "types.h"
@@ -20,7 +21,16 @@
 //------------------------------------------------------------------------------
 
 DataTable::DataTable()
-  : nrows(0), ncols(0), nkeys(0) {}
+  : nrows(0), ncols(0), nkeys(0)
+{
+  TRACK(this, sizeof(*this), "DataTable");
+}
+
+DataTable::~DataTable() {
+  for (auto col : columns) delete col;
+  columns.clear();
+  UNTRACK(this);
+}
 
 
 DataTable::DataTable(colvec&& cols) : DataTable()
@@ -58,11 +68,6 @@ DataTable::DataTable(colvec&& cols, const DataTable* nn)
   : DataTable(std::move(cols))
 {
   copy_names_from(nn);
-}
-
-DataTable::~DataTable() {
-  for (auto col : columns) delete col;
-  columns.clear();
 }
 
 

--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -204,7 +204,7 @@ void UNTRACK(void* ptr) {
     // UNTRACK() is usually called from a destructor, so cannot throw any
     // exceptions there :(
     std::cerr << "ERROR: Trying to remove pointer " << ptr
-              << " which is not tracked";
+              << " which is not tracked\n";
   }
   tracked_objects.erase(ptr);
 }

--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -201,9 +201,10 @@ void TRACK(void* ptr, size_t size, const char* name) {
 
 void UNTRACK(void* ptr) {
   if (tracked_objects.count(ptr) == 0) {
-    // throw RuntimeError() << "Trying to remove pointer " << ptr << " which "
-    //     "is not tracked";
-    std::cout << "Trying to remove pointer " << ptr << " which is not tracked";
+    // UNTRACK() is usually called from a destructor, so cannot throw any
+    // exceptions there :(
+    std::cerr << "ERROR: Trying to remove pointer " << ptr
+              << " which is not tracked";
   }
   tracked_objects.erase(ptr);
 }

--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -5,7 +5,8 @@
 //
 // © H2O.ai 2018
 //------------------------------------------------------------------------------
-#include "datatablemodule.h"
+#include <iostream>
+#include <unordered_map>
 #include <Python.h>
 #include "../datatable/include/datatable.h"
 #include "csv/writer.h"
@@ -17,6 +18,9 @@
 #include "extras/aggregator.h"
 #include "extras/py_ftrl.h"
 #include "frame/py_frame.h"
+#include "python/_all.h"
+#include "python/string.h"
+#include "datatablemodule.h"
 #include "options.h"
 #include "py_column.h"
 #include "py_datatable.h"
@@ -166,6 +170,58 @@ static void _column_save_to_disk(const py::PKArgs& args) {
 
 
 
+//------------------------------------------------------------------------------
+// Support memory leak detection
+//------------------------------------------------------------------------------
+#ifdef DTDEBUG
+
+struct PtrInfo {
+  size_t alloc_size;
+  const char* name;
+
+  std::string to_string() {
+    std::ostringstream io;
+    io << name << "[" << alloc_size << "]";
+    return io.str();
+  }
+};
+
+static std::unordered_map<void*, PtrInfo> tracked_objects;
+
+
+void TRACK(void* ptr, size_t size, const char* name) {
+  if (tracked_objects.count(ptr)) {
+    throw RuntimeError() << "Pointer " << ptr << " is already tracked. Old "
+        "pointer contains " << tracked_objects[ptr].to_string() << ", new: "
+        << (PtrInfo {size, name}).to_string();
+  }
+  tracked_objects.insert({ptr, PtrInfo {size, name}});
+}
+
+
+void UNTRACK(void* ptr) {
+  if (tracked_objects.count(ptr) == 0) {
+    throw RuntimeError() << "Trying to remove pointer " << ptr << " which "
+        "is not tracked";
+  }
+  tracked_objects.erase(ptr);
+}
+
+
+static py::PKArgs args_get_tracked_objects(
+    0, 0, 0, false, false, {}, "get_tracked_objects", nullptr);
+
+static py::oobj get_tracked_objects(const py::PKArgs&) {
+  py::odict res;
+  for (auto kv : tracked_objects) {
+    res.set(py::oint(reinterpret_cast<size_t>(kv.first)),
+            py::ostring(kv.second.to_string()));
+  }
+  return std::move(res);
+}
+
+#endif
+
 
 //------------------------------------------------------------------------------
 // Module definition
@@ -192,6 +248,9 @@ void DatatableModule::init_methods() {
   init_methods_str();
   #ifdef DTTEST
     init_tests();
+  #endif
+  #ifdef DTDEBUG
+    ADD_FN(&get_tracked_objects, args_get_tracked_objects);
   #endif
 }
 

--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -201,11 +201,18 @@ void TRACK(void* ptr, size_t size, const char* name) {
 
 void UNTRACK(void* ptr) {
   if (tracked_objects.count(ptr) == 0) {
-    throw RuntimeError() << "Trying to remove pointer " << ptr << " which "
-        "is not tracked";
+    // throw RuntimeError() << "Trying to remove pointer " << ptr << " which "
+    //     "is not tracked";
+    std::cout << "Trying to remove pointer " << ptr << " which is not tracked";
   }
   tracked_objects.erase(ptr);
 }
+
+
+bool IS_TRACKED(void* ptr) {
+  return (tracked_objects.count(ptr) > 0);
+}
+
 
 
 static py::PKArgs args_get_tracked_objects(

--- a/c/datatablemodule.h
+++ b/c/datatablemodule.h
@@ -46,6 +46,15 @@ class DatatableModule : public py::ExtModule<DatatableModule> {
 };
 
 
+#ifdef DTDEBUG
+  void TRACK(void* ptr, size_t size, const char* name);
+  void UNTRACK(void* ptr);
+#else
+  #define TRACK(ptr, size, name)
+  #define UNTRACK(ptr)
+#endif
+
+
 extern SType force_stype;  // Declared in py_buffers
 
 void init_jay();

--- a/c/datatablemodule.h
+++ b/c/datatablemodule.h
@@ -49,9 +49,11 @@ class DatatableModule : public py::ExtModule<DatatableModule> {
 #ifdef DTDEBUG
   void TRACK(void* ptr, size_t size, const char* name);
   void UNTRACK(void* ptr);
+  bool IS_TRACKED(void* ptr);
 #else
   #define TRACK(ptr, size, name)
   #define UNTRACK(ptr)
+  #define IS_TRACKED(ptr) 1
 #endif
 
 

--- a/c/expr/base_expr.cc
+++ b/c/expr/base_expr.cc
@@ -22,6 +22,7 @@
 #include <memory>             // std::unique_ptr
 #include <stdlib.h>
 #include "datatable.h"
+#include "datatablemodule.h"
 #include "expr/base_expr.h"
 #include "expr/py_expr.h"
 #include "expr/workframe.h"
@@ -36,7 +37,13 @@ namespace dt {
 
 using base_expr_ptr = std::unique_ptr<base_expr>;
 
-base_expr::~base_expr() {}
+base_expr::base_expr() {
+  TRACK(this, sizeof(*this), "dt::base_expr");
+}
+
+base_expr::~base_expr() {
+  UNTRACK(this);
+}
 
 bool base_expr::is_column_expr() const { return false; }
 

--- a/c/expr/base_expr.h
+++ b/c/expr/base_expr.h
@@ -79,6 +79,7 @@ using pexpr = std::unique_ptr<base_expr>;
 
 class base_expr {
   public:
+    base_expr();
     virtual ~base_expr();
     virtual SType resolve(const workframe&) = 0;
     virtual GroupbyMode get_groupby_mode(const workframe&) const = 0;

--- a/c/expr/by_node.cc
+++ b/c/expr/by_node.cc
@@ -27,7 +27,7 @@
 #include "python/arg.h"
 #include "python/tuple.h"
 #include "utils/exceptions.h"
-
+#include "datatablemodule.h"
 namespace dt {
 
 
@@ -47,6 +47,11 @@ by_node::column_descriptor::column_descriptor(
 
 by_node::by_node() {
   n_group_columns = 0;
+  TRACK(this, sizeof(*this), "by_node");
+}
+
+by_node::~by_node() {
+  UNTRACK(this);
 }
 
 

--- a/c/expr/by_node.h
+++ b/c/expr/by_node.h
@@ -68,6 +68,8 @@ class by_node {
 
   public:
     by_node();
+    ~by_node();
+
     void add_groupby_columns(workframe&, collist_ptr&&);
     void add_sortby_columns(workframe&, collist_ptr&&);
 

--- a/c/expr/i_node.cc
+++ b/c/expr/i_node.cc
@@ -25,6 +25,7 @@
 #include "frame/py_frame.h"
 #include "python/_all.h"
 #include "python/string.h"
+#include "datatablemodule.h"
 namespace dt {
 
 
@@ -599,7 +600,13 @@ void multislice_in::execute_grouped(workframe&) {
 // i_node
 //------------------------------------------------------------------------------
 
-i_node::~i_node() {}
+i_node::i_node() {
+  TRACK(this, sizeof(*this), "i_node");
+}
+
+i_node::~i_node() {
+  UNTRACK(this);
+}
 
 void i_node::post_init_check(workframe&) {}
 

--- a/c/expr/i_node.h
+++ b/c/expr/i_node.h
@@ -41,6 +41,7 @@ class i_node {
   public:
     static i_node_ptr make(py::robj src, workframe& wf);
 
+    i_node();
     virtual ~i_node();
     virtual void post_init_check(workframe&);
     virtual void execute(workframe&) = 0;

--- a/c/expr/j_node.cc
+++ b/c/expr/j_node.cc
@@ -25,6 +25,7 @@
 #include "expr/j_node.h"
 #include "expr/repl_node.h"
 #include "expr/workframe.h"   // dt::workframe
+#include "datatablemodule.h"
 namespace dt {
 
 
@@ -349,7 +350,13 @@ j_node_ptr j_node::make(py::robj src, workframe& wf) {
 }
 
 
-j_node::~j_node() {}
+j_node::j_node() {
+  TRACK(this, sizeof(*this), "j_node");
+}
+
+j_node::~j_node() {
+  UNTRACK(this);
+}
 
 
 

--- a/c/expr/j_node.h
+++ b/c/expr/j_node.h
@@ -36,6 +36,7 @@ class j_node {
   public:
     static j_node_ptr make(py::robj src, workframe& wf);
 
+    j_node();
     virtual ~j_node();
     virtual GroupbyMode get_groupby_mode(workframe&) = 0;
     virtual void select(workframe&) = 0;

--- a/c/expr/repl_node.cc
+++ b/c/expr/repl_node.cc
@@ -20,13 +20,13 @@
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #include <unordered_map>
-#include "datatable.h"
 #include "expr/base_expr.h"
 #include "expr/collist.h"
 #include "expr/repl_node.h"
 #include "expr/workframe.h"
 #include "utils/exceptions.h"
-
+#include "datatable.h"
+#include "datatablemodule.h"
 namespace dt {
 
 
@@ -470,7 +470,13 @@ void exprlist_rn::replace_values(workframe&, const intvec&) const {
 // dt::repl_node
 //------------------------------------------------------------------------------
 
-repl_node::~repl_node() {}
+repl_node::repl_node() {
+  TRACK(this, sizeof(*this), "repl_node");
+}
+
+repl_node::~repl_node() {
+  UNTRACK(this);
+}
 
 
 repl_node_ptr repl_node::make(workframe& wf, py::oobj src) {

--- a/c/expr/repl_node.h
+++ b/c/expr/repl_node.h
@@ -32,6 +32,7 @@ using repl_node_ptr = std::unique_ptr<repl_node>;
 
 class repl_node {
   public:
+    repl_node();
     virtual ~repl_node();
     static repl_node_ptr make(workframe& wf, py::oobj src);
 

--- a/c/frame/__init__.cc
+++ b/c/frame/__init__.cc
@@ -85,7 +85,7 @@ class FrameInitializationManager {
     }
 
     ~FrameInitializationManager() {
-      for (auto col : cols) dt::free(col);
+      for (auto col : cols) delete col;
     }
 
 

--- a/c/py_buffers.cc
+++ b/c/py_buffers.cc
@@ -68,9 +68,10 @@ static char strB[] = "B";
 
 Column* Column::from_buffer(const py::robj& obuffer)
 {
+  using pybufptr = std::unique_ptr<Py_buffer>;
   PyObject* buffer = obuffer.to_borrowed_ref();
-  Py_buffer* view = static_cast<Py_buffer*>(std::calloc(1, sizeof(Py_buffer)));
-  if (!view) throw PyError();
+  pybufptr pview = pybufptr(new Py_buffer());
+  Py_buffer* view = pview.get();
 
   // Request the buffer (not writeable). Flag PyBUF_FORMAT indicates that
   // the `view->format` field should be filled; and PyBUF_ND will fill the
@@ -99,7 +100,7 @@ Column* Column::from_buffer(const py::robj& obuffer)
   // If buffer is in float16 format, convert it to float32
   if (view->itemsize == 2 && std::strcmp(view->format, "e") == 0) {
     PyBuffer_Release(view);
-    py::oobj newbuf = py::robj(buffer).invoke("astype", "(s)", "float32");
+    py::oobj newbuf = obuffer.invoke("astype", "(s)", "float32");
     return Column::from_buffer(newbuf);
   }
 
@@ -110,7 +111,7 @@ Column* Column::from_buffer(const py::robj& obuffer)
   if (stype == SType::STR32) {
     res = convert_fwchararray_to_column(view);
   } else if (view->strides == nullptr) {
-    res = Column::new_xbuf_column(stype, nrows, view);
+    res = Column::new_xbuf_column(stype, nrows, pview.release());
   } else {
     res = Column::new_data_column(stype, nrows);
     size_t stride = static_cast<size_t>(view->strides[0] / view->itemsize);

--- a/c/py_buffers.cc
+++ b/c/py_buffers.cc
@@ -272,18 +272,11 @@ struct XInfo {
     shape[0] = shape[1] = 0;
     strides[0] = strides[1] = 0;
     stype = SType::VOID;
+    TRACK(this, sizeof(*this), "py-buffer");
   }
 
   ~XInfo() {
-    // if (mbuf.is_nonempty()) {
-      // if (mbuf->get_refcount() == 1 && stype == SType::OBJ) {
-      //   PyObject** elems = static_cast<PyObject**>(mbuf->get());
-      //   size_t nelems = mbuf->size() / sizeof(PyObject*);
-      //   for (size_t i = 0; i < nelems; ++i) {
-      //     Py_DECREF(elems[i]);
-      //   }
-      // }
-    // }
+    UNTRACK(this);
   }
 };
 

--- a/c/py_datatable.cc
+++ b/c/py_datatable.cc
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <vector>
 #include "datatable.h"
+#include "datatablemodule.h"
 #include "frame/py_frame.h"
 #include "py_column.h"
 #include "py_rowindex.h"
@@ -307,9 +308,15 @@ PyObject* save_jay(obj* self, PyObject* args) {
 // Misc
 //------------------------------------------------------------------------------
 
+static int __init__(PyObject* self, PyObject*, PyObject*) {
+  TRACK(self, sizeof(pydatatable::obj), "pydatatable::obj");
+  return 0;
+}
+
 static void dealloc(obj* self) {
   delete self->ref;
   Py_TYPE(self)->tp_free(self);
+  UNTRACK(self);
 }
 
 
@@ -391,7 +398,7 @@ PyTypeObject type = {
   nullptr,                            /* tp_descr_get */
   nullptr,                            /* tp_descr_set */
   0,                                  /* tp_dictoffset */
-  nullptr,                            /* tp_init */
+  __init__,                           /* tp_init */
   nullptr,                            /* tp_alloc */
   nullptr,                            /* tp_new */
   nullptr,                            /* tp_free */

--- a/c/python/ext_type.h
+++ b/c/python/ext_type.h
@@ -213,6 +213,7 @@ namespace _impl {
     try {
       T* tself = static_cast<T*>(self);
       tself->m__dealloc__();
+      Py_TYPE(self)->tp_free(self);
     } catch (const std::exception& e) {
       exception_to_python(e);
     }

--- a/c/python/obj.cc
+++ b/c/python/obj.cc
@@ -466,7 +466,7 @@ char** _obj::to_cstringlist(const error_manager&) const {
     Py_ssize_t count = Py_SIZE(v);
     char** res = nullptr;
     try {
-      res = new char*[count + 1];
+      res = new char*[count + 1]();
       for (Py_ssize_t i = 0; i <= count; ++i) res[i] = nullptr;
       for (Py_ssize_t i = 0; i < count; ++i) {
         PyObject* item = islist? PyList_GET_ITEM(v, i)

--- a/c/rowindex.cc
+++ b/c/rowindex.cc
@@ -20,18 +20,22 @@
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #include <cstring>     // std::memcpy
+#include "utils/assert.h"
+#include "utils/parallel.h"
+#include "datatablemodule.h"
 #include "rowindex.h"
 #include "rowindex_impl.h"
 #include "utils.h"
-#include "utils/assert.h"
-#include "utils/parallel.h"
 
 
 //------------------------------------------------------------------------------
 // Construction
 //------------------------------------------------------------------------------
 
-RowIndex::RowIndex() : impl(nullptr) {}
+RowIndex::RowIndex() {
+  impl = nullptr;
+  TRACK(this, sizeof(*this), "RowIndex");
+}
 
 // copy-constructor, performs shallow copying
 RowIndex::RowIndex(const RowIndex& other) : RowIndex() {
@@ -53,6 +57,7 @@ RowIndex::RowIndex(RowIndex&& other) {
 
 RowIndex::~RowIndex() {
   if (impl) impl = impl->release();
+  UNTRACK(this);
 }
 
 

--- a/c/rowindex.cc
+++ b/c/rowindex.cc
@@ -197,8 +197,7 @@ void RowIndex::resize(size_t nrows) {
     auto newimpl = impl->resized(nrows);
     xassert(newimpl->refcount == 0);
     impl->release();
-    impl = newimpl;
-    impl->acquire();
+    impl = newimpl->acquire();
   } else {
     impl->resize(nrows);
   }

--- a/c/rowindex.cc
+++ b/c/rowindex.cc
@@ -53,6 +53,7 @@ RowIndex& RowIndex::operator=(const RowIndex& other) {
 RowIndex::RowIndex(RowIndex&& other) {
   impl = other.impl;
   other.impl = nullptr;
+  TRACK(this, sizeof(*this), "RowIndex");
 }
 
 RowIndex::~RowIndex() {
@@ -64,45 +65,55 @@ RowIndex::~RowIndex() {
 // Private constructor
 RowIndex::RowIndex(RowIndexImpl* rii) {
   impl = rii? rii->acquire() : nullptr;
+  TRACK(this, sizeof(*this), "RowIndex");
 }
 
 
-RowIndex::RowIndex(size_t start, size_t count, size_t step){
+RowIndex::RowIndex(size_t start, size_t count, size_t step) {
   impl = (new SliceRowIndexImpl(start, count, step))->acquire();
+  TRACK(this, sizeof(*this), "RowIndex");
 }
 
 RowIndex::RowIndex(const arr64_t& starts,
                    const arr64_t& counts,
                    const arr64_t& steps) {
   impl = (new ArrayRowIndexImpl(starts, counts, steps))->acquire();
+  TRACK(this, sizeof(*this), "RowIndex");
 }
 
 RowIndex::RowIndex(arr32_t&& arr, bool sorted) {
   impl = (new ArrayRowIndexImpl(std::move(arr), sorted))->acquire();
+  TRACK(this, sizeof(*this), "RowIndex");
 }
 
 RowIndex::RowIndex(arr64_t&& arr, bool sorted) {
   impl = (new ArrayRowIndexImpl(std::move(arr), sorted))->acquire();
+  TRACK(this, sizeof(*this), "RowIndex");
 }
 
 RowIndex::RowIndex(arr32_t&& arr, size_t min, size_t max) {
   impl = (new ArrayRowIndexImpl(std::move(arr), min, max))->acquire();
+  TRACK(this, sizeof(*this), "RowIndex");
 }
 
 RowIndex::RowIndex(arr64_t&& arr, size_t min, size_t max) {
   impl = (new ArrayRowIndexImpl(std::move(arr), min, max))->acquire();
+  TRACK(this, sizeof(*this), "RowIndex");
 }
 
 RowIndex::RowIndex(filterfn32* f, size_t n, bool sorted) {
   impl = (new ArrayRowIndexImpl(f, n, sorted))->acquire();
+  TRACK(this, sizeof(*this), "RowIndex");
 }
 
 RowIndex::RowIndex(filterfn64* f, size_t n, bool sorted) {
   impl = (new ArrayRowIndexImpl(f, n, sorted))->acquire();
+  TRACK(this, sizeof(*this), "RowIndex");
 }
 
 RowIndex::RowIndex(const Column* col) {
   impl = (new ArrayRowIndexImpl(col))->acquire();
+  TRACK(this, sizeof(*this), "RowIndex");
 }
 
 

--- a/c/rowindex_array.cc
+++ b/c/rowindex_array.cc
@@ -696,17 +696,5 @@ void ArrayRowIndexImpl::_resize_data() {
   }
   size_t elemsize = type == RowIndexType::ARR32? 4 : 8;
   size_t allocsize = length * elemsize;
-  if (allocsize) {
-    void* ptr = dt::realloc(data, allocsize);
-    if (!ptr) {
-      throw MemoryError() << "Cannot allocate " << allocsize << " bytes "
-          "for a RowIndex object";
-    }
-    data = ptr;
-  } else {
-    // If allocsize==0, the behavior of std::realloc is implementation-defined
-    // See https://en.cppreference.com/w/cpp/memory/c/realloc
-    std::free(data);
-    data = nullptr;
-  }
+  data = dt::realloc(data, allocsize);
 }

--- a/c/rowindex_array.cc
+++ b/c/rowindex_array.cc
@@ -697,7 +697,7 @@ void ArrayRowIndexImpl::_resize_data() {
   size_t elemsize = type == RowIndexType::ARR32? 4 : 8;
   size_t allocsize = length * elemsize;
   if (allocsize) {
-    void* ptr = std::realloc(data, allocsize);
+    void* ptr = dt::realloc(data, allocsize);
     if (!ptr) {
       throw MemoryError() << "Cannot allocate " << allocsize << " bytes "
           "for a RowIndex object";

--- a/c/rowindex_array.cc
+++ b/c/rowindex_array.cc
@@ -322,7 +322,7 @@ ArrayRowIndexImpl::ArrayRowIndexImpl(filterfn64* ff, size_t n, bool sorted) {
 
 ArrayRowIndexImpl::~ArrayRowIndexImpl() {
   if (data && owned) {
-    std::free(data);
+    dt::free(data);
   }
   data = nullptr;
 }

--- a/c/rowindex_array.cc
+++ b/c/rowindex_array.cc
@@ -37,7 +37,7 @@
     o->refcount--;
   }
 #else
-  inline static void test(ArrayRowIndexImpl*) {}
+  #define test(ptr)
 #endif
 
 

--- a/c/sort.cc
+++ b/c/sort.cc
@@ -122,15 +122,16 @@
 //
 //
 //------------------------------------------------------------------------------
-#include "sort.h"
 #include <algorithm>  // std::min
 #include <cstdlib>    // std::abs
 #include <cstring>    // std::memset, std::memcpy
 #include <vector>     // std::vector
 #include "column.h"
 #include "datatable.h"
+#include "datatablemodule.h"
 #include "options.h"
 #include "rowindex.h"
+#include "sort.h"
 #include "types.h"
 #include "utils.h"
 #include "utils/alloc.h"
@@ -1113,6 +1114,7 @@ class SortContext {
       // } else {
       own_tmp = true;
       tmp = new int32_t[size0 * nthreads];
+      TRACK(tmp, sizeof(tmp), "sort.tmp");
       // }
     }
     #pragma omp parallel num_threads(nthreads)
@@ -1165,7 +1167,10 @@ class SortContext {
       gg.from_chunks(rrmap, _nradixes);
     }
 
-    if (own_tmp) delete[] tmp;
+    if (own_tmp) {
+      delete[] tmp;
+      UNTRACK(tmp);
+    }
   }
 
 

--- a/c/stats.cc
+++ b/c/stats.cc
@@ -10,6 +10,7 @@
 #include <limits>       // std::numeric_limits
 #include <type_traits>  // std::is_floating_point
 #include "column.h"
+#include "datatablemodule.h"
 #include "rowindex.h"
 #include "utils.h"
 #include "utils/parallel.h"
@@ -47,6 +48,15 @@ static const char* stat_name(Stat s) {
 //==============================================================================
 // Base Stats
 //==============================================================================
+
+Stats::Stats() {
+  TRACK(this, sizeof(*this), "Stats");
+}
+
+Stats::~Stats() {
+  UNTRACK(this);
+}
+
 
 void Stats::reset() {
   _computed.reset();

--- a/c/stats.h
+++ b/c/stats.h
@@ -77,8 +77,8 @@ class Stats {
     size_t _nmodal;
 
   public:
-    Stats() = default;
-    virtual ~Stats() {}
+    Stats();
+    virtual ~Stats();
     Stats(const Stats&) = delete;
     void operator=(const Stats&) = delete;
 

--- a/c/utils/alloc.cc
+++ b/c/utils/alloc.cc
@@ -18,9 +18,8 @@ namespace dt
 
 
 void* _realloc(void* ptr, size_t n) {
-  if (!n) {
-    std::free(ptr);
-    // if (ptr) untrack_object(ptr);
+  if (n == 0) {
+    dt::free(ptr);
     return nullptr;
   }
   int attempts = 3;
@@ -36,10 +35,8 @@ void* _realloc(void* ptr, size_t n) {
     // | C11 DR 400.
     void* newptr = std::realloc(ptr, n);
     if (newptr) {
-      if (ptr != newptr) {
-        // if (ptr) untrack_object(ptr);
-        // track_object(ptr, "_realloc");
-      }
+      // if (ptr) UNTRACK(ptr);
+      // TRACK(newptr, n, "malloc");
       return newptr;
     }
     if (errno == 12 && attempts--) {
@@ -57,8 +54,9 @@ void* _realloc(void* ptr, size_t n) {
 
 
 void free(void* ptr) {
+  if (!ptr) return;
   std::free(ptr);
-  // untrack_object(ptr);
+  // UNTRACK(ptr);
 }
 
 

--- a/c/utils/alloc.cc
+++ b/c/utils/alloc.cc
@@ -5,10 +5,12 @@
 //
 // © H2O.ai 2018
 //------------------------------------------------------------------------------
-#include "utils/alloc.h"
 #include <cerrno>              // errno
 #include <cstdlib>             // std::realloc, std::free
+#include <unordered_map>
+#include "utils/alloc.h"
 #include "utils/exceptions.h"  // MemoryError
+#include "datatablemodule.h"
 #include "mmm.h"               // MemoryMapManager
 
 namespace dt
@@ -18,6 +20,7 @@ namespace dt
 void* _realloc(void* ptr, size_t n) {
   if (!n) {
     std::free(ptr);
+    // if (ptr) untrack_object(ptr);
     return nullptr;
   }
   int attempts = 3;
@@ -33,6 +36,10 @@ void* _realloc(void* ptr, size_t n) {
     // | C11 DR 400.
     void* newptr = std::realloc(ptr, n);
     if (newptr) {
+      if (ptr != newptr) {
+        // if (ptr) untrack_object(ptr);
+        // track_object(ptr, "_realloc");
+      }
       return newptr;
     }
     if (errno == 12 && attempts--) {
@@ -51,6 +58,7 @@ void* _realloc(void* ptr, size_t n) {
 
 void free(void* ptr) {
   std::free(ptr);
+  // untrack_object(ptr);
 }
 
 

--- a/c/utils/alloc.cc
+++ b/c/utils/alloc.cc
@@ -35,8 +35,8 @@ void* _realloc(void* ptr, size_t n) {
     // | C11 DR 400.
     void* newptr = std::realloc(ptr, n);
     if (newptr) {
-      // if (ptr) UNTRACK(ptr);
-      // TRACK(newptr, n, "malloc");
+      if (ptr) UNTRACK(ptr);
+      TRACK(newptr, n, "malloc");
       return newptr;
     }
     if (errno == 12 && attempts--) {
@@ -56,7 +56,7 @@ void* _realloc(void* ptr, size_t n) {
 void free(void* ptr) {
   if (!ptr) return;
   std::free(ptr);
-  // UNTRACK(ptr);
+  UNTRACK(ptr);
 }
 
 

--- a/c/writebuf.cc
+++ b/c/writebuf.cc
@@ -5,16 +5,17 @@
 //
 // © H2O.ai 2018
 //------------------------------------------------------------------------------
-#include "writebuf.h"
 #include <cstring>     // std::memcpy
 #include <errno.h>     // errno
 #include <sys/mman.h>  // mmap
 #include <unistd.h>    // write
-#include "memrange.h"
 #include "utils/alloc.h"   // dt::realloc
 #include "utils/assert.h"
 #include "utils/parallel.h"
+#include "datatablemodule.h"
+#include "memrange.h"
 #include "utils.h"
+#include "writebuf.h"
 
 
 
@@ -69,10 +70,12 @@ std::unique_ptr<WritableBuffer> WritableBuffer::create_target(
 
 FileWritableBuffer::FileWritableBuffer(const std::string& path) {
   file = new File(path, File::OVERWRITE);
+  TRACK(this, sizeof(*this), "FileWritableBuffer");
 }
 
 FileWritableBuffer::~FileWritableBuffer() {
   delete file;
+  UNTRACK(this);
 }
 
 
@@ -191,11 +194,13 @@ MemoryWritableBuffer::MemoryWritableBuffer(size_t size)
   : ThreadsafeWritableBuffer()
 {
   this->realloc(size);
+  TRACK(this, sizeof(*this), "MemoryWritableBuffer");
 }
 
 
 MemoryWritableBuffer::~MemoryWritableBuffer() {
   dt::free(buffer);
+  UNTRACK(this);
 }
 
 
@@ -243,11 +248,13 @@ MmapWritableBuffer::MmapWritableBuffer(const std::string& path, size_t size)
     allocsize = size;
     map(file.descriptor(), size);
   }
+  TRACK(this, sizeof(*this), "MmapWritableBuffer");
 }
 
 
 MmapWritableBuffer::~MmapWritableBuffer() {
   unmap();
+  UNTRACK(this);
 }
 
 

--- a/ci/asan-env.sh
+++ b/ci/asan-env.sh
@@ -26,7 +26,6 @@ if [ ! -d ".asan" ]; then
     pip install colorama
     pip install typesentry
     pip install blessed
-    pip install llvmlite
     pip install pytest
     pip install pandas
 fi

--- a/tests/test_dt_create.py
+++ b/tests/test_dt_create.py
@@ -106,6 +106,16 @@ def test_wrong_source():
     assert ("Cannot create a column from <class 'int'>" == str(e.value))
 
 
+def test_wrong_source_heavy():
+    # Repeatedly try to fail the constructor; make sure that the internal state
+    # does not get corrupted in the process...
+    for i in range(100):
+        try:
+            dt.Frame(A=[1], B=2)
+        except TypeError:
+            pass
+
+
 def test_different_column_lengths():
     with pytest.raises(ValueError) as e:
         dt.Frame([range(10), [3, 4, 6]])


### PR DESCRIPTION
This PR attempts to make the process of finding leaks easier. To that end, 2 macros are defined: `TRACK` and `UNTRACK`. They are used wherever any dynamic memory is allocated / deallocated. The idea is that by the end of running a certain set of tests, and after destroying all objects created, there should be no more "tracked" objects left of any kind. If there are, then they were leaked. The current set of tracked objects can be queried using `dt.lib._datatable.get_tracked_objects()`.

These macros are only defined in debug mode, so there should be no performance impact for regular (non-debug) usage.

This approach helped discover several instances where small amount of memory was leaked:
- in Frame constructor, if there was an exception during the construction;
- in Column::from_buffer, the `view` object was sometimes not properly freed;
- python objects defined via `ext_type.h` were not freed properly upon destruction.

Closes #1596