### PR TITLE
 Convert Frame.to_pandas() into C++

### DIFF
--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -279,8 +279,6 @@ PyMODINIT_FUNC PyInit__datatable() noexcept
     init_csvwrite_constants();
     init_exceptions();
 
-    force_stype = SType::VOID;
-
     m = dtmod.init();
 
     // Initialize submodules

--- a/c/datatablemodule.h
+++ b/c/datatablemodule.h
@@ -57,9 +57,14 @@ class DatatableModule : public py::ExtModule<DatatableModule> {
 #endif
 
 
-extern SType force_stype;  // Declared in py_buffers
+namespace pybuffers {
+  extern size_t single_col;  // Declared in py_buffers
+  extern SType force_stype;
+}
+
 
 void init_jay();
+
 PyMODINIT_FUNC PyInit__datatable() noexcept;
 
 

--- a/c/frame/py_frame.cc
+++ b/c/frame/py_frame.cc
@@ -22,9 +22,6 @@
 #include <iostream>
 #include "frame/py_frame.h"
 #include "python/_all.h"
-
-extern SType force_stype;
-
 namespace py {
 
 PyObject* Frame_Type = nullptr;

--- a/c/frame/py_frame.h
+++ b/c/frame/py_frame.h
@@ -79,8 +79,8 @@ class Frame : public PyObject {
     void m__setitem__(robj item, robj value);
     oobj m__getstate__(const PKArgs&);  // pickling support
     void m__setstate__(const PKArgs&);
-
     oobj _repr_html_(const PKArgs&);
+
     oobj get_ncols() const;
     oobj get_nrows() const;
     oobj get_shape() const;
@@ -102,6 +102,7 @@ class Frame : public PyObject {
     oobj to_list(const PKArgs&);
     oobj to_tuples(const PKArgs&);
     oobj to_numpy(const PKArgs&);
+    oobj to_pandas(const PKArgs&);
     oobj head(const PKArgs&);
     oobj tail(const PKArgs&);
     void repeat(const PKArgs&);

--- a/c/py_datatable.cc
+++ b/c/py_datatable.cc
@@ -270,14 +270,6 @@ PyObject* materialize(obj* self, PyObject*) {
 }
 
 
-PyObject* use_stype_for_buffers(obj*, PyObject* args) {
-  int st = 0;
-  if (!PyArg_ParseTuple(args, "|i:use_stype_for_buffers", &st))
-    return nullptr;
-  force_stype = static_cast<SType>(st);
-  Py_RETURN_NONE;
-}
-
 
 PyObject* save_jay(obj* self, PyObject* args) {
   DataTable* dt = self->ref;
@@ -350,7 +342,6 @@ static PyMethodDef datatable_methods[] = {
   METHOD0(mean1),
   METHOD0(sd1),
   METHOD0(materialize),
-  METHODv(use_stype_for_buffers),
   METHODv(save_jay),
   {nullptr, nullptr, 0, nullptr}           /* sentinel */
 };

--- a/c/py_datatable.h
+++ b/c/py_datatable.h
@@ -13,8 +13,6 @@
 #include "py_utils.h"
 namespace py { class Frame; }
 
-extern SType force_stype;
-
 #define BASECLS pydatatable::obj
 #define CLSNAME DataTable
 #define HOMEFLAG dt_PY_DATATABLE_cc
@@ -100,10 +98,6 @@ DECLARE_METHOD(
   materialize,
   "materialize()\n\n"
   "Convert DataTable from 'view' into 'data' representation.\n")
-
-DECLARE_METHOD(
-  use_stype_for_buffers,
-  "use_stype_for_buffers(stype)\n\n")
 
 DECLARE_METHOD(
   save_jay,

--- a/c/python/arg.cc
+++ b/c/python/arg.cc
@@ -94,6 +94,7 @@ DataTable*  Arg::to_frame()        const { return pyobj.to_frame(*this); }
 Arg::operator int32_t() const { return to_int32_strict(); }
 Arg::operator int64_t() const { return to_int64_strict(); }
 Arg::operator size_t()  const { return to_size_t(); }
+Arg::operator SType()   const { return to_stype(); }
 
 
 //------------------------------------------------------------------------------

--- a/c/python/arg.h
+++ b/c/python/arg.h
@@ -95,6 +95,7 @@ class Arg : public _obj::error_manager {
     operator int32_t() const;
     operator int64_t() const;
     operator size_t() const;
+    operator SType() const;
 
     /**
      * Convert argument to different list objects.

--- a/c/python/args.h
+++ b/c/python/args.h
@@ -273,7 +273,7 @@ class VarArgsIterable {
 
 template <typename T>
 T PKArgs::get(size_t i) const {
-  if (bound_args[i].is_undefined()) {
+  if (bound_args[i].is_none_or_undefined()) {
     throw TypeError() << "Argument `" << arg_names[i] << "` is missing";
   }
   return static_cast<T>(bound_args[i]);
@@ -281,7 +281,7 @@ T PKArgs::get(size_t i) const {
 
 template <typename T>
 T PKArgs::get(size_t i, T default_value) const {
-  return bound_args[i].is_undefined()
+  return bound_args[i].is_none_or_undefined()
           ? default_value
           : static_cast<T>(bound_args[i]);
 }

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -281,22 +281,8 @@ class Frame(core.Frame):
 
 
     #---------------------------------------------------------------------------
-    # Converters
+    # Deprecated
     #---------------------------------------------------------------------------
-
-    def to_pandas(self):
-        """
-        Convert Frame to a pandas DataFrame, or raise an error if `pandas`
-        module is not installed.
-        """
-        pandas = load_module("pandas")
-        # self.materialize()
-
-        pd = pandas.DataFrame({name: self[:, i].to_numpy().ravel()
-                               for i, name in enumerate(self.names)},
-                              columns=self.names)
-        return pd
-
 
     def topython(self):
         warnings.warn(


### PR DESCRIPTION
Conversion was made slightly more efficient: now we don't need to select an individual column via `self[:, i]`, but instead the operation is controlled via a global parameter `pybuffers::single_col`. The numpy arrays returned from this are already 1D, so no need to apply `.ravel()` afterwards either.

WIP for #1066