### PR TITLE
Add option to display a Frame interactively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   any NA values (#1619).
 
 
+### Changed
+
+- A Frame will no longer be shown in "interactive" mode in console by default.
+  The previous behavior can be restored with
+  `dt.options.display.interactive = True`. Alternatively, you can explore a
+  Frame interactively using `frame.view(True)`.
+
+
 ### Deprecated
 
 - Frame method `.scalar()` is now deprecated and will be removed in release

--- a/c/options.cc
+++ b/c/options.cc
@@ -28,6 +28,7 @@ int32_t sort_nthreads = 1;
 bool fread_anonymize = false;
 int64_t frame_names_auto_index = 0;
 std::string frame_names_auto_prefix = "C";
+bool display_interactive = false;
 bool display_interactive_hint = true;
 
 
@@ -141,6 +142,9 @@ static py::oobj set_option(const py::PKArgs& args) {
   } else if (name == "frame.names_auto_prefix") {
     frame_names_auto_prefix = value.to_string();
 
+  } else if (name == "display.interactive") {
+    display_interactive = value.to_bool_strict();
+
   } else if (name == "display.interactive_hint") {
     display_interactive_hint = value.to_bool_strict();
 
@@ -192,6 +196,9 @@ static py::oobj get_option(const py::PKArgs& args) {
 
   } else if (name == "frame.names_auto_prefix") {
     return py::ostring(frame_names_auto_prefix);
+
+  } else if (name == "display.interactive") {
+    return py::oint(display_interactive);
 
   } else if (name == "display.interactive_hint") {
     return py::oint(display_interactive_hint);

--- a/c/options.cc
+++ b/c/options.cc
@@ -5,13 +5,13 @@
 //
 // © H2O.ai 2018
 //------------------------------------------------------------------------------
-#include "options.h"
-#include "datatablemodule.h"
+#include "python/_all.h"
 #include "python/ext_type.h"
-#include "python/int.h"
 #include "python/obj.h"
 #include "python/string.h"
 #include "utils/parallel.h"
+#include "datatablemodule.h"
+#include "options.h"
 
 
 namespace config
@@ -189,7 +189,7 @@ static py::oobj get_option(const py::PKArgs& args) {
     return logger? py::oobj(logger) : py::None();
 
   } else if (name == "fread.anonymize") {
-    return py::oint(fread_anonymize);
+    return py::obool(fread_anonymize);
 
   } else if (name == "frame.names_auto_index") {
     return py::oint(frame_names_auto_index);
@@ -198,10 +198,10 @@ static py::oobj get_option(const py::PKArgs& args) {
     return py::ostring(frame_names_auto_prefix);
 
   } else if (name == "display.interactive") {
-    return py::oint(display_interactive);
+    return py::obool(display_interactive);
 
   } else if (name == "display.interactive_hint") {
-    return py::oint(display_interactive_hint);
+    return py::obool(display_interactive_hint);
 
   } else {
     throw ValueError() << "Unknown option `" << name << "`";

--- a/c/options.h
+++ b/c/options.h
@@ -24,6 +24,7 @@ extern int32_t sort_nthreads;
 extern bool fread_anonymize;
 extern int64_t frame_names_auto_index;
 extern std::string frame_names_auto_prefix;
+extern bool display_interactive;
 extern bool display_interactive_hint;
 
 int32_t normalize_nthreads(int32_t nth);

--- a/c/python/bool.cc
+++ b/c/python/bool.cc
@@ -20,11 +20,14 @@
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #include "python/bool.h"
-#include "python/dict.h"
-#include "python/float.h"
-#include "python/int.h"
-#include "python/iter.h"
-#include "python/namedtuple.h"
-#include "python/range.h"
-#include "python/slice.h"
-#include "python/tuple.h"
+
+namespace py {
+
+
+obool::obool(bool x) {
+  v = x? Py_True : Py_False;
+  Py_INCREF(v);
+}
+
+
+}  // namespace py

--- a/c/python/bool.h
+++ b/c/python/bool.h
@@ -19,12 +19,25 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
-#include "python/bool.h"
-#include "python/dict.h"
-#include "python/float.h"
-#include "python/int.h"
-#include "python/iter.h"
-#include "python/namedtuple.h"
-#include "python/range.h"
-#include "python/slice.h"
-#include "python/tuple.h"
+#ifndef dt_PYTHON_BOOL_h
+#define dt_PYTHON_BOOL_h
+#include <Python.h>
+#include "python/obj.h"
+
+namespace py {
+
+
+class obool : public oobj {
+  public:
+    obool() = default;
+    obool(const obool&) = default;
+    obool(obool&&) = default;
+    obool& operator=(const obool&) = default;
+    obool& operator=(obool&&) = default;
+
+    explicit obool(bool x);
+};
+
+
+}  // namespace py
+#endif

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -63,10 +63,6 @@ class Frame(core.Frame):
         scols = plural(self.ncols, "col")
         return "<Frame [%s x %s]>" % (srows, scols)
 
-    def _display_in_terminal_(self):  # pragma: no cover
-        # This method is called from the display hook set from .utils.terminal
-        self.view()
-
     def _repr_pretty_(self, p, cycle):
         # Called by IPython terminal when displaying the datatable
         if not term.jupyter:
@@ -84,7 +80,7 @@ class Frame(core.Frame):
             "rownumbers": ["%*d" % (length, x) for x in range(row0, row1)],
         }
 
-    def view(self, interactive=True):
+    def view(self, interactive=None):
         widget = DataFrameWidget(self.nrows, self.ncols, len(self.key),
                                  self._data_viewer, interactive)
         widget.render()

--- a/datatable/utils/terminal.py
+++ b/datatable/utils/terminal.py
@@ -10,6 +10,7 @@ Various functions to help display something in a terminal.
 import sys
 import blessed
 import _locale
+from datatable.lib import core
 
 __all__ = ("term", "wait_for_keypresses", "register_onresize")
 
@@ -97,17 +98,12 @@ for i, ll in enumerate(_lls):
 
 
 
-# Override sys.displayhook to allow better control over what is being printed
-# in the console. In particular, if an object to be displayed has method
-# ``_display_in_terminal_``, then that method will be used for custom object
-# rendering. Otherwise the default handler is used, which simply prints
-# ``repr(obj)`` if obj is not None.
+# Override sys.displayhook to allow datatable Frame to show a rich
+# display when viewed.
 #
 def _new_displayhook(value):
-    if value is None:
-        return
-    if hasattr(value, "_display_in_terminal_") and not isinstance(value, type):
-        value._display_in_terminal_()
+    if isinstance(value, core.Frame):
+        value.view()
     else:
         _original_displayhook(value)
 

--- a/datatable/widget.py
+++ b/datatable/widget.py
@@ -195,6 +195,7 @@ class DataFrameWidget(object):
                     self._view_ncols = i + 1
 
         # Generate the elements of the display
+        at_last_row = (self._view_row0 + self._view_nrows == self._frame_nrows)
         grey = term.bright_black
         header = ["".join(col.header for col in columns),
                   grey("".join(col.divider for col in columns))]
@@ -202,7 +203,8 @@ class DataFrameWidget(object):
                 for j in range(self._view_nrows)]
         srows = plural_form(self._frame_nrows, "row")
         scols = plural_form(self._frame_ncols, "column")
-        footer = [grey("..."), "[%s x %s]" % (srows, scols), ""]
+        footer = ["" if at_last_row else grey("..."),
+                  "[%s x %s]" % (srows, scols), ""]
 
         # Display hint about navigation keys
         if self._show_navbar:

--- a/datatable/widget.py
+++ b/datatable/widget.py
@@ -37,7 +37,7 @@ class DataFrameWidget(object):
     VIEW_NROWS_MAX = 30
     RIGHT_MARGIN = 2
 
-    def __init__(self, nrows, ncols, nkeys, viewdata_callback, interactive=True):
+    def __init__(self, nrows, ncols, nkeys, viewdata_callback, interactive):
         """
         Initialize a new frame widget.
 
@@ -51,6 +51,9 @@ class DataFrameWidget(object):
             "columns" is the frame's data within the requested view, stored
             as a list of columns.
         """
+        if interactive is None:
+            interactive = options.display.interactive
+
         # number of rows / columns in the dataframe being displayed
         self._frame_nrows = nrows
         self._frame_ncols = ncols
@@ -199,7 +202,7 @@ class DataFrameWidget(object):
                 for j in range(self._view_nrows)]
         srows = plural_form(self._frame_nrows, "row")
         scols = plural_form(self._frame_ncols, "column")
-        footer = ["", "[%s x %s]" % (srows, scols), ""]
+        footer = [grey("..."), "[%s x %s]" % (srows, scols), ""]
 
         # Display hint about navigation keys
         if self._show_navbar:
@@ -499,3 +502,7 @@ options.register_option(
     "display.interactive_hint", xtype=bool, default=True,
     doc="Display navigation hint at the bottom of a Frame when viewing "
         "its contents in the console.")
+
+options.register_option(
+    "display.interactive", xtype=bool, default=False,
+    doc="Show datatable Frame interactively in a Python console.")

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -185,7 +185,6 @@ def test_dt_view(dt0, patched_terminal, capsys):
             " 3    0   1   1   4.4       0  world\n"
             "\n"
             "[4 rows x 7 columns]\n"
-            "Press q to quit  ↑←↓→ to move  wasd to page  t to toggle types"
             in out)
 
 

--- a/tests/test_dt_options.py
+++ b/tests/test_dt_options.py
@@ -17,7 +17,8 @@ def test_options_all():
     assert set(dir(dt.options.sort)) == {
         "insert_method_threshold", "thread_multiplier", "max_chunk_length",
         "max_radix_bits", "over_radix_bits", "nthreads"}
-    assert set(dir(dt.options.display)) == {"interactive_hint"}
+    assert set(dir(dt.options.display)) == {
+        "interactive", "interactive_hint"}
     assert set(dir(dt.options.frame)) == {
         "names_auto_index", "names_auto_prefix"}
     assert set(dir(dt.options.fread)) == {"anonymize"}


### PR DESCRIPTION
- Added option `dt.options.display.interactive` to control whether Frames will be displayed in interactive mode in a console or not.
- The default value of `dt.options.display.interactive` changed to `False`.
- Added a helper class `py::obool`.

Closes #1668 