### PR TITLE
Cbind without materialization

### DIFF
--- a/c/column_fw.cc
+++ b/c/column_fw.cc
@@ -193,6 +193,7 @@ template <typename T>
 void FwColumn<T>::resize_and_fill(size_t new_nrows)
 {
   if (new_nrows == nrows) return;
+  reify();
 
   mbuf.resize(sizeof(T) * new_nrows);
 

--- a/c/column_pyobj.cc
+++ b/c/column_pyobj.cc
@@ -65,6 +65,7 @@ void PyObjectColumn::replace_buffer(MemoryRange&& new_mbuf) {
 
 void PyObjectColumn::resize_and_fill(size_t new_nrows) {
   if (new_nrows == nrows) return;
+  reify();
 
   mbuf.resize(sizeof(PyObject*) * new_nrows);
 

--- a/c/column_string.cc
+++ b/c/column_string.cc
@@ -387,6 +387,7 @@ void StringColumn<T>::resize_and_fill(size_t new_nrows)
 {
   size_t old_nrows = nrows;
   if (new_nrows == old_nrows) return;
+  reify();
 
   if (new_nrows > INT32_MAX && sizeof(T) == 4) {
     // TODO: instead of throwing an error, upcast the column to <uint64_t>

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -106,7 +106,7 @@ class DataTable {
     void replace_groupby(const Groupby& newgb);
     void reify();
     void rbind(std::vector<DataTable*>, std::vector<intvec>);
-    DataTable* cbind(std::vector<DataTable*>);
+    void cbind(std::vector<DataTable*>);
     DataTable* copy() const;
     size_t memory_footprint() const;
 

--- a/c/py_rowindex.cc
+++ b/c/py_rowindex.cc
@@ -47,7 +47,7 @@ oobj orowindex::pyobject::m__repr__() {
   if (ri->isarr32()) out << "int32[" << ri->size() << "]";
   if (ri->isarr64()) out << "int64[" << ri->size() << "]";
   if (ri->isslice()) out << ri->slice_start() << '/' << ri->size() << '/'
-                        << ri->slice_step();
+                         << static_cast<int64_t>(ri->slice_step());
   out << ")";
   return ostring(out.str());
 }

--- a/tests/munging/test_dt_cbind.py
+++ b/tests/munging/test_dt_cbind.py
@@ -13,7 +13,7 @@ from datatable import stype, DatatableWarning
 
 def dt_compute_stats(*dts):
     """
-    Force computing all Stats on the datatable.
+    Force computing all Stats on all frames.
 
     Currently, computing a single stat causes all other stats to be computed
     as well.
@@ -23,7 +23,7 @@ def dt_compute_stats(*dts):
 
 
 #-------------------------------------------------------------------------------
-# Run the tests
+# cbind tests
 #-------------------------------------------------------------------------------
 
 def test_cbind_exists():
@@ -84,7 +84,7 @@ def test_cbind_notforced():
     d1 = dt.Frame([4, 5])
     with pytest.raises(ValueError) as e:
         d0.cbind(d1)
-    assert ("Cannot merge frame with 2 rows to a frame with 3 rows"
+    assert ("Cannot cbind frame with 2 rows to a frame with 3 rows"
             in str(e.value))
 
 
@@ -165,6 +165,23 @@ def test_cbind_views2():
     d1.cbind(d3)
     dr = dt.Frame({"A": [2, 3, 4], "B": ["h", "i", "j"]})
     assert_equals(d1, dr)
+
+
+def test_cbind_views3():
+    from datatable.internal import frame_column_rowindex
+    d0 = dt.Frame(A=range(10))[::-1, :]
+    d1 = dt.Frame(B=list("abcde") * 2)
+    d2 = dt.Frame(C=range(1000))[[14, 19, 35, 17, 3, 0, 1, 0, 10, 777], :]
+    d0.cbind([d1, d2])
+    assert d0.to_list() == [list(range(10))[::-1],
+                            list("abcde" * 2),
+                            [14, 19, 35, 17, 3, 0, 1, 0, 10, 777]]
+    assert (repr(frame_column_rowindex(d0, 0)) ==
+            "datatable.internal.RowIndex(9/10/-1)")
+    assert frame_column_rowindex(d0, 1) is None
+    assert (repr(frame_column_rowindex(d0, 2)) ==
+            "datatable.internal.RowIndex(int32[10])")
+
 
 
 def test_cbind_multiple():
@@ -260,7 +277,7 @@ def test_cbind_error_1():
     DT = dt.Frame(A=[1, 5])
     with pytest.raises(ValueError) as e:
         DT.cbind(dt.Frame(B=[]))
-    assert ("Cannot merge frame with 0 rows to a frame with 2 rows"
+    assert ("Cannot cbind frame with 0 rows to a frame with 2 rows"
             in str(e.value))
 
 
@@ -268,7 +285,7 @@ def test_cbind_error_2():
     DT = dt.Frame(A=[])
     with pytest.raises(ValueError) as e:
         DT.cbind(dt.Frame(B=[1, 5]))
-    assert ("Cannot merge frame with 2 rows to a frame with 0 rows"
+    assert ("Cannot cbind frame with 2 rows to a frame with 0 rows"
             in str(e.value))
 
 
@@ -278,5 +295,5 @@ def test_cbind_error_3():
     assert DT.shape == (5, 0)
     with pytest.raises(ValueError) as e:
         DT.cbind(dt.Frame(B=[]))
-    assert ("Cannot merge frame with 0 rows to a frame with 5 rows"
+    assert ("Cannot cbind frame with 0 rows to a frame with 5 rows"
             in str(e.value))


### PR DESCRIPTION
- When cbinding different frames, their columns will no longer be materialized (owing to the fact that now we support having multiple columns with different rowindices in the same frame).
- The columns will still be materialized though if we need to change their shape due to the `force=True` flag.
- fixed minor bug in `__repr__` of `dt.internal.RowIndex` class when displaying a slice rowindex with negative step.

Closes #1674