### PR TITLE
Refactor Terminal class

### DIFF
--- a/datatable/csv.py
+++ b/datatable/csv.py
@@ -7,7 +7,6 @@
 import os
 from datatable.lib import core
 from datatable.utils.terminal import term
-_log_color = term.bright_black
 
 __all__ = ("write_csv", "CsvWriter")
 
@@ -69,4 +68,4 @@ class CsvWriter(object):
         if self._log_newline:
             print("  ", end="")
         self._log_newline = message.endswith("\n")
-        print(_log_color(message), end="", flush=True)
+        print(term.color("bright_black", message), end="", flush=True)

--- a/datatable/fread.py
+++ b/datatable/fread.py
@@ -27,7 +27,6 @@ from datatable.types import stype, ltype
 from datatable.xls import read_xls_workbook
 
 
-_log_color = term.bright_black
 _url_regex = re.compile(r"(?:https?|ftp|file)://")
 _glob_regex = re.compile(r"[\*\?\[\]]")
 _psutil_load_attempted = False
@@ -732,15 +731,16 @@ class GenericReader(object):
         out += bs[frac_chars - 1] if frac_chars > 0 else ""
         outlen = len(out)
         if status == 2:
-            out += term.red("(error)")
+            out += term.color("red", "(error)")
             outlen += 7
         elif status == 3:
-            out += term.dim_yellow("(cancelled)")
+            out += term.color("yellow", "(cancelled)")
             outlen += 11
         out += " " * (bar_width - outlen)
         endf, endl = self._bar_ends
         out = "\r" + s0 + endf + out + endl + s1
-        print(_log_color(out), end=("\n" if status else ""), flush=True)
+        print(term.color("bright_black", out),
+              end=("\n" if status else ""), flush=True)
 
 
     def _get_destination(self, estimated_size):
@@ -1033,7 +1033,7 @@ class _DefaultLogger:
     def debug(self, message):
         if message[0] != "[":
             message = "  " + message
-        print(_log_color(message), flush=True)
+        print(term.color("bright_black", message), flush=True)
 
     def warning(self, message):
         warnings.warn(message, category=FreadWarning)

--- a/datatable/utils/terminal.py
+++ b/datatable/utils/terminal.py
@@ -91,7 +91,7 @@ class Terminal:
 
     def rewrite_lines(self, lines, nold, end=""):
         if self._enable_terminal_codes and nold:
-            print("\x1B[1G\x1B%dA" % nold +
+            print("\x1B[1G\x1B[%dA" % nold +
                   "\x1B[K\n".join(lines) + "\x1B[K", end=end)
         else:
             print("\n".join(lines), end=end)

--- a/datatable/utils/terminal.py
+++ b/datatable/utils/terminal.py
@@ -8,33 +8,93 @@
 Various functions to help display something in a terminal.
 """
 import sys
-import blessed
-import _locale
 from datatable.lib import core
 
-__all__ = ("term", "wait_for_keypresses", "register_onresize")
+__all__ = ("term", "register_onresize")
+
+
+_default_palette = {
+    "reset": "\x1B[m",
+    "bold": "\x1B[1m",
+    "red": "\x1B[31m",
+    "green": "\x1B[32m",
+    "yellow": "\x1B[33m",
+    "blue": "\x1B[34m",
+    "magenta": "\x1B[35m",
+    "cyan": "\x1B[36m",
+    "white": "\x1B[37m",
+    "bright_black": "\x1B[90m",
+    "bright_red": "\x1B[91m",
+    "bright_green": "\x1B[92m",
+    "bright_yellow": "\x1B[93m",
+    "bright_cyan": "\x1B[96m",
+    "bright_white": "\x1B[97m",
+}
 
 
 # Initialize the terminal
-class MyTerminal(blessed.Terminal):
+class Terminal:
+
     def __init__(self):
-        super().__init__()
-        self.override_width = 0
-        self.jupyter = None
-        self._check_ipython()
+        if sys.__stdin__ and sys.__stdout__:
+            import blessed
+            import _locale
+
+            # Save current locale settings
+            try:
+                _lls = []
+                for i in range(100):
+                    ll = _locale.setlocale(i)
+                    _lls.append(ll)
+            except _locale.Error:
+                pass
+
+            self._blessed_term = blessed.Terminal()
+
+            # Restore previous locale settings
+            for i, ll in enumerate(_lls):
+                _locale.setlocale(i, ll)
+
+            self._enable_keyboard = True
+            self._enable_colors = True
+            self._enable_terminal_codes = True
+            self._encoding = self._blessed_term._encoding
+            self.is_a_tty = sys.__stdin__.isatty() and sys.__stdout__.isatty()
+            self._width = 0
+            self._height = 0
+            self.jupyter = None
+            self._check_ipython()
+        else:
+            self._enable_keyboard = False
+            self._enable_colors = False
+            self._enable_terminal_codes = False
+            self._encoding = "UTF8"
+            self.is_a_tty = False
+            self._width = 80
+            self._height = 25
+            self.jupyter = False
 
     @property
     def width(self):
-        return self.override_width or blessed.Terminal.width.fget(self)
+        return self._width or self._blessed_term.width
 
-    def disable_styling(self):
-        # The `does_styling` attr is read-only, so in order to actually change
-        # it we do a small hack: create a new Terminal object which has styling
-        # disabled, and then replace the "guts" of the current object with those
-        # of the newly created object.
-        tt = blessed.Terminal(force_styling=None)
-        tt.override_width = self.override_width
-        self.__dict__, tt.__dict__ = tt.__dict__, self.__dict__
+    @property
+    def height(self):
+        return self._height or self._blessed_term.height
+
+    def length(self, x):
+        return self._blessed_term.length(x)
+
+    def clear_line(self, end=""):
+        if self._enable_terminal_codes:
+            print("\x1B[1G\x1B[K", end=end)
+
+    def rewrite_lines(self, lines, nold, end=""):
+        if self._enable_terminal_codes and nold:
+            print("\x1B[1G\x1B%dA" % nold +
+                  "\x1B[K\n".join(lines) + "\x1B[K", end=end)
+        else:
+            print("\n".join(lines), end=end)
 
     def _check_ipython(self):
         # When running inside a Jupyter notebook, IPython and ipykernel will
@@ -48,53 +108,42 @@ class MyTerminal(blessed.Terminal):
                 self._encoding = "UTF8"
                 self.jupyter = ipy
 
+    def use_colors(self, f):
+        self._enable_colors = f
 
-def noop(self, s):
-    return s
+    def use_keyboard(self, f):
+        self._enable_keyboard = f
 
-class NoTerminal:
-    is_a_tty = False
-    jupyter = False
-    width = 80
-    height = 25
-    _encoding = "UTF8"
-    bold = noop
-    bright_black = noop
-    bright_red = noop
-    bright_white = noop
-    cyan = noop
-    dim_yellow = noop
-    green = noop
-    clear_eol = ""
-    move_up = ""
+    def use_terminal_codes(self, f):
+        self._enable_terminal_codes = f
 
-    def length(self, s):
-        return len(s)
+    def color(self, color, text):
+        if self._enable_colors:
+            return _default_palette[color] + text + "\x1B[m"
+        else:
+            return text
 
-    def move_x(self, n):
-        return ""
+    def wait_for_keypresses(self, refresh_rate=1):
+        """
+        Listen to user's keystrokes and return them to caller one at a time.
+
+        The produced values are instances of blessed.keyboard.Keystroke class.
+        If the user did not press anything with the last `refresh_rate` seconds
+        the generator will yield `None`, allowing the caller to perform any
+        updates necessary.
+
+        This generator is infinite, and thus needs to be stopped explicitly.
+        """
+        if not self._enable_keyboard:
+            return
+        with self._blessed_term.cbreak():
+            while True:
+                yield self._blessed_term.inkey(timeout=refresh_rate)
 
 
-
-# Save current locale settings
-try:
-    _lls = []
-    for i in range(100):
-        ll = _locale.setlocale(i)
-        _lls.append(ll)
-except _locale.Error:
-    pass
 
 # Instantiate a terminal
-if sys.__stdin__ and sys.__stdout__:
-    term = MyTerminal()
-else:
-    term = NoTerminal()
-
-
-# Restore previous locale settings
-for i, ll in enumerate(_lls):
-    _locale.setlocale(i, ll)
+term = Terminal()
 
 
 
@@ -111,23 +160,6 @@ def _new_displayhook(value):
 _original_displayhook = sys.displayhook
 if not term.jupyter:
     sys.displayhook = _new_displayhook
-
-
-
-def wait_for_keypresses(refresh_rate=1):
-    """
-    Listen to user's keystrokes and return them to caller one at a time.
-
-    The produced values are instances of blessed.keyboard.Keystroke class.
-    If the user did not press anything with the last `refresh_rate` seconds
-    the generator will yield `None`, allowing the caller to perform any
-    updates necessary.
-
-    This generator is infinite, and thus needs to be stopped explicitly.
-    """
-    with term.cbreak():
-        while True:
-            yield term.inkey(timeout=refresh_rate)
 
 
 

--- a/datatable/utils/typechecks.py
+++ b/datatable/utils/typechecks.py
@@ -69,9 +69,8 @@ NumpyMaskedArray_t = _LazyClass("numpy.ma", "MaskedArray")
 
 class DatatableWarning(UserWarning):
     def _handle_(self):
-        name = self.__class__.__name__
-        message = str(self)
-        print(term.dim_yellow(name + ": ") + term.bright_black(message))
+        print(term.color("yellow", self.__class__.__name__ + ": ") +
+              term.color("bright_black", str(self)))
 
 
 def dtwarn(message):

--- a/datatable/widget.py
+++ b/datatable/widget.py
@@ -136,6 +136,8 @@ class DataFrameWidget(object):
         self._draw()
         if self._interactive:
             self._interact()
+        else:
+            print()
 
 
     #---------------------------------------------------------------------------

--- a/tests/random_driver.py
+++ b/tests/random_driver.py
@@ -36,13 +36,14 @@ def start_random_attack(n_attacks=None, maxfail=None):
             if n_errors >= maxfail:
                 raise KeyboardInterrupt
             if skip_successful_seeds:
-                print(term.bold_bright_white(" Seeds tried: %d" % (i + 1)),
+                print(term.color("bright_white",
+                        term.color("bold", " Seeds tried: %d" % (i + 1))),
                       end="\r")
     except KeyboardInterrupt:
         errmsg = "errors: %d" % n_errors
         if n_errors:
-            errmsg = term.bright_red(errmsg)
-        print("\r" + term.bright_cyan("DONE.") +
+            errmsg = term.color("bright_red", errmsg)
+        print("\r" + term.color("bright_cyan", "DONE.") +
               " Seeds tested: %d, %s" % (n_tests, errmsg))
 
 
@@ -59,13 +60,13 @@ def try_seed(seed):
         return True
 
     if rc == 0:
-        status = term.bright_green("OK")
+        status = term.color("bright_green", "OK")
     elif rc > 0:
-        status = term.yellow("FAIL")
+        status = term.color("yellow", "FAIL")
     elif rc == -9:
-        status = term.cyan("HANG")
+        status = term.color("cyan", "HANG")
     else:
-        status = term.bright_red("ABORT")
+        status = term.color("bright_red", "ABORT")
     if rc != 0:
         status += " (%d)" % rc
     print("%-19d: %s" % (seed, status))

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -202,7 +202,7 @@ def test_dt_view_keyed(patched_terminal, capsys):
             "g  |  3\n"
             "\n"
             "[5 rows x 2 columns]\n"
-            == out)
+            in out)
 
 
 def test_dt_getitem(dt0):

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -54,12 +54,11 @@ def dt0():
 
 
 @pytest.fixture()
-def patched_terminal(monkeypatch):
-    def send1(refresh_rate=1):
-        yield None
-    monkeypatch.setattr("datatable.utils.terminal.wait_for_keypresses", send1)
-    dt.utils.terminal.term.override_width = 100
-    dt.utils.terminal.term.disable_styling()
+def patched_terminal():
+    dt.utils.terminal.term._width = 100
+    dt.utils.terminal.term.use_colors(False)
+    dt.utils.terminal.term.use_keyboard(False)
+    dt.utils.terminal.term.use_terminal_codes(False)
 
 
 def assert_valueerror(frame, rows, error_message):


### PR DESCRIPTION
- `MyTerminal` and `NoTerminal` are merged into the single `Terminal` class.
- Certain functions that were provided by `blessed` before are now implemented natively.
- The terminal can now cleanly switch between "colored" and "monochrome" mode.
- The terminal now has a mode to never emit special terminal code sequences (useful for testing).
- The terminal now has a mode to ignore the `wait_for_keypresses()` command

WIP for #1677