### PR TITLE
Simplify the way how otuple constructor can be used

### DIFF
--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -88,10 +88,8 @@ static py::oobj frame_column_data_r(const py::PKArgs& args) {
   auto u = _unpack_args(args);
   DataTable* dt = u.first;
   size_t col = u.second;
-  const void* ptr = dt->columns[col]->data();
-  py::otuple init_args(1);
-  init_args.set(0, py::oint(reinterpret_cast<size_t>(ptr)));
-  return c_void_p.call(init_args);
+  size_t iptr = reinterpret_cast<size_t>(dt->columns[col]->data());
+  return c_void_p.call({py::oint(iptr)});
 }
 
 

--- a/c/expr/by_node.cc
+++ b/c/expr/by_node.cc
@@ -252,9 +252,7 @@ oby::oby(const oobj& src) : oobj(src) {}
 
 oby oby::make(const robj& r) {
   robj oby_type(reinterpret_cast<PyObject*>(&pyobj::Type::type));
-  otuple args(1);
-  args.set(0, r);
-  return oby(oby_type.call(args));
+  return oby(oby_type.call({r}));
 }
 
 

--- a/c/expr/i_node.cc
+++ b/c/expr/i_node.cc
@@ -389,9 +389,7 @@ static i_node* _from_nparray(py::oobj src) {
     size_t dim0 = shape[0].to_size_t();
     size_t dim1 = shape[1].to_size_t();
     if (dim0 == 1 || dim1 == 1) {
-      py::otuple args(1);
-      args.set(0, py::oint(dim0 * dim1));
-      src = src.invoke("reshape", args);
+      src = src.invoke("reshape", {py::oint(dim0 * dim1)});
       shape = src.get_attr("shape").to_otuple();
       ndims = shape.size();
     }
@@ -410,9 +408,7 @@ static i_node* _from_nparray(py::oobj src) {
   }
   // Now convert numpy array into a datatable Frame
   auto dt_Frame = py::oobj(reinterpret_cast<PyObject*>(&py::Frame::Type::type));
-  py::otuple args(1);
-  args.set(0, src);
-  py::oobj frame = dt_Frame.call(args);
+  py::oobj frame = dt_Frame.call({src});
   return new frame_in(frame);
 }
 

--- a/c/frame/__init__.cc
+++ b/c/frame/__init__.cc
@@ -362,10 +362,7 @@ class FrameInitializationManager {
 
 
     void init_from_string() {
-      py::otuple call_args(1);
-      call_args.set(0, src.to_pyobj());
-
-      py::oobj res = py::robj(py::fread_fn).call(call_args);
+      py::oobj res = py::robj(py::fread_fn).call({src.to_pyobj()});
       if (res.is_frame()) {
         Frame* resframe = static_cast<Frame*>(res.to_borrowed_ref());
         std::swap(frame->dt,      resframe->dt);

--- a/c/frame/__repr__.cc
+++ b/c/frame/__repr__.cc
@@ -429,10 +429,7 @@ void Frame::view(const PKArgs& args) {
   oobj DFWidget = oobj::import("datatable")
                   .get_attr("widget")
                   .get_attr("DataFrameWidget");
-  otuple call_args(2);
-  call_args.set(0, oobj(this));
-  call_args.set(1, interactive);
-  DFWidget.call(call_args).invoke("render");
+  DFWidget.call({oobj(this), interactive}).invoke("render");
 }
 
 
@@ -443,4 +440,5 @@ void Frame::Type::_init_repr(Methods& mm) {
   ADD_METHOD(mm, &Frame::view, args_view);
 }
 
-}
+
+}  // namespace py

--- a/c/frame/py_frame.cc
+++ b/c/frame/py_frame.cc
@@ -44,10 +44,8 @@ Return the first `n` rows of the frame, same as ``self[:n, :]``.
 oobj Frame::head(const PKArgs& args) {
   size_t n = std::min(args.get<size_t>(0, 10),
                       dt->nrows);
-  py::otuple aa(2);
-  aa.set(0, py::oslice(0, static_cast<int64_t>(n), 1));
-  aa.set(1, py::None());
-  return m__getitem__(aa);
+  return m__getitem__(otuple(oslice(0, static_cast<int64_t>(n), 1),
+                             None()));
 }
 
 
@@ -65,10 +63,9 @@ oobj Frame::tail(const PKArgs& args) {
   size_t n = std::min(args.get<size_t>(0, 10),
                       dt->nrows);
   // Note: usual slice `-n::` doesn't work as expected when `n = 0`
-  py::otuple aa(2);
-  aa.set(0, py::oslice(static_cast<int64_t>(dt->nrows - n), py::oslice::NA, 1));
-  aa.set(1, py::None());
-  return m__getitem__(aa);
+  int64_t start = static_cast<int64_t>(dt->nrows - n);
+  return m__getitem__(otuple(oslice(start, oslice::NA, 1),
+                             None()));
 }
 
 
@@ -196,10 +193,7 @@ static GSArgs args_shape(
   "Tuple with (nrows, ncols) dimensions of the Frame\n");
 
 oobj Frame::get_shape() const {
-  py::otuple shape(2);
-  shape.set(0, get_nrows());
-  shape.set(1, get_ncols());
-  return std::move(shape);
+  return otuple(get_nrows(), get_ncols());
 }
 
 

--- a/c/frame/py_frame.h
+++ b/c/frame/py_frame.h
@@ -104,14 +104,16 @@ class Frame : public PyObject {
     oobj colindex(const PKArgs&);
     oobj copy(const PKArgs&);
     void replace(const PKArgs&);
+    oobj head(const PKArgs&);
+    oobj tail(const PKArgs&);
+    void repeat(const PKArgs&);
+
+    // Conversion methods
     oobj to_dict(const PKArgs&);
     oobj to_list(const PKArgs&);
     oobj to_tuples(const PKArgs&);
     oobj to_numpy(const PKArgs&);
     oobj to_pandas(const PKArgs&);
-    oobj head(const PKArgs&);
-    oobj tail(const PKArgs&);
-    void repeat(const PKArgs&);
 
     // Stats functions
     oobj stat(const PKArgs&);

--- a/c/models/aggregator.h
+++ b/c/models/aggregator.h
@@ -162,7 +162,7 @@ Aggregator<T>::Aggregator(size_t min_rows_in, size_t n_bins_in,
 *     and the exemplars gathered in `dt_exemplars`.
 */
 template <typename T>
-void Aggregator<T>::aggregate(DataTable* dt_in, 
+void Aggregator<T>::aggregate(DataTable* dt_in,
                               dtptr& dt_exemplars_in,
                               dtptr& dt_members_in)
 {
@@ -985,9 +985,6 @@ void Aggregator<T>::progress(float progress, int status_code /*= 0*/) {
   if (progress_fn.is_none()) {
     print_progress(progress, status_code);
   } else {
-    py::otuple args(2);
-    args.set(0, py::ofloat(progress));
-    args.set(1, py::oint(status_code));
-    progress_fn.call(args);
+    progress_fn.call({py::ofloat(progress), py::oint(status_code)});
   }
 }

--- a/c/models/kfold.cc
+++ b/c/models/kfold.cc
@@ -86,14 +86,10 @@ static oobj kfold(const PKArgs& args) {
   int64_t n = static_cast<int64_t>(nrows);
 
   olist res(nsplits);
-  otuple split_first(2);
-  split_first.set(0, orange(n/k, n));
-  split_first.set(1, orange(0, n/k));
-  otuple split_last(2);
-  split_last.set(0, orange(0, (k-1)*n/k));
-  split_last.set(1, orange((k-1)*n/k, n));
-  res.set(0, split_first);
-  res.set(nsplits-1, split_last);
+  res.set(0, otuple(orange(n/k, n),
+                    orange(0, n/k)));
+  res.set(nsplits-1, otuple(orange(0, (k-1)*n/k),
+                            orange((k-1)*n/k, n)));
 
   std::vector<int32_t*> data;
 
@@ -105,10 +101,9 @@ static oobj kfold(const PKArgs& args) {
     DataTable* dt = new DataTable({col});
     data.push_back(static_cast<int32_t*>(col->data_w()));
 
-    otuple split_i(2);
-    split_i.set(0, oobj::from_new_reference(Frame::from_datatable(dt)));
-    split_i.set(1, orange(b1, b2));
-    res.set(static_cast<size_t>(ii), split_i);
+    res.set(static_cast<size_t>(ii),
+            otuple(oobj::from_new_reference(Frame::from_datatable(dt)),
+                   orange(b1, b2)));
   }
 
   for (int64_t t = 0; t < k*(k-2); ++t) {

--- a/c/models/py_ftrl.cc
+++ b/c/models/py_ftrl.cc
@@ -1027,15 +1027,13 @@ void Ftrl::set_params_namedtuple(robj params) {
 
 
 oobj Ftrl::get_params_tuple() const {
-  py::otuple params(7);
-  params.set(0, get_alpha());
-  params.set(1, get_beta());
-  params.set(2, get_lambda1());
-  params.set(3, get_lambda2());
-  params.set(4, get_nbins());
-  params.set(5, get_nepochs());
-  params.set(6, get_interactions());
-  return std::move(params);
+  return otuple {get_alpha(),
+                 get_beta(),
+                 get_lambda1(),
+                 get_lambda2(),
+                 get_nbins(),
+                 get_nepochs(),
+                 get_interactions()};
 }
 
 
@@ -1082,7 +1080,6 @@ static PKArgs args___getstate__(
 
 
 oobj Ftrl::m__getstate__(const PKArgs&) {
-  py::otuple pickle(6);
   py::oobj params = get_params_tuple();
   py::oobj model = get_model();
   py::oobj fi = get_fi_tuple();
@@ -1096,13 +1093,7 @@ oobj Ftrl::m__getstate__(const PKArgs&) {
                        );
   }
 
-  pickle.set(0, params);
-  pickle.set(1, model);
-  pickle.set(2, fi);
-  pickle.set(3, df_feature_names);
-  pickle.set(4, labels);
-  pickle.set(5, py_reg_type);
-  return std::move(pickle);
+  return otuple {params, model, fi, df_feature_names, labels, py_reg_type};
 }
 
 

--- a/c/python/namedtuple.cc
+++ b/c/python/namedtuple.cc
@@ -63,11 +63,7 @@ onamedtupletype::onamedtupletype(const std::string& cls_name,
     argnames.set(i, py::ostring(fields[i].name));
   }
 
-  py::otuple args(2);
-  args.set(0, py::ostring(cls_name));
-  args.set(1, argnames);
-
-  auto type = namedtuple.call(args);
+  auto type = namedtuple.call({py::ostring(cls_name), argnames});
   auto res = std::move(type).release();
 
   // Set namedtuple doc

--- a/c/python/obj.cc
+++ b/c/python/obj.cc
@@ -123,7 +123,6 @@ oobj oobj::import(const char* mod, const char* symbol) {
   if (!mod_obj) throw PyError();
   return mod_obj.get_attr(symbol);
 }
-
 oobj oobj::import(const char* mod) {
   PyObject* module = PyImport_ImportModule(mod);
   if (!module) {

--- a/c/python/range.cc
+++ b/c/python/range.cc
@@ -37,10 +37,7 @@ orange::orange(int64_t start, int64_t stop) : orange(start, stop, 1) {}
 
 
 orange::orange(int64_t start, int64_t stop, int64_t step) {
-  py::otuple args(3);
-  args.set(0, py::oint(start));
-  args.set(1, py::oint(stop));
-  args.set(2, py::oint(step));
+  otuple args = otuple(py::oint(start), py::oint(stop), py::oint(step));
   v = PyObject_CallObject(reinterpret_cast<PyObject*>(&PyRange_Type),
                           args.to_borrowed_ref());
   if (!v) throw PyError();

--- a/c/python/tuple.cc
+++ b/c/python/tuple.cc
@@ -32,6 +32,43 @@ otuple::otuple(size_t n) {
   v = PyTuple_New(static_cast<Py_ssize_t>(n));
 }
 
+otuple::otuple(std::initializer_list<oobj> list) : otuple(list.size()) {
+  size_t i = 0;
+  for (const oobj& item: list) {
+    set(i++, item);
+  }
+}
+
+otuple::otuple(const _obj& o1) : otuple(1) {
+  set(0, o1);
+}
+
+otuple::otuple(const _obj& o1, const _obj& o2) : otuple(2) {
+  set(0, o1);
+  set(1, o2);
+}
+
+otuple::otuple(const _obj& o1, const _obj& o2, const _obj& o3) : otuple(3) {
+  set(0, o1);
+  set(1, o2);
+  set(2, o3);
+}
+
+otuple::otuple(oobj&& o1) : otuple(1) {
+  set(0, std::move(o1));
+}
+
+otuple::otuple(oobj&& o1, oobj&& o2) : otuple(2) {
+  set(0, std::move(o1));
+  set(1, std::move(o2));
+}
+
+otuple::otuple(oobj&& o1, oobj&& o2, oobj&& o3) : otuple(3) {
+  set(0, std::move(o1));
+  set(1, std::move(o2));
+  set(2, std::move(o3));
+}
+
 otuple::otuple(const robj& src) : oobj(src) {}
 rtuple::rtuple(const robj& src) : robj(src) {}
 

--- a/c/python/tuple.h
+++ b/c/python/tuple.h
@@ -21,6 +21,7 @@
 //------------------------------------------------------------------------------
 #ifndef dt_PYTHON_TUPLE_h
 #define dt_PYTHON_TUPLE_h
+#include <initializer_list>
 #include <Python.h>
 #include "python/obj.h"
 
@@ -44,6 +45,13 @@ class otuple : public oobj {
     otuple& operator=(otuple&&) = default;
 
     otuple(size_t n);
+    otuple(std::initializer_list<oobj>);
+    otuple(const _obj&);
+    otuple(const _obj&, const _obj&);
+    otuple(const _obj&, const _obj&, const _obj&);
+    otuple(oobj&&);
+    otuple(oobj&&, oobj&&);
+    otuple(oobj&&, oobj&&, oobj&&);
 
     size_t size() const noexcept;
 


### PR DESCRIPTION
Added several new constructors for `py::otuple` to simplify the use of method `obj.call()`. Now you can simply say
```
   callable_obj.call({arg1, arg2, arg3});
```