### PR TITLE
to_jay()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Frame method `.append()` is now deprecated and will be removed in release
   0.10.0. Please use `.rbind()` instead.
 
+- Frame method `.save()` was renamed into `.to_jay()` (for consistency with
+  other `.to_*()` methods). The old name is still usable, but marked as
+  deprecated and will be removed in 0.10.0.
+
 
 ### Notes
 

--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -284,7 +284,6 @@ PyMODINIT_FUNC PyInit__datatable() noexcept
     if (!pycolumn::static_init(m)) return nullptr;
     if (!pydatatable::static_init(m)) return nullptr;
     if (!init_py_encodings(m)) return nullptr;
-    init_jay();
 
     py::Frame::Type::init(m);
     py::Ftrl::Type::init(m);

--- a/c/datatablemodule.h
+++ b/c/datatablemodule.h
@@ -65,8 +65,6 @@ namespace pybuffers {
 }
 
 
-void init_jay();
-
 PyMODINIT_FUNC PyInit__datatable() noexcept;
 
 

--- a/c/frame/py_frame.cc
+++ b/c/frame/py_frame.cc
@@ -271,6 +271,7 @@ void Frame::Type::init_methods_and_getsets(Methods& mm, GetSetters& gs) {
   _init_cbind(mm);
   _init_key(gs);
   _init_init(mm);
+  _init_jay(mm);
   _init_names(mm, gs);
   _init_rbind(mm);
   _init_replace(mm);

--- a/c/frame/py_frame.h
+++ b/c/frame/py_frame.h
@@ -58,6 +58,7 @@ class Frame : public PyObject {
       private:
         static void _init_cbind(Methods&);
         static void _init_init(Methods&);
+        static void _init_jay(Methods&);
         static void _init_key(GetSetters&);
         static void _init_names(Methods&, GetSetters&);
         static void _init_rbind(Methods&);
@@ -112,12 +113,13 @@ class Frame : public PyObject {
     oobj tail(const PKArgs&);
 
     // Conversion methods
+    oobj to_csv(const PKArgs&);
     oobj to_dict(const PKArgs&);
+    oobj to_jay(const PKArgs&);  // See jay/save_jay.cc
     oobj to_list(const PKArgs&);
-    oobj to_tuples(const PKArgs&);
     oobj to_numpy(const PKArgs&);
     oobj to_pandas(const PKArgs&);
-    oobj to_csv(const PKArgs&);
+    oobj to_tuples(const PKArgs&);
 
     // Stats functions
     oobj stat(const PKArgs&);

--- a/c/jay/save_jay.cc
+++ b/c/jay/save_jay.cc
@@ -5,9 +5,13 @@
 //
 // © H2O.ai 2018
 //------------------------------------------------------------------------------
+#include "frame/py_frame.h"
 #include "jay/jay_generated.h"
-#include "datatable.h"
+#include "python/_all.h"
+#include "python/args.h"
+#include "python/string.h"
 #include "utils/assert.h"
+#include "datatable.h"
 #include "writebuf.h"
 
 void init_jay();  // called once from datatablemodule.c
@@ -219,3 +223,78 @@ static flatbuffers::Offset<void> saveStats(
   flatbuffers::Offset<void> o = fbb.CreateStruct(ss).Union();
   return o;
 }
+
+
+
+//------------------------------------------------------------------------------
+// py::Frame interface
+//------------------------------------------------------------------------------
+namespace py {
+
+
+static PKArgs args_to_jay(
+  1, 0, 1, false, false, {"path", "_strategy"}, "to_jay",
+
+R"(to_jay(self, path, _strategy='auto')
+--
+
+Save this frame to a binary file on disk, in .jay format.
+
+Parameters
+----------
+path: str
+    The destination file name. Although not necessary, we recommend
+    using extension ".jay" for the file. If the file exists, it will
+    be overwritten.
+    If this argument is omitted, the file will be created in memory
+    instead, and returned as a `bytes` object.
+
+_strategy: 'mmap' | 'write' | 'auto'
+    Which method to use for writing the file to disk. The "write"
+    method is more portable across different operating systems, but
+    may be slower. This parameter has no effect when `path` is
+    omitted.
+)");
+
+
+oobj Frame::to_jay(const PKArgs& args) {
+  // path
+  oobj path = args[0].to<oobj>(ostring(""));
+  if (!path.is_string()) {
+    throw TypeError() << "Parameter `path` in Frame.to_jay() should be a "
+        "string, instead got " << path.typeobj();
+  }
+  path = oobj::import("os", "path", "expanduser").call({path});
+  std::string filename = path.to_string();
+
+  // _strategy
+  auto strategy = args[1].to<std::string>("auto");
+  auto sstrategy = (strategy == "mmap")  ? WritableBuffer::Strategy::Mmap :
+                   (strategy == "write") ? WritableBuffer::Strategy::Write :
+                   (strategy == "auto")  ? WritableBuffer::Strategy::Auto :
+                                           WritableBuffer::Strategy::Unknown;
+  if (sstrategy == WritableBuffer::Strategy::Unknown) {
+    throw TypeError() << "Parameter `_strategy` in Frame.to_jay() should be "
+        "one of 'mmap', 'write' or 'auto'; instead got '" << strategy << "'";
+  }
+
+  if (filename.empty()) {
+    MemoryRange mr = dt->save_jay();
+    auto data = static_cast<const char*>(mr.xptr());
+    auto size = static_cast<Py_ssize_t>(mr.size());
+    return oobj::from_new_reference(PyBytes_FromStringAndSize(data, size));
+  }
+  else {
+    dt->save_jay(filename, sstrategy);
+    return None();
+  }
+}
+
+
+
+void Frame::Type::_init_jay(Methods& mm) {
+  ADD_METHOD(mm, &Frame::to_jay, args_to_jay);
+}
+
+
+} // namespace py

--- a/c/jay/save_jay.cc
+++ b/c/jay/save_jay.cc
@@ -14,8 +14,6 @@
 #include "datatable.h"
 #include "writebuf.h"
 
-void init_jay();  // called once from datatablemodule.c
-
 using WritableBufferPtr = std::unique_ptr<WritableBuffer>;
 static jay::Type stype_to_jaytype[DT_STYPES_COUNT];
 static flatbuffers::Offset<jay::Column> column_to_jay(
@@ -178,19 +176,6 @@ static flatbuffers::Offset<jay::Column> column_to_jay(
 // Helpers
 //------------------------------------------------------------------------------
 
-void init_jay() {
-  stype_to_jaytype[int(SType::BOOL)]    = jay::Type_Bool8;
-  stype_to_jaytype[int(SType::INT8)]    = jay::Type_Int8;
-  stype_to_jaytype[int(SType::INT16)]   = jay::Type_Int16;
-  stype_to_jaytype[int(SType::INT32)]   = jay::Type_Int32;
-  stype_to_jaytype[int(SType::INT64)]   = jay::Type_Int64;
-  stype_to_jaytype[int(SType::FLOAT32)] = jay::Type_Float32;
-  stype_to_jaytype[int(SType::FLOAT64)] = jay::Type_Float64;
-  stype_to_jaytype[int(SType::STR32)]   = jay::Type_Str32;
-  stype_to_jaytype[int(SType::STR64)]   = jay::Type_Str64;
-}
-
-
 static jay::Buffer saveMemoryRange(
     const MemoryRange* mbuf, WritableBuffer* wb)
 {
@@ -294,6 +279,16 @@ oobj Frame::to_jay(const PKArgs& args) {
 
 void Frame::Type::_init_jay(Methods& mm) {
   ADD_METHOD(mm, &Frame::to_jay, args_to_jay);
+
+  stype_to_jaytype[int(SType::BOOL)]    = jay::Type_Bool8;
+  stype_to_jaytype[int(SType::INT8)]    = jay::Type_Int8;
+  stype_to_jaytype[int(SType::INT16)]   = jay::Type_Int16;
+  stype_to_jaytype[int(SType::INT32)]   = jay::Type_Int32;
+  stype_to_jaytype[int(SType::INT64)]   = jay::Type_Int64;
+  stype_to_jaytype[int(SType::FLOAT32)] = jay::Type_Float32;
+  stype_to_jaytype[int(SType::FLOAT64)] = jay::Type_Float64;
+  stype_to_jaytype[int(SType::STR32)]   = jay::Type_Str32;
+  stype_to_jaytype[int(SType::STR64)]   = jay::Type_Str64;
 }
 
 

--- a/c/py_datatable.cc
+++ b/c/py_datatable.cc
@@ -188,31 +188,6 @@ PyObject* materialize(obj* self, PyObject*) {
 
 
 
-PyObject* save_jay(obj* self, PyObject* args) {
-  DataTable* dt = self->ref;
-  PyObject* arg1;
-  PyObject* arg2;
-  if (!PyArg_ParseTuple(args, "OO:save_jay", &arg1, &arg2))
-    return nullptr;
-
-  auto filename = py::robj(arg1).to_string();
-  auto strategy = py::robj(arg2).to_string();
-  auto sstrategy = (strategy == "mmap")  ? WritableBuffer::Strategy::Mmap :
-                   (strategy == "write") ? WritableBuffer::Strategy::Write :
-                                           WritableBuffer::Strategy::Auto;
-  if (!filename.empty()) {
-    dt->save_jay(filename, sstrategy);
-    Py_RETURN_NONE;
-  } else {
-    MemoryRange mr = dt->save_jay();
-    auto data = static_cast<const char*>(mr.xptr());
-    auto size = static_cast<Py_ssize_t>(mr.size());
-    return PyBytes_FromStringAndSize(data, size);
-  }
-}
-
-
-
 //------------------------------------------------------------------------------
 // Misc
 //------------------------------------------------------------------------------
@@ -238,7 +213,6 @@ static PyMethodDef datatable_methods[] = {
   METHOD0(check),
   METHODv(column),
   METHOD0(materialize),
-  METHODv(save_jay),
   {nullptr, nullptr, 0, nullptr}           /* sentinel */
 };
 

--- a/c/py_datatable.h
+++ b/c/py_datatable.h
@@ -94,11 +94,6 @@ DECLARE_METHOD(
   "materialize()\n\n"
   "Convert DataTable from 'view' into 'data' representation.\n")
 
-DECLARE_METHOD(
-  save_jay,
-  "save_jay(file, colnames)\n\n"
-  "Save DataTable into a .jay file.\n")
-
 
 };
 #undef BASECLS

--- a/c/writebuf.h
+++ b/c/writebuf.h
@@ -24,7 +24,7 @@ protected:
   size_t bytes_written;
 
 public:
-  enum class Strategy : int8_t { Auto, Mmap, Write };
+  enum class Strategy : int8_t { Unknown, Auto, Mmap, Write };
 
   WritableBuffer();
   virtual ~WritableBuffer();

--- a/datatable/__init__.py
+++ b/datatable/__init__.py
@@ -29,7 +29,7 @@ from .lib._datatable import (
     unique, union, intersect, setdiff, symdiff,
     repeat, by, join, sort, cbind, rbind
 )
-from .nff import save, open
+from .nff import open
 from .options import options
 from .str import split_into_nhot
 from .types import stype, ltype

--- a/datatable/expr/isna_expr.py
+++ b/datatable/expr/isna_expr.py
@@ -8,8 +8,7 @@ import math
 from .base_expr import BaseExpr
 from .dtproxy import f
 from .unary_expr import unary_op_codes, baseexpr_opcodes
-from ..utils.typechecks import TTypeError, Frame_t, is_type
-from ..types import stype
+from ..utils.typechecks import TTypeError
 from datatable.lib import core
 
 __all__ = ("isna", )
@@ -37,7 +36,7 @@ class Isna(BaseExpr):
 def isna(x):
     if isinstance(x, BaseExpr):
         return Isna(x)
-    if is_type(x, Frame_t):
+    if isinstance(x, core.Frame):
         if x.ncols != 1:
             raise TTypeError("Frame must have a single column")
         return x[:, isna(f[0])]

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -165,9 +165,11 @@ class Frame(core.Frame):
             category=FutureWarning)
         if format == "jay":
             return self.to_jay(path, _strategy=_strategy)
+        elif format == "nff":
+            from datatable.nff import save_nff
+            return save_nff(self, path, _strategy=_strategy)
         else:
-            from datatable.nff import save
-            return save(self, path, format=format, _strategy=_strategy)
+            raise ValueError("Unknown `format` value: %s" % format)
 
 
 

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -26,8 +26,6 @@ import time
 import warnings
 
 from datatable.lib import core
-from datatable.nff import save as dt_save
-from datatable.utils.typechecks import (TTypeError, TValueError)
 from datatable.options import options
 
 __all__ = ("Frame", )
@@ -45,9 +43,6 @@ class Frame(core.Frame):
 
     This is a primary data structure for datatable module.
     """
-
-    # Methods defined externally
-    save = dt_save
 
     def sort(self, *cols):
         """
@@ -163,6 +158,17 @@ class Frame(core.Frame):
             print("Time taken: %d ms" % (1000 * (time.time() - time0)))
         return res
 
+    def save(self, path, format="jay", _strategy="auto"):
+        warnings.warn(
+            "Method `Frame.save()` is deprecated (will be removed in "
+            "0.10.0), please use `Frame.to_jay()` instead",
+            category=FutureWarning)
+        if format == "jay":
+            return self.to_jay(path, _strategy=_strategy)
+        else:
+            from datatable.nff import save
+            return save(self, path, format=format, _strategy=_strategy)
+
 
 
 
@@ -170,8 +176,6 @@ class Frame(core.Frame):
 # Global settings
 #-------------------------------------------------------------------------------
 
-core._register_function(4, TTypeError)
-core._register_function(5, TValueError)
 core._register_function(7, Frame)
 core._install_buffer_hooks(Frame())
 

--- a/datatable/nff.py
+++ b/datatable/nff.py
@@ -21,31 +21,20 @@ def _stringify(x):
     return str(x)
 
 
-def save(self, dest=None, format="jay", _strategy="auto"):
+def save_nff(self, dest, _strategy="auto"):
     """
     Save Frame in binary NFF/Jay format.
 
     :param dest: destination where the Frame should be saved.
-    :param format: either "nff" or "jay"
     :param _strategy: one of "mmap", "write" or "auto"
     """
-    if dest is None:
-        return self.internal.save_jay(None, None)
     if _strategy not in ("auto", "write", "mmap"):
         raise TValueError("Invalid parameter _strategy: only 'write' / 'mmap' "
                           "/ 'auto' are allowed")
-    if format not in ("nff", "jay"):
-        raise TValueError("Invalid parameter `format`: only 'nff' or 'jay' "
-                          "are supported")
-    dest = os.path.expanduser(dest)
-    if os.path.exists(dest):
-        pass
-    elif format == "nff":
-        os.makedirs(dest)
 
-    if format == "jay":
-        self.internal.save_jay(dest, _strategy)
-        return
+    dest = os.path.expanduser(dest)
+    if not os.path.exists(dest):
+        os.makedirs(dest)
 
     self.materialize()
     mins = self.min().to_list()

--- a/datatable/nff.py
+++ b/datatable/nff.py
@@ -9,8 +9,6 @@ import re
 
 import datatable as dt
 from datatable.lib import core
-# from datatable.fread import Frame
-# from datatable.fread import fread
 from datatable.utils.typechecks import TTypeError, TValueError, dtwarn
 
 _builtin_open = open

--- a/datatable/utils/typechecks.py
+++ b/datatable/utils/typechecks.py
@@ -35,33 +35,6 @@ TImportError.__qualname__ = "ImportError"
 TImportError.__name__ = "ImportError"
 
 
-class _LazyClass(typesentry.MagicType):
-    def __init__(self, module, symbol):
-        self._module = module
-        self._symbol = symbol
-        self._checker = None
-
-    def name(self):
-        if self._module == "datatable":
-            return self._symbol
-        else:
-            return self._module + "." + self._symbol
-
-    def check(self, var):
-        if self._module in sys.modules:
-            mod = sys.modules[self._module]
-            cls = getattr(mod, self._symbol, tuple())
-            return isinstance(var, cls)
-        return False
-
-
-Frame_t = _LazyClass("datatable", "Frame")
-PandasDataFrame_t = _LazyClass("pandas", "DataFrame")
-PandasSeries_t = _LazyClass("pandas", "Series")
-NumpyArray_t = _LazyClass("numpy", "ndarray")
-NumpyMaskedArray_t = _LazyClass("numpy.ma", "MaskedArray")
-
-
 
 #-------------------------------------------------------------------------------
 # Warnings
@@ -93,4 +66,4 @@ core._register_function(6, DatatableWarning)
 
 
 __all__ = ("typed", "is_type", "U", "TTypeError", "TValueError", "TImportError",
-           "Frame_t", "NumpyArray_t", "DatatableWarning", "dtwarn", "name_type")
+           "DatatableWarning", "dtwarn", "name_type")

--- a/datatable/utils/typechecks.py
+++ b/datatable/utils/typechecks.py
@@ -62,6 +62,8 @@ def _showwarning(message, category, filename, lineno, file=None, line=None):
 _default_warnings_hoook = warnings.showwarning
 warnings.showwarning = _showwarning
 
+core._register_function(4, TTypeError)
+core._register_function(5, TValueError)
 core._register_function(6, DatatableWarning)
 
 

--- a/docs/quick-start.rst
+++ b/docs/quick-start.rst
@@ -305,4 +305,4 @@ list of values; or a list of rows, where each row is a tuple of values::
 You can also save a frame into a CSV file, or into a binary .jay file::
 
     DT.to_csv("out.csv")
-    DT.save("data.jay")
+    DT.to_jay("data.jay")

--- a/docs/using-datatable.rst
+++ b/docs/using-datatable.rst
@@ -155,7 +155,7 @@ Save a Frame into a binary format on disk, then open it later instantly, regardl
 
 ::
 
-   df.save("out.jay")
+   df.to_jay("out.jay")
    df2 = dt.open("out.jay")
 
 Basic Frame Properties

--- a/tests/munging/test_dt_rows.py
+++ b/tests/munging/test_dt_rows.py
@@ -888,7 +888,7 @@ def test_issue689(tempfile):
     n = 300000  # Must be > 65536
     data = [i % 8 for i in range(n)]
     d0 = dt.Frame(data, names=["A"])
-    d0.save(tempfile)
+    d0.to_jay(tempfile)
     del d0
     d1 = dt.open(tempfile)
     # Do not check d1! we want it to be lazy at this point

--- a/tests/munging/test_rbind.py
+++ b/tests/munging/test_rbind.py
@@ -263,7 +263,7 @@ def test_rbind_self():
 
 def test_rbind_mmapped(tempfile):
     dt0 = dt.Frame({"A": [1, 5, 7], "B": ["one", "two", None]})
-    dt0.save(tempfile)
+    dt0.to_jay(tempfile)
     del dt0
     dt1 = dt.open(tempfile)
     dt2 = dt.Frame({"A": [-1], "B": ["zero"]})

--- a/tests/test_dt_sort.py
+++ b/tests/test_dt_sort.py
@@ -802,8 +802,6 @@ def test_sort_random_multi(seed):
     sorted_data = [[col[j] for j in order] for col in data]
     d0 = dt.Frame(data, names=list("ABCDEF"))
     d0.internal.check()
-    # d0.save("multi.jay", format="jay")
-    # dt.Frame(sorted_data).save("test.jay", format="jay")
     d1 = d0.sort("B", "C", "D")
     assert d1.to_list() == sorted_data
 
@@ -908,7 +906,7 @@ def test_sort_expr():
 
 def test_h2oai7014(tempfile):
     data = dt.Frame([[None, 't'], [3580, 1047]], names=["ID", "count"])
-    data.save(tempfile)
+    data.to_jay(tempfile)
     # The data has to be opened from file
     counts = dt.open(tempfile)
     counts = counts[1:, :]

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -147,7 +147,7 @@ def test_key_save(tempfile):
     dt0 = dt.Frame(D=range(6), A=[3, 7, 5, 2, 2, 3], B=[1, 2, 2, 3, 4, 4])
     dt0.key = ["A", "B"]
     dt0.internal.check()
-    dt0.save(tempfile, format="jay")
+    dt0.to_jay(tempfile)
     dt1 = dt.open(tempfile)
     assert dt1.key == ("A", "B")
     dt1.internal.check()

--- a/tests/test_nff.py
+++ b/tests/test_nff.py
@@ -43,7 +43,8 @@ def test_save_and_load():
     dt0 = dt.Frame({"A": [1, 7, 100, 12],
                     "B": [True, None, False, None],
                     "C": ["alpha", "beta", None, "delta"]})
-    dt0.save(dir1, format="nff")
+    with pytest.warns(FutureWarning):
+        dt0.save(dir1, format="nff")
     dt1 = dt.open(dir1)
     assert_equals(dt0, dt1)
     shutil.rmtree(dir1)
@@ -56,7 +57,8 @@ def test_empty_string_col():
     """
     dir1 = tempfile.mkdtemp()
     dt0 = dt.Frame([[1, 2, 3], ["", "", ""]])
-    dt0.save(dir1, format="nff")
+    with pytest.warns(FutureWarning):
+        dt0.save(dir1, format="nff")
     dt1 = dt.open(dir1)
     assert_equals(dt0, dt1)
     shutil.rmtree(dir1)
@@ -67,7 +69,8 @@ def test_issue627():
     dir1 = tempfile.mkdtemp()
     dt0 = dt.Frame({"py": [1], "ру": [2], "рy": [3], "pу": [4]})
     assert dt0.shape == (1, 4)
-    dt0.save(dir1, format="nff")
+    with pytest.warns(FutureWarning):
+        dt0.save(dir1, format="nff")
     dt1 = dt.open(dir1)
     assert_equals(dt0, dt1)
     shutil.rmtree(dir1)
@@ -82,8 +85,9 @@ def test_obj_columns(tempdir):
     assert d0.shape == (4, 2)
     with pytest.warns(DatatableWarning) as ws:
         d0.save(tempdir, format="nff")
-    assert len(ws) == 1
-    assert "Column 'B' of type obj64 was not saved" in ws[0].message.args[0]
+    assert len(ws) == 2
+    assert "Method `Frame.save()` is deprecated" in ws[0].message.args[0]
+    assert "Column 'B' of type obj64 was not saved" in ws[1].message.args[0]
     del d0
     d1 = dt.open(tempdir)
     d1.internal.check()
@@ -97,7 +101,8 @@ def test_save_view(tempdir):
     dt1 = dt0.sort(0)
     assert dt1.internal.isview
     dt1.internal.check()
-    dt1.save(tempdir, format="nff")
+    with pytest.warns(FutureWarning):
+        dt1.save(tempdir, format="nff")
     dt2 = dt.open(tempdir)
     assert not dt2.internal.isview
     dt2.internal.check()
@@ -114,7 +119,7 @@ def test_jay_simple(tempfile):
     dt0 = dt.Frame({"A": [-1, 7, 10000, 12],
                     "B": [True, None, False, None],
                     "C": ["alpha", "beta", None, "delta"]})
-    dt0.save(tempfile, format="jay")
+    dt0.to_jay(tempfile)
     assert os.path.isfile(tempfile)
     with open(tempfile, "rb") as inp:
         assert inp.read(8) == b"JAY1\x00\x00\x00\x00"
@@ -124,7 +129,7 @@ def test_jay_simple(tempfile):
 
 def test_jay_empty_string_col(tempfile):
     dt0 = dt.Frame([[1, 2, 3], ["", "", ""]], names=["hogs", "warts"])
-    dt0.save(tempfile)
+    dt0.to_jay(tempfile)
     assert os.path.isfile(tempfile)
     dt1 = dt.open(tempfile)
     assert_equals(dt0, dt1)
@@ -137,7 +142,7 @@ def test_jay_view(tempfile, seed):
     dt0 = dt.Frame({"values": src})
     dt1 = dt0.sort(0)
     assert dt1.internal.isview
-    dt1.save(tempfile)
+    dt1.to_jay(tempfile)
     assert os.path.isfile(tempfile)
     dt2 = dt.open(tempfile)
     assert not dt2.internal.isview
@@ -151,7 +156,7 @@ def test_jay_view(tempfile, seed):
 def test_jay_unicode_names(tempfile):
     dt0 = dt.Frame({"py": [1], "ру": [2], "рy": [3], "pу": [4]})
     assert len(set(dt0.names)) == 4
-    dt0.save(tempfile)
+    dt0.to_jay(tempfile)
     assert os.path.isfile(tempfile)
     dt1 = dt.open(tempfile)
     assert dt0.names == dt1.names
@@ -164,7 +169,7 @@ def test_jay_object_columns(tempfile):
     d0 = dt.Frame([src1, src2], names=["A", "B"])
     assert d0.stypes == (dt.int8, dt.obj64)
     with pytest.warns(DatatableWarning) as ws:
-        d0.save(tempfile)
+        d0.to_jay(tempfile)
     assert len(ws) == 1
     assert "Column `B` of type obj64 was not saved" in ws[0].message.args[0]
     d1 = dt.open(tempfile)
@@ -175,7 +180,7 @@ def test_jay_object_columns(tempfile):
 
 def test_jay_empty_frame(tempfile):
     d0 = dt.Frame()
-    d0.save(tempfile)
+    d0.to_jay(tempfile)
     assert os.path.isfile(tempfile)
     d1 = dt.open(tempfile)
     assert d1.shape == (0, 0)
@@ -201,7 +206,7 @@ def test_jay_all_types(tempfile):
     noop(d0.min())
     noop(d0.max())
     assert len(set(d0.stypes)) == d0.ncols
-    d0.save(tempfile)
+    d0.to_jay(tempfile)
     assert os.path.isfile(tempfile)
     d1 = dt.open(tempfile)
     assert_equals(d0, d1)
@@ -214,7 +219,7 @@ def test_jay_keys(tempfile):
     assert len(d0.key) == 1
     assert d0.to_list() == [["ab", "aop", "cd", "coo", "eee"],
                             [1, 5, 2, 4, 3]]
-    d0.save(tempfile)
+    d0.to_jay(tempfile)
     d1 = dt.open(tempfile)
     assert d1.key == ("x",)
     assert_equals(d0, d1)


### PR DESCRIPTION
- Method `Frame.save()` renamed into `Frame.to_jay()`;
- The old method name is deprecated, together with the NFF format (unless we find a compelling reason to keep NFF around);
- The C++ code for `.to_jay()` refactored.

WIP for #1066