### PR TITLE
re_match() function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Method `.len()` can be applied to a string column to obtain the lengths
   of strings in each row.
 
+- Method `.re_match(re)` applies to a string column, and produces boolean
+  indicator whether each value matches the regular expression `re` or not.
+  The method matches the entire string, not just the beginning. Thus, it
+  most closely resembles Python function `re.fullmatch()`.
+
 
 ### Fixed
 

--- a/c/expr/base_expr.cc
+++ b/c/expr/base_expr.cc
@@ -657,6 +657,14 @@ void py::base_expr::m__init__(py::PKArgs& args) {
       expr = new dt::expr_reduce_nullary(op);
       break;
     }
+    case dt::exprCode::STRINGFN: {
+      check_args_count(va, 3);
+      size_t op = va[0].to_size_t();
+      dt::base_expr* arg = to_base_expr(va[1]);
+      oobj params = va[2];
+      expr = dt::expr_string_fn(op, arg, params);
+      break;
+    }
   }
 }
 

--- a/c/expr/base_expr.h
+++ b/c/expr/base_expr.h
@@ -36,6 +36,7 @@ enum exprCode : size_t {
   CAST     = 5,
   UNREDUCE = 6,
   NUREDUCE = 7,
+  STRINGFN = 8,
 };
 
 enum class biop : size_t {
@@ -68,6 +69,10 @@ enum class unop : size_t {
   LOGE   = 7,
   LOG10  = 8,
   LEN    = 9,
+};
+
+enum class strop : size_t {
+  RE_MATCH = 1,
 };
 
 class base_expr;
@@ -111,8 +116,11 @@ class expr_column : public base_expr {
 };
 
 
+base_expr* expr_string_fn(size_t op, base_expr* arg, py::oobj params);
 
-}
+
+
+}  // namespace dt
 namespace py {
 
 

--- a/c/expr/string_expr.cc
+++ b/c/expr/string_expr.cc
@@ -25,6 +25,18 @@
 
 namespace dt {
 
+static Error translate_exception(const std::regex_error& e) {
+  auto ret = ValueError() << "Invalid regular expression: ";
+  const char* desc = e.what();
+  if (std::memcmp(desc, "The expression ", 15) == 0) {
+    ret << "it " << desc + 15;
+  } else {
+    ret << desc;
+  }
+  return ret;
+}
+
+
 
 //------------------------------------------------------------------------------
 // re_match()
@@ -71,7 +83,7 @@ expr_string_match_re::expr_string_match_re(base_expr* expr, py::oobj params) {
   try {
     regex = std::regex(pattern, std::regex::nosubs);
   } catch (const std::regex_error& e) {
-    throw ValueError() << "Invalid regular expression: " << e.what();
+    throw translate_exception(e);
   }
 }
 

--- a/c/expr/string_expr.cc
+++ b/c/expr/string_expr.cc
@@ -1,0 +1,146 @@
+//------------------------------------------------------------------------------
+// Copyright 2018 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#include <regex>
+#include "expr/base_expr.h"
+#include "utils/exceptions.h"
+
+namespace dt {
+
+
+//------------------------------------------------------------------------------
+// re_match()
+//------------------------------------------------------------------------------
+
+class expr_string_match_re : public base_expr {
+  private:
+    base_expr* arg;
+    std::string pattern;
+    std::regex regex;
+    // int flags;
+
+  public:
+    expr_string_match_re(base_expr* expr, py::oobj params);
+    SType resolve(const workframe& wf) override;
+    GroupbyMode get_groupby_mode(const workframe&) const override;
+    Column* evaluate_eager(workframe& wf) override;
+
+  private:
+    template <typename T>
+    Column* _compute(Column* src);
+};
+
+
+expr_string_match_re::expr_string_match_re(base_expr* expr, py::oobj params) {
+  arg = expr;
+  py::otuple tp = params.to_otuple();
+  xassert(tp.size() == 2);
+
+  // Pattern
+  py::oobj pattern_arg = tp[0];
+  if (pattern_arg.is_string()) {
+    pattern = pattern_arg.to_string();
+  } else if (pattern_arg.has_attr("pattern")) {
+    pattern = pattern_arg.get_attr("pattern").to_string();
+  } else {
+    throw TypeError() << "Parameter `pattern` in .match_re() should be "
+        "a string, instead got " << pattern_arg.typeobj();
+  }
+
+  // Flags (ignore for now)
+  // py::oobj flags_arg = tp[1];
+
+  try {
+    regex = std::regex(pattern, std::regex::nosubs);
+  } catch (const std::regex_error& e) {
+    throw ValueError() << "Invalid regular expression: " << e.what();
+  }
+}
+
+
+SType expr_string_match_re::resolve(const workframe& wf) {
+  SType arg_stype = arg->resolve(wf);
+  if (!(arg_stype == SType::STR32 || arg_stype == SType::STR64)) {
+    throw TypeError() << "Method `.re_match()` cannot be applied to a "
+        "column of type " << arg_stype;
+  }
+  return SType::BOOL;
+}
+
+
+GroupbyMode expr_string_match_re::get_groupby_mode(const workframe& wf) const {
+  return arg->get_groupby_mode(wf);
+}
+
+
+Column* expr_string_match_re::evaluate_eager(workframe& wf) {
+  Column* arg_res = arg->evaluate_eager(wf);
+  SType arg_stype = arg_res->stype();
+  xassert(arg_stype == SType::STR32 || arg_stype == SType::STR64);
+  return arg_stype == SType::STR32? _compute<uint32_t>(arg_res)
+                                  : _compute<uint64_t>(arg_res);
+}
+
+
+template <typename T>
+Column* expr_string_match_re::_compute(Column* src) {
+  auto ssrc = dynamic_cast<StringColumn<T>*>(src);
+  size_t nrows = ssrc->nrows;
+  RowIndex src_rowindex = ssrc->rowindex();
+  const char* src_strdata = ssrc->strdata();
+  const T* src_offsets = ssrc->offsets();
+
+  auto trg = new BoolColumn(nrows);
+  int8_t* trg_data = static_cast<int8_t*>(trg->data_w());
+
+  #pragma omp parallel for schedule(dynamic)
+  for (size_t i = 0; i < nrows; ++i) {
+    size_t j = src_rowindex[i];
+    T start = src_offsets[j - 1] & ~GETNA<T>();
+    T end = src_offsets[j];
+    if (ISNA<T>(end)) {
+      trg_data[i] = GETNA<int8_t>();
+      continue;
+    }
+    bool res = std::regex_match(src_strdata + start,
+                                src_strdata + end,
+                                regex);
+    trg_data[i] = res;
+  }
+  return trg;
+}
+
+
+
+
+//------------------------------------------------------------------------------
+// Factory function
+//------------------------------------------------------------------------------
+
+base_expr* expr_string_fn(size_t op, base_expr* arg, py::oobj params) {
+  switch (static_cast<strop>(op)) {
+    case strop::RE_MATCH: return new expr_string_match_re(arg, params);
+  }
+}
+
+
+
+} // namespace dt

--- a/datatable/__init__.py
+++ b/datatable/__init__.py
@@ -45,7 +45,7 @@ except ImportError:
 
 __all__ = ("__version__", "__git_revision__",
            "Frame", "max", "mean", "min", "open", "sd", "sum", "count", "first",
-           "isna", "fread", "GenericReader", "save", "stype", "ltype", "f", "g",
+           "isna", "fread", "GenericReader", "stype", "ltype", "f", "g",
            "join", "by", "abs", "exp", "log", "log10",
            "TypeError", "ValueError", "DatatableWarning", "FreadWarning",
            "DataTable", "options",

--- a/datatable/expr/base_expr.py
+++ b/datatable/expr/base_expr.py
@@ -184,8 +184,15 @@ class BaseExpr:
         """Unary plus (no-op)."""
         return datatable.expr.UnaryOpExpr("+", self)
 
+
+    #----- String functions ----------------------------------------------------
+
     def len(self):
         return datatable.expr.UnaryOpExpr("len", self)
+
+    def re_match(self, pattern, flags=None):
+        return datatable.expr.StringExpr("re_match", self, pattern, flags)
+
 
 
     #----- Code generation -----------------------------------------------------

--- a/datatable/expr/string_expr.py
+++ b/datatable/expr/string_expr.py
@@ -20,41 +20,34 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 #-------------------------------------------------------------------------------
-
-from .abs_expr import abs
 from .base_expr import BaseExpr
-from .binary_expr import BinaryOpExpr
-from .cast_expr import CastExpr
-from .column_expr import ColSelectorExpr, NewColumnExpr
-from .dtproxy import f, g
-from .exp_expr import exp, log, log10
-from .literal_expr import LiteralExpr
-from .reduce_expr import ReduceExpr, sum, count, first, mean, min, max, sd
-from .relop_expr import RelationalOpExpr
-from .string_expr import StringExpr
-from .unary_expr import UnaryOpExpr, isna
+# from datatable.frame import Frame
+from datatable.lib import core
 
-__all__ = (
-    "abs",
-    "count",
-    "exp",
-    "f",
-    "first",
-    "isna",
-    "log",
-    "log10",
-    "max",
-    "mean",
-    "min",
-    "sd",
-    "sum",
-    "BinaryOpExpr",
-    "CastExpr",
-    "ColSelectorExpr",
-    "NewColumnExpr",
-    "BaseExpr",
-    "LiteralExpr",
-    "ReduceExpr",
-    "RelationalOpExpr",
-    "UnaryOpExpr",
-)
+# See "c/expr/base_expr.h"
+BASEEXPR_OPCODE_STRINGFN = 8
+
+
+
+class StringExpr(BaseExpr):
+    __slots__ = ["_op", "_expr", "_params"]
+
+    def __init__(self, opcode, expr, *args):
+        super().__init__()
+        self._op = opcode
+        self._expr = expr
+        self._params = args
+
+    def __str__(self):
+        return "%s(%s, %r)" % (self._op, self._expr, self._params)
+
+    def _core(self):
+        return core.base_expr(BASEEXPR_OPCODE_STRINGFN,
+                              string_opcodes[self._op],
+                              self._expr._core(),
+                              self._params)
+
+
+string_opcodes = {
+    "re_match": 1,
+}

--- a/tests/munging/test_str.py
+++ b/tests/munging/test_str.py
@@ -17,8 +17,9 @@
 import datatable as dt
 import pytest
 import random
+import re
 from datatable import stype, f
-from tests import noop
+from tests import noop, random_string
 
 
 #-------------------------------------------------------------------------------
@@ -164,3 +165,84 @@ def test_len_wrong_col():
         noop(f0[:, f[0].len()])
     assert ("Unary operator `len` cannot be applied to a column with stype "
             "`int32`" == str(e.value))
+
+
+
+#-------------------------------------------------------------------------------
+# re_match()
+#-------------------------------------------------------------------------------
+
+def test_re_match():
+    f0 = dt.Frame(A=["abc", "abd", "cab", "acc", None, "aaa"])
+    f1 = f0[:, f.A.re_match("ab.")]
+    assert f1.stypes == (dt.stype.bool8,)
+    assert f1.to_list() == [[True, True, False, False, None, False]]
+
+
+def test_re_match2():
+    # re_match() matches the entire string, not just the beginning...
+    f0 = dt.Frame(A=["a", "ab", "abc", "aaaa"])
+    f1 = f0[:, f.A.re_match("a.?")]
+    assert f1.stypes == (dt.stype.bool8,)
+    assert f1.to_list() == [[True, True, False, False]]
+
+
+def test_re_match_ignore_groups():
+    # Groups within the regular expression ought to be ignored
+    f0 = dt.Frame(list("abcdibaldfn"))
+    f1 = f0[f[0].re_match("([a-c]+)"), :]
+    assert f1.to_list() == [["a", "b", "c", "b", "a"]]
+
+
+def test_re_match_bad_regex1():
+    with pytest.raises(ValueError) as e:
+        noop(dt.Frame(["abc"])[f.A.re_match("(."), :])
+    assert ("Invalid regular expression: it contained mismatched ( and )"
+            in str(e.value))
+
+
+def test_re_match_bad_regex2():
+    with pytest.raises(ValueError) as e:
+        noop(dt.Frame(["abc"])[f.A.re_match("\\j"), :])
+    assert ("Invalid regular expression: it contained an invalid escaped "
+            "character, or a trailing escape"
+            in str(e.value))
+
+
+def test_re_match_bad_regex3():
+    with pytest.raises(ValueError) as e:
+        noop(dt.Frame(["abc"])[f.A.re_match("???"), :])
+    assert ("Invalid regular expression: One of *?+{ was not preceded by a "
+            "valid regular expression"
+            in str(e.value))
+
+
+@pytest.mark.parametrize("seed", [random.getrandbits(32) for _ in range(5)])
+def test_re_match_random(seed):
+    random.seed(seed)
+    n = int(random.expovariate(0.001) + 100)
+    k = random.randint(2, 12)
+    random_re = ""
+    random_len = 0
+    while random_len < k:
+        t = random.random()
+        if t < 0.4:
+            random_re += "."
+        elif t < 0.6:
+            random_re += random.choice("abcdefgh")
+        elif t < 0.8:
+            random_re += ".*"
+            random_len += 3
+        else:
+            random_re += "\\w"
+        random_len += 1
+    random_rx = re.compile(random_re)
+
+    src = [random_string(k) for _ in range(n)]
+    frame = dt.Frame(A=src)
+    frame_res = frame[:, f.A.re_match(random_rx)]
+    assert frame_res.shape == (n, 1)
+
+    res = [bool(re.fullmatch(random_rx, s)) for s in src]
+    dtres = frame_res.to_list()[0]
+    assert res == dtres


### PR DESCRIPTION
Function `col.re_match(pattern)` can be applied to string columns and produce a boolean column indicating whether each string value matches the given pattern or not. The pattern must be either a string, or a compiled regular expression (however, there is no benefit in precompiling it, since we are not using python's code to match the regular expression).

This API is currently tentative, we may want to update it before the next release.

Closes #1684 