### PR TITLE
Prevent overflow when constructing str32 columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - A keyed frame will now be rendered correctly when viewing it in python
   console via `Frame.view()` (#1672).
 
+- Str32 column can no longer overflow during the `.replace()` operation,
+  or when converting from python, numpy or pandas, etc. In all these cases
+  we will now transparently create a Str64 column instead (#1694).
+
 
 ### Changed
 
@@ -86,7 +90,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
   [arno candel][] (#1619),
   [antorsae][] (#1639),
-  [pasha stetsenko][] (#1672)
+  [pasha stetsenko][] (#1672, #1694)
 
 
 

--- a/c/column.cc
+++ b/c/column.cc
@@ -127,19 +127,6 @@ Column* Column::new_mbuf_column(SType stype, MemoryRange&& mbuf) {
   return col;
 }
 
-Column* Column::new_mbuf_column(SType stype, MemoryRange&& mbuf,
-                                MemoryRange&& strbuf)
-{
-  Column* col = new_column(stype);
-  if (stype == SType::STR32 || stype == SType::STR64) {
-    col->replace_buffer(std::move(mbuf), std::move(strbuf));
-  } else {
-    xassert(!strbuf);
-    col->replace_buffer(std::move(mbuf));
-  }
-  return col;
-}
-
 
 
 void Column::replace_buffer(MemoryRange&&) {

--- a/c/column.h
+++ b/c/column.h
@@ -588,7 +588,6 @@ template <typename T> class StringColumn : public Column
 
 public:
   StringColumn(size_t nrows);
-  StringColumn(size_t nrows, MemoryRange&& offbuf, MemoryRange&& strbuf);
   void save_to_disk(const std::string& filename,
                     WritableBuffer::Strategy strategy) override;
   void replace_buffer(MemoryRange&&, MemoryRange&&) override;
@@ -623,6 +622,7 @@ public:
 
 protected:
   StringColumn();
+  StringColumn(size_t nrows, MemoryRange&& offbuf, MemoryRange&& strbuf);
   void init_data() override;
   void init_mmap(const std::string& filename) override;
   void open_mmap(const std::string& filename, bool recode) override;
@@ -647,8 +647,11 @@ protected:
 
   friend Column;
   friend FreadReader;  // friend Column* alloc_column(SType, size_t, int);
+  friend Column* new_string_column(size_t, MemoryRange&&, MemoryRange&&);
 };
 
+
+Column* new_string_column(size_t n, MemoryRange&& data, MemoryRange&& str);
 
 template <> void StringColumn<uint32_t>::cast_into(StringColumn<uint64_t>*) const;
 template <> void StringColumn<uint64_t>::cast_into(StringColumn<uint64_t>*) const;

--- a/c/column.h
+++ b/c/column.h
@@ -118,6 +118,10 @@ public:  // TODO: convert this into private
   size_t nrows;
 
 public:
+  static constexpr size_t MAX_STRING_SIZE = 0x7FFFFFFF;
+  static constexpr size_t MAX_STR32_BUFFER_SIZE = 0x7FFFFFFF;
+  static constexpr size_t MAX_STR32_NROWS = 0x7FFFFFFF;
+
   static Column* new_data_column(SType, size_t nrows);
   static Column* new_na_column(SType, size_t nrows);
   static Column* new_mmap_column(SType, size_t nrows, const std::string& filename);
@@ -125,7 +129,6 @@ public:
                                   bool recode = false);
   static Column* new_xbuf_column(SType, size_t nrows, Py_buffer* pybuffer);
   static Column* new_mbuf_column(SType, MemoryRange&&);
-  static Column* new_mbuf_column(SType, MemoryRange&&, MemoryRange&&);
   static Column* from_pylist(const py::olist& list, int stype0 = 0);
   static Column* from_pylist_of_tuples(const py::olist& list, size_t index, int stype0);
   static Column* from_pylist_of_dicts(const py::olist& list, py::robj name, int stype0);
@@ -643,15 +646,19 @@ protected:
   void cast_into(StringColumn<uint64_t>*) const override;
   void fill_na() override;
 
-  //int verify_meta_integrity(std::vector<char>*, int, const char* = "Column") const override;
-
   friend Column;
   friend FreadReader;  // friend Column* alloc_column(SType, size_t, int);
   friend Column* new_string_column(size_t, MemoryRange&&, MemoryRange&&);
 };
 
 
+/**
+ * Use this function to create a column from existing offsets & strdata.
+ * It will create either StringColumn<uint32_t>* or StringColumn<uint64_t>*
+ * depending on the size of the data.
+ */
 Column* new_string_column(size_t n, MemoryRange&& data, MemoryRange&& str);
+
 
 template <> void StringColumn<uint32_t>::cast_into(StringColumn<uint64_t>*) const;
 template <> void StringColumn<uint64_t>::cast_into(StringColumn<uint64_t>*) const;

--- a/c/column_bool.cc
+++ b/c/column_bool.cc
@@ -75,7 +75,7 @@ inline static MemoryRange cast_str_helper(
   for (size_t i = 0; i < src->nrows; ++i) {
     int8_t x = src_data[i];
     if (ISNA<int8_t>(x)) {
-      toffsets[i] = offset | GETNA<T>();
+      toffsets[i] = offset ^ GETNA<T>();
     } else {
       *ch++ = '0' + x;
       offset++;

--- a/c/column_from_pylist.cc
+++ b/c/column_from_pylist.cc
@@ -480,17 +480,18 @@ static bool parse_as_pyobj(const iterable* list, MemoryRange& membuf)
 // Parse controller
 //------------------------------------------------------------------------------
 
-static int find_next_stype(int curr_stype, int stype0) {
+static SType find_next_stype(SType curr_stype, int stype0) {
+  int istype = static_cast<int>(curr_stype);
   if (stype0 > 0) {
-    return stype0;
+    return static_cast<SType>(stype0);
   }
   if (stype0 < 0) {
-    return std::min(curr_stype + 1, -stype0);
+    return static_cast<SType>(std::min(istype + 1, -stype0));
   }
-  if (curr_stype == DT_STYPES_COUNT - 1) {
+  if (istype == DT_STYPES_COUNT - 1) {
     return curr_stype;
   }
-  return (curr_stype + 1) % int(DT_STYPES_COUNT);
+  return static_cast<SType>((istype + 1) % int(DT_STYPES_COUNT));
 }
 
 
@@ -500,12 +501,12 @@ Column* Column::from_py_iterable(const iterable* il, int stype0)
   MemoryRange membuf;
   MemoryRange strbuf;
   // TODO: Perhaps `stype` and `curr_stype` should have type SType ?
-  int stype = find_next_stype(0, stype0);
+  SType stype = find_next_stype(SType::VOID, stype0);
   size_t i = 0;
-  while (stype) {
-    int next_stype = find_next_stype(stype, stype0);
+  while (stype != SType::VOID) {
+    SType next_stype = find_next_stype(stype, stype0);
     if (stype == next_stype) {
-      switch (static_cast<SType>(stype)) {
+      switch (stype) {
         case SType::BOOL:    force_as_bool(il, membuf); break;
         case SType::INT8:    force_as_int<int8_t>(il, membuf); break;
         case SType::INT16:   force_as_int<int16_t>(il, membuf); break;
@@ -523,7 +524,7 @@ Column* Column::from_py_iterable(const iterable* il, int stype0)
       break; // while(stype)
     } else {
       bool ret = false;
-      switch (static_cast<SType>(stype)) {
+      switch (stype) {
         case SType::BOOL:    ret = parse_as_bool(il, membuf, i); break;
         case SType::INT8:    ret = parse_as_int<int8_t>(il, membuf, i); break;
         case SType::INT16:   ret = parse_as_int<int16_t>(il, membuf, i); break;
@@ -539,18 +540,16 @@ Column* Column::from_py_iterable(const iterable* il, int stype0)
       stype = next_stype;
     }
   }
-  Column* col = Column::new_column(static_cast<SType>(stype));
-  if (static_cast<SType>(stype) == SType::OBJ) {
-    membuf.set_pyobjects(/* clear_data = */ false);
+  if (stype == SType::STR32 || stype == SType::STR64) {
+    size_t nrows = il->size();
+    return new_string_column(nrows, std::move(membuf), std::move(strbuf));
   }
-  if (static_cast<SType>(stype) == SType::STR32 ||
-      static_cast<SType>(stype) == SType::STR64)
-  {
-    col->replace_buffer(std::move(membuf), std::move(strbuf));
-  } else {
-    col->replace_buffer(std::move(membuf));
+  else {
+    if (stype == SType::OBJ) {
+      membuf.set_pyobjects(/* clear_data = */ false);
+    }
+    return Column::new_mbuf_column(stype, std::move(membuf));
   }
-  return col;
 }
 
 

--- a/c/column_from_pylist.cc
+++ b/c/column_from_pylist.cc
@@ -335,7 +335,7 @@ static bool parse_as_str(const iterable* list, MemoryRange& offbuf,
     py::robj item = list->item(i);
 
     if (item.is_none()) {
-      offsets[i] = curr_offset | GETNA<T>();
+      offsets[i] = curr_offset ^ GETNA<T>();
       continue;
     }
     if (item.is_string()) {
@@ -411,7 +411,7 @@ static void force_as_str(const iterable* list, MemoryRange& offbuf,
     py::oobj item = list->item(i);
 
     if (item.is_none()) {
-      offsets[i] = curr_offset | GETNA<T>();
+      offsets[i] = curr_offset ^ GETNA<T>();
       continue;
     }
     if (!item.is_string()) {
@@ -425,7 +425,7 @@ static void force_as_str(const iterable* list, MemoryRange& offbuf,
         if (std::is_same<T, int32_t>::value &&
               (static_cast<int64_t>(tlen) != cstr.size ||
                next_offset < curr_offset)) {
-          offsets[i] = curr_offset | GETNA<T>();
+          offsets[i] = curr_offset ^ GETNA<T>();
           continue;
         }
         if (strbuf.size() < static_cast<size_t>(next_offset)) {
@@ -441,7 +441,7 @@ static void force_as_str(const iterable* list, MemoryRange& offbuf,
       offsets[i] = curr_offset;
       continue;
     } else {
-      offsets[i] = curr_offset | GETNA<T>();
+      offsets[i] = curr_offset ^ GETNA<T>();
     }
   }
   strbuf.resize(curr_offset);

--- a/c/column_int.cc
+++ b/c/column_int.cc
@@ -95,7 +95,7 @@ inline static MemoryRange cast_str_helper(
   for (size_t i = 0; i < nrows; ++i) {
     IT x = src[i];
     if (ISNA<IT>(x)) {
-      toffsets[i] = offset | GETNA<OT>();
+      toffsets[i] = offset ^ GETNA<OT>();
     } else {
       char* ch0 = ch;
       toa<IT>(&ch, x);

--- a/c/column_pyobj.cc
+++ b/c/column_pyobj.cc
@@ -125,7 +125,7 @@ inline static MemoryRange cast_str_helper(
       offset += static_cast<OT>(xcstr.size);
       toffsets[i] = offset;
     } else {
-      toffsets[i] = offset | GETNA<OT>();
+      toffsets[i] = offset ^ GETNA<OT>();
     }
   }
   wb->finalize();

--- a/c/column_real.cc
+++ b/c/column_real.cc
@@ -81,7 +81,7 @@ inline static MemoryRange cast_str_helper(
   for (size_t i = 0; i < src->nrows; ++i) {
     IT x = src_data[i];
     if (ISNA<IT>(x)) {
-      toffsets[i] = offset | GETNA<OT>();
+      toffsets[i] = offset ^ GETNA<OT>();
     } else {
       char* ch0 = ch;
       toa<IT>(&ch, x);

--- a/c/expr/repl_node.cc
+++ b/c/expr/repl_node.cc
@@ -366,12 +366,7 @@ colptr scalar_string_rn::make_column(SType st, size_t nrows) const {
   }
   MemoryRange strbuf = MemoryRange::mem(len);
   std::memcpy(strbuf.xptr(), value.data(), len);
-  Column* col = nullptr;
-  if (elemsize == 4) {
-    col = new StringColumn<uint32_t>(1, std::move(offbuf), std::move(strbuf));
-  } else {
-    col = new StringColumn<uint64_t>(1, std::move(offbuf), std::move(strbuf));
-  }
+  Column* col = new_string_column(1, std::move(offbuf), std::move(strbuf));
   col->replace_rowindex(RowIndex(size_t(0), nrows, 0));
   return colptr(col);
 }

--- a/c/frame/rbind.cc
+++ b/c/frame/rbind.cc
@@ -394,7 +394,7 @@ void StringColumn<T>::rbind_impl(std::vector<const Column*>& columns,
       rows_to_fill += col->nrows;
     } else {
       if (rows_to_fill) {
-        const T na = curr_offset | GETNA<T>();
+        const T na = curr_offset ^ GETNA<T>();
         set_value(offs, &na, sizeof(T), rows_to_fill);
         offs += rows_to_fill;
         rows_to_fill = 0;
@@ -416,7 +416,7 @@ void StringColumn<T>::rbind_impl(std::vector<const Column*>& columns,
     delete col;
   }
   if (rows_to_fill) {
-    const T na = curr_offset | GETNA<T>();
+    const T na = curr_offset ^ GETNA<T>();
     set_value(offs, &na, sizeof(T), rows_to_fill);
   }
 }

--- a/c/frame/replace.cc
+++ b/c/frame/replace.cc
@@ -569,6 +569,7 @@ void ReplaceAgent::process_str_column(size_t colidx) {
   }
   Column* newcol = replace_str<T>(x_str.size(), x_str.data(), y_str.data(),
                                   col);
+  columns_cast = (newcol->stype() != col->stype());
   dt->columns[colidx] = newcol;
   delete col;
 }

--- a/c/frame/stats.cc
+++ b/c/frame/stats.cc
@@ -57,7 +57,7 @@ static Column* _make_column_str(CString value) {
     mbuf.set_element<T>(0, 0);
     mbuf.set_element<T>(1, GETNA<T>());
   }
-  return new StringColumn<T>(1, std::move(mbuf), std::move(strbuf));
+  return new_string_column(1, std::move(mbuf), std::move(strbuf));
 }
 
 static Column* _nacol(Stats*, const Column* col) {

--- a/c/py_buffers.cc
+++ b/c/py_buffers.cc
@@ -175,8 +175,7 @@ static Column* convert_fwchararray_to_column(Py_buffer* view)
   }
 
   strbuf.resize(static_cast<size_t>(offset));
-  return new StringColumn<uint32_t>(nrows,
-                                    std::move(offbuf), std::move(strbuf));
+  return new_string_column(nrows, std::move(offbuf), std::move(strbuf));
 }
 
 
@@ -244,7 +243,7 @@ static Column* try_to_resolve_object_column(Column* col)
   xassert(offset < strbuf.size());
   strbuf.resize(offset);
   delete col;
-  return new StringColumn<uint32_t>(nrows, std::move(offbuf), std::move(strbuf));
+  return new_string_column(nrows, std::move(offbuf), std::move(strbuf));
 }
 
 

--- a/c/py_buffers.cc
+++ b/c/py_buffers.cc
@@ -224,7 +224,7 @@ static Column* try_to_resolve_object_column(Column* col)
   uint32_t offset = 0;
   for (size_t i = 0; i < nrows; ++i) {
     if (data[i] == Py_None) {
-      offsets[i] = offset | GETNA<uint32_t>();
+      offsets[i] = offset ^ GETNA<uint32_t>();
     } else {
       PyObject *z = PyUnicode_AsEncodedString(data[i], "utf-8", "strict");
       size_t sz = static_cast<size_t>(PyBytes_Size(z));

--- a/c/read/fread/fread_thread_context.cc
+++ b/c/read/fread/fread_thread_context.cc
@@ -277,7 +277,7 @@ void FreadThreadContext::postprocess() {
           coldata->str32.offset = output_offset;
         } else {
           xassert(coldata->str32.isna());
-          coldata->str32.offset = output_offset | GETNA<uint32_t>();
+          coldata->str32.offset = output_offset ^ GETNA<uint32_t>();
         }
         coldata += tbuf_ncols;
         xassert(output_offset <= sbuf.size());

--- a/c/wstringcol.cc
+++ b/c/wstringcol.cc
@@ -25,26 +25,59 @@ namespace dt {
 //------------------------------------------------------------------------------
 
 writable_string_col::writable_string_col(size_t nrows)
-  : strdata(new MemoryWritableBuffer(nrows)),
+  : strdata(nrows),
     offdata(MemoryRange::mem((nrows + 1) * sizeof(uint32_t))),
     n(nrows) {}
 
 
 Column* writable_string_col::to_column() && {
-  strdata->finalize();
+  strdata.finalize();
+  auto strbuf = strdata.get_mbuf();
   offdata.set_element<uint32_t>(0, 0);
-  return new StringColumn<uint32_t>(n, std::move(offdata), strdata->get_mbuf());
+  return new_string_column(n, std::move(offdata), std::move(strbuf));
+  /*
+  if (strbuf.size() <= MAX_STR32_BUFFER_SIZE && n <= MAX_STR32_NROWS) {
+    return new StringColumn<uint32_t>(n, std::move(offdata),
+                                      std::move(strbuf));
+  }
+  else {
+    // Offsets need to be recoded into uint64_t array
+    // TODO: this conversion can also be done in parallel, using
+    //
+    MemoryRange offsets64 = MemoryRange::mem(sizeof(uint64_t) * (n + 1));
+    auto data64 = static_cast<uint64_t*>(offsets64.xptr());
+    auto data32 = static_cast<const uint32_t*>(offdata.rptr());
+    uint64_t curr_offset = 0;
+    data64[0] = 0;
+    for (size_t i = 1; i <= n; ++i) {
+      uint32_t len = data32[i] - data32[i - 1];
+      if (len == GETNA<uint32_t>()) {
+        data64[i] = curr_offset | GETNA<uint64_t>();
+      } else {
+        curr_offset += len;
+        data64[i] = curr_offset;
+      }
+    }
+    xassert(curr_offset == strbuf.size());
+    return new StringColumn<uint64_t>(n, std::move(offsets64),
+                                      std::move(strbuf));
+  }
+  */
 }
 
+
+
+//------------------------------------------------------------------------------
+// writable_string_col::buffer
+//------------------------------------------------------------------------------
 
 writable_string_col::buffer::buffer(writable_string_col& s)
-  : col(s), strbuf(1024)
-{
-  strbuf_used = 0;
-  strbuf_write_pos = 0;
-  offptr = nullptr;
-  offptr0 = nullptr;
-}
+  : col(s),
+    strbuf(1024),
+    strbuf_used(0),
+    strbuf_write_pos(0),
+    offptr(nullptr),
+    offptr0(nullptr) {}
 
 
 void writable_string_col::buffer::write(const CString& str) {
@@ -56,13 +89,18 @@ void writable_string_col::buffer::write(const std::string& str) {
 }
 
 void writable_string_col::buffer::write(const char* ch, size_t len) {
+  // Note: `strbuf_used` may overflow during the conversion into uint32_t.
+  // If this happens, we would have to convert into STR64. It will be
+  // possible to restore the correct offsets, provided that no single string
+  // item exceeds MAX_ITEM_SIZE in size.
   if (ch) {
-    xassert(len < GETNA<uint32_t>());
+    xassert(len <= MAX_ITEM_SIZE);
     strbuf.ensuresize(strbuf_used + len);
     std::memcpy(strbuf.data() + strbuf_used, ch, len);
     strbuf_used += len;
     *offptr++ = static_cast<uint32_t>(strbuf_used);
   } else {
+    // Use XOR instead of OR in case the buffer overflows int32_t.
     *offptr++ = static_cast<uint32_t>(strbuf_used) ^ GETNA<uint32_t>();
   }
 }
@@ -73,12 +111,12 @@ void writable_string_col::buffer::write_na() {
 
 
 void writable_string_col::buffer::order() {
-  strbuf_write_pos = col.strdata->prep_write(strbuf_used, strbuf.data());
+  strbuf_write_pos = col.strdata.prep_write(strbuf_used, strbuf.data());
 }
 
 
 void writable_string_col::buffer::commit_and_start_new_chunk(size_t i0) {
-  col.strdata->write_at(strbuf_write_pos, strbuf_used, strbuf.data());
+  col.strdata.write_at(strbuf_write_pos, strbuf_used, strbuf.data());
   for (uint32_t* p = offptr0; p < offptr; ++p) {
     *p += strbuf_write_pos;
   }

--- a/c/wstringcol.cc
+++ b/c/wstringcol.cc
@@ -92,9 +92,9 @@ void writable_string_col::buffer::write(const char* ch, size_t len) {
   // Note: `strbuf_used` may overflow during the conversion into uint32_t.
   // If this happens, we would have to convert into STR64. It will be
   // possible to restore the correct offsets, provided that no single string
-  // item exceeds MAX_ITEM_SIZE in size.
+  // item exceeds MAX_STRING_SIZE in size.
   if (ch) {
-    xassert(len <= MAX_ITEM_SIZE);
+    xassert(len <= Column::MAX_STRING_SIZE);
     strbuf.ensuresize(strbuf_used + len);
     std::memcpy(strbuf.data() + strbuf_used, ch, len);
     strbuf_used += len;

--- a/c/wstringcol.cc
+++ b/c/wstringcol.cc
@@ -21,23 +21,23 @@ namespace dt {
 
 
 //------------------------------------------------------------------------------
-// fixed_height_string_col
+// writable_string_col
 //------------------------------------------------------------------------------
 
-fixed_height_string_col::fixed_height_string_col(size_t nrows)
+writable_string_col::writable_string_col(size_t nrows)
   : strdata(new MemoryWritableBuffer(nrows)),
     offdata(MemoryRange::mem((nrows + 1) * sizeof(uint32_t))),
     n(nrows) {}
 
 
-Column* fixed_height_string_col::to_column() && {
+Column* writable_string_col::to_column() && {
   strdata->finalize();
   offdata.set_element<uint32_t>(0, 0);
   return new StringColumn<uint32_t>(n, std::move(offdata), strdata->get_mbuf());
 }
 
 
-fixed_height_string_col::buffer::buffer(fixed_height_string_col& s)
+writable_string_col::buffer::buffer(writable_string_col& s)
   : col(s), strbuf(1024)
 {
   strbuf_used = 0;
@@ -47,36 +47,37 @@ fixed_height_string_col::buffer::buffer(fixed_height_string_col& s)
 }
 
 
-void fixed_height_string_col::buffer::write(const CString& str) {
+void writable_string_col::buffer::write(const CString& str) {
   write(str.ch, static_cast<size_t>(str.size));
 }
 
-void fixed_height_string_col::buffer::write(const std::string& str) {
+void writable_string_col::buffer::write(const std::string& str) {
   write(str.data(), str.size());
 }
 
-void fixed_height_string_col::buffer::write(const char* ch, size_t len) {
+void writable_string_col::buffer::write(const char* ch, size_t len) {
   if (ch) {
+    xassert(len < GETNA<uint32_t>());
     strbuf.ensuresize(strbuf_used + len);
     std::memcpy(strbuf.data() + strbuf_used, ch, len);
     strbuf_used += len;
     *offptr++ = static_cast<uint32_t>(strbuf_used);
   } else {
-    *offptr++ = static_cast<uint32_t>(strbuf_used) | GETNA<uint32_t>();
+    *offptr++ = static_cast<uint32_t>(strbuf_used) ^ GETNA<uint32_t>();
   }
 }
 
-void fixed_height_string_col::buffer::write_na() {
-  *offptr++ = static_cast<uint32_t>(strbuf_used) | GETNA<uint32_t>();
+void writable_string_col::buffer::write_na() {
+  *offptr++ = static_cast<uint32_t>(strbuf_used) ^ GETNA<uint32_t>();
 }
 
 
-void fixed_height_string_col::buffer::order() {
+void writable_string_col::buffer::order() {
   strbuf_write_pos = col.strdata->prep_write(strbuf_used, strbuf.data());
 }
 
 
-void fixed_height_string_col::buffer::commit_and_start_new_chunk(size_t i0) {
+void writable_string_col::buffer::commit_and_start_new_chunk(size_t i0) {
   col.strdata->write_at(strbuf_write_pos, strbuf_used, strbuf.data());
   for (uint32_t* p = offptr0; p < offptr; ++p) {
     *p += strbuf_write_pos;

--- a/c/wstringcol.h
+++ b/c/wstringcol.h
@@ -29,7 +29,7 @@ namespace dt {
 // TODO: merge into parallel.h
 
 //------------------------------------------------------------------------------
-// Fixed-height writable string column
+// (Fixed-height) writable string column
 //------------------------------------------------------------------------------
 
 /**
@@ -39,9 +39,13 @@ namespace dt {
  */
 class writable_string_col {
   private:
-    std::unique_ptr<MemoryWritableBuffer> strdata;
+    MemoryWritableBuffer strdata;
     MemoryRange offdata;
     size_t n;
+
+    static constexpr size_t MAX_ITEM_SIZE = 0x7FFFFFFF;
+    static constexpr size_t MAX_STR32_BUFFER_SIZE = 0x7FFFFFFF;
+    static constexpr size_t MAX_STR32_NROWS = 0x7FFFFFFF;
 
   public:
     writable_string_col(size_t nrows);

--- a/c/wstringcol.h
+++ b/c/wstringcol.h
@@ -26,6 +26,7 @@ template <typename T> class StringColumn;
 
 namespace dt {
 
+// TODO: merge into parallel.h
 
 //------------------------------------------------------------------------------
 // Fixed-height writable string column
@@ -36,19 +37,19 @@ namespace dt {
  * number of rows is known in advance).
  *
  */
-class fixed_height_string_col {
+class writable_string_col {
   private:
     std::unique_ptr<MemoryWritableBuffer> strdata;
     MemoryRange offdata;
     size_t n;
 
   public:
-    fixed_height_string_col(size_t nrows);
+    writable_string_col(size_t nrows);
     Column* to_column() &&;
 
     class buffer {
       private:
-        fixed_height_string_col& col;
+        writable_string_col& col;
         dt::array<char> strbuf;
         size_t strbuf_used;
         size_t strbuf_write_pos;
@@ -56,7 +57,7 @@ class fixed_height_string_col {
         uint32_t* offptr0;
 
       public:
-        buffer(fixed_height_string_col&);
+        buffer(writable_string_col&);
 
         void write(const CString&);
         void write(const std::string&);
@@ -69,7 +70,7 @@ class fixed_height_string_col {
 };
 
 
-
+using fixed_height_string_col = writable_string_col;
 
 
 

--- a/c/wstringcol.h
+++ b/c/wstringcol.h
@@ -43,10 +43,6 @@ class writable_string_col {
     MemoryRange offdata;
     size_t n;
 
-    static constexpr size_t MAX_ITEM_SIZE = 0x7FFFFFFF;
-    static constexpr size_t MAX_STR32_BUFFER_SIZE = 0x7FFFFFFF;
-    static constexpr size_t MAX_STR32_NROWS = 0x7FFFFFFF;
-
   public:
     writable_string_col(size_t nrows);
     Column* to_column() &&;

--- a/tests/munging/test_replace.py
+++ b/tests/munging/test_replace.py
@@ -252,6 +252,26 @@ def test_replace_str_large(seed):
     assert df.to_list() == [src]
 
 
+def test_replace_str_huge():
+    # Issue #1694: the output column is too large to fit into str32, so it
+    # must be converted into str64.
+    n = 10000000
+    src = ["a"] * n
+    src[-1] = None
+    src[-100] = None
+    src[-10000] = None
+    src[-1000000] = None
+    DT = dt.Frame(src)
+    assert DT.stypes == (dt.str32,)
+    DT.replace("a", "A" * 250)
+    DT.internal.check()
+    assert DT.stypes == (dt.str64,)
+    assert DT.shape == (n, 1)
+    assert DT[-2, 0] == "A" * 250
+    assert DT[-1, 0] is None
+    assert DT[-100, 0] is None
+
+
 
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
Direct construction of `StringColumn<T>` objects is now prohibited (except for the cases when a blank column is created). Instead, we use `new_string_column()` function which returns either `StringColumn<uint32_t>*` or `StingColumn<uint64_t>*`, whichever is more appropriate. 

This function also takes care of "fixing" the offsets array in case it overflown during the construction. This works provided that no individual string in the column exceeds 2Gb in size.

Closes #1694 