### PR TITLE
More accurate __sizeof__()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - A keyed frame will now be rendered correctly when viewing it in python
   console via `Frame.view()` (#1672).
 
+- The reported frame size (`sys.getsizeof(DT)`) is now more accurate; in
+  particular the content of string columns is no longer ignored (#1697).
+
 
 ### Changed
 
@@ -86,7 +89,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
   [arno candel][] (#1619),
   [antorsae][] (#1639),
-  [pasha stetsenko][] (#1672)
+  [pasha stetsenko][] (#1672, #1697)
 
 
 

--- a/c/column.cc
+++ b/c/column.cc
@@ -196,22 +196,6 @@ void Column::replace_rowindex(const RowIndex& newri) {
 
 
 
-/**
- * Get the total size of the memory occupied by this Column. This is different
- * from `column->alloc_size`, which in general reports byte size of the `data`
- * portion of the column.
- */
-size_t Column::memory_footprint() const
-{
-  size_t sz = sizeof(*this);
-  sz += mbuf.memory_footprint();
-  // sz += ri.memory_footprint();
-  if (stats) sz += stats->memory_footprint();
-  return sz;
-}
-
-
-
 //------------------------------------------------------------------------------
 // Stats
 //------------------------------------------------------------------------------

--- a/c/column.h
+++ b/c/column.h
@@ -154,7 +154,7 @@ public:
   size_t alloc_size() const;
 
   virtual size_t data_nrows() const = 0;
-  size_t memory_footprint() const;
+  virtual size_t memory_footprint() const;
 
   RowIndex sort(Groupby* out_groups) const;
 
@@ -609,6 +609,7 @@ public:
   const uint8_t* ustrdata() const;
   const T* offsets() const;
   T* offsets_w();
+  size_t memory_footprint() const override;
 
   CString mode() const;
 

--- a/c/datatable.cc
+++ b/c/datatable.cc
@@ -262,18 +262,6 @@ void DataTable::reify() {
 
 
 
-size_t DataTable::memory_footprint() const {
-  size_t sz = 0;
-  sz += sizeof(*this);
-  sz += (ncols + 1) * sizeof(Column*);
-  for (size_t i = 0; i < ncols; ++i) {
-    sz += columns[i]->memory_footprint();
-  }
-  return sz;
-}
-
-
-
 /**
  * Verify that all internal constraints in the DataTable hold, and that there
  * are no any inappropriate values/elements.

--- a/c/frame/__sizeof__.cc
+++ b/c/frame/__sizeof__.cc
@@ -1,0 +1,60 @@
+//------------------------------------------------------------------------------
+// Copyright 2018 H2O.ai
+//------------------------------------------------------------------------------
+#include "frame/py_frame.h"
+#include "python/_all.h"
+namespace py {
+
+
+static PKArgs args__sizeof__(
+  0, 0, 0, false, false, {}, "__sizeof__",
+
+R"(__sizeof__(self)
+--
+
+Return the size of this Frame in memory.
+
+The function attempts to compute the total memory size of the Frame
+as precisely as possible. In particular, it takes into account not
+only the size of data in columns, but also sizes of all auxiliary
+internal structures.
+
+Special cases: if Frame is a view (say, `d2 = DT[:1000, :]`), then
+the reported size will not contain the size of the data, because that
+data "belongs" to the original datatable and is not copied. However if
+a Frame selects only a subset of columns (say, `d3 = DT[:, :5]`),
+then a view is not created and instead the columns are copied by
+reference. Frame `d3` will report the "full" size of its columns,
+even though they do not occupy any extra memory compared to `DT`.
+This behavior may be changed in the future.
+
+This function is not intended for manual use. Instead, in order to
+get the size of a datatable `DT`, call `sys.getsizeof(DT)`.
+)");
+
+
+oobj Frame::m__sizeof__(const PKArgs&) {
+  size_t sz = dt->memory_footprint();
+  sz += sizeof(*this);
+  if (ltypes) sz += _PySys_GetSizeOf(ltypes);
+  if (stypes) sz += _PySys_GetSizeOf(stypes);
+
+  /*
+  // if (self->names) {
+  //   PyObject* names = self->names;
+  //   sz += _PySys_GetSizeOf(names);
+  //   for (Py_ssize_t i = 0; i < Py_SIZE(names); ++i) {
+  //     sz += _PySys_GetSizeOf(PyTuple_GET_ITEM(names, i));
+  //   }
+  // }
+  */
+  return oint(sz);
+}
+
+
+void Frame::Type::_init_sizeof(Methods& mm) {
+  ADD_METHOD(mm, &Frame::m__sizeof__, args__sizeof__);
+}
+
+
+}

--- a/c/frame/py_frame.cc
+++ b/c/frame/py_frame.cc
@@ -276,6 +276,7 @@ void Frame::Type::init_methods_and_getsets(Methods& mm, GetSetters& gs) {
   _init_rbind(mm);
   _init_replace(mm);
   _init_repr(mm);
+  _init_sizeof(mm);
   _init_stats(mm);
   _init_tocsv(mm);
   _init_tonumpy(mm);

--- a/c/frame/py_frame.h
+++ b/c/frame/py_frame.h
@@ -64,6 +64,7 @@ class Frame : public PyObject {
         static void _init_rbind(Methods&);
         static void _init_replace(Methods&);
         static void _init_repr(Methods&);
+        static void _init_sizeof(Methods&);
         static void _init_stats(Methods&);
         static void _init_tocsv(Methods&);
         static void _init_tonumpy(Methods&);
@@ -83,6 +84,7 @@ class Frame : public PyObject {
     void m__setitem__(robj item, robj value);
     oobj m__getstate__(const PKArgs&);  // pickling support
     void m__setstate__(const PKArgs&);
+    oobj m__sizeof__(const PKArgs&);
 
     // Frame display
     oobj m__repr__();

--- a/c/py_datatable.cc
+++ b/c/py_datatable.cc
@@ -84,26 +84,6 @@ PyObject* get_datatable_ptr(obj* self) {
 }
 
 
-/**
- * Return size of the referenced DataTable, and the current `pydatatable::obj`.
- */
-PyObject* get_alloc_size(obj* self) {
-  DataTable* dt = self->ref;
-  size_t sz = dt->memory_footprint();
-  sz += sizeof(*self);
-  // if (self->ltypes) sz += _PySys_GetSizeOf(self->ltypes);
-  // if (self->stypes) sz += _PySys_GetSizeOf(self->stypes);
-  // if (self->names) {
-  //   PyObject* names = self->names;
-  //   sz += _PySys_GetSizeOf(names);
-  //   for (Py_ssize_t i = 0; i < Py_SIZE(names); ++i) {
-  //     sz += _PySys_GetSizeOf(PyTuple_GET_ITEM(names, i));
-  //   }
-  // }
-  return PyLong_FromSize_t(sz);
-}
-
-
 
 //==============================================================================
 // PyDatatable methods
@@ -219,7 +199,6 @@ static PyMethodDef datatable_methods[] = {
 static PyGetSetDef datatable_getseters[] = {
   GETTER(isview),
   GETTER(datatable_ptr),
-  GETTER(alloc_size),
   {nullptr, nullptr, nullptr, nullptr, nullptr}  /* sentinel */
 };
 

--- a/c/py_datatable.h
+++ b/c/py_datatable.h
@@ -69,10 +69,6 @@ DECLARE_GETTER(
   datatable_ptr,
   "Get pointer (converted to an int) to the wrapped DataTable object")
 
-DECLARE_GETTER(
-  alloc_size,
-  "DataTable's internal size, in bytes")
-
 
 
 //---- Methods -----------------------------------------------------------------

--- a/c/python/obj.cc
+++ b/c/python/obj.cc
@@ -733,6 +733,11 @@ PyTypeObject* _obj::typeobj() const noexcept {
 }
 
 
+size_t _obj::get_sizeof() const {
+  return _PySys_GetSizeOf(v);
+}
+
+
 PyObject* oobj::release() && {
   PyObject* t = v;
   v = nullptr;

--- a/c/python/obj.h
+++ b/c/python/obj.h
@@ -141,6 +141,7 @@ class _obj {
     oobj call(otuple args, odict kws) const;
     ostring str() const;
     PyTypeObject* typeobj() const noexcept;  // borrowed ref
+    size_t get_sizeof() const;
 
     explicit operator bool() const noexcept;  // opposite of is_undefined()
     bool operator==(const _obj& other) const noexcept;

--- a/c/rowindex.cc
+++ b/c/rowindex.cc
@@ -290,7 +290,10 @@ RowIndex RowIndex::negate(size_t nrows) const {
 
 
 size_t RowIndex::memory_footprint() const {
-  return sizeof(this) + (impl? impl->memory_footprint() : 0);
+  // If multiple columns share a rowindex, we don't want to account for it
+  // multiple times. Instead, try to assign each instance an "equal share"
+  // of this object's memory footprint.
+  return sizeof(this) + (impl? impl->memory_footprint() / impl->refcount : 0);
 }
 
 

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -73,29 +73,6 @@ class Frame(core.Frame):
             self._dt.materialize()
 
 
-    def __sizeof__(self):
-        """
-        Return the size of this Frame in memory.
-
-        The function attempts to compute the total memory size of the Frame
-        as precisely as possible. In particular, it takes into account not only
-        the size of data in columns, but also sizes of all auxiliary internal
-        structures.
-
-        Special cases: if Frame is a view (say, `d2 = d[:1000, :]`), then
-        the reported size will not contain the size of the data, because that
-        data "belongs" to the original datatable and is not copied. However if
-        a Frame selects only a subset of columns (say, `d3 = d[:, :5]`),
-        then a view is not created and instead the columns are copied by
-        reference. Frame `d3` will report the "full" size of its columns,
-        even though they do not occupy any extra memory compared to `d`. This
-        behavior may be changed in the future.
-
-        This function is not intended for manual use. Instead, in order to get
-        the size of a datatable `d`, call `sys.getsizeof(d)`.
-        """
-        return self._dt.alloc_size
-
 
     #---------------------------------------------------------------------------
     # Deprecated

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -163,6 +163,11 @@ def test_dt_properties(dt0):
     assert sys.getsizeof(dt0) > 500
 
 
+def test_sizeof():
+    DT1 = dt.Frame(A=["foo"])
+    DT2 = dt.Frame(A=["foo" * 1001])
+    assert sys.getsizeof(DT2) - sys.getsizeof(DT1) == 3000
+
 
 def test_internal():
     # Run C++ tests

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -160,8 +160,7 @@ def test_dt_properties(dt0):
                           ltype.bool, ltype.bool, ltype.str)
     assert dt0.stypes == (stype.int8, stype.bool8, stype.bool8, stype.float64,
                           stype.bool8, stype.bool8, stype.str32)
-    assert dt0.internal.alloc_size > 500
-    assert sys.getsizeof(dt0) >= dt0.internal.alloc_size
+    assert sys.getsizeof(dt0) > 500
 
 
 


### PR DESCRIPTION
- `Frame.__sizeof__()` method is now declared in C++;
- More accurately count different quantities that take up the Frame's memory.

WIP for #1066 
Closes #1697
