### PR TITLE
Avoid using static py::oobj objects in a function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   Another memory leak was during generation of string columns, now also fixed
   (#1705).
 
+- Fixed crash upon exiting from a python terminal, if the user ever called
+  function `frame_column_rowindex().type` (#1703).
+
 
 ### Changed
 
@@ -103,7 +106,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
   [arno candel][] (#1619),
   [antorsae][] (#1639),
-  [pasha stetsenko][] (#1672, #1694, #1695, #1697, #1705)
+  [pasha stetsenko][] (#1672, #1694, #1695, #1697, #1703, #1705)
 
 
 

--- a/c/py_rowindex.cc
+++ b/c/py_rowindex.cc
@@ -57,13 +57,10 @@ oobj orowindex::pyobject::m__repr__() {
 static GSArgs args_type("type");
 
 oobj orowindex::pyobject::get_type() const {
-  static oobj tSlice = ostring("slice");
-  static oobj tArr32 = ostring("arr32");
-  static oobj tArr64 = ostring("arr64");
   RowIndexType rt = ri->type();
-  return rt == RowIndexType::SLICE? tSlice :
-         rt == RowIndexType::ARR32? tArr32 :
-         rt == RowIndexType::ARR64? tArr64 : None();
+  return rt == RowIndexType::SLICE? ostring("slice") :
+         rt == RowIndexType::ARR32? ostring("arr32") :
+         rt == RowIndexType::ARR64? ostring("arr64") : None();
 }
 
 

--- a/c/python/obj.cc
+++ b/c/python/obj.cc
@@ -83,7 +83,7 @@ oobj::oobj() {
 
 oobj::oobj(PyObject* p) {
   v = p;
-  Py_XINCREF(p);
+  if (p) Py_INCREF(p);
 }
 
 oobj::oobj(const oobj& other) : oobj(other.v) {}
@@ -143,7 +143,7 @@ oobj oobj::import(const char* mod, const char* sym1, const char* sym2) {
 }
 
 oobj::~oobj() {
-  Py_XDECREF(v);
+  if (v) Py_DECREF(v);
 }
 
 


### PR DESCRIPTION
This is a very weird bug. The crash occurs in
```
* thread #1, queue = 'com.apple.main-thread', stop reason = breakpoint 2.1
    frame #0: 0x0000000102b97ca0 _datatable.cpython-36m-darwin.so`py::oobj::~oobj(this=0x0000000102c5d3a0) at obj.cc:145
   142 	  return import(mod, sym1).get_attr(sym2);
   143 	}
   144 	
-> 145 	oobj::~oobj() {
   146 	  Py_XDECREF(v);
   147 	}
   148 	
```
where `this` object is static `py::oobj tArr64` from function `orowindex::pyobject::get_type()`. I have verified that the object has indeed been created before, and that it was in the valid state, that `v`'s ref-count is 1, and that nobody even touched that object since the point of its creation.

Still, the call to `Py_XDECREF` complains that the memory was not allocated.

Also, at the point just before the crash, the stack trace looks as follows:
```
* thread #1, queue = 'com.apple.main-thread', stop reason = breakpoint 2.1
  * frame #0: 0x0000000102b97ca0 _datatable.cpython-36m-darwin.so`py::oobj::~oobj(this=0x0000000102c5d3a0) at obj.cc:145
    frame #1: 0x00007fff7904eeed libsystem_c.dylib`__cxa_finalize_ranges + 351
    frame #2: 0x00007fff7904f1fe libsystem_c.dylib`exit + 55
    frame #3: 0x00007fff78fa201c libdyld.dylib`start + 8
    frame #4: 0x00007fff78fa2015 libdyld.dylib`start + 1
```

My hypothesis is that the reason for the error is that the python variable is destroyed at a moment when there is no longer a python executable on the stack; which probably means that by now Python has finished and finalized everything, which might have involved deleting `PyObject`s that it cached (even though their refcount > 0). Which is why when the static `tArr64` tries to clean up itself, it fails because that memory has already been cleaned.

Regardless of the reason, eliminating static variables in that function avoids any problems.

Closes #1703