### PR TITLE
 Frame.materialize() method moved to C++

### DIFF
--- a/c/column.cc
+++ b/c/column.cc
@@ -240,7 +240,7 @@ SType VoidColumn::stype() const noexcept { return SType::VOID; }
 size_t VoidColumn::elemsize() const { return 0; }
 bool VoidColumn::is_fixedwidth() const { return true; }
 size_t VoidColumn::data_nrows() const { return nrows; }
-void VoidColumn::reify() {}
+void VoidColumn::materialize() {}
 void VoidColumn::resize_and_fill(size_t) {}
 void VoidColumn::rbind_impl(std::vector<const Column*>&, size_t, bool) {}
 void VoidColumn::apply_na_mask(const BoolColumn*) {}

--- a/c/column.h
+++ b/c/column.h
@@ -272,7 +272,7 @@ public:
    * by replacing the current rowindex with the "plain slice" (i.e. a slice
    * with step 1).
    */
-  virtual void reify() = 0;
+  virtual void materialize() = 0;
 
   virtual py::oobj get_value_at_index(size_t i) const = 0;
 
@@ -352,7 +352,7 @@ public:
   void apply_na_mask(const BoolColumn* mask) override;
   size_t elemsize() const override;
   bool is_fixedwidth() const override;
-  virtual void reify() override;
+  virtual void materialize() override;
   virtual void replace_values(RowIndex at, const Column* with) override;
   void replace_values(const RowIndex& at, T with);
   virtual RowIndex join(const Column* keycol) const override;
@@ -515,7 +515,7 @@ protected:
 
   void resize_and_fill(size_t nrows) override;
   void fill_na() override;
-  void reify() override;
+  void materialize() override;
   friend Column;
 };
 
@@ -538,7 +538,7 @@ public:
   size_t elemsize() const override;
   bool is_fixedwidth() const override;
 
-  void reify() override;
+  void materialize() override;
   void resize_and_fill(size_t nrows) override;
   void apply_na_mask(const BoolColumn* mask) override;
   RowIndex join(const Column* keycol) const override;
@@ -606,7 +606,7 @@ class VoidColumn : public Column {
     size_t elemsize() const override;
     bool is_fixedwidth() const override;
     size_t data_nrows() const override;
-    void reify() override;
+    void materialize() override;
     void resize_and_fill(size_t) override;
     void rbind_impl(std::vector<const Column*>&, size_t, bool) override;
     void apply_na_mask(const BoolColumn*) override;

--- a/c/column_fw.cc
+++ b/c/column_fw.cc
@@ -102,7 +102,7 @@ const T* FwColumn<T>::elements_r() const {
 
 template <typename T>
 T* FwColumn<T>::elements_w() {
-  if (ri) reify();
+  if (ri) materialize();
   return static_cast<T*>(mbuf.wptr());
 }
 
@@ -128,7 +128,7 @@ void FwColumn<T>::set_elem(size_t i, T value) {
 
 
 template <typename T>
-void FwColumn<T>::reify() {
+void FwColumn<T>::materialize() {
   // If the rowindex is absent, then the column is already materialized.
   if (!ri) return;
   bool simple_slice = ri.isslice() && ri.slice_step() == 1;
@@ -184,7 +184,7 @@ template <typename T>
 void FwColumn<T>::resize_and_fill(size_t new_nrows)
 {
   if (new_nrows == nrows) return;
-  reify();
+  materialize();
 
   mbuf.resize(sizeof(T) * new_nrows);
 
@@ -249,7 +249,7 @@ template <typename T>
 void FwColumn<T>::replace_values(
     RowIndex replace_at, const Column* replace_with)
 {
-  reify();
+  materialize();
   if (!replace_with) {
     return replace_values(replace_at, GETNA<T>());
   }

--- a/c/column_pyobj.cc
+++ b/c/column_pyobj.cc
@@ -59,7 +59,7 @@ void PyObjectColumn::fill_na() {
 
 void PyObjectColumn::resize_and_fill(size_t new_nrows) {
   if (new_nrows == nrows) return;
-  reify();
+  materialize();
 
   mbuf.resize(sizeof(PyObject*) * new_nrows);
 
@@ -81,9 +81,9 @@ void PyObjectColumn::resize_and_fill(size_t new_nrows) {
 }
 
 
-void PyObjectColumn::reify() {
+void PyObjectColumn::materialize() {
   if (ri.isabsent()) return;
-  FwColumn<PyObject*>::reify();
+  FwColumn<PyObject*>::materialize();
 
   // ???
   // After regular reification, we need to increment ref-counts for each

--- a/c/column_string.cc
+++ b/c/column_string.cc
@@ -226,7 +226,7 @@ T* StringColumn<T>::offsets_w() {
 
 
 template <typename T>
-void StringColumn<T>::reify() {
+void StringColumn<T>::materialize() {
   // If our rowindex is null, then we're already done
   if (ri.isabsent()) return;
   bool simple_slice = ri.isslice() && ri.slice_step() == 1;
@@ -331,7 +331,7 @@ template <typename T>
 void StringColumn<T>::replace_values(
     RowIndex replace_at, const Column* replace_with)
 {
-  reify();
+  materialize();
   Column* rescol = nullptr;
 
   if (replace_with && replace_with->stype() != stype()){
@@ -392,7 +392,7 @@ void StringColumn<T>::resize_and_fill(size_t new_nrows)
 {
   size_t old_nrows = nrows;
   if (new_nrows == old_nrows) return;
-  reify();
+  materialize();
 
   if (new_nrows > INT32_MAX && sizeof(T) == 4) {
     // TODO: instead of throwing an error, upcast the column to <uint64_t>
@@ -476,7 +476,7 @@ void StringColumn<T>::apply_na_mask(const BoolColumn* mask) {
 
 template <typename T>
 void StringColumn<T>::fill_na() {
-  // Perform a mini reify (the actual `reify` method will copy string and offset
+  // Perform a mini materialize (the actual `materialize` method will copy string and offset
   // data, both of which are extraneous for this method)
   strbuf.resize(0);
   size_t new_mbuf_size = sizeof(T) * (nrows + 1);

--- a/c/datatable.cc
+++ b/c/datatable.cc
@@ -254,9 +254,9 @@ void DataTable::replace_groupby(const Groupby& newgb) {
  * The resulting DataTable should have a NULL RowIndex and Stats array.
  * Do nothing if the DataTable is not a view.
  */
-void DataTable::reify() {
+void DataTable::materialize() {
   for (auto col : columns) {
-    col->reify();
+    col->materialize();
   }
 }
 

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -104,7 +104,7 @@ class DataTable {
     void replace_rowindex(const RowIndex& newri);
     void apply_rowindex(const RowIndex&);
     void replace_groupby(const Groupby& newgb);
-    void reify();
+    void materialize();
     void rbind(const std::vector<DataTable*>&, const std::vector<intvec>&);
     void cbind(const std::vector<DataTable*>&);
     DataTable* copy() const;

--- a/c/expr/binaryop.cc
+++ b/c/expr/binaryop.cc
@@ -533,8 +533,8 @@ static mapperfn resolve0(SType lhs_type, SType rhs_type, size_t opcode, void** p
 
 Column* binaryop(size_t opcode, Column* lhs, Column* rhs)
 {
-  lhs->reify();
-  rhs->reify();
+  lhs->materialize();
+  rhs->materialize();
   size_t lhs_nrows = lhs->nrows;
   size_t rhs_nrows = rhs->nrows;
   if (lhs_nrows == 0 || rhs_nrows == 0) {

--- a/c/expr/reduceop.cc
+++ b/c/expr/reduceop.cc
@@ -51,7 +51,7 @@ Column* reduce_first(const Column* col, const Groupby& groupby) {
   RowIndex ri = RowIndex(std::move(indices), true)
                 * col->rowindex();
   Column* res = col->shallowcopy(ri);
-  if (ngrps == 1) res->reify();
+  if (ngrps == 1) res->materialize();
   return res;
 }
 

--- a/c/expr/unaryop.cc
+++ b/c/expr/unaryop.cc
@@ -176,7 +176,7 @@ static mapperfn resolve0(SType stype, dt::unop opcode) {
 Column* unaryop(dt::unop opcode, Column* arg)
 {
   if (opcode == dt::unop::PLUS) return arg->shallowcopy();
-  arg->reify();
+  arg->materialize();
 
   SType arg_type = arg->stype();
   SType res_type = arg_type;

--- a/c/frame/join.cc
+++ b/c/frame/join.cc
@@ -404,7 +404,7 @@ RowIndex natural_join(const DataTable* xdt, const DataTable* jdt) {
   // its columns have the same rowindex (or at least all columns needed to
   // compute the result).
   for (size_t j : xcols) {
-    xdt->columns[j]->reify();
+    xdt->columns[j]->materialize();
   }
 
   arr32_t arr_result_indices(xdt->nrows);

--- a/c/frame/key.cc
+++ b/c/frame/key.cc
@@ -156,7 +156,7 @@ void DataTable::set_key(std::vector<size_t>& col_indices) {
 
   // Apply sort key
   apply_rowindex(ri);
-  reify();
+  materialize();
 
   nkeys = K;
 }

--- a/c/frame/py_frame.cc
+++ b/c/frame/py_frame.cc
@@ -145,6 +145,32 @@ void Frame::_clear_types() const {
 }
 
 
+static PKArgs args_materialize(
+  0, 0, 0, false, false, {}, "materialize",
+
+R"(materialize(self)
+--
+
+Convert a "view" frame into a regular data frame.
+
+Certain datatable operation produce frames that contain "view"
+columns. These columns refer to the data in some other column, via
+a RowIndex object that describes which values from the other column
+should be picked. This is done in order to improve performance and
+reduce memory usage of certain operations: a view column avoids
+copying data from its parent column.
+
+Usually view columns are created transparently to the user, and they
+are materialized by datatable when necessary. This method, on the
+other hand, will force all view columns in the frame to be
+materialized immediately.
+)");
+
+void Frame::materialize(const PKArgs&) {
+  dt->materialize();
+}
+
+
 
 
 //------------------------------------------------------------------------------
@@ -293,6 +319,7 @@ void Frame::Type::init_methods_and_getsets(Methods& mm, GetSetters& gs) {
   ADD_METHOD(mm, &Frame::head, args_head);
   ADD_METHOD(mm, &Frame::tail, args_tail);
   ADD_METHOD(mm, &Frame::copy, args_copy);
+  ADD_METHOD(mm, &Frame::materialize, args_materialize);
 }
 
 

--- a/c/frame/py_frame.h
+++ b/c/frame/py_frame.h
@@ -113,6 +113,7 @@ class Frame : public PyObject {
     void repeat(const PKArgs&);
     void replace(const PKArgs&);
     oobj tail(const PKArgs&);
+    void materialize(const PKArgs&);
 
     // Conversion methods
     oobj to_csv(const PKArgs&);

--- a/c/frame/rbind.cc
+++ b/c/frame/rbind.cc
@@ -271,7 +271,7 @@ void DataTable::rbind(
   xassert(new_ncols >= ncols);
 
   // If this is a view Frame, then it must be materialized.
-  this->reify();
+  this->materialize();
 
   columns.resize(new_ncols, nullptr);
   for (size_t i = ncols; i < new_ncols; ++i) {
@@ -290,7 +290,7 @@ void DataTable::rbind(
       Column* col = k == INVALID_INDEX
                       ? new VoidColumn(dts[j]->nrows)
                       : dts[j]->columns[k]->shallowcopy();
-      col->reify();
+      col->materialize();
       cols_to_append[j] = col;
     }
     columns[i] = columns[i]->rbind(cols_to_append);

--- a/c/jay/save_jay.cc
+++ b/c/jay/save_jay.cc
@@ -55,7 +55,7 @@ MemoryRange DataTable::save_jay() {
 
 void DataTable::save_jay_impl(WritableBuffer* wb) {
   // Cannot store a view frame, so materialize first.
-  reify();
+  materialize();
 
   wb->write(8, "JAY1\0\0\0\0");
 

--- a/c/py_buffers.cc
+++ b/c/py_buffers.cc
@@ -467,7 +467,7 @@ static int getbuffer_DataTable(
   for (size_t i = 0; i < ncols; ++i) {
     // either a shallow copy, or "materialized" column
     // Column* col = dt->columns[i + i0]->shallowcopy();
-    // col->reify();
+    // col->materialize();
 
     // xmb becomes a "view" on a portion of the buffer `mbuf`. An
     // ExternalMemBuf object is documented to be readonly; however in

--- a/c/py_datatable.cc
+++ b/c/py_datatable.cc
@@ -160,14 +160,6 @@ PyObject* column(obj* self, PyObject* args) {
 
 
 
-PyObject* materialize(obj* self, PyObject*) {
-  DataTable* dt = self->ref;
-  dt->materialize();
-  Py_RETURN_NONE;
-}
-
-
-
 //------------------------------------------------------------------------------
 // Misc
 //------------------------------------------------------------------------------
@@ -192,7 +184,6 @@ static void dealloc(obj* self) {
 static PyMethodDef datatable_methods[] = {
   METHOD0(check),
   METHODv(column),
-  METHOD0(materialize),
   {nullptr, nullptr, 0, nullptr}           /* sentinel */
 };
 

--- a/c/py_datatable.cc
+++ b/c/py_datatable.cc
@@ -162,7 +162,7 @@ PyObject* column(obj* self, PyObject* args) {
 
 PyObject* materialize(obj* self, PyObject*) {
   DataTable* dt = self->ref;
-  dt->reify();
+  dt->materialize();
   Py_RETURN_NONE;
 }
 

--- a/c/py_datatable.h
+++ b/c/py_datatable.h
@@ -85,11 +85,6 @@ DECLARE_METHOD(
   "column(index)\n\n"
   "Get the requested column in the datatable")
 
-DECLARE_METHOD(
-  materialize,
-  "materialize()\n\n"
-  "Convert DataTable from 'view' into 'data' representation.\n")
-
 
 };
 #undef BASECLS

--- a/c/rowindex_array.cc
+++ b/c/rowindex_array.cc
@@ -430,7 +430,7 @@ void ArrayRowIndexImpl::init_from_integer_column(const Column* col) {
     max = static_cast<size_t>(imax);
   }
   Column* col2 = col->shallowcopy();
-  col2->reify();  // noop if col has no rowindex
+  col2->materialize();  // noop if col has no rowindex
 
   length = col->nrows;
   Column* col3 = nullptr;

--- a/c/set_funcs.cc
+++ b/c/set_funcs.cc
@@ -55,7 +55,7 @@ static py::oobj make_pyframe(sort_result& sr, arr32_t&& arr) {
   // in the input are sorted before they are compared.
   RowIndex out_ri = RowIndex(std::move(arr), false);
   Column* out_col = sr.col->shallowcopy(out_ri);
-  out_col->reify();
+  out_col->materialize();
   DataTable* dt = new DataTable({out_col}, {sr.colname});
   return py::oobj::from_new_reference(py::Frame::from_datatable(dt));
 }
@@ -74,7 +74,7 @@ static ccolvec columns_from_args(const py::PKArgs& args) {
       if (dt->ncols == 0) continue;
       verify_frame_1column(dt);
       Column* col = dt->columns[0]->shallowcopy();
-      col->reify();
+      col->materialize();
       res.cols.push_back(col);
       if (res.colname.empty()) res.colname = dt->get_names()[0];
     }
@@ -84,7 +84,7 @@ static ccolvec columns_from_args(const py::PKArgs& args) {
         if (dt->ncols == 0) continue;
         verify_frame_1column(dt);
         Column* col = dt->columns[0]->shallowcopy();
-        col->reify();
+        col->materialize();
         res.cols.push_back(col);
         if (res.colname.empty()) res.colname = dt->get_names()[0];
       }
@@ -109,7 +109,7 @@ static sort_result sort_columns(ccolvec&& cv) {
   }
   if (cols.size() == 1) {
     res.col = std::unique_ptr<Column>(const_cast<Column*>(cols[0]));
-    res.col->reify();
+    res.col->materialize();
   } else {
     // Note: `rbind` will delete all the columns in the vector `cols`...
     // Therefore, `cols` cannot be used after this call

--- a/c/sort.cc
+++ b/c/sort.cc
@@ -1269,7 +1269,7 @@ RiGb DataTable::group(const std::vector<sort_spec>& spec, bool as_view) const
   #endif
   if (!as_view) {
     for (auto& s : spec) {
-      columns[s.col_index]->reify();
+      columns[s.col_index]->materialize();
     }
   }
 

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -68,11 +68,6 @@ class Frame(core.Frame):
         return self[:, :, datatable.sort(*cols)]
 
 
-    def materialize(self):
-        if self._dt.isview:
-            self._dt.materialize()
-
-
 
     #---------------------------------------------------------------------------
     # Deprecated

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -1040,6 +1040,27 @@ def test_tail_bad():
 
 
 #-------------------------------------------------------------------------------
+# Materialize
+#-------------------------------------------------------------------------------
+
+def test_materialize():
+    DT1 = dt.Frame(A=range(12))[::2, :]
+    DT2 = dt.repeat(dt.Frame(B=["red", "green", "blue"]), 2)
+    DT3 = dt.Frame(C=[4, 2, 9.1, 12, 0])
+    DT = dt.cbind(DT1, DT2, DT3, force=True)
+    assert frame_column_rowindex(DT, 0).type == "slice"
+    assert frame_column_rowindex(DT, 1).type == "arr32"
+    assert frame_column_rowindex(DT, 2) is None
+    DT.materialize()
+    assert frame_column_rowindex(DT, 0) is None
+    assert frame_column_rowindex(DT, 1) is None
+    assert frame_column_rowindex(DT, 2) is None
+
+
+
+
+
+#-------------------------------------------------------------------------------
 # HTML repr
 #-------------------------------------------------------------------------------
 


### PR DESCRIPTION
- Renamed internal method `.reify()` into `.materialize()`, so that the internal name of the method is consistent with its external usage;
- Added a test and documentation.

WIP for #1066 