### PR TITLE
Make aggregator working on views

### DIFF
--- a/c/models/column_convertor.h
+++ b/c/models/column_convertor.h
@@ -24,6 +24,11 @@
 #include "py_datatable.h"
 
 
+// TODO: the only reason why we cast all the columns to `T` is that
+// stats calculation is faster on real columns. When #219 gets fixed,
+// we could do value casting on-the-fly, making use of the commented
+// parts of the code.
+
 /*
 *  Helper template structures to convert C++ float/double types to
 *  datatable STypes::FLOAT32/STypes::FLOAT64. respectively.
@@ -80,8 +85,7 @@ template<typename T>
 ColumnConvertor<T>::ColumnConvertor(const Column* col) :
   ri(col->rowindex()),
   nrows(col->nrows)
-{
-}
+{}
 
 
 /*
@@ -143,7 +147,6 @@ ColumnConvertorReal<T1, T2, T3>::ColumnConvertorReal(const Column* column_in) :
   this->min = column_real->min();
   this->max = column_real->max();
   values = column_real->elements_r();
-  // TODO: when #219 is fixed, use the commented code
   // auto columnT = static_cast<const T3*>(column_in);
   // this->min = static_cast<T2>(columnT->min());
   // this->max = static_cast<T2>(columnT->max());

--- a/c/models/column_convertor.h
+++ b/c/models/column_convertor.h
@@ -80,7 +80,8 @@ template<typename T>
 ColumnConvertor<T>::ColumnConvertor(const Column* col) :
   ri(col->rowindex()),
   nrows(col->nrows)
-{}
+{
+}
 
 
 /*
@@ -119,7 +120,7 @@ size_t ColumnConvertor<T>::get_nrows() {
 template<typename T1, typename T2, typename T3>
 class ColumnConvertorReal : public ColumnConvertor<T2> {
   private:
-    const /* T1 */ T2* values;
+    const /* T1* */ T2* values;
     colptr column;
   public:
     explicit ColumnConvertorReal(const Column*);
@@ -142,10 +143,11 @@ ColumnConvertorReal<T1, T2, T3>::ColumnConvertorReal(const Column* column_in) :
   this->min = column_real->min();
   this->max = column_real->max();
   values = column_real->elements_r();
-//  auto columnT = static_cast<const T3*>(column_in);
-//  this->min = static_cast<T2>(columnT->min());
-//  this->max = static_cast<T2>(columnT->max());
-//  values = static_cast<const T1*>(column_in->data());
+  // TODO: when #219 is fixed, use the commented code
+  // auto columnT = static_cast<const T3*>(column_in);
+  // this->min = static_cast<T2>(columnT->min());
+  // this->max = static_cast<T2>(columnT->max());
+  // values = static_cast<const T1*>(column_in->data());
 }
 
 
@@ -157,11 +159,13 @@ ColumnConvertorReal<T1, T2, T3>::ColumnConvertorReal(const Column* column_in) :
 */
 template<typename T1, typename T2, typename T3>
 T2 ColumnConvertorReal<T1, T2, T3>::operator[](size_t row) const {
-  size_t i = this->ri[row];
+  size_t i = row;
+  // size_t i = this->ri[row];
   if (i == RowIndex::NA /* || ISNA<T1>(values[i]) */) {
     return GETNA<T2>();
   } else {
     return values[i];
+    // return static_cast<T2>(values[i]);
   }
 }
 
@@ -172,15 +176,17 @@ T2 ColumnConvertorReal<T1, T2, T3>::operator[](size_t row) const {
 */
 template<typename T1, typename T2, typename T3>
 void ColumnConvertorReal<T1, T2, T3>::get_rows(std::vector<T2>& buffer,
-                                                     size_t from,
-                                                     size_t step,
-                                                     size_t count) const {
+                                               size_t from,
+                                               size_t step,
+                                               size_t count) const {
   for (size_t j = 0; j < count; ++j) {
-    size_t i = this->ri[from + j * step];
+    size_t i = from + j * step;
+    // size_t i = this->ri[from + j * step];
     if (i == RowIndex::NA /*|| ISNA<T1>(values[i])*/) {
       buffer[j] = GETNA<T2>();
     } else {
       buffer[j] = values[i];
+      // buffer[j] = static_cast<T2>(values[i]);
     }
   }
 }

--- a/tests/models/test_aggregate.py
+++ b/tests/models/test_aggregate.py
@@ -603,3 +603,41 @@ def test_aggregate_view_2d_categorical():
                                      [None, "blue", "red"],
                                      [1, 2, 1]]
     assert_equals(d_in, d_in_copy)
+
+
+def test_aggregate_view_1d_continuous_integer():
+    d_in = dt.Frame([0, 1, None, 2, None, 3, 3, 4, 4, None, 5])
+    d_in_copy = dt.Frame(d_in)
+    d_in_view = d_in[5:11, :]
+    [d_exemplars, d_members] = aggregate(d_in_view, min_rows=0, n_bins=5,
+                                         progress_fn=report_progress)
+
+    frame_integrity_check(d_members)
+    assert d_members.shape == (6, 1)
+    assert d_members.ltypes == (ltype.int,)
+    assert d_members.to_list() == [[1, 1, 2, 2, 0, 3]]
+
+    frame_integrity_check(d_exemplars)
+    assert d_exemplars.shape == (4, 2)
+    assert d_exemplars.ltypes == (ltype.int, ltype.int)
+    assert d_exemplars.to_list() == [[None, 3, 4, 5], [1, 2, 2, 1]]
+    assert_equals(d_in, d_in_copy)
+
+
+def test_aggregate_view_1d_continuous_float():
+    d_in = dt.Frame([0.0, 1.1, None, 2.2, None, 3.1, 3.2, 4.1, 4.0, None, 5.1])
+    d_in_copy = dt.Frame(d_in)
+    d_in_view = d_in[5:11, :]
+    [d_exemplars, d_members] = aggregate(d_in_view, min_rows=0, n_bins=5,
+                                         progress_fn=report_progress)
+
+    frame_integrity_check(d_members)
+    assert d_members.shape == (6, 1)
+    assert d_members.ltypes == (ltype.int,)
+    assert d_members.to_list() == [[1, 1, 2, 2, 0, 3]]
+
+    frame_integrity_check(d_exemplars)
+    assert d_exemplars.shape == (4, 2)
+    assert d_exemplars.ltypes == (ltype.real, ltype.int)
+    assert d_exemplars.to_list() == [[None, 3.1, 4.1, 5.1], [1, 2, 2, 1]]
+    assert_equals(d_in, d_in_copy)


### PR DESCRIPTION
As of #1704, columns with an existing rowindex could be casted. In this PR we also fix aggregator not working properly on views, consisting of numeric columns. Categorical column views were already fixed with #1666.

Closes #1618 