### PR TITLE
Upgrade the wheel URL in requirements_docs.txt

### DIFF
--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,3 +1,3 @@
 sphinx>=1.8
 nbsphinx>=0.3.5
-https://s3.amazonaws.com/artifacts.h2o.ai/releases/ai/h2o/pydatatable/0.7.0.dev492/x86_64-centos7/datatable-0.7.0.dev492-cp35-cp35m-linux_x86_64.whl
+https://s3.amazonaws.com/artifacts.h2o.ai/releases/ai/h2o/pydatatable/0.8.0.dev551/x86_64-centos7/datatable-0.8.0.dev551-cp37-cp37m-linux_x86_64.whl


### PR DESCRIPTION
Until #952 is implemented, we cannot have a proper "latest" version of documentation on RTFD.io. What we can do, for now, is to manually update every once in a while the URL of the latest wheel in "requirements_docs.txt".

Also it appears that RTD site has switched to using Python3.7, so we need to update the wheel for that reason as well.