### PR TITLE
Upgrade the wheel URL in requirements_docs.txt

### DIFF
--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,3 +1,3 @@
 sphinx>=1.8
 nbsphinx>=0.3.5
-https://s3.amazonaws.com/artifacts.h2o.ai/releases/ai/h2o/pydatatable/0.7.0.dev492/x86_64-centos7/datatable-0.7.0.dev492-cp35-cp35m-linux_x86_64.whl
+https://s3.amazonaws.com/artifacts.h2o.ai/releases/ai/h2o/pydatatable/0.8.0.dev498/x86_64-centos7/datatable-0.8.0.dev498-cp37-cp37m-linux_x86_64.whl


### PR DESCRIPTION
Ideally, we should be able to say `datatable==0.8.0` in the requirements file, but it won't work because we can't publish Linux wheels on PyPI. Instead, we'll be using the hardcoded wheel URL referring to our S3 bucket.

Closes #1720 