### PR TITLE
Properly convert pandas bool column into datatable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed crash upon exiting from a python terminal, if the user ever called
   function `frame_column_rowindex().type` (#1703).
 
+- Pandas "boolean column with NAs" (of dtype `object`) now converts into
+  datatable `bool8` column when pandas DataFrame is converted into a datatable
+  Frame (#1730).
+
 
 ### Changed
 
@@ -116,7 +120,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Thanks to everyone who helped make `datatable` more stable by discovering
   and reporting bugs that were fixed in this release:
 
-  [arno candel][] (#1619),
+  [arno candel][] (#1619, #1730),
   [antorsae][] (#1639),
   [pasha stetsenko][] (#1672, #1694, #1695, #1697, #1703, #1705)
 

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -32,7 +32,7 @@ import time
 from collections import namedtuple
 from datatable import stype, ltype
 from datatable.internal import frame_column_rowindex, frame_integrity_check
-from tests import same_iterables, list_equals, noop, isview
+from tests import same_iterables, list_equals, noop, isview, assert_equals
 
 
 
@@ -695,6 +695,21 @@ def test_topandas_view_mixed():
     assert pp["B"].tolist() == d2.to_list()[0]
     assert pp["V"].tolist()[0] == 2.2222
     assert all(math.isnan(x) for x in pp["V"].tolist()[1:])
+
+
+@pytest.mark.usefixtures("pandas", "numpy")
+def test_topandas_bool_nas():
+    d0 = dt.Frame(A=[True, False, None, True])
+    pf = d0.to_pandas()
+    pf_values = pf["A"].values.tolist()
+    assert pf_values[0] is True
+    assert pf_values[1] is False
+    assert pf_values[2] is None or (isinstance(pf_values[2], float) and
+                                    math.isnan(pf_values[2]))
+    d1 = dt.Frame(pf)
+    assert_equals(d0, d1)
+    d2 = dt.Frame(d0.to_numpy(), names=["A"])
+    assert_equals(d0, d2)
 
 
 def test_tonumpy0(numpy):


### PR DESCRIPTION
Now a pandas column containing bools with NAs converts cleanly into a datatable `bool8` column.

Closes #1730