### PR TITLE
Fix warnings/errors when compiling with gcc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -262,10 +262,6 @@ centos7_build_in_docker_impl:
 		--entrypoint /bin/bash \
 		-e "CI_VERSION_SUFFIX=$(CI_VERSION_SUFFIX)" \
 		-e "DTBL_GIT_HASH=$(DTBL_GIT_HASH)" \
-		-e "LLVM6=" \
-		-e "LLVM_CONFIG=" \
-		-e "CC=g++" \
-		-e "CXX=g++" \
 		$(CUSTOM_ARGS) \
 		$(CENTOS_DOCKER_IMAGE_NAME) \
 		-c ". activate $(BUILD_VENV) && \

--- a/Makefile
+++ b/Makefile
@@ -262,6 +262,10 @@ centos7_build_in_docker_impl:
 		--entrypoint /bin/bash \
 		-e "CI_VERSION_SUFFIX=$(CI_VERSION_SUFFIX)" \
 		-e "DTBL_GIT_HASH=$(DTBL_GIT_HASH)" \
+		-e "LLVM6=" \
+		-e "LLVM_CONFIG=" \
+		-e "CC=g++" \
+		-e "CXX=g++" \
 		$(CUSTOM_ARGS) \
 		$(CENTOS_DOCKER_IMAGE_NAME) \
 		-c ". activate $(BUILD_VENV) && \

--- a/c/csv/reader_fread.cc
+++ b/c/csv/reader_fread.cc
@@ -1016,10 +1016,10 @@ void FreadObserver::type_bump_info(
   static const int BUF_SIZE = 1000;
   char temp[BUF_SIZE + 1];
   int n = snprintf(temp, BUF_SIZE,
-    "Column %zu (%s) bumped from %s to %s due to <<%.*s>> on row %lld",
+    "Column %zu (%s) bumped from %s to %s due to <<%.*s>> on row %zu",
     icol, col.repr_name(g), col.typeName(),
     ParserLibrary::info(new_type).cname(),
-    static_cast<int>(len), field, lineno);
+    static_cast<int>(len), field, static_cast<size_t>(lineno));
   n = std::min(n, BUF_SIZE);
   messages.push_back(std::string(temp, static_cast<size_t>(n)));
 }

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -7,8 +7,9 @@
 //------------------------------------------------------------------------------
 #ifndef dt_DATATABLE_h
 #define dt_DATATABLE_h
-#include <vector>
-#include <string>
+#include <memory>         // std::unique_ptr
+#include <string>         // std::string
+#include <vector>         // std::vector
 #include "python/_all.h"
 #include "rowindex.h"
 #include "types.h"

--- a/c/expr/base_expr.h
+++ b/c/expr/base_expr.h
@@ -74,9 +74,7 @@ enum class ReduceOp : size_t {
 // Each ReduceOp must be < REDUCEOP_COUNT
 constexpr size_t REDUCEOP_COUNT = 8 + 1;
 
-static const char* reducer_names[REDUCEOP_COUNT] = {
-  "", "mean", "min", "max", "stdev", "first", "sum", "count", "median"
-};
+
 
 
 class expr_reduce : public dt::base_expr {

--- a/c/expr/binaryop.cc
+++ b/c/expr/binaryop.cc
@@ -41,6 +41,7 @@
 #include <type_traits>         // std::is_integral
 #include "expr/py_expr.h"
 #include "utils/exceptions.h"
+#include "utils/macros.h"
 #include "types.h"
 
 
@@ -424,7 +425,7 @@ static mapperfn resolve0(SType lhs_type, SType rhs_type, size_t opcode, void** p
         if (opcode == OpCode::LogicalAnd) return resolve2<int8_t, int8_t, int8_t, op_and>(mode);
         if (opcode == OpCode::LogicalOr)  return resolve2<int8_t, int8_t, int8_t, op_or>(mode);
       }
-      [[clang::fallthrough]];
+      FALLTHROUGH;
 
     case SType::INT8:
       switch (rhs_type) {

--- a/c/expr/reduce.cc
+++ b/c/expr/reduce.cc
@@ -24,6 +24,10 @@ constexpr T infinity() {
 
 using colptr = std::unique_ptr<Column>;
 
+static const char* reducer_names[REDUCEOP_COUNT] = {
+  "", "mean", "min", "max", "stdev", "first", "sum", "count", "median"
+};
+
 
 
 //------------------------------------------------------------------------------

--- a/c/expr/reduce.cc
+++ b/c/expr/reduce.cc
@@ -57,7 +57,7 @@ class ReducerLibrary {
     }
 
   private:
-    constexpr inline size_t key(ReduceOp op, SType stype) const {
+    static constexpr size_t key(ReduceOp op, SType stype) {
       return static_cast<size_t>(op) +
              REDUCEOP_COUNT * static_cast<size_t>(stype);
     }

--- a/c/expr/string_expr.cc
+++ b/c/expr/string_expr.cc
@@ -152,6 +152,7 @@ pexpr expr_string_fn(size_t op, pexpr&& arg, py::oobj params) {
     case strop::RE_MATCH:
       return pexpr(new expr_string_match_re(std::move(arg), params));
   }
+  return pexpr();  // LCOV_EXCL_LINE
 }
 
 

--- a/c/memrange.h
+++ b/c/memrange.h
@@ -8,6 +8,7 @@
 #ifndef dt_MEMRANGE_h
 #define dt_MEMRANGE_h
 #include <cstdint>
+#include <memory>             // std::unique_ptr
 #include <string>             // std::string
 #include <type_traits>        // std::is_same
 #include <Python.h>

--- a/c/models/dt_ftrl_real.cc
+++ b/c/models/dt_ftrl_real.cc
@@ -20,6 +20,7 @@
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #include "models/dt_ftrl_real.h"
+#include "utils/macros.h"
 
 
 namespace dt {
@@ -80,7 +81,7 @@ double FtrlReal<T>::dispatch_fit(const DataTable* dt_X_in,
     case SType::INT64:   epoch = fit_regression<int64_t>(); break;
     case SType::FLOAT32: epoch = fit_regression<float>(); break;
     case SType::FLOAT64: epoch = fit_regression<double>(); break;
-    case SType::STR32:   [[clang::fallthrough]];
+    case SType::STR32:   FALLTHROUGH;
     case SType::STR64:   epoch = fit_multinomial(); break;
     default:             throw TypeError() << "Targets of type `"
                                            << stype_y << "` are not supported";

--- a/c/models/murmurhash.cc
+++ b/c/models/murmurhash.cc
@@ -4,6 +4,7 @@
 // https://github.com/aappleby/smhasher
 //------------------------------------------------------------------------------
 #include "models/murmurhash.h"
+#include "utils/macros.h"
 
 
 /*
@@ -33,12 +34,12 @@ uint64_t hash_murmur2(const void* key, uint64_t len, unsigned int seed)
   const uint8_t* data2 = reinterpret_cast<const uint8_t*>(data);
 
   switch (len & 7) {
-    case 7: h ^= uint64_t(data2[6]) << 48; [[clang::fallthrough]];
-    case 6: h ^= uint64_t(data2[5]) << 40; [[clang::fallthrough]];
-    case 5: h ^= uint64_t(data2[4]) << 32; [[clang::fallthrough]];
-    case 4: h ^= uint64_t(data2[3]) << 24; [[clang::fallthrough]];
-    case 3: h ^= uint64_t(data2[2]) << 16; [[clang::fallthrough]];
-    case 2: h ^= uint64_t(data2[1]) << 8;  [[clang::fallthrough]];
+    case 7: h ^= uint64_t(data2[6]) << 48; FALLTHROUGH;
+    case 6: h ^= uint64_t(data2[5]) << 40; FALLTHROUGH;
+    case 5: h ^= uint64_t(data2[4]) << 32; FALLTHROUGH;
+    case 4: h ^= uint64_t(data2[3]) << 24; FALLTHROUGH;
+    case 3: h ^= uint64_t(data2[2]) << 16; FALLTHROUGH;
+    case 2: h ^= uint64_t(data2[1]) << 8;  FALLTHROUGH;
     case 1: h ^= uint64_t(data2[0]);
             h *= m;
   };
@@ -90,22 +91,22 @@ void hash_murmur3(const void* key, const uint64_t len, unsigned int seed,
   uint64_t k2 = 0;
 
   switch (len & 15) {
-    case 15: k2 ^= (static_cast<uint64_t>(tail[14])) << 48; [[clang::fallthrough]];
-    case 14: k2 ^= (static_cast<uint64_t>(tail[13])) << 40; [[clang::fallthrough]];
-    case 13: k2 ^= (static_cast<uint64_t>(tail[12])) << 32; [[clang::fallthrough]];
-    case 12: k2 ^= (static_cast<uint64_t>(tail[11])) << 24; [[clang::fallthrough]];
-    case 11: k2 ^= (static_cast<uint64_t>(tail[10])) << 16; [[clang::fallthrough]];
-    case 10: k2 ^= (static_cast<uint64_t>(tail[ 9])) << 8; [[clang::fallthrough]];
+    case 15: k2 ^= (static_cast<uint64_t>(tail[14])) << 48; FALLTHROUGH;
+    case 14: k2 ^= (static_cast<uint64_t>(tail[13])) << 40; FALLTHROUGH;
+    case 13: k2 ^= (static_cast<uint64_t>(tail[12])) << 32; FALLTHROUGH;
+    case 12: k2 ^= (static_cast<uint64_t>(tail[11])) << 24; FALLTHROUGH;
+    case 11: k2 ^= (static_cast<uint64_t>(tail[10])) << 16; FALLTHROUGH;
+    case 10: k2 ^= (static_cast<uint64_t>(tail[ 9])) << 8; FALLTHROUGH;
     case  9: k2 ^= (static_cast<uint64_t>(tail[ 8])) << 0;
-             k2 *= c2; k2 = ROTL64(k2, 33); k2 *= c1; h2 ^= k2; [[clang::fallthrough]];
+             k2 *= c2; k2 = ROTL64(k2, 33); k2 *= c1; h2 ^= k2; FALLTHROUGH;
 
-    case  8: k1 ^= (static_cast<uint64_t>(tail[ 7])) << 56; [[clang::fallthrough]];
-    case  7: k1 ^= (static_cast<uint64_t>(tail[ 6])) << 48; [[clang::fallthrough]];
-    case  6: k1 ^= (static_cast<uint64_t>(tail[ 5])) << 40; [[clang::fallthrough]];
-    case  5: k1 ^= (static_cast<uint64_t>(tail[ 4])) << 32; [[clang::fallthrough]];
-    case  4: k1 ^= (static_cast<uint64_t>(tail[ 3])) << 24; [[clang::fallthrough]];
-    case  3: k1 ^= (static_cast<uint64_t>(tail[ 2])) << 16; [[clang::fallthrough]];
-    case  2: k1 ^= (static_cast<uint64_t>(tail[ 1])) << 8; [[clang::fallthrough]];
+    case  8: k1 ^= (static_cast<uint64_t>(tail[ 7])) << 56; FALLTHROUGH;
+    case  7: k1 ^= (static_cast<uint64_t>(tail[ 6])) << 48; FALLTHROUGH;
+    case  6: k1 ^= (static_cast<uint64_t>(tail[ 5])) << 40; FALLTHROUGH;
+    case  5: k1 ^= (static_cast<uint64_t>(tail[ 4])) << 32; FALLTHROUGH;
+    case  4: k1 ^= (static_cast<uint64_t>(tail[ 3])) << 24; FALLTHROUGH;
+    case  3: k1 ^= (static_cast<uint64_t>(tail[ 2])) << 16; FALLTHROUGH;
+    case  2: k1 ^= (static_cast<uint64_t>(tail[ 1])) << 8; FALLTHROUGH;
     case  1: k1 ^= (static_cast<uint64_t>(tail[ 0])) << 0;
              k1 *= c1; k1 = ROTL64(k1, 31); k1 *= c2; h1 ^= k1;
   };

--- a/c/utils/exceptions.cc
+++ b/c/utils/exceptions.cc
@@ -61,7 +61,7 @@ Error::Error(const Error& other) {
 }
 
 Error::Error(Error&& other) : Error() {
-  #if defined(__gnuc__) && __GNUC__ < 5
+  #if defined(__GNUC__) && __GNUC__ < 5
     // In gcc4.8 string stream was not moveable
     error << other.error.str();
   #else

--- a/c/utils/exceptions.cc
+++ b/c/utils/exceptions.cc
@@ -61,13 +61,13 @@ Error::Error(const Error& other) {
 }
 
 Error::Error(Error&& other) : Error() {
-  swap(*this, other);
-}
-
-void swap(Error& first, Error& second) noexcept {
-  using std::swap;
-  swap(first.error, second.error);
-  swap(first.pycls, second.pycls);
+  #if defined(__gnuc__) && __GNUC__ < 5
+    // In gcc4.8 string stream was not moveable
+    error << other.error.str();
+  #else
+    std::swap(error, other.error);
+  #endif
+  std::swap(pycls, other.pycls);
 }
 
 

--- a/c/utils/exceptions.h
+++ b/c/utils/exceptions.h
@@ -39,7 +39,6 @@ public:
   Error(const Error& other);
   Error(Error&& other);
   virtual ~Error() override {}
-  friend void swap(Error& first, Error& second) noexcept;
 
   Error& operator<<(const std::string&);
   Error& operator<<(const char*);

--- a/c/utils/logger.h
+++ b/c/utils/logger.h
@@ -42,7 +42,17 @@ class LogMessage {
   public:
     explicit LogMessage(py::oobj logger_) : logger(logger_) {}
     LogMessage(const LogMessage&) = delete;
-    LogMessage(LogMessage&&) = default;
+
+    LogMessage(LogMessage&& other) {
+      #if defined(__GNUC__) && __GNUC__ < 5
+        // In gcc4.8 string stream was not moveable
+        out << other.out.str();
+      #else
+        std::swap(out, other.out);
+      #endif
+      logger = std::move(other.logger);
+    }
+
     ~LogMessage() {
       if (!logger) return;
       try {

--- a/c/utils/macros.h
+++ b/c/utils/macros.h
@@ -1,0 +1,36 @@
+//------------------------------------------------------------------------------
+// Copyright 2018 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#ifndef dt_UTILS_MACROS_h
+#define dt_UTILS_MACROS_h
+
+
+#if defined(__clang__)
+  #define FALLTHROUGH [[clang::fallthrough]]
+#elif defined(__GNUC__) && __GNUC__ >= 7
+  #define FALLTHROUGH [[gnu::fallthrough]]
+#else
+  #define FALLTHROUGH
+#endif
+
+
+
+#endif

--- a/c/utils/misc.cc
+++ b/c/utils/misc.cc
@@ -19,6 +19,10 @@ namespace dt {
  */
 template <typename T>
 int nlz(T x) {
+  // The warning is spurious, because shifts triggering the warning are
+  // within if() conditions that get statically ignored.
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wshift-count-overflow"
   T y;
   int n = sizeof(T) * 8;
   if (sizeof(T) >= 8) {
@@ -36,6 +40,7 @@ int nlz(T x) {
     y = x >> 1;  if (y != 0) return n - 2;
   }
   return n - static_cast<int>(x);
+  #pragma GCC diagnostic pop
 }
 
 template int nlz(uint64_t);

--- a/c/writebuf.h
+++ b/c/writebuf.h
@@ -7,10 +7,11 @@
 //------------------------------------------------------------------------------
 #ifndef dt_WRITEBUF_H
 #define dt_WRITEBUF_H
-#include <stdio.h>     // size_t
+#include <memory>      // std::unique_ptr
 #include <string>      // std::string
 #include "utils/file.h"
 #include "utils/shared_mutex.h"
+using std::size_t;
 
 class MemoryRange;
 

--- a/ci/setup_utils.py
+++ b/ci/setup_utils.py
@@ -28,7 +28,7 @@ import sys
 import sysconfig
 import tempfile
 from functools import lru_cache as memoize
-from distutils.errors import DistutilsExecError
+from distutils.errors import DistutilsExecError, CompileError
 
 __all__ = (
     "find_linked_dynamic_libraries",

--- a/ci/setup_utils.py
+++ b/ci/setup_utils.py
@@ -265,6 +265,15 @@ def get_rpath():
         return "$ORIGIN/."
 
 
+def print_compiler_version(log, cc):
+    cmd = [cc, "--version"]
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+    stdout, _ = proc.communicate()
+    stdout = stdout.decode().strip()
+    log.info(" ".join(cmd) + " :")
+    for line in stdout.split("\n"):
+        log.info("  " + line.strip())
+
 
 @memoize()
 def get_compiler():
@@ -274,6 +283,7 @@ def get_compiler():
             if cc:
                 log.info("Using compiler from environment variable `%s`: %s"
                          % (envvar, cc))
+                print_compiler_version(log, cc)
                 return cc
             else:
                 log.info("Environment variable `%s` is not set" % envvar)
@@ -284,6 +294,7 @@ def get_compiler():
                 cc += ".exe"
             if os.path.isfile(cc):
                 log.info("Found Clang compiler %s" % cc)
+                print_compiler_version(log, cc)
                 return cc
             else:
                 log.info("Cannot find Clang compiler at %s" % cc)
@@ -322,6 +333,7 @@ def get_compiler():
                     stderr = stderr.decode().strip()
                     if proc.returncode == 0:
                         log.info("Compiler `%s` will be used" % cc)
+                        print_compiler_version(log, cc)
                         return cc
                     elif omp_enabled() and "-fopenmp" in stderr:
                         log.info("Compiler `%s` does not support OpenMP" % cc)
@@ -342,7 +354,8 @@ def get_compiler():
 
 @memoize()
 def is_gcc():
-    return "gcc" in get_compiler()
+    cc = get_compiler()
+    return ("gcc" in cc or "g++" in cc) and ("clang" not in cc)
 
 @memoize()
 def is_clang():

--- a/ci/setup_utils.py
+++ b/ci/setup_utils.py
@@ -725,7 +725,7 @@ def monkey_patch_compiler():
                 compiler_so = _osx_support.compiler_fixup(compiler_so, cc_args)
             for token in ["-Wstrict-prototypes", "-O2"]:
                 if token in compiler_so:
-                    del compiler_so[token]
+                    del compiler_so[compiler_so.index(token)]
             return compiler_so
 
 
@@ -735,7 +735,8 @@ def monkey_patch_compiler():
             outdir = args[3] if len(args) >= 4 else kwargs["output_dir"]
             if outdir is not None:
                 outname = os.path.join(outdir, outname)
-            self.postlink(outname)
+            if ismacos():
+                self.postlink(outname)
 
 
         def postlink(self, outname):

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ Build script for the `datatable` module.
 import os
 import shutil
 import sys
+assert sys.version_info >= (3, 5), "Unsupported python version: " + sys.version
 from setuptools import setup, find_packages, Extension
 from ci.setup_utils import (get_datatable_version, make_git_version_file,
                             get_compiler, get_extra_compile_flags,

--- a/setup.py
+++ b/setup.py
@@ -155,8 +155,7 @@ if cmd in ("build", "bdist_wheel", "build_ext", "install"):
                 log.info("Copying %s to %s" % (libpath, trgfile))
                 shutil.copy(libpath, trgfile)
 
-    if ismacos():
-        monkey_patch_compiler()
+    monkey_patch_compiler()
 
 
 # Create the git version file

--- a/tests/munging/test_str.py
+++ b/tests/munging/test_str.py
@@ -196,26 +196,26 @@ def test_re_match_ignore_groups():
 
 
 def test_re_match_bad_regex1():
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(ValueError):
         noop(dt.Frame(["abc"])[f.A.re_match("(."), :])
-    assert ("Invalid regular expression: it contained mismatched ( and )"
-            in str(e.value))
+    # assert ("Invalid regular expression: it contained mismatched ( and )"
+    #         in str(e.value))
 
 
 def test_re_match_bad_regex2():
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(ValueError):
         noop(dt.Frame(["abc"])[f.A.re_match("\\j"), :])
-    assert ("Invalid regular expression: it contained an invalid escaped "
-            "character, or a trailing escape"
-            in str(e.value))
+    # assert ("Invalid regular expression: it contained an invalid escaped "
+    #         "character, or a trailing escape"
+    #         in str(e.value))
 
 
 def test_re_match_bad_regex3():
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(ValueError):
         noop(dt.Frame(["abc"])[f.A.re_match("???"), :])
-    assert ("Invalid regular expression: One of *?+{ was not preceded by a "
-            "valid regular expression"
-            in str(e.value))
+    # assert ("Invalid regular expression: One of *?+{ was not preceded by a "
+    #         "valid regular expression"
+    #         in str(e.value))
 
 
 @pytest.mark.parametrize("seed", [random.getrandbits(32) for _ in range(5)])


### PR DESCRIPTION
- centos7 docker image now always uses gcc for compilation;
- `monkey_patch_compiler` is now executed on all platforms, and it attempts to remove compilation flags that are harmful;
- added `FALLTHROUGH` macro which uses either clang or gcc "fallthrough" attribute;
- some warnings ignored;
- move constructor of `Error()` does copying on gcc4.8, since it didn't support moving string streams;
- disabled tests of error messages from bad regular expressions: these messages are compiler-specific;
- setup.py now checks the python version first, to give a reasonable error message if the user accidentally tries to compile datatable under python2.7