### PR TITLE
Use static schedule in dt::run_parallel()

### DIFF
--- a/c/utils/parallel.cc
+++ b/c/utils/parallel.cc
@@ -26,16 +26,16 @@ namespace dt {
 
 void run_parallel(rangefn run, size_t nrows)
 {
-  // `min_nrows_per_thread`: avoid processing less than this many rows in each
+  // `min_nrows_per_chunk`: avoid processing less than this many rows in each
   // thread, reduce the number of threads if necessary.
   // `min_nrows_per_batch`: the minimum number of rows to process within each
   // thread before sending a progress report signal and checking for
   // interrupts.
   //
-  constexpr size_t min_nrows_per_thread = 100;
-  constexpr size_t min_nrows_per_batch = 10000;
+  constexpr size_t min_nrows_per_chunk = 4096;
+  // constexpr size_t min_nrows_per_batch = 10000;
 
-  if (nrows < min_nrows_per_thread) {
+  if (nrows < min_nrows_per_chunk) {
     run(0, nrows, 1);
     // progress.report(nrows);
   }
@@ -43,25 +43,42 @@ void run_parallel(rangefn run, size_t nrows)
     // If the number of rows is too small, then we want to reduce the number of
     // processing threads.
     int nth0 = std::min(config::nthreads,
-                        static_cast<int>(nrows / min_nrows_per_thread));
+                        static_cast<int>(nrows / min_nrows_per_chunk));
     xassert(nth0 > 0);
     OmpExceptionManager oem;
     #pragma omp parallel num_threads(nth0)
     {
       size_t ith = static_cast<size_t>(omp_get_thread_num());
       size_t nth = static_cast<size_t>(omp_get_num_threads());
-      size_t batchsize = min_nrows_per_batch * nth;
+      size_t nchunks = std::min(static_cast<size_t>(nth0),
+                                nrows / min_nrows_per_chunk);  // >= 1
+      size_t chunksize = nrows / nchunks;
+
       try {
-        size_t i = ith;
-        do {
-          size_t iend = std::min(i + batchsize, nrows);
-          run(i, iend, nth);
-          i = iend;
-          // if (ith == 0) progress.report(iend);
-        } while (i < nrows && !oem.stop_requested());
+        for (size_t j = ith; j < nchunks; j += nth) {
+          size_t i0 = j * chunksize;
+          size_t i1 = i0 + chunksize;
+          if (j == nchunks - 1) i1 = nrows;
+
+          run(i0, i1, 1);
+          // if (ith == 0) progress.report(i1);
+        }
       } catch (...) {
         oem.capture_exception();
       }
+
+      // size_t batchsize = min_nrows_per_batch * nth;
+      // try {
+      //   size_t i = ith;
+      //   do {
+      //     size_t iend = std::min(i + batchsize, nrows);
+      //     run(i, iend, nth);
+      //     i = iend;
+      //     // if (ith == 0) progress.report(iend);
+      //   } while (i < nrows && !oem.stop_requested());
+      // } catch (...) {
+      //   oem.capture_exception();
+      // }
     }
     oem.rethrow_exception_if_any();
   }


### PR DESCRIPTION
In tests of cast functionality, this improved functionality significantly.