### PR TITLE
Use static schedule for ND aggregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ information see [Build instructions](https://github.com/h2oai/datatable/wiki/Bui
 
 ## See also
 
-* [Build instructions](https://github.com/h2oai/datatable/blob/master/docs/install.rst)
+* [Build instructions](https://datatable.readthedocs.io/en/latest/install.html)
 * [Changelog](https://github.com/h2oai/datatable/blob/master/CHANGELOG.md)
 * [Documentation](https://datatable.readthedocs.io/en/latest/?badge=latest)
 


### PR DESCRIPTION
Improve performance of ND aggregator by switching to static schedule for the main loop.