### PR TITLE
Reimplement dt::run_parallel using the new thread pool

### DIFF
--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -150,7 +150,7 @@ R"(Return system ids of all threads used internally by datatable)");
 
 static py::oobj get_thread_ids(const py::PKArgs&) {
   std::mutex m;
-  py::olist list(dt::get_thread_pool().size());
+  py::olist list(dt::get_num_threads());
 
   dt::run_once_per_thread([&](size_t i) {
     std::stringstream ss;

--- a/c/frame/cast.cc
+++ b/c/frame/cast.cc
@@ -111,8 +111,8 @@ static void cast_fw0(const Column* col, size_t start, void* out_data)
   auto inp = static_cast<const T*>(col->data()) + start;
   auto out = static_cast<U*>(out_data);
   dt::run_parallel(
-      [=](size_t i0, size_t i1, size_t di) {
-        for (size_t i = i0; i < i1; i += di) {
+      [=](size_t i0, size_t i1) {
+        for (size_t i = i0; i < i1; ++i) {
           out[i] = CAST_OP(inp[i]);
         }
       },
@@ -127,8 +127,8 @@ static void cast_fw1(const Column* col, const int32_t* indices,
   auto inp = static_cast<const T*>(col->data());
   auto out = static_cast<U*>(out_data);
   dt::run_parallel(
-      [=](size_t start, size_t stop, size_t step) {
-        for (size_t i = start; i < stop; i += step) {
+      [=](size_t start, size_t stop) {
+        for (size_t i = start; i < stop; ++i) {
           size_t j = static_cast<size_t>(indices[i]);
           T x = (j == RowIndex::NA)? GETNA<T>() : inp[j];
           out[i] = CAST_OP(x);
@@ -145,8 +145,8 @@ static void cast_fw2(const Column* col, void* out_data)
   auto out = static_cast<U*>(out_data);
   const RowIndex& rowindex = col->rowindex();
   dt::run_parallel(
-      [=](size_t start, size_t stop, size_t step) {
-        for (size_t i = start; i < stop; i += step) {
+      [=](size_t start, size_t stop) {
+        for (size_t i = start; i < stop; ++i) {
           size_t j = rowindex[i];
           T x = (j == RowIndex::NA)? GETNA<T>() : inp[j];
           out[i] = CAST_OP(x);

--- a/c/frame/replace.cc
+++ b/c/frame/replace.cc
@@ -606,15 +606,15 @@ void ReplaceAgent::replace_fw1(T* x, T* y, size_t nrows, T* data) {
   T x0 = x[0], y0 = y[0];
   if (std::is_floating_point<T>::value && ISNA<T>(x0)) {
     dt::run_parallel(
-      [=](size_t istart, size_t iend, size_t di) {
-        for (size_t i = istart; i < iend; i += di) {
+      [=](size_t istart, size_t iend) {
+        for (size_t i = istart; i < iend; ++i) {
           if (ISNA<T>(data[i])) data[i] = y0;
         }
       }, nrows);
   } else {
     dt::run_parallel(
-      [=](size_t istart, size_t iend, size_t di) {
-        for (size_t i = istart; i < iend; i += di) {
+      [=](size_t istart, size_t iend) {
+        for (size_t i = istart; i < iend; ++i) {
           if (data[i] == x0) data[i] = y0;
         }
       }, nrows);
@@ -629,8 +629,8 @@ void ReplaceAgent::replace_fw2(T* x, T* y, size_t nrows, T* data) {
   xassert(!ISNA<T>(x0));
   if (std::is_floating_point<T>::value && ISNA<T>(x1)) {
     dt::run_parallel(
-      [=](size_t istart, size_t iend, size_t di) {
-        for (size_t i = istart; i < iend; i += di) {
+      [=](size_t istart, size_t iend) {
+        for (size_t i = istart; i < iend; ++i) {
           T v = data[i];
           if (v == x0) data[i] = y0;
           else if (ISNA<T>(v)) data[i] = y1;
@@ -638,8 +638,8 @@ void ReplaceAgent::replace_fw2(T* x, T* y, size_t nrows, T* data) {
       }, nrows);
   } else {
     dt::run_parallel(
-      [=](size_t istart, size_t iend, size_t di) {
-        for (size_t i = istart; i < iend; i += di) {
+      [=](size_t istart, size_t iend) {
+        for (size_t i = istart; i < iend; ++i) {
           T v = data[i];
           if (v == x0) data[i] = y0;
           else if (v == x1) data[i] = y1;
@@ -654,8 +654,8 @@ void ReplaceAgent::replace_fwN(T* x, T* y, size_t nrows, T* data, size_t n) {
   if (std::is_floating_point<T>::value && ISNA<T>(x[n-1])) {
     n--;
     dt::run_parallel(
-      [=](size_t istart, size_t iend, size_t di) {
-        for (size_t i = istart; i < iend; i += di) {
+      [=](size_t istart, size_t iend) {
+        for (size_t i = istart; i < iend; ++i) {
           T v = data[i];
           if (ISNA<T>(v)) {
             data[i] = y[n];
@@ -671,8 +671,8 @@ void ReplaceAgent::replace_fwN(T* x, T* y, size_t nrows, T* data, size_t n) {
       }, nrows);
   } else {
     dt::run_parallel(
-      [=](size_t istart, size_t iend, size_t di) {
-        for (size_t i = istart; i < iend; i += di) {
+      [=](size_t istart, size_t iend) {
+        for (size_t i = istart; i < iend; ++i) {
           T v = data[i];
           for (size_t j = 0; j < n; ++j) {
             if (v == x[j]) {

--- a/c/models/dt_ftrl_real.cc
+++ b/c/models/dt_ftrl_real.cc
@@ -325,11 +325,11 @@ double FtrlReal<T>::fit(T(*linkfn)(T), T(*lossfn)(T,U)) {
     chunk_end = std::min((c + 1) * chunk_nrows, total_nrows);
 
     dt::run_parallel(
-      [&](size_t i0, size_t i1, size_t di) {
+      [&](size_t i0, size_t i1) {
         uint64ptr x = uint64ptr(new uint64_t[nfeatures]);
         tptr<T> w = tptr<T>(new T[nfeatures]());
         tptr<T> fi = tptr<T>(new T[nfeatures]());
-        for (size_t i = chunk_start + i0; i < chunk_start + i1; i += di) {
+        for (size_t i = chunk_start + i0; i < chunk_start + i1; ++i) {
           size_t ii = i % dt_X->nrows;
           const size_t j0 = ri[0][ii];
           // Note that for FtrlModelType::BINOMIAL and FtrlModelType::REGRESSION
@@ -369,12 +369,12 @@ double FtrlReal<T>::fit(T(*linkfn)(T), T(*lossfn)(T,U)) {
     // if the loss does not improve.
     if (validation) {
       dt::run_parallel(
-        [&](size_t i0, size_t i1, size_t di) {
+        [&](size_t i0, size_t i1) {
           uint64ptr x = uint64ptr(new uint64_t[nfeatures]);
           tptr<T> w = tptr<T>(new T[nfeatures]());
           T loss_local = 0.0;
 
-          for (size_t i = i0; i < i1; i += di) {
+          for (size_t i = i0; i < i1; ++i) {
             const size_t j0 = ri_val[0][i];
             if (j0 != RowIndex::NA && !ISNA<U>(data_val[0][j0])) {
               hash_row(x, hashers_val, i);
@@ -487,11 +487,11 @@ dtptr FtrlReal<T>::predict(const DataTable* dt_X_in) {
   }
 
   dt::run_parallel(
-    [&](size_t i0, size_t i1, size_t di) {
+    [&](size_t i0, size_t i1) {
       uint64ptr x = uint64ptr(new uint64_t[nfeatures]);
       tptr<T> w = tptr<T>(new T[nfeatures]);
 
-      for (size_t i = i0; i < i1; i += di) {
+      for (size_t i = i0; i < i1; ++i) {
         hash_row(x, hashers, i);
         for (size_t k = 0; k < nlabels; ++k) {
           data_p[k][i] = linkfn(predict_row(x, w, k, [&](size_t, T){}));
@@ -544,9 +544,8 @@ void FtrlReal<T>::normalize_rows(dtptr& dt) {
   }
 
   dt::run_parallel(
-    [&](size_t i0, size_t i1, size_t di) {
-
-      for (size_t i = i0; i < i1; i += di) {
+    [&](size_t i0, size_t i1) {
+      for (size_t i = i0; i < i1; ++i) {
         T denom = static_cast<T>(0.0);
         for (size_t j = 0; j < ncols; ++j) {
           denom += data[j][i];

--- a/c/parallel/api.h
+++ b/c/parallel/api.h
@@ -28,6 +28,12 @@ thread_pool& get_thread_pool();
 
 
 /**
+ * Return the current number of threads in the pool.
+ */
+size_t get_num_threads();
+
+
+/**
  * Return the number of concurrent threads supported by the machine. This
  * value is approximate. If the number of concurrent threads is unknown,
  * this function returns 1.

--- a/c/parallel/thread_pool.cc
+++ b/c/parallel/thread_pool.cc
@@ -75,6 +75,11 @@ thread_pool& get_thread_pool() {
 }
 
 
+size_t get_num_threads() {
+  return get_thread_pool().size();
+}
+
+
 size_t get_hardware_concurrency() noexcept {
   unsigned int nth = std::thread::hardware_concurrency();
   if (!nth) nth = 1;

--- a/c/rowindex.cc
+++ b/c/rowindex.cc
@@ -223,8 +223,8 @@ void RowIndex::extract_into(arr32_t& target) const {
         size_t start = slice_start();
         size_t step = slice_step();
         dt::run_parallel(
-          [&](size_t i0, size_t i1, size_t di) {
-            for (size_t i = i0; i < i1; i += di) {
+          [&](size_t i0, size_t i1) {
+            for (size_t i = i0; i < i1; ++i) {
               target[i] = static_cast<int32_t>(start + i * step);
             }
           }, szlen);

--- a/c/utils/parallel.h
+++ b/c/utils/parallel.h
@@ -44,7 +44,7 @@ namespace dt {
 // Order-less iteration over range [0; n)
 //------------------------------------------------------------------------------
 
-using rangefn = dt::function<void(size_t, size_t, size_t)>;
+using rangefn = dt::function<void(size_t, size_t)>;
 
 /**
  * Execute function `run` in parallel, over the range `[0 .. nrows - 1]`.


### PR DESCRIPTION
Also, changed the signature of `dt::run_parallel()` so that the step is not passed (since it is always 1).

WIP for #1736