### PR TITLE
Implement class atomic<double> and atomic<float>

### DIFF
--- a/c/csv/reader_fread.h
+++ b/c/csv/reader_fread.h
@@ -11,7 +11,7 @@
 #include "csv/reader.h"           // GenericReader
 #include "csv/reader_parsers.h"   // ParserLibrary, ParserFnPtr
 #include "read/field64.h"         // dt::read::field64
-
+#include "parallel/atomic.h"      // dt::atomic
 
 namespace dt {
 namespace read {
@@ -40,8 +40,8 @@ class FreadObserver {
     double t_frame_allocated;
     double t_data_read;
     double t_data_reread;
-    double time_read_data;
-    double time_push_data;
+    dt::atomic<double> time_read_data;
+    dt::atomic<double> time_push_data;
     size_t n_rows_read;
     size_t n_cols_read;
     size_t input_size;

--- a/c/models/column_hasher.cc
+++ b/c/models/column_hasher.cc
@@ -77,9 +77,10 @@ template <typename T>
 uint64_t HasherFloat<T>::hash(size_t row) const {
   size_t i = ri[row];
   T value = (i == RowIndex::NA)? GETNA<T>() : values[i];
-  auto x = static_cast<double>(value);
-  uint64_t* h = reinterpret_cast<uint64_t*>(&x);
-  return *h;
+  double x = static_cast<double>(value);
+  uint64_t h;
+  std::memcpy(&h, &x, sizeof(double));
+  return h;
 }
 
 

--- a/c/models/dt_ftrl_real.cc
+++ b/c/models/dt_ftrl_real.cc
@@ -393,7 +393,7 @@ double FtrlReal<T>::fit(T(*linkfn)(T), T(*lossfn)(T,U)) {
         dt_X_val->nrows
       );
 
-      // If loss doesn't not decrease, do early stopping.
+      // If loss does not decrease, do early stopping.
       T loss_current = loss.load();
       loss_current /= (dt_X_val->nrows * dt_y_val->ncols);
       T loss_diff = (loss_old - loss_current) / loss_old;

--- a/c/models/dt_ftrl_real.cc
+++ b/c/models/dt_ftrl_real.cc
@@ -388,12 +388,12 @@ double FtrlReal<T>::fit(T(*linkfn)(T), T(*lossfn)(T,U)) {
               }
             }
           }
-          loss += loss_local;
+          loss.fetch_add(loss_local);
         },
         dt_X_val->nrows
       );
 
-      // If loss do not decrease, do early stopping.
+      // If loss doesn't not decrease, do early stopping.
       T loss_current = loss.load();
       loss_current /= (dt_X_val->nrows * dt_y_val->ncols);
       T loss_diff = (loss_old - loss_current) / loss_old;

--- a/c/parallel/atomic.h
+++ b/c/parallel/atomic.h
@@ -1,0 +1,136 @@
+//------------------------------------------------------------------------------
+// Copyright 2019 H2O.ai
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//------------------------------------------------------------------------------
+#ifndef dt_PARALLEL_ATOMIC_h
+#define dt_PARALLEL_ATOMIC_h
+#include <atomic>       // std::atomic, std::memory_order
+#include <cstring>      // std::memcpy
+#include <type_traits>  // std::is_floating_point, std::enable_if
+namespace dt {
+
+template <typename T> struct int_from_real {};
+template <> struct int_from_real<float> { using t = int32_t; };
+template <> struct int_from_real<double> { using t = int64_t; };
+
+
+
+// Note: `std::atomic<T>` has specializations for float and double only since
+// C++20, so we need to implement our own class for those.
+//
+template <typename T, typename = typename std::enable_if<
+                      std::is_floating_point<T>::value>::type>
+class atomic {
+  // T is float or double
+  // V is int32_t or int64_t
+  using V = typename int_from_real<T>::t;
+  static_assert(sizeof(T) == sizeof(V), "Invalid size of int/float");
+  static constexpr std::memory_order DEFAULT_MO = std::memory_order_seq_cst;
+
+  private:
+    std::atomic<V> v;
+
+  public:
+    atomic() noexcept = default;
+    atomic(T x) noexcept : v(real_to_int(x)) {}
+    atomic& operator=(const atomic&) = delete;
+    T operator=(T x) noexcept { v = real_to_int(x); return x; }
+
+    void store(T x, std::memory_order order = DEFAULT_MO) noexcept {
+      v.store(real_to_int(x), order);
+    }
+    T load(std::memory_order order = DEFAULT_MO) const noexcept {
+      return int_to_real(v.load(order));
+    }
+    operator T() const noexcept { return load(); }
+
+    T exchange(T x, std::memory_order order = DEFAULT_MO) noexcept {
+      V old = v.exchange(real_to_int(x), order);
+      return int_to_real(old);
+    }
+    bool compare_exchange_weak(T& expected, T desired,
+                               std::memory_order success,
+                               std::memory_order failure) noexcept {
+      V expv = real_to_int(expected);
+      V desv = real_to_int(desired);
+      bool ret = compare_exchange_weak(expv, desv, success, failure);
+      expected = int_to_real(expv);
+      return ret;
+    }
+    bool compare_exchange_weak(T& expected, T desired,
+                               std::memory_order order = DEFAULT_MO) noexcept {
+      V expv = real_to_int(expected);
+      V desv = real_to_int(desired);
+      bool ret = compare_exchange_weak(expv, desv, order);
+      expected = int_to_real(expv);
+      return ret;
+    }
+
+    T fetch_add(T arg, std::memory_order order = DEFAULT_MO) noexcept {
+      V vcurr = v.load(order);
+      while (!v.compare_exchange_weak(vcurr,
+                                      real_to_int(int_to_real(vcurr) + arg),
+                                      order));
+      return int_to_real(vcurr);
+    }
+
+    T fetch_sub(T arg, std::memory_order order = DEFAULT_MO) noexcept {
+      V vcurr = v.load(order);
+      while (!v.compare_exchange_weak(vcurr,
+                                      real_to_int(int_to_real(vcurr) - arg),
+                                      order));
+      return int_to_real(vcurr);
+    }
+
+    T fetch_mul(T arg, std::memory_order order = DEFAULT_MO) noexcept {
+      V vcurr = v.load(order);
+      while (!v.compare_exchange_weak(vcurr,
+                                      real_to_int(int_to_real(vcurr) * arg),
+                                      order));
+      return int_to_real(vcurr);
+    }
+
+    T fetch_div(T arg, std::memory_order order = DEFAULT_MO) noexcept {
+      V vcurr = v.load(order);
+      while (!v.compare_exchange_weak(vcurr,
+                                      real_to_int(int_to_real(vcurr) / arg),
+                                      order));
+      return int_to_real(vcurr);
+    }
+
+    T operator+=(T arg) noexcept { return fetch_add(arg) + arg; }
+    T operator-=(T arg) noexcept { return fetch_sub(arg) - arg; }
+    T operator*=(T arg) noexcept { return fetch_mul(arg) * arg; }
+    T operator/=(T arg) noexcept { return fetch_div(arg) / arg; }
+
+  private:
+    // The only safe way to convert float<->int (bitwise) is via memcpy, see
+    // https://en.cppreference.com/w/cpp/language/reinterpret_cast
+    // https://chromium.googlesource.com/chromium/src/+/1587f7d/base/macros.h#76
+    static inline V real_to_int(T x) noexcept {
+      V res;
+      std::memcpy(&res, &x, sizeof(V));
+      return res;
+    }
+    static inline T int_to_real(V y) noexcept {
+      T res;
+      std::memcpy(&res, &y, sizeof(T));
+      return res;
+    }
+};
+
+
+
+}  // namespace dt
+#endif

--- a/c/parallel/atomic_test.cc
+++ b/c/parallel/atomic_test.cc
@@ -1,0 +1,77 @@
+//------------------------------------------------------------------------------
+// Copyright 2018 H2O.ai
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//------------------------------------------------------------------------------
+#ifdef DTTEST
+#include <atomic>       // std::atomic
+#include <cmath>        // std::pow, std::abs
+#include "parallel/api.h"
+#include "parallel/atomic.h"
+#include "utils/exceptions.h"
+#include "ztest.h"
+namespace dttest {
+
+
+template <typename T>
+static void test_atomic_impl() {
+  size_t n = dt::get_num_threads();
+  std::atomic<int> barrier { static_cast<int>(n) };
+
+  dt::atomic<T> x { T(0.0) };
+  dt::atomic<T> y { T(1.0) };
+  dt::atomic<T> z { T(1.3e20) };
+
+  dt::run_once_per_thread(
+    [&](size_t i) {
+      barrier--;
+      while (barrier.load());
+
+      x += static_cast<T>(i);
+      y *= static_cast<T>(2.0);
+      z /= static_cast<T>(7.0);
+      x -= static_cast<T>(1.0);
+    });
+
+  T x_exp = static_cast<T>(n * (n - 1) / 2 - n);
+  T y_exp = static_cast<T>(std::pow(2.0, n));
+  T z_exp = static_cast<T>(1.3e20 / std::pow(7.0, n));
+  T x_act = x.load();
+  T y_act = y.load();
+  T z_act = z.load();
+
+  T eps = static_cast<T>(sizeof(T) == 4? 1e-6 : 1e-10);
+  if (std::abs(x_act/x_exp - 1) > eps) {
+    throw AssertionError() << "Invalid x = " << x_act << " after " << n
+        << " atomic operations, expected = " << x_exp;
+  }
+  if (std::abs(y_act/y_exp - 1) > eps) {
+    throw AssertionError() << "Invalid y = " << y_act << " after " << n
+        << " atomic operations, expected = " << y_exp;
+  }
+  if (std::abs(z_act/z_exp - 1) > eps) {
+    throw AssertionError() << "Invalid z = " << z_act << " after " << n
+        << " atomic operations, expected = " << z_exp;
+  }
+}
+
+
+void test_atomic() {
+  test_atomic_impl<float>();
+  test_atomic_impl<double>();
+}
+
+
+
+} // namespace dt
+#endif

--- a/c/read/fread/fread_thread_context.cc
+++ b/c/read/fread/fread_thread_context.cc
@@ -41,9 +41,7 @@ FreadThreadContext::FreadThreadContext(
 }
 
 FreadThreadContext::~FreadThreadContext() {
-  #pragma omp atomic update
   freader.fo.time_push_data += ttime_push;
-  #pragma omp atomic update
   freader.fo.time_read_data += ttime_read;
   ttime_push = 0;
   ttime_read = 0;

--- a/c/ztest.cc
+++ b/c/ztest.cc
@@ -32,11 +32,18 @@ static void test_shmutex(const PKArgs& args) {
   dttest::test_shmutex(n_iters, n_threads, impl);
 }
 
+static PKArgs arg_test_atomic(0, 0, 0, false, false, {}, "test_atomic");
+
+static void test_atomic(const PKArgs&) {
+  dttest::test_atomic();
+}
+
 
 
 void DatatableModule::init_tests() {
   ADD_FN(&test_coverage, arg_test_coverage);
   ADD_FN(&test_shmutex, arg_test_shmutex);
+  ADD_FN(&test_atomic, arg_test_atomic);
 }
 
 

--- a/c/ztest.h
+++ b/c/ztest.h
@@ -23,6 +23,9 @@ void cover_names_integrity_checks();
 // Defined in utils/shared_mutex_test.cc
 void test_shmutex(size_t n_iters, size_t n_threads, int impl);
 
+// Defined in parallel/atomic_test.cc
+void test_atomic();
+
 }  // namespace dttest
 
 #endif

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -188,6 +188,12 @@ def test_internal_shared_bmutex():
         core.test_shmutex(1000, dt.options.nthreads * 2, 0)
 
 
+def test_internal_atomic():
+    from datatable.lib import core
+    if hasattr(core, "test_atomic"):
+        core.test_atomic()
+
+
 def test_dt_view(dt0, patched_terminal, capsys):
     dt0.view(interactive=False)
     out, err = capsys.readouterr()


### PR DESCRIPTION
`std::atomic<double>` is specialized only in C++17, not in C++11. In C++11 there is generic `std::atomic<T>`, but it lacks arithmetic operators, which are very important for our use case. Hence, we implement our own atomic class, which reuses atomic ints at bit level.

WIP for #1736