### PR TITLE
Correct behavior of thread pool during forking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed conversion to numpy of a view Frame which contains NAs (#1738).
 
+- `datatable` can now be safely used with `multiprocessing`, or other modules
+  that perform fork-without-exec (#1758). The child process will spawn its
+  own thread pool that will have the same number of threads as the parent.
+  Adjust `dt.options.nthreads` in the child process(es) if different number
+  of threads is required.
+
 
 ### Changed
 

--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -154,7 +154,8 @@ R"(Return system ids of all threads used internally by datatable)");
 
 static py::oobj get_thread_ids(const py::PKArgs&) {
   std::mutex m;
-  py::olist list(dt::get_num_threads());
+  size_t n = dt::get_num_threads();
+  py::olist list(n);
 
   dt::run_once_per_thread([&](size_t i) {
     std::stringstream ss;
@@ -163,6 +164,9 @@ static py::oobj get_thread_ids(const py::PKArgs&) {
     list.set(i, py::ostring(ss.str()));
   });
 
+  for (size_t i = 0; i < n; ++i) {
+    xassert(list[i]);
+  }
   return std::move(list);
 }
 

--- a/c/options.cc
+++ b/c/options.cc
@@ -53,7 +53,7 @@ void set_nthreads(int32_t n) {
   // that do not use explicit `num_threads()` directive.
   omp_set_num_threads(n);
 
-  dt::get_thread_pool().resize(static_cast<size_t>(n));
+  dt::thread_pool::get_instance()->resize(static_cast<size_t>(n));
 }
 
 

--- a/c/parallel/api.h
+++ b/c/parallel/api.h
@@ -22,12 +22,6 @@ namespace dt {
 
 
 /**
- * thread_pool is a singleton, returned by this function
- */
-thread_pool& get_thread_pool();
-
-
-/**
  * Return the current number of threads in the pool.
  */
 size_t get_num_threads();

--- a/c/parallel/thread_pool.cc
+++ b/c/parallel/thread_pool.cc
@@ -99,11 +99,8 @@ void thread_pool::cleanup_after_fork() {
   _instance = new thread_pool;
   _instance->resize(num_threads_requested);
 
-  // Abandon the workers (since they are in an invalid state after the fork).
-  for (auto& worker : workers) {
-    worker.release();
-  }
-  delete this;
+  // Abandon the current instance (`this`) without deleting, since it is owned
+  // by the parent process anyways.
 }
 
 

--- a/c/parallel/thread_pool.cc
+++ b/c/parallel/thread_pool.cc
@@ -87,7 +87,9 @@ void thread_pool::resize_impl() {
 void thread_pool::execute_job(thread_scheduler* job) {
   if (workers.empty()) resize_impl();
   controller.awaken_and_run(job);
-  controller.join(num_threads_requested);
+  controller.join(workers.size());
+  // careful: workers.size() may not be equal to num_threads_requested during
+  // shutdown
 }
 
 

--- a/c/parallel/thread_pool.cc
+++ b/c/parallel/thread_pool.cc
@@ -13,10 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //------------------------------------------------------------------------------
-#include <thread>    // std::thread::hardware_concurrency
+#include <thread>      // std::thread::hardware_concurrency
+#include <pthread.h>   // pthread_atfork
 #include "parallel/api.h"
 #include "parallel/thread_pool.h"
 #include "parallel/thread_worker.h"
+#include "utils/assert.h"
 #include "utils/c+++.h"
 namespace dt {
 
@@ -26,14 +28,44 @@ namespace dt {
 // thread_pool
 //------------------------------------------------------------------------------
 
-thread_pool::thread_pool() {}
+thread_pool* thread_pool::_instance = nullptr;
+
+thread_pool* thread_pool::get_instance() {
+  if (!_instance) _instance = new thread_pool;
+  return _instance;
+}
+
+
+thread_pool::thread_pool() {
+  if (!_instance) {
+    pthread_atfork(
+      /* before_fork = */ nullptr,
+      /* after_fork_parent = */ nullptr,
+      /* after_fork_child = */ [] {
+        thread_pool::get_instance()->cleanup_after_fork();
+      }
+    );
+  }
+}
 
 thread_pool::~thread_pool() {
   resize(0);
 }
 
 
+size_t thread_pool::size() const noexcept {
+  return num_threads_requested;
+}
+
 void thread_pool::resize(size_t n) {
+  num_threads_requested = n;
+  if (!workers.empty()) {
+    resize_impl();
+  }
+}
+
+void thread_pool::resize_impl() {
+  size_t n = num_threads_requested;
   if (workers.size() == n) return;
   if (workers.size() < n) {
     workers.reserve(n);
@@ -53,13 +85,25 @@ void thread_pool::resize(size_t n) {
 
 
 void thread_pool::execute_job(thread_scheduler* job) {
+  if (workers.empty()) resize_impl();
   controller.awaken_and_run(job);
-  controller.join(workers.size());
+  controller.join(num_threads_requested);
 }
 
 
-size_t thread_pool::size() const noexcept {
-  return workers.size();
+// This function should be called in the child process after the fork only.
+void thread_pool::cleanup_after_fork() {
+  xassert(this == _instance);
+  // Replace the current thread pool instance with a new one, ensuring that all
+  // schedulers and workers have new mutexes/condition variables
+  _instance = new thread_pool;
+  _instance->resize(num_threads_requested);
+
+  // Abandon the workers (since they are in an invalid state after the fork).
+  for (auto& worker : workers) {
+    worker.release();
+  }
+  delete this;
 }
 
 
@@ -69,14 +113,8 @@ size_t thread_pool::size() const noexcept {
 // Misc
 //------------------------------------------------------------------------------
 
-thread_pool& get_thread_pool() {
-  static thread_pool tp;
-  return tp;
-}
-
-
 size_t get_num_threads() {
-  return get_thread_pool().size();
+  return thread_pool::get_instance()->size();
 }
 
 

--- a/c/parallel/thread_pool.h
+++ b/c/parallel/thread_pool.h
@@ -56,10 +56,18 @@ class thread_pool {
     // (these pointers are stored within each thread).
     std::vector<std::unique_ptr<thread_worker>> workers;
 
+    // Number of threads requested by the user; however, we will only
+    // instantiate the threads when `execute_job()` is first called.
+    size_t num_threads_requested;
+
     // Scheduler used to manage sleep/awake cycle of the threads in the pool.
     worker_controller controller;
 
+    // Singleton instance of the thread_pool, returned by `get_instance()`.
+    static thread_pool* _instance;
+
   public:
+    static thread_pool* get_instance();
     thread_pool();
     thread_pool(const thread_pool&) = delete;
     // Not moveable: workers hold pointers to this->controller.
@@ -70,6 +78,10 @@ class thread_pool {
 
     size_t size() const noexcept;
     void resize(size_t n);
+
+  private:
+    void resize_impl();
+    void cleanup_after_fork();
 };
 
 

--- a/c/parallel/thread_scheduler.cc
+++ b/c/parallel/thread_scheduler.cc
@@ -56,10 +56,10 @@ thread_task* once_scheduler::get_next_task(size_t i) {
 
 
 void run_once_per_thread(function<void(size_t)> f) {
-  thread_pool& thpool = get_thread_pool();
+  thread_pool* thpool = thread_pool::get_instance();
   simple_task task(f);
-  once_scheduler sch(thpool.size(), &task);
-  thpool.execute_job(&sch);
+  once_scheduler sch(thpool->size(), &task);
+  thpool->execute_job(&sch);
 }
 
 

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -176,6 +176,20 @@ def test_coverage():
         core.test_coverage()
 
 
+def test_multiprocessing_threadpool():
+    # Verify that threads work properly after forking (#1758)
+    import multiprocessing as mp
+    from datatable.internal import get_thread_ids
+    parent_threads = get_thread_ids()
+    n = 4
+    pool = mp.Pool(processes=n)
+    child_threads = pool.starmap(get_thread_ids, [()] * n, chunksize=1)
+    assert len(child_threads) == n
+    for chthreads in child_threads:
+        assert len(parent_threads) == len(chthreads)
+        assert chthreads != parent_threads
+
+
 def test_internal_shared_mutex():
     from datatable.lib import core
     if hasattr(core, "test_shmutex"):


### PR DESCRIPTION
This PR introduces two changes to the thread pool:

1. The threads are now initialized lazily, that is on the first run that they are actually required. For example function `get_thread_ids()` will always cause the threads to spawn, whereas `dt::run_parallel()` may not, if the number of rows is small enough to run single-threadedly.

2. Fixed problems with datatable hanging after the process was forked by an external module such as `multiprocessing`. Now we re-initialize the thread pool in every child process, ensuring that they do not accidentally share mutexes / condition variables / threads. 

Closes #1758 
Closes #1757