### PR TITLE
Return loss, when validation dataset is provided to FTRL algo

### DIFF
--- a/c/models/dt_ftrl.h
+++ b/c/models/dt_ftrl.h
@@ -53,7 +53,7 @@ struct FtrlParams {
 /*
 *  When FTRL fitting is completed, this structure is returned
 *  containing epoch at which fitting stopped, and, in the case validation set
-*  was provided, the non-zero final loss.
+*  was provided, non-zero final loss.
 */
 struct FtrlFitOutput {
     double epoch;

--- a/c/models/dt_ftrl.h
+++ b/c/models/dt_ftrl.h
@@ -53,7 +53,7 @@ struct FtrlParams {
 /*
 *  When FTRL fitting is completed, this structure is returned
 *  containing epoch at which fitting stopped, and, in the case validation set
-*  was provided, non-zero final loss.
+*  was provided, the corresponding final loss.
 */
 struct FtrlFitOutput {
     double epoch;

--- a/c/models/dt_ftrl.h
+++ b/c/models/dt_ftrl.h
@@ -31,8 +31,8 @@ namespace dt {
 
 
 /*
-* All the FTRL parameters provided in Python are stored in this structure,
-* that also defines their default values.
+*  All the FTRL parameters provided in Python are stored in this structure,
+*  that also defines their default values.
 */
 struct FtrlParams {
     double alpha;
@@ -51,6 +51,17 @@ struct FtrlParams {
 
 
 /*
+*  When FTRL fitting is completed, this structure is returned
+*  containing epoch at which fitting stopped, and, in the case validation set
+*  was provided, the non-zero final loss.
+*/
+struct FtrlFitOutput {
+    double epoch;
+    double loss;
+};
+
+
+/*
 * Supported FTRL model types.
 */
 enum class FtrlModelType : size_t {
@@ -62,8 +73,8 @@ enum class FtrlModelType : size_t {
 
 
 /*
-* An abstract dt::Ftrl class that declares all the virtual functions
-* needed by py::Ftrl.
+*  An abstract dt::Ftrl class that declares all the virtual functions
+*  needed by py::Ftrl.
 */
 class Ftrl {
   public:
@@ -72,9 +83,9 @@ class Ftrl {
     // - binomial logistic regression (BOOL);
     // - multinomial logistic regression (STR32, STR64);
     // - numerical regression (INT8, INT16, INT32, INT64, FLOAT32, FLOAT64).
-    virtual double dispatch_fit(const DataTable*, const DataTable*,
-                                const DataTable*, const DataTable*,
-                                double, double) = 0;
+    virtual FtrlFitOutput dispatch_fit(const DataTable*, const DataTable*,
+                                       const DataTable*, const DataTable*,
+                                       double, double) = 0;
     virtual dtptr predict(const DataTable*) = 0;
     virtual void reset() = 0;
     virtual bool is_trained() = 0;

--- a/c/models/dt_ftrl_real.cc
+++ b/c/models/dt_ftrl_real.cc
@@ -297,10 +297,10 @@ FtrlFitOutput FtrlReal<T>::fit(T(*linkfn)(T), T(*lossfn)(T,U)) {
   size_t nchunks = nepochs;
   size_t chunk_nrows = dt_X->nrows;
 
-  // If a validation set has been provided, we train on chunks of data.
-  // After each chunk was fitted, we calculate loss on the validation set,
-  // and do early stopping if needed.
-  T loss = 0.0;
+  // If a validation set is provided, we train on chunks of data.
+  // After each chunk, we calculate loss on the validation dataset,
+  // and do early stopping if loss does not improve.
+  T loss = std::numeric_limits<T>::quiet_NaN();;
   bool validation = !std::isnan(nepochs_val);
   constexpr T epsilon = std::numeric_limits<T>::epsilon();
   std::vector<hasherptr> hashers_val;

--- a/c/models/dt_ftrl_real.cc
+++ b/c/models/dt_ftrl_real.cc
@@ -59,7 +59,7 @@ FtrlReal<T>::FtrlReal(FtrlParams params_in) :
 * and returns epoch at which learning completed or was early stopped.
 */
 template <typename T>
-double FtrlReal<T>::dispatch_fit(const DataTable* dt_X_in,
+FtrlFitOutput FtrlReal<T>::dispatch_fit(const DataTable* dt_X_in,
                                  const DataTable* dt_y_in,
                                  const DataTable* dt_X_val_in,
                                  const DataTable* dt_y_val_in,
@@ -71,19 +71,19 @@ double FtrlReal<T>::dispatch_fit(const DataTable* dt_X_in,
   dt_y_val = dt_y_val_in;
   nepochs_val = static_cast<T>(nepochs_val_in);
   val_error = static_cast<T>(val_error_in);
+  FtrlFitOutput res;
 
-  double epoch;
   SType stype_y = dt_y->columns[0]->stype();
   switch (stype_y) {
-    case SType::BOOL:    epoch = fit_binomial(); break;
-    case SType::INT8:    epoch = fit_regression<int8_t>(); break;
-    case SType::INT16:   epoch = fit_regression<int16_t>(); break;
-    case SType::INT32:   epoch = fit_regression<int32_t>(); break;
-    case SType::INT64:   epoch = fit_regression<int64_t>(); break;
-    case SType::FLOAT32: epoch = fit_regression<float>(); break;
-    case SType::FLOAT64: epoch = fit_regression<double>(); break;
+    case SType::BOOL:    res = fit_binomial(); break;
+    case SType::INT8:    res = fit_regression<int8_t>(); break;
+    case SType::INT16:   res = fit_regression<int16_t>(); break;
+    case SType::INT32:   res = fit_regression<int32_t>(); break;
+    case SType::INT64:   res = fit_regression<int64_t>(); break;
+    case SType::FLOAT32: res = fit_regression<float>(); break;
+    case SType::FLOAT64: res = fit_regression<double>(); break;
     case SType::STR32:   FALLTHROUGH;
-    case SType::STR64:   epoch = fit_multinomial(); break;
+    case SType::STR64:   res = fit_multinomial(); break;
     default:             throw TypeError() << "Targets of type `"
                                            << stype_y << "` are not supported";
   }
@@ -96,13 +96,13 @@ double FtrlReal<T>::dispatch_fit(const DataTable* dt_X_in,
   val_error = std::numeric_limits<T>::quiet_NaN();
   map_val.clear();
 
-  return epoch;
+  return res;
 }
 
 
 
 template <typename T>
-double FtrlReal<T>::fit_binomial() {
+FtrlFitOutput FtrlReal<T>::fit_binomial() {
   xassert(dt_y->ncols == 1);
   if (model_type != FtrlModelType::NONE &&
       model_type != FtrlModelType::BINOMIAL) {
@@ -122,7 +122,7 @@ double FtrlReal<T>::fit_binomial() {
 
 template <typename T>
 template <typename U>
-double FtrlReal<T>::fit_regression() {
+FtrlFitOutput FtrlReal<T>::fit_regression() {
   xassert(dt_y->ncols == 1);
   if (model_type != FtrlModelType::NONE &&
       model_type != FtrlModelType::REGRESSION) {
@@ -141,7 +141,7 @@ double FtrlReal<T>::fit_regression() {
 
 
 template <typename T>
-double FtrlReal<T>::fit_multinomial() {
+FtrlFitOutput FtrlReal<T>::fit_multinomial() {
   if (model_type != FtrlModelType::NONE &&
       model_type != FtrlModelType::MULTINOMIAL) {
     throw TypeError() << "This model has already been trained in a "
@@ -280,7 +280,7 @@ dtptr FtrlReal<T>::create_y_val() {
 */
 template <typename T>
 template <typename U> /* column data type */
-double FtrlReal<T>::fit(T(*linkfn)(T), T(*lossfn)(T,U)) {
+FtrlFitOutput FtrlReal<T>::fit(T(*linkfn)(T), T(*lossfn)(T,U)) {
   // Define features and init weight pointers
   define_features();
   init_weights();
@@ -300,6 +300,7 @@ double FtrlReal<T>::fit(T(*linkfn)(T), T(*lossfn)(T,U)) {
   // If a validation set has been provided, we train on chunks of data.
   // After each chunk was fitted, we calculate loss on the validation set,
   // and do early stopping if needed.
+  T loss = 0.0;
   bool validation = !std::isnan(nepochs_val);
   constexpr T epsilon = std::numeric_limits<T>::epsilon();
   std::vector<hasherptr> hashers_val;
@@ -367,7 +368,7 @@ double FtrlReal<T>::fit(T(*linkfn)(T), T(*lossfn)(T,U)) {
     // Calculate loss on the validation dataset and do early stopping,
     // if the loss does not improve.
     if (validation) {
-      dt::atomic<T> loss { 0.0 };
+      dt::atomic<T> loss_global { 0.0 };
       dt::run_parallel(
         [&](size_t i0, size_t i1) {
           uint64ptr x = uint64ptr(new uint64_t[nfeatures]);
@@ -388,23 +389,23 @@ double FtrlReal<T>::fit(T(*linkfn)(T), T(*lossfn)(T,U)) {
               }
             }
           }
-          loss.fetch_add(loss_local);
+          loss_global.fetch_add(loss_local);
         },
         dt_X_val->nrows
       );
 
       // If loss does not decrease, do early stopping.
-      T loss_current = loss.load();
-      loss_current /= (dt_X_val->nrows * dt_y_val->ncols);
-      T loss_diff = (loss_old - loss_current) / loss_old;
-      if (c && (loss_current < epsilon || loss_diff < val_error)) break;
+      loss = loss_global.load() / (dt_X_val->nrows * dt_y_val->ncols);
+      T loss_diff = (loss_old - loss) / loss_old;
+      if (c && (loss < epsilon || loss_diff < val_error)) break;
 
       // If loss decreases, save current loss and continue training.
-      loss_old = loss_current;
+      loss_old = loss;
     }
   }
   double epoch_stopped = static_cast<double>(chunk_end) / dt_X->nrows;
-  return epoch_stopped;
+  FtrlFitOutput res = {epoch_stopped, static_cast<double>(loss)};
+  return res;
 }
 
 

--- a/c/models/dt_ftrl_real.h
+++ b/c/models/dt_ftrl_real.h
@@ -85,10 +85,10 @@ class FtrlReal : public dt::Ftrl {
     std::vector<size_t> map_val;
 
     // Fitting methods
-    double fit_binomial();
-    double fit_multinomial();
-    template <typename U> double fit_regression();
-    template <typename U> double fit(T(*)(T), T(*)(T, U));
+    FtrlFitOutput fit_binomial();
+    FtrlFitOutput fit_multinomial();
+    template <typename U> FtrlFitOutput fit_regression();
+    template <typename U> FtrlFitOutput fit(T(*)(T), T(*)(T, U));
     template <typename U>
     void update(const uint64ptr&, const tptr<T>&, T, U, size_t);
 
@@ -126,9 +126,9 @@ class FtrlReal : public dt::Ftrl {
     FtrlReal(FtrlParams);
 
     // Main fitting method
-    double dispatch_fit(const DataTable*, const DataTable*,
-                        const DataTable*, const DataTable*,
-                        double, double) override;
+    FtrlFitOutput dispatch_fit(const DataTable*, const DataTable*,
+                               const DataTable*, const DataTable*,
+                               double, double) override;
 
     // Main predicting method
     dtptr predict(const DataTable*) override;

--- a/c/models/py_ftrl.cc
+++ b/c/models/py_ftrl.cc
@@ -236,8 +236,8 @@ Returns
 -------
 A tuple consisting of two elements: `epoch` and `loss`, where
 `epoch` is the epoch at which model fitting stopped, and `loss` is the final
-loss. When validation dataset was not provided, `epoch` returned will be equal to
-`nepochs`, and `loss` will be zero.
+loss. When validation dataset is not provided, `epoch` returned is equal to
+`nepochs`, and `loss` is `float('nan')`.
 )");
 
 
@@ -349,10 +349,9 @@ oobj Ftrl::fit(const PKArgs& args) {
     } else val_error = 0.01;
   }
 
-  // Train the model and return epoch when training.
   dt::FtrlFitOutput output = dtft->dispatch_fit(dt_X, dt_y,
-                                         dt_X_val, dt_y_val,
-                                         nepochs_val, val_error);
+                                                dt_X_val, dt_y_val,
+                                                nepochs_val, val_error);
 
   static onamedtupletype ntt(
     "FtrlFitOutput",

--- a/c/models/py_ftrl.cc
+++ b/c/models/py_ftrl.cc
@@ -234,8 +234,10 @@ validation_error: float
 
 Returns
 -------
-Epoch at which model training stopped. If no validation dataset was provided,
-epoch returned will be equal to `nepochs`.
+A tuple consisting of two elements: `epoch` and `loss`, where
+`epoch` is the epoch at which model fitting stopped, and `loss` is the final
+loss. When validation dataset was not provided, `epoch` returned will be equal to
+`nepochs`, and `loss` will be zero.
 )");
 
 
@@ -348,10 +350,22 @@ oobj Ftrl::fit(const PKArgs& args) {
   }
 
   // Train the model and return epoch when training.
-  double epoch_stopped = dtft->dispatch_fit(dt_X, dt_y,
-                                            dt_X_val, dt_y_val,
-                                            nepochs_val, val_error);
-  return py::ofloat(epoch_stopped);
+  dt::FtrlFitOutput output = dtft->dispatch_fit(dt_X, dt_y,
+                                         dt_X_val, dt_y_val,
+                                         nepochs_val, val_error);
+
+  static onamedtupletype ntt(
+    "FtrlFitOutput",
+    "Tuple of fit output",
+    {{"epoch", "epoch at which fitting stopped"},
+     {"loss",  "final loss calculated on the validation dataset"}}
+  );
+
+  py::onamedtuple res(ntt);
+  res.set(0, py::ofloat(output.epoch));
+  res.set(1, py::ofloat(output.loss));
+
+  return res;
 }
 
 

--- a/docs/ftrl.rst
+++ b/docs/ftrl.rst
@@ -86,7 +86,7 @@ not improve. For this the model should be fit as
 
 ::
 
-  epoch = ftrl_model.fit(X_train, y_train, X_validation, y_validation, nepochs_validation, validation_error)
+  res = ftrl_model.fit(X_train, y_train, X_validation, y_validation, nepochs_validation, validation_error)
 
 
 where ``X_train`` and ``y_train`` are training and target frames,
@@ -94,8 +94,8 @@ respectively, ``X_validation`` and ``y_validation`` are validation frames,
 ``nepochs_validation`` specifies how often, in epoch units, validation
 error should be checked, and ``validation_error`` is the relative
 validation error improvement that the model should demonstrate within
-``nepochs_validation`` to continue training. Returned ``epoch`` value
-is an epoch at which training stopped.
+``nepochs_validation`` to continue training. Returned ``res`` tuple
+contains epoch at which training stopped and the corresponding loss.
 
 
 Resetting a Model

--- a/docs/ftrl.rst
+++ b/docs/ftrl.rst
@@ -146,7 +146,7 @@ feature names and their importances, that are normalized to [0; 1] range.
 
 
 Feature Interactions
--------------------
+--------------------
 
 By default each column of a training dataset is considered as a feature
 by FTRL model. User can provide additional features by specifying


### PR DESCRIPTION
FTRL `fit()` method now returns a named tuple `FtrlFitOutput` consisting of `epoch`, the epoch at which training stopped, and the corresponding `loss`.  If no validation dataset is provided, this method returns `FtrlFitOutput(epoch=nepochs, loss=nan)`, where `nepochs` is a number of epochs provided to FTRL constructor.