### PR TITLE
parallel_for_static nested inside parallel_region

### DIFF
--- a/c/column_fw.cc
+++ b/c/column_fw.cc
@@ -215,12 +215,12 @@ void FwColumn<T>::apply_na_mask(const BoolColumn* mask) {
   const int8_t* maskdata = mask->elements_r();
   T* coldata = this->elements_w();
 
-  dt::parallel_for_static(
+  dt::parallel_for_static(nrows,
     [=](size_t i0, size_t i1) {
       for (size_t i = i0; i < i1; ++i) {
         if (maskdata[i] == 1) coldata[i] = GETNA<T>();
       }
-    }, nrows);
+    });
   if (stats != nullptr) stats->reset();
 }
 
@@ -229,12 +229,12 @@ template <typename T>
 void FwColumn<T>::fill_na() {
   xassert(!ri);
   T* vals = static_cast<T*>(mbuf.wptr());
-  dt::parallel_for_static(
+  dt::parallel_for_static(nrows,
     [=](size_t i0, size_t i1) {
       for (size_t i = i0; i < i1; ++i) {
         vals[i] = GETNA<T>();
       }
-    }, nrows);
+    });
 }
 
 

--- a/c/column_fw.cc
+++ b/c/column_fw.cc
@@ -8,7 +8,7 @@
 #include <type_traits>
 #include "utils/assert.h"
 #include "utils/misc.h"
-#include "utils/parallel.h"  // dt::run_parallel
+#include "parallel/api.h"  // dt::parallel_for_static
 #include "column.h"
 
 
@@ -215,7 +215,7 @@ void FwColumn<T>::apply_na_mask(const BoolColumn* mask) {
   const int8_t* maskdata = mask->elements_r();
   T* coldata = this->elements_w();
 
-  dt::run_parallel(
+  dt::parallel_for_static(
     [=](size_t i0, size_t i1) {
       for (size_t i = i0; i < i1; ++i) {
         if (maskdata[i] == 1) coldata[i] = GETNA<T>();
@@ -229,7 +229,7 @@ template <typename T>
 void FwColumn<T>::fill_na() {
   xassert(!ri);
   T* vals = static_cast<T*>(mbuf.wptr());
-  dt::run_parallel(
+  dt::parallel_for_static(
     [=](size_t i0, size_t i1) {
       for (size_t i = i0; i < i1; ++i) {
         vals[i] = GETNA<T>();

--- a/c/column_string.cc
+++ b/c/column_string.cc
@@ -5,10 +5,11 @@
 //
 // © H2O.ai 2018
 //------------------------------------------------------------------------------
+#include "parallel/api.h"  // dt::parallel_for_static
 #include "python/string.h"
 #include "utils/assert.h"
 #include "utils/misc.h"
-#include "utils/parallel.h"  // dt::run_parallel
+#include "utils/parallel.h"
 #include "column.h"
 
 // Returns the expected path of the string data file given
@@ -481,7 +482,7 @@ void StringColumn<T>::fill_na() {
   T* off_data = offsets_w();
   off_data[-1] = 0;
 
-  dt::run_parallel(
+  dt::parallel_for_static(
     [=](size_t i0, size_t i1){
       for (size_t i = i0; i < i1; ++i) {
         off_data[i] = GETNA<T>();

--- a/c/column_string.cc
+++ b/c/column_string.cc
@@ -482,12 +482,12 @@ void StringColumn<T>::fill_na() {
   T* off_data = offsets_w();
   off_data[-1] = 0;
 
-  dt::parallel_for_static(
+  dt::parallel_for_static(nrows,
     [=](size_t i0, size_t i1){
       for (size_t i = i0; i < i1; ++i) {
         off_data[i] = GETNA<T>();
       }
-    }, nrows);
+    });
 }
 
 

--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -157,7 +157,7 @@ static py::oobj get_thread_ids(const py::PKArgs&) {
   size_t n = dt::get_num_threads();
   py::olist list(n);
 
-  dt::run_once_per_thread([&](size_t i) {
+  dt::parallel_region([&](size_t i) {
     std::stringstream ss;
     ss << std::this_thread::get_id();
     std::lock_guard<std::mutex> lock(m);

--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -156,12 +156,14 @@ static py::oobj get_thread_ids(const py::PKArgs&) {
   std::mutex m;
   size_t n = dt::get_num_threads();
   py::olist list(n);
+  xassert(dt::get_thread_num() == size_t(-1));
 
   dt::parallel_region([&](size_t i) {
     std::stringstream ss;
     ss << std::this_thread::get_id();
     std::lock_guard<std::mutex> lock(m);
     list.set(i, py::ostring(ss.str()));
+    xassert(i == dt::get_thread_num());
   });
 
   for (size_t i = 0; i < n; ++i) {

--- a/c/frame/cast.cc
+++ b/c/frame/cast.cc
@@ -24,6 +24,7 @@
 //
 #include <unordered_map>
 #include "csv/toa.h"
+#include "parallel/api.h"    // dt::parallel_for_static
 #include "python/_all.h"
 #include "python/string.h"
 #include "utils/parallel.h"
@@ -110,7 +111,7 @@ static void cast_fw0(const Column* col, size_t start, void* out_data)
                          : (start == 0));
   auto inp = static_cast<const T*>(col->data()) + start;
   auto out = static_cast<U*>(out_data);
-  dt::run_parallel(
+  dt::parallel_for_static(
       [=](size_t i0, size_t i1) {
         for (size_t i = i0; i < i1; ++i) {
           out[i] = CAST_OP(inp[i]);
@@ -126,7 +127,7 @@ static void cast_fw1(const Column* col, const int32_t* indices,
 {
   auto inp = static_cast<const T*>(col->data());
   auto out = static_cast<U*>(out_data);
-  dt::run_parallel(
+  dt::parallel_for_static(
       [=](size_t start, size_t stop) {
         for (size_t i = start; i < stop; ++i) {
           size_t j = static_cast<size_t>(indices[i]);
@@ -144,7 +145,7 @@ static void cast_fw2(const Column* col, void* out_data)
   auto inp = static_cast<const T*>(col->data());
   auto out = static_cast<U*>(out_data);
   const RowIndex& rowindex = col->rowindex();
-  dt::run_parallel(
+  dt::parallel_for_static(
       [=](size_t start, size_t stop) {
         for (size_t i = start; i < stop; ++i) {
           size_t j = rowindex[i];

--- a/c/frame/cast.cc
+++ b/c/frame/cast.cc
@@ -111,13 +111,12 @@ static void cast_fw0(const Column* col, size_t start, void* out_data)
                          : (start == 0));
   auto inp = static_cast<const T*>(col->data()) + start;
   auto out = static_cast<U*>(out_data);
-  dt::parallel_for_static(
+  dt::parallel_for_static(col->nrows,
       [=](size_t i0, size_t i1) {
         for (size_t i = i0; i < i1; ++i) {
           out[i] = CAST_OP(inp[i]);
         }
-      },
-      col->nrows);
+      });
 }
 
 
@@ -127,15 +126,14 @@ static void cast_fw1(const Column* col, const int32_t* indices,
 {
   auto inp = static_cast<const T*>(col->data());
   auto out = static_cast<U*>(out_data);
-  dt::parallel_for_static(
+  dt::parallel_for_static(col->nrows,
       [=](size_t start, size_t stop) {
         for (size_t i = start; i < stop; ++i) {
           size_t j = static_cast<size_t>(indices[i]);
           T x = (j == RowIndex::NA)? GETNA<T>() : inp[j];
           out[i] = CAST_OP(x);
         }
-      },
-      col->nrows);
+      });
 }
 
 
@@ -145,15 +143,14 @@ static void cast_fw2(const Column* col, void* out_data)
   auto inp = static_cast<const T*>(col->data());
   auto out = static_cast<U*>(out_data);
   const RowIndex& rowindex = col->rowindex();
-  dt::parallel_for_static(
+  dt::parallel_for_static(col->nrows,
       [=](size_t start, size_t stop) {
         for (size_t i = start; i < stop; ++i) {
           size_t j = rowindex[i];
           T x = (j == RowIndex::NA)? GETNA<T>() : inp[j];
           out[i] = CAST_OP(x);
         }
-      },
-      col->nrows);
+      });
 }
 
 

--- a/c/frame/replace.cc
+++ b/c/frame/replace.cc
@@ -606,19 +606,19 @@ template <typename T>
 void ReplaceAgent::replace_fw1(T* x, T* y, size_t nrows, T* data) {
   T x0 = x[0], y0 = y[0];
   if (std::is_floating_point<T>::value && ISNA<T>(x0)) {
-    dt::parallel_for_static(
+    dt::parallel_for_static(nrows,
       [=](size_t istart, size_t iend) {
         for (size_t i = istart; i < iend; ++i) {
           if (ISNA<T>(data[i])) data[i] = y0;
         }
-      }, nrows);
+      });
   } else {
-    dt::parallel_for_static(
+    dt::parallel_for_static(nrows,
       [=](size_t istart, size_t iend) {
         for (size_t i = istart; i < iend; ++i) {
           if (data[i] == x0) data[i] = y0;
         }
-      }, nrows);
+      });
   }
 }
 
@@ -629,23 +629,23 @@ void ReplaceAgent::replace_fw2(T* x, T* y, size_t nrows, T* data) {
   T x1 = x[1], y1 = y[1];
   xassert(!ISNA<T>(x0));
   if (std::is_floating_point<T>::value && ISNA<T>(x1)) {
-    dt::parallel_for_static(
+    dt::parallel_for_static(nrows,
       [=](size_t istart, size_t iend) {
         for (size_t i = istart; i < iend; ++i) {
           T v = data[i];
           if (v == x0) data[i] = y0;
           else if (ISNA<T>(v)) data[i] = y1;
         }
-      }, nrows);
+      });
   } else {
-    dt::parallel_for_static(
+    dt::parallel_for_static(nrows,
       [=](size_t istart, size_t iend) {
         for (size_t i = istart; i < iend; ++i) {
           T v = data[i];
           if (v == x0) data[i] = y0;
           else if (v == x1) data[i] = y1;
         }
-      }, nrows);
+      });
   }
 }
 
@@ -654,7 +654,7 @@ template <typename T>
 void ReplaceAgent::replace_fwN(T* x, T* y, size_t nrows, T* data, size_t n) {
   if (std::is_floating_point<T>::value && ISNA<T>(x[n-1])) {
     n--;
-    dt::parallel_for_static(
+    dt::parallel_for_static(nrows,
       [=](size_t istart, size_t iend) {
         for (size_t i = istart; i < iend; ++i) {
           T v = data[i];
@@ -669,9 +669,9 @@ void ReplaceAgent::replace_fwN(T* x, T* y, size_t nrows, T* data, size_t n) {
             }
           }
         }
-      }, nrows);
+      });
   } else {
-    dt::parallel_for_static(
+    dt::parallel_for_static(nrows,
       [=](size_t istart, size_t iend) {
         for (size_t i = istart; i < iend; ++i) {
           T v = data[i];
@@ -682,7 +682,7 @@ void ReplaceAgent::replace_fwN(T* x, T* y, size_t nrows, T* data, size_t n) {
             }
           }
         }
-      }, nrows);
+      });
   }
 }
 

--- a/c/frame/replace.cc
+++ b/c/frame/replace.cc
@@ -19,13 +19,14 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
-#include "frame/py_frame.h"
 #include <type_traits>
 #include <unordered_set>
+#include "frame/py_frame.h"
+#include "parallel/api.h"    // dt::parallel_for_static
 #include "python/dict.h"
 #include "python/list.h"
 #include "utils/assert.h"
-#include "utils/parallel.h"
+#include "utils/parallel.h"  // dt::map_str2str
 
 namespace py {
 
@@ -605,14 +606,14 @@ template <typename T>
 void ReplaceAgent::replace_fw1(T* x, T* y, size_t nrows, T* data) {
   T x0 = x[0], y0 = y[0];
   if (std::is_floating_point<T>::value && ISNA<T>(x0)) {
-    dt::run_parallel(
+    dt::parallel_for_static(
       [=](size_t istart, size_t iend) {
         for (size_t i = istart; i < iend; ++i) {
           if (ISNA<T>(data[i])) data[i] = y0;
         }
       }, nrows);
   } else {
-    dt::run_parallel(
+    dt::parallel_for_static(
       [=](size_t istart, size_t iend) {
         for (size_t i = istart; i < iend; ++i) {
           if (data[i] == x0) data[i] = y0;
@@ -628,7 +629,7 @@ void ReplaceAgent::replace_fw2(T* x, T* y, size_t nrows, T* data) {
   T x1 = x[1], y1 = y[1];
   xassert(!ISNA<T>(x0));
   if (std::is_floating_point<T>::value && ISNA<T>(x1)) {
-    dt::run_parallel(
+    dt::parallel_for_static(
       [=](size_t istart, size_t iend) {
         for (size_t i = istart; i < iend; ++i) {
           T v = data[i];
@@ -637,7 +638,7 @@ void ReplaceAgent::replace_fw2(T* x, T* y, size_t nrows, T* data) {
         }
       }, nrows);
   } else {
-    dt::run_parallel(
+    dt::parallel_for_static(
       [=](size_t istart, size_t iend) {
         for (size_t i = istart; i < iend; ++i) {
           T v = data[i];
@@ -653,7 +654,7 @@ template <typename T>
 void ReplaceAgent::replace_fwN(T* x, T* y, size_t nrows, T* data, size_t n) {
   if (std::is_floating_point<T>::value && ISNA<T>(x[n-1])) {
     n--;
-    dt::run_parallel(
+    dt::parallel_for_static(
       [=](size_t istart, size_t iend) {
         for (size_t i = istart; i < iend; ++i) {
           T v = data[i];
@@ -670,7 +671,7 @@ void ReplaceAgent::replace_fwN(T* x, T* y, size_t nrows, T* data, size_t n) {
         }
       }, nrows);
   } else {
-    dt::run_parallel(
+    dt::parallel_for_static(
       [=](size_t istart, size_t iend) {
         for (size_t i = istart; i < iend; ++i) {
           T v = data[i];

--- a/c/models/dt_ftrl_real.cc
+++ b/c/models/dt_ftrl_real.cc
@@ -333,7 +333,7 @@ FtrlFitOutput FtrlReal<T>::fit(T(*linkfn)(T), T(*lossfn)(T,U)) {
         tptr<T> w = tptr<T>(new T[nfeatures]);
         tptr<T> fi = tptr<T>(new T[nfeatures]());
 
-        dt::parallel_for_static(chunk_end - chunk_start,
+        dt::parallel_for_static(chunk_end - chunk_start, /* min_chunk_size= */ 1,
           [&](size_t i0, size_t i1) {
             for (size_t i = i0; i < i1; ++i) {
               size_t ii = (chunk_start + i) % dt_X->nrows;

--- a/c/models/dt_ftrl_real.cc
+++ b/c/models/dt_ftrl_real.cc
@@ -327,46 +327,41 @@ FtrlFitOutput FtrlReal<T>::fit(T(*linkfn)(T), T(*lossfn)(T,U)) {
     chunk_end = std::min((c + 1) * chunk_nrows, total_nrows);
     std::mutex m;
 
-    dt::parallel_region(
-      [&](size_t) {
+    dt::parallel_for_static(chunk_end - chunk_start,
+      [&](size_t i0, size_t i1) {
         uint64ptr x = uint64ptr(new uint64_t[nfeatures]);
         tptr<T> w = tptr<T>(new T[nfeatures]);
         tptr<T> fi = tptr<T>(new T[nfeatures]());
-
-        dt::parallel_for_static(chunk_end - chunk_start, /* min_chunk_size= */ 1,
-          [&](size_t i0, size_t i1) {
-            for (size_t i = i0; i < i1; ++i) {
-              size_t ii = (chunk_start + i) % dt_X->nrows;
-              const size_t j0 = ri[0][ii];
-              // Note that for FtrlModelType::BINOMIAL and FtrlModelType::REGRESSION
-              // dt_y has only one column that may contain NA's or be a view
-              // with an NA rowindex. For FtrlModelType::MULTINOMIAL we have as many
-              // columns as there are labels, and split_into_nhot() filters out
-              // NA's and can never be a view. Therefore, to ignore NA targets
-              // it is enough to check the condition below for the zero column only.
-              // FIXME: this condition can be removed for FtrlModelType::MULTINOMIAL.
-              if (j0 != RowIndex::NA && !ISNA<U>(data[0][j0])) {
-                hash_row(x, hashers, ii);
-                for (size_t k = 0; k < dt_y->ncols; ++k) {
-                  const size_t j = ri[k][ii];
-                  T p = linkfn(predict_row(
-                            x, w, k,
-                            [&](size_t f_id, T f_imp) {
-                              fi[f_id] += f_imp;
-                            }
-                        ));
-                  update(x, w, p, data[k][j], k);
-                }
-              }
+        for (size_t i = chunk_start + i0; i < chunk_start + i1; ++i) {
+          size_t ii = i % dt_X->nrows;
+          const size_t j0 = ri[0][ii];
+          // Note that for FtrlModelType::BINOMIAL and FtrlModelType::REGRESSION
+          // dt_y has only one column that may contain NA's or be a view
+          // with an NA rowindex. For FtrlModelType::MULTINOMIAL we have as many
+          // columns as there are labels, and split_into_nhot() filters out
+          // NA's and can never be a view. Therefore, to ignore NA targets
+          // it is enough to check the condition below for the zero column only.
+          // FIXME: this condition can be removed for FtrlModelType::MULTINOMIAL.
+          if (j0 != RowIndex::NA && !ISNA<U>(data[0][j0])) {
+            hash_row(x, hashers, ii);
+            for (size_t k = 0; k < dt_y->ncols; ++k) {
+              const size_t j = ri[k][ii];
+              T p = linkfn(predict_row(
+                        x, w, k,
+                        [&](size_t f_id, T f_imp) {
+                          fi[f_id] += f_imp;
+                        }
+                    ));
+              update(x, w, p, data[k][j], k);
             }
-          });
+          }
+        }
 
         std::lock_guard<std::mutex> lock(m);
         for (size_t i = 0; i < nfeatures; ++i) {
           data_fi[i] += fi[i];
         }
-      }
-    );
+      });
 
 
     // Calculate loss on the validation dataset and do early stopping,

--- a/c/models/dt_ftrl_real.cc
+++ b/c/models/dt_ftrl_real.cc
@@ -327,41 +327,49 @@ FtrlFitOutput FtrlReal<T>::fit(T(*linkfn)(T), T(*lossfn)(T,U)) {
     chunk_end = std::min((c + 1) * chunk_nrows, total_nrows);
     std::mutex m;
 
-    dt::parallel_for_static(chunk_end - chunk_start,
-      [&](size_t i0, size_t i1) {
+    dt::parallel_region(
+      [&](size_t) {
         uint64ptr x = uint64ptr(new uint64_t[nfeatures]);
-        tptr<T> w = tptr<T>(new T[nfeatures]());
-        tptr<T> fi = tptr<T>(new T[nfeatures]());
-        for (size_t i = chunk_start + i0; i < chunk_start + i1; ++i) {
-          size_t ii = i % dt_X->nrows;
-          const size_t j0 = ri[0][ii];
-          // Note that for FtrlModelType::BINOMIAL and FtrlModelType::REGRESSION
-          // dt_y has only one column that may contain NA's or be a view
-          // with an NA rowindex. For FtrlModelType::MULTINOMIAL we have as many
-          // columns as there are labels, and split_into_nhot() filters out
-          // NA's and can never be a view. Therefore, to ignore NA targets
-          // it is enough to check the condition below for the zero column only.
-          // FIXME: this condition can be removed for FtrlModelType::MULTINOMIAL.
-          if (j0 != RowIndex::NA && !ISNA<U>(data[0][j0])) {
-            hash_row(x, hashers, ii);
-            for (size_t k = 0; k < dt_y->ncols; ++k) {
-              const size_t j = ri[k][ii];
-              T p = linkfn(predict_row(
-                        x, w, k,
-                        [&](size_t f_id, T f_imp) {
-                          data_fi[f_id] += f_imp;
-                        }
-                    ));
-              update(x, w, p, data[k][j], k);
-            }
-          }
-        }
+        tptr<T> w = tptr<T>(new T[nfeatures]);
+        tptr<T> fi = tptr<T>(new T[nfeatures]);
 
-        std::lock_guard<std::mutex> lock(m);
-        for (size_t i = 0; i < nfeatures; ++i) {
-          data_fi[i] += fi[i];
-        }
-      });
+        dt::parallel_for_static(chunk_end - chunk_start,
+          [&](size_t i0, size_t i1) {
+            std::memset(w.get(), 0, nfeatures * sizeof(T));
+            std::memset(fi.get(), 0, nfeatures * sizeof(T));
+
+            for (size_t i = i0; i < i1; ++i) {
+              size_t ii = (chunk_start + i) % dt_X->nrows;
+              const size_t j0 = ri[0][ii];
+              // Note that for FtrlModelType::BINOMIAL and FtrlModelType::REGRESSION
+              // dt_y has only one column that may contain NA's or be a view
+              // with an NA rowindex. For FtrlModelType::MULTINOMIAL we have as many
+              // columns as there are labels, and split_into_nhot() filters out
+              // NA's and can never be a view. Therefore, to ignore NA targets
+              // it is enough to check the condition below for the zero column only.
+              // FIXME: this condition can be removed for FtrlModelType::MULTINOMIAL.
+              if (j0 != RowIndex::NA && !ISNA<U>(data[0][j0])) {
+                hash_row(x, hashers, ii);
+                for (size_t k = 0; k < dt_y->ncols; ++k) {
+                  const size_t j = ri[k][ii];
+                  T p = linkfn(predict_row(
+                            x, w, k,
+                            [=](size_t f_id, T f_imp) {
+                              fi[f_id] += f_imp;
+                            }
+                        ));
+                  update(x, w, p, data[k][j], k);
+                }
+              }
+            }
+
+            std::lock_guard<std::mutex> lock(m);
+            for (size_t i = 0; i < nfeatures; ++i) {
+              data_fi[i] += fi[i];
+            }
+          });
+      }
+    );
 
 
     // Calculate loss on the validation dataset and do early stopping,

--- a/c/models/py_ftrl.cc
+++ b/c/models/py_ftrl.cc
@@ -363,8 +363,7 @@ oobj Ftrl::fit(const PKArgs& args) {
   py::onamedtuple res(ntt);
   res.set(0, py::ofloat(output.epoch));
   res.set(1, py::ofloat(output.loss));
-
-  return res;
+  return std::move(res);
 }
 
 

--- a/c/parallel/api.h
+++ b/c/parallel/api.h
@@ -28,6 +28,13 @@ size_t get_num_threads();
 
 
 /**
+ * Return the index of the current thread: from 0 to `get_num_threads() - 1`.
+ * For the master thread this will return `size_t(-1)`.
+ */
+size_t get_thread_num();
+
+
+/**
  * Return the number of concurrent threads supported by the machine. This
  * value is approximate. If the number of concurrent threads is unknown,
  * this function returns 1.

--- a/c/parallel/api.h
+++ b/c/parallel/api.h
@@ -38,7 +38,7 @@ size_t get_hardware_concurrency() noexcept;
 /**
  * Call function `f` exactly once in each thread.
  */
-void run_once_per_thread(function<void(size_t)> f);
+void parallel_region(function<void(size_t)> f);
 
 
 

--- a/c/parallel/api.h
+++ b/c/parallel/api.h
@@ -48,7 +48,7 @@ size_t get_hardware_concurrency() noexcept;
 void parallel_region(function<void(size_t)> f);
 
 
-void parallel_for_static(function<void(size_t, size_t)> fn, size_t nrows);
+void parallel_for_static(size_t nrows, function<void(size_t, size_t)> fn);
 
 
 }  // namespace dt

--- a/c/parallel/api.h
+++ b/c/parallel/api.h
@@ -49,6 +49,8 @@ void parallel_region(function<void(size_t)> f);
 
 
 void parallel_for_static(size_t nrows, function<void(size_t, size_t)> fn);
+void parallel_for_static(size_t nrows, size_t min_chunk_size,
+                         function<void(size_t, size_t)> fn);
 
 
 }  // namespace dt

--- a/c/parallel/api.h
+++ b/c/parallel/api.h
@@ -48,6 +48,8 @@ size_t get_hardware_concurrency() noexcept;
 void parallel_region(function<void(size_t)> f);
 
 
+void parallel_for_static(function<void(size_t, size_t)> fn, size_t nrows);
+
 
 }  // namespace dt
 #endif

--- a/c/parallel/atomic_test.cc
+++ b/c/parallel/atomic_test.cc
@@ -32,7 +32,7 @@ static void test_atomic_impl() {
   dt::atomic<T> y { T(1.0) };
   dt::atomic<T> z { T(1.3e20) };
 
-  dt::run_once_per_thread(
+  dt::parallel_region(
     [&](size_t i) {
       barrier--;
       while (barrier.load());

--- a/c/parallel/thread_pool.cc
+++ b/c/parallel/thread_pool.cc
@@ -131,6 +131,15 @@ size_t get_num_threads() {
 }
 
 
+static thread_local size_t thread_index = size_t(-1);
+size_t get_thread_num() {
+  return thread_index;
+}
+void _set_thread_num(size_t i) {
+  thread_index = i;
+}
+
+
 size_t get_hardware_concurrency() noexcept {
   unsigned int nth = std::thread::hardware_concurrency();
   if (!nth) nth = 1;

--- a/c/parallel/thread_pool.cc
+++ b/c/parallel/thread_pool.cc
@@ -111,8 +111,12 @@ void thread_pool::cleanup_after_fork() {
 }
 
 
-bool thread_pool::in_master_thread() const {
+bool thread_pool::in_master_thread() const noexcept {
   return std::this_thread::get_id() == master_thread_id;
+}
+
+bool thread_pool::in_parallel_region() const noexcept {
+  return controller.is_running();
 }
 
 

--- a/c/parallel/thread_pool.h
+++ b/c/parallel/thread_pool.h
@@ -84,7 +84,8 @@ class thread_pool {
     size_t size() const noexcept;
     void resize(size_t n);
 
-    bool in_master_thread() const;
+    bool in_master_thread() const noexcept;
+    bool in_parallel_region() const noexcept;
 
   private:
     void resize_impl();

--- a/c/parallel/thread_pool.h
+++ b/c/parallel/thread_pool.h
@@ -16,6 +16,7 @@
 #ifndef dt_PARALLEL_THREAD_POOL_h
 #define dt_PARALLEL_THREAD_POOL_h
 #include <mutex>               // std::mutex
+#include <thread>              // std::thread::id
 #include <vector>              // std::vector
 #include "parallel/thread_scheduler.h"
 #include "parallel/thread_worker.h"
@@ -63,6 +64,10 @@ class thread_pool {
     // Scheduler used to manage sleep/awake cycle of the threads in the pool.
     worker_controller controller;
 
+    // Thread id of the main (python) thread, mostly used to verify that
+    // certain constructs are called from the master thread only.
+    std::thread::id master_thread_id;
+
     // Singleton instance of the thread_pool, returned by `get_instance()`.
     static thread_pool* _instance;
 
@@ -72,7 +77,7 @@ class thread_pool {
     thread_pool(const thread_pool&) = delete;
     // Not moveable: workers hold pointers to this->controller.
     thread_pool(thread_pool&&) = delete;
-    ~thread_pool();
+    // ~thread_pool();
 
     void execute_job(thread_scheduler*);
 

--- a/c/parallel/thread_pool.h
+++ b/c/parallel/thread_pool.h
@@ -55,7 +55,7 @@ class thread_pool {
     // Also, use pointers here instead of `thread_worker` objects, so that
     // the pointers to each worker remain constant when the vector resizes
     // (these pointers are stored within each thread).
-    std::vector<std::unique_ptr<thread_worker>> workers;
+    std::vector<thread_worker*> workers;
 
     // Number of threads requested by the user; however, we will only
     // instantiate the threads when `execute_job()` is first called.
@@ -83,6 +83,8 @@ class thread_pool {
 
     size_t size() const noexcept;
     void resize(size_t n);
+
+    bool in_master_thread() const;
 
   private:
     void resize_impl();

--- a/c/parallel/thread_scheduler.cc
+++ b/c/parallel/thread_scheduler.cc
@@ -55,7 +55,7 @@ thread_task* once_scheduler::get_next_task(size_t i) {
 
 
 
-void run_once_per_thread(function<void(size_t)> f) {
+void parallel_region(function<void(size_t)> f) {
   thread_pool* thpool = thread_pool::get_instance();
   simple_task task(f);
   once_scheduler sch(thpool->size(), &task);

--- a/c/parallel/thread_scheduler.cc
+++ b/c/parallel/thread_scheduler.cc
@@ -70,12 +70,12 @@ void parallel_region(function<void(size_t)> f) {
 // parallel_for_static
 //------------------------------------------------------------------------------
 
-void parallel_for_static(function<void(size_t, size_t)> f, size_t nrows) {
+void parallel_for_static(size_t nrows, function<void(size_t, size_t)> fn) {
   constexpr size_t min_nrows_per_chunk = 4096;
   size_t k = nrows / min_nrows_per_chunk;
 
   if (k == 0) {
-    f(0, nrows);
+    fn(0, nrows);
   }
   else {
     size_t nth = get_num_threads();
@@ -88,7 +88,7 @@ void parallel_for_static(function<void(size_t, size_t)> f, size_t nrows) {
           size_t i0 = j * chunksize;
           size_t i1 = i0 + chunksize;
           if (j == nchunks - 1) i1 = nrows;
-          f(i0, i1);
+          fn(i0, i1);
         }
       });
   }

--- a/c/parallel/thread_scheduler.cc
+++ b/c/parallel/thread_scheduler.cc
@@ -57,6 +57,7 @@ thread_task* once_scheduler::get_next_task(size_t i) {
 
 void parallel_region(function<void(size_t)> f) {
   thread_pool* thpool = thread_pool::get_instance();
+  xassert(thpool->in_master_thread());
   simple_task task(f);
   once_scheduler sch(thpool->size(), &task);
   thpool->execute_job(&sch);

--- a/c/parallel/thread_scheduler.cc
+++ b/c/parallel/thread_scheduler.cc
@@ -71,8 +71,13 @@ void parallel_region(function<void(size_t)> f) {
 //------------------------------------------------------------------------------
 
 void parallel_for_static(size_t nrows, function<void(size_t, size_t)> fn) {
-  constexpr size_t min_nrows_per_chunk = 4096;
-  size_t k = nrows / min_nrows_per_chunk;
+  parallel_for_static(nrows, 4096, fn);
+}
+
+void parallel_for_static(size_t nrows, size_t min_chunk_size,
+                         function<void(size_t, size_t)> fn)
+{
+  size_t k = nrows / min_chunk_size;
 
   size_t ith = dt::get_thread_num();
 

--- a/c/parallel/thread_scheduler.h
+++ b/c/parallel/thread_scheduler.h
@@ -56,7 +56,7 @@ class thread_scheduler {
 //------------------------------------------------------------------------------
 
 /**
- * Implementation class for `dt::run_once_per_thread()` function.
+ * Implementation class for `dt::parallel_region()` function.
  */
 class once_scheduler : public thread_scheduler {
   private:

--- a/c/parallel/thread_worker.cc
+++ b/c/parallel/thread_worker.cc
@@ -77,7 +77,7 @@ size_t thread_worker::get_index() const noexcept {
 
 
 //------------------------------------------------------------------------------
-// thread sleep scheduler
+// "worker controller" scheduler
 //------------------------------------------------------------------------------
 
 void worker_controller::sleep_task::execute(thread_worker* worker) {
@@ -124,6 +124,9 @@ void worker_controller::join(size_t nthreads) {
     std::unique_lock<std::mutex> lock(st.mutex);
     n_sleeping = st.n_threads_sleeping;
   }
+  // Clear `.next_scheduler` flag of the previous sleep task, indicating that
+  // we no longer run in a parallel region (see `is_running()`).
+  tsleep[(index - 1) % N_SLEEP_TASKS].next_scheduler = nullptr;
 
   if (saved_exception) {
     std::rethrow_exception(saved_exception);
@@ -142,6 +145,12 @@ void worker_controller::catch_exception() noexcept {
     std::lock_guard<std::mutex> lock(tsleep[index].mutex);
     saved_exception = std::current_exception();
   } catch (...) {}
+}
+
+
+bool worker_controller::is_running() const noexcept {
+  size_t j = (index - 1) % N_SLEEP_TASKS;
+  return (tsleep[j].next_scheduler != nullptr);
 }
 
 

--- a/c/parallel/thread_worker.cc
+++ b/c/parallel/thread_worker.cc
@@ -54,6 +54,7 @@ thread_worker::~thread_worker() {
  * variable inside the sleep task.
  */
 void thread_worker::run() noexcept {
+  _set_thread_num(thread_index);
   while (scheduler) {
     try {
       thread_task* task = scheduler->get_next_task(thread_index);

--- a/c/parallel/thread_worker.h
+++ b/c/parallel/thread_worker.h
@@ -187,6 +187,9 @@ class thread_shutdown_scheduler : public thread_scheduler {
 };
 
 
+// Helper function, defined in `thread_pool.cc`.
+// This should only be called within a new thread.
+void _set_thread_num(size_t);
 
 }  // namespace dt
 #endif

--- a/c/parallel/thread_worker.h
+++ b/c/parallel/thread_worker.h
@@ -154,6 +154,9 @@ class worker_controller : public thread_scheduler {
     // this exception, so that it can be re-thrown in the master thread.
     void catch_exception() noexcept;
 
+    // Return true if there is a task currently being run in parallel.
+    bool is_running() const noexcept;
+
   private:
     // Helper for thread_shutdown_scheduler: mark the current thread as if it
     // went to sleep, whereas in reality it shut down.

--- a/c/rowindex.cc
+++ b/c/rowindex.cc
@@ -22,7 +22,7 @@
 #include <cstring>     // std::memcpy
 #include "utils/assert.h"
 #include "utils/misc.h"
-#include "parallel/api.h"
+#include "parallel/api.h"     // dt::parallel_for_static
 #include "datatablemodule.h"
 #include "rowindex.h"
 #include "rowindex_impl.h"
@@ -222,12 +222,12 @@ void RowIndex::extract_into(arr32_t& target) const {
       if (szlen <= INT32_MAX && max() <= INT32_MAX) {
         size_t start = slice_start();
         size_t step = slice_step();
-        dt::parallel_for_static(
+        dt::parallel_for_static(szlen,
           [&](size_t i0, size_t i1) {
             for (size_t i = i0; i < i1; ++i) {
               target[i] = static_cast<int32_t>(start + i * step);
             }
-          }, szlen);
+          });
       }
       break;
     }

--- a/c/rowindex.cc
+++ b/c/rowindex.cc
@@ -22,7 +22,7 @@
 #include <cstring>     // std::memcpy
 #include "utils/assert.h"
 #include "utils/misc.h"
-#include "utils/parallel.h"
+#include "parallel/api.h"
 #include "datatablemodule.h"
 #include "rowindex.h"
 #include "rowindex_impl.h"
@@ -222,7 +222,7 @@ void RowIndex::extract_into(arr32_t& target) const {
       if (szlen <= INT32_MAX && max() <= INT32_MAX) {
         size_t start = slice_start();
         size_t step = slice_step();
-        dt::run_parallel(
+        dt::parallel_for_static(
           [&](size_t i0, size_t i1) {
             for (size_t i = i0; i < i1; ++i) {
               target[i] = static_cast<int32_t>(start + i * step);

--- a/c/utils/parallel.cc
+++ b/c/utils/parallel.cc
@@ -26,7 +26,7 @@ namespace dt {
 //------------------------------------------------------------------------------
 
 /*
-void parallel_for_static(rangefn run, size_t nrows)
+void parallel_for_static(size_t nrows, rangefn run)
 {
   // `min_nrows_per_chunk`: avoid processing less than this many rows in each
   // thread, reduce the number of threads if necessary.

--- a/c/utils/parallel.cc
+++ b/c/utils/parallel.cc
@@ -100,7 +100,7 @@ void run_parallel(rangefn f, size_t nrows) {
     size_t chunksize = nrows / k;
     size_t nchunks = nrows / chunksize;
 
-    dt::run_once_per_thread(
+    dt::parallel_region(
       [=](size_t ith) {
         for (size_t j = ith; j < nchunks; j += nth) {
           size_t i0 = j * chunksize;

--- a/c/utils/parallel.cc
+++ b/c/utils/parallel.cc
@@ -26,7 +26,7 @@ namespace dt {
 //------------------------------------------------------------------------------
 
 /*
-void run_parallel(rangefn run, size_t nrows)
+void parallel_for_static(rangefn run, size_t nrows)
 {
   // `min_nrows_per_chunk`: avoid processing less than this many rows in each
   // thread, reduce the number of threads if necessary.
@@ -86,31 +86,6 @@ void run_parallel(rangefn run, size_t nrows)
   }
 }
 */
-
-
-void run_parallel(rangefn f, size_t nrows) {
-  constexpr size_t min_nrows_per_chunk = 4096;
-  size_t k = nrows / min_nrows_per_chunk;
-
-  if (k == 0) {
-    f(0, nrows);
-  }
-  else {
-    size_t nth = get_num_threads();
-    size_t chunksize = nrows / k;
-    size_t nchunks = nrows / chunksize;
-
-    dt::parallel_region(
-      [=](size_t ith) {
-        for (size_t j = ith; j < nchunks; j += nth) {
-          size_t i0 = j * chunksize;
-          size_t i1 = i0 + chunksize;
-          if (j == nchunks - 1) i1 = nrows;
-          f(i0, i1);
-        }
-      });
-  }
-}
 
 
 

--- a/c/utils/parallel.h
+++ b/c/utils/parallel.h
@@ -49,7 +49,7 @@ using rangefn = dt::function<void(size_t, size_t)>;
 /**
  * Execute function `run` in parallel, over the range `[0 .. nrows - 1]`.
  * The signature of function `run` is that of the "range" function:
- * `(start, end, step)`. The function `run` is then expected to run a loop for
+ * `(start, end)`. The function `run` is then expected to run a loop for
  * the indices in this range.
  *
  * Each thread will thus run on a set of rows that are at a constant distance
@@ -57,7 +57,6 @@ using rangefn = dt::function<void(size_t, size_t)>;
  *   - The amount of work per row is relatively small;
  *   - The rows can be processed in any order.
  */
-void run_parallel(rangefn run, size_t nrows);
 
 
 


### PR DESCRIPTION
- Renamed `dt::run_once_per_thread()` into `dt::parallel_region()`;
- Renamed `dt::run_parallel()` into `dt::parallel_for_static()`;
- Added function `dt::get_thread_num()`;
- Added `thread_pool::in_master_thread()` and `thread_pool::in_parallel_region()`;
- `dt::parallel_for_static()` can now be used inside a `dt::parallel_region()` call, allowing support for thread-local contexts;
- Parallel loop in `Ftrl::fit()` now uses parallel-for-inside-parallel-region;
- Added optional parameter `min_chunk_size` to `dt::parallel_for_static` to control chunking behavior, default value = 4096.

Closes #1762 
WIP for #1736