### PR TITLE
Add mantissa_nbits parameter to FTRL algo

### DIFF
--- a/c/models/aggregator.cc
+++ b/c/models/aggregator.cc
@@ -83,11 +83,11 @@ A list `[frame_exemplars, frame_members]`, where
 );
 
 
-/*
-*  Read arguments from Python's `aggregate()` function and aggregate data
-*  either with single or double precision. Return a list consisting
-*  of two frames: `df_exemplars` and `df_members`.
-*/
+/**
+ *  Read arguments from Python's `aggregate()` function and aggregate data
+ *  either with single or double precision. Return a list consisting
+ *  of two frames: `df_exemplars` and `df_members`.
+ */
 static oobj aggregate(const PKArgs& args) {
   size_t min_rows = 500;
   size_t n_bins = 500;
@@ -191,9 +191,9 @@ static oobj aggregate(const PKArgs& args) {
 
 
 
-/*
-*  Destructor for the AggregatorBase class.
-*/
+/**
+ *  Destructor for the AggregatorBase class.
+ */
 AggregatorBase::~AggregatorBase() {}
 
 
@@ -203,9 +203,9 @@ void py::DatatableModule::init_methods_aggregate() {
 
 
 
-/*
-*  Constructor, initialize all the input parameters.
-*/
+/**
+ *  Constructor, initialize all the input parameters.
+ */
 template <typename T>
 Aggregator<T>::Aggregator(size_t min_rows_in, size_t n_bins_in,
                           size_t nx_bins_in, size_t ny_bins_in,
@@ -226,14 +226,14 @@ Aggregator<T>::Aggregator(size_t min_rows_in, size_t n_bins_in,
 }
 
 
-/*
-*  Main Aggregator method, convert all the numeric columns to `T`,
-*  do the corresponding grouping and final exemplar aggregation:
-*  - `dt` is an input datatable to aggregate;
-*  - `dt_exemplars` is the result of aggregation;
-*  - `dt_members` will store a relation between each of the original `dt` rows
-*     and the exemplars gathered in `dt_exemplars`.
-*/
+/**
+ *  Main Aggregator method, convert all the numeric columns to `T`,
+ *  do the corresponding grouping and final exemplar aggregation:
+ *  - `dt` is an input datatable to aggregate;
+ *  - `dt_exemplars` is the result of aggregation;
+ *  - `dt_members` will store a relation between each of the original `dt` rows
+ *     and the exemplars gathered in `dt_exemplars`.
+ */
 template <typename T>
 void Aggregator<T>::aggregate(DataTable* dt_in,
                               dtptr& dt_exemplars_in,
@@ -321,10 +321,10 @@ void Aggregator<T>::aggregate(DataTable* dt_in,
 }
 
 
-/*
-*  Check how many exemplars we have got, if there is more than `max_bins+1`
-*  (e.g. too many distinct categorical values) do random sampling.
-*/
+/**
+ *  Check how many exemplars we have got, if there is more than `max_bins+1`
+ *  (e.g. too many distinct categorical values) do random sampling.
+ */
 template <typename T>
 bool Aggregator<T>::sample_exemplars(size_t max_bins, size_t n_na_bins)
 {
@@ -373,14 +373,14 @@ bool Aggregator<T>::sample_exemplars(size_t max_bins, size_t n_na_bins)
 }
 
 
-/*
-*  Sort/group the members frame and set up the first member
-*  in each group as an exemplar with the corresponding `members_count`,
-*  that is essentially a number of members within the group.
-*  If members were randomly sampled, those who got `exemplar_id == NA`
-*  are ending up in the zero group, that is ignored and not included
-*  in the aggregated frame.
-*/
+/**
+ *  Sort/group the members frame and set up the first member
+ *  in each group as an exemplar with the corresponding `members_count`,
+ *  that is essentially a number of members within the group.
+ *  If members were randomly sampled, those who got `exemplar_id == NA`
+ *  are ending up in the zero group, that is ignored and not included
+ *  in the aggregated frame.
+ */
 template <typename T>
 void Aggregator<T>::aggregate_exemplars(bool was_sampled) {
   // Setting up offsets and members row index.
@@ -429,9 +429,9 @@ void Aggregator<T>::aggregate_exemplars(bool was_sampled) {
 }
 
 
-/*
-*  Do no grouping, i.e. all rows become exemplars sorted by the first column.
-*/
+/**
+ *  Do no grouping, i.e. all rows become exemplars sorted by the first column.
+ */
 template <typename T>
 void Aggregator<T>::group_0d() {
   if (dt->ncols > 0) {
@@ -448,9 +448,9 @@ void Aggregator<T>::group_0d() {
 }
 
 
-/*
-*  Call an appropriate function for 1D grouping.
-*/
+/**
+ *  Call an appropriate function for 1D grouping.
+ */
 template <typename T>
 void Aggregator<T>::group_1d() {
   if (contconvs.size()) {
@@ -461,18 +461,18 @@ void Aggregator<T>::group_1d() {
 }
 
 
-/*
-*  Call an appropriate function for 2D grouping.
-*  Dealing with NA's:
-*    - (value, NA) goes to bin -1;
-*    - (NA, value) goes to bin -2;
-*    - (NA, NA)    goes to bin -3.
-*  Rows having no NA's end up in the corresponding positive bins,
-*  so that we are not mixing NA and not NA members. After calling
-*  `aggregate_exemplars(...)` bins will be renumbered starting from 0,
-*  with NA bins (if ones exist) being gathered at the very beginning
-*  of the exemplar data frame.
-*/
+/**
+ *  Call an appropriate function for 2D grouping.
+ *  Dealing with NA's:
+ *    - (value, NA) goes to bin -1;
+ *    - (NA, value) goes to bin -2;
+ *    - (NA, NA)    goes to bin -3.
+ *  Rows having no NA's end up in the corresponding positive bins,
+ *  so that we are not mixing NA and not NA members. After calling
+ *  `aggregate_exemplars(...)` bins will be renumbered starting from 0,
+ *  with NA bins (if ones exist) being gathered at the very beginning
+ *  of the exemplar data frame.
+ */
 template <typename T>
 void Aggregator<T>::group_2d() {
   size_t ncont = contconvs.size();
@@ -487,9 +487,9 @@ void Aggregator<T>::group_2d() {
 }
 
 
-/*
-*  Do 1D grouping for a continuous column, i.e. 1D binning.
-*/
+/**
+ *  Do 1D grouping for a continuous column, i.e. 1D binning.
+ */
 template <typename T>
 void Aggregator<T>::group_1d_continuous() {
   auto d_members = static_cast<int32_t*>(dt_members->columns[0]->data_w());
@@ -508,9 +508,9 @@ void Aggregator<T>::group_1d_continuous() {
 }
 
 
-/*
-*  Do 2D grouping for two continuous columns, i.e. 2D binning.
-*/
+/**
+ *  Do 2D grouping for two continuous columns, i.e. 2D binning.
+ */
 template <typename T>
 void Aggregator<T>::group_2d_continuous() {
   auto d_members = static_cast<int32_t*>(dt_members->columns[0]->data_w());
@@ -536,9 +536,9 @@ void Aggregator<T>::group_2d_continuous() {
 }
 
 
-/*
-*  Do 1D grouping for a categorical column, i.e. just a `group by` operation.
-*/
+/**
+ *  Do 1D grouping for a categorical column, i.e. just a `group by` operation.
+ */
 template <typename T>
 void Aggregator<T>::group_1d_categorical() {
   std::vector<sort_spec> spec = {sort_spec(0)};
@@ -560,10 +560,10 @@ void Aggregator<T>::group_1d_categorical() {
 }
 
 
-/*
-*  Detect string types for both categorical columns and do a corresponding call
-*  to `group_2d_mixed_str`.
-*/
+/**
+ *  Detect string types for both categorical columns and do a corresponding call
+ *  to `group_2d_mixed_str`.
+ */
 template <typename T>
 void Aggregator<T>::group_2d_categorical () {
   switch (dt_cat->columns[0]->stype()) {
@@ -589,10 +589,10 @@ void Aggregator<T>::group_2d_categorical () {
 }
 
 
-/*
-*  Do 2D grouping for two categorical columns, i.e. two `group by` operations,
-*  and combine their results.
-*/
+/**
+ *  Do 2D grouping for two categorical columns, i.e. two `group by` operations,
+ *  and combine their results.
+ */
 template <typename T>
 template <typename U0, typename U1>
 void Aggregator<T>::group_2d_categorical_str() {
@@ -628,10 +628,10 @@ void Aggregator<T>::group_2d_categorical_str() {
 }
 
 
-/*
-*  Detect string type for a categorical column and do a corresponding call
-*  to `group_2d_mixed_str`.
-*/
+/**
+ *  Detect string type for a categorical column and do a corresponding call
+ *  to `group_2d_mixed_str`.
+ */
 template <typename T>
 void Aggregator<T>::group_2d_mixed() {
   switch (dt_cat->columns[0]->stype()) {
@@ -643,11 +643,11 @@ void Aggregator<T>::group_2d_mixed() {
 }
 
 
-/*
-*  Do 2D grouping for one continuous and one categorical string column,
-*  i.e. 1D binning for the continuous column and a `group by`
-*  operation for the categorical one.
-*/
+/**
+ *  Do 2D grouping for one continuous and one categorical string column,
+ *  i.e. 1D binning for the continuous column and a `group by`
+ *  operation for the categorical one.
+ */
 template<typename T>
 template<typename U0>
 void Aggregator<T>::group_2d_mixed_str() {
@@ -684,32 +684,32 @@ void Aggregator<T>::group_2d_mixed_str() {
 }
 
 
-/*
-*  Do ND grouping in the general case. The initial `delta` (`delta = radius^2`)
-*  is set to machine precision, so that we are gathering some initial exemplars.
-*  When this `delta` starts getting us more exemplars than is set by `nd_max_bins`
-*  do the following:
-*  - find the mean distance between all the gathered exemplars;
-*  - merge all the exemplars that are within half of this distance;
-*  - adjust `delta` taking into account initial size of bubbles;
-*  - store the merging info and use it in `adjust_members(...)`.
-*
-*  Another approach is to have a constant `delta` see `Develop` branch
-*  https://github.com/h2oai/vis-data-server/blob/master/library/src/main/java/com/
-*  h2o/data/Aggregator.java based on the estimates given at
-*  https://mathoverflow.net/questions/308018/coverage-of-balls-on-random-points-in-
-*  euclidean-space?answertab=active#tab-top i.e.
-*
-*  T radius2 = (d / 6.0) - 1.744 * sqrt(7.0 * d / 180.0);
-*  T radius = (d > 4)? .5 * sqrt(radius2) : .5 / pow(100.0, 1.0 / d);
-*  if (d > max_dimensions) {
-*    radius /= 7.0;
-*  }
-*  T delta = radius * radius;
-*
-*  However, for some datasets this `delta` results in too many (e.g. thousands) or
-*  too few (e.g. just one) exemplars.
-*/
+/**
+ *  Do ND grouping in the general case. The initial `delta` (`delta = radius^2`)
+ *  is set to machine precision, so that we are gathering some initial exemplars.
+ *  When this `delta` starts getting us more exemplars than is set by `nd_max_bins`
+ *  do the following:
+ *  - find the mean distance between all the gathered exemplars;
+ *  - merge all the exemplars that are within half of this distance;
+ *  - adjust `delta` taking into account initial size of bubbles;
+ *  - store the merging info and use it in `adjust_members(...)`.
+ *
+ *  Another approach is to have a constant `delta` see `Develop` branch
+ *  https://github.com/h2oai/vis-data-server/blob/master/library/src/main/java/com/
+ *  h2o/data/Aggregator.java based on the estimates given at
+ *  https://mathoverflow.net/questions/308018/coverage-of-balls-on-random-points-in-
+ *  euclidean-space?answertab=active#tab-top i.e.
+ *
+ *  T radius2 = (d / 6.0) - 1.744 * sqrt(7.0 * d / 180.0);
+ *  T radius = (d > 4)? .5 * sqrt(radius2) : .5 / pow(100.0, 1.0 / d);
+ *  if (d > max_dimensions) {
+ *    radius /= 7.0;
+ *  }
+ *  T delta = radius * radius;
+ *
+ *  However, for some datasets this `delta` results in too many (e.g. thousands) or
+ *  too few (e.g. just one) exemplars.
+ */
 template <typename T>
 void Aggregator<T>::group_nd() {
   OmpExceptionManager oem;
@@ -828,7 +828,7 @@ void Aggregator<T>::group_nd() {
 }
 
 
-/*
+/**
  *  Figure out how many threads we need to run ND groupping.
  */
 template <typename T>
@@ -844,16 +844,16 @@ size_t Aggregator<T>::get_nthreads(size_t nrows) {
   return nth;
 }
 
-/*
-*  Adjust `delta` (i.e. `radius^2`) based on the mean distance between
-*  the gathered exemplars and merge all the exemplars within that distance.
-*  Here we will just use an additional index `k` to map triangular matrix
-*  into 1D array of distances. However, one can also use mapping from `k` to `(i,j)`:
-*  i = n - 2 - floor(sqrt(-8 * k + 4 * n * (n - 1) - 7) / 2.0 - 0.5);
-*  j = k + i + 1 - n * (n - 1) / 2 + (n - i) * ((n - i) - 1) / 2;
-*  and mapping from `(i,j)` to `k`:
-*  k = (2 * n - i - 1 ) * i / 2 + j
-*/
+/**
+ *  Adjust `delta` (i.e. `radius^2`) based on the mean distance between
+ *  the gathered exemplars and merge all the exemplars within that distance.
+ *  Here we will just use an additional index `k` to map triangular matrix
+ *  into 1D array of distances. However, one can also use mapping from `k` to `(i,j)`:
+ *  i = n - 2 - floor(sqrt(-8 * k + 4 * n * (n - 1) - 7) / 2.0 - 0.5);
+ *  j = k + i + 1 - n * (n - 1) / 2 + (n - i) * ((n - i) - 1) / 2;
+ *  and mapping from `(i,j)` to `k`:
+ *  k = (2 * n - i - 1 ) * i / 2 + j
+ */
 template <typename T>
 void Aggregator<T>::adjust_delta(T& delta, std::vector<exptr>& exemplars,
                                  std::vector<size_t>& ids, size_t ndims) {
@@ -905,10 +905,10 @@ void Aggregator<T>::adjust_delta(T& delta, std::vector<exptr>& exemplars,
 }
 
 
-/*
-*  Based on the merging info adjust the members information,
-*  i.e. set which exemplar they belong to.
-*/
+/**
+ *  Based on the merging info adjust the members information,
+ *  i.e. set which exemplar they belong to.
+ */
 template <typename T>
 void Aggregator<T>::adjust_members(std::vector<size_t>& ids) {
 
@@ -934,9 +934,9 @@ void Aggregator<T>::adjust_members(std::vector<size_t>& ids) {
 }
 
 
-/*
-*  For each exemplar find the one it was merged to.
-*/
+/**
+ *  For each exemplar find the one it was merged to.
+ */
 template <typename T>
 size_t Aggregator<T>::calculate_map(std::vector<size_t>& ids, size_t id) {
   if (id == ids[id]) {
@@ -947,10 +947,10 @@ size_t Aggregator<T>::calculate_map(std::vector<size_t>& ids, size_t id) {
 }
 
 
-/*
-*  Calculate distance between two vectors. If `early_exit` is set to `true`,
-*  stop when the distance reaches `delta`.
-*/
+/**
+ *  Calculate distance between two vectors. If `early_exit` is set to `true`,
+ *  stop when the distance reaches `delta`.
+ */
 template <typename T>
 T Aggregator<T>::calculate_distance(tptr<T>& e1, tptr<T>& e2,
                                     size_t ndims, T delta,
@@ -971,9 +971,9 @@ T Aggregator<T>::calculate_distance(tptr<T>& e1, tptr<T>& e2,
 }
 
 
-/*
-*  Normalize the row elements to [0,1).
-*/
+/**
+ *  Normalize the row elements to [0,1).
+ */
 template <typename T>
 void Aggregator<T>::normalize_row(tptr<T>& r, size_t row, size_t ncols) {
   for (size_t i = 0; i < ncols; ++i) {
@@ -985,9 +985,9 @@ void Aggregator<T>::normalize_row(tptr<T>& r, size_t row, size_t ncols) {
 }
 
 
-/*
-*  Project a particular row on a subspace by using the projection matrix.
-*/
+/**
+ *  Project a particular row on a subspace by using the projection matrix.
+ */
 template <typename T>
 void Aggregator<T>::project_row(tptr<T>& r, size_t row, size_t ncols, tptr<T>& pmatrix)
 {
@@ -1011,9 +1011,9 @@ void Aggregator<T>::project_row(tptr<T>& r, size_t row, size_t ncols, tptr<T>& p
 }
 
 
-/*
-*  Generate projection matrix.
-*/
+/**
+ *  Generate projection matrix.
+ */
 template <typename T>
 std::unique_ptr<T[]> Aggregator<T>::generate_pmatrix(size_t ncols) {
   std::default_random_engine generator;
@@ -1035,18 +1035,18 @@ std::unique_ptr<T[]> Aggregator<T>::generate_pmatrix(size_t ncols) {
 }
 
 
-/*
-*  To normalize a continuous column x to [0; 1] range we use
-*  the following formula: x_i_new = (x_i - min) / (max - min),
-*  where x_i is the value stored in the i-th row, max and min are the column
-*  maximum and minimum, respectively. To save on arithmetics, this can be
-*  easily converted to x_i_new = x_i * norm_factor + norm_shift,
-*  where norm_factor = 1 / (max - min) and norm_shift = - min / (max - min).
-*  When max = min, i.e. the column is constant, there is a singularity
-*  that may lead to wrong distance calculations done by the Aggregator.
-*  One of the approaches here is to handle the constant columns separately
-*  and set their values to 0.5, i.e. norm_factor = 0 and norm_shift = 0.5.
-*/
+/**
+ *  To normalize a continuous column x to [0; 1] range we use
+ *  the following formula: x_i_new = (x_i - min) / (max - min),
+ *  where x_i is the value stored in the i-th row, max and min are the column
+ *  maximum and minimum, respectively. To save on arithmetics, this can be
+ *  easily converted to x_i_new = x_i * norm_factor + norm_shift,
+ *  where norm_factor = 1 / (max - min) and norm_shift = - min / (max - min).
+ *  When max = min, i.e. the column is constant, there is a singularity
+ *  that may lead to wrong distance calculations done by the Aggregator.
+ *  One of the approaches here is to handle the constant columns separately
+ *  and set their values to 0.5, i.e. norm_factor = 0 and norm_shift = 0.5.
+ */
 template <typename T>
 void Aggregator<T>::set_norm_coeffs(T& norm_factor, T& norm_shift,
                                     T c_min, T c_max, size_t c_bins) {
@@ -1060,10 +1060,10 @@ void Aggregator<T>::set_norm_coeffs(T& norm_factor, T& norm_shift,
 }
 
 
-/*
-*  Helper function to invoke the Python progress function if supplied,
-*  otherwise just print the progress bar.
-*/
+/**
+ *  Helper function to invoke the Python progress function if supplied,
+ *  otherwise just print the progress bar.
+ */
 template <typename T>
 void Aggregator<T>::progress(float progress, int status_code /*= 0*/) {
   if (progress_fn.is_none()) {

--- a/c/models/aggregator.h
+++ b/c/models/aggregator.h
@@ -43,9 +43,9 @@ template <typename T>
 using ccptrvec = typename std::vector<ccptr<T>>;
 
 
-/*
-*  Aggregator base class.
-*/
+/**
+ *  Aggregator base class.
+ */
 class AggregatorBase {
   public :
     virtual void aggregate(DataTable*, dtptr&, dtptr&) = 0;
@@ -53,12 +53,12 @@ class AggregatorBase {
 };
 
 
-/*
-*  Aggregator main template class, where `T` is a type used for all the distance
-*  calculations. Templated with either `float` or `double`, aggregator
-*  converges to roughly the same number of exemplars, and members distribution.
-*  At the same time, using `float` can reduce memory usage.
-*/
+/**
+ *  Aggregator main template class, where `T` is a type used for all the distance
+ *  calculations. Templated with either `float` or `double`, aggregator
+ *  converges to roughly the same number of exemplars, and members distribution.
+ *  At the same time, using `float` can reduce memory usage.
+ */
 template <typename T>
 class Aggregator : public AggregatorBase {
   public:

--- a/c/models/column_convertor.h
+++ b/c/models/column_convertor.h
@@ -26,10 +26,10 @@
 
 
 
-/*
-* An abstract base class for all the column convertors.
-* T is a destination type we are converting data to.
-*/
+/**
+ *  An abstract base class for all the column convertors.
+ *  T is a destination type we are converting data to.
+ */
 template<typename T>
 class ColumnConvertor {
   public:
@@ -49,10 +49,10 @@ class ColumnConvertor {
 };
 
 
-/*
-* Constructor for the base class, store rowindex and number of rows
-* to be used when the data are accessed.
-*/
+/**
+ *  Constructor for the base class, store rowindex and number of rows
+ *  to be used when the data are accessed.
+ */
 template<typename T>
 ColumnConvertor<T>::ColumnConvertor(const Column* col) :
   ri(col->rowindex()),
@@ -60,15 +60,15 @@ ColumnConvertor<T>::ColumnConvertor(const Column* col) :
 {}
 
 
-/*
-* Virtual destructor.
-*/
+/**
+ *  Virtual destructor.
+ */
 template<typename T>
 ColumnConvertor<T>::~ColumnConvertor() {}
 
-/*
-* Getters for min, max and nrows.
-*/
+/**
+ *  Getters for min, max and nrows.
+ */
 template<typename T>
 T ColumnConvertor<T>::get_min() {
   return min;
@@ -87,12 +87,12 @@ size_t ColumnConvertor<T>::get_nrows() {
 }
 
 
-/*
-* Template class to convert continuous columns data from type T1 to T2, where
-* - T1 is a source data type, i.e. int8_t/int16_t/int32_t/int64_t/float/double;
-* - T2 is a destination type, i.e. float/double;
-* - T3 is a column type, i.e. BoolColumn/IntColumn<*>/RealColumn<*>.
-*/
+/**
+ *  Template class to convert continuous columns data from type T1 to T2, where
+ *  - T1 is a source data type, i.e. int8_t/int16_t/int32_t/int64_t/float/double;
+ *  - T2 is a destination type, i.e. float/double;
+ *  - T3 is a column type, i.e. BoolColumn/IntColumn<*>/RealColumn<*>.
+ */
 template<typename T1, typename T2, typename T3>
 class ColumnConvertorReal : public ColumnConvertor<T2> {
   private:
@@ -105,10 +105,10 @@ class ColumnConvertorReal : public ColumnConvertor<T2> {
 };
 
 
-/*
-* Constructor for the derived class. Pre-calculate stats, so that it is ready
-* for the multi-threaded ND aggregator.
-*/
+/**
+ *  Constructor for the derived class. Pre-calculate stats, so that it is ready
+ *  for the multi-threaded ND aggregator.
+ */
 template<typename T1, typename T2, typename T3>
 ColumnConvertorReal<T1, T2, T3>::ColumnConvertorReal(const Column* column_in) :
   ColumnConvertor<T2>(column_in)
@@ -128,12 +128,12 @@ ColumnConvertorReal<T1, T2, T3>::ColumnConvertorReal(const Column* column_in) :
 }
 
 
-/*
-* operator[] to get a converted column value by
-* - casting it to T2;
-* - applying a rowindex;
-* - properly handling NA's.
-*/
+/**
+ *  operator[] to get a converted column value by
+ *  - casting it to T2;
+ *  - applying a rowindex;
+ *  - properly handling NA's.
+ */
 template<typename T1, typename T2, typename T3>
 T2 ColumnConvertorReal<T1, T2, T3>::operator[](size_t row) const {
   size_t i = row;
@@ -147,10 +147,10 @@ T2 ColumnConvertorReal<T1, T2, T3>::operator[](size_t row) const {
 }
 
 
-/*
-* This method does the same as above just for a chunk of data.
-* No bound checks are performed.
-*/
+/**
+ *  This method does the same as above just for a chunk of data.
+ *  No bound checks are performed.
+ */
 template<typename T1, typename T2, typename T3>
 void ColumnConvertorReal<T1, T2, T3>::get_rows(std::vector<T2>& buffer,
                                                size_t from,

--- a/c/models/column_hasher.cc
+++ b/c/models/column_hasher.cc
@@ -22,16 +22,16 @@
 #include "models/column_hasher.h"
 
 
-/*
-*  Abstract Hasher class constructor and destructor.
-*/
+/**
+ *  Abstract Hasher class constructor and destructor.
+ */
 Hasher::Hasher(const Column* col) : ri(col->rowindex()) {}
 Hasher::~Hasher() {}
 
 
-/*
-*  Hash booleans by casting them to `uint64_t`.
-*/
+/**
+ *  Hash booleans by casting them to `uint64_t`.
+ */
 HasherBool::HasherBool(const Column* col) : Hasher(col) {
   values = dynamic_cast<const BoolColumn*>(col)->elements_r();
 }
@@ -45,9 +45,9 @@ uint64_t HasherBool::hash(size_t row) const {
 }
 
 
-/*
-*  Hash integers by casting them to `uint64_t`.
-*/
+/**
+ *  Hash integers by casting them to `uint64_t`.
+ */
 template <typename T>
 HasherInt<T>::HasherInt(const Column* col) : Hasher(col) {
   values = static_cast<const T*>(col->data());
@@ -63,10 +63,10 @@ uint64_t HasherInt<T>::hash(size_t row) const {
 }
 
 
-/*
-*  Hash floats by interpreting their bit representation as `uint64_t`,
-*  also do mantissa binning here.
-*/
+/**
+ *  Hash floats by interpreting their bit representation as `uint64_t`,
+ *  also do mantissa binning here.
+ */
 template <typename T>
 HasherFloat<T>::HasherFloat(const Column* col, unsigned char shift_nbits_in) :
 Hasher(col), shift_nbits(shift_nbits_in) {
@@ -85,9 +85,9 @@ uint64_t HasherFloat<T>::hash(size_t row) const {
 }
 
 
-/*
-*  Hash strings using Murmur hash function.
-*/
+/**
+ *  Hash strings using Murmur hash function.
+ */
 template <typename T>
 HasherString<T>::HasherString(const Column* col) : Hasher(col){
   auto scol = dynamic_cast<const StringColumn<T>*>(col);

--- a/c/models/column_hasher.cc
+++ b/c/models/column_hasher.cc
@@ -20,6 +20,7 @@
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #include "models/column_hasher.h"
+#include <float.h>
 
 
 /*
@@ -68,8 +69,8 @@ uint64_t HasherInt<T>::hash(size_t row) const {
 * TODO: also support some binning here.
 */
 template <typename T>
-HasherFloat<T>::HasherFloat(const Column* col, unsigned char float_nbits) :
-Hasher(col), shift_nbits(sizeof(double) * 8 - float_nbits) {
+HasherFloat<T>::HasherFloat(const Column* col, unsigned char mantissa_nbits) :
+Hasher(col), shift_nbits(DBL_MANT_DIG - mantissa_nbits) {
   values = static_cast<const T*>(col->data());
 }
 
@@ -78,8 +79,8 @@ template <typename T>
 uint64_t HasherFloat<T>::hash(size_t row) const {
   size_t i = ri[row];
   T value = (i == RowIndex::NA)? GETNA<T>() : values[i];
-  double x = static_cast<double>(value);
   uint64_t h;
+  double x = static_cast<double>(value);
   std::memcpy(&h, &x, sizeof(double));
   return h >> shift_nbits;
 }

--- a/c/models/column_hasher.cc
+++ b/c/models/column_hasher.cc
@@ -20,7 +20,6 @@
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #include "models/column_hasher.h"
-#include <float.h>
 
 
 /*
@@ -69,8 +68,8 @@ uint64_t HasherInt<T>::hash(size_t row) const {
 *  also do mantissa binning here.
 */
 template <typename T>
-HasherFloat<T>::HasherFloat(const Column* col, unsigned char mantissa_nbits) :
-Hasher(col), shift_nbits(DBL_MANT_DIG - mantissa_nbits) {
+HasherFloat<T>::HasherFloat(const Column* col, unsigned char shift_nbits_in) :
+Hasher(col), shift_nbits(shift_nbits_in) {
   values = static_cast<const T*>(col->data());
 }
 

--- a/c/models/column_hasher.cc
+++ b/c/models/column_hasher.cc
@@ -24,14 +24,14 @@
 
 
 /*
-* Abstract Hasher class constructor and destructor.
+*  Abstract Hasher class constructor and destructor.
 */
 Hasher::Hasher(const Column* col) : ri(col->rowindex()) {}
 Hasher::~Hasher() {}
 
 
 /*
-* Hash booleans by casting them to `uint64_t`.
+*  Hash booleans by casting them to `uint64_t`.
 */
 HasherBool::HasherBool(const Column* col) : Hasher(col) {
   values = dynamic_cast<const BoolColumn*>(col)->elements_r();
@@ -47,7 +47,7 @@ uint64_t HasherBool::hash(size_t row) const {
 
 
 /*
-* Hash integers by casting them to `uint64_t`.
+*  Hash integers by casting them to `uint64_t`.
 */
 template <typename T>
 HasherInt<T>::HasherInt(const Column* col) : Hasher(col) {
@@ -65,8 +65,8 @@ uint64_t HasherInt<T>::hash(size_t row) const {
 
 
 /*
-* Hash floats by reinterpreting their bit representation as `uint64_t`.
-* TODO: also support some binning here.
+*  Hash floats by interpreting their bit representation as `uint64_t`,
+*  also do mantissa binning here.
 */
 template <typename T>
 HasherFloat<T>::HasherFloat(const Column* col, unsigned char mantissa_nbits) :
@@ -87,7 +87,7 @@ uint64_t HasherFloat<T>::hash(size_t row) const {
 
 
 /*
-* Hash strings using Murmur hash function.
+*  Hash strings using Murmur hash function.
 */
 template <typename T>
 HasherString<T>::HasherString(const Column* col) : Hasher(col){

--- a/c/models/column_hasher.cc
+++ b/c/models/column_hasher.cc
@@ -68,7 +68,8 @@ uint64_t HasherInt<T>::hash(size_t row) const {
 * TODO: also support some binning here.
 */
 template <typename T>
-HasherFloat<T>::HasherFloat(const Column* col) : Hasher(col){
+HasherFloat<T>::HasherFloat(const Column* col, unsigned char float_nbits) :
+Hasher(col), shift_nbits(sizeof(double) * 8 - float_nbits) {
   values = static_cast<const T*>(col->data());
 }
 
@@ -80,7 +81,7 @@ uint64_t HasherFloat<T>::hash(size_t row) const {
   double x = static_cast<double>(value);
   uint64_t h;
   std::memcpy(&h, &x, sizeof(double));
-  return h;
+  return h >> shift_nbits;
 }
 
 

--- a/c/models/column_hasher.h
+++ b/c/models/column_hasher.h
@@ -73,8 +73,10 @@ template <typename T>
 class HasherFloat : public Hasher {
   private:
     const T* values;
+    const unsigned char shift_nbits;
+    size_t: 56;
   public:
-    explicit HasherFloat(const Column*);
+    explicit HasherFloat(const Column*, unsigned char);
     uint64_t hash(size_t row) const override;
 };
 

--- a/c/models/column_hasher.h
+++ b/c/models/column_hasher.h
@@ -26,7 +26,7 @@
 
 
 /*
-* An abstract base class for all the hashers.
+*  An abstract base class for all the hashers.
 */
 class Hasher {
   public:
@@ -42,7 +42,7 @@ using hasherptr = std::unique_ptr<Hasher>;
 
 
 /*
-* Class to hash booleans.
+*  Class to hash booleans.
 */
 class HasherBool : public Hasher {
   private:
@@ -54,7 +54,7 @@ class HasherBool : public Hasher {
 
 
 /*
-* Template class to hash integers.
+*  Template class to hash integers.
 */
 template <typename T>
 class HasherInt : public Hasher {

--- a/c/models/column_hasher.h
+++ b/c/models/column_hasher.h
@@ -25,9 +25,9 @@
 #include "models/murmurhash.h"
 
 
-/*
-*  An abstract base class for all the hashers.
-*/
+/**
+ *  An abstract base class for all the hashers.
+ */
 class Hasher {
   public:
     explicit Hasher(const Column*);
@@ -41,9 +41,9 @@ class Hasher {
 using hasherptr = std::unique_ptr<Hasher>;
 
 
-/*
-*  Class to hash booleans.
-*/
+/**
+ *  Class to hash booleans.
+ */
 class HasherBool : public Hasher {
   private:
     const int8_t* values;
@@ -53,9 +53,9 @@ class HasherBool : public Hasher {
 };
 
 
-/*
-*  Template class to hash integers.
-*/
+/**
+ *  Template class to hash integers.
+ */
 template <typename T>
 class HasherInt : public Hasher {
   private:
@@ -66,9 +66,9 @@ class HasherInt : public Hasher {
 };
 
 
-/*
-*  Template class to hash floats.
-*/
+/**
+ *  Template class to hash floats.
+ */
 template <typename T>
 class HasherFloat : public Hasher {
   private:
@@ -81,9 +81,9 @@ class HasherFloat : public Hasher {
 };
 
 
-/*
-*  Template class to hash strings.
-*/
+/**
+ *  Template class to hash strings.
+ */
 template <typename T>
 class HasherString : public Hasher {
   private:

--- a/c/models/dt_ftrl.cc
+++ b/c/models/dt_ftrl.cc
@@ -25,9 +25,9 @@
 namespace dt {
 
 
-/*
-*  Destructor for the abstract `dt::Ftrl` class.
-*/
+/**
+ *  Destructor for the abstract `dt::Ftrl` class.
+ */
 Ftrl::~Ftrl() {}
 
 

--- a/c/models/dt_ftrl.cc
+++ b/c/models/dt_ftrl.cc
@@ -26,7 +26,7 @@ namespace dt {
 
 
 /*
-* Destructor for the abstract `dt::Ftrl` class.
+*  Destructor for the abstract `dt::Ftrl` class.
 */
 Ftrl::~Ftrl() {}
 

--- a/c/models/dt_ftrl.h
+++ b/c/models/dt_ftrl.h
@@ -41,12 +41,13 @@ struct FtrlParams {
     double lambda2;
     uint64_t nbins;
     size_t nepochs;
+    unsigned char float_nbits;
     bool double_precision;
     bool negative_class;
-    size_t: 48;
+    size_t: 40;
     FtrlParams() : alpha(0.005), beta(1.0), lambda1(0.0), lambda2(0.0),
-                   nbins(1000000), nepochs(1), double_precision(false),
-                   negative_class(false) {}
+                   nbins(1000000), nepochs(1), float_nbits(sizeof(double) * 8),
+                   double_precision(false), negative_class(false) {}
 };
 
 
@@ -102,6 +103,7 @@ class Ftrl {
     virtual double get_lambda1() = 0;
     virtual double get_lambda2() = 0;
     virtual uint64_t get_nbins() = 0;
+    virtual uint64_t get_float_nbits() = 0;
     virtual size_t get_nepochs() = 0;
     virtual const std::vector<sizetvec>& get_interactions() = 0;
     virtual bool get_double_precision() = 0;
@@ -118,6 +120,7 @@ class Ftrl {
     virtual void set_lambda1(double) = 0;
     virtual void set_lambda2(double) = 0;
     virtual void set_nbins(uint64_t) = 0;
+    virtual void set_float_nbits(unsigned char) = 0;
     virtual void set_nepochs(size_t) = 0;
     virtual void set_interactions(std::vector<sizetvec>) = 0;
     virtual void set_double_precision(bool) = 0;

--- a/c/models/dt_ftrl.h
+++ b/c/models/dt_ftrl.h
@@ -30,10 +30,10 @@
 namespace dt {
 
 
-/*
-*  All the FTRL parameters provided in Python are stored in this structure,
-*  that also defines their default values.
-*/
+/**
+ *  All the FTRL parameters provided in Python are stored in this structure,
+ *  that also defines their default values.
+ */
 struct FtrlParams {
     double alpha;
     double beta;
@@ -51,20 +51,20 @@ struct FtrlParams {
 };
 
 
-/*
-*  When FTRL fitting is completed, this structure is returned
-*  containing epoch at which fitting stopped, and, in the case validation set
-*  was provided, the corresponding final loss.
-*/
+/**
+ *  When FTRL fitting is completed, this structure is returned
+ *  containing epoch at which fitting stopped, and, in the case validation set
+ *  was provided, the corresponding final loss.
+ */
 struct FtrlFitOutput {
     double epoch;
     double loss;
 };
 
 
-/*
-* Supported FTRL model types.
-*/
+/**
+ * Supported FTRL model types.
+ */
 enum class FtrlModelType : size_t {
   NONE        = 0, // Untrained model
   REGRESSION  = 1, // Numerical regression
@@ -73,10 +73,10 @@ enum class FtrlModelType : size_t {
 };
 
 
-/*
-*  An abstract dt::Ftrl class that declares all the virtual functions
-*  needed by py::Ftrl.
-*/
+/**
+ *  An abstract dt::Ftrl class that declares all the virtual functions
+ *  needed by py::Ftrl.
+ */
 class Ftrl {
   public:
     static constexpr unsigned char DBL_MANT_NBITS = 52;

--- a/c/models/dt_ftrl.h
+++ b/c/models/dt_ftrl.h
@@ -41,12 +41,12 @@ struct FtrlParams {
     double lambda2;
     uint64_t nbins;
     size_t nepochs;
-    unsigned char float_nbits;
+    unsigned char mantissa_nbits;
     bool double_precision;
     bool negative_class;
     size_t: 40;
     FtrlParams() : alpha(0.005), beta(1.0), lambda1(0.0), lambda2(0.0),
-                   nbins(1000000), nepochs(1), float_nbits(sizeof(double) * 8),
+                   nbins(1000000), nepochs(1), mantissa_nbits(10),
                    double_precision(false), negative_class(false) {}
 };
 
@@ -103,7 +103,7 @@ class Ftrl {
     virtual double get_lambda1() = 0;
     virtual double get_lambda2() = 0;
     virtual uint64_t get_nbins() = 0;
-    virtual unsigned char get_float_nbits() = 0;
+    virtual unsigned char get_mantissa_nbits() = 0;
     virtual size_t get_nepochs() = 0;
     virtual const std::vector<sizetvec>& get_interactions() = 0;
     virtual bool get_double_precision() = 0;
@@ -120,7 +120,7 @@ class Ftrl {
     virtual void set_lambda1(double) = 0;
     virtual void set_lambda2(double) = 0;
     virtual void set_nbins(uint64_t) = 0;
-    virtual void set_float_nbits(unsigned char) = 0;
+    virtual void set_mantissa_nbits(unsigned char) = 0;
     virtual void set_nepochs(size_t) = 0;
     virtual void set_interactions(std::vector<sizetvec>) = 0;
     virtual void set_double_precision(bool) = 0;

--- a/c/models/dt_ftrl.h
+++ b/c/models/dt_ftrl.h
@@ -103,7 +103,7 @@ class Ftrl {
     virtual double get_lambda1() = 0;
     virtual double get_lambda2() = 0;
     virtual uint64_t get_nbins() = 0;
-    virtual uint64_t get_float_nbits() = 0;
+    virtual unsigned char get_float_nbits() = 0;
     virtual size_t get_nepochs() = 0;
     virtual const std::vector<sizetvec>& get_interactions() = 0;
     virtual bool get_double_precision() = 0;

--- a/c/models/dt_ftrl.h
+++ b/c/models/dt_ftrl.h
@@ -79,6 +79,7 @@ enum class FtrlModelType : size_t {
 */
 class Ftrl {
   public:
+    static constexpr unsigned char DBL_MANT_NBITS = 52;
     virtual ~Ftrl();
     // Depending on the target column stype, this method should do
     // - binomial logistic regression (BOOL);

--- a/c/models/dt_ftrl_real.cc
+++ b/c/models/dt_ftrl_real.cc
@@ -1034,7 +1034,7 @@ void FtrlReal<T>::set_nbins(uint64_t nbins_in) {
 template <typename T>
 void FtrlReal<T>::set_mantissa_nbits(unsigned char mantissa_nbits_in) {
   xassert(mantissa_nbits_in >= 0);
-  xassert(mantissa_nbits_in <= DBL_MANT_DIG);
+  xassert(mantissa_nbits_in <= dt::Ftrl::DBL_MANT_NBITS);
   params.mantissa_nbits = mantissa_nbits_in;
   mantissa_nbits = mantissa_nbits_in;
 }

--- a/c/models/dt_ftrl_real.cc
+++ b/c/models/dt_ftrl_real.cc
@@ -933,7 +933,7 @@ uint64_t FtrlReal<T>::get_nbins() {
 
 
 template <typename T>
-uint64_t FtrlReal<T>::get_float_nbits() {
+unsigned char FtrlReal<T>::get_float_nbits() {
   return params.float_nbits;
 }
 
@@ -1032,6 +1032,8 @@ void FtrlReal<T>::set_nbins(uint64_t nbins_in) {
 
 template <typename T>
 void FtrlReal<T>::set_float_nbits(unsigned char float_nbits_in) {
+  xassert(float_nbits_in > 0);
+  xassert(float_nbits_in < sizeof(double) * 8 + 1);
   params.float_nbits = float_nbits_in;
   float_nbits = float_nbits_in;
 }

--- a/c/models/dt_ftrl_real.cc
+++ b/c/models/dt_ftrl_real.cc
@@ -39,6 +39,7 @@ FtrlReal<T>::FtrlReal(FtrlParams params_in) :
   lambda1(static_cast<T>(params_in.lambda1)),
   lambda2(static_cast<T>(params_in.lambda2)),
   nbins(params_in.nbins),
+  float_nbits(params_in.float_nbits),
   nepochs(params_in.nepochs),
   nfeatures(0),
   dt_X(nullptr),
@@ -480,7 +481,7 @@ dtptr FtrlReal<T>::predict(const DataTable* dt_X_in) {
     case FtrlModelType::REGRESSION  : linkfn = identity<T>; break;
     case FtrlModelType::BINOMIAL    : linkfn = sigmoid<T>; break;
     case FtrlModelType::MULTINOMIAL : (nlabels < 3)? linkfn = sigmoid<T> :
-                                                      linkfn = std::exp;
+                                                     linkfn = std::exp;
                                       break;
     default : throw ValueError() << "Cannot make any predictions, "
                                  << "the model was trained in an unknown mode";
@@ -783,8 +784,8 @@ hasherptr FtrlReal<T>::create_hasher(const Column* col) {
     case SType::INT16:   return hasherptr(new HasherInt<int16_t>(col));
     case SType::INT32:   return hasherptr(new HasherInt<int32_t>(col));
     case SType::INT64:   return hasherptr(new HasherInt<int64_t>(col));
-    case SType::FLOAT32: return hasherptr(new HasherFloat<float>(col));
-    case SType::FLOAT64: return hasherptr(new HasherFloat<double>(col));
+    case SType::FLOAT32: return hasherptr(new HasherFloat<float>(col, float_nbits));
+    case SType::FLOAT64: return hasherptr(new HasherFloat<double>(col, float_nbits));
     case SType::STR32:   return hasherptr(new HasherString<uint32_t>(col));
     case SType::STR64:   return hasherptr(new HasherString<uint64_t>(col));
     default:             throw  TypeError() << "Cannot hash a column of type "
@@ -932,6 +933,12 @@ uint64_t FtrlReal<T>::get_nbins() {
 
 
 template <typename T>
+uint64_t FtrlReal<T>::get_float_nbits() {
+  return params.float_nbits;
+}
+
+
+template <typename T>
 const std::vector<sizetvec>& FtrlReal<T>::get_interactions() {
   return interactions;
 }
@@ -1020,6 +1027,13 @@ template <typename T>
 void FtrlReal<T>::set_nbins(uint64_t nbins_in) {
   params.nbins = nbins_in;
   nbins = nbins_in;
+}
+
+
+template <typename T>
+void FtrlReal<T>::set_float_nbits(unsigned char float_nbits_in) {
+  params.float_nbits = float_nbits_in;
+  float_nbits = float_nbits_in;
 }
 
 

--- a/c/models/dt_ftrl_real.cc
+++ b/c/models/dt_ftrl_real.cc
@@ -28,7 +28,7 @@ namespace dt {
 
 
 /**
- * Constructor. Set up parameters and initialize weights.
+ *  Constructor. Set up parameters and initialize weights.
  */
 template <typename T>
 FtrlReal<T>::FtrlReal(FtrlParams params_in) :
@@ -52,13 +52,13 @@ FtrlReal<T>::FtrlReal(FtrlParams params_in) :
 }
 
 
-/*
-* Depending on the target column stype, this method does
-* - binomial logistic regression (BOOL);
-* - multinomial logistic regression (STR32, STR64);
-* - numerical regression (INT8, INT16, INT32, INT64, FLOAT32, FLOAT64).
-* and returns epoch at which learning completed or was early stopped.
-*/
+/**
+ *  Depending on the target column stype, this method does
+ *  - binomial logistic regression (BOOL);
+ *  - multinomial logistic regression (STR32, STR64);
+ *  - numerical regression (INT8, INT16, INT32, INT64, FLOAT32, FLOAT64).
+ *  and returns epoch at which learning completed or was early stopped.
+ */
 template <typename T>
 FtrlFitOutput FtrlReal<T>::dispatch_fit(const DataTable* dt_X_in,
                                  const DataTable* dt_y_in,
@@ -174,9 +174,9 @@ FtrlFitOutput FtrlReal<T>::fit_multinomial() {
 }
 
 
-/*
-*  Create training targets.
-*/
+/**
+ *  Create training targets.
+ */
 template <typename T>
 dtptr FtrlReal<T>::create_y_train() {
   // Do nhot encoding and sort labels alphabetically.
@@ -227,9 +227,9 @@ dtptr FtrlReal<T>::create_y_train() {
 }
 
 
-/*
-*  Create a target frame with all the negatives.
-*/
+/**
+ *  Create a target frame with all the negatives.
+ */
 template <typename T>
 Column* FtrlReal<T>::create_negative_column(size_t nrows) {
   Column* col = Column::new_data_column(SType::BOOL, nrows);
@@ -239,11 +239,11 @@ Column* FtrlReal<T>::create_negative_column(size_t nrows) {
 }
 
 
-/*
-*  Create validation targets for early stopping. Only include the labels
-*  the model was already trained on. Also, create mapping between the validation
-*  labels and the model labels to be used during training.
-*/
+/**
+ *  Create validation targets for early stopping. Only include the labels
+ *  the model was already trained on. Also, create mapping between the validation
+ *  labels and the model labels to be used during training.
+ */
 template <typename T>
 dtptr FtrlReal<T>::create_y_val() {
   xassert(map_val.size() == 0);
@@ -276,9 +276,9 @@ dtptr FtrlReal<T>::create_y_val() {
 }
 
 
-/*
-*  Fit model on a datatable.
-*/
+/**
+ *  Fit model on a datatable.
+ */
 template <typename T>
 template <typename U> /* column data type */
 FtrlFitOutput FtrlReal<T>::fit(T(*linkfn)(T), T(*lossfn)(T,U)) {
@@ -410,9 +410,9 @@ FtrlFitOutput FtrlReal<T>::fit(T(*linkfn)(T), T(*lossfn)(T,U)) {
 }
 
 
-/*
-*  Make a prediction for an array of hashed features.
-*/
+/**
+ *  Make a prediction for an array of hashed features.
+ */
 template <typename T>
 template <typename F>
 T FtrlReal<T>::predict_row(const uint64ptr& x, tptr<T>& w, size_t k, F fifn) {
@@ -432,9 +432,9 @@ T FtrlReal<T>::predict_row(const uint64ptr& x, tptr<T>& w, size_t k, F fifn) {
 }
 
 
-/*
-*  Update weights based on a prediction p and the actual target y.
-*/
+/**
+ *  Update weights based on a prediction p and the actual target y.
+ */
 template <typename T>
 template <typename U /* column data type */>
 void FtrlReal<T>::update(const uint64ptr& x, const tptr<T>& w,
@@ -451,10 +451,10 @@ void FtrlReal<T>::update(const uint64ptr& x, const tptr<T>& w,
 }
 
 
-/*
-*  Predict on a datatable and return a new datatable with
-*  the predicted probabilities.
-*/
+/**
+ *  Predict on a datatable and return a new datatable with
+ *  the predicted probabilities.
+ */
 template <typename T>
 dtptr FtrlReal<T>::predict(const DataTable* dt_X_in) {
   if (model_type == FtrlModelType::NONE) {
@@ -513,9 +513,9 @@ dtptr FtrlReal<T>::predict(const DataTable* dt_X_in) {
 }
 
 
-/*
-* Obtain pointers to column rowindexes and data.
-*/
+/**
+ * Obtain pointers to column rowindexes and data.
+ */
 template <typename T>
 template <typename U /* column data type */>
 void FtrlReal<T>::fill_ri_data(const DataTable* dt,
@@ -531,9 +531,9 @@ void FtrlReal<T>::fill_ri_data(const DataTable* dt,
 }
 
 
-/*
-* Normalize rows in a datatable, so that their values sum up to one.
-*/
+/**
+ * Normalize rows in a datatable, so that their values sum up to one.
+ */
 template <typename T>
 void FtrlReal<T>::normalize_rows(dtptr& dt) {
   size_t nrows = dt->nrows;
@@ -562,10 +562,10 @@ void FtrlReal<T>::normalize_rows(dtptr& dt) {
 }
 
 
-/*
-* Crete model datatable of shape (nbins, 2 * nlabels) to store z and n
-* coefficients.
-*/
+/**
+ * Crete model datatable of shape (nbins, 2 * nlabels) to store z and n
+ * coefficients.
+ */
 template <typename T>
 void FtrlReal<T>::create_model() {
   size_t nlabels = labels.size();
@@ -580,12 +580,12 @@ void FtrlReal<T>::create_model() {
 }
 
 
-/*
-* This method is invoked in the case when we get new labels
-* for multinomial classification and need to add them to the model.
-* In such a case, we make a copy of the "negative" z and n
-* coefficients adding them to the existing `dt_model` columns.
-*/
+/**
+ * This method is invoked in the case when we get new labels
+ * for multinomial classification and need to add them to the model.
+ * In such a case, we make a copy of the "negative" z and n
+ * coefficients adding them to the existing `dt_model` columns.
+ */
 template <typename T>
 void FtrlReal<T>::adjust_model() {
   size_t ncols_model = dt_model->ncols;
@@ -622,9 +622,9 @@ void FtrlReal<T>::adjust_model() {
 }
 
 
-/*
-* Create datatable for predictions.
-*/
+/**
+ * Create datatable for predictions.
+ */
 template <typename T>
 dtptr FtrlReal<T>::create_p(size_t nrows) {
   size_t nlabels = labels.size();
@@ -639,9 +639,9 @@ dtptr FtrlReal<T>::create_p(size_t nrows) {
 }
 
 
-/*
-* Reset the model.
-*/
+/**
+ * Reset the model.
+ */
 template <typename T>
 void FtrlReal<T>::reset() {
   dt_model = nullptr;
@@ -653,9 +653,9 @@ void FtrlReal<T>::reset() {
 }
 
 
-/*
-* Initialize model coefficients with zeros.
-*/
+/**
+ * Initialize model coefficients with zeros.
+ */
 template <typename T>
 void FtrlReal<T>::init_model() {
   if (dt_model == nullptr) return;
@@ -666,9 +666,9 @@ void FtrlReal<T>::init_model() {
 }
 
 
-/*
-* Obtain pointers to the model column data.
-*/
+/**
+ * Obtain pointers to the model column data.
+ */
 template <typename T>
 void FtrlReal<T>::init_weights() {
   size_t model_ncols = dt_model->ncols;
@@ -686,9 +686,9 @@ void FtrlReal<T>::init_weights() {
 }
 
 
-/*
-* Create feature importance datatable.
-*/
+/**
+ * Create feature importance datatable.
+ */
 template <typename T>
 void FtrlReal<T>::create_fi() {
   const strvec& colnames = dt_X->get_names();
@@ -722,9 +722,9 @@ void FtrlReal<T>::create_fi() {
 }
 
 
-/*
-* Initialize feature importances with zeros.
-*/
+/**
+ * Initialize feature importances with zeros.
+ */
 template <typename T>
 void FtrlReal<T>::init_fi() {
   if (dt_fi == nullptr) return;
@@ -733,18 +733,18 @@ void FtrlReal<T>::init_fi() {
 }
 
 
-/*
-* Determine number of features.
-*/
+/**
+ * Determine number of features.
+ */
 template <typename T>
 void FtrlReal<T>::define_features() {
   nfeatures = dt_X->ncols + interactions.size();
 }
 
 
-/*
-* Create hashers for all datatable column.
-*/
+/**
+ * Create hashers for all datatable column.
+ */
 template <typename T>
 std::vector<hasherptr> FtrlReal<T>::create_hashers(const DataTable* dt) {
   std::vector<hasherptr> hashers;
@@ -772,9 +772,9 @@ std::vector<hasherptr> FtrlReal<T>::create_hashers(const DataTable* dt) {
 }
 
 
-/*
-* Depending on a column type, create a corresponding hasher.
-*/
+/**
+ * Depending on a column type, create a corresponding hasher.
+ */
 template <typename T>
 hasherptr FtrlReal<T>::create_hasher(const Column* col) {
   unsigned char shift_nbits = dt::Ftrl::DBL_MANT_NBITS - mantissa_nbits;
@@ -795,9 +795,9 @@ hasherptr FtrlReal<T>::create_hasher(const Column* col) {
 }
 
 
-/*
-*  Hash each element of the datatable row, do feature interactions if requested.
-*/
+/**
+ *  Hash each element of the datatable row, do feature interactions if requested.
+ */
 template <typename T>
 void FtrlReal<T>::hash_row(uint64ptr& x, std::vector<hasherptr>& hashers,
                            size_t row) {
@@ -823,18 +823,18 @@ void FtrlReal<T>::hash_row(uint64ptr& x, std::vector<hasherptr>& hashers,
 }
 
 
-/*
-*  Return training status.
-*/
+/**
+ *  Return training status.
+ */
 template <typename T>
 bool FtrlReal<T>::is_trained() {
   return model_type != FtrlModelType::NONE;
 }
 
 
-/*
-*  Get a shallow copy of a model if available.
-*/
+/**
+ *  Get a shallow copy of a model if available.
+ */
 template <typename T>
 DataTable* FtrlReal<T>::get_model() {
   if (dt_model == nullptr) return nullptr;
@@ -842,9 +842,9 @@ DataTable* FtrlReal<T>::get_model() {
 }
 
 
-/*
-*  Return model type.
-*/
+/**
+ *  Return model type.
+ */
 template <typename T>
 FtrlModelType FtrlReal<T>::get_model_type() {
   return model_type;
@@ -852,13 +852,13 @@ FtrlModelType FtrlReal<T>::get_model_type() {
 
 
 
-/*
-* Normalize a column of feature importances to [0; 1]
-* This column has only positive values, so we simply divide its
-* content by the maximum. Another option is to do min-max normalization,
-* but this may lead to some features having zero importance,
-* while in reality they don't.
-*/
+/**
+ * Normalize a column of feature importances to [0; 1]
+ * This column has only positive values, so we simply divide its
+ * content by the maximum. Another option is to do min-max normalization,
+ * but this may lead to some features having zero importance,
+ * while in reality they don't.
+ */
 template <typename T>
 DataTable* FtrlReal<T>::get_fi(bool normalize /* = true */) {
   if (dt_fi == nullptr) return nullptr;
@@ -881,10 +881,10 @@ DataTable* FtrlReal<T>::get_fi(bool normalize /* = true */) {
 }
 
 
-/*
-*  Other getters and setters.
-*  Here we assume that all the validation for setters is done by py::Ftrl.
-*/
+/**
+ *  Other getters and setters.
+ *  Here we assume that all the validation for setters is done by py::Ftrl.
+ */
 template <typename T>
 const std::vector<uint64_t>& FtrlReal<T>::get_colname_hashes() {
   return colname_hashes;

--- a/c/models/dt_ftrl_real.cc
+++ b/c/models/dt_ftrl_real.cc
@@ -19,7 +19,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
-#include <float.h>
+#include <cfloat>
 #include "models/dt_ftrl_real.h"
 #include "parallel/atomic.h"
 #include "utils/macros.h"
@@ -28,9 +28,9 @@
 namespace dt {
 
 
-/*
-*  Constructor. Set up parameters and initialize weights.
-*/
+/**
+ * Constructor. Set up parameters and initialize weights.
+ */
 template <typename T>
 FtrlReal<T>::FtrlReal(FtrlParams params_in) :
   model_type(FtrlModelType::NONE),
@@ -778,6 +778,7 @@ std::vector<hasherptr> FtrlReal<T>::create_hashers(const DataTable* dt) {
 */
 template <typename T>
 hasherptr FtrlReal<T>::create_hasher(const Column* col) {
+  unsigned char shift_nbits = dt::Ftrl::DBL_MANT_NBITS - mantissa_nbits;
   SType stype = col->stype();
   switch (stype) {
     case SType::BOOL:    return hasherptr(new HasherBool(col));
@@ -785,8 +786,8 @@ hasherptr FtrlReal<T>::create_hasher(const Column* col) {
     case SType::INT16:   return hasherptr(new HasherInt<int16_t>(col));
     case SType::INT32:   return hasherptr(new HasherInt<int32_t>(col));
     case SType::INT64:   return hasherptr(new HasherInt<int64_t>(col));
-    case SType::FLOAT32: return hasherptr(new HasherFloat<float>(col, mantissa_nbits));
-    case SType::FLOAT64: return hasherptr(new HasherFloat<double>(col, mantissa_nbits));
+    case SType::FLOAT32: return hasherptr(new HasherFloat<float>(col, shift_nbits));
+    case SType::FLOAT64: return hasherptr(new HasherFloat<double>(col, shift_nbits));
     case SType::STR32:   return hasherptr(new HasherString<uint32_t>(col));
     case SType::STR64:   return hasherptr(new HasherString<uint64_t>(col));
     default:             throw  TypeError() << "Cannot hash a column of type "

--- a/c/models/dt_ftrl_real.cc
+++ b/c/models/dt_ftrl_real.cc
@@ -349,7 +349,7 @@ FtrlFitOutput FtrlReal<T>::fit(T(*linkfn)(T), T(*lossfn)(T,U)) {
               T p = linkfn(predict_row(
                         x, w, k,
                         [&](size_t f_id, T f_imp) {
-                          data_fi[f_id] += f_imp;
+                          fi[f_id] += f_imp;
                         }
                     ));
               update(x, w, p, data[k][j], k);

--- a/c/models/dt_ftrl_real.cc
+++ b/c/models/dt_ftrl_real.cc
@@ -19,7 +19,6 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
-#include <cfloat>
 #include "models/dt_ftrl_real.h"
 #include "parallel/atomic.h"
 #include "utils/macros.h"

--- a/c/models/dt_ftrl_real.cc
+++ b/c/models/dt_ftrl_real.cc
@@ -514,7 +514,7 @@ dtptr FtrlReal<T>::predict(const DataTable* dt_X_in) {
 
 
 /**
- * Obtain pointers to column rowindexes and data.
+ *  Obtain pointers to column rowindexes and data.
  */
 template <typename T>
 template <typename U /* column data type */>
@@ -532,7 +532,7 @@ void FtrlReal<T>::fill_ri_data(const DataTable* dt,
 
 
 /**
- * Normalize rows in a datatable, so that their values sum up to one.
+ *  Normalize rows in a datatable, so that their values sum up to one.
  */
 template <typename T>
 void FtrlReal<T>::normalize_rows(dtptr& dt) {
@@ -563,8 +563,8 @@ void FtrlReal<T>::normalize_rows(dtptr& dt) {
 
 
 /**
- * Crete model datatable of shape (nbins, 2 * nlabels) to store z and n
- * coefficients.
+ *  Create model datatable of shape (nbins, 2 * nlabels) to store z and n
+ *  coefficients.
  */
 template <typename T>
 void FtrlReal<T>::create_model() {
@@ -581,10 +581,10 @@ void FtrlReal<T>::create_model() {
 
 
 /**
- * This method is invoked in the case when we get new labels
- * for multinomial classification and need to add them to the model.
- * In such a case, we make a copy of the "negative" z and n
- * coefficients adding them to the existing `dt_model` columns.
+ *  This method is invoked in the case when we get new labels
+ *  for multinomial classification and need to add them to the model.
+ *  In such a case, we make a copy of the "negative" z and n
+ *  coefficients adding them to the existing `dt_model` columns.
  */
 template <typename T>
 void FtrlReal<T>::adjust_model() {
@@ -623,7 +623,7 @@ void FtrlReal<T>::adjust_model() {
 
 
 /**
- * Create datatable for predictions.
+ *  Create datatable for predictions.
  */
 template <typename T>
 dtptr FtrlReal<T>::create_p(size_t nrows) {
@@ -640,7 +640,7 @@ dtptr FtrlReal<T>::create_p(size_t nrows) {
 
 
 /**
- * Reset the model.
+ *  Reset the model.
  */
 template <typename T>
 void FtrlReal<T>::reset() {
@@ -654,7 +654,7 @@ void FtrlReal<T>::reset() {
 
 
 /**
- * Initialize model coefficients with zeros.
+ *  Initialize model coefficients with zeros.
  */
 template <typename T>
 void FtrlReal<T>::init_model() {
@@ -667,7 +667,7 @@ void FtrlReal<T>::init_model() {
 
 
 /**
- * Obtain pointers to the model column data.
+ *  Obtain pointers to the model column data.
  */
 template <typename T>
 void FtrlReal<T>::init_weights() {

--- a/c/models/dt_ftrl_real.cc
+++ b/c/models/dt_ftrl_real.cc
@@ -39,7 +39,7 @@ FtrlReal<T>::FtrlReal(FtrlParams params_in) :
   lambda1(static_cast<T>(params_in.lambda1)),
   lambda2(static_cast<T>(params_in.lambda2)),
   nbins(params_in.nbins),
-  float_nbits(params_in.float_nbits),
+  mantissa_nbits(params_in.mantissa_nbits),
   nepochs(params_in.nepochs),
   nfeatures(0),
   dt_X(nullptr),
@@ -784,8 +784,8 @@ hasherptr FtrlReal<T>::create_hasher(const Column* col) {
     case SType::INT16:   return hasherptr(new HasherInt<int16_t>(col));
     case SType::INT32:   return hasherptr(new HasherInt<int32_t>(col));
     case SType::INT64:   return hasherptr(new HasherInt<int64_t>(col));
-    case SType::FLOAT32: return hasherptr(new HasherFloat<float>(col, float_nbits));
-    case SType::FLOAT64: return hasherptr(new HasherFloat<double>(col, float_nbits));
+    case SType::FLOAT32: return hasherptr(new HasherFloat<float>(col, mantissa_nbits));
+    case SType::FLOAT64: return hasherptr(new HasherFloat<double>(col, mantissa_nbits));
     case SType::STR32:   return hasherptr(new HasherString<uint32_t>(col));
     case SType::STR64:   return hasherptr(new HasherString<uint64_t>(col));
     default:             throw  TypeError() << "Cannot hash a column of type "
@@ -933,8 +933,8 @@ uint64_t FtrlReal<T>::get_nbins() {
 
 
 template <typename T>
-unsigned char FtrlReal<T>::get_float_nbits() {
-  return params.float_nbits;
+unsigned char FtrlReal<T>::get_mantissa_nbits() {
+  return params.mantissa_nbits;
 }
 
 
@@ -1031,11 +1031,11 @@ void FtrlReal<T>::set_nbins(uint64_t nbins_in) {
 
 
 template <typename T>
-void FtrlReal<T>::set_float_nbits(unsigned char float_nbits_in) {
-  xassert(float_nbits_in > 0);
-  xassert(float_nbits_in < sizeof(double) * 8 + 1);
-  params.float_nbits = float_nbits_in;
-  float_nbits = float_nbits_in;
+void FtrlReal<T>::set_mantissa_nbits(unsigned char mantissa_nbits_in) {
+  xassert(mantissa_nbits_in > 0);
+  xassert(mantissa_nbits_in < sizeof(double) * 8 + 1);
+  params.mantissa_nbits = mantissa_nbits_in;
+  mantissa_nbits = mantissa_nbits_in;
 }
 
 

--- a/c/models/dt_ftrl_real.cc
+++ b/c/models/dt_ftrl_real.cc
@@ -19,6 +19,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
+#include <float.h>
 #include "models/dt_ftrl_real.h"
 #include "parallel/atomic.h"
 #include "utils/macros.h"
@@ -1032,8 +1033,8 @@ void FtrlReal<T>::set_nbins(uint64_t nbins_in) {
 
 template <typename T>
 void FtrlReal<T>::set_mantissa_nbits(unsigned char mantissa_nbits_in) {
-  xassert(mantissa_nbits_in > 0);
-  xassert(mantissa_nbits_in < sizeof(double) * 8 + 1);
+  xassert(mantissa_nbits_in >= 0);
+  xassert(mantissa_nbits_in <= DBL_MANT_DIG);
   params.mantissa_nbits = mantissa_nbits_in;
   mantissa_nbits = mantissa_nbits_in;
 }

--- a/c/models/dt_ftrl_real.cc
+++ b/c/models/dt_ftrl_real.cc
@@ -723,7 +723,7 @@ void FtrlReal<T>::create_fi() {
 
 
 /**
- * Initialize feature importances with zeros.
+ *  Initialize feature importances with zeros.
  */
 template <typename T>
 void FtrlReal<T>::init_fi() {
@@ -734,7 +734,7 @@ void FtrlReal<T>::init_fi() {
 
 
 /**
- * Determine number of features.
+ *  Determine number of features.
  */
 template <typename T>
 void FtrlReal<T>::define_features() {
@@ -743,7 +743,7 @@ void FtrlReal<T>::define_features() {
 
 
 /**
- * Create hashers for all datatable column.
+ *  Create hashers for all datatable column.
  */
 template <typename T>
 std::vector<hasherptr> FtrlReal<T>::create_hashers(const DataTable* dt) {
@@ -773,7 +773,7 @@ std::vector<hasherptr> FtrlReal<T>::create_hashers(const DataTable* dt) {
 
 
 /**
- * Depending on a column type, create a corresponding hasher.
+ *  Depending on a column type, create a corresponding hasher.
  */
 template <typename T>
 hasherptr FtrlReal<T>::create_hasher(const Column* col) {
@@ -853,11 +853,11 @@ FtrlModelType FtrlReal<T>::get_model_type() {
 
 
 /**
- * Normalize a column of feature importances to [0; 1]
- * This column has only positive values, so we simply divide its
- * content by the maximum. Another option is to do min-max normalization,
- * but this may lead to some features having zero importance,
- * while in reality they don't.
+ *  Normalize a column of feature importances to [0; 1]
+ *  This column has only positive values, so we simply divide its
+ *  content by the maximum. Another option is to do min-max normalization,
+ *  but this may lead to some features having zero importance,
+ *  while in reality they don't.
  */
 template <typename T>
 DataTable* FtrlReal<T>::get_fi(bool normalize /* = true */) {

--- a/c/models/dt_ftrl_real.h
+++ b/c/models/dt_ftrl_real.h
@@ -57,7 +57,7 @@ class FtrlReal : public dt::Ftrl {
     T lambda1;
     T lambda2;
     uint64_t nbins;
-    unsigned char float_nbits;
+    unsigned char mantissa_nbits;
     size_t: 56;
     size_t nepochs;
     std::vector<sizetvec> interactions;
@@ -151,7 +151,7 @@ class FtrlReal : public dt::Ftrl {
     double get_lambda1() override;
     double get_lambda2() override;
     uint64_t get_nbins() override;
-    unsigned char get_float_nbits() override;
+    unsigned char get_mantissa_nbits() override;
     size_t get_nepochs() override;
     const std::vector<sizetvec>& get_interactions() override;
     bool get_double_precision() override;
@@ -168,7 +168,7 @@ class FtrlReal : public dt::Ftrl {
     void set_lambda1(double) override;
     void set_lambda2(double) override;
     void set_nbins(uint64_t) override;
-    void set_float_nbits(unsigned char) override;
+    void set_mantissa_nbits(unsigned char) override;
     void set_nepochs(size_t) override;
     void set_interactions(std::vector<sizetvec>) override;
     void set_double_precision(bool) override;

--- a/c/models/dt_ftrl_real.h
+++ b/c/models/dt_ftrl_real.h
@@ -151,7 +151,7 @@ class FtrlReal : public dt::Ftrl {
     double get_lambda1() override;
     double get_lambda2() override;
     uint64_t get_nbins() override;
-    uint64_t get_float_nbits() override;
+    unsigned char get_float_nbits() override;
     size_t get_nepochs() override;
     const std::vector<sizetvec>& get_interactions() override;
     bool get_double_precision() override;

--- a/c/models/dt_ftrl_real.h
+++ b/c/models/dt_ftrl_real.h
@@ -31,9 +31,9 @@
 namespace dt {
 
 
-/*
-* Class template that implements all the virtual methods declared in dt::Ftrl.
-*/
+/**
+ *  Class template that implements all the virtual methods declared in dt::Ftrl.
+ */
 template <typename T /* float or double */>
 class FtrlReal : public dt::Ftrl {
   private:

--- a/c/models/dt_ftrl_real.h
+++ b/c/models/dt_ftrl_real.h
@@ -57,6 +57,8 @@ class FtrlReal : public dt::Ftrl {
     T lambda1;
     T lambda2;
     uint64_t nbins;
+    unsigned char float_nbits;
+    size_t: 56;
     size_t nepochs;
     std::vector<sizetvec> interactions;
 
@@ -98,7 +100,7 @@ class FtrlReal : public dt::Ftrl {
 
     // Hashing methods
     std::vector<hasherptr> create_hashers(const DataTable*);
-    static hasherptr create_hasher(const Column*);
+    hasherptr create_hasher(const Column*);
     void hash_row(uint64ptr&, std::vector<hasherptr>&, size_t);
 
     // Model helper methods
@@ -149,6 +151,7 @@ class FtrlReal : public dt::Ftrl {
     double get_lambda1() override;
     double get_lambda2() override;
     uint64_t get_nbins() override;
+    uint64_t get_float_nbits() override;
     size_t get_nepochs() override;
     const std::vector<sizetvec>& get_interactions() override;
     bool get_double_precision() override;
@@ -165,6 +168,7 @@ class FtrlReal : public dt::Ftrl {
     void set_lambda1(double) override;
     void set_lambda2(double) override;
     void set_nbins(uint64_t) override;
+    void set_float_nbits(unsigned char) override;
     void set_nepochs(size_t) override;
     void set_interactions(std::vector<sizetvec>) override;
     void set_double_precision(bool) override;

--- a/c/models/murmurhash.cc
+++ b/c/models/murmurhash.cc
@@ -7,7 +7,7 @@
 #include "utils/macros.h"
 
 
-/*
+/**
  *  Murmur2 hash function.
  */
 uint64_t hash_murmur2(const void* key, uint64_t len, unsigned int seed)
@@ -52,7 +52,7 @@ uint64_t hash_murmur2(const void* key, uint64_t len, unsigned int seed)
 }
 
 
-/*
+/**
  *  Murmur3 hash function.
  */
 void hash_murmur3(const void* key, const uint64_t len, unsigned int seed,
@@ -131,24 +131,24 @@ void hash_murmur3(const void* key, const uint64_t len, unsigned int seed,
 }
 
 
-/*
- * Some helper functions for Murmur3 hash
+/**
+ *  Some helper functions for Murmur3 hash
  */
 inline uint64_t ROTL64(uint64_t x, int8_t r) {
   return (x << r) | (x >> (64 - r));
 }
 
-/*
- * Block read - if your platform needs to do endian-swapping or can only
- * handle aligned reads, do the conversion here
+/**
+ *  Block read - if your platform needs to do endian-swapping or can only
+ *  handle aligned reads, do the conversion here
  */
 inline uint64_t getblock64(const uint64_t* p, uint64_t i) {
   return p[i];
 }
 
 
-/*
- * Finalization mix - force all bits of a hash block to avalanche
+/**
+ *  Finalization mix - force all bits of a hash block to avalanche
  */
 inline uint64_t fmix64(uint64_t k) {
   k ^= k >> 33;

--- a/c/models/py_ftrl.cc
+++ b/c/models/py_ftrl.cc
@@ -19,12 +19,11 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
+#include <vector>
 #include "frame/py_frame.h"
 #include "python/_all.h"
 #include "python/string.h"
 #include "str/py_str.h"
-#include <vector>
-#include <float.h>
 #include "models/py_ftrl.h"
 #include "models/py_validator.h"
 #include "models/utils.h"
@@ -74,10 +73,10 @@ void Ftrl::m__init__(PKArgs& args) {
         defined_nepochs || defined_double_precision || defined_negative_class) {
 
       throw TypeError() << "You can either pass all the parameters with "
-            << "`params` or any of the individual parameters with `alpha`, "
-            << "`beta`, `lambda1`, `lambda2`, `nbins`, `mantissa_nbits`, `nepochs`, "
-            << "`double_precision` or `negative_class` to Ftrl constructor, "
-            << "but not both at the same time";
+        << "`params` or any of the individual parameters with `alpha`, "
+        << "`beta`, `lambda1`, `lambda2`, `nbins`, `mantissa_nbits`, `nepochs`, "
+        << "`double_precision` or `negative_class` to Ftrl constructor, "
+        << "but not both at the same time";
     }
 
     py::otuple py_params = arg_params.to_otuple();
@@ -106,7 +105,9 @@ void Ftrl::m__init__(PKArgs& args) {
     py::Validator::check_not_negative<double>(ftrl_params.lambda1, py_lambda1);
     py::Validator::check_not_negative<double>(ftrl_params.lambda2, py_lambda2);
     py::Validator::check_not_negative<double>(ftrl_params.nbins, py_nbins);
-    py::Validator::check_less_than<uint64_t>(mantissa_nbits, DBL_MANT_DIG + 1, py_negative_class);
+    py::Validator::check_less_than<uint64_t>(mantissa_nbits,
+                                             dt::Ftrl::DBL_MANT_NBITS + 1,
+                                             py_negative_class);
     ftrl_params.mantissa_nbits = static_cast<unsigned char>(mantissa_nbits);
 
   } else {
@@ -138,7 +139,9 @@ void Ftrl::m__init__(PKArgs& args) {
 
     if (defined_mantissa_nbits) {
       size_t mantissa_nbits = arg_mantissa_nbits.to_size_t();
-      py::Validator::check_less_than<uint64_t>(mantissa_nbits, DBL_MANT_DIG + 1, arg_mantissa_nbits);
+      py::Validator::check_less_than<uint64_t>(mantissa_nbits,
+                                               dt::Ftrl::DBL_MANT_NBITS + 1,
+                                               arg_mantissa_nbits);
       ftrl_params.mantissa_nbits = static_cast<unsigned char>(mantissa_nbits);
     }
 
@@ -783,7 +786,9 @@ void Ftrl::set_mantissa_nbits(robj py_mantissa_nbits) {
   }
 
   size_t mantissa_nbits = py_mantissa_nbits.to_size_t();
-  py::Validator::check_less_than<uint64_t>(mantissa_nbits, DBL_MANT_DIG + 1, py_mantissa_nbits);
+  py::Validator::check_less_than<uint64_t>(mantissa_nbits,
+                                           dt::Ftrl::DBL_MANT_NBITS + 1,
+                                           py_mantissa_nbits);
   dtft->set_mantissa_nbits(static_cast<unsigned char>(mantissa_nbits));
 }
 

--- a/c/models/py_ftrl.cc
+++ b/c/models/py_ftrl.cc
@@ -1049,6 +1049,9 @@ lambda2 : float
     L2 regularization parameter, defaults to `0`.
 nbins : int
     Number of bins to be used for the hashing trick, defaults to `10**6`.
+float_nbits : int
+    Number of bits to be taken into account when hashing float values,
+    defaults to maximum of `sizeof(double) * 8`, that is `64` on most of the systems.
 nepochs : int
     Number of training epochs, defaults to `1`.
 double_precision : bool

--- a/c/models/py_ftrl.cc
+++ b/c/models/py_ftrl.cc
@@ -768,7 +768,7 @@ void Ftrl::set_nbins(robj py_nbins) {
 */
 static GSArgs args_mantissa_nbits(
   "mantissa_nbits",
-  "Number of bits to be used for hashing float values");
+  "Number of bits from mantissa to be used for hashing float values");
 
 
 oobj Ftrl::get_mantissa_nbits() const {

--- a/c/models/py_ftrl.cc
+++ b/c/models/py_ftrl.cc
@@ -30,9 +30,9 @@
 
 namespace py {
 
-PKArgs Ftrl::Type::args___init__(0, 2, 7, false, false,
+PKArgs Ftrl::Type::args___init__(0, 2, 8, false, false,
                                  {"params", "alpha", "beta", "lambda1",
-                                 "lambda2", "nbins", "nepochs",
+                                 "lambda2", "nbins", "float_nbits", "nepochs",
                                  "double_precision", "negative_class"},
                                  "__init__", nullptr);
 
@@ -51,9 +51,10 @@ void Ftrl::m__init__(PKArgs& args) {
   const Arg& arg_lambda1          = args[3];
   const Arg& arg_lambda2          = args[4];
   const Arg& arg_nbins            = args[5];
-  const Arg& arg_nepochs          = args[6];
-  const Arg& arg_double_precision = args[7];
-  const Arg& arg_negative_class   = args[8];
+  const Arg& arg_float_nbits      = args[6];
+  const Arg& arg_nepochs          = args[7];
+  const Arg& arg_double_precision = args[8];
+  const Arg& arg_negative_class   = args[9];
 
   bool defined_params           = !arg_params.is_none_or_undefined();
   bool defined_alpha            = !arg_alpha.is_none_or_undefined();
@@ -61,18 +62,19 @@ void Ftrl::m__init__(PKArgs& args) {
   bool defined_lambda1          = !arg_lambda1.is_none_or_undefined();
   bool defined_lambda2          = !arg_lambda2.is_none_or_undefined();
   bool defined_nbins            = !arg_nbins.is_none_or_undefined();
+  bool defined_float_nbits      = !arg_float_nbits.is_none_or_undefined();
   bool defined_nepochs          = !arg_nepochs.is_none_or_undefined();
   bool defined_double_precision = !arg_double_precision.is_none_or_undefined();
   bool defined_negative_class   = !arg_negative_class.is_none_or_undefined();
 
   if (defined_params) {
     if (defined_alpha || defined_beta || defined_lambda1 ||
-        defined_lambda2 || defined_nbins || defined_nepochs ||
-        defined_double_precision || defined_negative_class) {
+        defined_lambda2 || defined_nbins || defined_float_nbits ||
+        defined_nepochs || defined_double_precision || defined_negative_class) {
 
       throw TypeError() << "You can either pass all the parameters with "
             << "`params` or any of the individual parameters with `alpha`, "
-            << "`beta`, `lambda1`, `lambda2`, `nbins`, `nepochs`, "
+            << "`beta`, `lambda1`, `lambda2`, `nbins`, `float_nbits`, `nepochs`, "
             << "`double_precision` or `negative_class` to Ftrl constructor, "
             << "but not both at the same time";
     }
@@ -83,6 +85,7 @@ void Ftrl::m__init__(PKArgs& args) {
     py::oobj py_lambda1 = py_params.get_attr("lambda1");
     py::oobj py_lambda2 = py_params.get_attr("lambda2");
     py::oobj py_nbins = py_params.get_attr("nbins");
+    py::oobj py_float_nbits = py_params.get_attr("float_nbits");
     py::oobj py_nepochs = py_params.get_attr("nepochs");
     py::oobj py_double_precision = py_params.get_attr("double_precision");
     py::oobj py_negative_class = py_params.get_attr("negative_class");
@@ -92,6 +95,7 @@ void Ftrl::m__init__(PKArgs& args) {
     ftrl_params.lambda1 = py_lambda1.to_double();
     ftrl_params.lambda2 = py_lambda2.to_double();
     ftrl_params.nbins = static_cast<uint64_t>(py_nbins.to_size_t());
+    size_t float_nbits = py_float_nbits.to_size_t();
     ftrl_params.nepochs = py_nepochs.to_size_t();
     ftrl_params.double_precision = py_double_precision.to_bool_strict();
     ftrl_params.negative_class = py_negative_class.to_bool_strict();
@@ -102,31 +106,42 @@ void Ftrl::m__init__(PKArgs& args) {
     py::Validator::check_not_negative<double>(ftrl_params.lambda2, py_lambda2);
     py::Validator::check_not_negative<double>(ftrl_params.nbins, py_nbins);
 
+    py::Validator::check_positive<uint64_t>(float_nbits, py_negative_class);
+    py::Validator::check_less_than<uint64_t>(float_nbits, sizeof(double) * 8 + 1, py_negative_class);
+    ftrl_params.float_nbits = static_cast<unsigned char>(float_nbits);
+
   } else {
 
     if (defined_alpha) {
       ftrl_params.alpha = arg_alpha.to_double();
-      py::Validator::check_positive<double>(ftrl_params.alpha, args[1]);
+      py::Validator::check_positive<double>(ftrl_params.alpha, arg_alpha);
     }
 
     if (defined_beta) {
       ftrl_params.beta = arg_beta.to_double();
-      py::Validator::check_not_negative<double>(ftrl_params.beta, args[2]);
+      py::Validator::check_not_negative<double>(ftrl_params.beta, arg_beta);
     }
 
     if (defined_lambda1) {
       ftrl_params.lambda1 = arg_lambda1.to_double();
-      py::Validator::check_not_negative<double>(ftrl_params.lambda1, args[3]);
+      py::Validator::check_not_negative<double>(ftrl_params.lambda1, arg_lambda1);
     }
 
     if (defined_lambda2) {
       ftrl_params.lambda2 = arg_lambda2.to_double();
-      py::Validator::check_not_negative<double>(ftrl_params.lambda2, args[4]);
+      py::Validator::check_not_negative<double>(ftrl_params.lambda2, arg_lambda2);
     }
 
     if (defined_nbins) {
       ftrl_params.nbins = static_cast<uint64_t>(arg_nbins.to_size_t());
-      py::Validator::check_positive<uint64_t>(ftrl_params.nbins, args[5]);
+      py::Validator::check_positive<uint64_t>(ftrl_params.nbins, arg_nbins);
+    }
+
+    if (defined_float_nbits) {
+      size_t float_nbits = arg_float_nbits.to_size_t();
+      py::Validator::check_positive<uint64_t>(float_nbits, arg_float_nbits);
+      py::Validator::check_less_than<uint64_t>(float_nbits, sizeof(double) * 8 + 1, arg_float_nbits);
+      ftrl_params.float_nbits = static_cast<unsigned char>(float_nbits);
     }
 
     if (defined_nepochs) {
@@ -744,9 +759,35 @@ void Ftrl::set_nbins(robj py_nbins) {
                        << "reset this model or create a new one";
   }
 
-  uint64_t nbins = static_cast<uint64_t>(py_nbins.to_size_t());
+  size_t nbins = py_nbins.to_size_t();
   py::Validator::check_positive(nbins, py_nbins);
-  dtft->set_nbins(nbins);
+  dtft->set_nbins(static_cast<uint64_t>(nbins));
+}
+
+
+/*
+*  .float_nbits
+*/
+static GSArgs args_float_nbits(
+  "float_nbits",
+  "Number of bits to be used for hashing float values");
+
+
+oobj Ftrl::get_float_nbits() const {
+  return py::oint(static_cast<size_t>(dtft->get_float_nbits()));
+}
+
+
+void Ftrl::set_float_nbits(robj py_float_nbits) {
+  if (dtft->is_trained()) {
+    throw ValueError() << "Cannot change `float_nbits` for a trained model, "
+                       << "reset this model or create a new one";
+  }
+
+  size_t float_nbits = py_float_nbits.to_size_t();
+  py::Validator::check_positive(float_nbits, py_float_nbits);
+  py::Validator::check_less_than<uint64_t>(float_nbits, 65, py_float_nbits);
+  dtft->set_float_nbits(static_cast<unsigned char>(float_nbits));
 }
 
 
@@ -870,6 +911,7 @@ oobj Ftrl::get_params_namedtuple() const {
      {args_lambda1.name,          args_lambda1.doc},
      {args_lambda2.name,          args_lambda2.doc},
      {args_nbins.name,            args_nbins.doc},
+     {args_float_nbits.name,      args_float_nbits.doc},
      {args_nepochs.name,          args_nepochs.doc},
      {args_double_precision.name, args_double_precision.doc},
      {args_negative_class.name,   args_negative_class.doc}}
@@ -881,9 +923,10 @@ oobj Ftrl::get_params_namedtuple() const {
   params.set(2, get_lambda1());
   params.set(3, get_lambda2());
   params.set(4, get_nbins());
-  params.set(5, get_nepochs());
-  params.set(6, get_double_precision());
-  params.set(7, get_negative_class());
+  params.set(5, get_float_nbits());
+  params.set(6, get_nepochs());
+  params.set(7, get_double_precision());
+  params.set(8, get_negative_class());
   return std::move(params);
 }
 
@@ -894,6 +937,7 @@ oobj Ftrl::get_params_tuple() const {
                  get_lambda1(),
                  get_lambda2(),
                  get_nbins(),
+                 get_float_nbits(),
                  get_nepochs(),
                  get_double_precision(),
                  get_negative_class()};
@@ -903,8 +947,8 @@ oobj Ftrl::get_params_tuple() const {
 void Ftrl::set_params_tuple(robj params) {
   py::otuple params_tuple = params.to_otuple();
   size_t n_params = params_tuple.size();
-  if (n_params != 8) {
-    throw ValueError() << "Tuple of FTRL parameters should have 8 elements, "
+  if (n_params != 9) {
+    throw ValueError() << "Tuple of FTRL parameters should have 9 elements, "
                        << "got: " << n_params;
   }
   set_alpha(params_tuple[0]);
@@ -912,9 +956,10 @@ void Ftrl::set_params_tuple(robj params) {
   set_lambda1(params_tuple[2]);
   set_lambda2(params_tuple[3]);
   set_nbins(params_tuple[4]);
-  set_nepochs(params_tuple[5]);
-  set_double_precision(params_tuple[6]);
-  set_negative_class(params_tuple[7]);
+  set_float_nbits(params_tuple[5]);
+  set_nepochs(params_tuple[6]);
+  set_double_precision(params_tuple[7]);
+  set_negative_class(params_tuple[8]);
 }
 
 
@@ -953,7 +998,7 @@ void Ftrl::m__setstate__(const PKArgs& args) {
   py::otuple pickle = args[0].to_otuple();
   py::otuple params = pickle[0].to_otuple();
 
-  bool double_precision = params[6].to_bool_strict();
+  bool double_precision = params[7].to_bool_strict();
   if (double_precision) {
     dtft = new dt::FtrlReal<double>(ftrl_params);
   } else {
@@ -1026,6 +1071,7 @@ void Ftrl::Type::init_methods_and_getsets(Methods& mm, GetSetters& gs)
   ADD_GETSET(gs, &Ftrl::get_lambda1, &Ftrl::set_lambda1, args_lambda1);
   ADD_GETSET(gs, &Ftrl::get_lambda2, &Ftrl::set_lambda2, args_lambda2);
   ADD_GETSET(gs, &Ftrl::get_nbins, &Ftrl::set_nbins, args_nbins);
+  ADD_GETSET(gs, &Ftrl::get_float_nbits, &Ftrl::set_float_nbits, args_float_nbits);
   ADD_GETSET(gs, &Ftrl::get_nepochs, &Ftrl::set_nepochs, args_nepochs);
   ADD_GETTER(gs, &Ftrl::get_double_precision, args_double_precision);
   ADD_GETTER(gs, &Ftrl::get_negative_class, args_negative_class);

--- a/c/models/py_ftrl.cc
+++ b/c/models/py_ftrl.cc
@@ -37,10 +37,10 @@ PKArgs Ftrl::Type::args___init__(0, 2, 8, false, false,
                                  "__init__", nullptr);
 
 
-/*
-*  Ftrl(...)
-*  Initialize Ftrl object with the provided parameters.
-*/
+/**
+ *  Ftrl(...)
+ *  Initialize Ftrl object with the provided parameters.
+ */
 void Ftrl::m__init__(PKArgs& args) {
   dtft = nullptr;
   dt::FtrlParams ftrl_params;
@@ -168,9 +168,9 @@ void Ftrl::m__init__(PKArgs& args) {
 }
 
 
-/*
-*  Deallocate underlying data for an Ftrl object
-*/
+/**
+ *  Deallocate underlying data for an Ftrl object
+ */
 void Ftrl::m__dealloc__() {
   if (dtft != nullptr) {
     delete dtft;
@@ -179,10 +179,10 @@ void Ftrl::m__dealloc__() {
 }
 
 
-/*
-*  Check if provided interactions are consistent with the column names
-*  of the training frame.
-*/
+/**
+ *  Check if provided interactions are consistent with the column names
+ *  of the training frame.
+ */
 std::vector<sizetvec> Ftrl::convert_interactions() {
   std::vector<sizetvec> interactions;
   auto py_iter = py_interactions.to_oiter();
@@ -213,10 +213,10 @@ std::vector<sizetvec> Ftrl::convert_interactions() {
 }
 
 
-/*
-*  .fit(...)
-*  Do dataset validation and a call to `dtft->dispatch_fit(...)` method.
-*/
+/**
+ *  .fit(...)
+ *  Do dataset validation and a call to `dtft->dispatch_fit(...)` method.
+ */
 static PKArgs args_fit(2, 4, 0, false, false, {"X_train", "y_train",
                        "X_validation", "y_validation",
                        "nepochs_validation", "validation_error"},
@@ -384,11 +384,11 @@ oobj Ftrl::fit(const PKArgs& args) {
 }
 
 
-/*
-*  .predict(...)
-*  Perform dataset validation, make a call to `dtft->predict(...)`,
-*  return frame with predictions.
-*/
+/**
+ *  .predict(...)
+ *  Perform dataset validation, make a call to `dtft->predict(...)`,
+ *  return frame with predictions.
+ */
 static PKArgs args_predict(1, 0, 0, false, false, {"X"}, "predict",
 R"(predict(self, X)
 --
@@ -445,10 +445,10 @@ oobj Ftrl::predict(const PKArgs& args) {
 }
 
 
-/*
-*  .reset()
-*  Reset the model by making a call to `dtft->reset()`.
-*/
+/**
+ *  .reset()
+ *  Reset the model by making a call to `dtft->reset()`.
+ */
 static PKArgs args_reset(0, 0, 0, false, false, {}, "reset",
 R"(reset(self)
 --
@@ -473,9 +473,9 @@ void Ftrl::reset(const PKArgs&) {
 }
 
 
-/*
-*  .labels
-*/
+/**
+ *  .labels
+ */
 static GSArgs args_labels(
   "labels",
   R"(List of labels used for classification.)");
@@ -513,9 +513,9 @@ void Ftrl::set_labels(robj py_labels) {
 
 
 
-/*
-*  .model
-*/
+/**
+ *  .model
+ */
 static GSArgs args_model(
   "model",
 R"(Model frame of shape `(nbins, 2 * nlabels)`, where nlabels is
@@ -576,9 +576,9 @@ void Ftrl::set_model(robj model) {
 }
 
 
-/*
-*  .feature_importances
-*/
+/**
+ *  .feature_importances
+ */
 static GSArgs args_fi(
   "feature_importances",
 R"(Two-column frame with feature names and the corresponding
@@ -600,9 +600,9 @@ oobj Ftrl::get_normalized_fi(bool normalize) const {
 }
 
 
-/*
-*  .colnames
-*/
+/**
+ *  .colnames
+ */
 static GSArgs args_colnames(
   "colnames",
   "Column names"
@@ -636,9 +636,9 @@ void Ftrl::set_colnames(robj py_colnames) {
 }
 
 
-/*
-*  .colname_hashes
-*/
+/**
+ *  .colname_hashes
+ */
 static GSArgs args_colname_hashes(
   "colname_hashes",
   "Column name hashes"
@@ -661,9 +661,9 @@ oobj Ftrl::get_colname_hashes() const {
 }
 
 
-/*
-*  .alpha
-*/
+/**
+ *  .alpha
+ */
 static GSArgs args_alpha(
   "alpha",
   "`alpha` in per-coordinate FTRL-Proximal algorithm");
@@ -681,9 +681,9 @@ void Ftrl::set_alpha(robj py_alpha) {
 }
 
 
-/*
-*  .beta
-*/
+/**
+ *  .beta
+ */
 static GSArgs args_beta(
   "beta",
   "`beta` in per-coordinate FTRL-Proximal algorithm");
@@ -701,9 +701,9 @@ void Ftrl::set_beta(robj py_beta) {
 }
 
 
-/*
-*  .lambda1
-*/
+/**
+ *  .lambda1
+ */
 static GSArgs args_lambda1(
   "lambda1",
   "L1 regularization parameter");
@@ -721,9 +721,9 @@ void Ftrl::set_lambda1(robj py_lambda1) {
 }
 
 
-/*
-*  .lambda2
-*/
+/**
+ *  .lambda2
+ */
 static GSArgs args_lambda2(
   "lambda2",
   "L2 regularization parameter");
@@ -741,9 +741,9 @@ void Ftrl::set_lambda2(robj py_lambda2) {
 }
 
 
-/*
-*  .nbins
-*/
+/**
+ *  .nbins
+ */
 static GSArgs args_nbins(
   "nbins",
   "Number of bins for the hashing trick");
@@ -766,9 +766,9 @@ void Ftrl::set_nbins(robj py_nbins) {
 }
 
 
-/*
-*  .mantissa_nbits
-*/
+/**
+ *  .mantissa_nbits
+ */
 static GSArgs args_mantissa_nbits(
   "mantissa_nbits",
   "Number of bits from mantissa to be used for hashing float values");
@@ -793,9 +793,9 @@ void Ftrl::set_mantissa_nbits(robj py_mantissa_nbits) {
 }
 
 
-/*
-*  .nepochs
-*/
+/**
+ *  .nepochs
+ */
 static GSArgs args_nepochs(
   "nepochs",
   "Number of epochs to train a model");
@@ -812,9 +812,9 @@ void Ftrl::set_nepochs(robj py_nepochs) {
 }
 
 
-/*
-*  .interactions
-*/
+/**
+ *  .interactions
+ */
 static GSArgs args_interactions(
   "interactions",
   "List of feature lists to do interactions for");
@@ -851,9 +851,9 @@ void Ftrl::set_interactions(robj arg_interactions) {
 }
 
 
-/*
-*  .double_precision
-*/
+/**
+ *  .double_precision
+ */
 static GSArgs args_double_precision(
   "double_precision",
   "Whether to use double precision arithmetic for modeling");
@@ -873,9 +873,9 @@ void Ftrl::set_double_precision(robj py_double_precision) {
 }
 
 
-/*
-*  .negative_class
-*/
+/**
+ *  .negative_class
+ */
 static GSArgs args_negative_class(
   "negative_class",
   "Whether to train on negatives in the case of multinomial classification.");
@@ -896,9 +896,9 @@ void Ftrl::set_negative_class(robj py_negative_class) {
 }
 
 
-/*
-*  .params
-*/
+/**
+ *  .params
+ */
 static GSArgs args_params(
   "params",
   "FTRL model parameters");
@@ -965,9 +965,9 @@ void Ftrl::set_params_tuple(robj params) {
 }
 
 
-/*
-*  Pickling support.
-*/
+/**
+ *  Pickling support.
+ */
 static PKArgs args___getstate__(
     0, 0, 0, false, false, {}, "__getstate__", nullptr);
 
@@ -987,9 +987,9 @@ oobj Ftrl::m__getstate__(const PKArgs&) {
 }
 
 
-/*
-*  Unpickling support.
-*/
+/**
+ *  Unpickling support.
+ */
 static PKArgs args___setstate__(
     1, 0, 0, false, false, {"state"}, "__setstate__", nullptr);
 
@@ -1019,9 +1019,9 @@ void Ftrl::m__setstate__(const PKArgs& args) {
 }
 
 
-/*
-*  py::Ftrl::Type
-*/
+/**
+ *  py::Ftrl::Type
+ */
 const char* Ftrl::Type::classname() {
   return "datatable.models.Ftrl";
 }
@@ -1063,9 +1063,9 @@ negative_class : bool
 }
 
 
-/*
-*  Initialize all the exposed methods and getters/setters.
-*/
+/**
+ *  Initialize all the exposed methods and getters/setters.
+ */
 void Ftrl::Type::init_methods_and_getsets(Methods& mm, GetSetters& gs)
 {
   // Input parameters

--- a/c/models/py_ftrl.cc
+++ b/c/models/py_ftrl.cc
@@ -105,9 +105,9 @@ void Ftrl::m__init__(PKArgs& args) {
     py::Validator::check_not_negative<double>(ftrl_params.lambda1, py_lambda1);
     py::Validator::check_not_negative<double>(ftrl_params.lambda2, py_lambda2);
     py::Validator::check_not_negative<double>(ftrl_params.nbins, py_nbins);
-    py::Validator::check_less_than<uint64_t>(mantissa_nbits,
-                                             dt::Ftrl::DBL_MANT_NBITS + 1,
-                                             py_negative_class);
+    py::Validator::check_less_than_or_equal_to<uint64_t>(mantissa_nbits,
+                                                         dt::Ftrl::DBL_MANT_NBITS,
+                                                         py_negative_class);
     ftrl_params.mantissa_nbits = static_cast<unsigned char>(mantissa_nbits);
 
   } else {
@@ -139,9 +139,9 @@ void Ftrl::m__init__(PKArgs& args) {
 
     if (defined_mantissa_nbits) {
       size_t mantissa_nbits = arg_mantissa_nbits.to_size_t();
-      py::Validator::check_less_than<uint64_t>(mantissa_nbits,
-                                               dt::Ftrl::DBL_MANT_NBITS + 1,
-                                               arg_mantissa_nbits);
+      py::Validator::check_less_than_or_equal_to<uint64_t>(mantissa_nbits,
+                                                           dt::Ftrl::DBL_MANT_NBITS,
+                                                           arg_mantissa_nbits);
       ftrl_params.mantissa_nbits = static_cast<unsigned char>(mantissa_nbits);
     }
 
@@ -786,8 +786,8 @@ void Ftrl::set_mantissa_nbits(robj py_mantissa_nbits) {
   }
 
   size_t mantissa_nbits = py_mantissa_nbits.to_size_t();
-  py::Validator::check_less_than<uint64_t>(mantissa_nbits,
-                                           dt::Ftrl::DBL_MANT_NBITS + 1,
+  py::Validator::check_less_than_or_equal_to<uint64_t>(mantissa_nbits,
+                                           dt::Ftrl::DBL_MANT_NBITS,
                                            py_mantissa_nbits);
   dtft->set_mantissa_nbits(static_cast<unsigned char>(mantissa_nbits));
 }

--- a/c/models/py_ftrl.h
+++ b/c/models/py_ftrl.h
@@ -77,6 +77,7 @@ class Ftrl : public PyObject {
     oobj get_lambda1() const;
     oobj get_lambda2() const;
     oobj get_nbins() const;
+    oobj get_float_nbits() const;
     oobj get_nepochs() const;
     oobj get_interactions() const;
     oobj get_double_precision() const;
@@ -93,6 +94,7 @@ class Ftrl : public PyObject {
     void set_lambda2(robj);
     void set_nepochs(robj);
     void set_nbins(robj);             // Disabled for a trained model
+    void set_float_nbits(robj);       // Disabled for a trained model
     void set_interactions(robj);      // Disabled for a trained model
     void set_double_precision(robj);  // Not exposed, used for unpickling only
     void set_negative_class(robj);    // Disabled for a trained model

--- a/c/models/py_ftrl.h
+++ b/c/models/py_ftrl.h
@@ -77,7 +77,7 @@ class Ftrl : public PyObject {
     oobj get_lambda1() const;
     oobj get_lambda2() const;
     oobj get_nbins() const;
-    oobj get_float_nbits() const;
+    oobj get_mantissa_nbits() const;
     oobj get_nepochs() const;
     oobj get_interactions() const;
     oobj get_double_precision() const;
@@ -94,7 +94,7 @@ class Ftrl : public PyObject {
     void set_lambda2(robj);
     void set_nepochs(robj);
     void set_nbins(robj);             // Disabled for a trained model
-    void set_float_nbits(robj);       // Disabled for a trained model
+    void set_mantissa_nbits(robj);       // Disabled for a trained model
     void set_interactions(robj);      // Disabled for a trained model
     void set_double_precision(robj);  // Not exposed, used for unpickling only
     void set_negative_class(robj);    // Disabled for a trained model

--- a/c/models/py_ftrl.h
+++ b/c/models/py_ftrl.h
@@ -30,9 +30,9 @@
 namespace py {
 
 
-/*
-* Main class that controls Python FTRL API.
-*/
+/**
+ *  Main class that controls Python FTRL API.
+ */
 class Ftrl : public PyObject {
   private:
     dt::Ftrl* dtft;
@@ -94,7 +94,7 @@ class Ftrl : public PyObject {
     void set_lambda2(robj);
     void set_nepochs(robj);
     void set_nbins(robj);             // Disabled for a trained model
-    void set_mantissa_nbits(robj);       // Disabled for a trained model
+    void set_mantissa_nbits(robj);    // Disabled for a trained model
     void set_interactions(robj);      // Disabled for a trained model
     void set_double_precision(robj);  // Not exposed, used for unpickling only
     void set_negative_class(robj);    // Disabled for a trained model

--- a/c/models/py_validator.cc
+++ b/c/models/py_validator.cc
@@ -28,6 +28,7 @@ Error py::Validator::error_manager::error_not_positive(PyObject* src,
   return ValueError() << name << " should be positive: " << src;
 }
 
+
 Error py::Validator::error_manager::error_negative(PyObject* src,
                                                    const std::string& name
 ) const {

--- a/c/models/py_validator.h
+++ b/c/models/py_validator.h
@@ -53,9 +53,9 @@ Error py::Validator::error_manager::error_larger_or_equal(PyObject* src,
 
 // py::_obj validators
 
-/*
-*  Less than check.
-*/
+/**
+ *  Less than check.
+ */
 template <typename T>
 void check_less_than(const T value,
                      const T value_max,
@@ -68,10 +68,10 @@ void check_less_than(const T value,
 }
 
 
-/*
-*  Positive check. Will emit an error, when `value` is not positive, `NaN`
-*  or infinity.
-*/
+/**
+ *  Positive check. Will emit an error, when `value` is not positive, `NaN`
+ *  or infinity.
+ */
 template <typename T>
 void check_positive(T value,
                     const py::_obj& o,
@@ -83,10 +83,10 @@ void check_positive(T value,
 }
 
 
-/*
-*  Not negative check. Will emit an error, when `value` is negative, `NaN`
-*  or infinity.
-*/
+/**
+ *  Not negative check. Will emit an error, when `value` is negative, `NaN`
+ *  or infinity.
+ */
 template <typename T>
 void check_not_negative(T value,
                         const py::_obj& o,

--- a/c/models/py_validator.h
+++ b/c/models/py_validator.h
@@ -28,13 +28,16 @@
 namespace py {
 namespace Validator {
 
+
+// Error manager
+
 struct error_manager {
   error_manager() = default;
   error_manager(const error_manager&) = default;
   Error error_not_positive (PyObject*, const std::string&) const;
   Error error_negative     (PyObject*, const std::string&) const;
   template <typename T>
-  Error error_larger_or_equal (PyObject*, const std::string&, T value_max) const;
+  Error error_greater_than (PyObject*, const std::string&, T value_max) const;
 };
 
 static std::string _name = "Value";
@@ -42,29 +45,29 @@ static error_manager _em;
 
 
 template <typename T>
-Error py::Validator::error_manager::error_larger_or_equal(PyObject* src,
-                                                   const std::string& name,
-                                                   T value_max
+Error py::Validator::error_manager::error_greater_than(PyObject* src,
+                                                       const std::string& name,
+                                                       T value_max
 ) const {
-  return ValueError() << name << " should be less than " << value_max << ", got: "
-                      << src;
+  return ValueError() << name << " should be less than or equal to " << value_max
+                      << ", got: " << src;
 }
 
 
 // py::_obj validators
 
 /**
- *  Less than check.
+ *  Less than or equal to check.
  */
 template <typename T>
-void check_less_than(const T value,
-                     const T value_max,
-                     const py::_obj& o,
-                     const std::string& name = _name,
-                     error_manager& em = _em)
+void check_less_than_or_equal_to(const T value,
+                                 const T value_max,
+                                 const py::_obj& o,
+                                 const std::string& name = _name,
+                                 error_manager& em = _em)
 {
-  if (!std::isinf(value) && value < value_max) return;
-  throw em.error_larger_or_equal<T>(o.to_borrowed_ref(), name, value_max);
+  if (!std::isinf(value) && value <= value_max) return;
+  throw em.error_greater_than<T>(o.to_borrowed_ref(), name, value_max);
 }
 
 
@@ -113,8 +116,8 @@ void check_not_negative(T value, const py::Arg& arg, error_manager& em = _em) {
 
 
 template <typename T>
-void check_less_than(T value, T value_max, const py::Arg& arg, error_manager& em = _em) {
-  check_less_than<T>(value, value_max, arg.to_pyobj(), arg.name(), em);
+void check_less_than_or_equal_to(T value, T value_max, const py::Arg& arg, error_manager& em = _em) {
+  check_less_than_or_equal_to<T>(value, value_max, arg.to_pyobj(), arg.name(), em);
 }
 
 

--- a/c/models/py_validator.h
+++ b/c/models/py_validator.h
@@ -34,7 +34,7 @@ struct error_manager {
   Error error_not_positive (PyObject*, const std::string&) const;
   Error error_negative     (PyObject*, const std::string&) const;
   template <typename T>
-  Error error_larger_or_equal_than (PyObject*, const std::string&, T value_max) const;
+  Error error_larger_or_equal (PyObject*, const std::string&, T value_max) const;
 };
 
 static std::string _name = "Value";
@@ -42,7 +42,7 @@ static error_manager _em;
 
 
 template <typename T>
-Error py::Validator::error_manager::error_larger_or_equal_than(PyObject* src,
+Error py::Validator::error_manager::error_larger_or_equal(PyObject* src,
                                                    const std::string& name,
                                                    T value_max
 ) const {
@@ -64,7 +64,7 @@ void check_less_than(const T value,
                      error_manager& em = _em)
 {
   if (!std::isinf(value) && value < value_max) return;
-  throw em.error_larger_or_equal_than<T>(o.to_borrowed_ref(), name, value_max);
+  throw em.error_larger_or_equal<T>(o.to_borrowed_ref(), name, value_max);
 }
 
 

--- a/c/models/utils.cc
+++ b/c/models/utils.cc
@@ -25,10 +25,10 @@
 #include "models/utils.h"
 
 
-/*
-*  For a given `n` calculate all the coprime numbers and return them
-*  as a `coprimes` vector.
-*/
+/**
+ *  For a given `n` calculate all the coprime numbers and return them
+ *  as a `coprimes` vector.
+ */
 void calculate_coprimes(size_t n, std::vector<size_t>& coprimes) {
   coprimes.clear();
   if (n == 1) {
@@ -56,10 +56,10 @@ void calculate_coprimes(size_t n, std::vector<size_t>& coprimes) {
 }
 
 
-/*
-*  Print a progress bar if `status_code == 0`, i.e. in-progress;
-*  clear the progress bar when `status_code != 0`, i.e. finished.
-*/
+/**
+ *  Print a progress bar if `status_code == 0`, i.e. in-progress;
+ *  clear the progress bar when `status_code != 0`, i.e. finished.
+ */
 void print_progress(float progress, int status_code) {
   int val = static_cast<int>(progress * 100);
   int lpad = static_cast<int>(progress * PBWIDTH);

--- a/c/models/utils.h
+++ b/c/models/utils.h
@@ -35,9 +35,9 @@ using sizetvec = std::vector<size_t>;
 void calculate_coprimes(size_t, std::vector<size_t>&);
 
 
-/*
-*  Create list of sorting indexes.
-*/
+/**
+ *  Create list of sorting indexes.
+ */
 template <typename T>
 sizetvec sort_index(const std::vector<T> &v) {
 
@@ -55,30 +55,30 @@ sizetvec sort_index(const std::vector<T> &v) {
 }
 
 
-/*
-*  Sigmoid function.
-*/
+/**
+ *  Sigmoid function.
+ */
 template<typename T>
 inline T sigmoid(T x) {
   constexpr T one = static_cast<T>(1.0);
   return one / (one + std::exp(-x));
 }
 
-/*
-*  Identity function.
-*/
+/**
+ *  Identity function.
+ */
 template<typename T>
 inline T identity(T x) {
   return x;
 }
 
-/*
-*  Calculate logloss(p, y) = -(y * log(p) + (1 - y) * log(1 - p)),
-*  where p is a prediction and y is the actual target:
-*  - apply minmax rule, so that p falls into the [epsilon; 1 - epsilon] interval,
-*    to prevent logloss being undefined;
-*  - simplify the logloss formula to more compact branchless code.
-*/
+/**
+ *  Calculate logloss(p, y) = -(y * log(p) + (1 - y) * log(1 - p)),
+ *  where p is a prediction and y is the actual target:
+ *  - apply minmax rule, so that p falls into the [epsilon; 1 - epsilon] interval,
+ *    to prevent logloss being undefined;
+ *  - simplify the logloss formula to more compact branchless code.
+ */
 template<typename T>
 inline T log_loss(T p, int8_t y) {
   constexpr T epsilon = std::numeric_limits<T>::epsilon();
@@ -87,10 +87,10 @@ inline T log_loss(T p, int8_t y) {
 }
 
 
-/*
-*  Squared loss, T1 is either float or double,
-*  T2 is any other numerical type.
-*/
+/**
+ *  Squared loss, T1 is either float or double,
+ *  T2 is any other numerical type.
+ */
 template<typename T1, typename T2>
 inline T1 squared_loss(T1 p, T2 y) {
   T1 y_T1 = static_cast<T1>(y);
@@ -98,9 +98,9 @@ inline T1 squared_loss(T1 p, T2 y) {
 }
 
 
-/*
-*  Progress reporting function and parameters.
-*/
+/**
+ *  Progress reporting function and parameters.
+ */
 #define PBSTR "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
 #define PBWIDTH 60
 void print_progress(float, int);

--- a/docs/ftrl.rst
+++ b/docs/ftrl.rst
@@ -45,6 +45,8 @@ namely:
 -  ``lambda1`` – L1 regularization parameter, defaults to ``0.0``.
 -  ``lambda2`` – L2 regularization parameter, defaults to ``1.0``.
 -  ``nbins`` – the number of bins for the hashing trick, defaults to ``10**6``.
+-  ``float_nbits`` – the number of bits to be taken into account when hashing float values,
+  defaults to maximum of ``sizeof(double) * 8``, that is ``64`` on most of the systems.
 -  ``nepochs`` – the number of epochs to train the model for, defaults to ``1``.
 -  ``negative_class`` – whether to create and train on a "negative" class in the case of multinomial classification, defaults to ``False``.
 

--- a/docs/ftrl.rst
+++ b/docs/ftrl.rst
@@ -45,8 +45,7 @@ namely:
 -  ``lambda1`` – L1 regularization parameter, defaults to ``0.0``.
 -  ``lambda2`` – L2 regularization parameter, defaults to ``1.0``.
 -  ``nbins`` – the number of bins for the hashing trick, defaults to ``10**6``.
--  ``float_nbits`` – the number of bits to be taken into account when hashing float values,
-  defaults to maximum of ``sizeof(double) * 8``, that is ``64`` on most of the systems.
+-  ``mantissa_nbits`` – the number of bits from mantissa to be used for hashing, defaults to ``10``.
 -  ``nepochs`` – the number of epochs to train the model for, defaults to ``1``.
 -  ``negative_class`` – whether to create and train on a "negative" class in the case of multinomial classification, defaults to ``False``.
 

--- a/tests/models/test_ftrl.py
+++ b/tests/models/test_ftrl.py
@@ -41,19 +41,20 @@ from tests import assert_equals, noop
 #-------------------------------------------------------------------------------
 # Define namedtuple of test parameters, test model and accuracy
 #-------------------------------------------------------------------------------
-Params = collections.namedtuple("Params",["alpha", "beta", "lambda1", "lambda2",
-                                          "nbins", "nepochs",
+Params = collections.namedtuple("FtrlParams",["alpha", "beta", "lambda1", "lambda2",
+                                          "nbins", "float_nbits", "nepochs",
                                           "double_precision", "negative_class"])
 tparams = Params(alpha = 1, beta = 2, lambda1 = 3, lambda2 = 4, nbins = 5,
-                 nepochs = 6, double_precision = True, negative_class = False)
+                 float_nbits = 6, nepochs = 7, double_precision = True,
+                 negative_class = False)
 
 tmodel = dt.Frame([[random.random() for _ in range(tparams.nbins)],
                    [random.random() for _ in range(tparams.nbins)]],
                    names=['z', 'n'])
 
 default_params = Params(alpha = 0.005, beta = 1, lambda1 = 0, lambda2 = 0,
-                        nbins = 10**6, nepochs = 1, double_precision = False,
-                        negative_class = False)
+                        nbins = 10**6, float_nbits = 64, nepochs = 1,
+                        double_precision = False, negative_class = False)
 
 epsilon = 0.01
 
@@ -97,6 +98,13 @@ def test_ftrl_construct_wrong_nbins_type():
             "instead got <class 'float'>" == str(e.value))
 
 
+def test_ftrl_construct_wrong_float_nbits_type():
+    with pytest.raises(TypeError) as e:
+        noop(Ftrl(float_nbits = 20.0))
+    assert ("Argument `float_nbits` in Ftrl() constructor should be an integer, "
+            "instead got <class 'float'>" == str(e.value))
+
+
 def test_ftrl_construct_wrong_nepochs_type():
     with pytest.raises(TypeError) as e:
         noop(Ftrl(nepochs = 10.0))
@@ -116,8 +124,9 @@ def test_ftrl_construct_wrong_combination():
         noop(Ftrl(params=tparams, alpha = tparams.alpha))
     assert ("You can either pass all the parameters with `params` or any of "
             "the individual parameters with `alpha`, `beta`, `lambda1`, "
-            "`lambda2`, `nbins`, `nepochs`, `double_precision` or `negative_class` "
-            "to Ftrl constructor, but not both at the same time" == str(e.value))
+            "`lambda2`, `nbins`, `float_nbits`, `nepochs`, `double_precision` or "
+            "`negative_class` to Ftrl constructor, but not both at the same time"
+            == str(e.value))
 
 
 def test_ftrl_construct_unknown_arg():
@@ -181,6 +190,16 @@ def test_ftrl_construct_wrong_nbins_value():
             == str(e.value))
 
 
+@pytest.mark.parametrize('value, message',
+                         [[0, "Argument `float_nbits` in Ftrl() constructor should be positive: 0"],
+                         [65, "Argument `float_nbits` in Ftrl() constructor should be less than 65, got: 65"]])
+def test_ftrl_construct_wrong_float_nbits_value(value, message):
+    ft = Ftrl()
+    with pytest.raises(ValueError) as e:
+        noop(Ftrl(float_nbits = value))
+    assert (message == str(e.value))
+
+
 def test_ftrl_construct_wrong_nepochs_value():
     with pytest.raises(ValueError) as e:
         noop(Ftrl(nepochs = -1))
@@ -204,12 +223,13 @@ def test_ftrl_create_params():
 
 def test_ftrl_create_individual():
     ft = Ftrl(alpha = tparams.alpha, beta = tparams.beta,
-                   lambda1 = tparams.lambda1, lambda2 = tparams.lambda2,
-                   nbins = tparams.nbins, nepochs = tparams.nepochs,
-                   double_precision = tparams.double_precision)
+              lambda1 = tparams.lambda1, lambda2 = tparams.lambda2,
+              nbins = tparams.nbins, float_nbits = tparams.float_nbits,
+              nepochs = tparams.nepochs,
+              double_precision = tparams.double_precision)
     assert ft.params == (tparams.alpha, tparams.beta,
                          tparams.lambda1, tparams.lambda2,
-                         tparams.nbins, tparams.nepochs,
+                         tparams.nbins, tparams.float_nbits, tparams.nepochs,
                          tparams.double_precision, tparams.negative_class)
 
 
@@ -220,8 +240,8 @@ def test_ftrl_create_individual():
 def test_ftrl_get_parameters():
     ft = Ftrl(tparams)
     assert ft.params == tparams
-    assert (ft.alpha, ft.beta, ft.lambda1, ft.lambda2, ft.nbins, ft.nepochs,
-            ft.double_precision, ft.negative_class) == tparams
+    assert (ft.alpha, ft.beta, ft.lambda1, ft.lambda2, ft.nbins, ft.float_nbits,
+            ft.nepochs, ft.double_precision, ft.negative_class) == tparams
 
 
 def test_ftrl_set_individual():
@@ -231,6 +251,7 @@ def test_ftrl_set_individual():
     ft.lambda1 = tparams.lambda1
     ft.lambda2 = tparams.lambda2
     ft.nbins = tparams.nbins
+    ft.float_nbits = tparams.float_nbits
     ft.nepochs = tparams.nepochs
     assert ft.params == tparams
 
@@ -271,6 +292,13 @@ def test_ftrl_set_wrong_nbins_type():
     ft = Ftrl()
     with pytest.raises(TypeError) as e:
         ft.nbins = "0"
+    assert ("Expected an integer, instead got <class 'str'>" == str(e.value))
+
+
+def test_ftrl_set_wrong_float_nbits_type():
+    ft = Ftrl()
+    with pytest.raises(TypeError) as e:
+        ft.float_nbits = "0"
     assert ("Expected an integer, instead got <class 'str'>" == str(e.value))
 
 
@@ -356,6 +384,16 @@ def test_ftrl_set_wrong_nbins_value():
     with pytest.raises(ValueError) as e:
         ft.nbins = 0
     assert ("Value should be positive: 0" == str(e.value))
+
+
+@pytest.mark.parametrize('value, message',
+                         [[0, "Value should be positive: 0"],
+                         [65, "Value should be less than 65, got: 65"]])
+def test_ftrl_set_wrong_float_nbits_value(value, message):
+    ft = Ftrl()
+    with pytest.raises(ValueError) as e:
+        ft.float_nbits = value
+    assert (message == str(e.value))
 
 
 def test_ftrl_set_wrong_nepochs_value():

--- a/tests/models/test_ftrl.py
+++ b/tests/models/test_ftrl.py
@@ -606,7 +606,8 @@ def test_ftrl_fit_predict_view():
 
 @pytest.mark.parametrize('parameter, value',
                          [("nbins", 100),
-                         ("interactions", [["C0", "C0"]])])
+                         ("interactions", [["C0", "C0"]]),
+                         ("float_nbits", 46)])
 def test_ftrl_disable_setters_after_fit(parameter, value):
     ft = Ftrl(nbins = 10)
     df_train = dt.Frame(range(ft.nbins))

--- a/tests/models/test_ftrl.py
+++ b/tests/models/test_ftrl.py
@@ -194,7 +194,6 @@ def test_ftrl_construct_wrong_nbins_value():
                          [[0, "Argument `float_nbits` in Ftrl() constructor should be positive: 0"],
                          [65, "Argument `float_nbits` in Ftrl() constructor should be less than 65, got: 65"]])
 def test_ftrl_construct_wrong_float_nbits_value(value, message):
-    ft = Ftrl()
     with pytest.raises(ValueError) as e:
         noop(Ftrl(float_nbits = value))
     assert (message == str(e.value))

--- a/tests/models/test_ftrl.py
+++ b/tests/models/test_ftrl.py
@@ -192,7 +192,7 @@ def test_ftrl_construct_wrong_nbins_value():
 
 @pytest.mark.parametrize('value, message',
                          [[-1, "Argument `mantissa_nbits` in Ftrl() constructor cannot be negative: -1"],
-                         [53, "Argument `mantissa_nbits` in Ftrl() constructor should be less than 53, got: 53"]])
+                         [53, "Argument `mantissa_nbits` in Ftrl() constructor should be less than or equal to 52, got: 53"]])
 def test_ftrl_construct_wrong_mantissa_nbits_value(value, message):
     with pytest.raises(ValueError) as e:
         noop(Ftrl(mantissa_nbits = value))
@@ -387,7 +387,7 @@ def test_ftrl_set_wrong_nbins_value():
 
 @pytest.mark.parametrize('value, message',
                          [[-1, "Integer value cannot be negative"],
-                         [53, "Value should be less than 53, got: 53"]])
+                         [53, "Value should be less than or equal to 52, got: 53"]])
 def test_ftrl_set_wrong_mantissa_nbits_value(value, message):
     ft = Ftrl()
     with pytest.raises(ValueError) as e:

--- a/tests/models/test_ftrl.py
+++ b/tests/models/test_ftrl.py
@@ -192,7 +192,7 @@ def test_ftrl_construct_wrong_nbins_value():
 
 @pytest.mark.parametrize('value, message',
                          [[-1, "Argument `mantissa_nbits` in Ftrl() constructor cannot be negative: -1"],
-                         [54, "Argument `mantissa_nbits` in Ftrl() constructor should be less than 54, got: 54"]])
+                         [53, "Argument `mantissa_nbits` in Ftrl() constructor should be less than 53, got: 53"]])
 def test_ftrl_construct_wrong_mantissa_nbits_value(value, message):
     with pytest.raises(ValueError) as e:
         noop(Ftrl(mantissa_nbits = value))
@@ -387,7 +387,7 @@ def test_ftrl_set_wrong_nbins_value():
 
 @pytest.mark.parametrize('value, message',
                          [[-1, "Integer value cannot be negative"],
-                         [54, "Value should be less than 54, got: 54"]])
+                         [53, "Value should be less than 53, got: 53"]])
 def test_ftrl_set_wrong_mantissa_nbits_value(value, message):
     ft = Ftrl()
     with pytest.raises(ValueError) as e:


### PR DESCRIPTION
Add `mantissa_nbits` parameter to FTRL algo that specifies how many mantissa bits should be used for hashing float values.