### PR TITLE
Clean up few more cases of `#pragma omp` uses

### DIFF
--- a/c/frame/join.cc
+++ b/c/frame/join.cc
@@ -19,20 +19,19 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
-#include <limits>
-#include <memory>
-#include <type_traits>
-#include <vector>
-#include "column.h"
-#include "datatable.h"
-#include "datatablemodule.h"
-#include "options.h"
-#include "py_rowindex.h"
+#include <limits>       // std::numeric_limits
+#include <memory>       // std::unique_ptr
+#include <type_traits>  // std::is_integral
+#include <vector>       // std::vector
+#include "parallel/api.h"
 #include "python/args.h"
 #include "python/obj.h"
 #include "python/tuple.h"
-#include "types.h"
 #include "utils/assert.h"
+#include "column.h"
+#include "datatable.h"
+#include "datatablemodule.h"
+#include "types.h"
 
 class Cmp;
 using indvec = std::vector<size_t>;
@@ -411,31 +410,25 @@ RowIndex natural_join(const DataTable* xdt, const DataTable* jdt) {
   if (xdt->nrows) {
     int32_t* result_indices = arr_result_indices.data();
     size_t nchunks = std::min(std::max(xdt->nrows / 200, size_t(1)),
-                              static_cast<size_t>(config::nthreads));
+                              dt::get_num_threads());
     xassert(nchunks);
 
-    OmpExceptionManager oem;
-    #pragma omp parallel num_threads(nchunks)
-    {
-      try {
+    dt::parallel_region(nchunks,
+      [&] {
         // Creating the comparator may fail if xcols and jcols are incompatible
         MultiCmp comparator(xcols, jcols, xdt, jdt);
 
-        #pragma omp for
-        for (size_t i = 0; i < xdt->nrows; ++i) {
-          int r = comparator.set_xrow(i);
-          if (r == 0) {
-            size_t j = binsearch(&comparator, jdt->nrows);
-            result_indices[i] = static_cast<int32_t>(j);
-          } else {
-            result_indices[i] = -1;
-          }
-        }
-      } catch (...) {
-        oem.capture_exception();
-      }
-    }
-    oem.rethrow_exception_if_any();
+        dt::parallel_for_static(xdt->nrows,
+          [&](size_t i) {
+            int r = comparator.set_xrow(i);
+            if (r == 0) {
+              size_t j = binsearch(&comparator, jdt->nrows);
+              result_indices[i] = static_cast<int32_t>(j);
+            } else {
+              result_indices[i] = -1;
+            }
+          });
+      });
   }
 
   return RowIndex(std::move(arr_result_indices));

--- a/c/parallel/parallel_for_test.cc
+++ b/c/parallel/parallel_for_test.cc
@@ -23,7 +23,6 @@ namespace dttest {
 
 void test_parallel_for_dynamic() {
   constexpr size_t n = 10000;
-  size_t nth = dt::get_num_threads();
   std::vector<size_t> data(n, 0);
 
   dt::parallel_for_dynamic(n,


### PR DESCRIPTION
Replaced `#pragma omp` with `dt::parallel...` constructs in the following files:
- join.cc
- string_expr.cc
- reduce.cc

WIP for #1736