### PR TITLE
Add Frame.__str__() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - New function `dt.median()` can be used to compute median of a certain
   column or expression, either per group or for the entire Frame (#1530).
 
+- `Frame.__str__()` now returns a string containing the preview of the
+  frame's data. This allows datatable frames to be used with `print()`.
+
 
 ### Fixed
 

--- a/c/frame/__repr__.cc
+++ b/c/frame/__repr__.cc
@@ -435,6 +435,7 @@ void Frame::view(const PKArgs& args) {
 
 
 void Frame::Type::_init_repr(Methods& mm) {
+  mm.add("__repr__", cxx2py<Frame, &Frame::m__repr__>);
   ADD_METHOD(mm, &Frame::_repr_html_, args__repr_html_);
   ADD_METHOD(mm, &Frame::_repr_pretty_, args__repr_pretty_);
   ADD_METHOD(mm, &Frame::view, args_view);

--- a/c/frame/__repr__.cc
+++ b/c/frame/__repr__.cc
@@ -399,6 +399,13 @@ oobj Frame::m__repr__() {
   return ostring(out.str());
 }
 
+oobj Frame::m__str__() {
+  oobj DFWidget = oobj::import("datatable")
+                  .get_attr("widget")
+                  .get_attr("DataFrameWidget");
+  return DFWidget.call({oobj(this)}).invoke("as_string");
+}
+
 
 static PKArgs args__repr_html_(
   0, 0, 0, false, false, {}, "_repr_html_", nullptr);
@@ -436,6 +443,7 @@ void Frame::view(const PKArgs& args) {
 
 void Frame::Type::_init_repr(Methods& mm) {
   mm.add("__repr__", cxx2py<Frame, &Frame::m__repr__>);
+  mm.add("__str__", cxx2py<Frame, &Frame::m__str__>);
   ADD_METHOD(mm, &Frame::_repr_html_, args__repr_html_);
   ADD_METHOD(mm, &Frame::_repr_pretty_, args__repr_pretty_);
   ADD_METHOD(mm, &Frame::view, args_view);

--- a/c/frame/py_frame.h
+++ b/c/frame/py_frame.h
@@ -80,6 +80,7 @@ class Frame : public PyObject {
 
     // Frame display
     oobj m__repr__();
+    oobj m__str__();
     oobj _repr_html_(const PKArgs&);
     oobj _repr_pretty_(const PKArgs&);
     void view(const PKArgs&);

--- a/c/py_rowindex.cc
+++ b/c/py_rowindex.cc
@@ -153,11 +153,13 @@ bool orowindex::pyobject::Type::is_subclassable() {
 void orowindex::pyobject::Type::init_methods_and_getsets(
     Methods& mm, GetSetters& gs)
 {
-  ADD_GETTER(gs, &orowindex::pyobject::get_type, args_type);
-  ADD_GETTER(gs, &orowindex::pyobject::get_nrows, args_nrows);
-  ADD_GETTER(gs, &orowindex::pyobject::get_min, args_min);
-  ADD_GETTER(gs, &orowindex::pyobject::get_max, args_max);
-  ADD_METHOD(mm, &orowindex::pyobject::to_list, args_to_list);
+  using ori = orowindex::pyobject;
+  ADD_GETTER(gs, &ori::get_type, args_type);
+  ADD_GETTER(gs, &ori::get_nrows, args_nrows);
+  ADD_GETTER(gs, &ori::get_min, args_min);
+  ADD_GETTER(gs, &ori::get_max, args_max);
+  ADD_METHOD(mm, &ori::to_list, args_to_list);
+  mm.add("__repr__", cxx2py<ori, &ori::m__repr__>);
 }
 
 

--- a/datatable/utils/terminal.py
+++ b/datatable/utils/terminal.py
@@ -108,6 +108,9 @@ class Terminal:
                 self._encoding = "UTF8"
                 self.jupyter = ipy
 
+    def using_colors(self):
+        return self._enable_colors
+
     def use_colors(self, f):
         self._enable_colors = f
 

--- a/datatable/widget.py
+++ b/datatable/widget.py
@@ -99,7 +99,7 @@ class DataFrameWidget(object):
     VIEW_NROWS_MAX = 30
     RIGHT_MARGIN = 2
 
-    def __init__(self, obj, interactive):
+    def __init__(self, obj, interactive=None):
         if interactive is None:
             interactive = options.display.interactive
         if term.jupyter:
@@ -140,11 +140,21 @@ class DataFrameWidget(object):
             print()
 
 
+    def as_string(self):
+        self._interactive = False
+        self._show_navbar = False
+        colors = term.using_colors()
+        term.use_colors(False)
+        out = self._draw(to_string=True)
+        term.use_colors(colors)
+        return out
+
+
     #---------------------------------------------------------------------------
     # Private
     #---------------------------------------------------------------------------
 
-    def _draw(self):
+    def _draw(self, to_string=False):
         self._fetch_data()
         columns = []
 
@@ -195,16 +205,14 @@ class DataFrameWidget(object):
         if extra_space > 0:
             if self._view_col0 + self._view_ncols < self._conn.frame_ncols:
                 self._view_ncols += max(1, extra_space // 8)
-                self._draw()
-                return
+                return self._draw(to_string)
             elif self._view_col0 > 0:
                 w = self._fetch_column_width(self._view_col0 - 1)
                 if w + 2 <= extra_space:
                     self._view_col0 -= 1
                     self._view_ncols += 1
                     self._max_col0 = self._view_col0
-                    self._draw()
-                    return
+                    return self._draw(to_string)
         else:
             if self._max_col0 == self._view_col0:
                 self._max_col0 += 1
@@ -250,6 +258,8 @@ class DataFrameWidget(object):
 
         # Render the table
         lines = header + rows + footer
+        if to_string:
+            return "\n".join(lines)
         term.rewrite_lines(lines, self._n_displayed_lines)
         self._n_displayed_lines = len(lines) - 1
 

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -265,6 +265,18 @@ def test_dt_view_keyed(patched_terminal, capsys):
             in out)
 
 
+def test_stringify(dt0):
+    assert ("     A   B   C     D   E   F  G    \n"
+            "--  --  --  --  ----  --  --  -----\n"
+            " 0   2   1   1   0.1       0  1    \n"
+            " 1   7   0   1   2         0  2    \n"
+            " 2   0   0   1  -4         0  hello\n"
+            " 3   0   1   1   4.4       0  world\n"
+            "\n"
+            "[4 rows x 7 columns]\n"
+            == str(dt0))
+
+
 def test_dt_getitem(dt0):
     dt1 = dt0[:, 0]
     assert dt1.shape == (4, 1)


### PR DESCRIPTION
Before this PR, `str(DT)` returned the same expression as repr: 
```
'<Frame [4 rows x 7 columns]>'
```
After this PR, `str(DT)` returns a string containing the preview of values in the frame. This looks like this:
```
'     A   B   C     D   E   F  G    \n--  --  --  --  ----  --  --  -----\n'
' 0   2   1   1   0.1       0  1    \n 1   7   0   1   2         0  2    \n'
' 2   0   0   1  -4         0  hello\n 3   0   1   1   4.4       0  world\n\n'
'[4 rows x 7 columns]\n'
```
which when printed becomes
```
     A   B   C     D   E   F  G    
--  --  --  --  ----  --  --  -----
 0   2   1   1   0.1       0  1    
 1   7   0   1   2         0  2    
 2   0   0   1  -4         0  hello
 3   0   1   1   4.4       0  world

[4 rows x 7 columns]
```

Closes #1740