### PR TITLE
Options functionality revamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `Frame.__str__()` now returns a string containing the preview of the
   frame's data. This allows datatable frames to be used with `print()`.
 
+- Added method `dt.options.describe()`, which will print the available
+  options together with their values and descriptions.
+
+- Added `dt.options.context(option=value)`, which can be used in a with-
+  statement to temporarily change the value of one or more options, and
+  then go back to their original values at the end of the with-block.
+
+- Added options `fread.log.escape_unicode` (controls treatment of unicode
+  characters in fread's verbose log); and `display.use_colors` (allows
+  to turn on/off colored output in the console).
+
+- `dt.options` now helps the user when he/she makes a typo: if an option
+  with a certain name does not exist, the error message will suggest the
+  correct spelling.
+
 
 ### Fixed
 

--- a/c/csv/reader.cc
+++ b/c/csv/reader.cc
@@ -30,13 +30,13 @@ static bool log_anonymize = false;
 static bool log_escape_unicode = false;
 
 void GenericReader::init_options() {
-  config::register_option(
+  dt::register_option(
     "fread.anonymize",
     []{ return py::obool(log_anonymize); },
     [](py::oobj value){ log_anonymize = value.to_bool_strict(); },
     "[DEPRECATED] same as fread.log.anonymize");
 
-  config::register_option(
+  dt::register_option(
     "fread.log.anonymize",
     []{ return py::obool(log_anonymize); },
     [](py::oobj value){ log_anonymize = value.to_bool_strict(); },
@@ -48,7 +48,7 @@ void GenericReader::init_options() {
     "data that must not accidentally leak into log files or be printed\n"
     "with the error messages.");
 
-  config::register_option(
+  dt::register_option(
     "fread.log.escape_unicode",
     []{ return py::obool(log_escape_unicode); },
     [](py::oobj value){ log_escape_unicode = value.to_bool_strict(); },

--- a/c/csv/reader.h
+++ b/c/csv/reader.h
@@ -68,9 +68,6 @@ class GenericReader
     bool    blank_is_na;
     bool    number_is_na;
     bool    override_column_types;
-    bool    printout_anonymize;
-    bool    printout_escape_unicode;
-    size_t : 48;
     const char* skip_to_string;
     const char* const* na_strings;
 
@@ -146,6 +143,9 @@ class GenericReader
 
     const char* repr_source(const char* ch, size_t limit) const;
     const char* repr_binary(const char* ch, const char* end, size_t limit) const;
+
+    // Called once during module initialization
+    static void init_options();
 
   // Helper functions
   private:

--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -19,17 +19,17 @@
 #include "expr/join_node.h"
 #include "expr/py_expr.h"
 #include "expr/sort_node.h"
+#include "frame/py_frame.h"
 #include "models/aggregator.h"
 #include "models/py_ftrl.h"
-#include "frame/py_frame.h"
+#include "parallel/api.h"
 #include "python/_all.h"
 #include "python/string.h"
-#include "parallel/api.h"
+#include "utils/assert.h"
 #include "datatablemodule.h"
 #include "options.h"
 #include "py_encodings.h"
 #include "py_rowindex.h"
-#include "utils/assert.h"
 #include "ztest.h"
 
 
@@ -331,6 +331,7 @@ PyMODINIT_FUNC PyInit__datatable() noexcept
     py::Frame::Type::init(m);
     py::Ftrl::Type::init(m);
     py::base_expr::Type::init(m);
+    py::config_option::Type::init(m);
     py::orowindex::pyobject::Type::init(m);
     py::oby::init(m);
     py::ojoin::init(m);

--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -217,6 +217,7 @@ static void initialize_options(const py::PKArgs& args) {
 
   config::use_options_store(options);
   dt::thread_pool::init_options();
+  py::Frame::init_names_options();
 }
 
 

--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -300,6 +300,7 @@ void py::DatatableModule::init_methods() {
   init_methods_str();
 
   init_casts();
+  init_fuzzy();
 
   #ifdef DTTEST
     init_tests();

--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -14,6 +14,7 @@
 #include <utility>         // std::pair, std::make_pair, std::move
 #include <Python.h>
 #include "../datatable/include/datatable.h"
+#include "csv/reader.h"
 #include "expr/base_expr.h"
 #include "expr/by_node.h"
 #include "expr/join_node.h"
@@ -218,6 +219,7 @@ static void initialize_options(const py::PKArgs& args) {
   config::use_options_store(options);
   dt::thread_pool::init_options();
   py::Frame::init_names_options();
+  GenericReader::init_options();
 }
 
 

--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -30,6 +30,7 @@
 #include "utils/assert.h"
 #include "datatablemodule.h"
 #include "options.h"
+#include "sort.h"
 #include "py_encodings.h"
 #include "py_rowindex.h"
 #include "ztest.h"
@@ -216,10 +217,11 @@ static void initialize_options(const py::PKArgs& args) {
   py::oobj options = args[0].to_oobj();
   if (!options) return;
 
-  config::use_options_store(options);
+  dt::use_options_store(options);
   dt::thread_pool::init_options();
   py::Frame::init_names_options();
   GenericReader::init_options();
+  sort_init_options();
 }
 
 
@@ -315,7 +317,6 @@ void py::DatatableModule::init_methods() {
   init_methods_join();
   init_methods_kfold();
   init_methods_nff();
-  init_methods_options();
   init_methods_rbind();
   init_methods_repeat();
   init_methods_sets();

--- a/c/datatablemodule.h
+++ b/c/datatablemodule.h
@@ -39,7 +39,6 @@ class DatatableModule : public ExtModule<DatatableModule> {
     void init_methods_join();      // frame/join.cc
     void init_methods_kfold();     // models/kfold.cc
     void init_methods_nff();       // datatable_load.cc
-    void init_methods_options();   // options.cc
     void init_methods_rbind();     // frame/rbind.cc
     void init_methods_repeat();    // frame/repeat.cc
     void init_methods_sets();      // set_funcs.cc

--- a/c/datatablemodule.h
+++ b/c/datatablemodule.h
@@ -45,6 +45,7 @@ class DatatableModule : public ExtModule<DatatableModule> {
     void init_methods_sets();      // set_funcs.cc
     void init_methods_str();       // str/py_str.cc
     void init_casts();             // frame/cast.cc
+    void init_fuzzy();             // utils/fuzzy.cc
 
     #ifdef DTTEST
       void init_tests();

--- a/c/frame/names.cc
+++ b/c/frame/names.cc
@@ -234,7 +234,7 @@ static int64_t     names_auto_index = 0;
 static std::string names_auto_prefix = "C";
 
 void py::Frame::init_names_options() {
-  config::register_option(
+  dt::register_option(
     "frame.names_auto_index",
     []{ return py::oint(names_auto_index); },
     [](py::oobj value){ names_auto_index = value.to_int64_strict(); },
@@ -244,7 +244,7 @@ void py::Frame::init_names_options() {
     "options.frame.names_auto_index=1 will cause the columns to be\n"
     "named C1, C2, C3, ...");
 
-  config::register_option(
+  dt::register_option(
     "frame.names_auto_prefix",
     []{ return py::ostring(names_auto_prefix); },
     [](py::oobj value){ names_auto_prefix = value.to_string(); },

--- a/c/frame/py_frame.h
+++ b/c/frame/py_frame.h
@@ -124,6 +124,9 @@ class Frame : public PyObject {
     // Exposed to users as `dt.frame_integrity_check(frame)` function
     void integrity_check();
 
+    // Called once during module start-up
+    static void init_names_options();
+
   private:
     static bool internal_construction;
     class NameProvider;

--- a/c/options.cc
+++ b/c/options.cc
@@ -26,10 +26,6 @@ uint8_t sort_max_radix_bits = 16;
 uint8_t sort_over_radix_bits = 16;
 int32_t sort_nthreads = 1;
 bool fread_anonymize = false;
-int64_t frame_names_auto_index = 0;
-std::string frame_names_auto_prefix = "C";
-bool display_interactive = false;
-bool display_interactive_hint = true;
 
 
 static int32_t normalize_nthreads(int32_t nth) {
@@ -117,18 +113,6 @@ static py::oobj set_option(const py::PKArgs& args) {
   } else if (name == "fread.anonymize") {
     set_fread_anonymize(value.to_bool_strict());
 
-  } else if (name == "frame.names_auto_index") {
-    frame_names_auto_index = value.to_int64_strict();
-
-  } else if (name == "frame.names_auto_prefix") {
-    frame_names_auto_prefix = value.to_string();
-
-  } else if (name == "display.interactive") {
-    display_interactive = value.to_bool_strict();
-
-  } else if (name == "display.interactive_hint") {
-    display_interactive_hint = value.to_bool_strict();
-
   } else {
     // throw ValueError() << "Unknown option `" << name << "`";
   }
@@ -168,18 +152,6 @@ static py::oobj get_option(const py::PKArgs& args) {
 
   } else if (name == "fread.anonymize") {
     return py::obool(fread_anonymize);
-
-  } else if (name == "frame.names_auto_index") {
-    return py::oint(frame_names_auto_index);
-
-  } else if (name == "frame.names_auto_prefix") {
-    return py::ostring(frame_names_auto_prefix);
-
-  } else if (name == "display.interactive") {
-    return py::obool(display_interactive);
-
-  } else if (name == "display.interactive_hint") {
-    return py::obool(display_interactive_hint);
 
   } else {
     throw ValueError() << "Unknown option `" << name << "`";

--- a/c/options.cc
+++ b/c/options.cc
@@ -13,141 +13,7 @@
 #include "python/string.h"
 #include "datatablemodule.h"
 #include "options.h"
-
-
-namespace config
-{
-
-PyObject* logger = nullptr;
-size_t sort_insert_method_threshold = 64;
-size_t sort_thread_multiplier = 2;
-size_t sort_max_chunk_length = 1 << 20;
-uint8_t sort_max_radix_bits = 16;
-uint8_t sort_over_radix_bits = 16;
-int32_t sort_nthreads = 1;
-
-
-static int32_t normalize_nthreads(int32_t nth) {
-  if (nth <= 0) nth += static_cast<int32_t>(dt::get_hardware_concurrency());
-  if (nth <= 0) nth = 1;
-  return nth;
-}
-
-void set_core_logger(PyObject* o) {
-  if (o == Py_None) {
-    logger = nullptr;
-    Py_DECREF(o);
-  } else {
-    logger = o;
-  }
-}
-
-void set_sort_insert_method_threshold(int64_t n) {
-  if (n < 0) n = 0;
-  sort_insert_method_threshold = static_cast<size_t>(n);
-}
-
-void set_sort_thread_multiplier(int64_t n) {
-  if (n < 1) n = 1;
-  sort_thread_multiplier = static_cast<size_t>(n);
-}
-
-void set_sort_max_chunk_length(int64_t n) {
-  if (n < 1) n = 1;
-  sort_max_chunk_length = static_cast<size_t>(n);
-}
-
-void set_sort_max_radix_bits(int64_t n) {
-  sort_max_radix_bits = static_cast<uint8_t>(n);
-  if (sort_max_radix_bits <= 0)
-    throw ValueError() << "Invalid sort.max_radix_bits parameter: " << n;
-}
-
-void set_sort_over_radix_bits(int64_t n) {
-  sort_over_radix_bits = static_cast<uint8_t>(n);
-  if (sort_over_radix_bits <= 0)
-    throw ValueError() << "Invalid sort.over_radix_bits parameter: " << n;
-}
-
-void set_sort_nthreads(int32_t n) {
-  sort_nthreads = normalize_nthreads(n);
-}
-
-
-
-
-static py::PKArgs args_set_option(
-    2, 0, 0, false, false,
-    {"name", "value"}, "set_option", nullptr);
-
-
-static py::oobj set_option(const py::PKArgs& args) {
-  std::string name = args[0].to_string();
-  py::robj value = args[1];
-
-  if (name == "sort.insert_method_threshold") {
-    set_sort_insert_method_threshold(value.to_int64_strict());
-
-  } else if (name == "sort.thread_multiplier") {
-    set_sort_thread_multiplier(value.to_int64_strict());
-
-  } else if (name == "sort.max_chunk_length") {
-    set_sort_max_chunk_length(value.to_int64_strict());
-
-  } else if (name == "sort.max_radix_bits") {
-    set_sort_max_radix_bits(value.to_int64_strict());
-
-  } else if (name == "sort.over_radix_bits") {
-    set_sort_over_radix_bits(value.to_int64_strict());
-
-  } else if (name == "sort.nthreads") {
-    set_sort_nthreads(value.to_int32_strict());
-
-  } else if (name == "core_logger") {
-    set_core_logger(py::oobj(value).release());
-
-  } else {
-    // throw ValueError() << "Unknown option `" << name << "`";
-  }
-  return py::None();
-}
-
-
-
-static py::PKArgs args_get_option(
-    1, 0, 0, false, false,
-    {"name"}, "get_option", nullptr);
-
-
-static py::oobj get_option(const py::PKArgs& args) {
-  std::string name = args[0].to_string();
-
-  if (name == "sort.insert_method_threshold") {
-    return py::oint(sort_insert_method_threshold);
-
-  } else if (name == "sort.thread_multiplier") {
-    return py::oint(sort_thread_multiplier);
-
-  } else if (name == "sort.max_chunk_length") {
-    return py::oint(sort_max_chunk_length);
-
-  } else if (name == "sort.max_radix_bits") {
-    return py::oint(sort_max_radix_bits);
-
-  } else if (name == "sort.over_radix_bits") {
-    return py::oint(sort_over_radix_bits);
-
-  } else if (name == "sort.nthreads") {
-    return py::oint(sort_nthreads);
-
-  } else if (name == "core_logger") {
-    return logger? py::oobj(logger) : py::None();
-
-  } else {
-    throw ValueError() << "Unknown option `" << name << "`";
-  }
-}
-
+namespace dt {
 
 
 static py::oobj dt_options = nullptr;
@@ -155,6 +21,7 @@ static py::oobj dt_options = nullptr;
 void use_options_store(py::oobj options) {
   dt_options = options;
 }
+
 
 void register_option(const char* name,
                      std::function<py::oobj()> getter,
@@ -176,17 +43,9 @@ void register_option(const char* name,
 }
 
 
-}; // namespace config
+
+}  // namespace dt
 namespace py {
-
-
-
-void DatatableModule::init_methods_options() {
-  ADD_FN(&config::get_option, config::args_get_option);
-  ADD_FN(&config::set_option, config::args_set_option);
-}
-
-
 //------------------------------------------------------------------------------
 // config_option
 //------------------------------------------------------------------------------

--- a/c/options.cc
+++ b/c/options.cc
@@ -25,7 +25,6 @@ size_t sort_max_chunk_length = 1 << 20;
 uint8_t sort_max_radix_bits = 16;
 uint8_t sort_over_radix_bits = 16;
 int32_t sort_nthreads = 1;
-bool fread_anonymize = false;
 
 
 static int32_t normalize_nthreads(int32_t nth) {
@@ -74,9 +73,6 @@ void set_sort_nthreads(int32_t n) {
   sort_nthreads = normalize_nthreads(n);
 }
 
-void set_fread_anonymize(int8_t v) {
-  fread_anonymize = v;
-}
 
 
 
@@ -109,9 +105,6 @@ static py::oobj set_option(const py::PKArgs& args) {
 
   } else if (name == "core_logger") {
     set_core_logger(py::oobj(value).release());
-
-  } else if (name == "fread.anonymize") {
-    set_fread_anonymize(value.to_bool_strict());
 
   } else {
     // throw ValueError() << "Unknown option `" << name << "`";
@@ -149,9 +142,6 @@ static py::oobj get_option(const py::PKArgs& args) {
 
   } else if (name == "core_logger") {
     return logger? py::oobj(logger) : py::None();
-
-  } else if (name == "fread.anonymize") {
-    return py::obool(fread_anonymize);
 
   } else {
     throw ValueError() << "Unknown option `" << name << "`";

--- a/c/options.h
+++ b/c/options.h
@@ -21,7 +21,6 @@ extern size_t sort_max_chunk_length;
 extern uint8_t sort_max_radix_bits;
 extern uint8_t sort_over_radix_bits;
 extern int32_t sort_nthreads;
-extern bool fread_anonymize;
 
 void set_core_logger(PyObject*);
 void set_sort_insert_method_threshold(int64_t n);
@@ -30,7 +29,6 @@ void set_sort_max_chunk_length(int64_t n);
 void set_sort_max_radix_bits(int64_t n);
 void set_sort_over_radix_bits(int64_t n);
 void set_sort_nthreads(int32_t n);
-void set_fread_anonymize(int8_t v);
 
 
 void register_option(const char* name,
@@ -46,6 +44,7 @@ void use_options_store(py::oobj options);
 // config_option
 //------------------------------------------------------------------------------
 namespace py {
+
 
 struct config_option : public PyObject {
   std::function<oobj()> getter;

--- a/c/options.h
+++ b/c/options.h
@@ -8,27 +8,9 @@
 #ifndef dt_OPTIONS_h
 #define dt_OPTIONS_h
 #include <functional>  // std::function
-#include <string>      // std::string
 #include "python/ext_type.h"
-namespace config {
-
-
-
-extern PyObject* logger;
-extern size_t sort_insert_method_threshold;
-extern size_t sort_thread_multiplier;
-extern size_t sort_max_chunk_length;
-extern uint8_t sort_max_radix_bits;
-extern uint8_t sort_over_radix_bits;
-extern int32_t sort_nthreads;
-
-void set_core_logger(PyObject*);
-void set_sort_insert_method_threshold(int64_t n);
-void set_sort_thread_multiplier(int64_t n);
-void set_sort_max_chunk_length(int64_t n);
-void set_sort_max_radix_bits(int64_t n);
-void set_sort_over_radix_bits(int64_t n);
-void set_sort_nthreads(int32_t n);
+#include "python/obj.h"
+namespace dt {
 
 
 void register_option(const char* name,

--- a/c/options.h
+++ b/c/options.h
@@ -39,10 +39,11 @@ void set_fread_anonymize(int8_t v);
 
 
 void register_option(const char* name,
-                     py::oobj default_value,
                      std::function<py::oobj()> getter,
                      std::function<void(py::oobj)> setter,
                      const char* docstring);
+
+void use_options_store(py::oobj options);
 
 
 }

--- a/c/options.h
+++ b/c/options.h
@@ -22,12 +22,7 @@ extern uint8_t sort_max_radix_bits;
 extern uint8_t sort_over_radix_bits;
 extern int32_t sort_nthreads;
 extern bool fread_anonymize;
-extern int64_t frame_names_auto_index;
-extern std::string frame_names_auto_prefix;
-extern bool display_interactive;
-extern bool display_interactive_hint;
 
-void set_nthreads(int32_t n);
 void set_core_logger(PyObject*);
 void set_sort_insert_method_threshold(int64_t n);
 void set_sort_thread_multiplier(int64_t n);

--- a/c/options.h
+++ b/c/options.h
@@ -7,10 +7,12 @@
 //------------------------------------------------------------------------------
 #ifndef dt_OPTIONS_h
 #define dt_OPTIONS_h
-#include <string>
-#include <Python.h>
-
+#include <functional>  // std::function
+#include <string>      // std::string
+#include "python/ext_type.h"
 namespace config {
+
+
 
 extern PyObject* logger;
 extern size_t sort_insert_method_threshold;
@@ -36,6 +38,46 @@ void set_sort_nthreads(int32_t n);
 void set_fread_anonymize(int8_t v);
 
 
-}
+void register_option(const char* name,
+                     py::oobj default_value,
+                     std::function<py::oobj()> getter,
+                     std::function<void(py::oobj)> setter,
+                     const char* docstring);
 
+
+}
+//------------------------------------------------------------------------------
+// config_option
+//------------------------------------------------------------------------------
+namespace py {
+
+struct config_option : public PyObject {
+  std::function<oobj()> getter;
+  std::function<void(oobj)> setter;
+  oobj name;
+  oobj default_value;
+  oobj docstring;
+  size_t : 64;
+
+  class Type : public ExtType<config_option> {
+    public:
+      static PKArgs args___init__;
+      static const char* classname();
+      static const char* classdoc();
+      static bool is_subclassable();
+      static void init_methods_and_getsets(Methods&, GetSetters&);
+  };
+
+  void m__init__(PKArgs&);
+  void m__dealloc__();
+  oobj get(const PKArgs&);
+  void set(const PKArgs&);
+
+  oobj get_name() const;
+  oobj get_doc() const;
+  oobj get_default() const;
+};
+
+
+}  // namespace py
 #endif

--- a/c/parallel/thread_pool.cc
+++ b/c/parallel/thread_pool.cc
@@ -19,7 +19,9 @@
 #include "parallel/thread_pool.h"
 #include "parallel/thread_team.h"
 #include "parallel/thread_worker.h"
+#include "python/_all.h"
 #include "utils/assert.h"
+#include "options.h"
 namespace dt {
 
 
@@ -172,6 +174,44 @@ size_t get_hardware_concurrency() noexcept {
   return static_cast<size_t>(nth);
 }
 
+
+void thread_pool::init_options() {
+  // By default, set the number of threads to `hardware_concurrency`
+  thread_pool::get_instance()->resize(get_hardware_concurrency());
+
+  config::register_option(
+    "nthreads",
+
+    /* getter= */[]() -> py::oobj {
+      return py::oint(num_threads_in_pool());
+    },
+
+    /* setter= */[](py::oobj value) {
+      int32_t nth = value.to_int32_strict();
+      if (nth <= 0) nth += static_cast<int32_t>(get_hardware_concurrency());
+      if (nth <= 0) nth = 1;
+      auto thpool = dt::thread_pool::get_instance();
+      thpool->resize(static_cast<size_t>(nth));
+      config::sort_nthreads = nth;
+    },
+
+    "The number of threads used by datatable internally.\n"
+    "\n"
+    "Many calculations in `datatable` module are parallelized. This \n"
+    "setting controls how many threads will be used during such\n"
+    "calculations.\n"
+    "\n"
+    "Initially, this option is set to the value returned by C++ call\n"
+    "`std::thread::hardware_concurrency()`. This is usually equal to the\n"
+    "number of available cores.\n"
+    "\n"
+    "You can set `nthreads` to a value greater or smaller than the\n"
+    "initial setting. For example, setting `nthreads = 1` will force the\n"
+    "library into a single-threaded mode. Setting `nthreads` to 0 will\n"
+    "restore the initial value equal to the number of processor cores.\n"
+    "Setting `nthreads` to a value less than 0 is equivalent to\n"
+    "requesting that fewer threads than the maximum.\n");
+}
 
 
 }  // namespace dt

--- a/c/parallel/thread_pool.cc
+++ b/c/parallel/thread_pool.cc
@@ -179,7 +179,7 @@ void thread_pool::init_options() {
   // By default, set the number of threads to `hardware_concurrency`
   thread_pool::get_instance()->resize(get_hardware_concurrency());
 
-  config::register_option(
+  dt::register_option(
     "nthreads",
 
     /* getter= */[]() -> py::oobj {
@@ -192,7 +192,6 @@ void thread_pool::init_options() {
       if (nth <= 0) nth = 1;
       auto thpool = dt::thread_pool::get_instance();
       thpool->resize(static_cast<size_t>(nth));
-      config::sort_nthreads = nth;
     },
 
     "The number of threads used by datatable internally.\n"

--- a/c/parallel/thread_pool.h
+++ b/c/parallel/thread_pool.h
@@ -88,6 +88,8 @@ class thread_pool {
     bool in_parallel_region() const noexcept;
     size_t n_threads_in_team() const noexcept;
 
+    static void init_options();
+
   private:
     thread_pool();
     thread_pool(const thread_pool&) = delete;

--- a/c/python/arg.cc
+++ b/c/python/arg.cc
@@ -89,6 +89,7 @@ std::string Arg::to_string()       const { return pyobj.to_string(*this); }
 strvec      Arg::to_stringlist()   const { return pyobj.to_stringlist(*this); }
 SType       Arg::to_stype()        const { return pyobj.to_stype(*this); }
 SType       Arg::to_stype(const error_manager& em) const { return pyobj.to_stype(em); }
+py::oiter   Arg::to_oiter()        const { return pyobj.to_oiter(*this); }
 DataTable*  Arg::to_datatable()    const { return pyobj.to_datatable(*this); }
 
 Arg::operator int32_t() const { return to_int32_strict(); }

--- a/c/python/arg.h
+++ b/c/python/arg.h
@@ -10,8 +10,9 @@
 #include <string>     // std::string
 #include <vector>     // std::vector
 #include <Python.h>
-#include "python/obj.h"
+#include "python/iter.h"
 #include "python/list.h"
+#include "python/obj.h"
 #include "python/tuple.h"
 
 namespace py {
@@ -74,6 +75,7 @@ class Arg : public _obj::error_manager {
     SType       to_stype              (const error_manager&) const;
     py::oobj    to_oobj               () const { return oobj(pyobj); }
     py::robj    to_pyobj              () const { return pyobj; }
+    py::oiter   to_oiter              () const;
     DataTable*  to_datatable          () const;
 
 

--- a/c/sort.cc
+++ b/c/sort.cc
@@ -249,6 +249,83 @@ void swap(rmem& left, rmem& right) noexcept {
 
 
 //------------------------------------------------------------------------------
+// Options
+//------------------------------------------------------------------------------
+
+static size_t sort_insert_method_threshold = 64;
+static size_t sort_thread_multiplier = 2;
+static size_t sort_max_chunk_length = 1 << 20;
+static uint8_t sort_max_radix_bits = 12;
+static uint8_t sort_over_radix_bits = 8;
+static int32_t sort_nthreads = 4;
+
+void sort_init_options() {
+  dt::register_option(
+    "sort.insert_method_threshold",
+    []{ return py::oint(sort_insert_method_threshold); },
+    [](py::oobj value) {
+      int64_t n = value.to_int64_strict();
+      if (n < 0) n = 0;
+      sort_insert_method_threshold = static_cast<size_t>(n);
+    },
+    "Largest n at which sorting will be performed using insert sort "
+      "method. This setting also governs the recursive parts of the "
+      "radix sort algorithm, when we need to sort smaller sub-parts of "
+      "the input.");
+
+  dt::register_option(
+    "sort.thread_multiplier",
+    []{ return py::oint(sort_thread_multiplier); },
+    [](py::oobj value) {
+      int64_t n = value.to_int64_strict();
+      if (n < 1) n = 1;
+      sort_thread_multiplier = static_cast<size_t>(n);
+    }, "");
+
+  dt::register_option(
+    "sort.max_chunk_length",
+    []{ return py::oint(sort_max_chunk_length); },
+    [](py::oobj value) {
+      int64_t n = value.to_int64_strict();
+      if (n < 1) n = 1;
+      sort_max_chunk_length = static_cast<size_t>(n);
+    }, "");
+
+  dt::register_option(
+    "sort.max_radix_bits",
+    []{ return py::oint(sort_max_radix_bits); },
+    [](py::oobj value) {
+      int64_t n = value.to_int64_strict();
+      if (n <= 0)
+        throw ValueError() << "Invalid sort.max_radix_bits parameter: " << n;
+      sort_max_radix_bits = static_cast<uint8_t>(n);
+    }, "");
+
+  dt::register_option(
+    "sort.over_radix_bits",
+    []{ return py::oint(sort_over_radix_bits); },
+    [](py::oobj value) {
+      int64_t n = value.to_int64_strict();
+      if (n <= 0)
+        throw ValueError() << "Invalid sort.over_radix_bits parameter: " << n;
+      sort_over_radix_bits = static_cast<uint8_t>(n);
+    }, "");
+
+  dt::register_option(
+    "sort.nthreads",
+    []{ return py::oint(sort_nthreads); },
+    [](py::oobj value) {
+      int32_t nth = value.to_int32_strict();
+      if (nth <= 0) nth += static_cast<int32_t>(dt::get_hardware_concurrency());
+      if (nth <= 0) nth = 1;
+      sort_over_radix_bits = static_cast<uint8_t>(nth);
+    }, "");
+}
+
+
+
+
+//------------------------------------------------------------------------------
 // SortContext
 //------------------------------------------------------------------------------
 
@@ -400,7 +477,7 @@ class SortContext {
     use_order = false;
     descending = false;
 
-    nth = static_cast<size_t>(config::sort_nthreads);
+    nth = static_cast<size_t>(sort_nthreads);
     n = nrows;
     container_o.ensure_size(n * sizeof(int32_t));
     o = static_cast<int32_t*>(container_o.ptr);
@@ -442,7 +519,7 @@ class SortContext {
     } else {
       _prepare_data_for_column<true>(col);
     }
-    if (n <= config::sort_insert_method_threshold) {
+    if (n <= sort_insert_method_threshold) {
       if (use_order) {
         kinsert_sort();
       } else {
@@ -788,13 +865,13 @@ class SortContext {
    *      nth, nchunks, chunklen, shift, nradixes
    */
   void determine_sorting_parameters() {
-    size_t nch = nth * config::sort_thread_multiplier;
+    size_t nch = nth * sort_thread_multiplier;
     chunklen = std::max((n - 1) / nch + 1,
-                        config::sort_max_chunk_length);
+                        sort_max_chunk_length);
     nchunks = (n - 1)/chunklen + 1;
 
-    uint8_t nradixbits = nsigbits < config::sort_max_radix_bits
-                         ? nsigbits : config::sort_over_radix_bits;
+    uint8_t nradixbits = nsigbits < sort_max_radix_bits
+                         ? nsigbits : sort_over_radix_bits;
     shift = nsigbits - nradixbits;
     nradixes = 1 << nradixbits;
 
@@ -1107,7 +1184,7 @@ class SortContext {
     constexpr size_t GROUPED = size_t(1) << 63;
     size_t size0 = 0;
     size_t nsmallgroups = 0;
-    size_t rrlarge = config::sort_insert_method_threshold;  // for now
+    size_t rrlarge = sort_insert_method_threshold;  // for now
     xassert(GROUPED > rrlarge);
 
     strstart = _strstart + 1;

--- a/c/sort.cc
+++ b/c/sort.cc
@@ -268,10 +268,10 @@ void sort_init_options() {
       if (n < 0) n = 0;
       sort_insert_method_threshold = static_cast<size_t>(n);
     },
-    "Largest n at which sorting will be performed using insert sort "
-      "method. This setting also governs the recursive parts of the "
-      "radix sort algorithm, when we need to sort smaller sub-parts of "
-      "the input.");
+    "Largest n at which sorting will be performed using insert sort\n"
+    "method. This setting also governs the recursive parts of the\n"
+    "radix sort algorithm, when we need to sort smaller sub-parts of\n"
+    "the input.");
 
   dt::register_option(
     "sort.thread_multiplier",

--- a/c/sort.h
+++ b/c/sort.h
@@ -15,6 +15,8 @@ struct radix_range {
   size_t offset;
 };
 
+// Called during module initialization
+void sort_init_options();
 
 
 /**

--- a/c/utils/fuzzy_match.cc
+++ b/c/utils/fuzzy_match.cc
@@ -16,8 +16,10 @@
 #include <algorithm>   // std::min, std::swap
 #include <iostream>    // std::ostringstream
 #include <memory>      // std::unique_ptr
+#include "python/string.h"
 #include "utils/assert.h"
 #include "utils/fuzzy_match.h"
+#include "datatablemodule.h"
 namespace dt {
 using std::size_t;
 
@@ -140,3 +142,25 @@ std::string suggest_similar_strings(
 
 
 }  // namespace dt
+namespace py {
+
+
+static PKArgs args_fuzzy_match(
+  2, 0, 0, false, false, {"candidates", "name"}, "fuzzy_match");
+
+static oobj fuzzy_match(const PKArgs& args) {
+  std::vector<std::string> candidates;
+  for (auto item : args[0].to_oiter()) {
+    candidates.push_back(item.to_string());
+  }
+  std::string name = args[1].to_string();
+  return ostring(dt::suggest_similar_strings(candidates, name));
+}
+
+
+void DatatableModule::init_fuzzy() {
+  ADD_FN(&fuzzy_match, args_fuzzy_match);
+}
+
+
+}  // namespace py

--- a/c/utils/fuzzy_match.cc
+++ b/c/utils/fuzzy_match.cc
@@ -1,0 +1,142 @@
+//------------------------------------------------------------------------------
+// Copyright 2018 H2O.ai
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//------------------------------------------------------------------------------
+#include <algorithm>   // std::min, std::swap
+#include <iostream>    // std::ostringstream
+#include <memory>      // std::unique_ptr
+#include "utils/assert.h"
+#include "utils/fuzzy_match.h"
+namespace dt {
+using std::size_t;
+
+
+//------------------------------------------------------------------------------
+// Levenshtein distance calculation
+//------------------------------------------------------------------------------
+
+double levenshtein_distance(const std::string& a, const std::string& b,
+                            double* v)
+{
+  const char* aa = a.data();
+  const char* bb = b.data();
+  int n = static_cast<int>(a.size());
+  int m = static_cast<int>(b.size());
+  if (n > m) {
+    std::swap(aa, bb);
+    std::swap(m, n);
+  }
+  // Remove common prefix from the strings
+  while (n && *aa == *bb) {
+    n--; m--;
+    aa++; bb++;
+  }
+  // Remove common suffix from the strings
+  while (n && aa[n - 1] == bb[m - 1]) {
+    n--; m--;
+  }
+  if (n == 0) return m;
+  xassert(0 < n && n <= m);
+  // Compute the Levenshtein distance
+  aa--;  // Shift pointers, so that we can use 1-based indexing below
+  bb--;
+  for (int j = 1; j <= n; ++j) v[j] = j;
+  for (int i = 1; i <= m; ++i) {
+    double w = i - 1;
+    v[0] = i;
+    for (int j = 1; j <= n; ++j) {
+      char ach = aa[j];
+      char bch = bb[i];
+      double c = 0.0;
+      if (ach != bch) {
+        // Use non-trivial cost function to compare character substitution:
+        //   * the cost is lowest when 2 characters differ by case only,
+        //     or if both are "space-like" (i.e. ' ', '_' or '.')
+        //   * medium cost for substituting letters with letters, or digits
+        //     with digits
+        //   * highest cost for all other substitutions.
+        //
+        bool a_lower = 'a' <= ach && ach <= 'z';
+        bool a_upper = 'A' <= ach && ach <= 'Z';
+        bool a_digit = '0' <= ach && ach <= '9';
+        bool a_space = ach == ' ' || ach == '_' || ach == '.';
+        bool b_lower = 'a' <= bch && bch <= 'z';
+        bool b_upper = 'A' <= bch && bch <= 'Z';
+        bool b_digit = '0' <= bch && bch <= '9';
+        bool b_space = bch == ' ' || bch == '_' || bch == '.';
+        c = (a_lower && ach == bch + ('a'-'A'))? 0.2 :
+            (a_upper && bch == ach + ('a'-'A'))? 0.2 :
+            (a_space && b_space)? 0.2 :
+            (a_digit && b_digit)? 0.75 :
+            ((a_lower|a_upper) && (b_lower|b_upper))? 0.75 : 1.0;
+      }
+      double del_cost = v[j] + 1;
+      double ins_cost = v[j - 1] + 1;
+      double sub_cost = w + c;
+      w = v[j];
+      v[j] = std::min(del_cost, std::min(ins_cost, sub_cost));
+    }
+  }
+  return v[n];
+}
+
+
+
+std::string suggest_similar_strings(
+    const std::vector<std::string>& candidates,
+    const std::string& name)
+{
+  size_t len = name.size();
+  auto tmp = std::unique_ptr<double[]>(new double[len + 1]);
+  double maxdist = len <= 3? 1 :
+                   len <= 6? 2 :
+                   len <= 9? 3 :
+                   len <= 16? 4 : 5;
+  struct scored_column {
+    size_t index;
+    double score;
+  };
+  auto col0 = scored_column { 0, 100.0 };
+  auto col1 = scored_column { 0, 100.0 };
+  auto col2 = scored_column { 0, 100.0 };
+  for (size_t i = 0; i < candidates.size(); ++i) {
+    double dist = levenshtein_distance(name, candidates[i], tmp.get());
+    if (dist <= maxdist) {
+      auto curr = scored_column { i, dist };
+      if (curr.score < col0.score) {
+        col2 = col1; col1 = col0; col0 = curr;
+      } else if (curr.score < col1.score) {
+        col2 = col1; col1 = curr;
+      } else if (curr.score < col2.score) {
+        col2 = curr;
+      }
+    }
+  }
+
+  std::ostringstream out;
+  if (col0.score < 10) {
+    out << '`' << candidates[col0.index] << '`';
+    if (col1.score < 10) {
+      out << (col2.score < 10? ", " : " or ");
+      out << '`' << candidates[col1.index] << '`';
+      if (col2.score < 10) {
+        out << " or `" << candidates[col2.index] << '`';
+      }
+    }
+  }
+  return out.str();
+}
+
+
+}  // namespace dt

--- a/c/utils/fuzzy_match.h
+++ b/c/utils/fuzzy_match.h
@@ -1,0 +1,41 @@
+//------------------------------------------------------------------------------
+// Copyright 2018 H2O.ai
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//------------------------------------------------------------------------------
+#ifndef dt_UTILS_FUZZY_MATCH_h
+#define dt_UTILS_FUZZY_MATCH_h
+#include <string>   // std::string
+#include <vector>   // std::vector
+namespace dt {
+
+
+/**
+ * Compute Levenshtein distance between two strings `a` and `b`, as described in
+ * https://en.wikipedia.org/wiki/Levenshtein_distance
+ *
+ * Use iterative algorithm, single-row version. The temporary storage required
+ * for the calculations is passed in array `v`, which must be allocated for at
+ * least `min(a.size(), b.size()) + 1` elements.
+ */
+double levenshtein_distance(const std::string& a, const std::string& b,
+                            double* v);
+
+
+std::string suggest_similar_strings(
+    const std::vector<std::string>& candidates,
+    const std::string& name);
+
+
+}  // namespace dt
+#endif

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -155,19 +155,3 @@ options.register_option(
 
 options.register_option(
     "sort.nthreads", xtype=int, default=4)
-
-options.register_option(
-    "frame.names_auto_index", xtype=int, default=0,
-    doc="When Frame needs to auto-name columns, they will be assigned "
-        "names C0, C1, C2, ... by default. This option allows you to "
-        "control the starting index in this sequence. For example, setting "
-        "options.frame.names_auto_index=1 will cause the columns to be "
-        "named C1, C2, C3, ...")
-
-options.register_option(
-    "frame.names_auto_prefix", xtype=str, default="C",
-    doc="When Frame needs to auto-name columns, they will be assigned "
-        "names C0, C1, C2, ... by default. This option allows you to "
-        "control the prefix used in this sequence. For example, setting "
-        "options.frame.names_auto_prefix='Z' will cause the columns to be "
-        "named Z0, Z1, Z2, ...")

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -127,31 +127,3 @@ class Frame(core.Frame):
 
 core._register_function(7, Frame)
 core._install_buffer_hooks(Frame)
-
-
-options.register_option(
-    "core_logger", xtype=callable, default=None,
-    doc="If you set this option to a Logger object, then every call to any "
-        "core function will be recorded via this object.")
-
-options.register_option(
-    "sort.insert_method_threshold", xtype=int, default=64,
-    doc="Largest n at which sorting will be performed using insert sort "
-        "method. This setting also governs the recursive parts of the "
-        "radix sort algorithm, when we need to sort smaller sub-parts of "
-        "the input.")
-
-options.register_option(
-    "sort.thread_multiplier", xtype=int, default=2)
-
-options.register_option(
-    "sort.max_chunk_length", xtype=int, default=1024)
-
-options.register_option(
-    "sort.max_radix_bits", xtype=int, default=12)
-
-options.register_option(
-    "sort.over_radix_bits", xtype=int, default=8)
-
-options.register_option(
-    "sort.nthreads", xtype=int, default=4)

--- a/datatable/fread.py
+++ b/datatable/fread.py
@@ -1043,9 +1043,6 @@ class _DefaultLogger:
 _pathlike = (str, bytes, os.PathLike) if hasattr(os, "PathLike") else \
             (str, bytes)
 
-options.register_option(
-    "fread.anonymize", xtype=bool, default=False)
-
 core._register_function(8, fread)
 
 

--- a/datatable/options.py
+++ b/datatable/options.py
@@ -262,7 +262,7 @@ options.register_option("core_logger", default=None, doc="[DEPRECATED]")
 
 options.register_option(
     "display.use_colors", True, xtype=bool,
-    onchange=lambda x: term.use_colors(x),
+    onchange=term.use_colors,
     doc="Whether to use colors when printing various messages into the\n"
         "console. Turn this off if your terminal is unable to display\n"
         "ANSI escape sequences, or if the colors make output not\n"

--- a/datatable/options.py
+++ b/datatable/options.py
@@ -99,8 +99,10 @@ class Config:
         if prefix not in self._options:
             self.register(Config(options=self._options, prefix=prefix + "."))
 
-    def register_option(self, name, default, xtype=None, doc=None):
-        opt = Option(name=name, default=default, doc=doc, xtype=xtype)
+    def register_option(self, name, default, xtype=None, doc=None,
+                        onchange=None):
+        opt = Option(name=name, default=default, doc=doc, xtype=xtype,
+                     onchange=onchange)
         self.register(opt)
 
     @property
@@ -209,12 +211,13 @@ def _render_options_list(options, prefix, indent):
 #-------------------------------------------------------------------------------
 
 class Option:
-    def __init__(self, name, default, doc, xtype):
+    def __init__(self, name, default, doc=None, xtype=None, onchange=None):
         self._name = name
         self._default = default
         self._doc = doc
         self._value = default
         self._xtype = xtype
+        self._onchange = onchange
         if xtype and not isinstance(default, xtype):
             raise TTypeError("Default value `%r` is not of type %s"
                              % (default, name_type(xtype)))
@@ -242,6 +245,8 @@ class Option:
                                  % (self._name, name_type(self._xtype),
                                     name_type(type(x))))
         self._value = x
+        if self._onchange is not None:
+            self._onchange(x)
 
 
 
@@ -254,3 +259,11 @@ options = Config(options={}, prefix="")
 core.initialize_options(options)
 
 options.register_option("core_logger", default=None, doc="[DEPRECATED]")
+
+options.register_option(
+    "display.use_colors", True, xtype=bool,
+    onchange=lambda x: term.use_colors(x),
+    doc="Whether to use colors when printing various messages into the\n"
+        "console. Turn this off if your terminal is unable to display\n"
+        "ANSI escape sequences, or if the colors make output not\n"
+        "legible.")

--- a/datatable/options.py
+++ b/datatable/options.py
@@ -6,6 +6,7 @@
 #-------------------------------------------------------------------------------
 from contextlib import contextmanager
 from datatable.lib import core
+from datatable.utils.terminal import term
 from datatable.utils.typechecks import TTypeError, TValueError, name_type
 
 __all__ = ("options", "Option")
@@ -139,6 +140,36 @@ class Config:
         finally:
             for opt, original_value in previous_settings:
                 opt.set(original_value)
+
+    def describe(self, name=None):
+        if name is None:  # describe all options
+            names = sorted(dir(self))
+        else:
+            opt = self._get_option(name)
+            if isinstance(opt, Config):
+                return opt.describe()
+            names = [name]
+        extras = ""
+        for name in names:
+            opt = self._get_option(name)
+            if isinstance(opt, Config):
+                extras += "%s [...]\n\n" % term.color("bold", opt.name)
+                continue
+            value = opt.get()
+            comment = ("(default)" if value == opt.default else
+                       "(default: %r)" % opt.default)
+            print("%s = %s %s" %
+                  (term.color("bold", opt.name),
+                   term.color("bright_green", repr(value)),
+                   term.color("bright_black", comment)))
+            for line in opt.doc.strip().split("\n"):
+                print("    " + line)
+            print()
+        if extras:
+            print(extras, end="")
+
+
+
 
 
 

--- a/datatable/options.py
+++ b/datatable/options.py
@@ -6,14 +6,13 @@
 #-------------------------------------------------------------------------------
 from contextlib import contextmanager
 from datatable.lib import core
-from datatable.utils.typechecks import (is_type, name_type, TTypeError,
-                                        TValueError)
+from datatable.utils.typechecks import TValueError
 
 __all__ = ("options", "Option")
 
 
 class DtAttributeError(AttributeError):
-    _handle_ = TTypeError._handle_
+    _handle_ = TValueError._handle_
 
 
 
@@ -198,23 +197,4 @@ class Option:
 #-------------------------------------------------------------------------------
 
 options = Config(options={}, prefix="")
-
-
-options.register_option(
-    "nthreads", int, default=0,
-    doc="The number of threads used by datatable internally.\n"
-        "\n"
-        "Many calculations in `datatable` module are parallelized. This \n"
-        "setting controls how many threads will be used during such\n"
-        "calculations.\n"
-        "\n"
-        "Initially, this option is set to the value returned by C++ call\n"
-        "`std::thread::hardware_concurrency()`. This is usually equal to the\n"
-        "number of available cores.\n"
-        "\n"
-        "You can set `nthreads` to a value greater or smaller than the\n"
-        "initial setting. For example, setting `nthreads = 1` will force the\n"
-        "library into a single-threaded mode. Setting `nthreads` to 0 will\n"
-        "restore the initial value equal to the number of processor cores.\n"
-        "Setting `nthreads` to a value less than 0 is equivalent to\n"
-        "requesting that fewer threads than the maximum.\n")
+core.initialize_options(options)

--- a/datatable/options.py
+++ b/datatable/options.py
@@ -4,230 +4,200 @@
 #   License, v. 2.0. If a copy of the MPL was not distributed with this
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #-------------------------------------------------------------------------------
+from contextlib import contextmanager
 from datatable.lib import core
 from datatable.utils.typechecks import (is_type, name_type, TTypeError,
                                         TValueError)
 
-__all__ = ("options", )
+__all__ = ("options", "Option")
 
 
 class DtAttributeError(AttributeError):
     _handle_ = TTypeError._handle_
 
-class _bool(int):
-    def __str__(self):
-        if self == 1:
-            return "True"
-        if self == 0:
-            return "False"
-
-class _function:
-    def __init__(self, v):
-        self._obj = v
-
-    def __call__(self):
-        self._obj()
-
-    def __repr__(self):
-        return repr(self._obj)
-
-    def __str__(self):
-        return str(self._obj)
-
-    def __eq__(self, other):
-        return self._obj.__eq__(other)
-
-    def __bool__(self):
-        return bool(self._obj)
-
 
 
 #-------------------------------------------------------------------------------
-# DtOption
+# Config
 #-------------------------------------------------------------------------------
 
-class DtOption:
+class Config:
     """
-    This is a 'lead node' class in the DtConfig tree of options. However, the
-    objects of this class are not directly returned to the user. Instead, the
-    DtConfig class invokes the following API:
-
-        dt.options.some_option      ->  return some_option.get()
-        dt.options.some_option = v  ->  some_option.set(v)
-        del dt.options.some_option  ->  some_option.reset()
-
-    The reasons why we don't return `some_option` directly to the user are:
-      - the return value must be derived from the appropriate base class,
-        such as `int`, `float`, `str`, so that the user may use the value
-        directly as if it was int / float / string;
-      - at the same time the option must be mutable (i.e. it should be
-        possible to change its value via assignment or a method), and base
-        classes listed above are immutable.
-
-    The value returned by `some_option.get()` is not the base value either: it
-    is additionally equipped with custom docstring.
+    Repository of datatable configuration options.
     """
-    __slots__ = ["_name", "_default", "_klass"]
+    # All options are stored in the dictionary ``self._options``,
+    # where the keys are full option names, and values are the objects
+    # of type ``DtOption`` or similar.
+    #
+    # In addition to each actual option, the ``_options`` dictionary
+    # stores nested ``Config`` objects corresponding to every prefix
+    # of all other options. For example, if the user declares option
+    # ``foo.bar.baz``, then ``Config``s will be created for ``foo.``
+    # and ``foo.bar.``. All these nested config objects share the same
+    # dictionary ``_options`` as their root.
+    #
+    __slots__ = ["_options", "_prefix"]
 
-    def __init__(self, name, xtype, default, doc=None):
-        if xtype == bool:
-            xtype = _bool
-        if xtype == callable:
-            xtype = _function
-        self._name = name
-        self._default = default
-        self._klass = type(xtype.__name__, (xtype,), dict(__doc__=doc))
-        self.set(default)
-
-    def get(self):
-        v = core.get_option(self._name)
-        return self._klass(v)
-
-    def set(self, v):
-        core.set_option(self._name, v)
-
-    def reset(self):
-        self.set(self._default)
-
-
-
-class DtConfig:
-    __slots__ = ["_keyvals", "_prefix"]
-
-    def __init__(self, prefix=""):
-        if prefix:
-            prefix += "."
+    def __init__(self, options, prefix):
         # Use object.__setattr__ instead of our own __setattr__ below; note:
         # __setattr__ is called for all attributes, regardless of whether they
         # exist in __slots__ or not.
-        object.__setattr__(self, "_keyvals", {})
+        object.__setattr__(self, "_options", options)
         object.__setattr__(self, "_prefix", prefix)
 
+    def __repr__(self):
+        options = sorted(self.__iter__(), key=lambda x: x.name)
+        s = "datatable.options.\n"
+        s += _render_options_list(options, self._prefix, "    ")
+        return s
 
     def __getattr__(self, key):
-        if key:
-            opt = self._get_opt(key)
-            if isinstance(opt, DtOption):
-                return opt.get()
-            else:
-                return opt
-        else:
-            res = {}
-            for k, v in self._keyvals.items():
-                if isinstance(v, DtOption):
-                    res[self._prefix + k] = v.get()
-                else:
-                    res.update(v.__getattr__(""))
-            return res
-
+        opt = self._get_option(key)
+        return opt.get()
 
     def __setattr__(self, key, val):
-        opt = self._get_opt(key)
-        if isinstance(opt, DtOption):
-            opt.set(val)
-        else:
-            raise DtAttributeError("Cannot modify group of options `%s`"
-                                   % (self._prefix + key))
-
+        opt = self._get_option(key)
+        opt.set(val)
 
     def __delattr__(self, key):
-        """Deleting an option resets it to default value."""
-        if key:
-            opt = self._get_opt(key)
-            if isinstance(opt, DtOption):
-                opt.reset()
-            else:
-                opt.__delattr__("")
-        else:
-            for o in self._keyvals.values():
-                if isinstance(o, DtOption):
-                    o.reset()
-                else:
-                    o.__delattr__("")
+        opt = self._get_option(key)
+        opt.set(opt.default)
 
+    def __iter__(self):
+        for key, opt in self._options.items():
+            if key.startswith(self._prefix):
+                yield opt
 
     def __dir__(self):
-        return list(self._keyvals.keys())
+        n = len(self._prefix)
+        return [key[n:] for key, opt in self._options.items()
+                        if key.startswith(self._prefix) and "." not in key[n:]]
 
-    def __repr__(self):
-        return ("<datatable.options.DtConfig: %s>"
-                % ", ".join("%s=%s" % (k, repr(v.get())
-                                       if isinstance(v, DtOption) else "...")
-                            for k, v in self._keyvals.items()))
+    def _get_option(self, key):
+        kkey = self._prefix + key
+        if kkey in self._options:
+            return self._options[kkey]
+        msg = "Unknown datatable option `%s`" % kkey
+        alternatives = core.fuzzy_match(self._options, kkey)
+        if alternatives:
+            msg += "; did you mean %s?" % alternatives
+        raise DtAttributeError(msg)
 
-    def _repr_pretty_(self, p, cycle):
-        with p.indent(4):
-            p.text("dt.options." + self._prefix)
-            p.break_()
-            for k, v in self._keyvals.items():
-                p.text(k)
-                p.text(" = ")
-                if isinstance(v, DtOption):
-                    p.pretty(v.get())
-                else:
-                    p.text("[...]")
-                p.break_()
+    def register(self, opt):
+        fullname = opt.name
+        if fullname.startswith("."):
+            raise TValueError("Invalid option name `%s`" % fullname)
+        self._options[fullname] = opt
+        prefix = fullname.rsplit('.', 1)[0]
+        if prefix not in self._options:
+            self.register(Config(options=self._options, prefix=prefix + "."))
 
-
-    def get(self, key=""):
-        return self.__getattr__(key)
-
-    def set(self, key, val):
-        self.__setattr__(key, val)
-
-    def reset(self, key=""):
-        self.__delattr__(key)
-
-
+    # TODO: remove
     def register_option(self, key, xtype, default, doc=None):
-        assert isinstance(key, str)
-        idot = key.find(".")
-        if idot == 0:
-            raise TValueError("Invalid option name `%s`" % key)
-        elif idot > 0:
-            prekey = key[:idot]
-            preval = self._keyvals.get(prekey, None)
-            if preval is None:
-                preval = DtConfig(self._prefix + prekey)
-                self._keyvals[prekey] = preval
-            if isinstance(preval, DtConfig):
-                subkey = key[idot + 1:]
-                preval.register_option(subkey, xtype, default, doc)
+        self.register(Option(key, default, doc))
+
+    @property
+    def name(self):
+        return self._prefix[:-1]
+
+    def get(self):
+        return self
+
+    def set(self, val):
+        raise TypeError("Cannot set the value of option set `%s`" % self._prefix)
+
+    @contextmanager
+    def context(self, **kwargs):
+        previous_settings = []
+        try:
+            for key, value in kwargs.items():
+                opt = self._get_option(key)
+                original_value = opt.get()
+                opt.set(value)
+                previous_settings.append((opt, original_value))
+
+            yield
+
+        finally:
+            for opt, original_value in previous_settings:
+                opt.set(original_value)
+
+
+
+
+
+
+def _render_options_list(options, prefix, indent):
+    simple_options = []
+    nested_options = []
+    skip_prefix = None
+    for opt in options:
+        if skip_prefix:
+            if opt.name.startswith(skip_prefix):
+                nested_options[-1][1].append(opt)
+                continue
             else:
-                fullkey = self._prefix + key
-                fullprekey = self._prefix + prekey
-                raise TValueError("Cannot register option `%s` because `%s` "
-                                  "is already registered as an option"
-                                  % (fullkey, fullprekey))
-        elif key in self._keyvals:
-            fullkey = self._prefix + key
-            raise TValueError("Option `%s` already registered" % fullkey)
-        elif not (xtype is callable or is_type(default, xtype)):
-            raise TValueError("Default value `%s` is not of type %s"
-                              % (default, name_type(xtype)))
+                skip_prefix = None
+        if isinstance(opt, Config):
+            nested_options.append((opt, []))
+            skip_prefix = opt._prefix
         else:
-            opt = DtOption(xtype=xtype, default=default, doc=doc,
-                           name=self._prefix + key)
-            self._keyvals[key] = opt
+            simple_options.append(opt)
+
+    n = len(prefix)
+    out = ""
+
+    for opt in simple_options:
+        out += "%s%s = %r\n" % (indent, opt.name[n:], opt.get())
+    for optset, opts in nested_options:
+        prefix = optset._prefix
+        out += "%s%s\n" % (indent, prefix)
+        out += _render_options_list(opts, prefix, indent + "    ")
+    return out
 
 
-    def _get_opt(self, key):
-        if key in self._keyvals:
-            return self._keyvals[key]
-
-        idot = key.find(".")
-        if idot >= 0:
-            prefix = key[:idot]
-            if prefix in self._keyvals:
-                subkey = key[idot + 1:]
-                return self._keyvals[prefix].__getattr__(subkey)
-
-        fullkey = self._prefix + key
-        raise DtAttributeError("Unknown datatable option `%s`" % fullkey)
 
 
+#-------------------------------------------------------------------------------
+# Option
+#-------------------------------------------------------------------------------
+
+class Option:
+    def __init__(self, name, default, doc):
+        self._name = name
+        self._default = default
+        self._doc = doc
+        # self._value = default
+        core.set_option(name, default)
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def default(self):
+        return self._default
+
+    @property
+    def doc(self):
+        return self._doc
+
+    def get(self):
+        # return self._value
+        return core.get_option(self._name)
+
+    def set(self, x):
+        # self._value = x
+        core.set_option(self._name, x)
+
+
+
+
+#-------------------------------------------------------------------------------
 # Global options store
-options = DtConfig()
+#-------------------------------------------------------------------------------
+
+options = Config(options={}, prefix="")
 
 
 options.register_option(

--- a/datatable/options.py
+++ b/datatable/options.py
@@ -183,7 +183,7 @@ class Option:
         self._name = name
         self._default = default
         self._doc = doc
-        core.set_option(name, default)
+        # core.set_option(name, default)
 
     @property
     def name(self):
@@ -198,10 +198,12 @@ class Option:
         return self._doc
 
     def get(self):
-        return core.get_option(self._name)
+        # return core.get_option(self._name)
+        return None
 
     def set(self, x):
-        core.set_option(self._name, x)
+        # core.set_option(self._name, x)
+        pass
 
 
 class Option2:
@@ -248,3 +250,5 @@ class Option2:
 
 options = Config(options={}, prefix="")
 core.initialize_options(options)
+
+options.register_option2("core_logger", default=None, doc="[DEPRECATED]")

--- a/datatable/options.py
+++ b/datatable/options.py
@@ -167,7 +167,7 @@ def _render_options_list(options, prefix, indent):
         out += "%s%s = %r\n" % (indent, opt.name[n:], opt.get())
     for optset, opts in nested_options:
         prefix = optset._prefix
-        out += "%s%s\n" % (indent, prefix)
+        out += "%s%s\n" % (indent, prefix[n:])
         out += _render_options_list(opts, prefix, indent + "    ")
     return out
 

--- a/datatable/options.py
+++ b/datatable/options.py
@@ -59,8 +59,8 @@ class Config:
     def __setattr__(self, key, val):
         opt = self._get_option(key)
         if isinstance(opt, Config):
-            raise TypeError("Cannot set the value of option set `%s`"
-                            % self._prefix)
+            raise TypeError("Cannot assign a value to group of options `%s.*`"
+                            % (self._prefix + key))
         opt.set(val)
 
     def __delattr__(self, key):
@@ -114,9 +114,15 @@ class Config:
         opt = self._get_option(name)
         opt.set(value)
 
-    def reset(self, name):
-        opt = self._get_option(name)
-        opt.set(opt.default)
+    def reset(self, name=None):
+        if name is None:
+            # reset all options
+            for opt in self.__iter__():
+                if not isinstance(opt, Config):
+                    opt.set(opt.default)
+        else:
+            opt = self._get_option(name)
+            opt.set(opt.default)
 
     @contextmanager
     def context(self, **kwargs):

--- a/datatable/options.py
+++ b/datatable/options.py
@@ -99,11 +99,7 @@ class Config:
             self.register(Config(options=self._options, prefix=prefix + "."))
 
     def register_option(self, name, default, xtype=None, doc=None):
-        opt = Option(name, default, doc)
-        self.register(opt)
-
-    def register_option2(self, name, default, xtype=None, doc=None):
-        opt = Option2(name=name, default=default, doc=doc, xtype=xtype)
+        opt = Option(name=name, default=default, doc=doc, xtype=xtype)
         self.register(opt)
 
     @property
@@ -137,9 +133,6 @@ class Config:
         finally:
             for opt, original_value in previous_settings:
                 opt.set(original_value)
-
-
-
 
 
 
@@ -179,34 +172,6 @@ def _render_options_list(options, prefix, indent):
 #-------------------------------------------------------------------------------
 
 class Option:
-    def __init__(self, name, default, doc):
-        self._name = name
-        self._default = default
-        self._doc = doc
-        # core.set_option(name, default)
-
-    @property
-    def name(self):
-        return self._name
-
-    @property
-    def default(self):
-        return self._default
-
-    @property
-    def doc(self):
-        return self._doc
-
-    def get(self):
-        # return core.get_option(self._name)
-        return None
-
-    def set(self, x):
-        # core.set_option(self._name, x)
-        pass
-
-
-class Option2:
     def __init__(self, name, default, doc, xtype):
         self._name = name
         self._default = default
@@ -251,4 +216,4 @@ class Option2:
 options = Config(options={}, prefix="")
 core.initialize_options(options)
 
-options.register_option2("core_logger", default=None, doc="[DEPRECATED]")
+options.register_option("core_logger", default=None, doc="[DEPRECATED]")

--- a/datatable/widget.py
+++ b/datatable/widget.py
@@ -8,7 +8,7 @@ import time
 
 import datatable
 from datatable.lib._datatable import Frame as coreFrame
-from datatable.options import options, Option
+from datatable.options import options
 from datatable.types import ltype
 from datatable.utils.misc import plural_form, clamp
 from datatable.utils.terminal import term, register_onresize

--- a/datatable/widget.py
+++ b/datatable/widget.py
@@ -552,14 +552,14 @@ def _float_tail(x):
         return -1
 
 
-options.register_option2(
+options.register_option(
     name="display.interactive_hint",
     default=True,
     xtype=bool,
     doc="Display navigation hint at the bottom of a Frame when viewing "
         "its contents in the console.")
 
-options.register_option2(
+options.register_option(
     name="display.interactive",
     default=False,
     xtype=bool,

--- a/datatable/widget.py
+++ b/datatable/widget.py
@@ -8,7 +8,7 @@ import time
 
 import datatable
 from datatable.lib._datatable import Frame as coreFrame
-from datatable.options import options
+from datatable.options import options, Option
 from datatable.types import ltype
 from datatable.utils.misc import plural_form, clamp
 from datatable.utils.terminal import term, register_onresize
@@ -552,11 +552,15 @@ def _float_tail(x):
         return -1
 
 
-options.register_option(
-    "display.interactive_hint", xtype=bool, default=True,
+options.register_option2(
+    name="display.interactive_hint",
+    default=True,
+    xtype=bool,
     doc="Display navigation hint at the bottom of a Frame when viewing "
         "its contents in the console.")
 
-options.register_option(
-    "display.interactive", xtype=bool, default=False,
+options.register_option2(
+    name="display.interactive",
+    default=False,
+    xtype=bool,
     doc="Show datatable Frame interactively in a Python console.")

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -65,20 +65,14 @@ def test_option_bad():
     assert ("Invalid value for option `gooo`: expected int, instead got float"
             in str(e.value))
 
-    # with pytest.raises(ValueError) as e:
-    #     dt.options.register_option("gooo.maxima", int, 0, "")
-    # assert ("Cannot register option `gooo.maxima` because `gooo` is already "
-    #         "registered as an option" in str(e.value))
 
-
-@pytest.mark.skip()
 def test_options_many():
-    dt.options.register_option("tmp1.alpha", int, 1, "A")
-    dt.options.register_option("tmp1.beta",  int, 2, "B")
-    dt.options.register_option("tmp1.gamma", int, 3, "C")
-    dt.options.register_option("tmp1.delta.x", int, 4, "X")
-    dt.options.register_option("tmp1.delta.y", int, 5, "Y")
-    dt.options.register_option("tmp1.delta.z.zz", int, 6, "Z")
+    dt.options.register_option("tmp1.alpha", 1, doc="A", xtype=int)
+    dt.options.register_option("tmp1.beta",  2, doc="B", xtype=int)
+    dt.options.register_option("tmp1.gamma", 3, doc="C", xtype=int)
+    dt.options.register_option("tmp1.delta.x", 4, doc="X", xtype=int)
+    dt.options.register_option("tmp1.delta.y", 5, doc="Y", xtype=int)
+    dt.options.register_option("tmp1.delta.z.zz", 6, doc="Z", xtype=int)
     for _ in [1, 2]:
         assert dt.options.tmp1.alpha == 1
         assert dt.options.tmp1.beta == 2
@@ -87,24 +81,22 @@ def test_options_many():
         assert dt.options.tmp1.delta.y == 5
         assert dt.options.tmp1.delta.z.zz == 6
         assert set(dir(dt.options.tmp1)) == {"alpha", "beta", "gamma", "delta"}
-        assert set(dt.options.tmp1.get()) == {"tmp1.alpha", "tmp1.beta",
-                                              "tmp1.gamma", "tmp1.delta.x",
-                                              "tmp1.delta.y", "tmp1.delta.z.zz"}
+        assert set(dir(dt.options.tmp1.delta)) == {"x", "y", "z"}
         dt.options.tmp1.delta.x = 0
         dt.options.tmp1.delta.z.zz = 0
-        del dt.options.tmp1
+        dt.options.tmp1.reset()
 
 
-@pytest.mark.skip()
 def test_options_many_bad():
-    dt.options.register_option("tmp2.foo.x", int, 4, "")
-    dt.options.register_option("tmp2.foo.y", int, 5, "")
+    dt.options.register_option("tmp2.foo.x", 4, xtype=int)
+    dt.options.register_option("tmp2.foo.y", 5, xtype=int)
     dt.options.tmp2.foo.x = 8
     assert dt.options.tmp2.foo.x == 8
     assert dt.options.get("tmp2.foo.x") == 8
-    with pytest.raises(AttributeError) as e:
+    with pytest.raises(TypeError) as e:
         dt.options.tmp2.foo = 0
-    assert "Cannot modify group of options `tmp2.foo`" in str(e.value)
+    assert ("Cannot assign a value to group of options `tmp2.foo.*`"
+            in str(e.value))
 
 
 
@@ -127,30 +119,6 @@ def test_nthreads():
         curr_threads = new_threads
 
     assert dt.options.nthreads == nthreads0
-
-
-
-def test_core_logger():
-    class MyLogger:
-        def __init__(self):
-            self.messages = ""
-        def info(self, msg):
-            self.messages += msg + '\n'
-
-    ml = MyLogger()
-    assert not dt.options.core_logger
-    dt.options.core_logger = ml
-    assert dt.options.core_logger == ml
-    f0 = dt.Frame([1, 2, 3])
-    assert f0.shape == (3, 1)
-    frame_integrity_check(f0)
-    # assert "call DataTable.datatable_from_list(...)" in ml.messages
-    # assert "call DataTable.ncols" in ml.messages
-    # assert "call DataTable.nrows" in ml.messages
-    # assert "call DataTable.check(...)" in ml.messages
-    # assert "done DataTable.check(...) in" in ml.messages
-    del dt.options.core_logger
-    assert not dt.options.core_logger
 
 
 def test_frame_names_auto_index():

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -26,7 +26,7 @@ def test_options_all():
 
 
 def test_option_api():
-    dt.options.register_option2(name="fooo", xtype=int, default=13,
+    dt.options.register_option(name="fooo", xtype=int, default=13,
                                 doc="a dozen")
     assert "fooo" in dir(dt.options)
     assert dt.options.fooo == 13
@@ -47,14 +47,14 @@ def test_option_bad():
         noop(dt.options.gooo)
 
     with pytest.raises(TypeError) as e:
-        dt.options.register_option2(name="gooo", xtype=str, default=3, doc="??")
+        dt.options.register_option(name="gooo", xtype=str, default=3, doc="??")
     assert "Default value `3` is not of type str" in str(e.value)
 
     with pytest.raises(ValueError) as e:
-        dt.options.register_option2(name=".hidden", xtype=int, default=0)
+        dt.options.register_option(name=".hidden", xtype=int, default=0)
     assert "Invalid option name `.hidden`" in str(e.value)
 
-    dt.options.register_option2(name="gooo", xtype=int, default=3)
+    dt.options.register_option(name="gooo", xtype=int, default=3)
 
     with pytest.raises(ValueError) as e:
         dt.options.register_option(name="gooo", xtype=int, default=4, doc="???")

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -19,7 +19,7 @@ def test_options_all():
         "insert_method_threshold", "thread_multiplier", "max_chunk_length",
         "max_radix_bits", "over_radix_bits", "nthreads"}
     assert set(dir(dt.options.display)) == {
-        "interactive", "interactive_hint"}
+        "interactive", "interactive_hint", "use_colors"}
     assert set(dir(dt.options.frame)) == {
         "names_auto_index", "names_auto_prefix"}
     assert set(dir(dt.options.fread)) == {"anonymize", "log"}

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -99,6 +99,45 @@ def test_options_many_bad():
             in str(e.value))
 
 
+def test_options_context1():
+    with dt.options.context(**{"fread.log.anonymize": True}):
+        assert dt.options.fread.log.anonymize is True
+    assert dt.options.fread.log.anonymize is False
+
+
+def test_options_context2():
+    with dt.options.fread.log.context(escape_unicode=True):
+        assert dt.options.fread.log.escape_unicode is True
+    assert dt.options.fread.log.escape_unicode is False
+
+
+def test_options_context3():
+    # Check that in case of exception the value still gets restored
+    dt.options.register_option("zoonk", 1, xtype=int)
+    try:
+        with dt.options.context(zoonk=100):
+            raise RuntimeError
+    except RuntimeError:
+        pass
+    assert dt.options.zoonk == 1
+
+
+def test_options_context4():
+    # Check that if context requires changing multiple parameters, that all
+    # their values are properly restored in the end, even if there is an
+    # exception during setting one of the parameters
+    dt.options.register_option("tmp1.odyn", 1, xtype=int)
+    dt.options.register_option("tmp1.dwa", 2, xtype=int)
+    try:
+        with dt.options.tmp1.context(odyn=10, dwa=None):
+            assert False, "Should not be able to enter this context"
+    except TypeError:
+        pass
+    assert dt.options.tmp1.odyn == 1
+    assert dt.options.tmp1.dwa == 2
+
+
+
 
 #-------------------------------------------------------------------------------
 # Individual options

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -22,10 +22,9 @@ def test_options_all():
         "interactive", "interactive_hint"}
     assert set(dir(dt.options.frame)) == {
         "names_auto_index", "names_auto_prefix"}
-    assert set(dir(dt.options.fread)) == {"anonymize"}
+    assert set(dir(dt.options.fread)) == {"anonymize", "log"}
 
 
-# @pytest.mark.skip()
 def test_option_api():
     dt.options.register_option2(name="fooo", xtype=int, default=13,
                                 doc="a dozen")

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -12,7 +12,7 @@ from tests import noop
 
 def test_options_all():
     # Update this test every time a new option is added
-    assert repr(dt.options).startswith("<datatable.options.DtConfig:")
+    assert repr(dt.options).startswith("datatable.options.")
     assert set(dir(dt.options)) == {
         "nthreads", "core_logger", "sort", "display", "frame", "fread"}
     assert set(dir(dt.options.sort)) == {
@@ -46,9 +46,9 @@ def test_option_bad():
     with pytest.raises(AttributeError):
         noop(dt.options.gooo)
 
-    with pytest.raises(ValueError) as e:
-        dt.options.register_option("gooo", str, 3, "??")
-    assert "Default value `3` is not of type str" in str(e.value)
+    # with pytest.raises(ValueError) as e:
+    #     dt.options.register_option("gooo", str, 3, "??")
+    # assert "Default value `3` is not of type str" in str(e.value)
 
     with pytest.raises(ValueError) as e:
         dt.options.register_option(".hidden", int, 0, "")

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -25,9 +25,10 @@ def test_options_all():
     assert set(dir(dt.options.fread)) == {"anonymize"}
 
 
-@pytest.mark.skip()
+# @pytest.mark.skip()
 def test_option_api():
-    dt.options.register_option("fooo", int, 13, "a dozen")
+    dt.options.register_option2(name="fooo", xtype=int, default=13,
+                                doc="a dozen")
     assert "fooo" in dir(dt.options)
     assert dt.options.fooo == 13
     assert dt.options.get("fooo") == 13
@@ -46,24 +47,24 @@ def test_option_bad():
     with pytest.raises(AttributeError):
         noop(dt.options.gooo)
 
-    # with pytest.raises(ValueError) as e:
-    #     dt.options.register_option("gooo", str, 3, "??")
-    # assert "Default value `3` is not of type str" in str(e.value)
+    with pytest.raises(TypeError) as e:
+        dt.options.register_option2(name="gooo", xtype=str, default=3, doc="??")
+    assert "Default value `3` is not of type str" in str(e.value)
 
     with pytest.raises(ValueError) as e:
-        dt.options.register_option(".hidden", int, 0, "")
+        dt.options.register_option2(name=".hidden", xtype=int, default=0)
     assert "Invalid option name `.hidden`" in str(e.value)
 
-    # dt.options.register_option("gooo", int, 3, "???")
+    dt.options.register_option2(name="gooo", xtype=int, default=3)
 
-    # with pytest.raises(ValueError) as e:
-    #     dt.options.register_option("gooo", int, 3, "???")
-    # assert "Option `gooo` already registered" in str(e.value)
+    with pytest.raises(ValueError) as e:
+        dt.options.register_option(name="gooo", xtype=int, default=4, doc="???")
+    assert "Option `gooo` already registered" in str(e.value)
 
-    # with pytest.raises(TypeError) as e:
-    #     dt.options.gooo = 2.5
-    # assert ("Invalid value for option `gooo`: expected type int, got float "
-    #         "instead" in str(e.value))
+    with pytest.raises(TypeError) as e:
+        dt.options.gooo = 2.5
+    assert ("Invalid value for option `gooo`: expected int, instead got float"
+            in str(e.value))
 
     # with pytest.raises(ValueError) as e:
     #     dt.options.register_option("gooo.maxima", int, 0, "")

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -66,6 +66,12 @@ def test_option_bad():
             in str(e.value))
 
 
+def test_option_suggest():
+    with pytest.raises(AttributeError) as e:
+        dt.options.fread.log.escapeunicode = False
+    assert ("did you mean `fread.log.escape_unicode`?" in str(e.value))
+
+
 def test_options_many():
     dt.options.register_option("tmp1.alpha", 1, doc="A", xtype=int)
     dt.options.register_option("tmp1.beta",  2, doc="B", xtype=int)


### PR DESCRIPTION
- The declaration of C++-related options moved entirely into C++;

- Added method `dt.options.describe()`, which will print the available options together with their values and descriptions.

 - Added `dt.options.context(option=value)`, which can be used in a with-statement to temporarily change the value of one or more options, and then go back to their original values at the end of the with-block.

 - Added options `fread.log.escape_unicode` (controls treatment of unicode characters in fread's verbose log); and `display.use_colors` (allows to turn on/off colored output in the console).

 - `dt.options` now helps the user when he/she makes a typo: if an option with a certain name does not exist, the error message will suggest the correct spelling.

Closes #1792