### PR TITLE
Add nthreads parameter to dt::parallel_for_static and dt::parallel_for_dynamic

### DIFF
--- a/c/models/dt_ftrl.cc
+++ b/c/models/dt_ftrl.cc
@@ -329,7 +329,6 @@ FtrlFitOutput Ftrl<T>::fit(T(*linkfn)(T), T(*lossfn)(T,U)) {
   // If we request more threads than is available, `dt::parallel_region()`
   // will fall back to the possible maximum.
   size_t nthreads = std::max(iteration_nrows / dt::FtrlBase::MIN_ROWS_PER_THREAD, 1lu);
-
   dt::parallel_region(nthreads,
     [&]() {
       // Each thread gets a private storage for hashes,

--- a/c/parallel/api.h
+++ b/c/parallel/api.h
@@ -23,7 +23,6 @@ using std::size_t;
 // Private
 void _parallel_for_static(size_t, size_t, size_t,
                           function<void(size_t, size_t)>);
-void _parallel_for_dynamic(size_t, size_t, function<void(size_t)>);
 
 
 //------------------------------------------------------------------------------

--- a/c/parallel/api.h
+++ b/c/parallel/api.h
@@ -23,6 +23,7 @@ using std::size_t;
 // Private
 void _parallel_for_static(size_t, size_t, size_t,
                           function<void(size_t, size_t)>);
+void _parallel_for_dynamic(size_t, size_t, function<void(size_t)>);
 
 
 //------------------------------------------------------------------------------
@@ -50,6 +51,13 @@ size_t num_threads_in_pool();
  * of iterations was small enough that using all of them was deamed suboptimal.
  */
 size_t num_threads_in_team();
+
+
+/**
+ * Return the total number of threads in the thread pool, when called from the
+ * master thread, and the total number of threads in a team, otherwise.
+ */
+size_t num_threads_available();
 
 
 /**
@@ -95,7 +103,7 @@ void barrier();
  */
 template <typename F>
 void parallel_for_static(size_t nrows, F f) {
-  _parallel_for_static(nrows, 4096, dt::num_threads_in_pool(),
+  _parallel_for_static(nrows, 4096, dt::num_threads_available(),
     [&](size_t i0, size_t i1) {
       for (size_t i = i0; i < i1; ++i) f(i);
     });
@@ -103,7 +111,7 @@ void parallel_for_static(size_t nrows, F f) {
 
 template <typename F>
 void parallel_for_static(size_t nrows, size_t chunk_size, F f) {
-  _parallel_for_static(nrows, chunk_size, dt::num_threads_in_pool(),
+  _parallel_for_static(nrows, chunk_size, dt::num_threads_available(),
     [&](size_t i0, size_t i1) {
       for (size_t i = i0; i < i1; ++i) f(i);
     });
@@ -112,7 +120,8 @@ void parallel_for_static(size_t nrows, size_t chunk_size, F f) {
 
 template <typename F>
 void parallel_for_static(size_t nrows, size_t chunk_size, size_t nthreads,
-                         F f) {
+                         F f)
+{
   _parallel_for_static(nrows, chunk_size, nthreads,
     [&](size_t i0, size_t i1) {
       for (size_t i = i0; i < i1; ++i) f(i);
@@ -124,6 +133,8 @@ void parallel_for_static(size_t nrows, size_t chunk_size, size_t nthreads,
  * Run parallel loop `for i in range(nrows): f(i)`, with dynamic scheduling.
  */
 void parallel_for_dynamic(size_t nrows, function<void(size_t)> fn);
+void parallel_for_dynamic(size_t nrows, size_t nthreads,
+                          function<void(size_t)> fn);
 
 
 

--- a/c/parallel/api.h
+++ b/c/parallel/api.h
@@ -95,7 +95,7 @@ void barrier();
  */
 template <typename F>
 void parallel_for_static(size_t nrows, F f) {
-  _parallel_for_static(nrows, 4096, dt::num_threads_in_team(),
+  _parallel_for_static(nrows, 4096, dt::num_threads_in_pool(),
     [&](size_t i0, size_t i1) {
       for (size_t i = i0; i < i1; ++i) f(i);
     });
@@ -103,7 +103,7 @@ void parallel_for_static(size_t nrows, F f) {
 
 template <typename F>
 void parallel_for_static(size_t nrows, size_t chunk_size, F f) {
-  _parallel_for_static(nrows, chunk_size, dt::num_threads_in_team(),
+  _parallel_for_static(nrows, chunk_size, dt::num_threads_in_pool(),
     [&](size_t i0, size_t i1) {
       for (size_t i = i0; i < i1; ++i) f(i);
     });

--- a/c/parallel/api.h
+++ b/c/parallel/api.h
@@ -21,7 +21,8 @@ namespace dt {
 using std::size_t;
 
 // Private
-void _parallel_for_static(size_t, size_t, function<void(size_t, size_t)>);
+void _parallel_for_static(size_t, size_t, size_t,
+                          function<void(size_t, size_t)>);
 
 
 //------------------------------------------------------------------------------
@@ -94,7 +95,7 @@ void barrier();
  */
 template <typename F>
 void parallel_for_static(size_t nrows, F f) {
-  _parallel_for_static(nrows, 4096,
+  _parallel_for_static(nrows, 4096, dt::num_threads_in_team(),
     [&](size_t i0, size_t i1) {
       for (size_t i = i0; i < i1; ++i) f(i);
     });
@@ -102,7 +103,17 @@ void parallel_for_static(size_t nrows, F f) {
 
 template <typename F>
 void parallel_for_static(size_t nrows, size_t chunk_size, F f) {
-  _parallel_for_static(nrows, chunk_size,
+  _parallel_for_static(nrows, chunk_size, dt::num_threads_in_team(),
+    [&](size_t i0, size_t i1) {
+      for (size_t i = i0; i < i1; ++i) f(i);
+    });
+}
+
+
+template <typename F>
+void parallel_for_static(size_t nrows, size_t chunk_size, size_t nthreads,
+                         F f) {
+  _parallel_for_static(nrows, chunk_size, nthreads,
     [&](size_t i0, size_t i1) {
       for (size_t i = i0; i < i1; ++i) f(i);
     });

--- a/c/parallel/parallel_for_dynamic.cc
+++ b/c/parallel/parallel_for_dynamic.cc
@@ -101,7 +101,7 @@ void dynamic_scheduler::abort_execution() {
 // parallel_for_dynamic
 //------------------------------------------------------------------------------
 
-void _parallel_for_dynamic(size_t nrows, size_t nthreads,
+void parallel_for_dynamic(size_t nrows, size_t nthreads,
                            function<void(size_t)> fn)
 {
   size_t ith = dt::this_thread_index();
@@ -130,14 +130,7 @@ void _parallel_for_dynamic(size_t nrows, size_t nthreads,
 
 
 void parallel_for_dynamic(size_t nrows, function<void(size_t)> fn) {
-  _parallel_for_dynamic(nrows, dt::num_threads_available(), fn);
-}
-
-void parallel_for_dynamic(size_t nrows,
-                          size_t nthreads,
-                          function<void(size_t)> fn)
-{
-  _parallel_for_dynamic(nrows, nthreads, fn);
+  parallel_for_dynamic(nrows, dt::num_threads_available(), fn);
 }
 
 

--- a/c/parallel/parallel_for_dynamic.cc
+++ b/c/parallel/parallel_for_dynamic.cc
@@ -120,6 +120,7 @@ void _parallel_for_dynamic(size_t nrows, size_t nthreads,
   else {
     thread_team* tt = thread_pool::get_team_unchecked();
     size_t tt_size = tt->size();
+    // Cannot change numnber of threads, if in a parallel region
     xassert(nthreads == tt_size);
     auto sch = tt->shared_scheduler<dynamic_scheduler>(tt_size, nrows);
     sch->set_task(fn, ith);

--- a/c/parallel/parallel_for_static.cc
+++ b/c/parallel/parallel_for_static.cc
@@ -27,7 +27,6 @@ void _parallel_for_static(size_t nrows, size_t min_chunk_size, size_t nthreads,
                           function<void(size_t, size_t)> fn)
 {
   size_t k = std::min(nrows / min_chunk_size, nthreads);
-
   size_t ith = dt::this_thread_index();
 
   // Standard parallel loop

--- a/c/parallel/parallel_for_static.cc
+++ b/c/parallel/parallel_for_static.cc
@@ -23,10 +23,10 @@ namespace dt {
 // parallel_for_static
 //------------------------------------------------------------------------------
 
-void _parallel_for_static(size_t nrows, size_t min_chunk_size,
+void _parallel_for_static(size_t nrows, size_t min_chunk_size, size_t nthreads,
                           function<void(size_t, size_t)> fn)
 {
-  size_t k = nrows / min_chunk_size;
+  size_t k = std::min(nrows / min_chunk_size, nthreads);
 
   size_t ith = dt::this_thread_index();
 
@@ -36,11 +36,11 @@ void _parallel_for_static(size_t nrows, size_t min_chunk_size,
       fn(0, nrows);
     }
     else {
-      size_t nth = num_threads_in_pool();
+      size_t nth = std::min(k, num_threads_in_pool());
       size_t chunksize = nrows / k;
       size_t nchunks = nrows / chunksize;
 
-      dt::parallel_region(
+      dt::parallel_region(nth,
         [=] {
           size_t ithread = this_thread_index();
           for (size_t j = ithread; j < nchunks; j += nth) {
@@ -58,7 +58,7 @@ void _parallel_for_static(size_t nrows, size_t min_chunk_size,
       if (ith == 0) fn(0, nrows);
     }
     else {
-      size_t nth = num_threads_in_team();
+      size_t nth = std::min(num_threads_in_team(), nthreads);
       size_t chunksize = nrows / k;
       size_t nchunks = nrows / chunksize;
 

--- a/c/parallel/parallel_for_static.cc
+++ b/c/parallel/parallel_for_static.cc
@@ -57,7 +57,9 @@ void _parallel_for_static(size_t nrows, size_t min_chunk_size, size_t nthreads,
       if (ith == 0) fn(0, nrows);
     }
     else {
-      size_t nth = std::min(num_threads_in_team(), nthreads);
+      size_t nth = num_threads_in_team();
+      // Cannot change numnber of threads, if in a parallel region
+      xassert(nth == nthreads);
       size_t chunksize = nrows / k;
       size_t nchunks = nrows / chunksize;
 

--- a/c/parallel/thread_pool.cc
+++ b/c/parallel/thread_pool.cc
@@ -158,6 +158,14 @@ size_t num_threads_in_team() {
   return _instance? _instance->n_threads_in_team() : 0;
 }
 
+size_t num_threads_available() {
+  size_t ith = dt::this_thread_index();
+  if (ith == size_t(-1)) {
+    return dt::num_threads_in_pool();
+  } else {
+    return dt::num_threads_in_team();
+  }
+}
 
 static thread_local size_t thread_index = size_t(-1);
 size_t this_thread_index() {


### PR DESCRIPTION
Add `nthreads` parameter to `parallel_for_static()` and `parallel_for_dynamic()`, so that when these functions are invoked not from `parallel_region()`, there is a way to adjust number of threads as needed.

Also, add a `dt::num_threads_available()` function, that returns number of threads in the pool, if called from the master thread, and number of threads in a team, otherwise.