### PR TITLE
Fixes for Ipython terminal 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,7 +114,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - The interactive mode is no longer improperly turned on in IPython (#1789).
 
 - Fixed issue with mis-aligned frame headers in IPython, caused by IPython
-  inserting "Out[X]:" in front of the rendered Frame display (#1793).
+  inserting `Out[X]:` in front of the rendered Frame display (#1793).
 
 - Improved rendering of Frames in terminals with white background: we no longer
   use 'bright_white' color for emphasis, only 'bold' (#1793).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - The interactive mode is no longer improperly turned on in IPython (#1789).
 
+- Fixed issue with mis-aligned frame headers in IPython, caused by IPython
+  inserting "Out[X]:" in front of the rendered Frame display (#1793).
+
+- Improved rendering of Frames in terminals with white background: we no longer
+  use 'bright_white' color for emphasis, only 'bold' (#1793).
+
 
 ### Changed
 
@@ -153,7 +159,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
   - [Arno Candel][] (#1619, #1730, #1738),
   - [Antorsae][] (#1639),
-  - [NachiGithub][] (#1789),
+  - [NachiGithub][] (#1789, #1793),
   - [Pasha Stetsenko][] (#1672, #1694, #1695, #1697, #1703, #1705)
 
 

--- a/c/frame/__repr__.cc
+++ b/c/frame/__repr__.cc
@@ -64,12 +64,12 @@ static const char* imgv =
     "i6KdW0w8AxFl+XL1lK8wAAAAASUVORK5CYII=');";
 
 static bool in_jupyter() {
-  static bool jup = !(py::oobj::import("datatable")
+  static bool jup = py::oobj::import("datatable")
                       .get_attr("utils")
                       .get_attr("terminal")
                       .get_attr("term")
                       .get_attr("jupyter")
-                      .is_none());
+                      .to_bool_strict();
   return jup;
 }
 

--- a/datatable/utils/terminal.py
+++ b/datatable/utils/terminal.py
@@ -36,6 +36,8 @@ _default_palette = {
 class Terminal:
 
     def __init__(self):
+        self.jupyter = False
+        self.ipython = False
         if sys.__stdin__ and sys.__stdout__:
             import blessed
             import _locale
@@ -62,7 +64,6 @@ class Terminal:
             self.is_a_tty = sys.__stdin__.isatty() and sys.__stdout__.isatty()
             self._width = 0
             self._height = 0
-            self.jupyter = None
             self._check_ipython()
         else:
             self._enable_keyboard = False
@@ -72,7 +73,6 @@ class Terminal:
             self.is_a_tty = False
             self._width = 80
             self._height = 25
-            self.jupyter = None
 
     @property
     def width(self):
@@ -100,13 +100,15 @@ class Terminal:
         # When running inside a Jupyter notebook, IPython and ipykernel will
         # already be preloaded (in sys.modules). We don't want to try to
         # import them, because it adds unnecessary startup delays.
-        if "IPython" in sys.modules and "ipykernel" in sys.modules:
-            IPython = sys.modules["IPython"]
-            ipykernel = sys.modules["ipykernel"]
-            ipy = IPython.get_ipython()
-            if ipy and isinstance(ipy, ipykernel.zmqshell.ZMQInteractiveShell):
+        if "IPython" in sys.modules:
+            ipy = sys.modules["IPython"].get_ipython()
+            ipy_type = str(type(ipy))
+            if "ZMQInteractiveShell" in ipy_type:
                 self._encoding = "UTF8"
-                self.jupyter = ipy
+                self.jupyter = True
+            elif "TerminalInteractiveShell" in ipy_type:
+                self.ipython = True
+
 
     def using_colors(self):
         return self._enable_colors

--- a/datatable/widget.py
+++ b/datatable/widget.py
@@ -487,8 +487,7 @@ class _Column(object):
         if self._width == 0:
             return ""
         else:
-            return (term.color("bright_white", self._format(self._name)) +
-                    self._rmargin)
+            return term.color("bold", self._format(self._name)) + self._rmargin
 
     @property
     def divider(self):

--- a/datatable/widget.py
+++ b/datatable/widget.py
@@ -255,6 +255,15 @@ class DataFrameWidget(object):
                 footer[2] = grey("Go to (row:col): ") + self._jump_string
 
         # Render the table
+        if term.ipython:
+            # In IPython, we insert an extra newline in front, because IPython
+            # prints "Out [3]: " in front of the output value, which causes all
+            # column headers to become misaligned.
+            # Likewise, IPython tends to insert an extra newline at the end of
+            # the output, so we remove our own extra newline.
+            header.insert(0, "")
+            if not footer[2]:
+                footer.pop()
         lines = header + rows + footer
         if to_string:
             return "\n".join(lines)

--- a/tests/random_driver.py
+++ b/tests/random_driver.py
@@ -36,8 +36,7 @@ def start_random_attack(n_attacks=None, maxfail=None):
             if n_errors >= maxfail:
                 raise KeyboardInterrupt
             if skip_successful_seeds:
-                print(term.color("bright_white",
-                        term.color("bold", " Seeds tried: %d" % (i + 1))),
+                print(term.color("bold", " Seeds tried: %d" % (i + 1)),
                       end="\r")
     except KeyboardInterrupt:
         errmsg = "errors: %d" % n_errors


### PR DESCRIPTION
- Frame headers are now aligned properly with their columns in IPython terminal;
- Use `bold` color instead of `bright_white` for emphasis: this works equally well on terminals with black backgrounds, and on terminals with white backgrounds (and I presume with any other backgrounds as well).

Closes #1793