### PR TITLE
Fixed a bug when assigning a frame in DT[i, f.newcol]=expr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Improved rendering of Frames in terminals with white background: we no longer
   use 'bright_white' color for emphasis, only 'bold' (#1793).
 
+- Fixed crash when a new column was created via partial assignment, i.e.
+  `DT[i, "new_col"] = expr` (#1800).
+
 
 ### Changed
 
@@ -157,7 +160,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Thanks to everyone who helped make `datatable` more stable by discovering
   and reporting bugs that were fixed in this release:
 
-  - [Arno Candel][] (#1619, #1730, #1738),
+  - [Arno Candel][] (#1619, #1730, #1738, #1800),
   - [Antorsae][] (#1639),
   - [NachiGithub][] (#1789, #1793),
   - [Pasha Stetsenko][] (#1672, #1694, #1695, #1697, #1703, #1705)

--- a/c/expr/repl_node.cc
+++ b/c/expr/repl_node.cc
@@ -101,7 +101,12 @@ void frame_rn::replace_values(workframe& wf, const intvec& indices) const {
   for (size_t i = 0; i < lcols; ++i) {
     size_t j = indices[i];
     Column* coli = dtr->columns[rcols == 1? 0 : i];
-    dt0->columns[j]->replace_values(ri0, coli);
+    Column* colj = dt0->columns[j];
+    if (!colj) {
+      colj = Column::new_na_column(coli->stype(), dt0->nrows);
+      dt0->columns[j] = colj;
+    }
+    colj->replace_values(ri0, coli);
   }
 }
 

--- a/tests/munging/test_assign.py
+++ b/tests/munging/test_assign.py
@@ -86,6 +86,24 @@ def test_assign_to_view():
     assert f0.to_list() == [list(range(10))]
 
 
+def test_assign_to_view2():
+    f0 = dt.Frame(A=range(10))
+    f0[::2, "B"] = 17
+    assert f0.to_list()[1] == [17, None] * 5
+
+
+def test_assign_to_view3():
+    f0 = dt.Frame(A=range(10))
+    f0[::2, "B"] = dt.Frame([5, 7, 9, 2, 1])
+    assert f0.to_list()[1] == [5, None, 7, None, 9, None, 2, None, 1, None]
+
+
+def test_assign_to_view4():
+    f0 = dt.Frame(A=range(10))
+    f0[1::2, "B"] = dt.Frame([3, 4])[[0, 1, 0, 1, 0], :]
+    assert f0.to_list()[1] == [None, 3, None, 4, None, 3, None, 4, None, 3]
+
+
 def test_assign_frame():
     f0 = dt.Frame({"A": range(10)})
     f1 = dt.Frame([i / 2 for i in range(100)])

--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -264,3 +264,15 @@ def test_issue1556():
     assert R.shape == (2, 2)
     assert R.to_dict() == {"A": ["Ahoy ye matey!", "hey"],
                            "B": [None, "Avast"]}
+
+
+def test_issue1800():
+    X1 = dt.Frame(A=range(5), B=[0.1, 0.2, 0.3, 0.4, 0.5])
+    X1.key = "A"
+    X2 = dt.Frame(A=[0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5])
+    joined = X2[:, :, dt.join(X1)]
+    idx = dt.Frame([True] * X2.nrows)
+    X2[idx, "N"] = joined[idx, "B"]
+    assert X2.to_dict() == {"A": [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5],
+                            "N": [0.1, 0.1, 0.2, 0.2, 0.3, 0.3, 0.4, 0.4,
+                                  0.5, 0.5, None, None]}


### PR DESCRIPTION
Function `replace_values` was not handling the case when the column where the values ought to be replaced does not exist yet, which caused crashes / unpredictable behavior.

Closes #1800