### PR TITLE
Fixed bad frame creation  when using parameter max_nrows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,7 +160,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Thanks to everyone who helped make `datatable` more stable by discovering
   and reporting bugs that were fixed in this release:
 
-  - [Arno Candel][] (#1619, #1730, #1738, #1800),
+  - [Arno Candel][] (#1619, #1730, #1738, #1800, #1803),
   - [Antorsae][] (#1639),
   - [NachiGithub][] (#1789, #1793),
   - [Pasha Stetsenko][] (#1672, #1694, #1695, #1697, #1703, #1705)

--- a/c/read/parallel_reader.cc
+++ b/c/read/parallel_reader.cc
@@ -205,7 +205,7 @@ void ParallelReader::read_all()
               tctx->used_nrows = nrows_max - nrows_written;
               nrows_new = nrows_max;
               realloc_output_columns(i, nrows_new);
-              o->set_n_iterations(i);
+              o->set_n_iterations(i + 1);
             } else {
               realloc_output_columns(i, nrows_new);
             }

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -140,10 +140,10 @@ def random_string(n):
 def find_file(*nameparts):
     root_var = "DT_LARGE_TESTS_ROOT"
     d = os.environ.get(root_var, "").strip()
-    filename = os.path.join(d, *nameparts)
     if not d:
-        pytest.skip("%s is not defined" % root_var)
-    elif not os.path.isdir(d):
+        return pytest.skip("%s is not defined" % root_var)
+    filename = os.path.join(d, *nameparts)
+    if not os.path.isdir(d):
         pytest.fail("Directory '%s' does not exist" % d)
     elif not os.path.isfile(filename):
         pytest.skip("File %s not found" % filename)

--- a/tests/fread/test_fread_issues.py
+++ b/tests/fread/test_fread_issues.py
@@ -491,3 +491,15 @@ def test_issue1233():
     # which means the re-read has to happen more than once too...
     d0 = dt.fread("NaN\n2\n")
     assert d0.to_list() == [[None, 2.0]]
+
+
+def test_issue1803():
+    ff = find_file("h2o-3", "smalldata", "airlines", "allyears2k.zip")
+    d0 = dt.fread(ff, max_nrows=10000)
+    frame_integrity_check(d0)
+    assert d0.nrows == 10000
+    assert d0[-1, :].to_tuples() == [(1992, 1, 6, 1, 752, 750, 838, 846, 'US',
+                                      53, None, 46, 56, None, -8, 2, 'CMH',
+                                      'IND', 182, None, None, False, None,
+                                      False, None, None, None, None, None,
+                                      'NO', 'YES')]


### PR DESCRIPTION
Off-by-1 error in parallel reader: current iteration was marked as last in the ordered section when max_nrows was reached, however in such a way that the last chunk was not properly finalized.

Closes #1803