### PR TITLE
Fix nthreads usage in parallel_for_dynamic, add C++ tests

### DIFF
--- a/c/parallel/parallel_for_dynamic.cc
+++ b/c/parallel/parallel_for_dynamic.cc
@@ -22,7 +22,6 @@
 #include "utils/assert.h"
 #include "utils/function.h"
 #include "utils/macros.h"          // cache_aligned
-#include <iostream>
 namespace dt {
 
 

--- a/c/parallel/parallel_for_dynamic.cc
+++ b/c/parallel/parallel_for_dynamic.cc
@@ -22,6 +22,7 @@
 #include "utils/assert.h"
 #include "utils/function.h"
 #include "utils/macros.h"          // cache_aligned
+#include <iostream>
 namespace dt {
 
 
@@ -51,6 +52,7 @@ void dynamic_task::execute(thread_worker*) {
 class dynamic_scheduler : public thread_scheduler {
   private:
     std::vector<cache_aligned<dynamic_task>> tasks;
+    size_t nthreads;
     size_t num_iterations;
     std::atomic<size_t> iteration_index;
 
@@ -63,15 +65,16 @@ class dynamic_scheduler : public thread_scheduler {
 };
 
 
-dynamic_scheduler::dynamic_scheduler(size_t nthreads, size_t niters)
-  : tasks(nthreads),
+dynamic_scheduler::dynamic_scheduler(size_t nthreads_, size_t niters)
+  : tasks(nthreads_),
+    nthreads(nthreads_),
     num_iterations(niters),
     iteration_index(0) {}
 
 
 void dynamic_scheduler::set_task(function<void(size_t)> f) {
-  for (auto& task : tasks)
-    task.v.fn = f;
+  for (size_t i = 0; i < nthreads; ++i)
+    tasks[i].v.fn = f;
 }
 
 void dynamic_scheduler::set_task(function<void(size_t)> f, size_t i) {
@@ -80,6 +83,7 @@ void dynamic_scheduler::set_task(function<void(size_t)> f, size_t i) {
 
 
 thread_task* dynamic_scheduler::get_next_task(size_t thread_index) {
+  if (thread_index >= nthreads) return nullptr;
   size_t next_iter = iteration_index.fetch_add(1);
   if (next_iter >= num_iterations) {
     return nullptr;
@@ -97,6 +101,7 @@ void dynamic_scheduler::abort_execution() {
 
 
 
+
 //------------------------------------------------------------------------------
 // parallel_for_dynamic
 //------------------------------------------------------------------------------
@@ -109,7 +114,10 @@ void parallel_for_dynamic(size_t nrows, size_t nthreads,
   // Running from the master thread
   if (ith == size_t(-1)) {
     thread_pool* thpool = thread_pool::get_instance_unchecked();
-    size_t tt_size = std::min(nthreads, thpool->size());
+
+    size_t tp_size = thpool->size();
+    if (nthreads == 0) nthreads = tp_size;
+    size_t tt_size = std::min(nthreads, tp_size);
     thread_team tt(tt_size, thpool);
     dynamic_scheduler sch(tt_size, nrows);
     sch.set_task(fn);

--- a/c/parallel/parallel_for_static.cc
+++ b/c/parallel/parallel_for_static.cc
@@ -23,9 +23,10 @@ namespace dt {
 // parallel_for_static
 //------------------------------------------------------------------------------
 
-void _parallel_for_static(size_t nrows, size_t min_chunk_size, size_t nthreads,
-                          function<void(size_t, size_t)> fn)
+void _parallel_for_static(size_t nrows, size_t min_chunk_size,
+                          size_t nthreads_in, function<void(size_t, size_t)> fn)
 {
+  size_t nthreads = nthreads_in? nthreads_in : dt::num_threads_in_pool();
   size_t k = std::min(nrows / min_chunk_size, nthreads);
   size_t ith = dt::this_thread_index();
 

--- a/c/parallel/ztest_parallel_for.cc
+++ b/c/parallel/ztest_parallel_for.cc
@@ -22,18 +22,41 @@
 namespace dttest {
 
 
+void test_parallel_for_static(size_t n) {
+  for (size_t nth = 0; nth <= dt::num_threads_in_pool(); ++nth) {
+    std::vector<size_t> data(n, 0);
+
+    dt::parallel_for_static(n, 1, nth,
+      [&](size_t i) {
+        data[i] += 1 + 2 * i;
+      });
+
+    for (size_t i = 0; i < n; ++i) {
+      if (data[i] != 1 + 2*i) {
+        throw AssertionError() << "Incorrect data[" << i << "] = " << data[i]
+          << " in test_parallel_for_static() for nth = " << nth
+          << ", expected " << 1 + 2*i;
+      }
+    }
+  }
+}
+
+
 void test_parallel_for_dynamic(size_t n) {
-  std::vector<size_t> data(n, 0);
+  for (size_t nth = 0; nth <= dt::num_threads_in_pool(); ++nth) {
+    std::vector<size_t> data(n, 0);
 
-  dt::parallel_for_dynamic(n,
-    [&](size_t i) {
-      data[i] += 1 + 2 * i;
-    });
+    dt::parallel_for_dynamic(n, nth,
+      [&](size_t i) {
+        data[i] += 1 + 2 * i;
+      });
 
-  for (size_t i = 0; i < n; ++i) {
-    if (data[i] != 1 + 2*i) {
-      throw AssertionError() << "Incorrect data[" << i << "] = " << data[i]
-        << " in test_parallel_for_dynamic(), expected " << 1 + 2*i;
+    for (size_t i = 0; i < n; ++i) {
+      if (data[i] != 1 + 2*i) {
+        throw AssertionError() << "Incorrect data[" << i << "] = " << data[i]
+          << " in test_parallel_for_dynamic() for nth = " << nth
+          << ", expected " << 1 + 2*i;
+      }
     }
   }
 }

--- a/c/ztest.cc
+++ b/c/ztest.cc
@@ -50,6 +50,15 @@ static void test_barrier(const PKArgs& args) {
 }
 
 
+static PKArgs arg_test_parallel_for_static(
+  1, 0, 0, false, false, {"n"}, "test_parallel_for_static");
+
+static void test_parallel_for_static(const PKArgs& args) {
+  size_t n = args[0].to_size_t();
+  dttest::test_parallel_for_static(n);
+}
+
+
 static PKArgs arg_test_parallel_for_dynamic(
   1, 0, 0, false, false, {"n"}, "test_parallel_for_dynamic");
 
@@ -75,6 +84,7 @@ void DatatableModule::init_tests() {
   ADD_FN(&test_shmutex, arg_test_shmutex);
   ADD_FN(&test_atomic, arg_test_atomic);
   ADD_FN(&test_barrier, arg_test_barrier);
+  ADD_FN(&test_parallel_for_static, arg_test_parallel_for_static);
   ADD_FN(&test_parallel_for_dynamic, arg_test_parallel_for_dynamic);
   ADD_FN(&test_parallel_for_ordered, arg_test_parallel_for_ordered);
 }

--- a/c/ztest.h
+++ b/c/ztest.h
@@ -27,6 +27,7 @@ void test_atomic();
 void test_barrier(size_t);
 
 // Defined in parallel/ztest_parallel_for.cc
+void test_parallel_for_static(size_t);
 void test_parallel_for_dynamic(size_t);
 void test_parallel_for_dynamic_nested(size_t);
 void test_parallel_for_ordered(size_t);

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -40,7 +40,8 @@ from tests import same_iterables, list_equals, noop, isview, assert_equals
 # Check if we need to run C++ tests
 #-------------------------------------------------------------------------------
 
-cpp_tests_enabled = hasattr(core, "test_coverage")
+cpp_test = pytest.mark.skipif(not hasattr(core, "test_coverage"),
+                              reason="C++ tests were not compiled")
 
 #-------------------------------------------------------------------------------
 # Prepare fixtures & helper functions
@@ -174,11 +175,9 @@ def test_sizeof():
     DT2 = dt.Frame(A=["foo" * 1001])
     assert sys.getsizeof(DT2) - sys.getsizeof(DT1) == 3000
 
-
+@cpp_test
 def test_coverage():
-    # Run additional C++ tests that ensure better coverage of underlying classes
-    if cpp_tests_enabled:
-        core.test_coverage()
+    core.test_coverage()
 
 
 def test_multiprocessing_threadpool():
@@ -195,49 +194,49 @@ def test_multiprocessing_threadpool():
         assert chthreads != parent_threads
 
 
+@cpp_test
 def test_internal_shared_mutex():
-    if cpp_tests_enabled:
-        core.test_shmutex(500, dt.options.nthreads * 2, 1)
+    core.test_shmutex(500, dt.options.nthreads * 2, 1)
 
 
+@cpp_test
 def test_internal_shared_bmutex():
-    if cpp_tests_enabled:
-        core.test_shmutex(1000, dt.options.nthreads * 2, 0)
+    core.test_shmutex(1000, dt.options.nthreads * 2, 0)
 
 
+@cpp_test
 def test_internal_atomic():
-    if cpp_tests_enabled:
-        core.test_atomic()
+    core.test_atomic()
 
 
+@cpp_test
 def test_internal_barrier():
-    if cpp_tests_enabled:
-        core.test_barrier(100)
+    core.test_barrier(100)
 
 
+@cpp_test
 def test_internal_parallel_for_static():
-    if cpp_tests_enabled:
-        core.test_parallel_for_static(1000)
+    core.test_parallel_for_static(1000)
 
 
+@cpp_test
 def test_internal_parallel_for_dynamic():
-    if cpp_tests_enabled:
-        core.test_parallel_for_dynamic(1000)
+    core.test_parallel_for_dynamic(1000)
 
 
+@cpp_test
 def test_internal_parallel_for_ordered1():
-    if cpp_tests_enabled:
-        core.test_parallel_for_ordered(17234)
+    core.test_parallel_for_ordered(17234)
 
 
+@cpp_test
 def test_internal_parallel_for_ordered2():
-    if cpp_tests_enabled:
-        n0 = dt.options.nthreads
-        try:
-            dt.options.nthreads = 2
-            core.test_parallel_for_ordered(17234)
-        finally:
-            dt.options.nthreads = n0
+    n0 = dt.options.nthreads
+    try:
+        dt.options.nthreads = 2
+        core.test_parallel_for_ordered(17234)
+    finally:
+        dt.options.nthreads = n0
 
 
 

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -32,9 +32,15 @@ import time
 from collections import namedtuple
 from datatable import stype, ltype
 from datatable.internal import frame_column_rowindex, frame_integrity_check
+from datatable.lib import core
 from tests import same_iterables, list_equals, noop, isview, assert_equals
 
 
+#-------------------------------------------------------------------------------
+# Check if we need to run C++ tests
+#-------------------------------------------------------------------------------
+
+cpp_tests_enabled = hasattr(core, "test_coverage")
 
 #-------------------------------------------------------------------------------
 # Prepare fixtures & helper functions
@@ -171,8 +177,7 @@ def test_sizeof():
 
 def test_coverage():
     # Run additional C++ tests that ensure better coverage of underlying classes
-    from datatable.lib import core
-    if hasattr(core, "test_coverage"):
+    if cpp_tests_enabled:
         core.test_coverage()
 
 
@@ -191,44 +196,42 @@ def test_multiprocessing_threadpool():
 
 
 def test_internal_shared_mutex():
-    from datatable.lib import core
-    if hasattr(core, "test_shmutex"):
+    if cpp_tests_enabled:
         core.test_shmutex(500, dt.options.nthreads * 2, 1)
 
 
 def test_internal_shared_bmutex():
-    from datatable.lib import core
-    if hasattr(core, "test_shmutex"):
+    if cpp_tests_enabled:
         core.test_shmutex(1000, dt.options.nthreads * 2, 0)
 
 
 def test_internal_atomic():
-    from datatable.lib import core
-    if hasattr(core, "test_atomic"):
+    if cpp_tests_enabled:
         core.test_atomic()
 
 
 def test_internal_barrier():
-    from datatable.lib import core
-    if hasattr(core, "test_barrier"):
+    if cpp_tests_enabled:
         core.test_barrier(100)
 
 
+def test_internal_parallel_for_static():
+    if cpp_tests_enabled:
+        core.test_parallel_for_static(1000)
+
+
 def test_internal_parallel_for_dynamic():
-    from datatable.lib import core
-    if hasattr(core, "test_parallel_for_dynamic"):
+    if cpp_tests_enabled:
         core.test_parallel_for_dynamic(1000)
 
 
 def test_internal_parallel_for_ordered1():
-    from datatable.lib import core
-    if hasattr(core, "test_parallel_for_ordered"):
+    if cpp_tests_enabled:
         core.test_parallel_for_ordered(17234)
 
 
 def test_internal_parallel_for_ordered2():
-    from datatable.lib import core
-    if hasattr(core, "test_parallel_for_ordered"):
+    if cpp_tests_enabled:
         n0 = dt.options.nthreads
         try:
             dt.options.nthreads = 2


### PR DESCRIPTION
- with @st-pasha's help fix `dt::parallel_for_dynamic()` that didn't account for `nthreads` being less than `num_threads_in_pool()`;
- add C++ tests for `parallel_for_static()` and `parallel_for_dynamic()` that test the above fix.