### PR TITLE
Fix attempt for parallel dynamic loop

### DIFF
--- a/c/parallel/api.h
+++ b/c/parallel/api.h
@@ -16,13 +16,14 @@
 #ifndef dt_PARALLEL_API_h
 #define dt_PARALLEL_API_h
 #include <cstddef>
+#include <functional>    // std::function
 #include "utils/function.h"
 namespace dt {
 using std::size_t;
 
 // Private
 void _parallel_for_static(size_t, size_t, size_t,
-                          function<void(size_t, size_t)>);
+                          std::function<void(size_t, size_t)>);
 
 
 //------------------------------------------------------------------------------
@@ -131,9 +132,9 @@ void parallel_for_static(size_t nrows, size_t chunk_size, size_t nthreads,
 /**
  * Run parallel loop `for i in range(nrows): f(i)`, with dynamic scheduling.
  */
-void parallel_for_dynamic(size_t nrows, function<void(size_t)> fn);
+void parallel_for_dynamic(size_t nrows, std::function<void(size_t)> fn);
 void parallel_for_dynamic(size_t nrows, size_t nthreads,
-                          function<void(size_t)> fn);
+                          std::function<void(size_t)> fn);
 
 
 

--- a/c/parallel/parallel_for_static.cc
+++ b/c/parallel/parallel_for_static.cc
@@ -24,7 +24,8 @@ namespace dt {
 //------------------------------------------------------------------------------
 
 void _parallel_for_static(size_t nrows, size_t min_chunk_size,
-                          size_t nthreads_in, function<void(size_t, size_t)> fn)
+                          size_t nthreads_in,
+                          std::function<void(size_t, size_t)> fn)
 {
   size_t nthreads = nthreads_in? nthreads_in : dt::num_threads_in_pool();
   size_t k = std::min(nrows / min_chunk_size, nthreads);

--- a/c/parallel/thread_scheduler.h
+++ b/c/parallel/thread_scheduler.h
@@ -26,8 +26,6 @@ class thread_worker;
 class thread_task {
   public:
     thread_task() = default;
-    thread_task(const thread_task&) = default;
-    thread_task(thread_task&&) = default;
     virtual ~thread_task();
     virtual void execute(thread_worker*) = 0;
 };

--- a/c/parallel/thread_team.cc
+++ b/c/parallel/thread_team.cc
@@ -36,7 +36,8 @@ thread_team::thread_team(size_t nth, thread_pool* pool)
 
 thread_team::~thread_team() {
   thpool->current_team = nullptr;
-  delete nested_scheduler;
+  auto tmp = nested_scheduler.load();
+  delete tmp;
 }
 
 

--- a/c/utils/function.h
+++ b/c/utils/function.h
@@ -47,7 +47,7 @@ class function<TReturn(TArgs...)>
     using callback_t = TReturn (*)(fptr, TArgs...);
 
     callback_t _callback = nullptr;
-    fptr _callable;
+    fptr _callable = nullptr;
 
     template<typename F>
     static TReturn callback_fn(fptr callable, TArgs ...params) {
@@ -58,6 +58,8 @@ class function<TReturn(TArgs...)>
   public:
     function() = default;
     function(std::nullptr_t) {}
+    function(const function&) = default;
+    function& operator=(const function&) = default;
 
     template <typename F, typename = typename std::enable_if<
                      !std::is_same<typename std::remove_reference<F>::type,

--- a/c/utils/macros.h
+++ b/c/utils/macros.h
@@ -43,6 +43,10 @@
   #define CACHELINE_SIZE 64
 #endif
 
+#define PAD_TO_CACHELINE(sz) \
+  char __attribute__((unused)) _padding[ \
+    (CACHELINE_SIZE - ((sz) % CACHELINE_SIZE)) % CACHELINE_SIZE]
+
 
 // Helper template to replace type `T` with a cache-aligned + padded wrapper
 // type. Using this structure may help reduce false sharing


### PR DESCRIPTION
An attempt to fix a rare exception that was showing up on ppc64le.

- Use `std::function` instead of `dt::function` in `parallel_for_static` and `parallel_for_dynamic`. The idea is that when these functions are used in a parallel region, then all executors are running at a different pace in different threads, and some of them will exit sooner than the others. When that happens, the compiler may decide to garbage-collect the function object while it is still being used in other threads.
- Instead of `cache_aligned<dynamic_task>` make `dynamic_task` cache-aligned naturally, to simplify debugging;
- `thread_team::shared_scheduler()` is now more careful about accessing `nested_scheduler` variable: it is now made atomic.