### PR TITLE
Fix compilation on older MacOS

### DIFF
--- a/c/column.h
+++ b/c/column.h
@@ -23,7 +23,6 @@
 #define dt_COLUMN_h
 #include <string>
 #include <vector>
-#include <Python.h>
 #include "groupby.h"
 #include "memrange.h"     // MemoryRange
 #include "python/list.h"

--- a/c/column_bool.cc
+++ b/c/column_bool.cc
@@ -5,7 +5,6 @@
 //
 // © H2O.ai 2018
 //------------------------------------------------------------------------------
-#include <Python.h>
 #include "python/_all.h"
 #include "column.h"
 #include "datatablemodule.h"

--- a/c/csv/reader_parsers.h
+++ b/c/csv/reader_parsers.h
@@ -9,7 +9,6 @@
 #define dt_CSV_READER_PARSERS_h
 #include <string>
 #include <vector>
-#include <Python.h>
 #include "types.h"
 
 namespace dt {

--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -12,7 +12,6 @@
 #include <sstream>         // std::stringstream
 #include <unordered_map>   // std::unordered_map
 #include <utility>         // std::pair, std::make_pair, std::move
-#include <Python.h>
 #include "../datatable/include/datatable.h"
 #include "csv/reader.h"
 #include "expr/base_expr.h"

--- a/c/encodings.h
+++ b/c/encodings.h
@@ -7,7 +7,8 @@
 //------------------------------------------------------------------------------
 #ifndef dt_ENCODINGS_H
 #define dt_ENCODINGS_H
-#include <stdint.h>
+#include <cstdint>
+using std::size_t;
 
 
 int is_valid_utf8(const uint8_t* src, size_t len);
@@ -19,5 +20,6 @@ int decode_escaped_csv_string(const uint8_t* src, int len, uint8_t* dest, uint8_
 int decode_sbcs(const uint8_t* src, int len, uint8_t* dest, uint32_t *map);
 
 int64_t utf32_to_utf8(uint32_t* buf, size_t maxchars, char* ch);
+
 
 #endif

--- a/c/memrange.h
+++ b/c/memrange.h
@@ -11,7 +11,6 @@
 #include <memory>             // std::unique_ptr
 #include <string>             // std::string
 #include <type_traits>        // std::is_same
-#include <Python.h>
 #include "utils/assert.h"
 #include "utils/exceptions.h"
 #include "writebuf.h"

--- a/c/parallel/parallel_for_ordered.cc
+++ b/c/parallel/parallel_for_ordered.cc
@@ -54,7 +54,7 @@ class ordered_task : public thread_task {
   public:
     ordered_task(f1t pre, f1t ord, f1t post);
     ordered_task(const ordered_task&) = delete;
-    ordered_task(ordered_task&&) = default;
+    ordered_task(ordered_task&&);
 
     bool ready_to_start()  const noexcept { return state == READY_TO_START; }
     bool ready_to_order()  const noexcept { return state == READY_TO_ORDER; }
@@ -74,6 +74,12 @@ ordered_task::ordered_task(f1t pre, f1t ord, f1t post)
     state(READY_TO_START),
     n_iter(0) {}
 
+ordered_task::ordered_task(ordered_task&& other)
+  : pre_ordered(std::move(other.pre_ordered)),
+    ordered(std::move(other.ordered)),
+    post_ordered(std::move(other.post_ordered)),
+    state(other.state),
+    n_iter(other.n_iter) {}
 
 void ordered_task::advance_state() {
   state++;

--- a/c/progress/_options.cc
+++ b/c/progress/_options.cc
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //------------------------------------------------------------------------------
-#include <Python.h>   // PyObject, Py_XSETREF
 #include "models/py_validator.h"
 #include "progress/_options.h"
 #include "python/_all.h"

--- a/c/progress/_options.h
+++ b/c/progress/_options.h
@@ -17,7 +17,7 @@
 // "options.h" from the parent directory.
 #ifndef dt_PROGRESS_OPTIONS_h
 #define dt_PROGRESS_OPTIONS_h
-#include <Python.h>
+#include "python/python.h"
 namespace dt {
 namespace progress {
 

--- a/c/progress/progress_bar.cc
+++ b/c/progress/progress_bar.cc
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //------------------------------------------------------------------------------
-#include <Python.h>
 #include "progress/_options.h"
 #include "progress/progress_bar.h"
 #include "python/string.h"          // py::ostring

--- a/c/py_encodings.h
+++ b/c/py_encodings.h
@@ -7,11 +7,11 @@
 //------------------------------------------------------------------------------
 #ifndef dt_PY_ENCODINGS_H
 #define dt_PY_ENCODINGS_H
-#include <Python.h>
+#include "python/python.h"
 #include "encodings.h"
 
 
-int init_py_encodings(PyObject *module);
+int init_py_encodings(PyObject* module);
 
 int decode_iso8859(const uint8_t* src, int len, uint8_t* dest);
 int decode_win1252(const uint8_t* src, int len, uint8_t* dest);

--- a/c/python/_all.h
+++ b/c/python/_all.h
@@ -19,6 +19,8 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
+#include "python/python.h"
+
 #include "python/bool.h"
 #include "python/dict.h"
 #include "python/float.h"

--- a/c/python/arg.h
+++ b/c/python/arg.h
@@ -9,12 +9,8 @@
 #define dt_PYTHON_ARG_h
 #include <string>     // std::string
 #include <vector>     // std::vector
-#include <Python.h>
-#include "python/iter.h"
+#include "python/_all.h"
 #include "python/list.h"
-#include "python/obj.h"
-#include "python/tuple.h"
-
 namespace py {
 
 class PKArgs;

--- a/c/python/args.h
+++ b/c/python/args.h
@@ -17,7 +17,6 @@
 #define dt_PYTHON_ARGS_h
 #include <unordered_map>   // std::unordered_map
 #include <vector>          // std::vector
-#include <Python.h>
 #include "python/arg.h"
 #include "utils/assert.h"
 #include "utils/exceptions.h"

--- a/c/python/dict.h
+++ b/c/python/dict.h
@@ -21,7 +21,6 @@
 //------------------------------------------------------------------------------
 #ifndef dt_PYTHON_DICT_h
 #define dt_PYTHON_DICT_h
-#include <Python.h>
 #include "python/obj.h"
 
 namespace py {

--- a/c/python/ext_module.h
+++ b/c/python/ext_module.h
@@ -16,7 +16,6 @@
 #ifndef dt_PYTHON_EXT_MODULE_h
 #define dt_PYTHON_EXT_MODULE_h
 #include <vector>
-#include <Python.h>
 #include "python/args.h"
 #include "python/obj.h"
 #include "utils/exceptions.h"

--- a/c/python/ext_type.h
+++ b/c/python/ext_type.h
@@ -16,7 +16,6 @@
 #ifndef dt_PYTHON_EXT_TYPE_h
 #define dt_PYTHON_EXT_TYPE_h
 #include <vector>
-#include <Python.h>
 #include "python/args.h"
 #include "python/obj.h"
 #include "utils/exceptions.h"

--- a/c/python/float.h
+++ b/c/python/float.h
@@ -21,7 +21,6 @@
 //------------------------------------------------------------------------------
 #ifndef dt_PYTHON_FLOAT_h
 #define dt_PYTHON_FLOAT_h
-#include <Python.h>
 #include "python/obj.h"
 
 namespace py {

--- a/c/python/int.h
+++ b/c/python/int.h
@@ -21,7 +21,6 @@
 //------------------------------------------------------------------------------
 #ifndef dt_PYTHON_INT_h
 #define dt_PYTHON_INT_h
-#include <Python.h>
 #include "python/obj.h"
 
 namespace py {

--- a/c/python/iter.h
+++ b/c/python/iter.h
@@ -21,7 +21,6 @@
 //------------------------------------------------------------------------------
 #ifndef dt_PYTHON_ITER_h
 #define dt_PYTHON_ITER_h
-#include <Python.h>
 #include "python/obj.h"
 
 namespace py {

--- a/c/python/list.h
+++ b/c/python/list.h
@@ -7,7 +7,6 @@
 //------------------------------------------------------------------------------
 #ifndef dt_PYTHON_LIST_h
 #define dt_PYTHON_LIST_h
-#include <Python.h>
 #include "python/obj.h"
 
 namespace py {

--- a/c/python/namedtuple.h
+++ b/c/python/namedtuple.h
@@ -21,7 +21,6 @@
 //------------------------------------------------------------------------------
 #ifndef dt_PYTHON_NAMEDTUPLE_h
 #define dt_PYTHON_NAMEDTUPLE_h
-#include <Python.h>
 #include "python/obj.h"
 #include "python/tuple.h"
 

--- a/c/python/obj.h
+++ b/c/python/obj.h
@@ -9,7 +9,6 @@
 #define dt_PYTHON_OBJ_h
 #include <string>
 #include <vector>
-#include <Python.h>
 #include "types.h"             // CString
 #include "utils/exceptions.h"  // Error
 

--- a/c/python/oset.h
+++ b/c/python/oset.h
@@ -7,9 +7,7 @@
 //------------------------------------------------------------------------------
 #ifndef dt_PYTHON_OSET_h
 #define dt_PYTHON_OSET_h
-#include <Python.h>
 #include "python/obj.h"
-
 namespace py {
 
 

--- a/c/python/python.h
+++ b/c/python/python.h
@@ -19,24 +19,8 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
-#ifndef dt_PYTHON_BOOL_h
-#define dt_PYTHON_BOOL_h
-#include "python/obj.h"
 
-namespace py {
-
-
-class obool : public oobj {
-  public:
-    obool() = default;
-    obool(const obool&) = default;
-    obool(obool&&) = default;
-    obool& operator=(const obool&) = default;
-    obool& operator=(obool&&) = default;
-
-    explicit obool(bool x);
-};
-
-
-}  // namespace py
-#endif
+// This header must be included before <Python.h>, otherwise datatable won't
+// compile on MacOS with Apple LLVM clang 9.1.0
+#include <locale>
+#include <Python.h>

--- a/c/python/range.h
+++ b/c/python/range.h
@@ -21,7 +21,6 @@
 //------------------------------------------------------------------------------
 #ifndef dt_PYTHON_RANGE_h
 #define dt_PYTHON_RANGE_h
-#include <Python.h>
 #include "python/obj.h"
 namespace py {
 

--- a/c/python/slice.h
+++ b/c/python/slice.h
@@ -21,7 +21,6 @@
 //------------------------------------------------------------------------------
 #ifndef dt_PYTHON_SLICE_h
 #define dt_PYTHON_SLICE_h
-#include <Python.h>
 #include "python/obj.h"
 
 namespace py {

--- a/c/python/string.h
+++ b/c/python/string.h
@@ -7,7 +7,6 @@
 //------------------------------------------------------------------------------
 #ifndef dt_PYTHON_STRING_h
 #define dt_PYTHON_STRING_h
-#include <Python.h>
 #include <string>
 #include "python/obj.h"
 

--- a/c/python/tuple.h
+++ b/c/python/tuple.h
@@ -22,7 +22,6 @@
 #ifndef dt_PYTHON_TUPLE_h
 #define dt_PYTHON_TUPLE_h
 #include <initializer_list>
-#include <Python.h>
 #include "python/obj.h"
 
 namespace py {

--- a/c/types.h
+++ b/c/types.h
@@ -11,7 +11,7 @@
 #include <cmath>     // isnan
 #include <limits>    // std::numeric_limits
 #include <string>    // std::string
-#include <Python.h>
+#include "python/python.h"
 
 
 struct CString {

--- a/c/utils/exceptions.h
+++ b/c/utils/exceptions.h
@@ -7,11 +7,10 @@
 //------------------------------------------------------------------------------
 #ifndef dt_UTILS_EXCEPTIONS_h
 #define dt_UTILS_EXCEPTIONS_h
-#include <Python.h>
-#include <stdint.h>
-#include <exception>
+#include <cstdint>
+#include <exception>  // std::exception
 #include <sstream>    // std::ostringstream
-#include <stdexcept>
+#include <string>     // std::string
 #include "types.h"
 
 class CErrno {};

--- a/c/utils/misc.h
+++ b/c/utils/misc.h
@@ -7,7 +7,6 @@
 //------------------------------------------------------------------------------
 #ifndef dt_UTILS_h
 #define dt_UTILS_h
-#include <Python.h>
 #include <stddef.h>
 #include <stdio.h>     // vsnprintf
 #include <stdint.h>

--- a/ci/asan-python.c
+++ b/ci/asan-python.c
@@ -6,6 +6,7 @@ $LLVM6/bin/clang \
   -L/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/config-3.6m-darwin -lpython3.6m -ldl -framework CoreFoundation \
   -fsanitize=address -o asan-python asan-python.c
 */
+#include <locale>  // do not remove (#1824)
 #include <Python.h>
 #include <dirent.h>
 

--- a/datatable/include/datatable.h
+++ b/datatable/include/datatable.h
@@ -21,6 +21,7 @@
 //------------------------------------------------------------------------------
 #ifndef dt_API_h
 #define dt_API_h
+#include <locale>  // do not remove (#1824)
 #include <Python.h>
 
 // This header file may be included from C code

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,13 @@ Build script for the `datatable` module.
 import os
 import shutil
 import sys
-assert sys.version_info >= (3, 5), "Unsupported python version: " + sys.version
+if sys.version_info < (3, 5):
+    # Check python version here, otherwise the import from ci.setup_utils
+    # below will fail in Python 2.7 with confusing error message
+    raise SystemExit("\x1B[91m\nSystemExit: datatable requires Python 3.5+, "
+                     "whereas your Python is %s\n\x1B[39m"
+                     % ".".join(str(d) for d in sys.version_info))
+
 from setuptools import setup, find_packages, Extension
 from ci.setup_utils import (get_datatable_version, make_git_version_file,
                             get_compiler, get_extra_compile_flags,


### PR DESCRIPTION
The problem described in #1824 was resolved by including header `<locale>` before `<Python.h>`.

In addition, improved error message displayed when trying to build datatable under Python2; 
also fixed a warning in `ordered_task`.

Closes #1824