### PR TITLE
Change the calling convention dt.options.progress.callback function

### DIFF
--- a/c/progress/_options.cc
+++ b/c/progress/_options.cc
@@ -138,18 +138,16 @@ static void init_option_callback(){
     "progress.callback",
     get_callback,
     set_callback,
-    "If None, then the builtin progress-reporting function will be used.\n"
-    "Otherwise, this value specifies a function or object to be called\n"
-    "at each progress event.\n"
+    "If None, then the built-in progress-reporting function will be used.\n"
+    "Otherwise, this value specifies a function to be called at each\n"
+    "progress event. The function takes a single parameter `p`, which is\n"
+    "a namedtuple with the following fields:\n"
     "\n"
-    "The function is expected to have the following signature:\n"
-    "\n"
-    "    fn(progress, status, message)\n"
-    "\n"
-    "where `progress` is a float in the range 0.0 .. 1.0; `status` is a\n"
-    "string, one of 'running', 'finished', 'error' or 'cancelled'; and\n"
-    "`message` is a custom string describing the operation currently\n"
-    "being performed."
+    "  - `p.progress` is a float in the range 0.0 .. 1.0;\n"
+    "  - `p.status` is a string, one of 'running', 'finished', 'error' or \n"
+    "    'cancelled'; and\n"
+    "  - `p.message` is a custom string describing the operation currently\n"
+    "    being performed."
   );
 }
 

--- a/c/progress/progress_bar.h
+++ b/c/progress/progress_bar.h
@@ -57,7 +57,6 @@ class progress_bar {
     py::oobj pyfn_write;
     py::oobj pyfn_flush;
     py::oobj pyfn_external;
-    py::otuple py_args;
     bool visible;
     bool force_redraw;
     size_t : 48;


### PR DESCRIPTION
Now the callback function accepts a single argument, `p`, which is a named tuple with 3 fields (more in the future). The fields are `p.progress`, `p.status` and `p.message`, having the same meaning as the three parameters `(progerss, status, message)` before. 

Closes #1823