### PR TITLE
Add loss averaging parameter to FTRL algo

### DIFF
--- a/c/models/dt_ftrl.cc
+++ b/c/models/dt_ftrl.cc
@@ -53,7 +53,7 @@ Ftrl<T>::Ftrl(FtrlParams params_in) :
   dt_y_val(nullptr),
   nepochs_val(T_NAN),
   val_error(T_NAN),
-  val_naverage(0)
+  val_niters(0)
 {
 }
 
@@ -72,14 +72,14 @@ FtrlFitOutput Ftrl<T>::dispatch_fit(const DataTable* dt_X_in,
                                     const DataTable* dt_y_val_in,
                                     double nepochs_val_in,
                                     double val_error_in,
-                                    size_t val_naverage_in) {
+                                    size_t val_niters_in) {
   dt_X = dt_X_in;
   dt_y = dt_y_in;
   dt_X_val = dt_X_val_in;
   dt_y_val = dt_y_val_in;
   nepochs_val = static_cast<T>(nepochs_val_in);
   val_error = static_cast<T>(val_error_in);
-  val_naverage = val_naverage_in;
+  val_niters = val_niters_in;
   FtrlFitOutput res;
 
   SType stype_y = dt_y->columns[0]->stype();
@@ -319,14 +319,14 @@ FtrlFitOutput Ftrl<T>::fit(T(*linkfn)(T), T(*lossfn)(T,U)) {
   // `val_error`.
   bool validation = !std::isnan(nepochs_val);
   T loss = T_NAN; // This value is returned when validation is not enabled
-  T loss_old = 0; // Value of `loss` for a previous iteraction
-  std::queue<T> loss_queue;
+  T loss_old = T_ZERO; // Value of `loss` for a previous iteraction
+  std::vector<T> loss_history;
   std::vector<hasherptr> hashers_val;
   if (validation) {
-    loss = 0;
     hashers_val = create_hashers(dt_X_val);
     iteration_nrows = static_cast<size_t>(nepochs_val * dt_X->nrows);
     niterations = total_nrows / iteration_nrows;
+    loss_history.resize(val_niters, 0.0);
     fill_ri_data<U>(dt_y_val, ri_val, data_val);
   }
 
@@ -406,16 +406,10 @@ FtrlFitOutput Ftrl<T>::fit(T(*linkfn)(T), T(*lossfn)(T,U)) {
           // all the threads after `barrier()`.
           if (dt::this_thread_index() == 0) {
             T loss_current = loss_global.load() / (dt_X_val->nrows * dt_y_val->ncols);
-            loss += loss_current;
-            loss_queue.push(loss_current);
-
-            if (loss_queue.size() > val_naverage) {
-              loss -= loss_queue.front();
-              loss_queue.pop();
-            }
-
-            T loss_diff = (loss_old - loss) / (loss_old * val_naverage);
-            bool is_loss_bad = (iter >= val_naverage) && (loss < T_EPSILON || loss_diff < val_error);
+            loss_history[iter % val_niters] = loss_current / val_niters;
+            loss = std::accumulate(loss_history.begin(), loss_history.end(), T_ZERO);
+            T loss_diff = (loss_old - loss) / loss_old;
+            bool is_loss_bad = (iter >= val_niters) && (loss < T_EPSILON || loss_diff < val_error);
             loss_old = is_loss_bad? T_NAN : loss;
           }
           barrier();

--- a/c/models/dt_ftrl.cc
+++ b/c/models/dt_ftrl.cc
@@ -24,10 +24,6 @@
 #include "parallel/atomic.h"
 #include "utils/macros.h"
 #include "wstringcol.h"
-#include <queue>
-#include <deque>
-#include <iostream>
-
 
 namespace dt {
 

--- a/c/models/dt_ftrl.h
+++ b/c/models/dt_ftrl.h
@@ -81,6 +81,7 @@ class Ftrl : public dt::FtrlBase {
     // Other temporary parameters that needed for validation.
     T nepochs_val;
     T val_error;
+    size_t val_naverage;
     std::vector<size_t> map_val;
 
     // Fitting methods
@@ -127,7 +128,7 @@ class Ftrl : public dt::FtrlBase {
     // Main fitting method
     FtrlFitOutput dispatch_fit(const DataTable*, const DataTable*,
                                const DataTable*, const DataTable*,
-                               double, double) override;
+                               double, double, size_t) override;
 
     // Main predicting method
     dtptr predict(const DataTable*) override;

--- a/c/models/dt_ftrl.h
+++ b/c/models/dt_ftrl.h
@@ -81,7 +81,7 @@ class Ftrl : public dt::FtrlBase {
     // Other temporary parameters that needed for validation.
     T nepochs_val;
     T val_error;
-    size_t val_naverage;
+    size_t val_niters;
     std::vector<size_t> map_val;
 
     // Fitting methods
@@ -174,9 +174,9 @@ class Ftrl : public dt::FtrlBase {
     void set_labels(strvec) override;
 
     // Some useful constants:
-    // T type NaN and epsilon.
     static constexpr T T_NAN = std::numeric_limits<T>::quiet_NaN();
     static constexpr T T_EPSILON = std::numeric_limits<T>::epsilon();
+    static constexpr T T_ZERO = static_cast<T>(0.0);
 };
 
 

--- a/c/models/dt_ftrl_base.h
+++ b/c/models/dt_ftrl_base.h
@@ -83,7 +83,7 @@ class FtrlBase {
     // - numerical regression (INT8, INT16, INT32, INT64, FLOAT32, FLOAT64).
     virtual FtrlFitOutput dispatch_fit(const DataTable*, const DataTable*,
                                        const DataTable*, const DataTable*,
-                                       double, double) = 0;
+                                       double, double, size_t) = 0;
     virtual dtptr predict(const DataTable*) = 0;
     virtual void reset() = 0;
     virtual bool is_trained() = 0;

--- a/c/models/py_ftrl.cc
+++ b/c/models/py_ftrl.cc
@@ -221,11 +221,11 @@ std::vector<sizetvec> Ftrl::convert_interactions() {
  *  .fit(...)
  *  Do dataset validation and a call to `dtft->dispatch_fit(...)` method.
  */
-static PKArgs args_fit(2, 4, 0, false, false, {"X_train", "y_train",
+static PKArgs args_fit(2, 5, 0, false, false, {"X_train", "y_train",
                        "X_validation", "y_validation",
-                       "nepochs_validation", "validation_error"},
-                       "fit",
-R"(fit(self, X_train, y_train, X_validation=None, y_validation=None, nepochs_validation=1, validation_error = 0.01)
+                       "nepochs_validation", "validation_error",
+                       "validation_naverage"}, "fit",
+R"(fit(self, X_train, y_train, X_validation=None, y_validation=None, nepochs_validation=1, validation_error = 0.01, validation_naverage = 1)
 --
 
 Train FTRL model on a dataset.
@@ -252,6 +252,9 @@ validation_error: float
     If within `nepochs_validation` relative validation error does not improve
     by at least `validation_error`, training stops.
 
+validation_naverage: int
+    Number of iterations to average relative validation error for.
+
 Returns
 -------
 A tuple consisting of two elements: `epoch` and `loss`, where
@@ -262,12 +265,13 @@ loss. When validation dataset is not provided, `epoch` returned is equal to
 
 
 oobj Ftrl::fit(const PKArgs& args) {
-  const Arg& arg_X_train            = args[0];
-  const Arg& arg_y_train            = args[1];
-  const Arg& arg_X_validation       = args[2];
-  const Arg& arg_y_validation       = args[3];
-  const Arg& arg_nepochs_validation = args[4];
-  const Arg& arg_validation_error   = args[5];
+  const Arg& arg_X_train             = args[0];
+  const Arg& arg_y_train             = args[1];
+  const Arg& arg_X_validation        = args[2];
+  const Arg& arg_y_validation        = args[3];
+  const Arg& arg_nepochs_validation  = args[4];
+  const Arg& arg_validation_error    = args[5];
+  const Arg& arg_validation_naverage = args[6];
 
   // Training set handling
   if (arg_X_train.is_undefined()) {
@@ -319,6 +323,7 @@ oobj Ftrl::fit(const PKArgs& args) {
   DataTable* dt_y_val = nullptr;
   double nepochs_val = std::numeric_limits<double>::quiet_NaN();
   double val_error = std::numeric_limits<double>::quiet_NaN();
+  size_t val_naverage = 0;
 
   if (!arg_X_validation.is_none_or_undefined() &&
       !arg_y_validation.is_none_or_undefined()) {
@@ -368,11 +373,16 @@ oobj Ftrl::fit(const PKArgs& args) {
       val_error = arg_validation_error.to_double();
       // py::Validator::check_positive<double>(val_error, arg_validation_error);
     } else val_error = 0.01;
+
+    if (!arg_validation_naverage.is_none_or_undefined()) {
+      val_naverage = arg_validation_naverage.to_size_t();
+      py::Validator::check_positive<size_t>(val_naverage, arg_validation_naverage);
+    } else val_naverage = 1;
   }
 
   dt::FtrlFitOutput output = dtft->dispatch_fit(dt_X, dt_y,
                                                 dt_X_val, dt_y_val,
-                                                nepochs_val, val_error);
+                                                nepochs_val, val_error, val_naverage);
 
   static onamedtupletype ntt(
     "FtrlFitOutput",

--- a/c/models/py_ftrl.cc
+++ b/c/models/py_ftrl.cc
@@ -253,7 +253,7 @@ validation_error: float
     by at least `validation_error`, training stops.
 
 validation_average_niterations: int
-    Number of iterations that are used to calculate average loss. Here, each
+    Number of iterations that is used to calculate average loss. Here, each
     iteration corresponds to `nepochs_validation` epochs.
 
 Returns

--- a/docs/ftrl.rst
+++ b/docs/ftrl.rst
@@ -87,16 +87,18 @@ not improve. For this the model should be fit as
 
 ::
 
-  res = ftrl_model.fit(X_train, y_train, X_validation, y_validation, nepochs_validation, validation_error)
+  res = ftrl_model.fit(X_train, y_train, X_validation, y_validation, nepochs_validation, validation_error, validation_average_niterations)
 
 
 where ``X_train`` and ``y_train`` are training and target frames,
 respectively, ``X_validation`` and ``y_validation`` are validation frames,
 ``nepochs_validation`` specifies how often, in epoch units, validation
-error should be checked, and ``validation_error`` is the relative
+error should be checked, ``validation_error`` is the relative
 validation error improvement that the model should demonstrate within
-``nepochs_validation`` to continue training. Returned ``res`` tuple
-contains epoch at which training stopped and the corresponding loss.
+``nepochs_validation`` to continue training, and
+``validation_average_niterations`` is the number of iterations
+to average when calculating the validation error. Returned ``res``
+tuple contains epoch at which training stopped and the corresponding loss.
 
 
 Resetting a Model

--- a/tests/models/test_ftrl.py
+++ b/tests/models/test_ftrl.py
@@ -763,6 +763,28 @@ def test_ftrl_fit_predict_multinomial_online(negative_class_value):
 # Test early stopping
 #-------------------------------------------------------------------------------
 
+
+def test_ftrl_wrong_validation_parameters():
+    nepochs = 1234
+    nepochs_validation = 56
+    nbins = 78
+    ft = Ftrl(alpha = 0.5, nbins = nbins, nepochs = nepochs)
+    r = range(ft.nbins)
+    df_X = dt.Frame(r)
+    df_y = dt.Frame(r)
+
+    with pytest.raises(ValueError) as e:
+        res = ft.fit(df_X, df_y, df_X, df_y,
+                     nepochs_validation = 0)
+    assert ("Argument `nepochs_validation` in Ftrl.fit() should be "
+            "positive: 0" == str(e.value))
+
+    with pytest.raises(ValueError) as e:
+        res = ft.fit(df_X, df_y, df_X, df_y,
+                     validation_average_niterations = 0)
+    assert ("Argument `validation_average_niterations` in Ftrl.fit() should be "
+            "positive: 0" == str(e.value))
+
 @pytest.mark.parametrize('double_precision_value', [False, True])
 def test_ftrl_no_validation_set(double_precision_value):
     nepochs = 1234
@@ -795,7 +817,8 @@ def test_ftrl_no_early_stopping():
     assert math.isnan(loss_stopped) == False
 
 
-def test_ftrl_early_stopping_int():
+@pytest.mark.parametrize('validation_average_niterations', [1,5,10])
+def test_ftrl_early_stopping_int(validation_average_niterations):
     nepochs = 10000
     nepochs_validation = 5
     nbins = 10
@@ -804,7 +827,8 @@ def test_ftrl_early_stopping_int():
     df_X = dt.Frame(r)
     df_y = dt.Frame(r)
     res = ft.fit(df_X, df_y, df_X, df_y,
-                 nepochs_validation = nepochs_validation)
+                 nepochs_validation = nepochs_validation,
+                 validation_average_niterations = validation_average_niterations)
     epoch_stopped = getattr(res, "epoch")
     loss_stopped = getattr(res, "loss")
     p = ft.predict(df_X)
@@ -815,7 +839,8 @@ def test_ftrl_early_stopping_int():
     assert max(delta) < epsilon
 
 
-def test_ftrl_early_stopping_float():
+@pytest.mark.parametrize('validation_average_niterations', [1,5,10])
+def test_ftrl_early_stopping_float(validation_average_niterations):
     nepochs = 10000
     nepochs_validation = 5.5
     nbins = 10
@@ -824,7 +849,8 @@ def test_ftrl_early_stopping_float():
     df_X = dt.Frame(r)
     df_y = dt.Frame(r)
     res = ft.fit(df_X, df_y, df_X, df_y,
-                 nepochs_validation = nepochs_validation)
+                 nepochs_validation = nepochs_validation,
+                 validation_average_niterations = validation_average_niterations)
     epoch_stopped = getattr(res, "epoch")
     loss_stopped = getattr(res, "loss")
     p = ft.predict(df_X)
@@ -836,7 +862,8 @@ def test_ftrl_early_stopping_float():
     assert max(delta) < epsilon
 
 
-def test_ftrl_early_stopping_regression():
+@pytest.mark.parametrize('validation_average_niterations', [1,5,10])
+def test_ftrl_early_stopping_regression(validation_average_niterations):
     nepochs = 10000
     nepochs_validation = 5
     nbins = 10
@@ -848,7 +875,8 @@ def test_ftrl_early_stopping_regression():
     df_y_validate = df_X_validate
     res = ft.fit(df_X_train, df_y_train,
                  df_X_validate[nbins::,:], df_y_validate[nbins::,:],
-                 nepochs_validation = nepochs_validation)
+                 nepochs_validation = nepochs_validation,
+                 validation_average_niterations = validation_average_niterations)
     epoch_stopped = getattr(res, "epoch")
     loss_stopped = getattr(res, "loss")
     p = ft.predict(df_X_train)


### PR DESCRIPTION
- add `validation_average_niterations` to FTRL `.fit()` method, that specifies how many iterations should be taken into account when calculating the loss. The loss is then averaged over the `validation_average_niterations`, and used to decide on whether early stopping should be done or not. The idea is that this parameter should help in situations, when loss is an oscillating function;
- add relevant tests.