### PR TITLE
Fix crash when dt.colindex() was used without arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   unicode characters in Jupyter notebook. The error only manifested for
   strings that were longer than 50 bytes in length (#1825).
 
+- Fixed crash when `Frame.colindex()` was used without any arguments, now this
+  raises an exception instead (#1834).
+
 
 ### Changed
 
@@ -178,6 +181,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
   - [Arno Candel][] (#1619, #1730, #1738, #1800, #1803),
   - [Antorsae][] (#1639),
+  - [Hawk Berry][] (#1834),
   - [Jonathan McKinney][] (#1816),
   - [NachiGithub][] (#1789, #1793),
   - [Pasha Stetsenko][] (#1672, #1694, #1695, #1697, #1703, #1705)
@@ -1098,6 +1102,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [antorsae]: https://github.com/antorsae
 [arno candel]: https://github.com/arnocandel
 [carlosthinkbig]: https://github.com/CarlosThinkBig
+[hawk berry]: https://github.com/hawkberry
 [jonathan mckinney]: https://github.com/pseudotensor
 [joseph granados]: https://github.com/g-eoj
 [megan kurka]: https://github.com/meganjkurka

--- a/c/frame/names.cc
+++ b/c/frame/names.cc
@@ -139,6 +139,10 @@ name: str
 
 oobj Frame::colindex(const PKArgs& args) {
   auto col = args[0];
+  if (!col) {
+    throw TypeError() << "Frame.colindex() is missing the required "
+                         "positional argument `name`";
+  }
 
   if (col.is_string()) {
     int64_t index = dt->colindex(col.to_pyobj());

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -325,23 +325,39 @@ def test_dt_colindex(dt0):
         assert dt0.colindex(ch) == i
 
 
-def test_dt_colindex_bad(dt0):
+def test_dt_colindex_bad1(dt0):
     with pytest.raises(ValueError) as e:
         dt0.colindex("a")
     assert "Column `a` does not exist in the Frame" in str(e.value)
+
+
+def test_dt_colindex_bad2(dt0):
     with pytest.raises(ValueError) as e:
         dt0.colindex(7)
     assert ("Column index `7` is invalid for a Frame with 7 columns" ==
             str(e.value))
+
+
+def test_dt_colindex_bad3(dt0):
     with pytest.raises(ValueError) as e:
         dt0.colindex(-8)
     assert ("Column index `-8` is invalid for a Frame with 7 columns" ==
             str(e.value))
-    for x in [False, None, 1.99, [1, 2, 3]]:
-        with pytest.raises(TypeError) as e:
-            dt0.colindex(x)
-        assert ("The argument to Frame.colindex() should be a string or an "
-                "integer, not %s" % type(x) == str(e.value))
+
+
+def test_dt_colindex_bad4(dt0):
+    with pytest.raises(TypeError) as e:
+        dt0.colindex()
+    assert ("Frame.colindex() is missing the required positional argument "
+            "`name`" == str(e.value))
+
+
+@pytest.mark.parametrize("x", [False, None, 1.99, [1, 2, 3]])
+def test_dt_colindex_bad5(dt0, x):
+    with pytest.raises(TypeError) as e:
+        dt0.colindex(x)
+    assert ("The argument to Frame.colindex() should be a string or an "
+            "integer, not %s" % type(x) == str(e.value))
 
 
 def test_dt_colindex_fuzzy_suggestions():


### PR DESCRIPTION
Closes #1834