### PR TITLE
Fixed crash on Linux when writing a Jay file and the disk is low on space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed crash when `Frame.colindex()` was used without any arguments, now this
   raises an exception instead (#1834).
 
+- Fixed possible crash when writing to disk that doesn't have enough free space
+  on it (#1837).
+
 
 ### Changed
 
@@ -182,7 +185,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   - [Arno Candel][] (#1619, #1730, #1738, #1800, #1803),
   - [Antorsae][] (#1639),
   - [Hawk Berry][] (#1834),
-  - [Jonathan McKinney][] (#1816),
+  - [Jonathan McKinney][] (#1816, #1837),
   - [NachiGithub][] (#1789, #1793),
   - [Pasha Stetsenko][] (#1672, #1694, #1695, #1697, #1703, #1705)
   - [Tom Kraljevic][] (#1805)

--- a/c/utils/file.cc
+++ b/c/utils/file.cc
@@ -95,8 +95,10 @@ void File::resize(size_t newsize) {
   // range starting at offset and continuing for len bytes. After a successful
   // call to posix_fallocate(), subsequent writes to bytes in the specified
   // range are guaranteed not to fail because of lack of disk space.
+  // (https://linux.die.net/man/3/posix_fallocate)
+  //
   #ifdef HAVE_POSIX_FALLOCATE
-    ret = fallocate(fd, 0, static_cast<off_t>(newsize));
+    ret = posix_fallocate(fd, 0, static_cast<off_t>(newsize));
     if (ret == ENOSPC) {
       throw IOError() << "Unable to create file " << name << " of size "
           << newsize << ": not enough space left on device";

--- a/c/utils/file.cc
+++ b/c/utils/file.cc
@@ -35,7 +35,7 @@ File::File(const std::string& file, int oflags, int fileno, mode_t mode) {
     fd = open(file.c_str(), oflags, mode);
     flags = oflags;
     if (fd == -1) {
-      throw RuntimeError() << "Cannot open file " << file << ": " << Errno;
+      throw IOError() << "Cannot open file " << file << ": " << Errno;
     }
   }
   name = file;
@@ -71,8 +71,7 @@ size_t File::asize(const std::string& name) {
   struct stat statbuf;
   int ret = stat(name.c_str(), &statbuf);
   if (ret == -1) {
-    throw RuntimeError() << "Unable to obtain size of " << name
-                         << ": " << Errno;
+    throw IOError() << "Unable to obtain size of " << name << ": " << Errno;
   }
   return static_cast<size_t>(statbuf.st_size);
 }
@@ -90,15 +89,16 @@ void File::resize(size_t newsize) {
   }
   statbuf.st_size = -1;  // force reload stats on next request
 
-  // The function posix_fallocate() ensures that disk space is allocated
-  // for the file referred to by the descriptor fd for the bytes in the
-  // range starting at offset and continuing for len bytes. After a successful
-  // call to posix_fallocate(), subsequent writes to bytes in the specified
-  // range are guaranteed not to fail because of lack of disk space.
-  // (https://linux.die.net/man/3/posix_fallocate)
-  //
+  off_t sz = static_cast<off_t>(newsize);
   #ifdef HAVE_POSIX_FALLOCATE
-    ret = posix_fallocate(fd, 0, static_cast<off_t>(newsize));
+    // The function posix_fallocate() ensures that disk space is allocated
+    // for the file referred to by the descriptor fd for the bytes in the
+    // range starting at offset and continuing for len bytes. After a successful
+    // call to posix_fallocate(), subsequent writes to bytes in the specified
+    // range are guaranteed not to fail because of lack of disk space.
+    // (https://linux.die.net/man/3/posix_fallocate)
+    //
+    ret = posix_fallocate(fd, 0, sz);
     if (ret == ENOSPC) {
       throw IOError() << "Unable to create file " << name << " of size "
           << newsize << ": not enough space left on device";
@@ -107,6 +107,21 @@ void File::resize(size_t newsize) {
       throw IOError() << "Unable to fallocate() file " << name
           << ": error " << ret;
     }
+  #elif defined __APPLE__
+    // On MacOS, use `fncl()` with `cmd=F_PREALLOCATE`. There are 2 modes of
+    // allocation: F_ALLOCATECONTIG and F_ALLOCATEALL. We will try both in
+    // turn, hoping at least one succeeds.
+    // See https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/fcntl.2.html
+    fstore_t store = {F_ALLOCATECONTIG, F_PEOFPOSMODE, 0, sz, 0};
+    ret = fcntl(fd, F_PREALLOCATE, &store);
+    if (ret == -1) {
+      store.fst_flags = F_ALLOCATEALL;
+      ret = fcntl(fd, F_PREALLOCATE, &store);
+      if (ret == -1) {
+        throw IOError() << "Unable to create file " << name << " of size "
+            << newsize << ": " << Errno;
+      }
+    }
   #endif
 }
 
@@ -114,7 +129,7 @@ void File::resize(size_t newsize) {
 void File::assert_is_not_dir() const {
   load_stats();
   if (S_ISDIR(statbuf.st_mode)) {
-    throw RuntimeError() << "File " << name << " is a directory";
+    throw IOError() << "File " << name << " is a directory";
   }
 }
 
@@ -122,8 +137,7 @@ void File::load_stats() const {
   if (statbuf.st_size >= 0) return;
   int ret = fstat(fd, &statbuf);
   if (ret == -1) {
-    throw RuntimeError() << "Error in fstat() for file " << name
-                         << ": " << Errno;
+    throw IOError() << "Error in fstat() for file " << name << ": " << Errno;
   }
 }
 
@@ -131,8 +145,7 @@ void File::remove(const std::string& name, bool except) {
   int ret = ::remove(name.c_str());
   if (ret == -1) {
     if (except) {
-      throw RuntimeError() << "Unable to remove file " << name
-                           << ": " << Errno;
+      throw IOError() << "Unable to remove file " << name << ": " << Errno;
     } else {
       printf("Unable to remove file %s: [errno %d] %s",
              name.c_str(), errno, strerror(errno));


### PR DESCRIPTION
Apparently we need to call `posix_fallocate` to ensure that writes to mem-mapped file will succeed. This function is available on Linux, but not on MacOS. 

On MacOS the equivalent can be achieved with `fcntl` command `F_PREALLOCATE` (see  https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/fcntl.2.html).

Not adding any tests, because on Linux creating and mounting a size-restricted file system requires root privileges, and on MacOS even that is not possible. Testing can be done manually as described in the issue.

Closes #1837