### PR TITLE
Fix creation of Frame in fread for str64 columns with NAs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed possible crash when writing to disk that doesn't have enough free space
   on it (#1837).
 
+- Fixed invalid Frame being created when reading a large string column (str64)
+  with fread, and the column contains NA values.
+
 
 ### Changed
 

--- a/c/csv/reader_fread.cc
+++ b/c/csv/reader_fread.cc
@@ -1023,15 +1023,3 @@ void FreadObserver::type_bump_info(
   n = std::min(n, BUF_SIZE);
   messages.push_back(std::string(temp, static_cast<size_t>(n)));
 }
-
-
-void FreadObserver::str64_bump(size_t icol, const dt::read::Column& col) {
-  static const int BUF_SIZE = 1000;
-  char temp[BUF_SIZE + 1];
-  int n = snprintf(temp, BUF_SIZE,
-    "Column %zu (%s) switched from Str32 to Str64 because its size "
-    "exceeded 2GB",
-    icol, col.repr_name(g));
-  n = std::min(n, BUF_SIZE);
-  messages.push_back(std::string(temp, static_cast<size_t>(n)));
-}

--- a/c/csv/reader_fread.h
+++ b/c/csv/reader_fread.h
@@ -59,7 +59,6 @@ class FreadObserver {
 
     void type_bump_info(size_t icol, const dt::read::Column& col, PT new_type,
                         const char* field, int64_t len, int64_t lineno);
-    void str64_bump(size_t icol, const dt::read::Column& col);
 
     void report();
 };

--- a/c/read/column.cc
+++ b/c/read/column.cc
@@ -194,19 +194,6 @@ void Column::set_in_buffer(bool f) {
 
 //---- Misc --------------------------------------------------------------------
 
-void Column::convert_to_str64() {
-  xassert(ptype == PT::Str32);
-  size_t nelems = databuf.size() / sizeof(int32_t);
-  MemoryRange new_mbuf = MemoryRange::mem(nelems * sizeof(int64_t));
-  const int32_t* old_data = static_cast<const int32_t*>(databuf.rptr());
-  int64_t* new_data = static_cast<int64_t*>(new_mbuf.wptr());
-  for (size_t i = 0; i < nelems; ++i) {
-    new_data[i] = old_data[i];
-  }
-  ptype = PT::Str64;
-  databuf = std::move(new_mbuf);
-}
-
 static PyTypeObject* init_nametypepytuple() {
   static const char* tuple_name = "column_descriptor";
   static const char* field0 = "name";

--- a/c/read/column.h
+++ b/c/read/column.h
@@ -97,7 +97,6 @@ class Column {
     void set_in_buffer(bool f);
 
     // Misc
-    void convert_to_str64();
     py::oobj py_descriptor() const;
     size_t memory_footprint() const;
 };

--- a/c/read/fread/fread_thread_context.cc
+++ b/c/read/fread/fread_thread_context.cc
@@ -308,15 +308,6 @@ void FreadThreadContext::orderBuffer() {
       WritableBuffer* wb = col.strdata_w();
       size_t write_at = wb->prep_write(sz, sbuf.data() + offset0);
       strinfo[j].write_at = write_at;
-
-      if (col.get_ptype() == PT::Str32 && write_at + sz > 0x80000000) {
-        dt::shared_lock<dt::shared_mutex> lock(shmutex, /* exclusive = */ true);
-        col.convert_to_str64();
-        types[i] = PT::Str64;
-        if (verbose) {
-          freader.fo.str64_bump(i, col);
-        }
-      }
     }
     ++j;
   }


### PR DESCRIPTION
So the problem was that the code in fread that handled conversion of `str32` -> `str64` columns was not taking into account NA values properly. This was an old code (which means the issue existed for a very long time). 
Today we have a similar code in `StringColumn` class itself, that handles the conversion correctly. Thus, simply removing the fread's code solved the problem: the conversion now happens automatically in the `StringColumn` class.

This PR also patches up a minor MacOS bug with `fcntl()` function sometimes returning `EINVAL` error even if it shouldn't. This bug was introduced yesterday, and it's unclear how it passed the unit tests. The "solution" is just to ignore this case, since the bug was fixed in the most recent version of MacOS already.

Closes https://github.com/h2oai/h2oai/issues/8417