### PR TITLE
kfold_random() function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Added function `dt.models.kfold(k, n)` to prepare indices for k-fold
-  splitting. This function will return `k` pairs of row selectors such that
-  when these selectors are applied to an `n`-rows frame, that frame will be
-  split into train and test part according to the K-fold splitting scheme.
+- Added function `dt.models.kfold(nrows, nsplits)` to prepare indices for
+  k-fold splitting. This function will return `nsplits` pairs of row selectors
+  such that when these selectors are applied to an `nrows`-rows frame, that
+  frame will be split into train and test part according to the K-fold
+  splitting scheme.
+
+- Added function `dt.models.kfold_random(nrows, nsplits)`, which is similar to
+  `kfold(nrows, nsplits)`, except that the assignment of rows into folds is
+  randomized, not deterministic.
 
 - `Frame.rbind()` can now also accept a list or tuple of frames (previously
   only a vararg sequence was allowed).

--- a/c/models/kfold.cc
+++ b/c/models/kfold.cc
@@ -19,15 +19,73 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
+#include <algorithm> // std::min
+#include <cmath>     // std::sqrt
+#include <numeric>   // std::accumulate
+#include <random>    // std::random_device, std::normal_distribution
+#include <vector>    // std::vector
 #include "frame/py_frame.h"
+#include "parallel/api.h"
 #include "python/_all.h"
 #include "python/arg.h"
 #include "utils/exceptions.h"
+#include "utils/function.h"
 #include "column.h"
 #include "datatable.h"
 #include "datatablemodule.h"
 
 namespace py {
+
+//------------------------------------------------------------------------------
+// Misc. helper functions
+//------------------------------------------------------------------------------
+
+static void extract_args(const PKArgs& args,
+                         size_t* out_nrows, size_t* out_nsplits)
+{
+  if (!args[0]) throw TypeError() << "Required parameter `nrows` is missing";
+  if (!args[1]) throw TypeError() << "Required parameter `nsplits` is missing";
+  size_t nrows = args[0].to_size_t();
+  size_t nsplits = args[1].to_size_t();
+  if (nsplits < 2) {
+    throw ValueError() << "The number of splits cannot be less than two";
+  }
+  if (nsplits > nrows) {
+    throw ValueError()
+      << "The number of splits cannot exceed the number of rows";
+  }
+  *out_nrows = nrows;
+  *out_nsplits = nsplits;
+}
+
+static size_t hypergeom(dt::function<double(void)> rnd,
+                        size_t population_size,
+                        size_t positive_size,
+                        size_t num_draws)
+{
+  xassert(population_size >= positive_size);
+  xassert(population_size >= num_draws);
+  if (population_size == positive_size) return num_draws;
+  if (population_size == num_draws) return positive_size;
+  if (num_draws == 0 || positive_size == 0) return 0;
+  double n = static_cast<double>(population_size);
+  double k = static_cast<double>(positive_size);
+  double m = static_cast<double>(num_draws);
+  double mean = m*k / n;
+  double var = mean * (n - k)*(n - m)/(n*(n-1));
+  double z = rnd();
+  double x = mean + std::sqrt(var) * z;
+  if (x < 0) x = 0;
+  size_t ret = static_cast<size_t>(x + 0.5);
+  if (ret > positive_size) ret = positive_size;
+  if (ret > num_draws) ret = num_draws;
+  if (positive_size + num_draws > population_size) {
+    size_t delta = positive_size + num_draws - population_size;
+    if (ret < delta) ret = delta;
+  }
+  return ret;
+}
+
 
 
 //------------------------------------------------------------------------------
@@ -70,17 +128,8 @@ nsplits: int
 
 
 static oobj kfold(const PKArgs& args) {
-  if (!args[0]) throw TypeError() << "Required parameter `nrows` is missing";
-  if (!args[1]) throw TypeError() << "Required parameter `nsplits` is missing";
-  size_t nrows = args[0].to_size_t();
-  size_t nsplits = args[1].to_size_t();
-  if (nsplits < 2) {
-    throw ValueError() << "The number of splits cannot be less than two";
-  }
-  if (nsplits > nrows) {
-    throw ValueError()
-      << "The number of splits cannot exceed the number of rows";
-  }
+  size_t nrows, nsplits;
+  extract_args(args, &nrows, &nsplits);
 
   int64_t k = static_cast<int64_t>(nsplits);
   int64_t n = static_cast<int64_t>(nrows);
@@ -106,19 +155,206 @@ static oobj kfold(const PKArgs& args) {
                    orange(b1, b2)));
   }
 
-  for (int64_t t = 0; t < k*(k-2); ++t) {
-    int64_t j = t / k;     // column index
-    int64_t i = t - j * k; // block of rows
-    ++j;
-    if (i == j) continue;
-    int64_t row0 = i * n / k;
-    int64_t row1 = (i+1) * n / k;
-    int64_t delta = i < j? 0 : (j+1)*n/k - j*n/k;
-    int32_t* ptr = data[static_cast<size_t>(j) - 1] - delta;
-    for (int64_t row = row0; row < row1; ++row) {
-      ptr[row] = static_cast<int32_t>(row);
-    }
+  size_t kk = nsplits;
+  size_t nn = nrows;
+  dt::parallel_for_dynamic(kk*(kk-2),
+    [&](size_t t) {
+      size_t j = t / kk;     // column index
+      size_t i = t - j * kk; // block of rows
+      ++j;
+      if (i == j) return;
+      size_t row0 = i * nn / kk;
+      size_t row1 = (i+1) * nn / kk;
+      size_t delta = i < j? 0 : (j+1)*nn/kk - j*nn/kk;
+      int32_t* ptr = data[static_cast<size_t>(j) - 1] - delta;
+      for (size_t row = row0; row < row1; ++row) {
+        ptr[row] = static_cast<int32_t>(row);
+      }
+    });
+
+  return std::move(res);
+}
+
+
+
+
+//------------------------------------------------------------------------------
+// kfold_random()
+//------------------------------------------------------------------------------
+
+static PKArgs args_kfold_random(
+  0, 0, 3, false, false,
+  {"nrows", "nsplits", "seed"}, "kfold_random",
+
+R"(kfold_random(nrows, nsplits, seed=None)
+--
+
+Computes randomized k-fold split of data with `nrows` rows into
+`nsplits` train/test subsets.
+
+The dataset itself is not passed to this function: it is sufficient
+to know only the number of rows in order to decide how the data should
+be divided. Instead, this function returns a list of `nsplits` tuples,
+each tuple containing `(train_rows, test_rows)`. Here `train_rows` and
+`test_rows` are "row selectors": they can be applied to any frame with
+`nrows` rows to select the desired folds.
+
+The optional `seed` argument, if passed, is used as a seed value for
+the random number generator. Calling this function several times with
+same seed values will produce same results, unless:
+  - you change the number of threads used; or
+  - the RNG implementation in the standard C++ library changes.
+
+)");
+
+
+static oobj kfold_random(const PKArgs& args) {
+  size_t nrows, nsplits;
+  extract_args(args, &nrows, &nsplits);
+
+  size_t seed = 0;
+  if (args[2].is_none_or_undefined()) {
+    std::random_device rd;
+    seed = rd();
+  } else {
+    seed = args[2].to_size_t();
   }
+
+  // The data will be processed in parallel, split by rows into
+  // `nchunks` chunks. Each chunk has size at least 1, and is comprised
+  // of rows `[i * nrows / nchunks .. (i + 1) * nrows / nchunks)`.
+  size_t nchunks = std::min(dt::num_threads_in_pool(), nrows);
+
+  // Now, we want each fold to have predetermined size of approximately
+  // `nrows/nsplits` (up to round-off error, more precisely each fold's
+  // size is given by `fold_size` computed below).
+  // Within each chunk `i`, there will be a random number `s[x,i]`
+  // of rows assigned to fold `x`. These random numbers satisfy the
+  // conditions
+  //
+  //     sum(s[x,i] for i in range(nchunks)) == fold_size(x)
+  //     sum(s[x,i] for x in range(nsplits)) == chunk_size(i)
+  //
+  std::vector<std::vector<size_t>> s(nsplits);
+  {
+    std::normal_distribution<> dis;
+    std::mt19937 gen;
+    gen.seed(static_cast<uint32_t>(seed));
+    auto rnd = [&]{ return dis(gen); };
+
+    std::vector<size_t> rows_in_chunk(nchunks);
+    for (size_t i = 0; i < nchunks; ++i) {
+      rows_in_chunk[i] = (i + 1) * nrows / nchunks - i * nrows / nchunks;
+    }
+    for (size_t x = 0; x < nsplits; ++x) {
+      size_t fold_size = (x + 1) * nrows / nsplits - x * nrows / nsplits;
+      size_t total = std::accumulate(rows_in_chunk.begin(),
+                                     rows_in_chunk.end(), size_t(0));
+      s[x].resize(nchunks);
+      for (size_t i = 0; i < nchunks; ++i) {
+        size_t v = hypergeom(rnd, total, rows_in_chunk[i], fold_size);
+        s[x][i] = v;
+        total -= rows_in_chunk[i];
+        rows_in_chunk[i] -= v;
+        fold_size -= v;
+      }
+    }
+    #ifndef NDEBUG
+      for (size_t i = 0; i < nchunks; ++i) {
+        size_t chunk_size = (i + 1) * nrows / nchunks - i * nrows / nchunks;
+        size_t actual = 0;
+        for (size_t x = 0; x < nsplits; ++x) actual += s[x][i];
+        xassert(actual == chunk_size);
+      }
+    #endif
+  }
+
+  // Cumulative sums of `s[x,i]` across each fold.
+  std::vector<std::vector<size_t>> cums(nsplits);
+  for (size_t x = 0; x < nsplits; ++x) {
+    cums[x].resize(nchunks);
+    cums[x][0] = s[x][0];
+    for (size_t i = 1; i < nchunks; ++i) {
+      cums[x][i] = cums[x][i - 1] + s[x][i];
+    }
+    xassert(cums[x][nchunks - 1] ==
+            (x + 1) * nrows / nsplits - x * nrows / nsplits);
+  }
+
+  // Create data arrays for each fold
+  using T = int32_t;
+  SType S = SType::INT32;
+  std::vector<T*> test_folds(nsplits);
+  std::vector<T*> train_folds(nsplits);
+
+  olist res(nsplits);
+  for (size_t x = 0; x < nsplits; ++x) {
+    size_t fold_size = (x + 1) * nrows / nsplits - x * nrows / nsplits;
+    Column* col1 = Column::new_data_column(S, nrows - fold_size);
+    Column* col2 = Column::new_data_column(S, fold_size);
+    DataTable* dt1 = new DataTable({col1});
+    DataTable* dt2 = new DataTable({col2});
+    oobj train = oobj::from_new_reference(Frame::from_datatable(dt1));
+    oobj test  = oobj::from_new_reference(Frame::from_datatable(dt2));
+    train_folds[x] = static_cast<T*>(col1->data_w());
+    test_folds[x] = static_cast<T*>(col2->data_w());
+    res.set(x, otuple{ train, test });
+  }
+
+  // Fill-in the folds arrays
+  dt::parallel_region(
+    /* nthreads = */ nchunks,
+    [&] {
+      size_t i = dt::this_thread_index();
+      size_t row0 = i * nrows / nchunks;
+      size_t row1 = (i + 1) * nrows / nchunks;
+
+      // Copy into a thread-private array so that arrays don't trample
+      // each other's cachelines.
+      std::vector<size_t> xcounts(nsplits);
+      for (size_t x = 0; x < nsplits; ++x) xcounts[x] = s[x][i];
+      // Each thread carries its own copy of a random generator
+      std::mt19937 gen;
+      gen.seed(static_cast<uint32_t>(seed + i * 134368500));
+      std::uniform_int_distribution<size_t> dis(0, nsplits - 1);
+
+      for (size_t j = row0; j < row1; ++j) {
+        size_t x = dis(gen);
+        while (xcounts[x] == 0) {
+          x++;
+          if (x == nsplits) x = 0;
+        }
+
+        // row `j` is assigned to (test) fold `x`
+        // `cums[x][i]` is how many rows will go into fold `x` for all chunks
+        // up to and including `i`-th.
+        // `xcounts[x]` is how many rows this chunk still has to assign to
+        // fold `x`.
+        // `cums[x][i] - xcounts[x]` is the position where this row `j` should
+        // be recorded within the fold `x`.
+        //
+        test_folds[x][cums[x][i] - xcounts[x]] = static_cast<T>(j);
+        xcounts[x]--;
+
+        // row `j` must also appear in all train folds != x
+        // This chunk will assign `chunk_size(i) - s[y,i]` rows into train
+        // fold `y` (where `chunk_size(i) = row1 - row0`).
+        // All previous chunks together with this one will assign
+        //     sum(chunk_size(ii) - s[y,ii] for ii in range(i))
+        //     = row1 - cums[y,i]
+        // rows into the train fold `y`.
+        // `row1 - j - xcounts[y]` is how many rows this chunk still has to
+        // assign to train fold `y`.
+        // Thus, row `j` should be written at index
+        //     j + xcounts[y] - cums[y,i]
+        //
+        for (size_t y = 0; y < nsplits; ++y) {
+          if (y == x) continue;
+          train_folds[y][j + xcounts[y] - cums[y][i]] = static_cast<T>(j);
+        }
+      }
+    }
+  );
 
   return std::move(res);
 }
@@ -127,6 +363,7 @@ static oobj kfold(const PKArgs& args) {
 
 void DatatableModule::init_methods_kfold() {
   ADD_FN(&kfold, args_kfold_simple);
+  ADD_FN(&kfold_random, args_kfold_random);
 }
 
 

--- a/datatable/models.py
+++ b/datatable/models.py
@@ -20,6 +20,11 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 #-------------------------------------------------------------------------------
-from datatable.lib._datatable import aggregate, Ftrl, kfold
+from datatable.lib._datatable import (
+	Ftrl,
+	aggregate,
+	kfold,
+	kfold_random,
+)
 
-__all__ = ("aggregate", "Ftrl", "kfold")
+__all__ = ("aggregate", "Ftrl", "kfold", "kfold_random")

--- a/tests/models/test_kfold.py
+++ b/tests/models/test_kfold.py
@@ -24,10 +24,13 @@
 import datatable as dt
 import pytest
 import random
-from datatable.models import kfold
+from datatable.models import kfold, kfold_random
 from tests import assert_type_error, assert_value_error
 
 
+#-------------------------------------------------------------------------------
+# kfold()
+#-------------------------------------------------------------------------------
 
 def test_kfold_api():
     assert_type_error(lambda: kfold(),
@@ -115,3 +118,93 @@ def test_kfold_k_any(seed):
         assert split[0].nrows + len(split[1]) == n
         assert split[0].ncols == 1
         assert split[0].to_list()[0] == list(range(0, hl)) + list(range(hu, n))
+
+
+
+#-------------------------------------------------------------------------------
+# kfold_random()
+#-------------------------------------------------------------------------------
+
+def test_kfold_random_api():
+    assert_type_error(lambda: kfold_random(),
+        "Required parameter `nrows` is missing")
+
+    assert_type_error(lambda: kfold_random(nrows=5, seed=12345678),
+        "Required parameter `nsplits` is missing")
+
+    assert_type_error(lambda: kfold_random(5, 2),
+        "kfold_random() takes no positional arguments, but 2 were given")
+
+    assert_type_error(lambda: kfold_random(nrows=5, nsplits=3.3),
+        "Argument `nsplits` in kfold_random() should be an integer")
+
+    assert_type_error(lambda: kfold_random(nrows=None, nsplits=7),
+        "Argument `nrows` in kfold_random() should be an integer")
+
+    assert_type_error(lambda: kfold_random(nrows=5, nsplits=2, seed="boo"),
+        "Argument `seed` in kfold_random() should be an integer")
+
+
+def test_kfold_random_bad_args():
+    assert_value_error(lambda: kfold_random(nrows=-1, nsplits=1),
+        "Argument `nrows` in kfold_random() cannot be negative")
+
+    assert_value_error(lambda: kfold_random(nrows=3, nsplits=-3),
+        "Argument `nsplits` in kfold_random() cannot be negative")
+
+    assert_value_error(lambda: kfold_random(nrows=10, nsplits=3, seed=-1),
+        "Argument `seed` in kfold_random() cannot be negative")
+
+    assert_value_error(lambda: kfold_random(nrows=5, nsplits=0),
+        "The number of splits cannot be less than two")
+
+    assert_value_error(lambda: kfold_random(nrows=1, nsplits=2),
+        "The number of splits cannot exceed the number of rows")
+
+
+def test_kfold_random_2_2():
+    splits = kfold_random(nrows=2, nsplits=2)
+    assert isinstance(splits, list) and len(splits) == 2
+    assert all(isinstance(s, tuple) and len(s) == 2 for s in splits)
+    assert all(frame.shape == (1, 1)
+               for split in splits
+               for frame in split)
+    a = splits[0][0][0, 0]
+    assert a == 0 or a == 1
+    assert splits[0][1][0, 0] == 1 - a
+    assert splits[1][0][0, 0] == 1 - a
+    assert splits[1][1][0, 0] == a
+
+
+@pytest.mark.parametrize("seed", [random.getrandbits(32)])
+def test_kfold_random_any(seed):
+    random.seed(seed)
+    k = 2 + int(random.expovariate(0.01))
+    n = k + int(random.expovariate(0.0001))
+    splits = kfold_random(nrows=n, nsplits=k, seed=seed)
+    assert isinstance(splits, list) and len(splits) == k
+    all_folds = []
+    for split in splits:
+        assert isinstance(split, tuple) and len(split) == 2
+        train, test = split
+        assert isinstance(train, dt.Frame)
+        assert isinstance(test, dt.Frame)
+        assert train.stypes == (dt.int32,)
+        assert test.stypes == (dt.int32,)
+        assert train.ncols == 1
+        assert test.ncols == 1
+        assert train.nrows + test.nrows == n
+        assert test.nrows in [n//k, n//k + 1]
+        train_data = train.to_list()[0]
+        test_data = test.to_list()[0]
+        assert train_data == sorted(train_data)
+        assert test_data == sorted(test_data)
+        train_set = set(train_data)
+        test_set = set(test_data)
+        assert len(train_set) == train.nrows
+        assert len(test_set) == test.nrows
+        assert (train_set | test_set) == set(range(n))
+        all_folds += test_data
+
+    all_folds.sort()
+    assert all_folds == list(range(n))


### PR DESCRIPTION
Added function `dt.models.kfold_random(nrows, nsplits)`, which is similar to `kfold(nrows, nsplits)`, except that the assignment of rows into folds is randomized, not deterministic.

The function uses efficient parallelized algorithm. Compared to sklearn's `KFold` I'm seeing 10-15 times speedup on my laptop:
```
n = 1000000, k = 3
  datatable: 0.008468151092529297
  sklearn:   0.08319830894470215
  speedup:   9.824849372149332

n = 10000000, k = 3
  datatable: 0.08074498176574707
  sklearn:   0.9456908702850342
  speedup:   11.712069897156221

n = 100000000, k = 3
  datatable: 0.7584438323974609
  sklearn:   11.31531810760498
  speedup:   14.919124692249078

n = 1000000, k = 5
  datatable: 0.016140222549438477
  sklearn:   0.09569597244262695
  speedup:   5.92903673722617

n = 10000000, k = 5
  datatable: 0.09220409393310547
  sklearn:   1.0930109024047852
  speedup:   11.854255660250509

n = 100000000, k = 5
  datatable: 1.0194816589355469
  sklearn:   13.898195028305054
  speedup:   13.632609185746732
```

Closes #1649