### PR TITLE
Make FTRL model to resume properly after pickling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed invalid Frame being created when reading a large string column (str64)
   with fread, and the column contains NA values.
 
+- Fixed FTRL model not resuming properly after unpickling (#1846).
+
 
 ### Changed
 
@@ -190,7 +192,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Thanks to everyone who helped make `datatable` more stable by discovering
   and reporting bugs that were fixed in this release:
 
-  - [Arno Candel][] (#1619, #1730, #1738, #1800, #1803),
+  - [Arno Candel][] (#1619, #1730, #1738, #1800, #1803, #1846),
   - [Antorsae][] (#1639),
   - [Hawk Berry][] (#1834),
   - [Jonathan McKinney][] (#1816, #1837),

--- a/c/models/py_ftrl.cc
+++ b/c/models/py_ftrl.cc
@@ -187,7 +187,7 @@ void Ftrl::m__dealloc__() {
  *  Check if provided interactions are consistent with the column names
  *  of the training frame.
  */
-std::vector<sizetvec> Ftrl::convert_interactions() {
+void Ftrl::init_dt_interactions() {
   std::vector<sizetvec> interactions;
   auto py_iter = py_interactions.to_oiter();
   interactions.reserve(py_iter.size());
@@ -212,8 +212,7 @@ std::vector<sizetvec> Ftrl::convert_interactions() {
 
     interactions.push_back(std::move(interaction));
   }
-
-  return interactions;
+  dtft->set_interactions(std::move(interactions));
 }
 
 
@@ -314,9 +313,8 @@ oobj Ftrl::fit(const PKArgs& args) {
                        << "model";
   }
 
-  if (!py_interactions.is_none()) {
-    std::vector<sizetvec> inters = convert_interactions();
-    dtft->set_interactions(std::move(inters));
+  if (!py_interactions.is_none() && !dtft->get_interactions().size()) {
+    init_dt_interactions();
   }
 
   // Validtion set handling
@@ -448,6 +446,10 @@ oobj Ftrl::predict(const PKArgs& args) {
   if (dt_X->get_names() != colnames) {
     throw ValueError() << "Frames used for training and predictions "
                        << "should have the same column names";
+  }
+
+  if (!py_interactions.is_none() && !dtft->get_interactions().size()) {
+    init_dt_interactions();
   }
 
 

--- a/c/models/py_ftrl.h
+++ b/c/models/py_ftrl.h
@@ -61,7 +61,7 @@ class Ftrl : public PyObject {
     oobj fit(const PKArgs&);
     oobj predict(const PKArgs&);
     void reset(const PKArgs&);
-    std::vector<sizetvec> convert_interactions();
+    void init_dt_interactions();
 
     // Getters
     oobj get_labels() const;

--- a/tests/models/test_ftrl.py
+++ b/tests/models/test_ftrl.py
@@ -1078,6 +1078,12 @@ def test_ftrl_pickling_binomial():
     assert ft.labels == ft_unpickled.labels
     assert ft.colnames == ft_unpickled.colnames
 
+    # Predict
+    target = ft.predict(df_train)
+    target_unpickled = ft_unpickled.predict(df_train)
+    assert_equals(ft.model, ft_unpickled.model)
+    assert_equals(target, target_unpickled)
+
     # Fit and predict
     ft_unpickled.fit(df_train, df_target)
     target_unpickled = ft_unpickled.predict(df_train)

--- a/tests/models/test_ftrl.py
+++ b/tests/models/test_ftrl.py
@@ -1114,11 +1114,17 @@ def test_ftrl_pickling_multinomial(negative_class_value):
     assert ft.colnames == ft_unpickled.colnames
     assert ft.interactions == ft_unpickled.interactions
 
-    # Fit and predict
-    ft_unpickled.fit(df_train, df_target)
+    # Predict
+    target = ft.predict(df_train)
     target_unpickled = ft_unpickled.predict(df_train)
+    assert_equals(ft.model, ft_unpickled.model)
+    assert_equals(target, target_unpickled)
+
+    # Fit and predict
     ft.fit(df_train, df_target)
     target = ft.predict(df_train)
+    ft_unpickled.fit(df_train, df_target)
+    target_unpickled = ft_unpickled.predict(df_train)
     assert_equals(ft.model, ft_unpickled.model)
     assert_equals(target, target_unpickled)
 


### PR DESCRIPTION
If FTRL model had some hyperfeatures (i.e. it was trained with non-empty `.interactions` list), and then was pickled, it was not resuming properly on `.predict()` call. Our tests only covered the situation when after unpickling `.fit()` and `.predict()` methods were called one after another.

The bug has been fixed by properly initializing the interactions list not just in `.fit()`, but also in `.predict()`. Tests were improved in order to also cover such a use case.