### PR TITLE
Add function dt.internal.compiler_version()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - most long-running operations in `datatable` will now show a progress bar.
   Its behavior can be controlled via `dt.options.progress` set of options.
 
+- internal function `dt.internal.compiler_version()`.
+
 
 ### Fixed
 

--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -185,6 +185,33 @@ static void _register_function(const py::PKArgs& args) {
 
 
 
+static py::PKArgs args_compiler_version(
+  0, 0, 0, false, false, {}, "compiler_version",
+  "Return the version of the C++ compiler used to compile this module");
+
+static py::oobj compiler_version(const py::PKArgs&) {
+  #define STR(x) STR1(x)
+  #define STR1(x) #x
+  return py::ostring(
+    #ifdef __clang__
+      "CLang " STR(__clang_major__) "." STR(__clang_minor__) "."
+      STR(__clang_patchlevel__)
+    #elif defined(_MSC_VER)
+      "MSVC " STR(_MSC_FULL_VER)
+    #elif defined(__GNUC__)
+      "GCC " STR(__GNUC__) "." STR(__GNUC_MINOR__) "." STR(__GNUC_PATCHLEVEL__)
+    #elif defined(__MINGW64__)
+      "MinGW64 " STR(__MINGW64_VERSION_MAJOR) "." STR(__MINGW64_VERSION_MINOR)
+    #else
+      "Unknown"
+    #endif
+  );
+  #undef STR
+  #undef STR1
+}
+
+
+
 static py::PKArgs args__column_save_to_disk(
   4, 0, 0, false, false,
   {"frame", "i", "filename", "strategy"},
@@ -309,6 +336,7 @@ void py::DatatableModule::init_methods() {
   ADD_FN(&frame_integrity_check, args_frame_integrity_check);
   ADD_FN(&get_thread_ids, args_get_thread_ids);
   ADD_FN(&initialize_options, args_initialize_options);
+  ADD_FN(&compiler_version, args_compiler_version);
 
   init_methods_aggregate();
   init_methods_buffers();

--- a/datatable/internal.py
+++ b/datatable/internal.py
@@ -22,6 +22,7 @@
 #-------------------------------------------------------------------------------
 
 from .lib._datatable import (
+    compiler_version,
     frame_column_data_r,
     frame_column_rowindex,
     frame_integrity_check,
@@ -31,6 +32,7 @@ from .lib._datatable import (
 )
 
 __all__ = [
+    "compiler_version",
     "frame_column_data_r",
     "frame_column_rowindex",
     "frame_integrity_check",

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -239,6 +239,11 @@ def test_internal_parallel_for_ordered2():
         dt.options.nthreads = n0
 
 
+def test_internal_compiler_version():
+    ver = dt.internal.compiler_version()
+    assert ver
+    assert ver != "Unknown"
+
 
 def test_dt_view(dt0, patched_terminal, capsys):
     dt0.view(interactive=False)


### PR DESCRIPTION
The function will report the version of the compiler used to compile the datatable binary. Helpful for error diagnostics.