### PR TITLE
Do not run fallocate() if file size is 0

### DIFF
--- a/c/utils/file.cc
+++ b/c/utils/file.cc
@@ -90,6 +90,7 @@ void File::resize(size_t newsize) {
   statbuf.st_size = -1;  // force reload stats on next request
 
   off_t sz = static_cast<off_t>(newsize);
+  if (!sz) return;
   #ifdef HAVE_POSIX_FALLOCATE
     // The function posix_fallocate() ensures that disk space is allocated
     // for the file referred to by the descriptor fd for the bytes in the

--- a/tests/test_tocsv.py
+++ b/tests/test_tocsv.py
@@ -22,6 +22,7 @@
 # IN THE SOFTWARE.
 #-------------------------------------------------------------------------------
 import datatable as dt
+import os
 import random
 import re
 import pytest
@@ -374,6 +375,15 @@ def test_save_empty_frame():
     assert DT.to_csv() == "A" + "\n" * 6
     DT.nrows = 0
     assert DT.to_csv() == "A\n"
+
+
+def test_save_empty_frame_to_file(tempfile):
+    # Check that saving an empty frame to a file will succeed. There was
+    # a problem once with `fallocate()` not being able to execute on
+    # 0-size file.
+    dt.Frame().to_csv(tempfile)
+    assert os.path.isfile(tempfile)
+    assert os.stat(tempfile).st_size == 0
 
 
 def test_issue1615():


### PR DESCRIPTION
Otherwise, on Linux this could produce the error `EINVAL`.