### PR TITLE
Fix split_into_nhot(), so that it encodes NA's into NA's

### DIFF
--- a/c/models/aggregator.cc
+++ b/c/models/aggregator.cc
@@ -94,6 +94,15 @@ A list `[frame_exemplars, frame_members]`, where
  *  of two frames: `df_exemplars` and `df_members`.
  */
 static oobj aggregate(const PKArgs& args) {
+  if (args[0].is_undefined()) {
+    throw ValueError() << "Required parameter `frame` is missing";
+  }
+
+  if (args[0].is_none()) {
+    return py::None();
+  }
+
+  DataTable* dt = args[0].to_datatable();
   size_t min_rows = 500;
   size_t n_bins = 500;
   size_t nx_bins = 50;
@@ -104,7 +113,6 @@ static oobj aggregate(const PKArgs& args) {
   unsigned int nthreads = 0;
   bool double_precision = false;
 
-  bool undefined_dt = args[0].is_none_or_undefined();
   bool defined_min_rows = !args[1].is_none_or_undefined();
   bool defined_n_bins = !args[2].is_none_or_undefined();
   bool defined_nx_bins = !args[3].is_none_or_undefined();
@@ -115,12 +123,6 @@ static oobj aggregate(const PKArgs& args) {
   bool defined_progress_fn = !args[8].is_none_or_undefined();
   bool defined_nthreads = !args[9].is_none_or_undefined();
   bool defined_double_precision = !args[10].is_none_or_undefined();
-
-  if (undefined_dt) {
-    throw ValueError() << "Required parameter `frame` is missing";
-  }
-
-  DataTable* dt = args[0].to_datatable();
 
   if (defined_min_rows) {
     min_rows = args[1].to_size_t();

--- a/c/models/dt_ftrl.cc
+++ b/c/models/dt_ftrl.cc
@@ -361,11 +361,13 @@ FtrlFitOutput Ftrl<T>::fit(T(*linkfn)(T), T(*lossfn)(T,U)) {
           // Note that for FtrlModelType::BINOMIAL and FtrlModelType::REGRESSION
           // dt_y has only one column that may contain NA's or be a view
           // with an NA rowindex. For FtrlModelType::MULTINOMIAL we have as many
-          // columns as there are labels, and split_into_nhot() filters out
-          // NA's and can never be a view. Therefore, to ignore NA targets
-          // it is enough to check the condition below for the zero column only.
-          // FIXME: this condition can be removed for FtrlModelType::MULTINOMIAL.
-          if (j0 != RowIndex::NA && !ISNA<U>(data[0][j0])) {
+          // columns as there is labels, plus possibly a `_negative` column
+          // populated with all the negateves. Therefore, to ignore NA targets
+          // during training, it is enough to check the last column value only.
+          // FIXME: `j0 != RowIndex::NA` condition can be safely
+          // removed for FtrlModelType::MULTINOMIAL, because in this case
+          // the target columns are coming directly from `split_into_nhot()`.
+          if (j0 != RowIndex::NA && !ISNA<U>(data[dt_y->ncols - 1][j0])) {
             hash_row(x, hashers, ii);
             for (size_t k = 0; k < dt_y->ncols; ++k) {
               const size_t j = ri[k][ii];
@@ -390,7 +392,7 @@ FtrlFitOutput Ftrl<T>::fit(T(*linkfn)(T), T(*lossfn)(T,U)) {
             const size_t j0 = ri_val[0][i];
             // This condition is kind of the same as for training, see comment
             // above.
-            if (j0 != RowIndex::NA && !ISNA<U>(data_val[0][j0])) {
+            if (j0 != RowIndex::NA && !ISNA<U>(data_val[dt_y_val->ncols - 1][j0])) {
               hash_row(x, hashers_val, i);
               for (size_t k = 0; k < dt_y_val->ncols; ++k) {
                 const size_t j = ri_val[k][i];

--- a/c/str/py_str.cc
+++ b/c/str/py_str.cc
@@ -29,6 +29,8 @@ static PKArgs args_split_into_nhot(
 
 static oobj split_into_nhot(const PKArgs& args) {
   DataTable* dt = args[0].to_datatable();
+  if (dt == nullptr) return py::None();
+
   std::string sep = args[1]? args[1].to_string() : ",";
   bool sort = args[2]? args[2].to_bool_strict() : false;
 

--- a/c/str/py_str.cc
+++ b/c/str/py_str.cc
@@ -32,9 +32,11 @@ static oobj split_into_nhot(const PKArgs& args) {
     throw ValueError() << "Required parameter `frame` is missing";
   }
 
-  DataTable* dt = args[0].to_datatable();
-  if (dt == nullptr) return py::None();
+  if (args[0].is_none()) {
+    return py::None();
+  }
 
+  DataTable* dt = args[0].to_datatable();
   std::string sep = args[1]? args[1].to_string() : ",";
   bool sort = args[2]? args[2].to_bool_strict() : false;
 

--- a/c/str/py_str.cc
+++ b/c/str/py_str.cc
@@ -23,11 +23,15 @@ namespace py {
 
 static PKArgs args_split_into_nhot(
     1, 0, 2, false, false,
-    {"col", "sep", "sort"}, "split_into_nhot", nullptr
+    {"frame", "sep", "sort"}, "split_into_nhot", nullptr
 );
 
 
 static oobj split_into_nhot(const PKArgs& args) {
+  if (args[0].is_undefined()) {
+    throw ValueError() << "Required parameter `frame` is missing";
+  }
+
   DataTable* dt = args[0].to_datatable();
   if (dt == nullptr) return py::None();
 

--- a/c/str/split_into_nhot.cc
+++ b/c/str/split_into_nhot.cc
@@ -90,13 +90,14 @@ static void encode_nones(const T* offsets, const RowIndex& ri, colvec& outcols) 
 
   dt::parallel_for_dynamic(nrows,
     [&](size_t irow) {
+
       size_t jrow = ri[irow];
       if (jrow == RowIndex::NA || ISNA(offsets[jrow])) {
         for (size_t i = 0; i < ncols; ++i) {
           coldata[i][irow] = GETNA<int8_t>();
         }
-
       }
+
     }
   );
 }
@@ -110,11 +111,13 @@ static void sort_colnames(colvec& outcols, strvec& outnames) {
   std::vector<std::string> outnames_sorted(ncols);
   std::vector<Column*> outcols_sorted(ncols);
   std::vector<size_t> colindex = sort_index<std::string>(outnames);
+
   for (size_t i = 0; i < ncols; ++i) {
     size_t j = colindex[i];
     outnames_sorted[i] = std::move(outnames[j]);
     outcols_sorted[i] = outcols[j];
   }
+
   outcols = std::move(outcols_sorted);
   outnames = std::move(outnames_sorted);
 }
@@ -209,6 +212,7 @@ DataTable* split_into_nhot(Column* col, char sep, bool sort /* = false */) {
   } else {
     encode_nones<uint64_t>(offsets64, ri, outcols);
   }
+
   if (sort) sort_colnames(outcols, outnames);
 
   return new DataTable(std::move(outcols), std::move(outnames));

--- a/c/str/split_into_nhot.cc
+++ b/c/str/split_into_nhot.cc
@@ -147,8 +147,8 @@ DataTable* split_into_nhot(Column* col, char sep, bool sort /* = false */) {
                 outdata.push_back(data);
                 outnames.push_back(s);
               } else {
-                // In case the name was already added from another thread while we
-                // were waiting for the exclusive lock
+                // In case the name was already added from another thread while
+                // we were waiting for the exclusive lock
                 size_t j = colsmap[s];
                 outdata[j][irow] = 1;
               }
@@ -158,7 +158,7 @@ DataTable* split_into_nhot(Column* col, char sep, bool sort /* = false */) {
         });
     });  // dt::parallel_region()
 
-  // // Set NA's .
+  // The above algo encoded NA's with zeros, here we encode them with NA's.
   size_t ncols = outcols.size();
   std::vector<int8_t*> coldata(ncols);
   for (size_t i = 0; i < ncols; ++i) {

--- a/c/str/split_into_nhot.cc
+++ b/c/str/split_into_nhot.cc
@@ -16,7 +16,7 @@
 #include <string>         // std::string
 #include <unordered_map>  // std::unordered_map
 #include <vector>         // std::vector
-#include "models/utils.h"        // sort_index
+#include "models/utils.h" // sort_index
 #include "parallel/api.h"
 #include "parallel/shared_mutex.h"
 #include "utils/exceptions.h"
@@ -74,6 +74,51 @@ static void tokenize_string(
 }
 
 
+/**
+ * Encode NA's with NA's
+ */
+template<typename T>
+static void encode_nones(const T* offsets, const RowIndex& ri, colvec& outcols) {
+  size_t ncols = outcols.size();
+  if (ncols == 0) return;
+
+  size_t nrows = outcols[0]->nrows;
+  std::vector<int8_t*> coldata(ncols);
+  for (size_t i = 0; i < ncols; ++i) {
+    coldata[i] = static_cast<int8_t*>(outcols[i]->data_w());
+  }
+
+  dt::parallel_for_dynamic(nrows,
+    [&](size_t irow) {
+      size_t jrow = ri[irow];
+      if (jrow == RowIndex::NA || ISNA(offsets[jrow])) {
+        for (size_t i = 0; i < ncols; ++i) {
+          coldata[i][irow] = GETNA<int8_t>();
+        }
+
+      }
+    }
+  );
+}
+
+
+/**
+ * Re-order columns, so that column names go in alphabetical order.
+ */
+static void sort_colnames(colvec& outcols, strvec& outnames) {
+  size_t ncols = outcols.size();
+  std::vector<std::string> outnames_sorted(ncols);
+  std::vector<Column*> outcols_sorted(ncols);
+  std::vector<size_t> colindex = sort_index<std::string>(outnames);
+  for (size_t i = 0; i < ncols; ++i) {
+    size_t j = colindex[i];
+    outnames_sorted[i] = std::move(outnames[j]);
+    outcols_sorted[i] = outcols[j];
+  }
+  outcols = std::move(outcols_sorted);
+  outnames = std::move(outnames_sorted);
+}
+
 
 DataTable* split_into_nhot(Column* col, char sep, bool sort /* = false */) {
   bool is32 = (col->stype() == SType::STR32);
@@ -93,9 +138,9 @@ DataTable* split_into_nhot(Column* col, char sep, bool sort /* = false */) {
 
   size_t nrows = col->nrows;
   std::unordered_map<std::string, size_t> colsmap;
-  std::vector<Column*> outcols;
+  strvec outnames;
+  colvec outcols;
   std::vector<int8_t*> outdata;
-  std::vector<std::string> outnames;
   dt::shared_mutex shmutex;
   const RowIndex& ri = col->rowindex();
 
@@ -158,40 +203,13 @@ DataTable* split_into_nhot(Column* col, char sep, bool sort /* = false */) {
         });
     });  // dt::parallel_region()
 
-  // The above algo encoded NA's with zeros, here we encode them with NA's.
-  size_t ncols = outcols.size();
-  std::vector<int8_t*> coldata(ncols);
-  for (size_t i = 0; i < ncols; ++i) {
-    coldata[i] = static_cast<int8_t*>(outcols[i]->data_w());
+  // At this point NA's are encoded with zeros, here we encode them with NA's.
+  if (is32) {
+    encode_nones<uint32_t>(offsets32, ri, outcols);
+  } else {
+    encode_nones<uint64_t>(offsets64, ri, outcols);
   }
-
-  dt::parallel_for_dynamic(nrows,
-    [&](size_t irow) {
-      size_t jrow = ri[irow];
-      if (jrow == RowIndex::NA ||
-          (is32? ISNA(offsets32[jrow]) : ISNA(offsets64[jrow]))) {
-
-        for (size_t i = 0; i < ncols; ++i) {
-          coldata[i][irow] = GETNA<int8_t>();
-        }
-
-      }
-    }
-  );
-
-  // Re-order columns, so that column names go in alphabetical order.
-  if (sort) {
-    std::vector<std::string> outnames_sorted(ncols);
-    std::vector<Column*> outcols_sorted(ncols);
-    std::vector<size_t> colindex = sort_index<std::string>(outnames);
-    for (size_t i = 0; i < ncols; ++i) {
-      size_t j = colindex[i];
-      outnames_sorted[i] = std::move(outnames[j]);
-      outcols_sorted[i] = outcols[j];
-    }
-    outcols = std::move(outcols_sorted);
-    outnames = std::move(outnames_sorted);
-  }
+  if (sort) sort_colnames(outcols, outnames);
 
   return new DataTable(std::move(outcols), std::move(outnames));
 }

--- a/tests/models/test_ftrl.py
+++ b/tests/models/test_ftrl.py
@@ -667,7 +667,7 @@ def test_ftrl_fit_predict_multinomial_vs_binomial(negative_class_value):
 
     ft_multinomial = Ftrl(nbins = 10, nepochs = 2,
                           negative_class = negative_class_value)
-    df_target_multinomial = dt.Frame(["target", None] * 5)
+    df_target_multinomial = dt.Frame(["target", "target_negative"] * 5)
     ft_multinomial.fit(df_train_binomial, df_target_multinomial)
     p_multinomial = ft_multinomial.predict(df_train_binomial)
 

--- a/tests/models/test_ftrl.py
+++ b/tests/models/test_ftrl.py
@@ -657,16 +657,14 @@ def test_ftrl_disable_setters_after_fit(parameter, value):
 # Test multinomial regression
 #-------------------------------------------------------------------------------
 
-@pytest.mark.parametrize('negative_class_value', [False, True])
-def test_ftrl_fit_predict_multinomial_vs_binomial(negative_class_value):
+def test_ftrl_fit_predict_multinomial_vs_binomial():
     ft_binomial = Ftrl(nbins = 10, nepochs = 2)
     df_train_binomial = dt.Frame(range(ft_binomial.nbins))
     df_target_binomial = dt.Frame({"target" : [True, False] * 5})
     ft_binomial.fit(df_train_binomial, df_target_binomial)
     p_binomial = ft_binomial.predict(df_train_binomial)
 
-    ft_multinomial = Ftrl(nbins = 10, nepochs = 2,
-                          negative_class = negative_class_value)
+    ft_multinomial = Ftrl(nbins = 10, nepochs = 2)
     df_target_multinomial = dt.Frame(["target", "target_negative"] * 5)
     ft_multinomial.fit(df_train_binomial, df_target_multinomial)
     p_multinomial = ft_multinomial.predict(df_train_binomial)

--- a/tests/munging/test_str.py
+++ b/tests/munging/test_str.py
@@ -122,18 +122,18 @@ def test_split_into_nhot_long(seed, st):
     data = [",".join(["liberty"] * col1[i] +
                      ["equality"] * col2[i] +
                      ["justice"] * col3[i]) for i in range(n)]
-    # Introduce 1% of None's
+    # Introduce 1% of None's, making sure we preserve freedom_index
     na_indices = random.sample(range(n), n // 100)
-    rand_index = random.randint(0, n - 1)
+    freedom_index = random.randint(0, n - 1)
     for i in na_indices:
-        if i == rand_index: continue
+        if i == freedom_index: continue
         col1[i] = None
         col2[i] = None
         col3[i] = None
         col4[i] = None
         data[i] = None
-    col4[rand_index] = 1
-    data[rand_index] += ", freedom"
+    col4[freedom_index] = 1
+    data[freedom_index] += ", freedom"
 
     f0 = dt.Frame(data, stype=st)
     assert f0.stypes == (st,)

--- a/tests/munging/test_str.py
+++ b/tests/munging/test_str.py
@@ -20,12 +20,22 @@ import random
 import re
 from datatable import stype, f
 from datatable.internal import frame_integrity_check
-from tests import noop, random_string
+from tests import noop, random_string, assert_equals
 
 
 #-------------------------------------------------------------------------------
 # split_into_nhot
 #-------------------------------------------------------------------------------
+
+def test_split_into_nhot_none():
+    f0 = dt.split_into_nhot(None)
+    assert(f0 == None)
+
+
+def test_split_into_nhot_empty():
+    f0 = dt.split_into_nhot(dt.Frame(["", None]))
+    assert_equals(f0, dt.Frame())
+
 
 @pytest.mark.parametrize('sort', [False, True])
 def test_split_into_nhot0(sort):
@@ -87,7 +97,6 @@ def test_split_into_nhot_quotes():
     f1 = dt.split_into_nhot(dt.Frame(['foo, "bar, baz']))
     assert set(f0.names) == {"foo", "bar, baz"}
     assert set(f1.names) == {"foo", '"bar', "baz"}
-
 
 
 def test_split_into_nhot_bad():

--- a/tests/munging/test_str.py
+++ b/tests/munging/test_str.py
@@ -27,6 +27,12 @@ from tests import noop, random_string, assert_equals
 # split_into_nhot
 #-------------------------------------------------------------------------------
 
+def test_split_into_nhot_noarg():
+    with pytest.raises(ValueError) as e:
+        noop(dt.split_into_nhot())
+    assert ("Required parameter `frame` is missing" == str(e.value))
+
+
 def test_split_into_nhot_none():
     f0 = dt.split_into_nhot(None)
     assert(f0 == None)

--- a/tests/munging/test_str.py
+++ b/tests/munging/test_str.py
@@ -122,7 +122,8 @@ def test_split_into_nhot_long(seed, st):
     data = [",".join(["liberty"] * col1[i] +
                      ["equality"] * col2[i] +
                      ["justice"] * col3[i]) for i in range(n)]
-    # Introduce 1% of None's, making sure we preserve freedom_index
+
+    # Introduce 1% of None's, making sure we preserve data at freedom_index
     na_indices = random.sample(range(n), n // 100)
     freedom_index = random.randint(0, n - 1)
     for i in na_indices:


### PR DESCRIPTION
- `split_into_nhot()` function encoded NA's into zeros, i.e. negatives. In this PR we fix it, so that NA's are encoded into NA's;
- minor change in FTRL to make it consistent with the new `split_into_nhot` output;
- fixed segfault when `split_into_nhot()` was called on `None`;
- add and adjust corresponding tests.