### PR TITLE
Virtual columns

### DIFF
--- a/c/expr/expr.cc
+++ b/c/expr/expr.cc
@@ -56,6 +56,10 @@ pexpr base_expr::get_negated_expr() { return pexpr(); }
 
 size_t base_expr::get_col_index(const workframe&) { return size_t(-1); }
 
+vcolptr base_expr::evaluate_lazy(workframe& wf) {
+  return virtualize(evaluate_eager(wf));
+}
+
 
 
 
@@ -154,7 +158,10 @@ py::oobj make_pyexpr(Op opcode, py::oobj arg1, py::oobj arg2) {
 }
 
 
+
+
 }}  // namespace dt::expr
+
 
 using namespace dt::expr;
 pexpr py::_obj::to_dtexpr() const {

--- a/c/expr/expr.h
+++ b/c/expr/expr.h
@@ -21,15 +21,17 @@
 //------------------------------------------------------------------------------
 #ifndef dt_EXPR_EXPR_h
 #define dt_EXPR_EXPR_h
-#include "column.h"
+#include "expr/virtual_column.h"
 #include "expr/workframe.h"
 #include "python/ext_type.h"
+#include "column.h"
 namespace dt {
 namespace expr {
 
 class base_expr;
 using pexpr = std::unique_ptr<base_expr>;
 using colptr = std::unique_ptr<Column>;
+using vcolptr = std::unique_ptr<virtual_column>;
 
 static constexpr size_t UNOP_FIRST    = 101;
 static constexpr size_t UNOP_LAST     = 111;
@@ -177,6 +179,7 @@ class base_expr {
     virtual SType resolve(const workframe&) = 0;
     virtual GroupbyMode get_groupby_mode(const workframe&) const = 0;
     virtual colptr evaluate_eager(workframe&) = 0;
+    virtual vcolptr evaluate_lazy(workframe&);
 
     virtual bool is_column_expr() const;
     virtual bool is_negated_expr() const;

--- a/c/expr/expr_binaryop.cc
+++ b/c/expr/expr_binaryop.cc
@@ -53,6 +53,9 @@ static size_t id(Op opcode, SType st1, SType st2);
 static std::vector<std::string> binop_names;
 static std::unordered_map<size_t, SType> binop_rules;
 
+// Singleton instance
+_binary_infos binary_infos;
+
 
 enum OpMode {
   Error = 0,
@@ -685,6 +688,27 @@ void init_binops() {
   binop_names[id(Op::LE)] = "<=";
 }
 
+
+
+
+//------------------------------------------------------------------------------
+// binary_infos
+//------------------------------------------------------------------------------
+
+constexpr size_t _binary_infos::id(Op opcode) noexcept {
+  return static_cast<size_t>(opcode) - BINOP_FIRST;
+}
+
+constexpr size_t _binary_infos::id(Op op, SType stype1, SType stype2) noexcept {
+  return ((static_cast<size_t>(op) - BINOP_FIRST) << 16) +
+         (static_cast<size_t>(stype1) << 8) +
+         static_cast<size_t>(stype2);
+}
+
+
+_binary_infos::_binary_infos() {
+
+}
 
 
 }}  // namespace dt::expr

--- a/c/expr/expr_binaryop.cc
+++ b/c/expr/expr_binaryop.cc
@@ -231,12 +231,34 @@ inline static int8_t op_eq(LT x, RT y) {  // x == y
          (x_isna && y_isna);
 }
 
+template <typename T>
+static int8_t op_eq1(T x, T y) {
+  if (std::is_integral<T>::value) {
+    return (x == y);
+  } else {
+    bool x_isna = ISNA<T>(x);
+    bool y_isna = ISNA<T>(y);
+    return (!x_isna && !y_isna && x == y) || (x_isna && y_isna);
+  }
+}
+
 template<typename LT, typename RT, typename VT>
 inline static int8_t op_ne(LT x, RT y) {  // x != y
   bool x_isna = ISNA<LT>(x);
   bool y_isna = ISNA<RT>(y);
   return (x_isna || y_isna || static_cast<VT>(x) != static_cast<VT>(y)) &&
          !(x_isna && y_isna);
+}
+
+template <typename T>
+static int8_t op_ne1(T x, T y) {
+  if (std::is_integral<T>::value) {
+    return (x != y);
+  } else {
+    bool x_isna = ISNA<T>(x);
+    bool y_isna = ISNA<T>(y);
+    return (x_isna || y_isna || x != y) && !(x_isna && y_isna);
+  }
 }
 
 template<typename LT, typename RT, typename VT>
@@ -694,6 +716,7 @@ void init_binops() {
 //------------------------------------------------------------------------------
 // binary_infos
 //------------------------------------------------------------------------------
+using erased_func_t = _binary_infos::erased_func_t;
 
 constexpr size_t _binary_infos::id(Op opcode) noexcept {
   return static_cast<size_t>(opcode) - BINOP_FIRST;
@@ -706,25 +729,58 @@ constexpr size_t _binary_infos::id(Op op, SType stype1, SType stype2) noexcept {
 }
 
 
-_binary_infos::_binary_infos() {
-  static Op relops[] = {Op::EQ, Op::NE, Op::GT, Op::LT, Op::GE, Op::LE};
-  static const char* relnames[] = {"==", "!=", ">", "<", ">=", "<="};
-  for (size_t i = 0; i < 6; ++i) {
-    register_op(relops[i], relnames[i], nullptr,
-      [=]{
-
-      });
+template <typename T>
+static erased_func_t resolve_op2(Op op) {
+  switch (op) {
+    case Op::EQ: return reinterpret_cast<erased_func_t>(op_eq1<T>);
+    case Op::NE: return reinterpret_cast<erased_func_t>(op_ne1<T>);
+    default: return nullptr;
   }
 }
 
+static erased_func_t resolve_op(Op op, SType stype) {
+  switch (stype) {
+    case SType::INT8:    return resolve_op2<int8_t>(op);
+    case SType::INT16:   return resolve_op2<int16_t>(op);
+    case SType::INT32:   return resolve_op2<int32_t>(op);
+    case SType::INT64:   return resolve_op2<int64_t>(op);
+    case SType::FLOAT32: return resolve_op2<float>(op);
+    case SType::FLOAT64: return resolve_op2<double>(op);
+    case SType::STR32:
+    case SType::STR64:   return resolve_op2<CString>(op);
+    default: return nullptr;  // LCOV_EXCL_LINE
+  }
+}
 
-void _binary_infos::register_op(Op opcode, const std::string& name,
-                                const py::PKArgs*,
-                                dt::function<void()> more)
-{
-  current_opcode = opcode;
-  names[id(opcode)] = std::move(name);
-  more();
+void _binary_infos::add_relop(Op op, const char* name) {
+  static SType stypes[] = {
+    SType::BOOL, SType::INT8, SType::INT16, SType::INT32, SType::INT64,
+    SType::FLOAT32, SType::FLOAT64, SType::STR32, SType::STR64
+  };
+  for (int i = 0; i < 9; ++i) {
+    for (int j = 0; j < 9; ++ j) {
+      if ((i < 7) != (j < 7)) continue;  // strings do not mix with numbers
+      int m = std::max(1, std::max(i, j));
+      size_t entry_id = id(op, stypes[i], stypes[j]);
+      infos[entry_id] = {
+        resolve_op(op, stypes[m]),
+        SType::BOOL,  // output_stype
+        (i == m || i >= 7)? SType::VOID : stypes[m],
+        (j == m || j >= 7)? SType::VOID : stypes[m]
+      };
+    }
+  }
+  names[id(op)] = name;
+}
+
+
+_binary_infos::_binary_infos() {
+  add_relop(Op::EQ, "==");
+  add_relop(Op::NE, "!=");
+  add_relop(Op::GT, ">");
+  add_relop(Op::LT, "<");
+  add_relop(Op::GE, ">=");
+  add_relop(Op::LE, "<=");
 }
 
 

--- a/c/expr/expr_binaryop.cc
+++ b/c/expr/expr_binaryop.cc
@@ -707,8 +707,27 @@ constexpr size_t _binary_infos::id(Op op, SType stype1, SType stype2) noexcept {
 
 
 _binary_infos::_binary_infos() {
+  static Op relops[] = {Op::EQ, Op::NE, Op::GT, Op::LT, Op::GE, Op::LE};
+  static const char* relnames[] = {"==", "!=", ">", "<", ">=", "<="};
+  for (size_t i = 0; i < 6; ++i) {
+    register_op(relops[i], relnames[i], nullptr,
+      [=]{
 
+      });
+  }
 }
+
+
+void _binary_infos::register_op(Op opcode, const std::string& name,
+                                const py::PKArgs*,
+                                dt::function<void()> more)
+{
+  current_opcode = opcode;
+  names[id(opcode)] = std::move(name);
+  more();
+}
+
+
 
 
 }}  // namespace dt::expr

--- a/c/expr/expr_binaryop.h
+++ b/c/expr/expr_binaryop.h
@@ -49,16 +49,10 @@ class expr_binaryop : public base_expr {
 //------------------------------------------------------------------------------
 
 class _binary_infos {
-  using binary_func_t = void(*)(size_t nrows, const void* lhs,
-                                const void* rhs, void* out);
-
   public:
+    using erased_func_t = void(*)();
     struct binfo {
-      binary_func_t vectorfn;
-      union {
-        double(*d_d)(double, double);
-        int64_t(*l_l)(int64_t, int64_t);
-      } scalarfn;
+      erased_func_t scalarfn;
       SType output_stype;
       SType lhs_cast_stype;
       SType rhs_cast_stype;
@@ -80,8 +74,7 @@ class _binary_infos {
     static constexpr opinfo_index_t id(Op) noexcept;
     static constexpr binfo_index_t id(Op, SType, SType) noexcept;
 
-    void register_op(Op opcode, const std::string& name, const py::PKArgs*,
-                     dt::function<void()>);
+    void add_relop(Op op, const char* name);
 };
 
 extern _binary_infos binary_infos;

--- a/c/expr/expr_binaryop.h
+++ b/c/expr/expr_binaryop.h
@@ -24,6 +24,7 @@
 #include <unordered_map>
 #include "expr/expr.h"
 #include "python/_all.h"
+#include "utils/function.h"
 namespace dt {
 namespace expr {
 

--- a/c/expr/expr_cast.cc
+++ b/c/expr/expr_cast.cc
@@ -51,5 +51,11 @@ colptr expr_cast::evaluate_eager(workframe& wf) {
 }
 
 
+vcolptr expr_cast::evaluate_lazy(workframe& wf) {
+  auto arg_vcol = arg->evaluate_lazy(wf);
+  return cast(std::move(arg_vcol), stype);
+}
+
+
 
 }} // namespace dt::expr

--- a/c/expr/expr_cast.h
+++ b/c/expr/expr_cast.h
@@ -38,6 +38,7 @@ class expr_cast : public base_expr {
     SType resolve(const workframe& wf) override;
     GroupbyMode get_groupby_mode(const workframe&) const override;
     colptr evaluate_eager(workframe& wf) override;
+    vcolptr evaluate_lazy(workframe& wf) override;
 };
 
 

--- a/c/expr/expr_unaryop.h
+++ b/c/expr/expr_unaryop.h
@@ -190,8 +190,6 @@ class unary_infos {
     void add_copy(Op op, SType input_stype, SType output_stype);
     template <Op OP, SType SI, SType SO, element_t<SO>(*)(element_t<SI>)>
     void add();
-    template <Op OP, SType SI, bool(*FN)(element_t<SI>)>
-    void add_bool();
     template <Op OP, SType SI, SType SO, element_t<SO>(*FN)(CString)>
     void add_str(unary_func_t mapfn);
     template <float(*F32)(float), double(*F64)(double)>

--- a/c/expr/expr_unaryop.h
+++ b/c/expr/expr_unaryop.h
@@ -42,6 +42,7 @@ class expr_unaryop : public base_expr {
     SType resolve(const workframe& wf) override;
     GroupbyMode get_groupby_mode(const workframe&) const override;
     colptr evaluate_eager(workframe& wf) override;
+    vcolptr evaluate_lazy(workframe& wf) override;
 
     bool is_negated_expr() const override;
     pexpr get_negated_expr() override;
@@ -194,14 +195,7 @@ class unary_infos {
 
     void register_op(Op opcode, const std::string& name, const py::PKArgs*,
                      dt::function<void()>);
-    void add_copy_converter(SType in, SType out = SType::VOID);
-    void add_converter(SType in, SType out, unary_func_t);
-    void add_converter(void(*)(size_t, const int8_t*, int8_t*));
-    void add_converter(void(*)(size_t, const int16_t*, int16_t*));
-    void add_converter(void(*)(size_t, const int32_t*, int32_t*));
-    void add_converter(void(*)(size_t, const int64_t*, int64_t*));
-    void add_converter(void(*)(size_t, const float*, float*));
-    void add_converter(void(*)(size_t, const double*, double*));
+    void add_vectorfn(SType in, SType out, unary_func_t);
     void add_scalarfn_l(int64_t(*)(int64_t));
     void add_scalarfn_l(bool(*)(int64_t));
     void add_scalarfn_d(double(*)(double));

--- a/c/expr/expr_unaryop.h
+++ b/c/expr/expr_unaryop.h
@@ -125,28 +125,26 @@ py::oobj unary_pyfn(const py::PKArgs&);
  *     This field could be `nullptr`, indicating that no transform
  *     is necessary: the output can be simply copied from the input.
  *
- * - scalarfn (union)
+ *     If the input column is of string type, then only the offsets
+ *     will be passed in the `input` field. More precisely, the
+ *     starting offsets of each string, and the array will be
+ *     `nrows + 1` elements long. There is no support for output
+ *     string columns. [Note: this may change in the future]
  *
- *     Function that can be applied to a single (scalar) input. In
- *     order to accommodate multiple possible signatures within the
- *     same `uinfo` struct, we use a union here. A particular member
- *     of the union will be selected according to the type of the
- *     input and the `output_stype` field.
+ * - scalarfn (erased_func_t)
  *
- *     Specifically, the following signatures are recognized:
+ *     Function that can be applied to a single (scalar) input. This
+ *     function is even more type-erased than `vectorfn`, but
+ *     generally it has signature `TO(*)(TI)`. The caller is expected
+ *     to know the actual signature in order to use this function.
  *
- *         (double | int64_t) -> (double | bool)
+ * - vcolfn (vcol_func_t)
  *
- *     The input type corresponds to python `float` and `int` types,
- *     the output is wrapped as python `float` or `bool`. In the
- *     future we may add support for more signatures, as the need
- *     arises.
- *
- *     This field can be `nullptr` indicating that the ufunc cannot
- *     be applied to this input type. This field will be `nullptr`
- *     for `uinfo`s corresponding to all input stypes other than
- *     INT64 or FLOAT64. If this field is non-null, then output_stype
- *     must be either FLOAT64 or BOOL.
+ *     Function that can be used to produce a virtual column
+ *     corresponding to this unary transform. This function takes a
+ *     single argument: a virtual column that is the argument of the
+ *     transform (possibly after applying cast specified in the
+ *     `cast_type` field).
  *
  * - output_stype (SType)
  *
@@ -161,17 +159,15 @@ py::oobj unary_pyfn(const py::PKArgs&);
  *
  */
 class unary_infos {
+  using vcol_func_t = vcolptr(*)(vcolptr&& arg);
   using unary_func_t = void(*)(size_t nrows, const void* inp, void* out);
+  using erased_func_t = void(*)();
 
   public:
     struct uinfo {
-      unary_func_t vectorfn;
-      union {
-        double(*d_d)(double);
-        bool(*d_b)(double);
-        int64_t(*l_l)(int64_t);
-        bool(*l_b)(int64_t);
-      } scalarfn;
+      unary_func_t  vectorfn;
+      erased_func_t scalarfn;
+      vcol_func_t   vcolfn;
       SType output_stype;
       SType cast_stype;
       size_t : 48;
@@ -186,23 +182,20 @@ class unary_infos {
     std::unordered_map<size_t /* Op, SType */, uinfo> info;
     std::unordered_map<size_t /* Op */, std::string> names;
     std::unordered_map<const py::PKArgs*, Op> opcodes;
-    Op current_opcode;  // used only when registering opcodes
 
     static constexpr size_t id(Op) noexcept;
     static constexpr size_t id(Op, SType) noexcept;
-    void add(Op, SType input_stype, SType output_stype, unary_func_t fn,
-             SType cast=SType::VOID);
 
-    void register_op(Op opcode, const std::string& name, const py::PKArgs*,
-                     dt::function<void()>);
-    void add_vectorfn(SType in, SType out, unary_func_t);
-    void add_scalarfn_l(int64_t(*)(int64_t));
-    void add_scalarfn_l(bool(*)(int64_t));
-    void add_scalarfn_d(double(*)(double));
-    void add_scalarfn_d(bool(*)(double));
-
+    void add_op(Op op, const char* name, const py::PKArgs* args);
+    void add_copy(Op op, SType input_stype, SType output_stype);
+    template <Op OP, SType SI, SType SO, element_t<SO>(*)(element_t<SI>)>
+    void add();
+    template <Op OP, SType SI, bool(*FN)(element_t<SI>)>
+    void add_bool();
+    template <Op OP, SType SI, SType SO, element_t<SO>(*FN)(CString)>
+    void add_str(unary_func_t mapfn);
     template <float(*F32)(float), double(*F64)(double)>
-    void register_math_op(Op, const std::string&, const py::PKArgs&);
+    void add_math(Op, const char*, const py::PKArgs&);
 };
 
 

--- a/c/expr/virtual_column.cc
+++ b/c/expr/virtual_column.cc
@@ -341,47 +341,51 @@ class cast_fw_vcol : public virtual_column {
     void compute(size_t i, int8_t* out) override {
       T x;
       arg->compute(i, &x);
-      *out = static_cast<int8_t>(x);
+      *out = ISNA<T>(x)? GETNA<int8_t>() : static_cast<int8_t>(x);
     }
 
     void compute(size_t i, int16_t* out) override {
       T x;
       arg->compute(i, &x);
-      *out = static_cast<int16_t>(x);
+      *out = ISNA<T>(x)? GETNA<int16_t>() : static_cast<int16_t>(x);
     }
 
     void compute(size_t i, int32_t* out) override {
       T x;
       arg->compute(i, &x);
-      *out = static_cast<int32_t>(x);
+      *out = ISNA<T>(x)? GETNA<int32_t>() : static_cast<int32_t>(x);
     }
 
     void compute(size_t i, int64_t* out) override {
       T x;
       arg->compute(i, &x);
-      *out = static_cast<int64_t>(x);
+      *out = ISNA<T>(x)? GETNA<int64_t>() : static_cast<int64_t>(x);
     }
 
     void compute(size_t i, float* out) override {
       T x;
       arg->compute(i, &x);
-      *out = static_cast<float>(x);
+      *out = ISNA<T>(x)? GETNA<float>() : static_cast<float>(x);
     }
 
     void compute(size_t i, double* out) override {
       T x;
       arg->compute(i, &x);
-      *out = static_cast<double>(x);
+      *out = ISNA<T>(x)? GETNA<double>() : static_cast<double>(x);
     }
 
     void compute(size_t i, CString* out) override {
       static thread_local char buffer[30];
       T x;
       arg->compute(i, &x);
-      char* ch = buffer;
-      toa<T>(&ch, x);
-      out->ch = buffer;
-      out->size = ch - buffer;
+      if (ISNA<T>(x)) {
+        out->ch = nullptr;
+      } else {
+        char* ch = buffer;
+        toa<T>(&ch, x);
+        out->ch = buffer;
+        out->size = ch - buffer;
+      }
     }
 };
 

--- a/c/expr/virtual_column.cc
+++ b/c/expr/virtual_column.cc
@@ -1,0 +1,315 @@
+//------------------------------------------------------------------------------
+// Copyright 2018-2019 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#include "expr/virtual_column.h"
+#include "parallel/api.h"
+#include "utils/exceptions.h"
+namespace dt {
+namespace expr {
+
+
+virtual_column::~virtual_column() {}
+
+
+
+void virtual_column::compute(size_t, int8_t*) {
+  throw RuntimeError() << "int8 value cannot be computed";   // LCOV_EXCL_LINE
+}
+
+void virtual_column::compute(size_t, int16_t*) {
+  throw RuntimeError() << "int16 value cannot be computed";  // LCOV_EXCL_LINE
+}
+
+void virtual_column::compute(size_t, int32_t*) {
+  throw RuntimeError() << "int32 value cannot be computed";  // LCOV_EXCL_LINE
+}
+
+void virtual_column::compute(size_t, int64_t*) {
+  throw RuntimeError() << "int64 value cannot be computed";  // LCOV_EXCL_LINE
+}
+
+void virtual_column::compute(size_t, float*) {
+  throw RuntimeError() << "float value cannot be computed";  // LCOV_EXCL_LINE
+}
+
+void virtual_column::compute(size_t, double*) {
+  throw RuntimeError() << "double value cannot be computed"; // LCOV_EXCL_LINE
+}
+
+void virtual_column::compute(size_t, CString*) {
+  throw RuntimeError() << "string value cannot be computed"; // LCOV_EXCL_LINE
+}
+
+
+
+//------------------------------------------------------------------------------
+// materialize
+//------------------------------------------------------------------------------
+
+template <typename T>
+void materialize_fw(virtual_column* self, Column* outcol) {
+  xassert(self->nrows() == outcol->nrows);
+  T* out_data = static_cast<T*>(outcol->data_w());
+  dt::parallel_for_static(
+    outcol->nrows,
+    [&](size_t i) {
+      self->compute(i, out_data + i);
+    });
+}
+
+
+colptr virtual_column::materialize() {
+  SType out_stype = stype();
+  Column* out = Column::new_data_column(out_stype, nrows());
+  colptr out_colptr(out);
+  switch (out_stype) {
+    case SType::BOOL:
+    case SType::INT8:    materialize_fw<int8_t> (this, out); break;
+    case SType::INT16:   materialize_fw<int16_t>(this, out); break;
+    case SType::INT32:   materialize_fw<int32_t>(this, out); break;
+    case SType::INT64:   materialize_fw<int64_t>(this, out); break;
+    case SType::FLOAT32: materialize_fw<float>  (this, out); break;
+    case SType::FLOAT64: materialize_fw<double> (this, out); break;
+    default:
+      throw NotImplError() << "virtual_column of stype " << out_stype
+          << " cannot be materialized";
+  }
+  return out_colptr;
+}
+
+
+
+//------------------------------------------------------------------------------
+// virtualize
+//------------------------------------------------------------------------------
+
+class _vcolumn : public virtual_column {
+  protected:
+    colptr column;
+
+  public:
+    _vcolumn(colptr&& col);
+    SType stype() const override;
+    size_t nrows() const override;
+    colptr materialize() override;
+};
+
+_vcolumn::_vcolumn(colptr&& col) : column(std::move(col)) {}
+SType _vcolumn::stype() const { return column->stype(); }
+size_t _vcolumn::nrows() const { return column->nrows; }
+colptr _vcolumn::materialize() { return std::move(column); }
+
+
+
+template <typename T>
+class fw_vcol : public _vcolumn {
+  protected:
+    const T* data;
+
+  public:
+    fw_vcol(colptr&& col)
+      : _vcolumn(std::move(col)),
+        data(static_cast<const T*>(column->data())) {}
+
+    void compute(size_t i, T* out) override {
+      *out = data[i];
+    }
+};
+
+
+template <typename A, typename T>
+class arr_fw_vcol : public fw_vcol<T> {
+  private:
+    const A* index;
+
+  public:
+    arr_fw_vcol(colptr&& col, const A* indices)
+      : fw_vcol<T>(std::move(col)),
+        index(indices) {}
+
+    void compute(size_t i, T* out) override {
+      A j = index[i];
+      *out = (j == -1) ? GETNA<T>() : this->data[j];
+    }
+};
+
+
+template <typename T>
+class slice_fw_vcol : public fw_vcol<T> {
+  private:
+    size_t istart;
+    size_t istep;
+
+  public:
+    slice_fw_vcol(colptr&& col, size_t start, size_t step)
+      : fw_vcol<T>(std::move(col)),
+        istart(start),
+        istep(step) {}
+
+    void compute(size_t i, T* out) override {
+      size_t j = istart + i * istep;
+      *out = this->data[j];
+    }
+};
+
+
+
+template <typename T>
+class str_vcol : public _vcolumn {
+  protected:
+    const T* offsets;
+    const char* strdata;
+
+  public:
+    str_vcol(colptr&& col)
+      : _vcolumn(std::move(col)),
+        offsets(static_cast<StringColumn<T>*>(column.get())->offsets()),
+        strdata(static_cast<StringColumn<T>*>(column.get())->strdata()) {}
+
+    void compute(size_t i, CString* out) override {
+      T end = offsets[i];
+      T start = offsets[i - 1] & ~GETNA<T>();
+      out->size = static_cast<int64_t>(end - start);
+      out->ch = ISNA<T>(end) ? nullptr : strdata + start;
+    }
+};
+
+
+template <typename A, typename T>
+class arr_str_vcol : public str_vcol<T> {
+  private:
+    const A* index;
+
+  public:
+    arr_str_vcol(colptr&& col, const A* indices)
+      : str_vcol<T>(std::move(col)),
+        index(indices) {}
+
+    void compute(size_t i, CString* out) override {
+      A j = index[i];
+      if (j == -1) {
+        out->ch = nullptr;
+        out->size = 0;
+      } else {
+        str_vcol<T>::compute(static_cast<size_t>(j), out);
+      }
+    }
+};
+
+
+template <typename T>
+class slice_str_vcol : public str_vcol<T> {
+  private:
+    size_t istart;
+    size_t istep;
+
+  public:
+    slice_str_vcol(colptr&& col, size_t start, size_t step)
+      : str_vcol<T>(std::move(col)),
+        istart(start),
+        istep(step) {}
+
+    void compute(size_t i, CString* out) override {
+      size_t j = istart + i * istep;
+      str_vcol<T>::compute(j, out);
+    }
+};
+
+
+
+vcolptr virtualize(colptr&& col) {
+  SType st = col->stype();
+  const RowIndex& ri = col->rowindex();
+  switch (ri.type()) {
+    case RowIndexType::UNKNOWN: {
+      switch (st) {
+        case SType::BOOL:    return vcolptr(new fw_vcol<int8_t> (std::move(col)));
+        case SType::INT8:    return vcolptr(new fw_vcol<int8_t> (std::move(col)));
+        case SType::INT16:   return vcolptr(new fw_vcol<int16_t>(std::move(col)));
+        case SType::INT32:   return vcolptr(new fw_vcol<int32_t>(std::move(col)));
+        case SType::INT64:   return vcolptr(new fw_vcol<int64_t>(std::move(col)));
+        case SType::FLOAT32: return vcolptr(new fw_vcol<float>  (std::move(col)));
+        case SType::FLOAT64: return vcolptr(new fw_vcol<double> (std::move(col)));
+        case SType::STR32:   return vcolptr(new str_vcol<uint32_t>(std::move(col)));
+        case SType::STR64:   return vcolptr(new str_vcol<uint64_t>(std::move(col)));
+        default: break;
+      }
+      break;
+    }
+
+    case RowIndexType::ARR32: {
+      const int32_t* ind32 = ri.indices32();
+      switch (st) {
+        case SType::BOOL:    return vcolptr(new arr_fw_vcol<int32_t, int8_t> (std::move(col), ind32));
+        case SType::INT8:    return vcolptr(new arr_fw_vcol<int32_t, int8_t> (std::move(col), ind32));
+        case SType::INT16:   return vcolptr(new arr_fw_vcol<int32_t, int16_t>(std::move(col), ind32));
+        case SType::INT32:   return vcolptr(new arr_fw_vcol<int32_t, int32_t>(std::move(col), ind32));
+        case SType::INT64:   return vcolptr(new arr_fw_vcol<int32_t, int64_t>(std::move(col), ind32));
+        case SType::FLOAT32: return vcolptr(new arr_fw_vcol<int32_t, float>  (std::move(col), ind32));
+        case SType::FLOAT64: return vcolptr(new arr_fw_vcol<int32_t, double> (std::move(col), ind32));
+        case SType::STR32:   return vcolptr(new arr_str_vcol<int32_t, uint32_t>(std::move(col), ind32));
+        case SType::STR64:   return vcolptr(new arr_str_vcol<int32_t, uint64_t>(std::move(col), ind32));
+        default: break;
+      }
+      break;
+    }
+
+    case RowIndexType::ARR64: {
+      const int64_t* ind64 = ri.indices64();
+      switch (st) {
+        case SType::BOOL:    return vcolptr(new arr_fw_vcol<int64_t, int8_t> (std::move(col), ind64));
+        case SType::INT8:    return vcolptr(new arr_fw_vcol<int64_t, int8_t> (std::move(col), ind64));
+        case SType::INT16:   return vcolptr(new arr_fw_vcol<int64_t, int16_t>(std::move(col), ind64));
+        case SType::INT32:   return vcolptr(new arr_fw_vcol<int64_t, int32_t>(std::move(col), ind64));
+        case SType::INT64:   return vcolptr(new arr_fw_vcol<int64_t, int64_t>(std::move(col), ind64));
+        case SType::FLOAT32: return vcolptr(new arr_fw_vcol<int64_t, float>  (std::move(col), ind64));
+        case SType::FLOAT64: return vcolptr(new arr_fw_vcol<int64_t, double> (std::move(col), ind64));
+        case SType::STR32:   return vcolptr(new arr_str_vcol<int64_t, uint32_t>(std::move(col), ind64));
+        case SType::STR64:   return vcolptr(new arr_str_vcol<int64_t, uint64_t>(std::move(col), ind64));
+        default: break;
+      }
+      break;
+    }
+
+    case RowIndexType::SLICE: {
+      size_t start = ri.slice_start();
+      size_t step = ri.slice_step();
+      switch (st) {
+        case SType::BOOL:    return vcolptr(new slice_fw_vcol<int8_t> (std::move(col), start, step));
+        case SType::INT8:    return vcolptr(new slice_fw_vcol<int8_t> (std::move(col), start, step));
+        case SType::INT16:   return vcolptr(new slice_fw_vcol<int16_t>(std::move(col), start, step));
+        case SType::INT32:   return vcolptr(new slice_fw_vcol<int32_t>(std::move(col), start, step));
+        case SType::INT64:   return vcolptr(new slice_fw_vcol<int64_t>(std::move(col), start, step));
+        case SType::FLOAT32: return vcolptr(new slice_fw_vcol<float>  (std::move(col), start, step));
+        case SType::FLOAT64: return vcolptr(new slice_fw_vcol<double> (std::move(col), start, step));
+        case SType::STR32:   return vcolptr(new slice_str_vcol<uint32_t>(std::move(col), start, step));
+        case SType::STR64:   return vcolptr(new slice_str_vcol<uint64_t>(std::move(col), start, step));
+        default: break;
+      }
+      break;
+    }
+  }
+  throw NotImplError() << "Cannot create virtual column of stype " << st;  // LCOV_EXCL_LINE
+}
+
+
+
+}}  // namespace dt::expr

--- a/c/expr/virtual_column.cc
+++ b/c/expr/virtual_column.cc
@@ -116,7 +116,7 @@ class _vcolumn : public virtual_column {
     colptr column;
 
   public:
-    _vcolumn(colptr&& col);
+    explicit _vcolumn(colptr&& col);
     colptr materialize() override;
 };
 
@@ -136,7 +136,7 @@ class fw_vcol : public _vcolumn {
     const T* data;
 
   public:
-    fw_vcol(colptr&& col)
+    explicit fw_vcol(colptr&& col)
       : _vcolumn(std::move(col)),
         data(static_cast<const T*>(column->data())) {}
 
@@ -190,7 +190,7 @@ class str_vcol : public _vcolumn {
     const char* strdata;
 
   public:
-    str_vcol(colptr&& col)
+    explicit str_vcol(colptr&& col)
       : _vcolumn(std::move(col)),
         offsets(static_cast<StringColumn<T>*>(column.get())->offsets()),
         strdata(static_cast<StringColumn<T>*>(column.get())->strdata()) {}

--- a/c/expr/virtual_column.h
+++ b/c/expr/virtual_column.h
@@ -34,9 +34,8 @@ using vcolptr = std::unique_ptr<virtual_column>;
 
 /**
  * This class is a basic building block in creating lazy evaluation
- * pipelines. This is an abstract base class, each `base_expr` is
- * expected to create its own derived class(es) to implement actual
- * computations.
+ * pipelines. This is an abstract base class, the derived classes
+ * are expected to implement actual computations.
  *
  * A `virtual_column` is conceptually similar to a regular column:
  * it has an `_stype`, the number of rows `_nrows`, and a way to

--- a/c/expr/virtual_column.h
+++ b/c/expr/virtual_column.h
@@ -39,12 +39,21 @@ using vcolptr = std::unique_ptr<virtual_column>;
  * computations.
  *
  * A `virtual_column` is conceptually similar to a regular column:
- * it has an `stype()`, the number of rows `nrows()`, and a way to
+ * it has an `_stype`, the number of rows `_nrows`, and a way to
  * retrieve its `i`-th element via a set of `compute()` overloads.
  */
 class virtual_column {
+  private:
+    size_t _nrows;
+    SType  _stype;
+    size_t : 56;
+
   public:
+    virtual_column(size_t nrows, SType stype);
     virtual ~virtual_column();
+
+    size_t nrows() const noexcept;
+    SType stype() const noexcept;
 
     virtual void compute(size_t i, int8_t*  out);
     virtual void compute(size_t i, int16_t* out);
@@ -54,14 +63,13 @@ class virtual_column {
     virtual void compute(size_t i, double*  out);
     virtual void compute(size_t i, CString* out);
 
-    virtual SType stype() const = 0;
-    virtual size_t nrows() const = 0;
     virtual colptr materialize();
 };
 
 
 vcolptr virtualize(colptr&& column);
 
+vcolptr cast(vcolptr&& vcol, SType new_stype);
 
 
 }}  // namespace dt::expr

--- a/c/parallel/shared_mutex.h
+++ b/c/parallel/shared_mutex.h
@@ -10,8 +10,8 @@
 //   +/5de42e6621b3d0131472c3f8838b7f0ccf3e8963/sources/cxx-stl/llvm-libc++/
 //   libcxx/include/shared_mutex
 //------------------------------------------------------------------------------
-#ifndef dt_UTILS_SHARED_MUTEX_h
-#define dt_UTILS_SHARED_MUTEX_h
+#ifndef dt_PARALLEL_SHARED_MUTEX_h
+#define dt_PARALLEL_SHARED_MUTEX_h
 #include <atomic>              // std::atomic
 #include <condition_variable>  // std::condition_variable
 #include <mutex>               // std::mutex, std::unique_lock

--- a/c/parallel/string_utils.h
+++ b/c/parallel/string_utils.h
@@ -13,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //------------------------------------------------------------------------------
-#ifndef dt_UTILS_PARALLEL_h
-#define dt_UTILS_PARALLEL_h
+#ifndef dt_PARALLEL_STRING_UTILS_h
+#define dt_PARALLEL_STRING_UTILS_h
 #include <memory>             // std::unique_ptr
 #include <vector>             // std::vector
 #include "parallel/api.h"     // dt::parallel_for_ordered


### PR DESCRIPTION
This PR adds new functionality: lazy computation of expressions via virtual columns.

Consider a columnar expressions such as `f.A * exp(f.B / 2)`. An eager evaluator computes this expression roughly as follows: first, column `B` is extracted from the frame, then it is cast to `float64` type, then the `/` operator divides by 2.0 and stores into a temporary column, then we compute `exp()` of that column (creating a new column), then we extract column `A` and cast it into `float64` too, and finally compute the product of the latter 2 columns. As you can see, this whole process involves creating many intermediate columns, which affects performance and memory consumption.

The new "lazy" evaluator will instead do the following: first a virtual column for `B` is created, then we create a virtual column for `float64(B)`, then a virtual column for `float64(B) / 2`, and so on, until finally we have a virtual column for the entire expression. Only then we start "materializing" the virtual column: compute the entire expression for each row, and store the result into memory, just once.

Thus, a virtual column is just a class which knows how to compute the value at a specific index `i`.

This "virtual columns" framework has a number of potential advantages over the eager evaluation:
- No intermediate memory used during the calculations;
- Possibly better performance, since most operations are memory-bound not CPU-bound, so avoiding extra memory writes should in theory allow the final result be computed faster;
- The code can be extended more easily compared to the traditional "eager" mappers;
- String columns are easier to work with too;
- The framework can be extended to allow virtual columns to be stored in a Frame directly (without materializing);
- The virtual columns can also be used to implement compressed data storage (see #1748).

This PR includes the following functionality:
- `virtual_column` base class;
- virtual <-> real column conversion;
- cast functions for virtual columns;
- unary operators for virtual columns;
- literals (basic implementation only);

This does **not** include yet:
- binary operators for virtual columns (just started working on an implementation);
- ability to include virtual columns in a frame;
- switch between lazy / eager evaluation mode (thus, the whole framework is "not operational");
- tests.