### PR TITLE
Multiple optimizations to thread pool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ BUILDDIR := build/fast
 PYTHON   ?= python
 MODULE   ?= .
 ifneq ($(CI),)
-PYTEST_FLAGS := -vv -s
+PYTEST_FLAGS := -vv -s --showlocals
 endif
 
 # Platform details

--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -146,7 +146,7 @@ static py::oobj get_thread_ids(const py::PKArgs&) {
   std::mutex m;
   size_t n = dt::num_threads_in_pool();
   py::olist list(n);
-  xassert(dt::this_thread_index() == size_t(-1));
+  xassert(dt::this_thread_index() == 0);
 
   dt::parallel_region([&] {
     std::stringstream ss;

--- a/c/parallel/monitor_thread.cc
+++ b/c/parallel/monitor_thread.cc
@@ -59,13 +59,13 @@ void monitor_thread::run() noexcept {
 
     // Wake state
     while (is_active && running) {
+      lock.unlock();
       try {
         progress::manager.update_view();
       } catch(...) {
         controller->catch_exception();
-        // if (prev_sleep_task.next_scheduler)
-        //   prev_sleep_task.next_scheduler->abort_execution();
       }
+      lock.lock();
       sleep_state_cv.wait_for(lock, SLEEP_TIME);
     }
   }

--- a/c/parallel/monitor_thread.cc
+++ b/c/parallel/monitor_thread.cc
@@ -1,0 +1,92 @@
+//------------------------------------------------------------------------------
+// Copyright 2019 H2O.ai
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//------------------------------------------------------------------------------
+/* enable nice() function in unistd.h */
+#define _XOPEN_SOURCE
+#include <iostream>
+#include <unistd.h>
+#include "parallel/monitor_thread.h"
+#include "parallel/thread_worker.h"   // idle_job
+#include "progress/manager.h"  // dt::progress::manager
+#include "utils/exceptions.h"
+namespace dt {
+
+
+monitor_thread::monitor_thread(idle_job* wc)
+  : controller(wc),
+    running(true),
+    is_active(false)
+{
+  thread = std::thread(&monitor_thread::run, this);
+}
+
+
+monitor_thread::~monitor_thread() {
+  stop_running();
+  if (thread.joinable()) thread.join();
+}
+
+
+void monitor_thread::run() noexcept {
+  constexpr auto SLEEP_TIME = std::chrono::milliseconds(20);
+  // Reduce this thread's priority to a minimum.
+  // See http://man7.org/linux/man-pages/man2/nice.2.html
+  int ret = nice(+19);
+  if (ret == -1) {
+    std::cout << "[errno " << errno << "] "
+              << "when setting nice value of monitor thread\n";
+  }
+  _set_thread_num(size_t(-1));
+
+  std::unique_lock<std::mutex> lock(mutex);
+  while (running) {
+    // Sleep state
+    while (!is_active && running) {
+      sleep_state_cv.wait(lock);
+    }
+
+    // Wake state
+    while (is_active && running) {
+      try {
+        progress::manager.update_view();
+      } catch(...) {
+        controller->catch_exception();
+        // if (prev_sleep_task.next_scheduler)
+        //   prev_sleep_task.next_scheduler->abort_execution();
+      }
+      sleep_state_cv.wait_for(lock, SLEEP_TIME);
+    }
+  }
+}
+
+
+void monitor_thread::set_active(bool a) {
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    is_active = a;
+  }
+  sleep_state_cv.notify_one();
+}
+
+
+void monitor_thread::stop_running() {
+  std::lock_guard<std::mutex> lock(mutex);
+  running = false;
+  sleep_state_cv.notify_one();
+}
+
+
+
+}  // namespace dt

--- a/c/parallel/monitor_thread.h
+++ b/c/parallel/monitor_thread.h
@@ -1,0 +1,60 @@
+//------------------------------------------------------------------------------
+// Copyright 2019 H2O.ai
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//------------------------------------------------------------------------------
+#ifndef dt_PARALLEL_MONITOR_THREAD_h
+#define dt_PARALLEL_MONITOR_THREAD_h
+#include <condition_variable>   // std::condition_variable
+#include <cstddef>              // std::size_t
+#include <mutex>                // std::mutex
+#include <thread>               // std::thread
+namespace dt {
+using std::size_t;
+
+class idle_job;
+
+
+class monitor_thread {
+  private:
+    std::thread thread;
+    idle_job* controller;
+    std::mutex mutex;
+    std::condition_variable sleep_state_cv;
+    bool running;
+    bool is_active;
+    size_t : 48;
+
+  public:
+    monitor_thread(idle_job*);
+    monitor_thread(const monitor_thread&) = delete;
+    monitor_thread(monitor_thread&&) = delete;
+    ~monitor_thread();
+
+    /**
+     * set_active(true) will cause the thread to awaken and start
+     *   running its main job;
+     * set_active(false) puts the thread back to sleep.
+     */
+    void set_active(bool a);
+
+    void stop_running();
+
+  private:
+    void run() noexcept;
+};
+
+
+
+} // namespace dt
+#endif

--- a/c/parallel/parallel_for_dynamic.cc
+++ b/c/parallel/parallel_for_dynamic.cc
@@ -133,11 +133,10 @@ void dynamic_scheduler::abort_execution() {
 
 void parallel_for_dynamic(size_t nrows, size_t nthreads, dynamicfn_t fn) {
   size_t ith = dt::this_thread_index();
+  thread_pool* thpool = thread_pool::get_instance();
 
   // Running from the master thread
-  if (ith == size_t(-1)) {
-    thread_pool* thpool = thread_pool::get_instance_unchecked();
-
+  if (!thpool->in_parallel_region()) {
     size_t tp_size = thpool->size();
     if (nthreads == 0) nthreads = tp_size;
     size_t tt_size = std::min(nthreads, tp_size);

--- a/c/parallel/parallel_for_dynamic.cc
+++ b/c/parallel/parallel_for_dynamic.cc
@@ -133,7 +133,6 @@ void dynamic_scheduler::abort_execution() {
 
 void parallel_for_dynamic(size_t nrows, size_t nthreads, dynamicfn_t fn) {
   size_t ith = dt::this_thread_index();
-  thread_pool* thpool = thread_pool::get_instance();
 
   // Running from the master thread
   if (!thpool->in_parallel_region()) {

--- a/c/parallel/parallel_for_ordered.cc
+++ b/c/parallel/parallel_for_ordered.cc
@@ -313,7 +313,6 @@ void ordered::parallel(function<void(size_t)> pre_ordered,
   else {
     sch->tasks.emplace_back(pre_ordered, do_ordered, post_ordered);
     if (sch->tasks.size() == sch->n_tasks) {
-      thread_pool* thpool = thread_pool::get_instance();
       thpool->execute_job(sch);
     } else {
       init(this);
@@ -342,7 +341,6 @@ void parallel_for_ordered(size_t niters, size_t nthreads,
   if (!niters) return;
   dt::progress::work job(niters);
 
-  thread_pool* thpool = thread_pool::get_instance();
   thpool->instantiate_threads();  // temp fix
   xassert(!thpool->in_parallel_region());
   size_t nthreads0 = thpool->size();

--- a/c/parallel/parallel_for_static.cc
+++ b/c/parallel/parallel_for_static.cc
@@ -14,6 +14,7 @@
 // limitations under the License.
 //------------------------------------------------------------------------------
 #include "parallel/api.h"
+#include "parallel/thread_pool.h"
 #include "utils/assert.h"
 #include "utils/function.h"
 namespace dt {
@@ -32,7 +33,7 @@ void _parallel_for_static(size_t nrows, size_t min_chunk_size,
   size_t ith = dt::this_thread_index();
 
   // Standard parallel loop
-  if (ith == size_t(-1)) {
+  if (!dt::thread_pool::get_instance()->in_parallel_region()) {
     if (k == 0) {
       fn(0, nrows);
     }

--- a/c/parallel/parallel_for_static.cc
+++ b/c/parallel/parallel_for_static.cc
@@ -33,7 +33,7 @@ void _parallel_for_static(size_t nrows, size_t min_chunk_size,
   size_t ith = dt::this_thread_index();
 
   // Standard parallel loop
-  if (!dt::thread_pool::get_instance()->in_parallel_region()) {
+  if (!thpool->in_parallel_region()) {
     if (k == 0) {
       fn(0, nrows);
     }

--- a/c/parallel/parallel_region.cc
+++ b/c/parallel/parallel_region.cc
@@ -83,7 +83,6 @@ void parallel_region(function<void()> fn) {
 }
 
 void parallel_region(size_t nthreads, function<void()> fn) {
-  thread_pool* thpool = thread_pool::get_instance();
   xassert(!thpool->in_parallel_region());
   size_t nthreads0 = thpool->size();
   if (nthreads > nthreads0 || nthreads == 0) nthreads = nthreads0;

--- a/c/parallel/parallel_region.cc
+++ b/c/parallel/parallel_region.cc
@@ -84,7 +84,7 @@ void parallel_region(function<void()> fn) {
 
 void parallel_region(size_t nthreads, function<void()> fn) {
   thread_pool* thpool = thread_pool::get_instance();
-  xassert(thpool->in_master_thread());
+  xassert(!thpool->in_parallel_region());
   size_t nthreads0 = thpool->size();
   if (nthreads > nthreads0 || nthreads == 0) nthreads = nthreads0;
   thread_team tt(nthreads, thpool);

--- a/c/parallel/thread_pool.cc
+++ b/c/parallel/thread_pool.cc
@@ -70,7 +70,7 @@ void thread_pool::instantiate_threads() {
       }
     }
     // Wait until all threads are properly alive & safely asleep
-    controller.join(n);
+    controller.join();
   }
   else {
     thread_team tt(n, this);
@@ -81,6 +81,7 @@ void thread_pool::instantiate_threads() {
     }
     workers.resize(n);
   }
+  xassert(workers.size() == num_threads_requested);
 }
 
 
@@ -88,8 +89,8 @@ void thread_pool::execute_job(thread_scheduler* job) {
   xassert(in_master_thread());
   xassert(current_team);
   if (workers.empty()) instantiate_threads();
-  controller.awaken_and_run(job);
-  controller.join(workers.size());
+  controller.awaken_and_run(job, workers.size());
+  controller.join();
   // careful: workers.size() may not be equal to num_threads_requested during
   // shutdown
 }

--- a/c/parallel/thread_pool.h
+++ b/c/parallel/thread_pool.h
@@ -35,8 +35,8 @@ class thread_team;
  * using `set_number_of_threads()`.
  *
  * Normally, the thread pool is in the "sleeping" state. This means all workers
- * are idling, consuming sleep tasks from the `worker_controller`
- * (see documentation of `worker_controller` in "thread_worker.h").
+ * are idling, consuming sleep tasks from the `idle_job` (see documentation of
+ * this class in "thread_worker.h").
  *
  * However, once a user requests `execute_job()`, the threads are awakened and
  * use the supplied scheduler to perform the job. The method `execute_job()` is
@@ -66,7 +66,7 @@ class thread_pool {
 
     // Scheduler used to manage sleep/awake cycle of the workers in the pool.
     // See definition in thread_worker.h
-    worker_controller controller;
+    idle_job controller;
 
     // Mutex which can be used to guard operations that must be protected
     // across all threads.

--- a/c/parallel/thread_pool.h
+++ b/c/parallel/thread_pool.h
@@ -38,7 +38,7 @@ class thread_team;
  * are idling, consuming sleep tasks from the `worker_controller`
  * (see documentation of `worker_controller` in "thread_worker.h").
  *
- * However, once a user requests `execute_job()`, the threads are awaken and
+ * However, once a user requests `execute_job()`, the threads are awakened and
  * use the supplied scheduler to perform the job. The method `execute_job()` is
  * blocking, and will return only after the job is completely finished and the
  * thread pool has been put back to sleep.
@@ -46,7 +46,6 @@ class thread_team;
  */
 class thread_pool {
   friend class thread_team;
-  friend void _child_cleanup_after_fork();
   private:
     // Worker instances, each running on its own thread. Each thread has a
     // reference to its own worker, so these workers must be alive as long
@@ -77,8 +76,11 @@ class thread_pool {
     thread_team* current_team;
 
   public:
-    static thread_pool* get_instance();
-    static thread_pool* get_instance_unchecked() noexcept;
+    thread_pool();
+    thread_pool(const thread_pool&) = delete;
+    // Not moveable: workers hold pointers to this->controller.
+    thread_pool(thread_pool&&) = delete;
+
     static thread_team* get_team_unchecked() noexcept;
 
     void instantiate_threads();
@@ -91,14 +93,9 @@ class thread_pool {
     size_t n_threads_in_team() const noexcept;
 
     static void init_options();
-
-  private:
-    thread_pool();
-    thread_pool(const thread_pool&) = delete;
-    // Not moveable: workers hold pointers to this->controller.
-    thread_pool(thread_pool&&) = delete;
 };
 
+extern thread_pool* thpool;
 
 
 }  // namespace dt

--- a/c/parallel/thread_worker.cc
+++ b/c/parallel/thread_worker.cc
@@ -33,9 +33,15 @@ thread_worker::thread_worker(size_t i, worker_controller* wc)
     scheduler(wc),
     controller(wc)
 {
-  // Create actual execution thread only when `this` is fully initialized
-  wc->expect_new_thread();
-  thread = std::thread(&thread_worker::run, this);
+  if (i == 0) {
+    wc->set_master_worker(this);
+    scheduler = nullptr;
+    _set_thread_num(0);
+  } else {
+    // Create actual execution thread only when `this` is fully initialized
+    wc->expect_new_thread();
+    thread = std::thread(&thread_worker::run, this);
+  }
 }
 
 
@@ -71,6 +77,30 @@ void thread_worker::run() noexcept {
     }
   }
 }
+
+
+/**
+ * Similar to run(), but designed to run from the master thread. The
+ * differences are following:
+ *   - this method does NOT run continuously, instead it starts with
+ *     a new job, and finishes when the job is done.
+ *   - the `scheduler` is not used (since it is never set by the
+ *     controller), instead the `job` is passed explicitly.
+ */
+void thread_worker::run_master(thread_scheduler* job) noexcept {
+  if (!job) return;
+  while (true) {
+    try {
+      thread_task* task = job->get_next_task(0);
+      if (!task) break;
+      task->execute(this);
+    } catch (...) {
+      controller->catch_exception();
+      job->abort_execution();
+    }
+  }
+}
+
 
 size_t thread_worker::get_index() const noexcept {
   return thread_index;
@@ -109,7 +139,7 @@ void worker_controller::awaken_and_run(thread_scheduler* job, size_t nthreads) {
     std::lock_guard<std::mutex> lock(tsleep[i].mutex);
     tsleep[i].next_scheduler = job;
     tsleep[j].next_scheduler = nullptr;
-    tsleep[j].n_threads_running = nthreads;
+    tsleep[j].n_threads_running = nthreads - 1; // master never sleeps!
     index = j;
     saved_exception = nullptr;
   }
@@ -123,15 +153,16 @@ void worker_controller::join() {
   sleep_task& prev_sleep_task = tsleep[(index - 1) % N_SLEEP_TASKS];
   sleep_task& curr_sleep_task = tsleep[index];
 
+  master_worker->run_master(prev_sleep_task.next_scheduler);
   while (true) {
-    try {
-      progress::manager.update_view();
-    } catch(...) {
-      catch_exception();
-      if (prev_sleep_task.next_scheduler)
-        prev_sleep_task.next_scheduler->abort_execution();
-    }
-    std::this_thread::yield();
+    // try {
+    //   progress::manager.update_view();
+    // } catch(...) {
+    //   catch_exception();
+    //   if (prev_sleep_task.next_scheduler)
+    //     prev_sleep_task.next_scheduler->abort_execution();
+    // }
+    // std::this_thread::yield();
     std::unique_lock<std::mutex> lock(curr_sleep_task.mutex);
     if (curr_sleep_task.n_threads_running == 0) break;
   }
@@ -145,6 +176,10 @@ void worker_controller::join() {
   }
 }
 
+
+void worker_controller::set_master_worker(thread_worker* worker) noexcept {
+  master_worker = worker;
+}
 
 void worker_controller::pretend_thread_went_to_sleep() {
   std::lock_guard<std::mutex> lock(tsleep[index].mutex);

--- a/c/parallel/thread_worker.h
+++ b/c/parallel/thread_worker.h
@@ -55,6 +55,7 @@ class thread_worker {
     ~thread_worker();
 
     void run() noexcept;
+    void run_master(thread_scheduler*) noexcept;
     size_t get_index() const noexcept;
 };
 
@@ -135,6 +136,9 @@ class worker_controller : public thread_scheduler {
     // If an exception occurs during execution, it will be saved here
     std::exception_ptr saved_exception;
 
+    // Thread-worker object corresponding to the master thread.
+    thread_worker* master_worker;
+
   public:
     thread_task* get_next_task(size_t thread_index) override;
 
@@ -158,6 +162,7 @@ class worker_controller : public thread_scheduler {
     bool is_running() const noexcept;
 
     void expect_new_thread();
+    void set_master_worker(thread_worker*) noexcept;
 
   private:
     // Helper for thread_shutdown_scheduler: mark the current thread as if it

--- a/c/parallel/thread_worker.h
+++ b/c/parallel/thread_worker.h
@@ -117,7 +117,7 @@ class idle_job : public thread_scheduler {
   private:
     struct sleep_task : public thread_task {
       idle_job* const controller;
-      thread_scheduler* next_scheduler;
+      std::atomic<thread_scheduler*> next_scheduler;
 
       sleep_task(idle_job*);
       void execute(thread_worker* worker) override;

--- a/c/parallel/thread_worker.h
+++ b/c/parallel/thread_worker.h
@@ -116,6 +116,7 @@ class thread_worker {
 class idle_job : public thread_scheduler {
   private:
     struct sleep_task : public thread_task {
+      static constexpr int LIGHT_SLEEP_ITERATIONS = 65536;
       idle_job* const controller;
       std::atomic<thread_scheduler*> next_scheduler;
 

--- a/c/parallel/thread_worker.h
+++ b/c/parallel/thread_worker.h
@@ -15,6 +15,7 @@
 //------------------------------------------------------------------------------
 #ifndef dt_PARALLEL_THREAD_WORKER_h
 #define dt_PARALLEL_THREAD_WORKER_h
+#include <atomic>               // std::atomic
 #include <condition_variable>   // std::condition_variable
 #include <cstddef>              // std::size_t
 #include <memory>               // std::unique_ptr

--- a/c/parallel/thread_worker.h
+++ b/c/parallel/thread_worker.h
@@ -135,7 +135,8 @@ class idle_job : public thread_scheduler {
     std::condition_variable wakeup_all_threads_cv;
 
     // How many threads are currently active (i.e. not sleeping)
-    size_t n_threads_running;
+    std::atomic<int> n_threads_running;
+    int : 32;
 
     // If an exception occurs during execution, it will be saved here
     std::exception_ptr saved_exception;

--- a/ci/setup_utils.py
+++ b/ci/setup_utils.py
@@ -467,6 +467,8 @@ def get_extra_compile_flags():
             #   -Wswitch-enum: generates spurious warnings about missing
             #       cases even if `default` clause is present. -Wswitch
             #       does not suffer from this drawback.
+            #   -Wreserved-id-macros: macro _XOPEN_SOURCE is standard on Linux
+            #       platform, unclear why Clang would complain about it.
             #   -Wweak-template-vtables: this waning's purpose is unclear, and
             #       it is also unclear how to prevent it...
             #   -Wglobal-constructors, -Wexit-time-destructors: having static
@@ -480,6 +482,7 @@ def get_extra_compile_flags():
                 "-Wno-exit-time-destructors",
                 "-Wno-float-equal",
                 "-Wno-global-constructors",
+                "-Wno-reserved-id-macro",
                 "-Wno-switch-enum",
                 "-Wno-weak-template-vtables",
             ]

--- a/tests/models/test_aggregate.py
+++ b/tests/models/test_aggregate.py
@@ -517,11 +517,11 @@ def aggregate_nd(nd):
 
         messages = ("", "Preparing", "Aggregating", "Sampling", "Finalizing")
         message_index = 0
-        for i in range(len(progress_reports)):
+        for i, p in enumerate(progress_reports):
             if i > 0:
-                assert progress_reports[i].progress >= progress_reports[i-1].progress
-            message_index_new = messages.index(progress_reports[i].message)
-            assert message_index <= message_index_new or progress_reports[i].status == "finished"
+                assert p.progress >= progress_reports[i-1].progress
+            message_index_new = messages.index(p.message)
+            assert message_index <= message_index_new or p.status == "finished"
             message_index = message_index_new
 
         assert progress_reports[-1].progress == 1.0

--- a/tests/models/test_aggregate.py
+++ b/tests/models/test_aggregate.py
@@ -518,9 +518,6 @@ def aggregate_nd(nd):
         assert messages[0].progress == 0
         assert messages[0].status == "running"
         assert messages[0].message == "Preparing"
-        assert messages[-2].progress <= 1.0
-        assert messages[-2].status == "running"
-        assert messages[-2].message == "Finalizing"
         assert messages[-1].progress == 1.0
         assert messages[-1].status == "finished"
         assert messages[-1].message == ""

--- a/tests/models/test_kfold.py
+++ b/tests/models/test_kfold.py
@@ -166,9 +166,8 @@ def test_kfold_random_2_2():
     splits = kfold_random(nrows=2, nsplits=2)
     assert isinstance(splits, list) and len(splits) == 2
     assert all(isinstance(s, tuple) and len(s) == 2 for s in splits)
-    assert all(frame.shape == (1, 1)
-               for split in splits
-               for frame in split)
+    assert all(s[0].shape == (1, 1) and s[1].shape == (1, 1)
+               for s in splits)
     a = splits[0][0][0, 0]
     assert a == 0 or a == 1
     assert splits[0][1][0, 0] == 1 - a


### PR DESCRIPTION
- Worker 0 in the team no longer spawns a thread, instead it is supposed to use the master thread. Consequently, the thread_id of the master thread is now 0, and this variable can no longer be used to distinguish between running single-threaded or parallel code.
- Removed `thread_pool::get_instance()`: the singleton instance is now statically created at the start of the program and thus is always available. However, the spawning of workers is still delayed until actually needed.
- Added `monitor_thread` class, which is similar to a worker, but executes at a very low priority and only handles progress updates / log messages.
- `worker_controller` class renamed into `idle_job`.
- Added a "light sleep" phase, where the thread first busy-waits until the next scheduler may become available