### PR TITLE
Fix segfault in progress reporting

### DIFF
--- a/c/progress/manager.cc
+++ b/c/progress/manager.cc
@@ -34,6 +34,7 @@ progress_manager::progress_manager()
 void progress_manager::start_work(work* task) {
   if (tasks.empty()) {
     xassert(pbar == nullptr);
+    std::lock_guard<std::mutex> lock(mutex);
     pbar = new progress_bar;
     task->init(pbar, nullptr);
   } else {

--- a/c/progress/manager.cc
+++ b/c/progress/manager.cc
@@ -57,17 +57,17 @@ void progress_manager::finish_work(work* task, bool successfully) {
 }
 
 
-void progress_manager::update_view() {
+void progress_manager::update_view() const {
   xassert(dt::this_thread_index() == size_t(-1));
-  if (!pbar) return;
   std::lock_guard<std::mutex> lock(mutex);
+  if (!pbar) return;
   pbar->refresh();
 }
 
 
 void progress_manager::set_error_status(bool cancelled) noexcept {
-  if (!pbar) return;
   std::lock_guard<std::mutex> lock(mutex);
+  if (!pbar) return;
   try {
     pbar->set_status_error(cancelled);
   } catch (...) {}

--- a/c/progress/manager.cc
+++ b/c/progress/manager.cc
@@ -59,10 +59,9 @@ void progress_manager::finish_work(work* task, bool successfully) {
 
 void progress_manager::update_view() {
   xassert(dt::this_thread_index() == size_t(-1));
-  if (pbar) {
-    std::lock_guard<std::mutex> lock(mutex);
-    pbar->refresh();
-  }
+  if (!pbar) return;
+  std::lock_guard<std::mutex> lock(mutex);
+  pbar->refresh();
 }
 
 

--- a/c/progress/manager.cc
+++ b/c/progress/manager.cc
@@ -67,8 +67,8 @@ void progress_manager::update_view() {
 
 
 void progress_manager::set_error_status(bool cancelled) noexcept {
-  std::lock_guard<std::mutex> lock(mutex);
   if (!pbar) return;
+  std::lock_guard<std::mutex> lock(mutex);
   try {
     pbar->set_status_error(cancelled);
   } catch (...) {}

--- a/c/progress/manager.cc
+++ b/c/progress/manager.cc
@@ -33,8 +33,8 @@ progress_manager::progress_manager()
 
 void progress_manager::start_work(work* task) {
   if (tasks.empty()) {
-    xassert(pbar == nullptr);
     std::lock_guard<std::mutex> lock(mutex);
+    xassert(pbar == nullptr);
     pbar = new progress_bar;
     task->init(pbar, nullptr);
   } else {

--- a/c/progress/manager.cc
+++ b/c/progress/manager.cc
@@ -49,6 +49,7 @@ void progress_manager::finish_work(work* task, bool successfully) {
   xassert(pbar != nullptr);
   tasks.pop();
   if (successfully && tasks.empty()) {
+    std::lock_guard<std::mutex> lock(mutex);
     pbar->set_status_finished();
     delete pbar;
     pbar = nullptr;
@@ -56,15 +57,17 @@ void progress_manager::finish_work(work* task, bool successfully) {
 }
 
 
-void progress_manager::update_view() const {
+void progress_manager::update_view() {
   xassert(dt::this_thread_index() == size_t(-1));
   if (pbar) {
+    std::lock_guard<std::mutex> lock(mutex);
     pbar->refresh();
   }
 }
 
 
 void progress_manager::set_error_status(bool cancelled) noexcept {
+  std::lock_guard<std::mutex> lock(mutex);
   if (!pbar) return;
   try {
     pbar->set_status_error(cancelled);

--- a/c/progress/manager.h
+++ b/c/progress/manager.h
@@ -44,10 +44,17 @@ class progress_manager {
     // while more and more top-level tasks are received.
     progress_bar* pbar;
     std::stack<work*> tasks;
-    std::mutex mutex;
+
+    // This mutex is used to protect access to `pbar`. In particular,
+    // `finish_work()` method can delete `pbar` from one thread
+    // during finalization, while at the same time another thread
+    // can start doing `update_view()` or `set_error_status()`
+    // also accessing `pbar`. Without the mutex protection such an access
+    // can result in a segfault.
+    mutable std::mutex mutex;
 
   public:
-    void update_view();
+    void update_view() const;
     void set_error_status(bool cancelled) noexcept;
 
   public:  // package-private

--- a/c/progress/manager.h
+++ b/c/progress/manager.h
@@ -16,6 +16,7 @@
 #ifndef dt_PROGRESS_MANAGER_h
 #define dt_PROGRESS_MANAGER_h
 #include <stack>      // std::stack
+#include <mutex>      // std::mutex, std::lock_guard
 namespace dt {
 namespace progress {
 
@@ -43,9 +44,10 @@ class progress_manager {
     // while more and more top-level tasks are received.
     progress_bar* pbar;
     std::stack<work*> tasks;
+    std::mutex mutex;
 
   public:
-    void update_view() const;
+    void update_view();
     void set_error_status(bool cancelled) noexcept;
 
   public:  // package-private

--- a/c/utils/exceptions.cc
+++ b/c/utils/exceptions.cc
@@ -9,10 +9,12 @@
 #include <iostream>
 #include <errno.h>
 #include <string.h>
+#include "parallel/api.h"
 #include "progress/manager.h"
 #include "python/obj.h"
 #include "python/string.h"
 #include "utils/exceptions.h"
+#include "utils/assert.h"
 
 
 // Singleton, used to write the current "errno" into the stream
@@ -38,6 +40,7 @@ static bool is_string_empty(const char* msg) noexcept {
 
 
 void exception_to_python(const std::exception& e) noexcept {
+  wassert(dt::num_threads_in_team() == 0);
   const Error* error = dynamic_cast<const Error*>(&e);
   if (error) {
     dt::progress::manager.set_error_status(error->is_keyboard_interrupt());


### PR DESCRIPTION
In some cases `progress_manager` tries to access progress bar that is already deleted by `progress_manager::finish_work()` method, and this results in a segfault. In particular, some of the aggregator tests, that also tested progress reporting, segfaulted on Linux and PPC.

To fix it, we use `std::mutex` to protect progress bar access.