### PR TITLE
Skip extra flags when determining setup.py command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,8 +48,10 @@ from ci.setup_utils import (get_datatable_version, make_git_version_file,
 print()
 cmd = ""
 with TaskContext("Start setup.py") as log:
-    if len(sys.argv) > 1:
-        cmd = sys.argv[1]
+    for arg in sys.argv[1:]:
+        if not arg.startswith("--"):
+            cmd = arg
+            break
     log.info("command = `%s`" % cmd)
 
 


### PR DESCRIPTION
On rare occasions `python setup.py` may be invoked with additional flags, for example see #1875:
```
python setup.py --no-user-cfg build
```
In this case we should still detect the command as `build`, not as `--no-user-cfg`.

Closes #1875