### PR TITLE
Add fast compilation mode with full optimizations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,13 @@ ci/fast.mk:
 	@$(PYTHON) ci/make_fast.py
 endif
 
+ifeq ($(MAKECMDGOALS), dfast)
+-include ci/fast.mk
+ci/fast.mk:
+	@echo • Regenerating ci/fast.mk [debug mode]
+	@$(PYTHON) ci/make_fast.py debug
+endif
+
 ifeq ($(MAKECMDGOALS), main-fast)
 -include ci/fast.mk
 endif

--- a/ci/setup_utils.py
+++ b/ci/setup_utils.py
@@ -773,7 +773,6 @@ if __name__ == "__main__":
         if cmd == "--help":
             usage()
         elif cmd == "ccflags":
-            os.environ["DTDEBUG"] = "1"  # Force the debug flag
             flags = [get_default_compile_flags()] + get_extra_compile_flags()
             print(" ".join(flags))
         elif cmd == "compiler":
@@ -781,7 +780,6 @@ if __name__ == "__main__":
         elif cmd == "ext_suffix":
             print(sysconfig.get_config_var("EXT_SUFFIX"))
         elif cmd == "ldflags":
-            os.environ["DTDEBUG"] = "1"  # Force the debug flag
             flags = [get_default_link_flags()] + get_extra_link_args()
             print(" ".join(flags))
         elif cmd == "version":


### PR DESCRIPTION
Command `make fast` now compiles datatable with `-O3` flag, i.e. with optimizations turned on. New command `make dfast` will compile datatable in debug mode, i.e. how "make fast" behaved up to now. 