### PR TITLE
Improve efficiency of sorting

### DIFF
--- a/c/parallel/parallel_for_dynamic.cc
+++ b/c/parallel/parallel_for_dynamic.cc
@@ -132,6 +132,7 @@ void dynamic_scheduler::abort_execution() {
 //------------------------------------------------------------------------------
 
 void parallel_for_dynamic(size_t nrows, size_t nthreads, dynamicfn_t fn) {
+  if (nrows == 1) return fn(0);
   size_t ith = dt::this_thread_index();
 
   // Running from the master thread

--- a/c/parallel/parallel_for_static.cc
+++ b/c/parallel/parallel_for_static.cc
@@ -34,7 +34,7 @@ void _parallel_for_static(size_t nrows, size_t min_chunk_size,
 
   // Standard parallel loop
   if (!thpool->in_parallel_region()) {
-    if (k == 0) {
+    if (k <= 1) {
       fn(0, nrows);
     }
     else {
@@ -56,7 +56,7 @@ void _parallel_for_static(size_t nrows, size_t min_chunk_size,
   }
   // Parallel loop within a parallel region
   else {
-    if (k == 0) {
+    if (k <= 1) {
       if (ith == 0) fn(0, nrows);
     }
     else {


### PR DESCRIPTION
- In a static/dynamic parallel loop, do not wake up the team if the number of iterations is 1;
- For string sorting, replace insertion sort with binary insertion sort. The idea is that for strings comparisons are relatively expensive, so their number should be kept to a minimum. This gives only a modest improvement in this particular test, but the benefit could be more significant for strings that have long common prefixes.

For n = 10M rows, the benchmark timings are as follows:
```
== Old == 
Sort int time     :  0.15964913368225098
Group int time    :  0.1817028522491455
Sort float time   :  3.507260799407959
Group float time  :  4.043126106262207
Sort string time  :  5.56641697883606
Group string time :  6.105027914047241

== New ==
Sort int time     :  0.13961219787597656
Group int time    :  0.14629697799682617
Sort float time   :  1.3678579330444336
Group float time  :  1.863948106765747
Sort string time  :  3.837000846862793
Group string time :  4.501723289489746
```