### PR TITLE
Re-initialize progress manager instance during a fork

### DIFF
--- a/c/parallel/monitor_thread.cc
+++ b/c/parallel/monitor_thread.cc
@@ -67,7 +67,7 @@ void monitor_thread::run() noexcept {
         // joins the master thread is free to do any communication with the
         // python without feat that monitor thread might be doing the same at
         // the same time.
-        progress::manager.update_view();
+        progress::manager->update_view();
       } catch(...) {
         controller->catch_exception();
       }

--- a/c/parallel/thread_pool.cc
+++ b/c/parallel/thread_pool.cc
@@ -19,6 +19,7 @@
 #include "parallel/thread_pool.h"
 #include "parallel/thread_team.h"
 #include "parallel/thread_worker.h"
+#include "progress/manager.h"
 #include "python/_all.h"
 #include "utils/assert.h"
 #include "options.h"
@@ -35,6 +36,7 @@ static void _child_cleanup_after_fork() {
   // memory is owned by the parent process.
   size_t n = thpool->size();
   thpool = new thread_pool;
+  progress::manager = new progress::progress_manager;
   thpool->resize(n);
 }
 

--- a/c/progress/manager.cc
+++ b/c/progress/manager.cc
@@ -22,8 +22,9 @@ namespace dt {
 namespace progress {
 
 
-// Static instance
-progress_manager manager;
+// Static instance; it will be re-initialized when forking -- see
+// `parallel/thread_pool.cc::_child_cleanup_after_fork()`
+progress_manager* manager = new progress_manager;
 
 
 

--- a/c/progress/manager.h
+++ b/c/progress/manager.h
@@ -66,7 +66,7 @@ class progress_manager {
 };
 
 
-extern progress_manager manager;
+extern progress_manager* manager;
 
 
 }} // dt::progress

--- a/c/progress/work.cc
+++ b/c/progress/work.cc
@@ -31,7 +31,7 @@ work::work(size_t amount)
     pbar(nullptr),
     message_set(false)
 {
-  dt::progress::manager.start_work(this);
+  dt::progress::manager->start_work(this);
   // progress manager will call this->init();
 }
 
@@ -47,12 +47,12 @@ void work::init(progress_bar* pb, work* parent) {
 void work::done() {
   xassert(done_amount == total_amount);
   if (message_set) pbar->set_message("");
-  dt::progress::manager.finish_work(this, true);
+  dt::progress::manager->finish_work(this, true);
   pbar = nullptr;
 }
 
 work::~work() {
-  if (pbar) dt::progress::manager.finish_work(this, false);
+  if (pbar) dt::progress::manager->finish_work(this, false);
 }
 
 

--- a/c/utils/exceptions.cc
+++ b/c/utils/exceptions.cc
@@ -43,7 +43,7 @@ void exception_to_python(const std::exception& e) noexcept {
   wassert(dt::num_threads_in_team() == 0);
   const Error* error = dynamic_cast<const Error*>(&e);
   if (error) {
-    dt::progress::manager.set_error_status(error->is_keyboard_interrupt());
+    dt::progress::manager->set_error_status(error->is_keyboard_interrupt());
     error->to_python();
   }
   else if (!PyErr_Occurred()) {


### PR DESCRIPTION
`progress_manager` static instance contains a mutex, which might create a problem when the process is forked. In order to avoid this issue we re-create the static `progress_manager` singleton in the "at_fork" handler.