### PR TITLE
Improvements to sort

### DIFF
--- a/c/parallel/semaphore.h
+++ b/c/parallel/semaphore.h
@@ -211,7 +211,8 @@ class LightweightSemaphore {
         // the "real" work arrives, the thread may receive a priority penalty
         // from the OS (especially when the total number of threads is equal
         // to the number of cores in the system).
-        std::this_thread::yield();
+        __asm__ volatile(".byte 0xf3,0x90");
+        // std::this_thread::yield();
       } while (spin_count--);
 
       int old_count = m_count.fetch_sub(1, std::memory_order_acquire);

--- a/c/sort.cc
+++ b/c/sort.cc
@@ -257,7 +257,7 @@ static size_t sort_thread_multiplier = 2;
 static size_t sort_max_chunk_length = 1 << 8;
 static uint8_t sort_max_radix_bits = 12;
 static uint8_t sort_over_radix_bits = 8;
-static int32_t sort_nthreads = dt::get_hardware_concurrency();
+static int32_t sort_nthreads = static_cast<int>(dt::get_hardware_concurrency());
 
 void sort_init_options() {
   dt::register_option(

--- a/c/sort.cc
+++ b/c/sort.cc
@@ -1223,7 +1223,6 @@ class SortContext {
     // Finally iterate over all remaining radix ranges, in-parallel, and
     // sort each of them independently using a simpler insertion sort
     // method.
-    size_t nthreads = std::min(nth, nsmallgroups);
     int32_t* tmp = nullptr;
     bool own_tmp = false;
     if (size0) {
@@ -1232,18 +1231,18 @@ class SortContext {
       //   tmp = (int32_t*)_x;
       // } else {
       own_tmp = true;
-      tmp = new int32_t[size0 * nthreads];
+      tmp = new int32_t[size0 * nth];
       TRACK(tmp, sizeof(tmp), "sort.tmp");
       // }
     }
 
-    dt::parallel_region(nthreads,
+    dt::parallel_region(nth,
       [&] {
         size_t tnum = dt::this_thread_index();
         int32_t* oo = tmp + tnum * size0;
         GroupGatherer tgg;
 
-        dt::parallel_for_dynamic(
+        dt::nested_for_static(
           /* n_iterations */ _nradixes,
           [&](size_t i) {
             size_t zn  = rrmap[i].size;

--- a/c/sort.cc
+++ b/c/sort.cc
@@ -257,7 +257,7 @@ static size_t sort_thread_multiplier = 2;
 static size_t sort_max_chunk_length = 1 << 8;
 static uint8_t sort_max_radix_bits = 12;
 static uint8_t sort_over_radix_bits = 8;
-static int32_t sort_nthreads = 4;
+static int32_t sort_nthreads = dt::get_hardware_concurrency();
 
 void sort_init_options() {
   dt::register_option(

--- a/c/sort.cc
+++ b/c/sort.cc
@@ -254,7 +254,7 @@ void swap(rmem& left, rmem& right) noexcept {
 
 static size_t sort_insert_method_threshold = 64;
 static size_t sort_thread_multiplier = 2;
-static size_t sort_max_chunk_length = 1 << 20;
+static size_t sort_max_chunk_length = 1 << 8;
 static uint8_t sort_max_radix_bits = 12;
 static uint8_t sort_over_radix_bits = 8;
 static int32_t sort_nthreads = 4;
@@ -318,7 +318,7 @@ void sort_init_options() {
       int32_t nth = value.to_int32_strict();
       if (nth <= 0) nth += static_cast<int32_t>(dt::get_hardware_concurrency());
       if (nth <= 0) nth = 1;
-      sort_over_radix_bits = static_cast<uint8_t>(nth);
+      sort_nthreads = static_cast<uint8_t>(nth);
     }, "");
 }
 


### PR DESCRIPTION
- Main loop in sort.cc now uses static parallel schedule;
- Tweaked some other internal sorting parameters;
- Use asm instruction to perform thread pause (borrowed from OMP).

With these changes, sort times for 10M rows are (min/avg/max):
```
Ints:    0.0575 | 0.0809 | 0.5252
Floats:  0.3808 | 0.5535 | 0.7597
Strings: 1.351  | 1.612  | 1.920
```

For comparison, same benchmarks ran on the old "omp" version:
```
Ints:    0.05407 | 0.05901 | 0.09206
Floats:  0.5953  | 0.6148  | 0.6641
Strings: 1.322   | 1.531   | 1.844
```

Closes #1813