### PR TITLE
Remove deprecated APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `datatable` no longer uses OpenMP for parallelism. Instead, we use our own
   thread pool to perform multi-threaded computations (#1736).
 
+- Parameter `progress_fn` in function `dt.models.aggregate()` is removed.
+  In its place you can set the global option `dt.options.progress.callback`.
+
+- Removed deprecated Frame methods `.topython()`, `.topandas()`, `.tonumpy()`,
+  and `Frame.__call__()`.
+
 
 ### Deprecated
 
@@ -206,10 +212,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Frame method `.save()` was renamed into `.to_jay()` (for consistency with
   other `.to_*()` methods). The old name is still usable, but marked as
   deprecated and will be removed in 0.10.0.
-
-- Parameter `progress_fn` in function `dt.models.aggregate()` is deprecated,
-  to be removed in 0.9.0. In its place you can set the global option
-  `dt.options.progress.callback`.
 
 
 ### Notes

--- a/c/frame/__getitem__.cc
+++ b/c/frame/__getitem__.cc
@@ -89,9 +89,9 @@ oobj Frame::_main_getset(robj item, robj value) {
   rtuple targs = item.to_rtuple_lax();
   size_t nargs = targs? targs.size() : 0;
   if (nargs <= 1) {
-    throw ValueError() << "Single-item selectors `DT[col]` are prohibited "
-        "since 0.8.0; please use `DT[:, col]`. In 0.9.0 this expression "
-        "will be interpreted as a row selector instead.";
+    throw ValueError() << "Single-item selector `DT[a]` is not supported; "
+        "please use `DT[:, a]` for selecting columns, and `DT[a, :]` for "
+        "selecting rows.";
   }
 
   // "Fast" get/set only handles the case of the form `DT[i, j]` where

--- a/c/models/aggregator.cc
+++ b/c/models/aggregator.cc
@@ -33,10 +33,10 @@ namespace py {
 
 
 static PKArgs args_aggregate(
-  1, 0, 10, false, false,
+  1, 0, 9, false, false,
   {
     "frame", "min_rows", "n_bins", "nx_bins", "ny_bins", "nd_max_bins",
-    "max_dimensions", "seed", "progress_fn", "nthreads", "double_precision"
+    "max_dimensions", "seed", "nthreads", "double_precision"
   },
   "aggregate",
 
@@ -68,9 +68,6 @@ max_dimensions: int
     Number of columns at which start using the projection method.
 seed: int
     Seed to be used for the projection method.
-progress_fn:
-    [DEPRECATED]
-    Please use ``dt.options.progress.callback`` instead.
 nthreads: int
     Number of threads aggregator should use. `0` means
     use all the threads.
@@ -120,9 +117,8 @@ static oobj aggregate(const PKArgs& args) {
   bool defined_nd_max_bins = !args[5].is_none_or_undefined();
   bool defined_max_dimensions = !args[6].is_none_or_undefined();
   bool defined_seed = !args[7].is_none_or_undefined();
-  bool defined_progress_fn = !args[8].is_none_or_undefined();
-  bool defined_nthreads = !args[9].is_none_or_undefined();
-  bool defined_double_precision = !args[10].is_none_or_undefined();
+  bool defined_nthreads = !args[8].is_none_or_undefined();
+  bool defined_double_precision = !args[9].is_none_or_undefined();
 
   if (defined_min_rows) {
     min_rows = args[1].to_size_t();
@@ -152,18 +148,12 @@ static oobj aggregate(const PKArgs& args) {
     seed = static_cast<unsigned int>(args[7].to_size_t());
   }
 
-  if (defined_progress_fn) {
-    DeprecationWarning() << "Parameter `progress_fn` is ignored. It will be "
-        "removed in datatable 0.9.0. Please set `options.progress.callback` "
-        "instead";
-  }
-
   if (defined_nthreads) {
-    nthreads = static_cast<unsigned int>(args[9].to_size_t());
+    nthreads = static_cast<unsigned int>(args[8].to_size_t());
   }
 
   if (defined_double_precision) {
-    double_precision = args[10].to_bool_strict();
+    double_precision = args[9].to_bool_strict();
   }
 
   dtptr dt_members, dt_exemplars;

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -48,27 +48,6 @@ class Frame(core.Frame):
     # Deprecated
     #---------------------------------------------------------------------------
 
-    def topython(self):
-        warnings.warn(
-            "Method `Frame.topython()` is deprecated (will be removed in "
-            "0.9.0), please use `Frame.to_list()` instead",
-            category=FutureWarning)
-        return self.to_list()
-
-    def topandas(self):
-        warnings.warn(
-            "Method `Frame.topandas()` is deprecated (will be removed in "
-            "0.9.0), please use `Frame.to_pandas()` instead",
-            category=FutureWarning)
-        return self.to_pandas()
-
-    def tonumpy(self, stype=None):
-        warnings.warn(
-            "Method `Frame.tonumpy()` is deprecated (will be removed in "
-            "0.9.0), please use `Frame.to_numpy()` instead",
-            category=FutureWarning)
-        return self.to_numpy(stype)
-
     def scalar(self):
         warnings.warn(
             "Method `Frame.scalar()` is deprecated (will be removed in "
@@ -81,29 +60,6 @@ class Frame(core.Frame):
             "Method `Frame.append()` is deprecated (will be removed in "
             "0.10.0), please use `Frame.rbind()` instead",
             category=FutureWarning)
-
-    def __call__(self, rows=None, select=None, verbose=False, timeit=False,
-                 groupby=None, join=None, sort=None, engine=None
-                 ):
-        """DEPRECATED, use DT[i, j, ...] instead."""
-        warnings.warn(
-            "`DT(rows, select, ...)` is deprecated and will be removed in "
-            "version 0.9.0. Please use `DT[i, j, ...]` instead",
-            category=FutureWarning)
-        time0 = time.time() if timeit else 0
-        function = type(lambda: None)
-        if isinstance(rows, function):
-            rows = rows(datatable.f)
-        if isinstance(select, function):
-            select = select(datatable.f)
-
-        res = self[rows, select,
-                   datatable.join(join),
-                   datatable.by(groupby),
-                   datatable.sort(sort)]
-        if timeit:
-            print("Time taken: %d ms" % (1000 * (time.time() - time0)))
-        return res
 
     def save(self, path, format="jay", _strategy="auto"):
         warnings.warn(

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -305,7 +305,7 @@ def test_dt_getitem(dt0):
     assert "Invalid item at position 2 in DT[i, j, ...] call" == str(e.value)
     with pytest.raises(ValueError) as e:
         noop(dt0["A"])
-    assert ("Single-item selectors `DT[col]` are prohibited"
+    assert ("Single-item selector `DT[a]` is not supported"
             in str(e.value))
 
 
@@ -331,10 +331,10 @@ def test_frame_star_expansion(dt0):
 def test_issue1406(dt0):
     with pytest.raises(ValueError) as e:
         noop(dt0[tuple()])
-    assert "Single-item selectors `DT[col]` are prohibited" in str(e.value)
+    assert "Single-item selector `DT[a]` is not supported" in str(e.value)
     with pytest.raises(ValueError) as e:
         noop(dt0[(None,)])
-    assert "Single-item selectors `DT[col]` are prohibited" in str(e.value)
+    assert "Single-item selector `DT[a]` is not supported" in str(e.value)
 
 
 


### PR DESCRIPTION
- Parameter `progress_fn` in function `dt.models.aggregate()` is removed.
  In its place you can set the global option `dt.options.progress.callback`.

- Removed deprecated Frame methods `.topython()`, `.topandas()`, `.tonumpy()`,
  and `Frame.__call__()`.

Closes #1909