### PR TITLE
Single-column selector DT[col]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,6 +200,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Removed deprecated Frame methods `.topython()`, `.topandas()`, `.tonumpy()`,
   and `Frame.__call__()`.
 
+- Syntax `DT[col]` has been restored (was previously deprecated in 0.7.0),
+  however it works only for `col` an integer or a string. Support for slices
+  may be added in the future, or not: there is a potential to confuse
+  `DT[a:b]` for a row selection. A column slice may still be selected via
+  the i-j selector `DT[:, a:b]`.
+
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Frame can now be treated as an iterable over the columns. Thus, a Frame
   object can now be used in a for-loop, producing its individual columns.
 
+- A Frame can now be treated as a mapping; in particular both `dict(frame)`
+  and `**frame` are now valid.
+
+- Single-column frames can be be used as sources for Frame construction.
+
 
 ### Fixed
 

--- a/c/csv/py_csv.cc
+++ b/c/csv/py_csv.cc
@@ -36,8 +36,7 @@ static oobj read_csv(const PKArgs& args)
   robj pyreader = args[0];
   GenericReader rdr(pyreader);
   std::unique_ptr<DataTable> dtptr = rdr.read_all();
-  return oobj::from_new_reference(
-          Frame::from_datatable(dtptr.release()));
+  return Frame::oframe(dtptr.release());
 }
 
 

--- a/c/datatable.cc
+++ b/c/datatable.cc
@@ -102,6 +102,11 @@ DataTable* DataTable::copy() const {
   return res;
 }
 
+DataTable* DataTable::extract_column(size_t i) const {
+  xassert(i < ncols);
+  return new DataTable({columns[i]->shallowcopy()}, {names[i]});
+}
+
 
 
 void DataTable::delete_columns(std::vector<size_t>& cols_to_remove) {

--- a/c/datatable.cc
+++ b/c/datatable.cc
@@ -75,6 +75,17 @@ DataTable::DataTable(colvec&& cols, const DataTable* nn)
 // Public API
 //------------------------------------------------------------------------------
 
+size_t DataTable::xcolindex(int64_t index) const {
+  int64_t incols = static_cast<int64_t>(ncols);
+  if (index < -incols || index >= incols) {
+    throw ValueError() << "Column index `" << index << "` is invalid "
+        "for a frame with " << ncols << " column" << (ncols == 1? "" : "s");
+  }
+  if (index < 0) index += incols;
+  xassert(index >= 0 && index < incols);
+  return static_cast<size_t>(index);
+}
+
 /**
  * Make a shallow copy of the current DataTable.
  */

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -123,6 +123,7 @@ class DataTable {
     py::otuple get_pynames() const;
     int64_t colindex(const py::_obj& pyname) const;
     size_t xcolindex(const py::_obj& pyname) const;
+    size_t xcolindex(int64_t index) const;
     void copy_names_from(const DataTable* other);
     void set_names_to_default();
     void set_names(const py::olist& names_list);

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -109,6 +109,7 @@ class DataTable {
     void rbind(const std::vector<DataTable*>&, const std::vector<intvec>&);
     void cbind(const std::vector<DataTable*>&);
     DataTable* copy() const;
+    DataTable* extract_column(size_t i) const;
     size_t memory_footprint() const;
 
     /**

--- a/c/datatable_load.cc
+++ b/c/datatable_load.cc
@@ -101,9 +101,9 @@ static oobj open_nff(const PKArgs& args) {
   int recode = args[3].to_bool_strict();
 
   DataTable* dt = DataTable::load(colspec, nrows, path, recode);
-  Frame* frame = Frame::from_datatable(dt);
-  frame->set_names(args[4]);
-  return oobj::from_new_reference(frame);
+  oobj res = Frame::oframe(dt);
+  static_cast<Frame*>(res.to_borrowed_ref())->set_names(args[4]);
+  return res;
 }
 
 

--- a/c/expr/workframe.cc
+++ b/c/expr/workframe.cc
@@ -160,7 +160,7 @@ py::oobj workframe::get_result() {
       result->nrows = frames[0].ri? frames[0].ri.size()
                                   : frames[0].dt->nrows;
     }
-    return py::oobj::from_new_reference(py::Frame::from_datatable(result));
+    return py::Frame::oframe(result);
   }
   return py::None();
 }

--- a/c/frame/__getitem__.cc
+++ b/c/frame/__getitem__.cc
@@ -67,7 +67,6 @@
 #include "frame/py_frame.h"
 #include "python/_all.h"
 #include "python/string.h"
-
 namespace py {
 
 // Sentinel values for __getitem__() mode
@@ -107,26 +106,14 @@ oobj Frame::_main_getset(robj item, robj value) {
     if (a0int && (a1int || arg1.is_string())) {
       int64_t irow = arg0.to_int64_strict();
       int64_t nrows = static_cast<int64_t>(dt->nrows);
-      int64_t ncols = static_cast<int64_t>(dt->ncols);
       if (irow < -nrows || irow >= nrows) {
         throw ValueError() << "Row `" << irow << "` is invalid for a frame "
             "with " << nrows << " row" << (nrows == 1? "" : "s");
       }
       if (irow < 0) irow += nrows;
       size_t zrow = static_cast<size_t>(irow);
-      size_t zcol;
-      if (a1int) {
-        int64_t icol = arg1.to_int64_strict();
-        if (icol < -ncols || icol >= ncols) {
-          throw ValueError() << "Column index `" << icol << "` is invalid "
-              "for a frame with " << ncols << " column" <<
-              (ncols == 1? "" : "s");
-        }
-        if (icol < 0) icol += ncols;
-        zcol = static_cast<size_t>(icol);
-      } else {
-        zcol = dt->xcolindex(arg1);
-      }
+      size_t zcol = a1int? dt->xcolindex(arg1.to_int64_strict())
+                         : dt->xcolindex(arg1);
       Column* col = dt->columns[zcol];
       return col->get_value_at_index(zrow);
     }

--- a/c/frame/__init__.cc
+++ b/c/frame/__init__.cc
@@ -590,7 +590,15 @@ class FrameInitializationManager {
 
     void make_column(py::robj colsrc, SType s) {
       Column* col = nullptr;
-      if (colsrc.is_buffer()) {
+      if (colsrc.is_frame()) {
+        DataTable* srcdt = colsrc.to_datatable();
+        if (srcdt->ncols != 1) {
+          throw ValueError() << "A column cannot be constructed from a Frame "
+              "with " << srcdt->ncols << " columns";
+        }
+        col = srcdt->columns[0]->shallowcopy();
+      }
+      else if (colsrc.is_buffer()) {
         col = Column::from_buffer(colsrc);
       }
       else if (colsrc.is_list_or_tuple()) {

--- a/c/frame/__iter__.cc
+++ b/c/frame/__iter__.cc
@@ -63,7 +63,7 @@ class FrameIterator : public XObject<FrameIterator>
 
       DataTable* newdt = new DataTable({dt->columns[i]->shallowcopy()},
                                        {dt->get_names()[i]});
-      return oobj::from_new_reference(Frame::from_datatable(newdt));
+      return Frame::oframe(newdt);
     }
 
   public:

--- a/c/frame/__iter__.cc
+++ b/c/frame/__iter__.cc
@@ -60,10 +60,7 @@ class FrameIterator : public XObject<FrameIterator>
       }
       size_t i = (iteration_index++);
       if (reverse) i = dt->ncols - i - 1;
-
-      DataTable* newdt = new DataTable({dt->columns[i]->shallowcopy()},
-                                       {dt->get_names()[i]});
-      return Frame::oframe(newdt);
+      return Frame::oframe(dt->extract_column(i));
     }
 
   public:

--- a/c/frame/__repr__.cc
+++ b/c/frame/__repr__.cc
@@ -404,7 +404,7 @@ bool HtmlWidget::styles_emitted = false;
 //------------------------------------------------------------------------------
 namespace py {
 
-oobj Frame::m__repr__() {
+oobj Frame::m__repr__() const {
   size_t nrows = dt->nrows;
   size_t ncols = dt->ncols;
   std::ostringstream out;
@@ -413,7 +413,7 @@ oobj Frame::m__repr__() {
   return ostring(out.str());
 }
 
-oobj Frame::m__str__() {
+oobj Frame::m__str__() const {
   oobj DFWidget = oobj::import("datatable")
                   .get_attr("widget")
                   .get_attr("DataFrameWidget");

--- a/c/frame/names.cc
+++ b/c/frame/names.cc
@@ -146,23 +146,13 @@ oobj Frame::colindex(const PKArgs& args) {
   }
 
   if (col.is_string()) {
-    int64_t index = dt->colindex(col.to_robj());
-    if (index == -1) {
-      throw _name_not_found_error(dt, col.to_string());
-    }
+    size_t index = dt->xcolindex(col.to_robj());
     return py::oint(index);
   }
   if (col.is_int()) {
-    int64_t colidx = col.to_int64_strict();
-    int64_t ncols = static_cast<int64_t>(dt->ncols);
-    if (colidx < 0 && colidx + ncols >= 0) {
-      colidx += ncols;
-    }
-    if (colidx >= 0 && colidx < ncols) {
-      return py::oint(colidx);
-    }
-    throw ValueError() << "Column index `" << colidx << "` is invalid for a "
-        "Frame with " << ncols << " column" << (ncols==1? "" : "s");
+    // dt->xcolindex() throws an exception if column index is out of bounds
+    size_t index = dt->xcolindex(col.to_int64_strict());
+    return py::oint(index);
   }
   throw TypeError() << "The argument to Frame.colindex() should be a string "
       "or an integer, not " << col.typeobj();

--- a/c/frame/py_frame.cc
+++ b/c/frame/py_frame.cc
@@ -311,6 +311,7 @@ void Frame::impl_init_type(XTypeMaker& xt) {
   xt.add(METHOD(&Frame::tail, args_tail));
   xt.add(METHOD(&Frame::copy, args_copy));
   xt.add(METHOD(&Frame::materialize, args_materialize));
+  xt.add(METHOD0(&Frame::get_names, "keys"));
 }
 
 

--- a/c/frame/py_frame.cc
+++ b/c/frame/py_frame.cc
@@ -91,10 +91,11 @@ it was deep-copied.)"
 );
 
 oobj Frame::copy(const PKArgs&) {
-  Frame* newframe = Frame::from_datatable(dt->copy());
+  oobj res = Frame::oframe(dt->copy());
+  Frame* newframe = static_cast<Frame*>(res.to_borrowed_ref());
   newframe->stypes = stypes;  Py_XINCREF(stypes);
   newframe->ltypes = ltypes;  Py_XINCREF(ltypes);
-  return py::oobj::from_new_reference(newframe);
+  return res;
 }
 
 
@@ -105,8 +106,7 @@ oobj Frame::copy(const PKArgs&) {
 bool Frame::internal_construction = false;
 
 
-Frame* Frame::from_datatable(DataTable* dt) {
-  // PyObject* pytype = reinterpret_cast<PyObject*>(&Frame::Type::type);
+oobj Frame::oframe(DataTable* dt) {
   Frame::internal_construction = true;
   PyObject* res = PyObject_CallObject(Frame_Type, nullptr);
   Frame::internal_construction = false;
@@ -114,7 +114,7 @@ Frame* Frame::from_datatable(DataTable* dt) {
 
   Frame* frame = reinterpret_cast<Frame*>(res);
   frame->dt = dt;
-  return frame;
+  return oobj::from_new_reference(frame);
 }
 
 

--- a/c/frame/py_frame.h
+++ b/c/frame/py_frame.h
@@ -76,8 +76,8 @@ class Frame : public XObject<Frame> {
     oobj m__reversed__();
 
     // Frame display
-    oobj m__repr__();
-    oobj m__str__();
+    oobj m__repr__() const;
+    oobj m__str__() const;
     oobj _repr_html_(const PKArgs&);
     oobj _repr_pretty_(const PKArgs&);
     void view(const PKArgs&);

--- a/c/frame/py_frame.h
+++ b/c/frame/py_frame.h
@@ -60,7 +60,7 @@ class Frame : public XObject<Frame> {
 
     // Internal "constructor" of Frame objects. We do not use real constructors
     // because Frame objects must be allocated/initialized by Python.
-    static Frame* from_datatable(DataTable* dt);
+    static oobj oframe(DataTable* dt);
     DataTable* get_datatable() const { return dt; }
 
     void m__init__(const PKArgs&);

--- a/c/frame/py_frame.h
+++ b/c/frame/py_frame.h
@@ -131,7 +131,6 @@ class Frame : public XObject<Frame> {
 
     ~Frame() {}
     void _clear_types() const;
-    void _clear_names();
     void _init_names() const;
     void _init_inames() const;
     void _fill_default_names();
@@ -140,6 +139,8 @@ class Frame : public XObject<Frame> {
 
     // getitem / setitem support
     oobj _main_getset(robj item, robj value);
+    oobj _get_single_column(robj selector);
+    oobj _del_single_column(robj selector);
 
     friend class FrameInitializationManager;
     friend class pylistNP;

--- a/c/frame/repeat.cc
+++ b/c/frame/repeat.cc
@@ -110,7 +110,7 @@ static oobj repeat(const PKArgs& args) {
 
   // Empty Frame: repeating is a noop
   if (dt->ncols == 0 || dt->nrows == 0) {
-    return oobj::from_new_reference(Frame::from_datatable(dt->copy()));
+    return Frame::oframe(dt->copy());
   }
 
   // Single-colum fixed-width Frame:
@@ -121,7 +121,7 @@ static oobj repeat(const PKArgs& args) {
   {
     Column* newcol = col0->repeat(n);
     DataTable* newdt = new DataTable({newcol}, dt);  // copy names from dt
-    return oobj::from_new_reference(Frame::from_datatable(newdt));
+    return Frame::oframe(newdt);
   }
 
   constexpr size_t MAX32 = std::numeric_limits<int32_t>::max();
@@ -131,7 +131,7 @@ static oobj repeat(const PKArgs& args) {
                            : _make_repeat_rowindex<int64_t>(dt->nrows, n);
 
   DataTable* newdt = apply_rowindex(dt, ri);
-  return oobj::from_new_reference(Frame::from_datatable(newdt));
+  return Frame::oframe(newdt);
 }
 
 

--- a/c/frame/stats.cc
+++ b/c/frame/stats.cc
@@ -274,7 +274,7 @@ static PKArgs args_nmodal(0, 0, 0, false, false, {}, "nmodal", nullptr);
 oobj Frame::stat(const PKArgs& args) {
   Stat stat = stat_from_args[&args];
   DataTable* res = _make_frame(dt, stat);
-  return oobj::from_new_reference(Frame::from_datatable(res));
+  return Frame::oframe(res);
 }
 
 

--- a/c/frame/to_numpy.cc
+++ b/c/frame/to_numpy.cc
@@ -147,7 +147,7 @@ oobj Frame::to_numpy(const PKArgs& args) {
       });
 
     DataTable* mask_dt = new DataTable({mask_col});
-    oobj mask_frame = oobj::from_new_reference(Frame::from_datatable(mask_dt));
+    oobj mask_frame = Frame::oframe(mask_dt);
     oobj mask_array = nparray.call({mask_frame});
 
     mask_array = mask_array.invoke("reshape", {oint(ncols), oint(dt->nrows)})

--- a/c/jay/open_jay.cc
+++ b/c/jay/open_jay.cc
@@ -189,8 +189,7 @@ static oobj open_jay(const PKArgs& args) {
   else {
     throw TypeError() << "Invalid type of the argument to open_jay()";
   }
-  Frame* frame = Frame::from_datatable(dt);
-  return oobj::from_new_reference(frame);
+  return Frame::oframe(dt);
 }
 
 

--- a/c/models/aggregator.cc
+++ b/c/models/aggregator.cc
@@ -169,12 +169,8 @@ static oobj aggregate(const PKArgs& args) {
   }
 
   agg->aggregate(dt, dt_exemplars, dt_members);
-  py::oobj df_exemplars = py::oobj::from_new_reference(
-                            py::Frame::from_datatable(dt_exemplars.release())
-                          );
-  py::oobj df_members = py::oobj::from_new_reference(
-                          py::Frame::from_datatable(dt_members.release())
-                        );
+  py::oobj df_exemplars = py::Frame::oframe(dt_exemplars.release());
+  py::oobj df_members = py::Frame::oframe(dt_members.release());
 
   // Return exemplars and members frames
   py::olist list(2);

--- a/c/models/kfold.cc
+++ b/c/models/kfold.cc
@@ -166,8 +166,7 @@ static oobj kfold(const PKArgs& args) {
     data.push_back(static_cast<int32_t*>(col->data_w()));
 
     res.set(static_cast<size_t>(ii),
-            otuple(oobj::from_new_reference(Frame::from_datatable(dt)),
-                   orange(b1, b2)));
+            otuple(Frame::oframe(dt), orange(b1, b2)));
   }
 
   size_t kk = nsplits;
@@ -337,8 +336,8 @@ static oobj kfold_random(const PKArgs& args) {
     Column* col2 = Column::new_data_column(S, fold_size);
     DataTable* dt1 = new DataTable({col1});
     DataTable* dt2 = new DataTable({col2});
-    oobj train = oobj::from_new_reference(Frame::from_datatable(dt1));
-    oobj test  = oobj::from_new_reference(Frame::from_datatable(dt2));
+    oobj train = Frame::oframe(dt1);
+    oobj test  = Frame::oframe(dt2);
     train_folds[x] = static_cast<T*>(col1->data_w());
     test_folds[x] = static_cast<T*>(col2->data_w());
     res.set(x, otuple{ train, test });

--- a/c/models/py_ftrl.cc
+++ b/c/models/py_ftrl.cc
@@ -446,9 +446,7 @@ oobj Ftrl::predict(const PKArgs& args) {
 
 
   DataTable* dt_p = dtft->dispatch_predict(dt_X).release();
-  py::oobj df_p = py::oobj::from_new_reference(
-                         py::Frame::from_datatable(dt_p)
-                  );
+  py::oobj df_p = py::Frame::oframe(dt_p);
 
   return df_p;
 }
@@ -492,9 +490,7 @@ static GSArgs args_labels(
 oobj Ftrl::get_labels() const {
   DataTable* dt_labels = dtft->get_labels();
   if (dt_labels ==nullptr) return py::None();
-  py::oobj df_labels = py::oobj::from_new_reference(
-                     py::Frame::from_datatable(dt_labels)
-                   );
+  py::oobj df_labels = py::Frame::oframe(dt_labels);
   return df_labels;
 }
 
@@ -514,9 +510,7 @@ oobj Ftrl::get_model() const {
   if (!dtft->is_model_trained()) return py::None();
 
   DataTable* dt_model = dtft->get_model();
-  py::oobj df_model = py::oobj::from_new_reference(
-                        py::Frame::from_datatable(dt_model)
-                      );
+  py::oobj df_model = py::Frame::oframe(dt_model);
   return df_model;
 }
 
@@ -578,9 +572,7 @@ oobj Ftrl::get_normalized_fi(bool normalize) const {
   if (!dtft->is_model_trained()) return py::None();
 
   DataTable* dt_fi = dtft->get_fi(normalize);
-  py::oobj df_fi = py::oobj::from_new_reference(
-                     py::Frame::from_datatable(dt_fi)
-                   );
+  py::oobj df_fi = py::Frame::oframe(dt_fi);
   return df_fi;
 }
 

--- a/c/py_buffers.cc
+++ b/c/py_buffers.cc
@@ -77,8 +77,16 @@ Column* Column::from_buffer(const py::robj& pyobj)
     if (ret != 0) throw PyError();
   }
   if (view->ndim != 1) {
-    throw NotImplError() << "Source buffer has ndim=" << view->ndim
-      << ", however only 1-D buffers are supported";
+    int num_nontrivial_dimensions = view->ndim;
+    if (view->shape && !view->strides) {
+      for (int i = 0; i < view->ndim; ++i) {
+        num_nontrivial_dimensions -= (view->shape[i] == 1);
+      }
+    }
+    if (num_nontrivial_dimensions > 1) {
+      throw NotImplError() << "Source buffer has " << num_nontrivial_dimensions
+        << " non-trivial dimensions, however only 1-D buffers are supported";
+    }
   }
 
   SType stype = stype_from_format(view->format, view->itemsize);

--- a/c/python/xobject.h
+++ b/c/python/xobject.h
@@ -324,6 +324,19 @@ PyObject* _safe_repr(PyObject* self) noexcept {
 }
 
 
+template <typename T, py::oobj(T::*METH)() const>
+PyObject* _safe_repr(PyObject* self) noexcept {
+  try {
+    T* tself = static_cast<T*>(self);
+    return (tself->*METH)().release();
+  }
+  catch (const std::exception& e) {
+    exception_to_python(e);
+    return nullptr;
+  }
+}
+
+
 template <class T, oobj(T::*METH)() const>
 PyObject* _safe_getter(PyObject* obj, void*) noexcept {
   try {

--- a/c/set_funcs.cc
+++ b/c/set_funcs.cc
@@ -56,7 +56,7 @@ static py::oobj make_pyframe(sort_result& sr, arr32_t&& arr) {
   Column* out_col = sr.col->shallowcopy(out_ri);
   out_col->materialize();
   DataTable* dt = new DataTable({out_col}, {sr.colname});
-  return py::oobj::from_new_reference(py::Frame::from_datatable(dt));
+  return py::Frame::oframe(dt);
 }
 
 static void verify_frame_1column(DataTable* dt) {
@@ -122,8 +122,7 @@ static sort_result sort_columns(ccolvec&& cv) {
 
 static py::oobj _union(ccolvec&& cols) {
   if (cols.cols.empty()) {
-    return py::oobj::from_new_reference(
-              py::Frame::from_datatable(new DataTable()));
+    return py::Frame::oframe(new DataTable());
   }
   sort_result sorted = sort_columns(std::move(cols));
 

--- a/c/str/py_str.cc
+++ b/c/str/py_str.cc
@@ -58,7 +58,7 @@ static oobj split_into_nhot(const PKArgs& args) {
   }
 
   DataTable* res = dt::split_into_nhot(col0, sep[0], sort);
-  return Frame::from_datatable(res);
+  return Frame::oframe(res);
 }
 
 

--- a/tests/munging/test_assign.py
+++ b/tests/munging/test_assign.py
@@ -202,6 +202,22 @@ def test_stats_after_assign():
     assert DT.countna1() == 0
 
 
+def test_assign_to_single_column_selector():
+    DT = dt.Frame(A=range(5), B=list('abcde'))[:, ['A', 'B']]
+    DT["A"] = 17
+    assert_equals(DT, dt.Frame([[17] * 5, list('abcde')],
+                               names=('A', 'B'),
+                               stypes=(dt.int32, dt.str32)))
+    DT["C"] = False
+    assert_equals(DT, dt.Frame([[17] * 5, list('abcde'), [False] * 5],
+                               names=('A', 'B', 'C'),
+                               stypes=(dt.int32, dt.str32, dt.bool8)))
+    DT[-2] = "hi!"
+    assert_equals(DT, dt.Frame([[17] * 5, ["hi!"] * 5, [False] * 5],
+                               names=('A', 'B', 'C'),
+                               stypes=(dt.int32, dt.str32, dt.bool8)))
+
+
 
 
 #-------------------------------------------------------------------------------

--- a/tests/munging/test_delete.py
+++ b/tests/munging/test_delete.py
@@ -61,7 +61,7 @@ def test_del_1col_str_1():
 
 def test_del_1col_str_2():
     d0 = smalldt()
-    del d0[:, "B"]
+    del d0["B"]
     assert_equals(d0, dt.Frame([[i] for i in range(16) if i != 1],
                                names=list("ACDEFGHIJKLMNOP")))
 
@@ -85,6 +85,13 @@ def test_del_1col_int():
     del d0[:, -1]
     assert_equals(d0, dt.Frame([[i] for i in range(16) if i != 15],
                                names=list("ABCDEFGHIJKLMNO")))
+
+
+def test_del_1col_int2():
+    d0 = smalldt()
+    del d0[5]
+    assert_equals(d0, dt.Frame([[i] for i in range(16) if i != 5],
+                               names=list("ABCDEGHIJKLMNOP")))
 
 
 def test_del_1col_expr():

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -329,6 +329,7 @@ def test_frame_star_expansion(dt0):
     foo(*dt0)
 
 
+@pytest.mark.usefixtures("py36")
 def test_frame_as_mapping(dt0):
     assert dt0.keys() == dt0.names
     i = 0

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -303,10 +303,11 @@ def test_dt_getitem(dt0):
     with pytest.raises(TypeError) as e:
         noop(dt0[0, 1, 2, 3])
     assert "Invalid item at position 2 in DT[i, j, ...] call" == str(e.value)
-    with pytest.raises(ValueError) as e:
-        noop(dt0["A"])
-    assert ("Single-item selector `DT[a]` is not supported"
-            in str(e.value))
+
+
+def test_dt_getitem2(dt0):
+    assert_equals(dt0["A"], dt0[:, "A"])
+    assert_equals(dt0[1], dt0[:, 1])
 
 
 def test_frame_as_iterable(dt0):
@@ -331,10 +332,10 @@ def test_frame_star_expansion(dt0):
 def test_issue1406(dt0):
     with pytest.raises(ValueError) as e:
         noop(dt0[tuple()])
-    assert "Single-item selector `DT[a]` is not supported" in str(e.value)
+    assert "Invalid tuple of size 0 used as a frame selector" in str(e.value)
     with pytest.raises(ValueError) as e:
-        noop(dt0[(None,)])
-    assert "Single-item selector `DT[a]` is not supported" in str(e.value)
+        noop(dt0[3,])
+    assert "Invalid tuple of size 1 used as a frame selector" in str(e.value)
 
 
 

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -359,14 +359,14 @@ def test_dt_colindex_bad1(dt0):
 def test_dt_colindex_bad2(dt0):
     with pytest.raises(ValueError) as e:
         dt0.colindex(7)
-    assert ("Column index `7` is invalid for a Frame with 7 columns" ==
+    assert ("Column index `7` is invalid for a frame with 7 columns" ==
             str(e.value))
 
 
 def test_dt_colindex_bad3(dt0):
     with pytest.raises(ValueError) as e:
         dt0.colindex(-8)
-    assert ("Column index `-8` is invalid for a Frame with 7 columns" ==
+    assert ("Column index `-8` is invalid for a frame with 7 columns" ==
             str(e.value))
 
 

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -329,6 +329,27 @@ def test_frame_star_expansion(dt0):
     foo(*dt0)
 
 
+def test_frame_as_mapping(dt0):
+    assert dt0.keys() == dt0.names
+    i = 0
+    for name, col in dict(dt0).items():
+        assert name == dt0.names[i]
+        assert_equals(col, dt0[:, i])
+        i += 1
+
+
+def test_frame_doublestar_expansion(dt0):
+    def foo(**kwds):
+        for name, col in kwds.items():
+            assert isinstance(name, str)
+            assert isinstance(col, dt.Frame)
+            assert col.shape == (dt0.nrows, 1)
+            assert name == col.names[0]
+            frame_integrity_check(col)
+
+    foo(**dt0)
+
+
 def test_issue1406(dt0):
     with pytest.raises(ValueError) as e:
         noop(dt0[tuple()])

--- a/tests/test_dt_create.py
+++ b/tests/test_dt_create.py
@@ -124,6 +124,14 @@ def test_different_column_lengths():
             "columns (10)" == str(e.value))
 
 
+def test_from_frame_as_column():
+    DT = dt.Frame(A=[1, 2, 3], B=[7, 4, 1])
+    with pytest.raises(ValueError) as e:
+        dt.Frame(X=DT)
+    assert ("A column cannot be constructed from a Frame with 2 columns"
+            == str(e.value))
+
+
 
 #-------------------------------------------------------------------------------
 # Create empty Frame
@@ -351,6 +359,24 @@ def test_create_from_frame_error():
     with pytest.raises(TypeError) as e2:
         dt.Frame(d0, stypes=[stype.str32])
     assert str(e1.value) == str(e2.value)
+
+
+@pytest.mark.usefixtures("py36")
+def test_create_from_column_frames():
+    DT0 = dt.Frame(A=range(5), B=list("dfkjd"),
+                   C=[False, True, True, None, True])
+    DT1 = dt.Frame(a=DT0["A"], b=DT0["B"], c=DT0["C"])
+    assert DT1.names == ("a", "b", "c")
+    assert DT1.stypes == DT0.stypes
+    assert DT1.to_list() == DT0.to_list()
+
+
+@pytest.mark.usefixtures("py36")
+def test_create_from_doublestar_expansion():
+    DT0 = dt.Frame(A=range(3), B=["df", "qe;r", None])
+    DT1 = dt.Frame(D=[7.99, -12.5, 0.1], E=[None]*3)
+    DT = dt.Frame(**DT0, **DT1)
+    assert_equals(DT, dt.cbind(DT0, DT1))
 
 
 


### PR DESCRIPTION
The expression `DT[a]` is now valid when `a` is either an integer or a string, and it is interpreted as a column selector from `DT`. This is not a breaking API change, however previously expression `DT[a]` produced an error message saying that it will eventually be interpreted as row-selection.

Few other changes:
- added C++ method `Frame::oframe(DataTable*)->oobj` to simplify creation of Frame objects;
- A single-column Frame can now be used as a source for constructing a frame, e.g.: `dt.Frame(A=DT)` where DT is single-column;
- Added "hidden" Frame method `.keys()`, which returns just the tuple of column names. This method is needed to satisfy the requirements of python mapping interface;
- `**DT` can now be used -- expands into a sequence of columnname=column named arguments. For example, cbinding can be equivalently written as `dt.Frame(**DT1, **DT2)` (however if the frames have duplicate names, an exception will be raised).

Closes #1910