### PR TITLE
`quoting` parameter in to_csv()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - CSV writer now quotes fields containing single-quote mark (`'`).
 
+- Added parameter `quoting=` to method `Frame.to_csv()`. The accepted values
+  are 4 constants from the standard `csv` module: `csv.QUOTE_MINIMAL`
+  (default), `csv.QUOTE_ALL`, `csv.QUOTE_NONNUMERIC` and `csv.QUOTE_NONE`.
+
 
 ### Fixed
 
@@ -189,6 +193,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed a crash when writing a joined frame into CSV (#1919).
 
+- Fixed a crash when writing into CSV string view columns, especially of
+  str64 type (#1921).
+
 
 ### Changed
 
@@ -240,7 +247,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   and reporting bugs that were fixed in this release:
 
   - [Arno Candel][] (#1619, #1730, #1738, #1800, #1803, #1846, #1857, #1890,
-    #1891, #1919),
+    #1891, #1919, #1921),
 
   - [Antorsae][] (#1639),
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -227,6 +227,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   `DT[a:b]` for a row selection. A column slice may still be selected via
   the i-j selector `DT[:, a:b]`.
 
+- The `nthreads=` parameter in `Frame.to_csv()` was removed. If needed, please
+  set the global option `dt.options.nthreads`.
+
 
 ### Deprecated
 

--- a/c/write/column_builder.cc
+++ b/c/write/column_builder.cc
@@ -38,10 +38,22 @@ size_t column_builder::get_dynamic_output_size() const {
 }
 
 
-void column_builder::write(writing_context& ctx, size_t row) {
+void column_builder::write_normal(writing_context& ctx, size_t row) {
   bool isvalid = reader->read(ctx, row);
   if (isvalid) {
     writer->write(ctx);
+  } else {
+    ctx.write_na();
+  }
+}
+
+
+void column_builder::write_quoted(writing_context& ctx, size_t row) {
+  bool isvalid = reader->read(ctx, row);
+  if (isvalid) {
+    *ctx.ch++ = '"';
+    writer->write(ctx);
+    *ctx.ch++ = '"';
   } else {
     ctx.write_na();
   }

--- a/c/write/column_builder.h
+++ b/c/write/column_builder.h
@@ -39,7 +39,8 @@ class column_builder {
     size_t get_static_output_size() const;
     size_t get_dynamic_output_size() const;
 
-    void write(writing_context& ctx, size_t row);
+    void write_normal(writing_context& ctx, size_t row);
+    void write_quoted(writing_context& ctx, size_t row);
 };
 
 

--- a/c/write/output_options.h
+++ b/c/write/output_options.h
@@ -21,8 +21,17 @@
 //------------------------------------------------------------------------------
 #ifndef dt_WRITE_OUTPUT_OPTIONS_h
 #define dt_WRITE_OUTPUT_OPTIONS_h
+#include <cstdint>   // int8_t
 namespace dt {
 namespace write {
+
+// These constants coincide with those defined in the python `csv` module.
+enum class Quoting : int8_t {
+  MINIMAL = 0,
+  ALL = 1,
+  NONNUMERIC = 2,
+  NONE = 3
+};
 
 
 struct output_options {
@@ -33,7 +42,8 @@ struct output_options {
   bool strings_never_quote;
   bool strings_always_quote;
   bool strings_escape_quotes;
-  int : 16;
+  Quoting quoting_mode;
+  int : 8;
 
   output_options()
     : floats_as_hex(false),
@@ -45,7 +55,8 @@ struct output_options {
 };
 
 
-static_assert(sizeof(output_options) == 8, "Unexpected size of output_options");
+static_assert(sizeof(output_options) == 8,
+              "Unexpected size of output_options");
 
 
 }}  // namespace dt::write

--- a/c/write/write_manager.cc
+++ b/c/write/write_manager.cc
@@ -59,6 +59,9 @@ void write_manager::set_usehex(bool f) {
   options.integers_as_hex = f;
 }
 
+void write_manager::set_quoting(int q) {
+  options.quoting_mode = static_cast<Quoting>(q);
+}
 
 
 

--- a/c/write/write_manager.h
+++ b/c/write/write_manager.h
@@ -102,6 +102,7 @@ class write_manager {
     void set_strategy(WritableBuffer::Strategy);
     void set_logger(py::oobj logger);
     void set_usehex(bool);
+    void set_quoting(int);
 
     void write_main();
     py::oobj get_result();


### PR DESCRIPTION
Added `quoting=` parameter to the .to_csv() method of Frame.
The meaning of the parameter is the same as in the standard `csv` module. Four quoting modes are supported: `csv.QUOTE_MINIMAL`, `csv.QUOTE_ALL`, `csv.QUOTE_NONNUMERIC` and `csv.QUOTE_NONE`.

Closes #1925