### PR TITLE
Use zero seed in Murmur hash functions

### DIFF
--- a/c/models/column_hasher.cc
+++ b/c/models/column_hasher.cc
@@ -108,7 +108,7 @@ uint64_t HasherString<T>::hash(size_t row) const {
     const T strstart = offsets[i - 1] & ~GETNA<T>();
     const char* c_str = strdata + strstart;
     T len = offsets[i] - strstart;
-    return hash_murmur2(c_str, len * sizeof(char), 0);
+    return hash_murmur2(c_str, len * sizeof(char));
   }
 }
 

--- a/c/models/dt_ftrl.cc
+++ b/c/models/dt_ftrl.cc
@@ -976,8 +976,7 @@ std::vector<hasherptr> Ftrl<T>::create_hashers(const DataTable* dt) {
   colname_hashes.reserve(dt->ncols);
   for (size_t i = 0; i < dt->ncols; i++) {
     uint64_t h = hash_murmur2(c_names[i].c_str(),
-                             c_names[i].length() * sizeof(char),
-                             0);
+                             c_names[i].length() * sizeof(char));
     colname_hashes.push_back(h);
   }
 

--- a/c/models/murmurhash.cc
+++ b/c/models/murmurhash.cc
@@ -10,7 +10,7 @@
 /**
  *  Murmur2 hash function.
  */
-uint64_t hash_murmur2(const void* key, uint64_t len, unsigned int seed)
+uint64_t hash_murmur2(const void* key, uint64_t len, unsigned int seed /* =0 */)
 {
   if (!key) return 0;
   constexpr uint64_t m = 0xc6a4a7935bd1e995LLU;
@@ -56,8 +56,9 @@ uint64_t hash_murmur2(const void* key, uint64_t len, unsigned int seed)
 /**
  *  Murmur3 hash function.
  */
-void hash_murmur3(const void* key, const uint64_t len, unsigned int seed,
-                  void* out)
+void hash_murmur3(const void* key, const uint64_t len, void* out,
+                  unsigned int seed /* = 0 */
+                  )
 {
   const uint8_t* data = static_cast<const uint8_t*>(key);
   const uint64_t nblocks = len / 16;

--- a/c/models/murmurhash.cc
+++ b/c/models/murmurhash.cc
@@ -10,13 +10,15 @@
 /**
  *  Murmur2 hash function.
  */
-uint64_t hash_murmur2(const void* key, uint64_t len, unsigned int seed /* =0 */)
+uint64_t hash_murmur2(const void* key, uint64_t len)
 {
   if (!key) return 0;
   constexpr uint64_t m = 0xc6a4a7935bd1e995LLU;
   constexpr int r = 47;
 
-  uint64_t h = seed ^ (len * m);
+  // uint64_t h = seed ^ (len * m);
+  // Use zero seed
+  uint64_t h = len * m;
 
   const uint64_t* data = static_cast<const uint64_t*>(key);
   const uint64_t* end = data + (len/8);
@@ -56,15 +58,15 @@ uint64_t hash_murmur2(const void* key, uint64_t len, unsigned int seed /* =0 */)
 /**
  *  Murmur3 hash function.
  */
-void hash_murmur3(const void* key, const uint64_t len, void* out,
-                  unsigned int seed /* = 0 */
-                  )
-{
+void hash_murmur3(const void* key, const uint64_t len, void* out) {
   const uint8_t* data = static_cast<const uint8_t*>(key);
   const uint64_t nblocks = len / 16;
 
-  uint64_t h1 = seed;
-  uint64_t h2 = seed;
+  // uint64_t h1 = seed;
+  // uint64_t h2 = seed;
+  // Use zero seed
+  uint64_t h1 = 0;
+  uint64_t h2 = 0;
 
   constexpr uint64_t c1 = 0x87c37b91114253d5LLU;
   constexpr uint64_t c2 = 0x4cf5ad432745937fLLU;

--- a/c/models/murmurhash.h
+++ b/c/models/murmurhash.h
@@ -5,8 +5,8 @@
 //------------------------------------------------------------------------------
 #include "types.h"
 
-uint64_t hash_murmur2(const void *, uint64_t, unsigned int);
-void hash_murmur3(const void *, uint64_t, unsigned int, void *);
+uint64_t hash_murmur2(const void *, uint64_t, unsigned int seed = 0);
+void hash_murmur3(const void *, uint64_t, void *, unsigned int seed = 0);
 
 uint64_t ROTL64(uint64_t, int8_t);
 uint64_t getblock64 (const uint64_t *, uint64_t);

--- a/c/models/murmurhash.h
+++ b/c/models/murmurhash.h
@@ -5,8 +5,8 @@
 //------------------------------------------------------------------------------
 #include "types.h"
 
-uint64_t hash_murmur2(const void *, uint64_t, unsigned int seed = 0);
-void hash_murmur3(const void *, uint64_t, void *, unsigned int seed = 0);
+uint64_t hash_murmur2(const void *, uint64_t);
+void hash_murmur3(const void *, uint64_t, void *);
 
 uint64_t ROTL64(uint64_t, int8_t);
 uint64_t getblock64 (const uint64_t *, uint64_t);

--- a/c/stats.cc
+++ b/c/stats.cc
@@ -597,7 +597,7 @@ void StringStats<T>::compute_sorted_stats(const Column* col) {
 
 struct StrHasher {
   size_t operator()(const CString& s) const {
-    return hash_murmur2(s.ch, static_cast<size_t>(s.size), 0);
+    return hash_murmur2(s.ch, static_cast<size_t>(s.size));
   }
 };
 


### PR DESCRIPTION
For the datatable purposes we don't need to vary `seed` parameter in Murmur hash functions. So to be safer and slightly faster, in this PR we remove this parameter and replace it with a zero seed.