### PR TITLE
Cast to floats on-the-fly in Aggregator

### DIFF
--- a/c/models/column_convertor.h
+++ b/c/models/column_convertor.h
@@ -96,7 +96,7 @@ size_t ColumnConvertor<T>::get_nrows() {
 template<typename T1, typename T2, typename T3>
 class ColumnConvertorReal : public ColumnConvertor<T2> {
   private:
-    const /* T1* */ T2* values;
+    const  T1*  /* T2* */ values;
     OColumn column;
   public:
     explicit ColumnConvertorReal(const OColumn&);
@@ -114,17 +114,17 @@ ColumnConvertorReal<T1, T2, T3>::ColumnConvertorReal(const OColumn& column_in) :
   ColumnConvertor<T2>(column_in)
 {
   xassert((std::is_same<T2, float>::value || std::is_same<T2, double>::value));
-  SType to_stype = (sizeof(T2) == 4)? SType::FLOAT32 : SType::FLOAT64;
+  // SType to_stype = (sizeof(T2) == 4)? SType::FLOAT32 : SType::FLOAT64;
 
-  column = OColumn(column_in->cast(to_stype));
-  auto column_real = static_cast<const RealColumn<T2>*>(column.get());
-  this->min = column_real->min();
-  this->max = column_real->max();
-  values = column_real->elements_r();
-  // auto columnT = static_cast<const T3*>(column_in);
-  // this->min = static_cast<T2>(columnT->min());
-  // this->max = static_cast<T2>(columnT->max());
-  // values = static_cast<const T1*>(column_in->data());
+  // column = OColumn(column_in->cast(to_stype));
+  // auto column_real = static_cast<const RealColumn<T2>*>(column.get());
+  // this->min = column_real->min();
+  // this->max = column_real->max();
+  // values = column_real->elements_r();
+  auto columnT = static_cast<const T3*>(column_in.get());
+  this->min = static_cast<T2>(columnT->min());
+  this->max = static_cast<T2>(columnT->max());
+  values = static_cast<const T1*>(column_in->data());
 }
 
 
@@ -136,13 +136,13 @@ ColumnConvertorReal<T1, T2, T3>::ColumnConvertorReal(const OColumn& column_in) :
  */
 template<typename T1, typename T2, typename T3>
 T2 ColumnConvertorReal<T1, T2, T3>::operator[](size_t row) const {
-  size_t i = row;
-  // size_t i = this->ri[row];
-  if (i == RowIndex::NA /* || ISNA<T1>(values[i]) */) {
+  // size_t i = row;
+  size_t i = this->ri[row];
+  if (i == RowIndex::NA  || ISNA<T1>(values[i]) ) {
     return GETNA<T2>();
   } else {
-    return values[i];
-    // return static_cast<T2>(values[i]);
+    // return values[i];
+    return static_cast<T2>(values[i]);
   }
 }
 
@@ -157,13 +157,13 @@ void ColumnConvertorReal<T1, T2, T3>::get_rows(std::vector<T2>& buffer,
                                                size_t step,
                                                size_t count) const {
   for (size_t j = 0; j < count; ++j) {
-    size_t i = from + j * step;
-    // size_t i = this->ri[from + j * step];
-    if (i == RowIndex::NA /*|| ISNA<T1>(values[i])*/) {
+    // size_t i = from + j * step;
+    size_t i = this->ri[from + j * step];
+    if (i == RowIndex::NA || ISNA<T1>(values[i])) {
       buffer[j] = GETNA<T2>();
     } else {
-      buffer[j] = values[i];
-      // buffer[j] = static_cast<T2>(values[i]);
+      // buffer[j] = values[i];
+      buffer[j] = static_cast<T2>(values[i]);
     }
   }
 }

--- a/c/progress/progress_bar.cc
+++ b/c/progress/progress_bar.cc
@@ -225,6 +225,7 @@ void progress_bar::_render_message(std::stringstream& out) {
   switch (status) {
     case Status::RUNNING:
       out << message;
+      out << "\x1B[K"; // clear till the end of the terminal line
       return;
 
     case Status::FINISHED:


### PR DESCRIPTION
As we had a performance issue calculating stats on integer columns, some time ago Aggregator was switched to cast all data to float columns and calculate stats on the casted columns only. Though this approach made Aggregator faster, it obviously introduced a significant memory overhead (~x2).

As of #1894 most of the performance issues connected to stats are solved, so now we can do casting on-the-fly in Aggregator. With this PR we decrease memory usage by about factor of two, as well as slightly improve overall Aggregator performance.

Thanks to @st-pasha, in this PR we fix minor glitch with progress bar rendering too. Testing progress bar capabilities further revealed problem #1937, that should also be fixed at some point.