### PR TITLE
Ocolumn2

### DIFF
--- a/c/column.cc
+++ b/c/column.cc
@@ -368,6 +368,15 @@ void OColumn::materialize() {
   pcol->materialize();
 }
 
+OColumn OColumn::cast(SType stype) const {
+  return OColumn(pcol->cast(stype));
+}
+
+OColumn OColumn::cast(SType stype, MemoryRange&& mem) const {
+  return OColumn(pcol->cast(stype, std::move(mem)));
+}
+
+
 
 
 //==============================================================================

--- a/c/column.cc
+++ b/c/column.cc
@@ -82,7 +82,7 @@ Column* Column::new_mmap_column(SType stype, size_t nrows,
  * If a file with the given name already exists, it will be overwritten.
  */
 void Column::save_to_disk(const std::string& filename,
-                          WritableBuffer::Strategy strategy) {
+                          WritableBuffer::Strategy strategy) const {
   mbuf.save_to_disk(filename, strategy);
 }
 

--- a/c/column.cc
+++ b/c/column.cc
@@ -335,7 +335,6 @@ static inline py::oobj getelem(const OColumn& col, size_t i) {
 }
 
 py::oobj OColumn::get_element_as_pyobject(size_t i) const {
-  // return pcol->get_value_at_index(i);
   switch (stype()) {
     case SType::BOOL: {
       int32_t x;
@@ -393,5 +392,4 @@ void VoidColumn::init_xbuf(Py_buffer*) {}
 Stats* VoidColumn::get_stats() const { return nullptr; }
 void VoidColumn::fill_na() {}
 RowIndex VoidColumn::join(const Column*) const { return RowIndex(); }
-py::oobj VoidColumn::get_value_at_index(size_t) const { return py::oobj(); }
 void VoidColumn::fill_na_mask(int8_t*, size_t, size_t) {}

--- a/c/column.h
+++ b/c/column.h
@@ -162,6 +162,13 @@ public:
   virtual bool is_fixedwidth() const = 0;
   LType ltype() const noexcept { return info(stype()).ltype(); }
 
+  virtual bool get_element(size_t i, int32_t* out) const;
+  virtual bool get_element(size_t i, int64_t* out) const;
+  virtual bool get_element(size_t i, float* out) const;
+  virtual bool get_element(size_t i, double* out) const;
+  virtual bool get_element(size_t i, CString* out) const;
+  virtual bool get_element(size_t i, py::oobj* out) const;
+
   const RowIndex& rowindex() const noexcept { return ri; }
   RowIndex remove_rowindex();
   void replace_rowindex(const RowIndex& newri);
@@ -472,6 +479,7 @@ public:
   double sd() const;
   BooleanStats* get_stats() const override;
 
+  bool get_element(size_t i, int32_t* out) const override;
   py::oobj get_value_at_index(size_t i) const override;
 
   protected:
@@ -504,6 +512,8 @@ public:
   int64_t max_int64() const override;
   IntegerStats<T>* get_stats() const override;
 
+  bool get_element(size_t i, int32_t* out) const override;
+  bool get_element(size_t i, int64_t* out) const override;
   py::oobj get_value_at_index(size_t i) const override;
 
 protected:
@@ -537,6 +547,7 @@ public:
   double kurt() const;
   RealStats<T>* get_stats() const override;
 
+  bool get_element(size_t i, T* out) const override;
   py::oobj get_value_at_index(size_t i) const override;
 
 protected:
@@ -575,6 +586,7 @@ public:
   virtual SType stype() const noexcept override;
   PyObjectStats* get_stats() const override;
 
+  bool get_element(size_t i, py::oobj* out) const override;
   py::oobj get_value_at_index(size_t i) const override;
 
 protected:
@@ -633,6 +645,7 @@ public:
 
   void verify_integrity(const std::string& name) const override;
 
+  bool get_element(size_t i, CString* out) const override;
   py::oobj get_value_at_index(size_t i) const override;
   void fill_na_mask(int8_t* outmask, size_t row0, size_t row1) override;
 

--- a/c/column.h
+++ b/c/column.h
@@ -281,7 +281,6 @@ public:
    */
   virtual void materialize() = 0;
 
-  virtual py::oobj get_value_at_index(size_t i) const = 0;
 
   virtual RowIndex join(const Column* keycol) const = 0;
 
@@ -480,7 +479,6 @@ public:
   BooleanStats* get_stats() const override;
 
   bool get_element(size_t i, int32_t* out) const override;
-  py::oobj get_value_at_index(size_t i) const override;
 
   protected:
 
@@ -514,7 +512,6 @@ public:
 
   bool get_element(size_t i, int32_t* out) const override;
   bool get_element(size_t i, int64_t* out) const override;
-  py::oobj get_value_at_index(size_t i) const override;
 
 protected:
   using Column::stats;
@@ -548,7 +545,6 @@ public:
   RealStats<T>* get_stats() const override;
 
   bool get_element(size_t i, T* out) const override;
-  py::oobj get_value_at_index(size_t i) const override;
 
 protected:
   using Column::stats;
@@ -587,7 +583,6 @@ public:
   PyObjectStats* get_stats() const override;
 
   bool get_element(size_t i, py::oobj* out) const override;
-  py::oobj get_value_at_index(size_t i) const override;
 
 protected:
   PyObjectColumn();
@@ -646,7 +641,6 @@ public:
   void verify_integrity(const std::string& name) const override;
 
   bool get_element(size_t i, CString* out) const override;
-  py::oobj get_value_at_index(size_t i) const override;
   void fill_na_mask(int8_t* outmask, size_t row0, size_t row1) override;
 
 protected:
@@ -698,7 +692,6 @@ class VoidColumn : public Column {
     void replace_values(RowIndex, const Column*) override;
     RowIndex join(const Column* keycol) const override;
     Stats* get_stats() const override;
-    py::oobj get_value_at_index(size_t i) const override;
     void fill_na_mask(int8_t* outmask, size_t row0, size_t row1) override;
   protected:
     VoidColumn();

--- a/c/column.h
+++ b/c/column.h
@@ -284,7 +284,7 @@ public:
 
   virtual RowIndex join(const Column* keycol) const = 0;
 
-  virtual void save_to_disk(const std::string&, WritableBuffer::Strategy);
+  virtual void save_to_disk(const std::string&, WritableBuffer::Strategy) const;
 
   size_t countna() const;
   size_t nunique() const;
@@ -633,7 +633,7 @@ template <typename T> class StringColumn : public Column
 public:
   StringColumn(size_t nrows);
   void save_to_disk(const std::string& filename,
-                    WritableBuffer::Strategy strategy) override;
+                    WritableBuffer::Strategy strategy) const override;
 
   SType stype() const noexcept override;
   size_t elemsize() const override;

--- a/c/column.h
+++ b/c/column.h
@@ -426,6 +426,8 @@ class OColumn
 
     void rbind(colvec& columns);
     void materialize();
+    OColumn cast(SType stype) const;
+    OColumn cast(SType stype, MemoryRange&& mr) const;
 
     friend void swap(OColumn& lhs, OColumn& rhs);
 };

--- a/c/column.h
+++ b/c/column.h
@@ -396,12 +396,31 @@ class OColumn
   // Data access
   //------------------------------------
   public:
+    // Each `get_element(i, *out)` function retrieves the column's element
+    // at index `i` and stores it in the variable `out`. The return value
+    // is true if the returned element is NA (missing), or false otherwise.
+    // When `true` is returned, the `out` value may contain garbage data,
+    // and should not be used in any way.
+    //
+    // Multiple overloads of `get_element()` correspond to different stypes
+    // of the underlying column. It is the caller's responsibility to call
+    // the correct function variant; calling a method that doesn't match
+    // this column's SType will likely result in an exception thrown.
+    //
+    // The function expects (but doesn't check) that `i < nrows`. A segfault
+    // may occur if this assumption is violated.
+    //
     bool get_element(size_t i, int32_t* out) const;
     bool get_element(size_t i, int64_t* out) const;
     bool get_element(size_t i, float* out) const;
     bool get_element(size_t i, double* out) const;
     bool get_element(size_t i, CString* out) const;
     bool get_element(size_t i, py::oobj* out) const;
+
+    // `get_element_as_pyobject(i)` returns the i-th element of the column
+    // wrapped into a pyobject of the appropriate type. Use this function
+    // for interoperation with Python.
+    //
     py::oobj get_element_as_pyobject(size_t i) const;
 
 

--- a/c/column.h
+++ b/c/column.h
@@ -642,7 +642,7 @@ public:
   void apply_na_mask(const BoolColumn* mask) override;
   RowIndex join(const Column* keycol) const override;
 
-  MemoryRange str_buf() { return strbuf; }
+  MemoryRange str_buf() const { return strbuf; }
   size_t datasize() const;
   size_t data_nrows() const override;
   const char* strdata() const;

--- a/c/column_bool.cc
+++ b/c/column_bool.cc
@@ -23,6 +23,14 @@ py::oobj BoolColumn::get_value_at_index(size_t i) const {
   return ISNA(x)? py::None() : x? py::True() : py::False();
 }
 
+bool BoolColumn::get_element(size_t i, int32_t* x) const {
+  size_t j = ri[i];
+  if (j == RowIndex::NA) return true;
+  int8_t value = elements_r()[j];
+  *x = static_cast<int32_t>(value);
+  return ISNA<int8_t>(value);
+}
+
 
 
 //------------------------------------------------------------------------------

--- a/c/column_bool.cc
+++ b/c/column_bool.cc
@@ -16,13 +16,6 @@ SType BoolColumn::stype() const noexcept {
   return SType::BOOL;
 }
 
-py::oobj BoolColumn::get_value_at_index(size_t i) const {
-  size_t j = ri[i];
-  if (j == RowIndex::NA) return py::None();
-  int8_t x = elements_r()[j];
-  return ISNA(x)? py::None() : x? py::True() : py::False();
-}
-
 bool BoolColumn::get_element(size_t i, int32_t* x) const {
   size_t j = ri[i];
   if (j == RowIndex::NA) return true;

--- a/c/column_int.cc
+++ b/c/column_int.cc
@@ -20,14 +20,6 @@ SType IntColumn<T>::stype() const noexcept {
 }
 
 template <typename T>
-py::oobj IntColumn<T>::get_value_at_index(size_t i) const {
-  size_t j = (this->ri)[i];
-  if (j == RowIndex::NA) return py::None();
-  T x = this->elements_r()[j];
-  return ISNA<T>(x)? py::None() : py::oint(x);
-}
-
-template <typename T>
 bool IntColumn<T>::get_element(size_t i, int32_t* out) const {
   size_t j = (this->ri)[i];
   if (j == RowIndex::NA) return true;

--- a/c/column_int.cc
+++ b/c/column_int.cc
@@ -27,6 +27,24 @@ py::oobj IntColumn<T>::get_value_at_index(size_t i) const {
   return ISNA<T>(x)? py::None() : py::oint(x);
 }
 
+template <typename T>
+bool IntColumn<T>::get_element(size_t i, int32_t* out) const {
+  size_t j = (this->ri)[i];
+  if (j == RowIndex::NA) return true;
+  T x = this->elements_r()[j];
+  *out = static_cast<int32_t>(x);
+  return ISNA<T>(x);
+}
+
+template <typename T>
+bool IntColumn<T>::get_element(size_t i, int64_t* out) const {
+  size_t j = (this->ri)[i];
+  if (j == RowIndex::NA) return true;
+  T x = this->elements_r()[j];
+  *out = static_cast<int64_t>(x);
+  return ISNA<T>(x);
+}
+
 
 
 //------------------------------------------------------------------------------

--- a/c/column_pyobj.cc
+++ b/c/column_pyobj.cc
@@ -32,12 +32,6 @@ SType PyObjectColumn::stype() const noexcept {
   return SType::OBJ;
 }
 
-py::oobj PyObjectColumn::get_value_at_index(size_t i) const {
-  size_t j = (this->ri)[i];
-  if (j == RowIndex::NA) return py::None();
-  PyObject* x = this->elements_r()[j];
-  return py::oobj(x);
-}
 
 bool PyObjectColumn::get_element(size_t i, py::oobj* out) const {
   size_t j = (this->ri)[i];

--- a/c/column_pyobj.cc
+++ b/c/column_pyobj.cc
@@ -39,6 +39,14 @@ py::oobj PyObjectColumn::get_value_at_index(size_t i) const {
   return py::oobj(x);
 }
 
+bool PyObjectColumn::get_element(size_t i, py::oobj* out) const {
+  size_t j = (this->ri)[i];
+  if (j == RowIndex::NA) return true;
+  PyObject* x = this->elements_r()[j];
+  *out = x;
+  return (x == Py_None);
+}
+
 
 // "PyObject" columns cannot be properly saved. So if somehow they were, then
 // when opening, we'll just fill the column with NAs.

--- a/c/column_real.cc
+++ b/c/column_real.cc
@@ -26,6 +26,15 @@ py::oobj RealColumn<T>::get_value_at_index(size_t i) const {
   return ISNA<T>(x)? py::None() : py::ofloat(x);
 }
 
+template <typename T>
+bool RealColumn<T>::get_element(size_t i, T* out) const {
+  size_t j = (this->ri)[i];
+  if (j == RowIndex::NA) return true;
+  T x = this->elements_r()[j];
+  *out = x;
+  return ISNA<T>(x);
+}
+
 
 
 //------------------------------------------------------------------------------

--- a/c/column_real.cc
+++ b/c/column_real.cc
@@ -19,14 +19,6 @@ SType RealColumn<T>::stype() const noexcept {
 }
 
 template <typename T>
-py::oobj RealColumn<T>::get_value_at_index(size_t i) const {
-  size_t j = (this->ri)[i];
-  if (j == RowIndex::NA) return py::None();
-  T x = this->elements_r()[j];
-  return ISNA<T>(x)? py::None() : py::ofloat(x);
-}
-
-template <typename T>
 bool RealColumn<T>::get_element(size_t i, T* out) const {
   size_t j = (this->ri)[i];
   if (j == RowIndex::NA) return true;

--- a/c/column_string.cc
+++ b/c/column_string.cc
@@ -142,7 +142,7 @@ void StringColumn<T>::init_xbuf(Py_buffer*) {
 
 template <typename T>
 void StringColumn<T>::save_to_disk(const std::string& filename,
-                                   WritableBuffer::Strategy strategy) {
+                                   WritableBuffer::Strategy strategy) const {
   mbuf.save_to_disk(filename, strategy);
   strbuf.save_to_disk(path_str(filename), strategy);
 }

--- a/c/column_string.cc
+++ b/c/column_string.cc
@@ -165,6 +165,19 @@ SType StringColumn<T>::stype() const noexcept {
 
 
 template <typename T>
+bool StringColumn<T>::get_element(size_t i, CString* out) const {
+  size_t j = (this->ri)[i];
+  if (j == RowIndex::NA) return true;
+  const T* offs = this->offsets();
+  T off_end = offs[j];
+  if (ISNA<T>(off_end)) return true;
+  T off_beg = offs[j - 1] & ~GETNA<T>();
+  out->ch = this->strdata() + off_beg,
+  out->size = static_cast<int64_t>(off_end - off_beg);
+  return false;
+}
+
+template <typename T>
 py::oobj StringColumn<T>::get_value_at_index(size_t i) const {
   size_t j = (this->ri)[i];
   if (j == RowIndex::NA) return py::None();

--- a/c/column_string.cc
+++ b/c/column_string.cc
@@ -177,18 +177,6 @@ bool StringColumn<T>::get_element(size_t i, CString* out) const {
   return false;
 }
 
-template <typename T>
-py::oobj StringColumn<T>::get_value_at_index(size_t i) const {
-  size_t j = (this->ri)[i];
-  if (j == RowIndex::NA) return py::None();
-  const T* offs = this->offsets();
-  T off_end = offs[j];
-  if (ISNA<T>(off_end)) return py::None();
-  T off_beg = offs[j - 1] & ~GETNA<T>();
-  return py::ostring(this->strdata() + off_beg,
-                     static_cast<size_t>(off_end - off_beg));
-}
-
 
 template <typename T>
 size_t StringColumn<T>::elemsize() const {

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -120,6 +120,9 @@ class DataTable {
     void set_column(size_t i, Column* newcol) {
       columns[i] = OColumn(newcol);
     }
+    void set_column(size_t i, OColumn&& newcol) {
+      columns[i] = std::move(newcol);
+    }
 
     /**
      * Sort the DataTable by specified columns, and return the corresponding

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -108,19 +108,13 @@ class DataTable {
     DataTable* extract_column(size_t i) const;
     size_t memory_footprint() const;
 
-    Column* get_column(size_t i) {
-      return const_cast<Column*>(columns[i].get());
-    }
     const OColumn& get_ocolumn(size_t i) const {
       return columns[i];
     }
     OColumn& get_ocolumn(size_t i) {
       return columns[i];
     }
-    void set_column(size_t i, Column* newcol) {
-      columns[i] = OColumn(newcol);
-    }
-    void set_column(size_t i, OColumn&& newcol) {
+    void set_ocolumn(size_t i, OColumn&& newcol) {
       columns[i] = std::move(newcol);
     }
 

--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -77,7 +77,7 @@ static py::oobj frame_column_rowindex(const py::PKArgs& args) {
   DataTable* dt = u.first;
   size_t col = u.second;
 
-  RowIndex ri = dt->get_column(col)->rowindex();
+  RowIndex ri = dt->get_ocolumn(col)->rowindex();
   return ri? py::orowindex(ri) : py::None();
 }
 
@@ -98,7 +98,7 @@ static py::oobj frame_column_data_r(const py::PKArgs& args) {
   auto u = _unpack_frame_column_args(args);
   DataTable* dt = u.first;
   size_t col = u.second;
-  size_t iptr = reinterpret_cast<size_t>(dt->get_column(col)->data());
+  size_t iptr = reinterpret_cast<size_t>(dt->get_ocolumn(col)->data());
   return c_void_p.call({py::oint(iptr)});
 }
 
@@ -243,7 +243,7 @@ static void _column_save_to_disk(const py::PKArgs& args) {
   std::string filename = args[2].to_string();
   std::string strategy = args[3].to_string();
 
-  Column* col = dt->get_column(i);
+  const OColumn& col = dt->get_ocolumn(i);
   auto sstrategy = (strategy == "mmap")  ? WritableBuffer::Strategy::Mmap :
                    (strategy == "write") ? WritableBuffer::Strategy::Write :
                                            WritableBuffer::Strategy::Auto;

--- a/c/expr/j_node.cc
+++ b/c/expr/j_node.cc
@@ -196,7 +196,7 @@ void collist_jn::delete_(workframe& wf) {
   const RowIndex& ri0 = wf.get_rowindex(0);
   if (ri0) {
     for (size_t i : indices) {
-      dt0->get_column(i)->replace_values(ri0, nullptr);
+      dt0->get_ocolumn(i)->replace_values(ri0, nullptr);
     }
   } else {
     dt0->delete_columns(indices);

--- a/c/expr/repl_node.cc
+++ b/c/expr/repl_node.cc
@@ -66,9 +66,9 @@ void frame_rn::replace_columns(workframe& wf, const intvec& indices) const {
   size_t lrows = dt0->nrows;
   xassert(rcols == 1 || rcols == lcols);  // enforced in `check_compatibility()`
 
-  Column* col0 = nullptr;
+  OColumn col0;
   if (rcols == 1) {
-    col0 = dtr->get_column(0)->shallowcopy();
+    col0 = dtr->get_ocolumn(0);  // copy
     // Avoid resizing `col0` multiple times in the loop below
     if (rrows == 1) {
       col0->resize_and_fill(lrows);  // TODO: use function from repeat.cc
@@ -76,14 +76,12 @@ void frame_rn::replace_columns(workframe& wf, const intvec& indices) const {
   }
   for (size_t i = 0; i < lcols; ++i) {
     size_t j = indices[i];
-    Column* coli = rcols == 1? col0->shallowcopy()
-                             : dtr->get_column(i)->shallowcopy();
+    OColumn coli = (rcols == 1)? col0 : dtr->get_ocolumn(i);  // copy
     if (coli->nrows == 1) {
       coli->resize_and_fill(lrows);  // TODO: use function from repeat.cc
     }
-    dt0->set_column(j, coli);
+    dt0->set_column(j, std::move(coli));
   }
-  delete col0;
 }
 
 

--- a/c/expr/repl_node.cc
+++ b/c/expr/repl_node.cc
@@ -171,20 +171,18 @@ void scalar_rn::replace_values(workframe& wf, const intvec& indices) const {
   check_column_types(dt0, indices);
 
   for (size_t j : indices) {
-    Column* col = dt0->get_column(j);
-    SType st = col? col->stype() : SType::VOID;
-    OColumn replcol = make_column(st, 1);
-    if (col) {
-      SType res_stype = replcol->stype();
-      if (col->stype() != res_stype) {
-        dt0->set_column(j, col->cast(res_stype));
-        col = dt0->get_column(j);
-      }
-    } else {
-      col = Column::new_na_column(replcol->stype(), dt0->nrows);
-      dt0->set_column(j, col);
+    const OColumn& colj = dt0->get_ocolumn(j);
+    SType stype = colj? colj.stype() : SType::VOID;
+    OColumn replcol = make_column(stype, 1);
+    stype = replcol.stype();  // may change from VOID to BOOL, FIXME!
+    if (!colj) {
+      dt0->set_column(j, OColumn(Column::new_na_column(stype, dt0->nrows)));
     }
-    col->replace_values(ri0, replcol.get());
+    else if (colj.stype() != stype) {
+      dt0->set_column(j, colj.cast(stype));
+    }
+    OColumn& ocol = dt0->get_ocolumn(j);
+    ocol->replace_values(ri0, replcol.get());
   }
 }
 

--- a/c/expr/repl_node.cc
+++ b/c/expr/repl_node.cc
@@ -80,7 +80,7 @@ void frame_rn::replace_columns(workframe& wf, const intvec& indices) const {
     if (coli->nrows == 1) {
       coli->resize_and_fill(lrows);  // TODO: use function from repeat.cc
     }
-    dt0->set_column(j, std::move(coli));
+    dt0->set_ocolumn(j, std::move(coli));
   }
 }
 
@@ -99,7 +99,7 @@ void frame_rn::replace_values(workframe& wf, const intvec& indices) const {
     size_t j = indices[i];
     const OColumn& coli = dtr->get_ocolumn(rcols == 1? 0 : i);
     if (!dt0->get_ocolumn(j)) {
-      dt0->set_column(j,
+      dt0->set_ocolumn(j,
           OColumn(Column::new_na_column(coli.stype(), dt0->nrows)));
     }
     OColumn& colj = dt0->get_ocolumn(j);
@@ -161,7 +161,7 @@ void scalar_rn::replace_columns(workframe& wf, const intvec& indices) const {
       new_columns[stype] = make_column(stype, dt0->nrows);
     }
     OColumn newcol = new_columns[stype];  // copy
-    dt0->set_column(j, std::move(newcol));
+    dt0->set_ocolumn(j, std::move(newcol));
   }
 }
 
@@ -177,10 +177,10 @@ void scalar_rn::replace_values(workframe& wf, const intvec& indices) const {
     OColumn replcol = make_column(stype, 1);
     stype = replcol.stype();  // may change from VOID to BOOL, FIXME!
     if (!colj) {
-      dt0->set_column(j, OColumn(Column::new_na_column(stype, dt0->nrows)));
+      dt0->set_ocolumn(j, OColumn(Column::new_na_column(stype, dt0->nrows)));
     }
     else if (colj.stype() != stype) {
-      dt0->set_column(j, colj.cast(stype));
+      dt0->set_ocolumn(j, colj.cast(stype));
     }
     OColumn& ocol = dt0->get_ocolumn(j);
     ocol->replace_values(ri0, replcol.get());
@@ -451,7 +451,7 @@ void exprlist_rn::replace_columns(workframe& wf, const intvec& indices) const {
     OColumn col = (i < rcols)? exprs[i]->evaluate_eager(wf)
                              : dt0->get_ocolumn(indices[0]);
     xassert(col.nrows() == dt0->nrows);
-    dt0->set_column(j, std::move(col));
+    dt0->set_ocolumn(j, std::move(col));
   }
 }
 

--- a/c/frame/__getitem__.cc
+++ b/c/frame/__getitem__.cc
@@ -161,8 +161,8 @@ oobj Frame::_main_getset(robj item, robj value) {
       size_t zrow = static_cast<size_t>(irow);
       size_t zcol = a1int? dt->xcolindex(arg1.to_int64_strict())
                          : dt->xcolindex(arg1);
-      Column* col = dt->get_column(zcol);
-      return col->get_value_at_index(zrow);
+      const OColumn& col = dt->get_ocolumn(zcol);
+      return col.get_element_as_pyobject(zrow);
     }
     // otherwise fall-through
   }

--- a/c/frame/replace.cc
+++ b/c/frame/replace.cc
@@ -443,19 +443,20 @@ void ReplaceAgent::check_uniqueness(std::vector<T>& data) {
 
 void ReplaceAgent::process_bool_column(size_t colidx) {
   if (x_bool.empty()) return;
-  auto col = static_cast<BoolColumn*>(dt->get_column(colidx));
-  int8_t* coldata = col->elements_w();
+  OColumn& col = dt->get_ocolumn(colidx);
+  int8_t* coldata = static_cast<int8_t*>(col->data_w());
   size_t n = x_bool.size();
   xassert(n == y_bool.size());
   if (n == 0) return;
-  replace_fw<int8_t>(x_bool.data(), y_bool.data(), col->nrows, coldata, n);
+  replace_fw<int8_t>(x_bool.data(), y_bool.data(), col.nrows(), coldata, n);
 }
 
 
 template <typename T>
 void ReplaceAgent::process_int_column(size_t colidx) {
   if (x_int.empty()) return;
-  auto col = static_cast<IntColumn<T>*>(dt->get_column(colidx));
+  OColumn& ocol = dt->get_ocolumn(colidx);
+  auto col = static_cast<IntColumn<T>*>(const_cast<Column*>(ocol.get()));
   int64_t col_min = col->min();
   int64_t col_max = col->max();
   bool col_has_nas = (col->countna() > 0);
@@ -511,7 +512,8 @@ template <typename T>
 void ReplaceAgent::process_real_column(size_t colidx) {
   constexpr double MAX_FLOAT = double(std::numeric_limits<float>::max());
   if (x_real.empty()) return;
-  auto col = static_cast<RealColumn<T>*>(dt->get_column(colidx));
+  OColumn& ocol = dt->get_ocolumn(colidx);
+  auto col = static_cast<RealColumn<T>*>(const_cast<Column*>(ocol.get()));
   double col_min = static_cast<double>(col->min());
   double col_max = static_cast<double>(col->max());
   bool col_has_nas = (col->countna() > 0);
@@ -562,7 +564,8 @@ void ReplaceAgent::process_real_column(size_t colidx) {
 template <typename T>
 void ReplaceAgent::process_str_column(size_t colidx) {
   if (x_str.empty()) return;
-  auto col = static_cast<StringColumn<T>*>(dt->get_column(colidx));
+  OColumn& ocol = dt->get_ocolumn(colidx);
+  auto col = static_cast<StringColumn<T>*>(const_cast<Column*>(ocol.get()));
   if (x_str.size() == 1 && x_str[0].isna()) {
     if (col->countna() == 0) return;
   }

--- a/c/frame/replace.cc
+++ b/c/frame/replace.cc
@@ -163,8 +163,8 @@ void Frame::replace(const PKArgs& args) {
     // a string column remains a view, however the iterator `dt::map_str2str`
     // takes the rowindex into account when iterating.
     //
-    Column* col = dt->get_column(i);
-    switch (col->stype()) {
+    const OColumn& col = dt->get_ocolumn(i);
+    switch (col.stype()) {
       case SType::BOOL:    ra.process_bool_column(i); break;
       case SType::INT8:    ra.process_int_column<int8_t>(i); break;
       case SType::INT16:   ra.process_int_column<int16_t>(i); break;
@@ -261,7 +261,7 @@ void ReplaceAgent::split_x_y_by_type() {
        done_bool = false,
        done_str = false;
   for (size_t i = 0; i < dt->ncols; ++i) {
-    SType s = dt->get_column(i)->stype();
+    SType s = dt->get_ocolumn(i).stype();
     switch (s) {
       case SType::BOOL: {
         if (done_bool) continue;

--- a/c/frame/replace.cc
+++ b/c/frame/replace.cc
@@ -489,8 +489,7 @@ void ReplaceAgent::process_int_column(size_t colidx) {
   if (maxy) {
     SType new_stype = (maxy > std::numeric_limits<int32_t>::max())
                       ? SType::INT64 : SType::INT32;
-    Column* newcol = col->cast(new_stype);
-    dt->set_column(colidx, newcol);
+    dt->set_ocolumn(colidx, ocol.cast(new_stype));
     columns_cast = true;
     if (new_stype == SType::INT64) {
       process_int_column<int64_t>(colidx);
@@ -545,8 +544,7 @@ void ReplaceAgent::process_real_column(size_t colidx) {
     }
   }
   if (std::is_same<T, float>::value && maxy > 0) {
-    Column* newcol = col->cast(SType::FLOAT64);
-    dt->set_column(colidx, newcol);
+    dt->set_ocolumn(colidx, ocol.cast(SType::FLOAT64));
     columns_cast = true;
     process_real_column<double>(colidx);
   } else {
@@ -572,7 +570,7 @@ void ReplaceAgent::process_str_column(size_t colidx) {
   Column* newcol = replace_str<T>(x_str.size(), x_str.data(), y_str.data(),
                                   col);
   columns_cast = (newcol->stype() != col->stype());
-  dt->set_column(colidx, newcol);
+  dt->set_ocolumn(colidx, OColumn(newcol));
 }
 
 

--- a/c/jay/save_jay.cc
+++ b/c/jay/save_jay.cc
@@ -17,8 +17,8 @@
 using WritableBufferPtr = std::unique_ptr<WritableBuffer>;
 static jay::Type stype_to_jaytype[DT_STYPES_COUNT];
 static flatbuffers::Offset<jay::Column> column_to_jay(
-    Column* col, const std::string& name, flatbuffers::FlatBufferBuilder& fbb,
-    WritableBuffer* wb);
+    const OColumn& col, const std::string& name,
+    flatbuffers::FlatBufferBuilder& fbb, WritableBuffer* wb);
 static jay::Buffer saveMemoryRange(const MemoryRange*, WritableBuffer*);
 template <typename T, typename StatBuilder>
 static flatbuffers::Offset<void> saveStats(
@@ -63,8 +63,8 @@ void DataTable::save_jay_impl(WritableBuffer* wb) {
 
   std::vector<flatbuffers::Offset<jay::Column>> msg_columns;
   for (size_t i = 0; i < ncols; ++i) {
-    Column* col = get_column(i);
-    if (col->stype() == SType::OBJ) {
+    const OColumn& col = get_ocolumn(i);
+    if (col.stype() == SType::OBJ) {
       DatatableWarning() << "Column `" << names[i]
           << "` of type obj64 was not saved";
     } else {
@@ -101,13 +101,13 @@ void DataTable::save_jay_impl(WritableBuffer* wb) {
 //------------------------------------------------------------------------------
 
 static flatbuffers::Offset<jay::Column> column_to_jay(
-    Column* col, const std::string& name, flatbuffers::FlatBufferBuilder& fbb,
+    const OColumn& col, const std::string& name, flatbuffers::FlatBufferBuilder& fbb,
     WritableBuffer* wb)
 {
   jay::Stats jsttype = jay::Stats_NONE;
   flatbuffers::Offset<void> jsto;
   Stats* colstats = col->get_stats_if_exist();
-  switch (col->stype()) {
+  switch (col.stype()) {
     case SType::BOOL:
       jsto = saveStats<int8_t,  jay::StatsBool>(colstats, fbb);
       jsttype = jay::Stats_Bool;
@@ -142,9 +142,9 @@ static flatbuffers::Offset<jay::Column> column_to_jay(
   auto sname = fbb.CreateString(name.c_str());
 
   jay::ColumnBuilder cbb(fbb);
-  cbb.add_type(stype_to_jaytype[static_cast<int>(col->stype())]);
+  cbb.add_type(stype_to_jaytype[static_cast<int>(col.stype())]);
   cbb.add_name(sname);
-  cbb.add_nullcount(static_cast<uint64_t>(col->countna()));
+  cbb.add_nullcount(col.na_count());
 
   MemoryRange mbuf = col->data_buf();  // shallow copt of col's `mbuf`
   jay::Buffer saved_mbuf = saveMemoryRange(&mbuf, wb);
@@ -154,14 +154,14 @@ static flatbuffers::Offset<jay::Column> column_to_jay(
     cbb.add_stats(jsto);
   }
 
-  if (col->stype() == SType::STR32) {
-    auto scol = static_cast<StringColumn<uint32_t>*>(col);
+  if (col.stype() == SType::STR32) {
+    auto scol = static_cast<const StringColumn<uint32_t>*>(col.get());
     MemoryRange sbuf = scol->str_buf();
     jay::Buffer saved_strbuf = saveMemoryRange(&sbuf, wb);
     cbb.add_strdata(&saved_strbuf);
   }
-  if (col->stype() == SType::STR64) {
-    auto scol = static_cast<StringColumn<uint64_t>*>(col);
+  if (col.stype() == SType::STR64) {
+    auto scol = static_cast<const StringColumn<uint64_t>*>(col.get());
     MemoryRange sbuf = scol->str_buf();
     jay::Buffer saved_strbuf = saveMemoryRange(&sbuf, wb);
     cbb.add_strdata(&saved_strbuf);

--- a/c/memrange.cc
+++ b/c/memrange.cc
@@ -353,7 +353,7 @@
   //---- Utility functions -----------------------
 
   void MemoryRange::save_to_disk(const std::string& path,
-                                 WritableBuffer::Strategy strategy)
+                                 WritableBuffer::Strategy strategy) const
   {
     auto wb = WritableBuffer::create_target(path, o->impl->size(), strategy);
     wb->write(o->impl->size(), o->impl->ptr());

--- a/c/memrange.h
+++ b/c/memrange.h
@@ -244,7 +244,7 @@ class MemoryRange
     void save_to_disk(
       const std::string& file,
       WritableBuffer::Strategy strategy = WritableBuffer::Strategy::Auto
-    );
+    ) const;
 
     // Utility functions
     //

--- a/c/models/aggregator.cc
+++ b/c/models/aggregator.cc
@@ -346,7 +346,7 @@ bool Aggregator<T>::sample_exemplars(size_t max_bins, size_t n_na_bins)
   // for the additional N/A bins that may appear during grouping.
   if (gb_members.ngroups() > max_bins + n_na_bins) {
     const int32_t* offsets = gb_members.offsets_r();
-    auto d_members = static_cast<int32_t*>(dt_members->get_column(0)->data_w());
+    auto d_members = static_cast<int32_t*>(dt_members->get_ocolumn(0)->data_w());
 
     // First, set all `exemplar_id`s to `N/A`.
     for (size_t i = 0; i < dt_members->nrows; ++i) {
@@ -371,7 +371,7 @@ bool Aggregator<T>::sample_exemplars(size_t max_bins, size_t n_na_bins)
         k++;
       }
     }
-    dt_members->get_column(0)->get_stats()->reset();
+    dt_members->get_ocolumn(0)->get_stats()->reset();
     was_sampled = true;
   }
 
@@ -406,7 +406,7 @@ void Aggregator<T>::aggregate_exemplars(bool was_sampled) {
   std::memset(d_counts, 0, n_exemplars * sizeof(int32_t));
 
   // Setting up exemplar indices and counts
-  auto d_members = static_cast<int32_t*>(dt_members->get_column(0)->data_w());
+  auto d_members = static_cast<int32_t*>(dt_members->get_ocolumn(0)->data_w());
   for (size_t i = was_sampled; i < gb_members.ngroups(); ++i) {
     size_t i_sampled = i - was_sampled;
     size_t off_i = static_cast<size_t>(offsets[i]);

--- a/c/models/aggregator.cc
+++ b/c/models/aggregator.cc
@@ -428,7 +428,7 @@ void Aggregator<T>::aggregate_exemplars(bool was_sampled) {
         d_members[ri_members[member_shift + j]] = static_cast<int32_t>(i_sampled);
       }
     });
-  dt_members->get_column(0)->get_stats()->reset();
+  dt_members->get_ocolumn(0)->get_stats()->reset();
 
   // Applying exemplars row index and binding exemplars with the counts.
   RowIndex ri_exemplars = RowIndex(std::move(exemplar_indices));
@@ -448,7 +448,7 @@ void Aggregator<T>::group_0d() {
     auto res = dt->group(spec);
     RowIndex ri_exemplars = std::move(res.first);
 
-    auto d_members = static_cast<int32_t*>(dt_members->get_column(0)->data_w());
+    auto d_members = static_cast<int32_t*>(dt_members->get_ocolumn(0)->data_w());
     ri_exemplars.iterate(0, dt->nrows, 1,
       [&](size_t i, size_t j) {
         d_members[j] = static_cast<int32_t>(i);
@@ -501,7 +501,7 @@ void Aggregator<T>::group_2d() {
  */
 template <typename T>
 void Aggregator<T>::group_1d_continuous() {
-  auto d_members = static_cast<int32_t*>(dt_members->get_column(0)->data_w());
+  auto d_members = static_cast<int32_t*>(dt_members->get_ocolumn(0)->data_w());
   T norm_factor, norm_shift;
   set_norm_coeffs(norm_factor, norm_shift, contconvs[0]->get_min(), contconvs[0]->get_max(), n_bins);
 
@@ -522,7 +522,7 @@ void Aggregator<T>::group_1d_continuous() {
  */
 template <typename T>
 void Aggregator<T>::group_2d_continuous() {
-  auto d_members = static_cast<int32_t*>(dt_members->get_column(0)->data_w());
+  auto d_members = static_cast<int32_t*>(dt_members->get_ocolumn(0)->data_w());
 
   T normx_factor, normx_shift;
   T normy_factor, normy_shift;
@@ -555,7 +555,7 @@ void Aggregator<T>::group_1d_categorical() {
   RowIndex ri0 = std::move(res.first);
   Groupby grpby0 = std::move(res.second);
 
-  auto d_members = static_cast<int32_t*>(dt_members->get_column(0)->data_w());
+  auto d_members = static_cast<int32_t*>(dt_members->get_ocolumn(0)->data_w());
   const int32_t* offsets0 = grpby0.offsets_r();
 
   dt::parallel_for_dynamic(grpby0.ngroups(),
@@ -575,8 +575,8 @@ void Aggregator<T>::group_1d_categorical() {
  */
 template <typename T>
 void Aggregator<T>::group_2d_categorical () {
-  switch (dt_cat->get_column(0)->stype()) {
-    case SType::STR32:  switch (dt_cat->get_column(1)->stype()) {
+  switch (dt_cat->get_ocolumn(0).stype()) {
+    case SType::STR32:  switch (dt_cat->get_ocolumn(1).stype()) {
                           case SType::STR32:  group_2d_categorical_str<uint32_t, uint32_t>(); break;
                           case SType::STR64:  group_2d_categorical_str<uint32_t, uint64_t>(); break;
                           default:            throw ValueError() << "For 2D categorical aggregation, all column types"
@@ -584,7 +584,7 @@ void Aggregator<T>::group_2d_categorical () {
                         }
                         break;
 
-    case SType::STR64:  switch (dt_cat->get_column(1)->stype()) {
+    case SType::STR64:  switch (dt_cat->get_ocolumn(1).stype()) {
                           case SType::STR32:  group_2d_categorical_str<uint64_t, uint32_t>(); break;
                           case SType::STR64:  group_2d_categorical_str<uint64_t, uint64_t>(); break;
                           default:            throw ValueError() << "For 2D categorical aggregation, all column types"
@@ -611,12 +611,12 @@ void Aggregator<T>::group_2d_categorical_str() {
   RowIndex ri = std::move(res.first);
   Groupby grpby = std::move(res.second);
 
-  auto c0 = static_cast<const StringColumn<U0>*>(dt_cat->get_column(0));
-  auto c1 = static_cast<const StringColumn<U1>*>(dt_cat->get_column(1));
+  auto c0 = static_cast<const StringColumn<U0>*>(dt_cat->get_ocolumn(0).get());
+  auto c1 = static_cast<const StringColumn<U1>*>(dt_cat->get_ocolumn(1).get());
   const U0* d_c0 = c0->offsets();
   const U1* d_c1 = c1->offsets();
 
-  auto d_members = static_cast<int32_t*>(dt_members->get_column(0)->data_w());
+  auto d_members = static_cast<int32_t*>(dt_members->get_ocolumn(0)->data_w());
   const int32_t* offsets = grpby.offsets_r();
 
   dt::parallel_for_dynamic(grpby.ngroups(),
@@ -643,7 +643,7 @@ void Aggregator<T>::group_2d_categorical_str() {
  */
 template <typename T>
 void Aggregator<T>::group_2d_mixed() {
-  switch (dt_cat->get_column(0)->stype()) {
+  switch (dt_cat->get_ocolumn(0).stype()) {
     case SType::STR32:  group_2d_mixed_str<uint32_t>(); break;
     case SType::STR64:  group_2d_mixed_str<uint64_t>(); break;
     default:            throw ValueError() << "For 2D mixed aggretation, the categorical column "
@@ -660,7 +660,7 @@ void Aggregator<T>::group_2d_mixed() {
 template<typename T>
 template<typename U0>
 void Aggregator<T>::group_2d_mixed_str() {
-  auto c_cat = static_cast<const StringColumn<U0>*>(dt_cat->get_column(0));
+  auto c_cat = static_cast<const StringColumn<U0>*>(dt_cat->get_ocolumn(0).get());
   const U0* d_cat = c_cat->offsets();
 
   std::vector<sort_spec> spec = {sort_spec(0)};
@@ -668,7 +668,7 @@ void Aggregator<T>::group_2d_mixed_str() {
   RowIndex ri_cat = std::move(res.first);
   Groupby grpby = std::move(res.second);
 
-  auto d_members = static_cast<int32_t*>(dt_members->get_column(0)->data_w());
+  auto d_members = static_cast<int32_t*>(dt_members->get_ocolumn(0)->data_w());
   const int32_t* offsets_cat = grpby.offsets_r();
 
   T normx_factor, normx_shift;
@@ -732,7 +732,7 @@ void Aggregator<T>::group_nd() {
   size_t nexemplars = 0;
   size_t ncoprimes = 0;
 
-  auto d_members = static_cast<int32_t*>(dt_members->get_column(0)->data_w());
+  auto d_members = static_cast<int32_t*>(dt_members->get_ocolumn(0)->data_w());
   tptr<T> pmatrix;
   bool do_projection = ncols > max_dimensions;
   if (do_projection) pmatrix = generate_pmatrix(ncols);
@@ -915,7 +915,7 @@ void Aggregator<T>::adjust_delta(T& delta, std::vector<exptr>& exemplars,
 template <typename T>
 void Aggregator<T>::adjust_members(std::vector<size_t>& ids) {
 
-  auto d_members = static_cast<int32_t*>(dt_members->get_column(0)->data_w());
+  auto d_members = static_cast<int32_t*>(dt_members->get_ocolumn(0)->data_w());
   auto map = std::unique_ptr<size_t[]>(new size_t[ids.size()]);
   auto nids = ids.size();
 

--- a/c/models/dt_ftrl.cc
+++ b/c/models/dt_ftrl.cc
@@ -353,7 +353,7 @@ void Ftrl<T>::create_y_multinomial(const DataTable* dt,
   // If we only got NA targets, return to stop training.
   if (dt_labels_in == nullptr) return;
 
-  auto data_label_ids_in = static_cast<const int32_t*>(dt_labels_in->get_column(1)->data());
+  auto data_label_ids_in = static_cast<const int32_t*>(dt_labels_in->get_ocolumn(1)->data());
   size_t nlabels_in = dt_labels_in->nrows;
 
   // When we only start training, all the incoming labels become the model

--- a/c/models/py_ftrl.cc
+++ b/c/models/py_ftrl.cc
@@ -331,7 +331,7 @@ oobj Ftrl::fit(const PKArgs& args) {
                          << "one column";
     }
 
-    if (dt_y_val->get_column(0)->stype() != dt_y->get_column(0)->stype()) {
+    if (dt_y_val->get_ocolumn(0).stype() != dt_y->get_ocolumn(0).stype()) {
       throw ValueError() << "Validation target frame must have the same "
                             "stype as the target frame";
     }
@@ -533,14 +533,13 @@ void Ftrl::set_model(robj model) {
   }
 
   SType stype = (double_precision)? SType::FLOAT64 : SType::FLOAT32;
-  bool (*has_negatives)(const Column*) = (double_precision)?
-                                         py::Validator::has_negatives<double>:
+  auto has_negatives = double_precision? py::Validator::has_negatives<double>:
                                          py::Validator::has_negatives<float>;
 
   for (size_t i = 0; i < ncols; ++i) {
-    Column* col = dt_model->get_column(i);
-    SType c_stype = col->stype();
-    if (col->stype() != stype) {
+    const OColumn& col = dt_model->get_ocolumn(i);
+    SType c_stype = col.stype();
+    if (col.stype() != stype) {
       throw ValueError() << "Column " << i << " in the model frame should "
                          << "have a type of " << stype << ", whereas it has "
                          << "the following type: "

--- a/c/models/py_validator.h
+++ b/c/models/py_validator.h
@@ -93,9 +93,11 @@ void check_less_than_or_equal_to(T value, T value_max, const py::Arg& arg, error
 
 
 template<typename T>
-bool has_negatives(const Column* col) {
+bool has_negatives(const OColumn& col) {
+  // TODO: check if the column has min() value computed, and if it does
+  //       simply check whether the min is negative
   auto d_n = static_cast<const T*>(col->data());
-  for (size_t i = 0; i < col->nrows; ++i) {
+  for (size_t i = 0; i < col.nrows(); ++i) {
     if (d_n[i] < 0) return true;
   }
   return false;

--- a/c/py_buffers.cc
+++ b/c/py_buffers.cc
@@ -423,13 +423,15 @@ void py::Frame::m__getbuffer__(Py_buffer* view, int flags) {
     // is possible. The effect of this call is that `newcol` will be
     // created having the converted data; but the side-effect of this is
     // that `mbuf` will have the same data, and in the right place.
-    Column* newcol = dt->get_column(i + i0)->cast(stype, std::move(xmb));
-    xassert(newcol->alloc_size() == colsize);
-    // We can now delete the new column: this will delete `xmb` as well,
-    // however an ExternalMemBuf object does not attempt to free its
-    // memory buffer. The converted data that was written to `mbuf` will
-    // thus remain intact. No need to delete `xmb` either.
-    delete newcol;
+    {
+      OColumn newcol = dt->get_ocolumn(i + i0).cast(stype, std::move(xmb));
+      newcol.materialize();
+      xassert(newcol->alloc_size() == colsize);
+      // We can now delete the new column: this will delete `xmb` as well,
+      // however an ExternalMemBuf object does not attempt to free its
+      // memory buffer. The converted data that was written to `mbuf` will
+      // thus remain intact. No need to delete `xmb` either.
+    }
 
     // Delete the `col` pointer, which was extracted from the i-th column
     // of the DataTable.

--- a/c/py_buffers.cc
+++ b/c/py_buffers.cc
@@ -374,9 +374,9 @@ void py::Frame::m__getbuffer__(Py_buffer* view, int flags) {
   // Check whether we have a single-column DataTable that doesn't need to be
   // copied -- in which case it should be possible to return the buffer
   // by-reference instead of copying the data into an intermediate buffer.
-  if (ncols == 1 && !dt->get_column(i0)->rowindex() && !REQ_WRITABLE(flags) &&
-      dt->get_column(i0)->is_fixedwidth() &&
-      pybuffers::force_stype == SType::VOID)
+  const OColumn& col_i0 = dt->get_ocolumn(i0);
+  if (ncols == 1 && !col_i0.is_virtual() && !REQ_WRITABLE(flags) &&
+      col_i0.is_fixedwidth() && pybuffers::force_stype == SType::VOID)
   {
     return getbuffer_1_col(this, view, flags);
   }
@@ -392,7 +392,7 @@ void py::Frame::m__getbuffer__(Py_buffer* view, int flags) {
     // Auto-detect common stype
     uint64_t stypes_mask = 0;
     for (size_t i = 0; i < ncols; ++i) {
-      SType next_stype = dt->get_column(i + i0)->stype();
+      SType next_stype = dt->get_ocolumn(i + i0).stype();
       uint64_t unstype = static_cast<uint64_t>(next_stype);
       if (stypes_mask & (1 << unstype)) continue;
       stypes_mask |= 1 << unstype;

--- a/c/py_buffers.cc
+++ b/c/py_buffers.cc
@@ -330,16 +330,16 @@ static void getbuffer_1_col(py::Frame* self, Py_buffer* view, int flags)
   bool one_col = (pybuffers::single_col != size_t(-1));
   size_t i0 = one_col? pybuffers::single_col : 0;
   XInfo* xinfo = nullptr;
-  Column* col = self->get_datatable()->get_column(i0);
-  const char* fmt = format_from_stype(col->stype());
+  const OColumn& col = self->get_datatable()->get_ocolumn(i0);
+  const char* fmt = format_from_stype(col.stype());
 
   xinfo = new XInfo();
   xinfo->mbuf = col->data_buf();
-  xinfo->shape[0] = static_cast<Py_ssize_t>(col->nrows);
+  xinfo->shape[0] = static_cast<Py_ssize_t>(col.nrows());
   xinfo->shape[1] = 1;
-  xinfo->strides[0] = static_cast<Py_ssize_t>(col->elemsize());
+  xinfo->strides[0] = static_cast<Py_ssize_t>(col.elemsize());
   xinfo->strides[1] = static_cast<Py_ssize_t>(xinfo->mbuf.size());
-  xinfo->stype = col->stype();
+  xinfo->stype = col.stype();
 
   view->buf = const_cast<void*>(xinfo->mbuf.rptr());
   view->obj = py::oobj(self).release();

--- a/c/python/string.cc
+++ b/c/python/string.cc
@@ -26,23 +26,20 @@ ostring ostring::from_new_reference(PyObject* ref) {
 }
 
 
-ostring::ostring(const std::string& s) {
-  Py_ssize_t slen = static_cast<Py_ssize_t>(s.size());
-  v = PyUnicode_FromStringAndSize(s.data(), slen);
-  if (!v) throw PyError();
-}
-
 ostring::ostring(const char* str, size_t len) {
   Py_ssize_t slen = static_cast<Py_ssize_t>(len);
   v = PyUnicode_FromStringAndSize(str, slen);
   if (!v) throw PyError();
 }
 
-ostring::ostring(const char* str) {
-  Py_ssize_t slen = static_cast<Py_ssize_t>(std::strlen(str));
-  v = PyUnicode_FromStringAndSize(str, slen);
-  if (!v) throw PyError();
-}
+ostring::ostring(const std::string& s)
+  : ostring(s.data(), s.size()) {}
+
+ostring::ostring(const CString& s)
+  : ostring(s.ch, static_cast<size_t>(s.size)) {}
+
+ostring::ostring(const char* str)
+  : ostring(str, std::strlen(str)) {}
 
 
 ostring::ostring(const ostring& other) : oobj(other) {}

--- a/c/python/string.h
+++ b/c/python/string.h
@@ -19,7 +19,8 @@ namespace py {
 class ostring : public oobj {
   public:
     ostring();
-    ostring(const std::string& s);
+    ostring(const std::string&);
+    ostring(const CString&);
     ostring(const char* str);
     ostring(const char* str, size_t len);
     ostring(const ostring&);

--- a/c/str/py_str.cc
+++ b/c/str/py_str.cc
@@ -40,13 +40,13 @@ static oobj split_into_nhot(const PKArgs& args) {
   std::string sep = args[1]? args[1].to_string() : ",";
   bool sort = args[2]? args[2].to_bool_strict() : false;
 
-  Column* col0 = dt->ncols == 1? dt->get_column(0) : nullptr;
-  if (!col0) {
+  if (dt->ncols != 1) {
     throw ValueError() << "Function split_into_nhot() may only be applied to "
       "a single-column Frame of type string;" << " got frame with "
       << dt->ncols << " columns";
   }
-  SType st = col0->stype();
+  const OColumn& col0 = dt->get_ocolumn(0);
+  SType st = col0.stype();
   if (!(st == SType::STR32 || st == SType::STR64)) {
     throw TypeError() << "Function split_into_nhot() may only be applied to "
       "a single-column Frame of type string;" << " received a column of type "

--- a/c/str/py_str.h
+++ b/c/str/py_str.h
@@ -19,7 +19,7 @@
 
 
 namespace dt {
-  DataTable* split_into_nhot(Column* col, char sep, bool sort = false);
+  DataTable* split_into_nhot(const OColumn& col, char sep, bool sort = false);
 }
 
 

--- a/c/str/split_into_nhot.cc
+++ b/c/str/split_into_nhot.cc
@@ -123,18 +123,19 @@ static void sort_colnames(colvec& outcols, strvec& outnames) {
 }
 
 
-DataTable* split_into_nhot(Column* col, char sep, bool sort /* = false */) {
+DataTable* split_into_nhot(const OColumn& ocol, char sep, bool sort /* = false */) {
+  const Column* col = ocol.get();
   bool is32 = (col->stype() == SType::STR32);
   xassert(is32 || (col->stype() == SType::STR64));
   const uint32_t* offsets32 = nullptr;
   const uint64_t* offsets64 = nullptr;
   const char* strdata;
   if (is32) {
-    auto scol = static_cast<StringColumn<uint32_t>*>(col);
+    auto scol = static_cast<const StringColumn<uint32_t>*>(col);
     offsets32 = scol->offsets();
     strdata = scol->strdata();
   } else {
-    auto scol = static_cast<StringColumn<uint64_t>*>(col);
+    auto scol = static_cast<const StringColumn<uint64_t>*>(col);
     offsets64 = scol->offsets();
     strdata = scol->strdata();
   }


### PR DESCRIPTION
- Implemented `get_element()` methods for OColumn;
- Implemented `get_element_as_pyobject()`;
- Removed `get_column()` and `set_column()` from DataTable, now only ocolumn versions remain;
- added additional constructor for `py::ocolumn(const CString&)`.

WIP for #1396