### PR TITLE
Further OColumn refactoring

### DIFF
--- a/c/column.cc
+++ b/c/column.cc
@@ -346,7 +346,6 @@ OColumn OColumn::cast(SType stype, MemoryRange&& mem) const {
 
 VoidColumn::VoidColumn() { _stype = SType::VOID; }
 VoidColumn::VoidColumn(size_t nrows) : Column(nrows) { _stype = SType::VOID; }
-size_t VoidColumn::elemsize() const { return 0; }
 size_t VoidColumn::data_nrows() const { return nrows; }
 void VoidColumn::materialize() {}
 void VoidColumn::resize_and_fill(size_t) {}

--- a/c/column.cc
+++ b/c/column.cc
@@ -219,12 +219,6 @@ const Column* OColumn::get() const {
   return pcol;  // borrowed ref
 }
 
-Column* OColumn::release() {
-  Column* ret = pcol;
-  pcol = nullptr;
-  return ret;
-}
-
 Column* OColumn::operator->() {
   return pcol;
 }

--- a/c/column.cc
+++ b/c/column.cc
@@ -345,7 +345,7 @@ void VoidColumn::materialize() {}
 void VoidColumn::resize_and_fill(size_t) {}
 void VoidColumn::rbind_impl(colvec&, size_t, bool) {}
 void VoidColumn::apply_na_mask(const BoolColumn*) {}
-void VoidColumn::replace_values(RowIndex, const Column*) {}
+void VoidColumn::replace_values(RowIndex, const OColumn&) {}
 void VoidColumn::init_data() {}
 void VoidColumn::init_xbuf(Py_buffer*) {}
 Stats* VoidColumn::get_stats() const { return nullptr; }

--- a/c/column.cc
+++ b/c/column.cc
@@ -315,9 +315,6 @@ py::oobj OColumn::get_element_as_pyobject(size_t i) const {
 
 
 
-void OColumn::rbind(colvec& columns) {
-  pcol = pcol->rbind(columns);
-}
 
 void OColumn::materialize() {
   pcol->materialize();

--- a/c/column.cc
+++ b/c/column.cc
@@ -245,7 +245,7 @@ size_t OColumn::na_count() const {
 }
 
 SType OColumn::stype() const noexcept {
-  return pcol->stype();
+  return pcol->_stype;
 }
 
 LType OColumn::ltype() const noexcept {
@@ -344,9 +344,8 @@ OColumn OColumn::cast(SType stype, MemoryRange&& mem) const {
 // VoidColumn
 //==============================================================================
 
-VoidColumn::VoidColumn() {}
-VoidColumn::VoidColumn(size_t nrows) : Column(nrows) {}
-SType VoidColumn::stype() const noexcept { return SType::VOID; }
+VoidColumn::VoidColumn() { _stype = SType::VOID; }
+VoidColumn::VoidColumn(size_t nrows) : Column(nrows) { _stype = SType::VOID; }
 size_t VoidColumn::elemsize() const { return 0; }
 size_t VoidColumn::data_nrows() const { return nrows; }
 void VoidColumn::materialize() {}

--- a/c/column.cc
+++ b/c/column.cc
@@ -95,32 +95,32 @@ Column* Column::new_mbuf_column(SType stype, MemoryRange&& mbuf) {
 
 bool Column::get_element(size_t, int32_t*) const {
   throw NotImplError()
-    << "Cannot retrieve int32 values from a column of type " << stype();
+    << "Cannot retrieve int32 values from a column of type " << _stype;
 }
 
 bool Column::get_element(size_t, int64_t*) const {
   throw NotImplError()
-    << "Cannot retrieve int64 values from a column of type " << stype();
+    << "Cannot retrieve int64 values from a column of type " << _stype;
 }
 
 bool Column::get_element(size_t, float*) const {
   throw NotImplError()
-    << "Cannot retrieve float values from a column of type " << stype();
+    << "Cannot retrieve float values from a column of type " << _stype;
 }
 
 bool Column::get_element(size_t, double*) const {
   throw NotImplError()
-    << "Cannot retrieve double values from a column of type " << stype();
+    << "Cannot retrieve double values from a column of type " << _stype;
 }
 
 bool Column::get_element(size_t, CString*) const {
   throw NotImplError()
-    << "Cannot retrieve string values from a column of type " << stype();
+    << "Cannot retrieve string values from a column of type " << _stype;
 }
 
 bool Column::get_element(size_t, py::oobj*) const {
   throw NotImplError()
-    << "Cannot retrieve object values from a column of type " << stype();
+    << "Cannot retrieve object values from a column of type " << _stype;
 }
 
 
@@ -130,7 +130,7 @@ bool Column::get_element(size_t, py::oobj*) const {
  * Create a shallow copy of the column; possibly applying the provided rowindex.
  */
 Column* Column::shallowcopy(const RowIndex& new_rowindex) const {
-  Column* col = new_column(stype());
+  Column* col = new_column(_stype);
   col->nrows = nrows;
   col->mbuf = mbuf;
   // TODO: also copy Stats object
@@ -249,11 +249,11 @@ SType OColumn::stype() const noexcept {
 }
 
 LType OColumn::ltype() const noexcept {
-  return info(pcol->stype()).ltype();
+  return info(pcol->_stype).ltype();
 }
 
 bool OColumn::is_fixedwidth() const noexcept {
-  return !info(pcol->stype()).is_varwidth();
+  return !info(pcol->_stype).is_varwidth();
 }
 
 bool OColumn::is_virtual() const noexcept {
@@ -261,7 +261,7 @@ bool OColumn::is_virtual() const noexcept {
 }
 
 size_t OColumn::elemsize() const noexcept {
-  return info(pcol->stype()).elemsize();
+  return info(pcol->_stype).elemsize();
 }
 
 OColumn::operator bool() const noexcept {

--- a/c/column.h
+++ b/c/column.h
@@ -226,8 +226,8 @@ public:
    * creation of the resulting column (the Column will assume ownership of the
    * provided MemoryRange).
    */
-  Column* cast(SType stype) const;
-  Column* cast(SType stype, MemoryRange&& mr) const;
+  OColumn cast(SType stype) const;
+  OColumn cast(SType stype, MemoryRange&& mr) const;
 
   /**
    * Replace values at positions given by the RowIndex `replace_at` with

--- a/c/column.h
+++ b/c/column.h
@@ -243,7 +243,7 @@ public:
    * with NAs.
    */
   virtual void replace_values(
-    RowIndex replace_at, const Column* replace_with) = 0;
+    RowIndex replace_at, const OColumn& replace_with) = 0;
 
   /**
    * Appends the provided columns to the bottom of the current column and
@@ -447,7 +447,7 @@ public:
   void resize_and_fill(size_t nrows) override;
   void apply_na_mask(const BoolColumn* mask) override;
   virtual void materialize() override;
-  virtual void replace_values(RowIndex at, const Column* with) override;
+  void replace_values(RowIndex at, const OColumn& with) override;
   void replace_values(const RowIndex& at, T with);
   virtual RowIndex join(const Column* keycol) const override;
   void fill_na_mask(int8_t* outmask, size_t row0, size_t row1) override;
@@ -639,7 +639,7 @@ public:
   CString mode() const;
 
   Column* shallowcopy(const RowIndex& new_rowindex) const override;
-  void replace_values(RowIndex at, const Column* with) override;
+  void replace_values(RowIndex at, const OColumn& with) override;
   StringStats<T>* get_stats() const override;
 
   void verify_integrity(const std::string& name) const override;
@@ -688,7 +688,7 @@ class VoidColumn : public Column {
     void resize_and_fill(size_t) override;
     void rbind_impl(colvec&, size_t, bool) override;
     void apply_na_mask(const BoolColumn*) override;
-    void replace_values(RowIndex, const Column*) override;
+    void replace_values(RowIndex, const OColumn&) override;
     RowIndex join(const Column* keycol) const override;
     Stats* get_stats() const override;
     void fill_na_mask(int8_t* outmask, size_t row0, size_t row1) override;

--- a/c/column.h
+++ b/c/column.h
@@ -259,7 +259,7 @@ public:
    * Individual entries in the `columns` array may be instances of `VoidColumn`,
    * indicating columns that should be replaced with NAs.
    */
-  Column* rbind(colvec& columns);
+  // Column* rbind(colvec& columns);
 
   /**
    * "Materialize" the Column. If the Column has no rowindex, this is a no-op.

--- a/c/column.h
+++ b/c/column.h
@@ -131,10 +131,10 @@ protected:
   MemoryRange mbuf;
   RowIndex ri;
   mutable Stats* stats;
-  SType _stype;
-  size_t : 56;
 
 public:  // TODO: convert this into private
+  SType _stype;
+  size_t : 56;
   size_t nrows;
 
 public:
@@ -156,7 +156,6 @@ public:
   Column(Column&&) = delete;
   virtual ~Column();
 
-  SType stype() const noexcept { return _stype; }
   virtual size_t elemsize() const = 0;
 
   virtual bool get_element(size_t i, int32_t* out) const;

--- a/c/column.h
+++ b/c/column.h
@@ -365,11 +365,6 @@ class OColumn
 
     // TEMP accessors to the underlying implementation
     const Column* get() const;
-    Column* release() {
-      Column* ret = pcol;
-      pcol = nullptr;
-      return ret;
-    }
 
     Column* operator->();
     const Column* operator->() const;

--- a/c/column.h
+++ b/c/column.h
@@ -131,6 +131,8 @@ protected:
   MemoryRange mbuf;
   RowIndex ri;
   mutable Stats* stats;
+  SType _stype;
+  size_t : 56;
 
 public:  // TODO: convert this into private
   size_t nrows;
@@ -154,7 +156,7 @@ public:
   Column(Column&&) = delete;
   virtual ~Column();
 
-  virtual SType stype() const noexcept = 0;
+  SType stype() const noexcept { return _stype; }
   virtual size_t elemsize() const = 0;
 
   virtual bool get_element(size_t i, int32_t* out) const;
@@ -476,8 +478,8 @@ extern template class FwColumn<PyObject*>;
 class BoolColumn : public FwColumn<int8_t>
 {
 public:
-  using FwColumn<int8_t>::FwColumn;
-  SType stype() const noexcept override;
+  BoolColumn(size_t nrows = 0);
+  BoolColumn(size_t nrows, MemoryRange&&);
 
   int8_t min() const;
   int8_t max() const;
@@ -504,8 +506,8 @@ public:
 template <typename T> class IntColumn : public FwColumn<T>
 {
 public:
-  using FwColumn<T>::FwColumn;
-  virtual SType stype() const noexcept override;
+  IntColumn(size_t nrows = 0);
+  IntColumn(size_t nrows, MemoryRange&&);
 
   T min() const;
   T max() const;
@@ -540,8 +542,8 @@ extern template class IntColumn<int64_t>;
 template <typename T> class RealColumn : public FwColumn<T>
 {
 public:
-  using FwColumn<T>::FwColumn;
-  virtual SType stype() const noexcept override;
+  RealColumn(size_t nrows = 0);
+  RealColumn(size_t nrows, MemoryRange&&);
 
   T min() const;
   T max() const;
@@ -588,7 +590,6 @@ class PyObjectColumn : public FwColumn<PyObject*>
 public:
   PyObjectColumn(size_t nrows);
   PyObjectColumn(size_t nrows, MemoryRange&&);
-  virtual SType stype() const noexcept override;
   PyObjectStats* get_stats() const override;
 
   bool get_element(size_t i, py::oobj* out) const override;
@@ -619,7 +620,6 @@ template <typename T> class StringColumn : public Column
 public:
   StringColumn(size_t nrows);
 
-  SType stype() const noexcept override;
   size_t elemsize() const override;
 
   void materialize() override;
@@ -683,7 +683,6 @@ extern template class StringColumn<uint64_t>;
 class VoidColumn : public Column {
   public:
     VoidColumn(size_t nrows);
-    SType stype() const noexcept override;
     size_t elemsize() const override;
     size_t data_nrows() const override;
     void materialize() override;

--- a/c/column.h
+++ b/c/column.h
@@ -156,7 +156,7 @@ public:
   Column(Column&&) = delete;
   virtual ~Column();
 
-  virtual size_t elemsize() const = 0;
+  size_t elemsize() const { return info(_stype).elemsize(); }
 
   virtual bool get_element(size_t i, int32_t* out) const;
   virtual bool get_element(size_t i, int64_t* out) const;
@@ -442,7 +442,6 @@ public:
   size_t data_nrows() const override;
   void resize_and_fill(size_t nrows) override;
   void apply_na_mask(const BoolColumn* mask) override;
-  size_t elemsize() const override;
   virtual void materialize() override;
   virtual void replace_values(RowIndex at, const Column* with) override;
   void replace_values(const RowIndex& at, T with);
@@ -619,8 +618,6 @@ template <typename T> class StringColumn : public Column
 public:
   StringColumn(size_t nrows);
 
-  size_t elemsize() const override;
-
   void materialize() override;
   void resize_and_fill(size_t nrows) override;
   void apply_na_mask(const BoolColumn* mask) override;
@@ -682,7 +679,6 @@ extern template class StringColumn<uint64_t>;
 class VoidColumn : public Column {
   public:
     VoidColumn(size_t nrows);
-    size_t elemsize() const override;
     size_t data_nrows() const override;
     void materialize() override;
     void resize_and_fill(size_t) override;

--- a/c/column.h
+++ b/c/column.h
@@ -150,7 +150,7 @@ public:
   static Column* from_pylist_of_tuples(const py::olist& list, size_t index, int stype0);
   static Column* from_pylist_of_dicts(const py::olist& list, py::robj name, int stype0);
   static Column* from_buffer(const py::robj& buffer);
-  static Column* from_range(int64_t start, int64_t stop, int64_t step, SType s);
+  static OColumn from_range(int64_t start, int64_t stop, int64_t step, SType s);
 
   Column(const Column&) = delete;
   Column(Column&&) = delete;
@@ -365,7 +365,11 @@ class OColumn
 
     // TEMP accessors to the underlying implementation
     const Column* get() const;
-    Column* release();
+    Column* release() {
+      Column* ret = pcol;
+      pcol = nullptr;
+      return ret;
+    }
 
     Column* operator->();
     const Column* operator->() const;

--- a/c/column_bool.cc
+++ b/c/column_bool.cc
@@ -10,11 +10,15 @@
 #include "datatablemodule.h"
 
 
-
-
-SType BoolColumn::stype() const noexcept {
-  return SType::BOOL;
+BoolColumn::BoolColumn(size_t nrows) : FwColumn<int8_t>(nrows) {
+  _stype = SType::BOOL;
 }
+
+BoolColumn::BoolColumn(size_t nrows, MemoryRange&& mem)
+  : FwColumn<int8_t>(nrows, std::move(mem)) {
+  _stype = SType::BOOL;
+}
+
 
 bool BoolColumn::get_element(size_t i, int32_t* x) const {
   size_t j = ri[i];

--- a/c/column_from_pylist.cc
+++ b/c/column_from_pylist.cc
@@ -581,7 +581,7 @@ Column* Column::from_pylist_of_dicts(
 //------------------------------------------------------------------------------
 
 template <typename T>
-static Column* _make_range_column(
+static OColumn _make_range_column(
     int64_t start, int64_t length, int64_t step, SType stype)
 {
   Column* col = Column::new_data_column(stype, static_cast<size_t>(length));
@@ -590,11 +590,11 @@ static Column* _make_range_column(
     elems[i] = static_cast<T>(j);
     j += step;
   }
-  return col;
+  return OColumn(col);
 }
 
 
-Column* Column::from_range(
+OColumn Column::from_range(
     int64_t start, int64_t stop, int64_t step, SType stype)
 {
   int64_t length = (stop - start - (step > 0 ? 1 : -1)) / step + 1;
@@ -609,10 +609,8 @@ Column* Column::from_range(
     case SType::INT32: return _make_range_column<int32_t>(start, length, step, stype);
     case SType::INT64: return _make_range_column<int64_t>(start, length, step, stype);
     default: {
-      Column* col = _make_range_column<int64_t>(start, length, step, SType::INT64);
-      Column* res = col->cast(stype).release();
-      delete col;
-      return res;
+      OColumn col = _make_range_column<int64_t>(start, length, step, SType::INT64);
+      return col->cast(stype);
     }
   }
 }

--- a/c/column_from_pylist.cc
+++ b/c/column_from_pylist.cc
@@ -610,7 +610,7 @@ Column* Column::from_range(
     case SType::INT64: return _make_range_column<int64_t>(start, length, step, stype);
     default: {
       Column* col = _make_range_column<int64_t>(start, length, step, SType::INT64);
-      Column* res = col->cast(stype);
+      Column* res = col->cast(stype).release();
       delete col;
       return res;
     }

--- a/c/column_fw.cc
+++ b/c/column_fw.cc
@@ -22,12 +22,12 @@ FwColumn<T>::FwColumn() : Column(0) {}
 
 template <typename T>
 FwColumn<T>::FwColumn(size_t nrows_) : Column(nrows_) {
-  mbuf.resize(elemsize() * nrows_);
+  mbuf.resize(sizeof(T) * nrows_);
 }
 
 template <typename T>
 FwColumn<T>::FwColumn(size_t nrows_, MemoryRange&& mr) : Column(nrows_) {
-  size_t req_size = elemsize() * nrows_;
+  size_t req_size = sizeof(T) * nrows_;
   if (mr) {
     xassert(mr.size() == req_size);
   } else {
@@ -44,7 +44,7 @@ FwColumn<T>::FwColumn(size_t nrows_, MemoryRange&& mr) : Column(nrows_) {
 template <typename T>
 void FwColumn<T>::init_data() {
   xassert(!ri);
-  mbuf.resize(nrows * elemsize());
+  mbuf.resize(nrows * sizeof(T));
 }
 
 template <typename T>
@@ -64,12 +64,6 @@ void FwColumn<T>::init_xbuf(Py_buffer* pybuffer) {
 
 
 //==============================================================================
-
-template <typename T>
-size_t FwColumn<T>::elemsize() const {
-  return sizeof(T);
-}
-
 
 template <typename T>
 const T* FwColumn<T>::elements_r() const {

--- a/c/column_fw.cc
+++ b/c/column_fw.cc
@@ -229,8 +229,8 @@ void FwColumn<T>::replace_values(
   if (!replace_with) {
     return replace_values(replace_at, GETNA<T>());
   }
-  if (replace_with->stype() != stype()) {
-    replace_with = replace_with->cast(stype());
+  if (replace_with->_stype != _stype) {
+    replace_with = replace_with->cast(_stype);
   }
 
   if (replace_with->nrows == 1) {
@@ -276,7 +276,7 @@ static int32_t binsearch(const T* data, int32_t len, T value) {
 
 template <typename T>
 RowIndex FwColumn<T>::join(const Column* keycol) const {
-  xassert(stype() == keycol->stype());
+  xassert(_stype == keycol->_stype);
 
   auto kcol = static_cast<const FwColumn<T>*>(keycol);
   xassert(!kcol->ri);

--- a/c/column_fw.cc
+++ b/c/column_fw.cc
@@ -224,7 +224,7 @@ void FwColumn<T>::replace_values(
     return replace_values(replace_at, GETNA<T>());
   }
   if (replace_with->_stype != _stype) {
-    replace_with = replace_with->cast(_stype);
+    replace_with = replace_with->cast(_stype).release();
   }
 
   if (replace_with->nrows == 1) {

--- a/c/column_int.cc
+++ b/c/column_int.cc
@@ -9,15 +9,25 @@
 #include "column.h"
 #include "datatablemodule.h"
 
+template <typename T> constexpr SType stype_for() { return SType::VOID; }
+template <> constexpr SType stype_for<int8_t>()  { return SType::INT8; }
+template <> constexpr SType stype_for<int16_t>() { return SType::INT16; }
+template <> constexpr SType stype_for<int32_t>() { return SType::INT32; }
+template <> constexpr SType stype_for<int64_t>() { return SType::INT64; }
 
 
 template <typename T>
-SType IntColumn<T>::stype() const noexcept {
-  return sizeof(T) == 1? SType::INT8 :
-         sizeof(T) == 2? SType::INT16 :
-         sizeof(T) == 4? SType::INT32 :
-         sizeof(T) == 8? SType::INT64 : SType::VOID;
+IntColumn<T>::IntColumn(size_t nrows) : FwColumn<T>(nrows) {
+  this->_stype = stype_for<T>();
 }
+
+template <typename T>
+IntColumn<T>::IntColumn(size_t nrows, MemoryRange&& mem)
+  : FwColumn<T>(nrows, std::move(mem))
+{
+  this->_stype = stype_for<T>();
+}
+
 
 template <typename T>
 bool IntColumn<T>::get_element(size_t i, int32_t* out) const {

--- a/c/column_pyobj.cc
+++ b/c/column_pyobj.cc
@@ -13,24 +13,22 @@
 
 
 PyObjectColumn::PyObjectColumn() : FwColumn<PyObject*>() {
+  _stype = SType::OBJ;
   mbuf.set_pyobjects(/*clear_data = */ true);
 }
 
 PyObjectColumn::PyObjectColumn(size_t nrows_) : FwColumn<PyObject*>(nrows_) {
+  _stype = SType::OBJ;
   mbuf.set_pyobjects(/*clear_data = */ true);
 }
 
 PyObjectColumn::PyObjectColumn(size_t nrows_, MemoryRange&& mb)
     : FwColumn<PyObject*>(nrows_, std::move(mb))
 {
+  _stype = SType::OBJ;
   mbuf.set_pyobjects(/*clear_data = */ true);
 }
 
-
-
-SType PyObjectColumn::stype() const noexcept {
-  return SType::OBJ;
-}
 
 
 bool PyObjectColumn::get_element(size_t i, py::oobj* out) const {

--- a/c/column_real.cc
+++ b/c/column_real.cc
@@ -10,13 +10,22 @@
 #include "datatablemodule.h"
 #include "python/float.h"
 
-
+template <typename T> constexpr SType stype_for() { return SType::VOID; }
+template <> constexpr SType stype_for<float>()  { return SType::FLOAT32; }
+template <> constexpr SType stype_for<double>() { return SType::FLOAT64; }
 
 template <typename T>
-SType RealColumn<T>::stype() const noexcept {
-  return sizeof(T) == 4? SType::FLOAT32 :
-         sizeof(T) == 8? SType::FLOAT64 : SType::VOID;
+RealColumn<T>::RealColumn(size_t nrows) : FwColumn<T>(nrows) {
+  this->_stype = stype_for<T>();
 }
+
+template <typename T>
+RealColumn<T>::RealColumn(size_t nrows, MemoryRange&& mem)
+  : FwColumn<T>(nrows, std::move(mem))
+{
+  this->_stype = stype_for<T>();
+}
+
 
 template <typename T>
 bool RealColumn<T>::get_element(size_t i, T* out) const {

--- a/c/column_string.cc
+++ b/c/column_string.cc
@@ -138,14 +138,6 @@ bool StringColumn<T>::get_element(size_t i, CString* out) const {
 
 
 template <typename T>
-size_t StringColumn<T>::elemsize() const {
-  return sizeof(T);
-}
-
-
-
-
-template <typename T>
 size_t StringColumn<T>::datasize() const{
   size_t sz = mbuf.size();
   const T* end = static_cast<const T*>(mbuf.rptr(sz));

--- a/c/column_string.cc
+++ b/c/column_string.cc
@@ -288,8 +288,8 @@ void StringColumn<T>::replace_values(
   materialize();
   Column* rescol = nullptr;
 
-  if (replace_with && replace_with->stype() != stype()){
-    replace_with = replace_with->cast(stype());
+  if (replace_with && replace_with->_stype != _stype){
+    replace_with = replace_with->cast(_stype);
   }
   // This could be nullptr too
   auto repl_col = static_cast<const StringColumn<T>*>(replace_with);
@@ -333,7 +333,7 @@ void StringColumn<T>::replace_values(
   }
 
   xassert(rescol);
-  if (rescol->stype() != stype()) {
+  if (rescol->_stype != _stype) {
     throw NotImplError() << "When replacing string values, the size of the "
       "resulting column exceeds the maximum for str32";
   }
@@ -509,7 +509,7 @@ static int32_t binsearch(const uint8_t* strdata, const T* offsets, uint32_t len,
 
 template <typename T>
 RowIndex StringColumn<T>::join(const Column* keycol) const {
-  xassert(stype() == keycol->stype());
+  xassert(_stype == keycol->_stype);
 
   auto kcol = static_cast<const StringColumn<T>*>(keycol);
   xassert(!kcol->ri);

--- a/c/expr/expr_binaryop.cc
+++ b/c/expr/expr_binaryop.cc
@@ -560,8 +560,8 @@ static Column* binaryop(Op opcode, Column* lhs, Column* rhs)
     lhs_nrows = rhs_nrows = 0;
   }
   size_t nrows = std::max(lhs_nrows, rhs_nrows);
-  SType lhs_type = lhs->stype();
-  SType rhs_type = rhs->stype();
+  SType lhs_type = lhs->_stype;
+  SType rhs_type = rhs->_stype;
   void* params[3];
   params[0] = lhs;
   params[1] = rhs;

--- a/c/expr/expr_column.cc
+++ b/c/expr/expr_column.cc
@@ -95,7 +95,7 @@ OColumn expr_column::evaluate_eager(workframe& wf) {
   if (dt_ri) {
     newcol->replace_rowindex(wf._product(dt_ri, col_ri));
   }
-  return OColumn(newcol.release());
+  return newcol;
 }
 
 

--- a/c/expr/expr_literal.cc
+++ b/c/expr/expr_literal.cc
@@ -32,7 +32,7 @@ expr_literal::expr_literal(py::robj v) {
 
 
 SType expr_literal::resolve(const workframe&) {
-  return col->stype();
+  return col.stype();
 }
 
 
@@ -42,7 +42,7 @@ GroupbyMode expr_literal::get_groupby_mode(const workframe&) const {
 
 
 OColumn expr_literal::evaluate_eager(workframe&) {
-  return OColumn(col->shallowcopy());
+  return col;  // copy
 }
 
 

--- a/c/expr/expr_reduce.cc
+++ b/c/expr/expr_reduce.cc
@@ -308,7 +308,7 @@ OColumn expr_reduce1::evaluate_eager(workframe& wf)
 {
   auto input_col = arg->evaluate_eager(wf);
   Groupby gb = wf.get_groupby();
-  if (!gb) gb = Groupby::single_group(input_col->nrows);
+  if (!gb) gb = Groupby::single_group(input_col.nrows());
 
   size_t out_nrows = gb.ngroups();
   if (!out_nrows) out_nrows = 1;  // only when input_col has 0 rows
@@ -317,7 +317,7 @@ OColumn expr_reduce1::evaluate_eager(workframe& wf)
     return reduce_first(input_col, gb);
   }
 
-  SType in_stype = input_col->stype();
+  SType in_stype = input_col.stype();
   auto reducer = library.lookup(opcode, in_stype);
   xassert(reducer);  // checked in .resolve()
 

--- a/c/expr/expr_str.cc
+++ b/c/expr/expr_str.cc
@@ -99,7 +99,7 @@ GroupbyMode expr_string_match_re::get_groupby_mode(const workframe& wf) const {
 
 OColumn expr_string_match_re::evaluate_eager(workframe& wf) {
   auto arg_res = arg->evaluate_eager(wf);
-  SType arg_stype = arg_res->stype();
+  SType arg_stype = arg_res.stype();
   xassert(arg_stype == SType::STR32 || arg_stype == SType::STR64);
   return arg_stype == SType::STR32? _compute<uint32_t>(arg_res.get())
                                   : _compute<uint64_t>(arg_res.get());

--- a/c/expr/i_node.cc
+++ b/c/expr/i_node.cc
@@ -281,8 +281,7 @@ void expr_in::execute(workframe& wf) {
         "was of type " << st;
   }
   auto col = expr->evaluate_eager(wf);
-  OColumn ocol(col.release());
-  RowIndex res(ocol);
+  RowIndex res(col);
   wf.apply_rowindex(res);
 }
 

--- a/c/expr/j_node.cc
+++ b/c/expr/j_node.cc
@@ -297,8 +297,7 @@ void exprlist_jn::select(workframe& wf) {
   RowIndex ri0;  // empty rowindex
   for (size_t i = 0; i < n; ++i) {
     auto col = exprs[i]->evaluate_eager(wf);
-    OColumn newcol(col.release());
-    wf.add_column(std::move(newcol), ri0, std::move(names[i]));
+    wf.add_column(std::move(col), ri0, std::move(names[i]));
   }
 }
 

--- a/c/expr/j_node.cc
+++ b/c/expr/j_node.cc
@@ -196,7 +196,7 @@ void collist_jn::delete_(workframe& wf) {
   const RowIndex& ri0 = wf.get_rowindex(0);
   if (ri0) {
     for (size_t i : indices) {
-      dt0->get_ocolumn(i)->replace_values(ri0, nullptr);
+      dt0->get_ocolumn(i)->replace_values(ri0, OColumn());
     }
   } else {
     dt0->delete_columns(indices);

--- a/c/expr/repl_node.cc
+++ b/c/expr/repl_node.cc
@@ -103,7 +103,7 @@ void frame_rn::replace_values(workframe& wf, const intvec& indices) const {
           OColumn(Column::new_na_column(coli.stype(), dt0->nrows)));
     }
     OColumn& colj = dt0->get_ocolumn(j);
-    colj->replace_values(ri0, coli.get());
+    colj->replace_values(ri0, coli);
   }
 }
 
@@ -183,7 +183,7 @@ void scalar_rn::replace_values(workframe& wf, const intvec& indices) const {
       dt0->set_ocolumn(j, colj.cast(stype));
     }
     OColumn& ocol = dt0->get_ocolumn(j);
-    ocol->replace_values(ri0, replcol.get());
+    ocol->replace_values(ri0, replcol);
   }
 }
 

--- a/c/expr/virtual_column.cc
+++ b/c/expr/virtual_column.cc
@@ -121,7 +121,7 @@ class _vcolumn : public virtual_column {
 };
 
 _vcolumn::_vcolumn(OColumn&& col)
-  : virtual_column(col->nrows, col->stype()),
+  : virtual_column(col.nrows(), col.stype()),
     column(std::move(col)) {}
 
 OColumn _vcolumn::materialize() {
@@ -247,7 +247,7 @@ class slice_str_vcol : public str_vcol<T> {
 
 
 vcolptr virtualize(OColumn&& col) {
-  SType st = col->stype();
+  SType st = col.stype();
   const RowIndex& ri = col->rowindex();
   switch (ri.type()) {
     case RowIndexType::UNKNOWN: {

--- a/c/frame/__init__.cc
+++ b/c/frame/__init__.cc
@@ -328,7 +328,7 @@ class FrameInitializationManager {
 
 
     void init_mystery_frame() {
-      cols.emplace_back(Column::from_range(42, 43, 1, SType::VOID));
+      cols.push_back(Column::from_range(42, 43, 1, SType::VOID));
       make_datatable(strvec { "?" });
     }
 
@@ -601,7 +601,7 @@ class FrameInitializationManager {
       }
       else if (colsrc.is_range()) {
         auto r = colsrc.to_orange();
-        col = OColumn(Column::from_range(r.start(), r.stop(), r.step(), s));
+        col = Column::from_range(r.start(), r.stop(), r.step(), s);
       }
       else {
         throw TypeError() << "Cannot create a column from " << colsrc.typeobj();

--- a/c/frame/__init__.cc
+++ b/c/frame/__init__.cc
@@ -448,7 +448,7 @@ class FrameInitializationManager {
           auto masksrc = npsrc.get_attr("mask").get_item(col_key);
           make_column(colsrc, SType::VOID);
           Column* maskcol = Column::from_buffer(masksrc);
-          xassert(maskcol->stype() == SType::BOOL);
+          xassert(maskcol->_stype == SType::BOOL);
           cols.back()->apply_na_mask(static_cast<BoolColumn*>(maskcol));
           delete maskcol;
         }

--- a/c/frame/cast.cc
+++ b/c/frame/cast.cc
@@ -190,7 +190,7 @@ static void cast_str_to_pyobj(const Column* col, void* out_data)
 
 
 template <typename T, void (*CAST_OP)(T, dt::string_buf*)>
-static Column* cast_to_str(const Column* col, MemoryRange&& out_offsets,
+static OColumn cast_to_str(const Column* col, MemoryRange&& out_offsets,
                            SType target_stype)
 {
   auto inp = static_cast<const T*>(col->data());
@@ -213,7 +213,7 @@ static Column* cast_to_str(const Column* col, MemoryRange&& out_offsets,
 
 
 template <typename T>
-static Column* cast_str_to_str(const Column* col, MemoryRange&& out_offsets,
+static OColumn cast_str_to_str(const Column* col, MemoryRange&& out_offsets,
                                SType target_stype)
 {
   auto scol = static_cast<const StringColumn<T>*>(col);
@@ -258,7 +258,7 @@ class cast_manager {
     using castfn0 = void (*)(const Column*, size_t start, void* out);
     using castfn1 = void (*)(const Column*, const int32_t* indices, void* out);
     using castfn2 = void (*)(const Column*, void* out);
-    using castfnx = Column* (*)(const Column*, MemoryRange&&, SType);
+    using castfnx = OColumn (*)(const Column*, MemoryRange&&, SType);
     struct cast_info {
       castfn0  f0;
       castfn1  f1;
@@ -275,7 +275,7 @@ class cast_manager {
     inline void add(SType st_from, SType st_to, castfn2 f);
     inline void add(SType st_from, SType st_to, castfnx f);
 
-    Column* execute(const Column*, MemoryRange&&, SType);
+    OColumn execute(const Column*, MemoryRange&&, SType);
 
   private:
     static inline constexpr size_t key(SType st1, SType st2) {
@@ -310,7 +310,7 @@ void cast_manager::add(SType st_from, SType st_to, castfnx f) {
 }
 
 
-Column* cast_manager::execute(const Column* src, MemoryRange&& target_mbuf,
+OColumn cast_manager::execute(const Column* src, MemoryRange&& target_mbuf,
                               SType target_stype)
 {
   xassert(!target_mbuf.is_pyobjects());
@@ -355,7 +355,7 @@ Column* cast_manager::execute(const Column* src, MemoryRange&& target_mbuf,
     target_mbuf.set_pyobjects(/* clear = */ false);
   }
 
-  return Column::new_mbuf_column(target_stype, std::move(target_mbuf));
+  return OColumn(Column::new_mbuf_column(target_stype, std::move(target_mbuf)));
 }
 
 
@@ -558,10 +558,10 @@ void py::DatatableModule::init_casts()
 // Column (base methods)
 //------------------------------------------------------------------------------
 
-Column* Column::cast(SType new_stype) const {
+OColumn Column::cast(SType new_stype) const {
   return cast(new_stype, MemoryRange());
 }
 
-Column* Column::cast(SType new_stype, MemoryRange&& mr) const {
+OColumn Column::cast(SType new_stype, MemoryRange&& mr) const {
   return casts.execute(this, std::move(mr), new_stype);
 }

--- a/c/frame/cast.cc
+++ b/c/frame/cast.cc
@@ -207,7 +207,7 @@ static Column* cast_to_str(const Column* col, MemoryRange&& out_offsets,
       col->nrows,
       std::move(out_offsets),
       /* force_str64 = */ (target_stype == SType::STR64),
-      /* force_single_threaded = */ (col->stype() == SType::OBJ)
+      /* force_single_threaded = */ (col->_stype == SType::OBJ)
   );
 }
 
@@ -314,10 +314,10 @@ Column* cast_manager::execute(const Column* src, MemoryRange&& target_mbuf,
                               SType target_stype)
 {
   xassert(!target_mbuf.is_pyobjects());
-  size_t id = key(src->stype(), target_stype);
+  size_t id = key(src->_stype, target_stype);
   if (all_casts.count(id) == 0) {
     throw NotImplError()
-        << "Unable to cast `" << src->stype() << "` into `"
+        << "Unable to cast `" << src->_stype << "` into `"
         << target_stype << "`";
   }
 

--- a/c/frame/rbind.cc
+++ b/c/frame/rbind.cc
@@ -329,7 +329,7 @@ Column* Column::rbind(colvec& columns)
   } else if (_stype == new_stype) {
     res = this;
   } else {
-    res = this->cast(new_stype);
+    res = this->cast(new_stype).release();
   }
   xassert(res->_stype == new_stype);
 
@@ -458,8 +458,7 @@ void FwColumn<T>::rbind_impl(colvec& columns, size_t new_nrows, bool col_empty)
         rows_to_fill = 0;
       }
       if (col.stype() != _stype) {
-        Column* newcol = col->cast(_stype);
-        col = OColumn(newcol);
+        col = col->cast(_stype);
       }
       std::memcpy(resptr, col->data(), col->alloc_size());
       resptr += col->alloc_size();
@@ -501,8 +500,7 @@ void PyObjectColumn::rbind_impl(
       dest_data += col->nrows;
     } else {
       if (col.stype() != SType::OBJ) {
-        Column* newcol = col->cast(_stype);
-        col = OColumn(newcol);
+        col = col->cast(_stype);
       }
       auto src_data = static_cast<PyObject* const*>(col->data());
       for (size_t i = 0; i < col->nrows; ++i) {

--- a/c/frame/rbind.cc
+++ b/c/frame/rbind.cc
@@ -503,7 +503,7 @@ void PyObjectColumn::rbind_impl(
         col = col->cast(_stype);
       }
       auto src_data = static_cast<PyObject* const*>(col->data());
-      for (size_t i = 0; i < col->nrows; ++i) {
+      for (size_t i = 0; i < col.nrows(); ++i) {
         Py_INCREF(src_data[i]);
         Py_DECREF(*dest_data);
         *dest_data = src_data[i];

--- a/c/frame/repeat.cc
+++ b/c/frame/repeat.cc
@@ -58,12 +58,12 @@ static RowIndex _make_repeat_rowindex(size_t nrows, size_t nreps) {
 
 
 Column* Column::repeat(size_t nreps) const {
-  xassert(!info(stype()).is_varwidth());
+  xassert(!info(_stype).is_varwidth());
   xassert(!ri);
   size_t esize = elemsize();
   size_t new_nrows = nrows * nreps;
 
-  Column* newcol = Column::new_data_column(stype(), new_nrows);
+  Column* newcol = Column::new_data_column(_stype, new_nrows);
   if (!new_nrows) {
     return newcol;
   }

--- a/c/frame/replace.cc
+++ b/c/frame/replace.cc
@@ -569,7 +569,7 @@ void ReplaceAgent::process_str_column(size_t colidx) {
   }
   Column* newcol = replace_str<T>(x_str.size(), x_str.data(), y_str.data(),
                                   col);
-  columns_cast = (newcol->stype() != col->stype());
+  columns_cast = (newcol->_stype != ocol.stype());
   dt->set_ocolumn(colidx, OColumn(newcol));
 }
 

--- a/c/frame/replace.cc
+++ b/c/frame/replace.cc
@@ -65,10 +65,10 @@ class ReplaceAgent {
     template <typename T> void replace_fw1(T* x, T* y, size_t nrows, T* data);
     template <typename T> void replace_fw2(T* x, T* y, size_t nrows, T* data);
     template <typename T> void replace_fwN(T* x, T* y, size_t nrows, T* data, size_t n);
-    template <typename T> Column* replace_str(size_t n, CString* x, CString* y, StringColumn<T>*);
-    template <typename T> Column* replace_str1(CString* x, CString* y, StringColumn<T>*);
-    template <typename T> Column* replace_str2(CString* x, CString* y, StringColumn<T>*);
-    template <typename T> Column* replace_strN(CString* x, CString* y, StringColumn<T>*, size_t n);
+    template <typename T> OColumn replace_str(size_t n, CString* x, CString* y, StringColumn<T>*);
+    template <typename T> OColumn replace_str1(CString* x, CString* y, StringColumn<T>*);
+    template <typename T> OColumn replace_str2(CString* x, CString* y, StringColumn<T>*);
+    template <typename T> OColumn replace_strN(CString* x, CString* y, StringColumn<T>*, size_t n);
     bool types_changed() const { return columns_cast; }
 
   private:
@@ -567,10 +567,10 @@ void ReplaceAgent::process_str_column(size_t colidx) {
   if (x_str.size() == 1 && x_str[0].isna()) {
     if (col->countna() == 0) return;
   }
-  Column* newcol = replace_str<T>(x_str.size(), x_str.data(), y_str.data(),
+  OColumn newcol = replace_str<T>(x_str.size(), x_str.data(), y_str.data(),
                                   col);
-  columns_cast = (newcol->_stype != ocol.stype());
-  dt->set_ocolumn(colidx, OColumn(newcol));
+  columns_cast = (newcol.stype() != ocol.stype());
+  dt->set_ocolumn(colidx, std::move(newcol));
 }
 
 
@@ -674,7 +674,7 @@ void ReplaceAgent::replace_fwN(T* x, T* y, size_t nrows, T* data, size_t n) {
 
 
 template <typename T>
-Column* ReplaceAgent::replace_str(size_t n, CString* x, CString* y,
+OColumn ReplaceAgent::replace_str(size_t n, CString* x, CString* y,
                                   StringColumn<T>* col)
 {
   if (n == 1) {
@@ -685,7 +685,7 @@ Column* ReplaceAgent::replace_str(size_t n, CString* x, CString* y,
 }
 
 template <typename T>
-Column* ReplaceAgent::replace_str1(
+OColumn ReplaceAgent::replace_str1(
     CString* x, CString* y, StringColumn<T>* col)
 {
   return dt::map_str2str(col,
@@ -696,7 +696,7 @@ Column* ReplaceAgent::replace_str1(
 
 
 template <typename T>
-Column* ReplaceAgent::replace_strN(CString* x, CString* y,
+OColumn ReplaceAgent::replace_strN(CString* x, CString* y,
                                    StringColumn<T>* col, size_t n)
 {
   return dt::map_str2str(col,

--- a/c/models/dt_ftrl.cc
+++ b/c/models/dt_ftrl.cc
@@ -832,7 +832,8 @@ dtptr Ftrl<T>::create_p(size_t nrows) {
   size_t nlabels = dt_labels->nrows;
   xassert(nlabels > 0);
 
-  auto scol = static_cast<StringColumn<uint64_t>*>(dt_labels->get_ocolumn(0)->cast(SType::STR64));
+  OColumn col0_str64 = dt_labels->get_ocolumn(0)->cast(SType::STR64);
+  auto scol = static_cast<StringColumn<uint64_t>*>(const_cast<Column*>(col0_str64.get()));
   const uint64_t* offsets = scol->offsets();
   const char* strdata = scol->strdata();
 

--- a/c/models/dt_ftrl.cc
+++ b/c/models/dt_ftrl.cc
@@ -995,7 +995,7 @@ std::vector<hasherptr> Ftrl<T>::create_hashers(const DataTable* dt) {
 template <typename T>
 hasherptr Ftrl<T>::create_hasher(const OColumn& col) {
   unsigned char shift_nbits = dt::FtrlBase::DOUBLE_MANTISSA_NBITS - mantissa_nbits;
-  SType stype = col->stype();
+  SType stype = col.stype();
   switch (stype) {
     case SType::BOOL:    return hasherptr(new HasherBool(col));
     case SType::INT8:    return hasherptr(new HasherInt<int8_t>(col));

--- a/c/parallel/string_utils.cc
+++ b/c/parallel/string_utils.cc
@@ -26,7 +26,7 @@ namespace dt {
 // Ordered iteration, produce a string column
 //------------------------------------------------------------------------------
 
-Column* generate_string_column(function<void(size_t, string_buf*)> fn,
+OColumn generate_string_column(function<void(size_t, string_buf*)> fn,
                                size_t nrows,
                                MemoryRange&& offsets_buffer,
                                bool force_str64,
@@ -67,7 +67,7 @@ Column* generate_string_column(function<void(size_t, string_buf*)> fn,
       sb->commit_and_start_new_chunk(nrows);
     });
 
-  return std::move(outcol).to_ocolumn().release();
+  return std::move(outcol).to_ocolumn();
 }
 
 

--- a/c/parallel/string_utils.h
+++ b/c/parallel/string_utils.h
@@ -30,7 +30,7 @@ namespace dt {
 
 using string_buf = writable_string_col::buffer;
 
-Column* generate_string_column(dt::function<void(size_t, string_buf*)> fn,
+OColumn generate_string_column(dt::function<void(size_t, string_buf*)> fn,
                                size_t n,
                                MemoryRange&& offsets_buffer = MemoryRange(),
                                bool force_str64 = false,
@@ -44,7 +44,7 @@ Column* generate_string_column(dt::function<void(size_t, string_buf*)> fn,
 //------------------------------------------------------------------------------
 
 template <typename T, typename F>
-Column* map_str2str(StringColumn<T>* input_col, F f) {
+OColumn map_str2str(StringColumn<T>* input_col, F f) {
   size_t nrows = input_col->nrows;
   writable_string_col output_col(nrows, /* str64= */ sizeof(T)==8);
 
@@ -93,7 +93,7 @@ Column* map_str2str(StringColumn<T>* input_col, F f) {
       sb->commit_and_start_new_chunk(nrows);
     });
 
-  return std::move(output_col).to_ocolumn().release();
+  return std::move(output_col).to_ocolumn();
 }
 
 

--- a/c/py_buffers.cc
+++ b/c/py_buffers.cc
@@ -126,7 +126,7 @@ Column* Column::from_buffer(const py::robj& pyobj)
       }
     }
   }
-  if (res->stype() == SType::OBJ) {
+  if (res->_stype == SType::OBJ) {
     res = try_to_resolve_object_column(res);
   }
   return res;

--- a/c/rowindex_array.cc
+++ b/c/rowindex_array.cc
@@ -305,7 +305,6 @@ void ArrayRowIndexImpl::init_from_integer_column(const Column* col) {
   col2->materialize();  // noop if col has no rowindex
 
   length = col->nrows;
-  Column* col3 = nullptr;
   if (length <= INT32_MAX && max <= INT32_MAX) {
     type = RowIndexType::ARR32;
     _resize_data();
@@ -315,17 +314,16 @@ void ArrayRowIndexImpl::init_from_integer_column(const Column* col) {
     // the column is destructed.
     MemoryRange xbuf = MemoryRange::external(data, length * sizeof(int32_t));
     xassert(xbuf.is_writable());
-    col3 = col2->cast(SType::INT32, std::move(xbuf));
+    auto col3 = col2->cast(SType::INT32, std::move(xbuf));
   } else {
     type = RowIndexType::ARR64;
     _resize_data();
     MemoryRange xbuf = MemoryRange::external(data, length * sizeof(int64_t));
     xassert(xbuf.is_writable());
-    col3 = col2->cast(SType::INT64, std::move(xbuf));
+    auto col3 = col2->cast(SType::INT64, std::move(xbuf));
   }
 
   delete col2;
-  delete col3;
 }
 
 

--- a/c/set_funcs.cc
+++ b/c/set_funcs.cc
@@ -109,8 +109,8 @@ static sort_result sort_columns(ccolvec&& cv) {
     res.column = std::move(cv.columns[0]);
     res.column.materialize();
   } else {
-    // TODO: std::move(cv.columns) here
-    res.column = OColumn((new VoidColumn(0))->rbind(cv.columns));
+    res.column = OColumn(new VoidColumn(0));
+    res.column.rbind(cv.columns);
   }
   res.ri = res.column->sort(&res.gb);
 

--- a/c/sort.cc
+++ b/c/sort.cc
@@ -620,7 +620,7 @@ class SortContext {
     strdata = nullptr;
     // These will initialize `x`, `elemsize` and `nsigbits`, and also
     // `strdata`, `stroffs`, `strstart` for string columns
-    SType stype = col->stype();
+    SType stype = col->_stype;
     switch (stype) {
       case SType::BOOL:    _initB<ASC>(col); break;
       case SType::INT8:    _initI<ASC, int8_t,  uint8_t>(col); break;


### PR DESCRIPTION
- Column::stype() was converted from a virtual method into a property;
- Several new methods now return OColumns or take OColumns as arguments;
- OColumn::release() was removed -- the class no longer relinquishes ownership of the underlying Column pointer.

WIP for #1396