### PR TITLE
Fix Frame creation from a degenerate range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   command `cmd` in the shell. Previously the error was silently discarded
   (#1935).
 
+- datatable now correctly handles the case of a degenerate range, producing
+  an empty Frame instead of a 1-row Frame (#1942).
+
 
 ### Changed
 

--- a/c/column.h
+++ b/c/column.h
@@ -150,7 +150,6 @@ public:
   static Column* from_pylist_of_tuples(const py::olist& list, size_t index, int stype0);
   static Column* from_pylist_of_dicts(const py::olist& list, py::robj name, int stype0);
   static Column* from_buffer(const py::robj& buffer);
-  static OColumn from_range(int64_t start, int64_t stop, int64_t step, SType s);
 
   Column(const Column&) = delete;
   Column(Column&&) = delete;
@@ -356,12 +355,16 @@ class OColumn
   //------------------------------------
   public:
     OColumn();
-    explicit OColumn(Column* col);  // Steal ownership
     OColumn(const OColumn&);
     OColumn(OColumn&&);
     OColumn& operator=(const OColumn&);
     OColumn& operator=(OColumn&&);
     ~OColumn();
+
+    static OColumn from_range(int64_t start, int64_t stop, int64_t step, SType);
+
+    // TODO: remove
+    explicit OColumn(Column* col);  // Steal ownership
 
     // TEMP accessors to the underlying implementation
     const Column* get() const;

--- a/c/column_from_pylist.cc
+++ b/c/column_from_pylist.cc
@@ -594,10 +594,12 @@ static OColumn _make_range_column(
 }
 
 
-OColumn Column::from_range(
+OColumn OColumn::from_range(
     int64_t start, int64_t stop, int64_t step, SType stype)
 {
-  int64_t length = (stop - start - (step > 0 ? 1 : -1)) / step + 1;
+  xassert(step != 0);
+  int64_t length = (step > 0) ? (stop - start + step - 1) / step
+                              : (start - stop - step - 1) / (-step);
   if (length < 0) length = 0;
   if (stype == SType::VOID) {
     stype = (start == static_cast<int32_t>(start) &&

--- a/c/frame/__init__.cc
+++ b/c/frame/__init__.cc
@@ -328,7 +328,7 @@ class FrameInitializationManager {
 
 
     void init_mystery_frame() {
-      cols.push_back(Column::from_range(42, 43, 1, SType::VOID));
+      cols.push_back(OColumn::from_range(42, 43, 1, SType::VOID));
       make_datatable(strvec { "?" });
     }
 
@@ -601,7 +601,7 @@ class FrameInitializationManager {
       }
       else if (colsrc.is_range()) {
         auto r = colsrc.to_orange();
-        col = Column::from_range(r.start(), r.stop(), r.step(), s);
+        col = OColumn::from_range(r.start(), r.stop(), r.step(), s);
       }
       else {
         throw TypeError() << "Cannot create a column from " << colsrc.typeobj();

--- a/tests/test_dt_create.py
+++ b/tests/test_dt_create.py
@@ -214,6 +214,19 @@ def test_create_from_range():
     assert d0.to_list() == [list(range(8))]
 
 
+@pytest.mark.parametrize("r", [range(1, 3), range(2, 7, 3), range(-1, 4, 2),
+                               range(5, 2, -1), range(278, -14, -5),
+                               range(2, 2, 2), range(2, 3, 15), range(-3, -1),
+                               range(4, 3, 3), range(2, 3, -2),
+                               range(4, 6, -10), range(4, 8, -2),
+                               range(4, 2, -2)])
+def test_create_from_range2(r):
+    DT = dt.Frame(A=r)
+    frame_integrity_check(DT)
+    assert DT.ncols == 1
+    assert DT.to_list()[0] == list(r)
+
+
 
 #-------------------------------------------------------------------------------
 # Create from a list of lists


### PR DESCRIPTION
The length of range object was incorrectly interpreted when `start-step < stop <= start`. This was due to C division rules for negative numbers different from Python rules.

In addition, `Column::make_range()` was moved to `OColumn` class.

Closes #1942