### PR TITLE
Further refactoring of Column / OColumn

### DIFF
--- a/c/column.cc
+++ b/c/column.cc
@@ -116,18 +116,12 @@ bool Column::get_element(size_t, py::oobj*) const {
 /**
  * Create a shallow copy of the column; possibly applying the provided rowindex.
  */
-Column* Column::shallowcopy(const RowIndex& new_rowindex) const {
+Column* Column::shallowcopy() const {
   Column* col = new_column_impl(_stype);
   col->nrows = nrows;
   col->mbuf = mbuf;
+  col->ri = ri;
   // TODO: also copy Stats object
-
-  if (new_rowindex) {
-    col->ri = new_rowindex;
-    col->nrows = new_rowindex.size();
-  } else if (ri) {
-    col->ri = ri;
-  }
   return col;
 }
 

--- a/c/column.cc
+++ b/c/column.cc
@@ -60,9 +60,9 @@ Column* Column::new_data_column(SType stype, size_t nrows) {
 
 // TODO: create a special "NA" column instead
 OColumn OColumn::new_na_column(SType stype, size_t nrows) {
-  Column* col = Column::new_data_column(stype, nrows);
+  OColumn col = OColumn(Column::new_data_column(stype, nrows));
   col->fill_na();
-  return OColumn(col);
+  return col;
 }
 
 

--- a/c/column.cc
+++ b/c/column.cc
@@ -58,10 +58,11 @@ Column* Column::new_data_column(SType stype, size_t nrows) {
   return col;
 }
 
-Column* Column::new_na_column(SType stype, size_t nrows) {
-  Column* col = new_data_column(stype, nrows);
+// TODO: create a special "NA" column instead
+OColumn OColumn::new_na_column(SType stype, size_t nrows) {
+  Column* col = Column::new_data_column(stype, nrows);
   col->fill_na();
-  return col;
+  return OColumn(col);
 }
 
 

--- a/c/column.cc
+++ b/c/column.cc
@@ -51,7 +51,6 @@ Column* Column::new_column(SType stype) {
 
 
 OColumn OColumn::new_data_column(SType stype, size_t nrows) {
-  xassert(stype != SType::VOID);
   Column* col = Column::new_column(stype);
   col->nrows = nrows;
   col->init_data();

--- a/c/column.cc
+++ b/c/column.cc
@@ -50,17 +50,18 @@ Column* Column::new_column(SType stype) {
 }
 
 
-Column* Column::new_data_column(SType stype, size_t nrows) {
+OColumn OColumn::new_data_column(SType stype, size_t nrows) {
   xassert(stype != SType::VOID);
-  Column* col = new_column(stype);
+  Column* col = Column::new_column(stype);
   col->nrows = nrows;
   col->init_data();
-  return col;
+  return OColumn(col);
 }
+
 
 // TODO: create a special "NA" column instead
 OColumn OColumn::new_na_column(SType stype, size_t nrows) {
-  OColumn col = OColumn(Column::new_data_column(stype, nrows));
+  OColumn col = OColumn::new_data_column(stype, nrows);
   col->fill_na();
   return col;
 }

--- a/c/column.cc
+++ b/c/column.cc
@@ -70,14 +70,14 @@ OColumn OColumn::new_na_column(SType stype, size_t nrows) {
 /**
  * Construct a column using existing MemoryRanges.
  */
-Column* Column::new_mbuf_column(SType stype, MemoryRange&& mbuf) {
+OColumn OColumn::new_mbuf_column(SType stype, MemoryRange&& mbuf) {
   size_t elemsize = info(stype).elemsize();
-  Column* col = new_column(stype);
+  Column* col = Column::new_column(stype);
   xassert(mbuf.size() % elemsize == 0);
   xassert(stype == SType::OBJ? mbuf.is_pyobjects() : true);
   col->nrows = mbuf.size() / elemsize;
   col->mbuf = std::move(mbuf);
-  return col;
+  return OColumn(col);
 }
 
 

--- a/c/column.cc
+++ b/c/column.cc
@@ -84,10 +84,11 @@ Column* Column::new_xbuf_column(SType stype,
  * Construct a column using existing MemoryRanges.
  */
 Column* Column::new_mbuf_column(SType stype, MemoryRange&& mbuf) {
+  size_t elemsize = info(stype).elemsize();
   Column* col = new_column(stype);
-  xassert(mbuf.size() % col->elemsize() == 0);
+  xassert(mbuf.size() % elemsize == 0);
   xassert(stype == SType::OBJ? mbuf.is_pyobjects() : true);
-  col->nrows = mbuf.size() / col->elemsize();
+  col->nrows = mbuf.size() / elemsize;
   col->mbuf = std::move(mbuf);
   return col;
 }

--- a/c/column.cc
+++ b/c/column.cc
@@ -74,7 +74,9 @@ OColumn OColumn::new_mbuf_column(SType stype, MemoryRange&& mbuf) {
   size_t elemsize = info(stype).elemsize();
   Column* col = Column::new_column(stype);
   xassert(mbuf.size() % elemsize == 0);
-  xassert(stype == SType::OBJ? mbuf.is_pyobjects() : true);
+  if (stype == SType::OBJ) {
+    xassert(mbuf.is_pyobjects() || !mbuf.is_writable());
+  }
   col->nrows = mbuf.size() / elemsize;
   col->mbuf = std::move(mbuf);
   return OColumn(col);
@@ -332,7 +334,6 @@ void VoidColumn::rbind_impl(colvec&, size_t, bool) {}
 void VoidColumn::apply_na_mask(const BoolColumn*) {}
 void VoidColumn::replace_values(RowIndex, const OColumn&) {}
 void VoidColumn::init_data() {}
-void VoidColumn::init_xbuf(Py_buffer*) {}
 Stats* VoidColumn::get_stats() const { return nullptr; }
 void VoidColumn::fill_na() {}
 RowIndex VoidColumn::join(const Column*) const { return RowIndex(); }

--- a/c/column.cc
+++ b/c/column.cc
@@ -68,20 +68,6 @@ OColumn OColumn::new_na_column(SType stype, size_t nrows) {
 
 
 /**
- * Construct a column from the externally provided buffer.
- */
-Column* Column::new_xbuf_column(SType stype,
-                                size_t nrows,
-                                Py_buffer* pybuffer)
-{
-  Column* col = new_column(stype);
-  col->nrows = nrows;
-  col->init_xbuf(pybuffer);
-  return col;
-}
-
-
-/**
  * Construct a column using existing MemoryRanges.
  */
 Column* Column::new_mbuf_column(SType stype, MemoryRange&& mbuf) {

--- a/c/column.cc
+++ b/c/column.cc
@@ -322,7 +322,7 @@ size_t VoidColumn::data_nrows() const { return nrows; }
 void VoidColumn::materialize() {}
 void VoidColumn::resize_and_fill(size_t) {}
 void VoidColumn::rbind_impl(colvec&, size_t, bool) {}
-void VoidColumn::apply_na_mask(const BoolColumn*) {}
+void VoidColumn::apply_na_mask(const OColumn&) {}
 void VoidColumn::replace_values(RowIndex, const OColumn&) {}
 void VoidColumn::init_data() {}
 Stats* VoidColumn::get_stats() const { return nullptr; }

--- a/c/column.cc
+++ b/c/column.cc
@@ -327,5 +327,5 @@ void VoidColumn::replace_values(RowIndex, const OColumn&) {}
 void VoidColumn::init_data() {}
 Stats* VoidColumn::get_stats() const { return nullptr; }
 void VoidColumn::fill_na() {}
-RowIndex VoidColumn::join(const Column*) const { return RowIndex(); }
+RowIndex VoidColumn::join(const OColumn&) const { return RowIndex(); }
 void VoidColumn::fill_na_mask(int8_t*, size_t, size_t) {}

--- a/c/column.h
+++ b/c/column.h
@@ -82,6 +82,21 @@ template <> struct _elt<SType::OBJ>     { using t = PyObject*; };
 template <SType s>
 using element_t = typename _elt<s>::t;
 
+template <SType s> struct _gelt {};
+template <> struct _gelt<SType::BOOL>    { using t = int32_t; };
+template <> struct _gelt<SType::INT8>    { using t = int32_t; };
+template <> struct _gelt<SType::INT16>   { using t = int32_t; };
+template <> struct _gelt<SType::INT32>   { using t = int32_t; };
+template <> struct _gelt<SType::INT64>   { using t = int64_t; };
+template <> struct _gelt<SType::FLOAT32> { using t = float; };
+template <> struct _gelt<SType::FLOAT64> { using t = double; };
+template <> struct _gelt<SType::STR32>   { using t = CString; };
+template <> struct _gelt<SType::STR64>   { using t = CString; };
+template <> struct _gelt<SType::OBJ>     { using t = PyObject*; };
+
+template <SType s>
+using getelement_t = typename _gelt<s>::t;
+
 
 
 //==============================================================================

--- a/c/column.h
+++ b/c/column.h
@@ -146,9 +146,6 @@ public:
   static Column* new_na_column(SType, size_t nrows);
   static Column* new_xbuf_column(SType, size_t nrows, Py_buffer* pybuffer);
   static Column* new_mbuf_column(SType, MemoryRange&&);
-  static Column* from_pylist(const py::olist& list, int stype0 = 0);
-  static Column* from_pylist_of_tuples(const py::olist& list, size_t index, int stype0);
-  static Column* from_pylist_of_dicts(const py::olist& list, py::robj name, int stype0);
 
   Column(const Column&) = delete;
   Column(Column&&) = delete;
@@ -320,7 +317,6 @@ protected:
 
 private:
   static Column* new_column(SType);
-  static Column* from_py_iterable(const iterable*, int stype0);
 
   // FIXME
   friend FreadReader;  // friend Column* realloc_column(Column *col, SType stype, size_t nrows, int j);
@@ -359,6 +355,9 @@ class OColumn
     ~OColumn();
 
     static OColumn from_buffer(const py::robj& buffer);
+    static OColumn from_pylist(const py::olist& list, int stype0 = 0);
+    static OColumn from_pylist_of_tuples(const py::olist& list, size_t index, int stype0);
+    static OColumn from_pylist_of_dicts(const py::olist& list, py::robj name, int stype0);
     static OColumn from_range(int64_t start, int64_t stop, int64_t step, SType);
 
     // TODO: remove

--- a/c/column.h
+++ b/c/column.h
@@ -358,14 +358,9 @@ class OColumn
     static OColumn from_pylist_of_dicts(const py::olist& list, py::robj name, int stype0);
     static OColumn from_range(int64_t start, int64_t stop, int64_t step, SType);
 
-    // TODO: make private
-    explicit OColumn(Column* col);  // Steal ownership
-
-    // TEMP accessors to the underlying implementation
-    const Column* get() const;
-
-    Column* operator->();
-    const Column* operator->() const;
+  private:
+    // Assumes ownership of the `col` object
+    explicit OColumn(Column* col);
 
   //------------------------------------
   // Properties
@@ -380,6 +375,12 @@ class OColumn
     size_t elemsize() const noexcept;
 
     operator bool() const noexcept;
+
+    // TEMP accessors to the underlying implementation
+    const Column* get() const;
+
+    Column* operator->();
+    const Column* operator->() const;
 
   //------------------------------------
   // Data access
@@ -419,6 +420,7 @@ class OColumn
     OColumn cast(SType stype, MemoryRange&& mr) const;
 
     friend void swap(OColumn& lhs, OColumn& rhs);
+    friend OColumn new_string_column(size_t, MemoryRange&&, MemoryRange&&);
 };
 
 

--- a/c/column.h
+++ b/c/column.h
@@ -142,8 +142,6 @@ public:
   static constexpr size_t MAX_STR32_BUFFER_SIZE = 0x7FFFFFFF;
   static constexpr size_t MAX_STR32_NROWS = 0x7FFFFFFF;
 
-  static Column* new_data_column(SType, size_t nrows);
-
   Column(const Column&) = delete;
   Column(Column&&) = delete;
   virtual ~Column();
@@ -351,6 +349,7 @@ class OColumn
     OColumn& operator=(OColumn&&);
     ~OColumn();
 
+    static OColumn new_data_column(SType, size_t nrows);
     static OColumn new_na_column(SType, size_t nrows);
     static OColumn new_mbuf_column(SType, MemoryRange&&);
     static OColumn from_buffer(const py::robj& buffer);
@@ -359,7 +358,7 @@ class OColumn
     static OColumn from_pylist_of_dicts(const py::olist& list, py::robj name, int stype0);
     static OColumn from_range(int64_t start, int64_t stop, int64_t step, SType);
 
-    // TODO: remove
+    // TODO: make private
     explicit OColumn(Column* col);  // Steal ownership
 
     // TEMP accessors to the underlying implementation

--- a/c/column.h
+++ b/c/column.h
@@ -298,7 +298,6 @@ public:
 protected:
   Column(size_t nrows = 0);
   virtual void init_data() = 0;
-  virtual void init_xbuf(Py_buffer* pybuffer) = 0;
   virtual void rbind_impl(colvec& columns, size_t nrows, bool isempty) = 0;
 
   /**
@@ -449,7 +448,6 @@ public:
 
 protected:
   void init_data() override;
-  void init_xbuf(Py_buffer* pybuffer) override;
   static constexpr T na_elem = GETNA<T>();
   void rbind_impl(colvec& columns, size_t nrows, bool isempty) override;
   void fill_na() override;
@@ -644,7 +642,6 @@ protected:
   StringColumn();
   StringColumn(size_t nrows, MemoryRange&& offbuf, MemoryRange&& strbuf);
   void init_data() override;
-  void init_xbuf(Py_buffer* pybuffer) override;
 
   void rbind_impl(colvec& columns, size_t nrows, bool isempty) override;
 
@@ -688,7 +685,6 @@ class VoidColumn : public Column {
   protected:
     VoidColumn();
     void init_data() override;
-    void init_xbuf(Py_buffer*) override;
     void fill_na() override;
 
     friend Column;

--- a/c/column.h
+++ b/c/column.h
@@ -143,7 +143,6 @@ public:
   static constexpr size_t MAX_STR32_NROWS = 0x7FFFFFFF;
 
   static Column* new_data_column(SType, size_t nrows);
-  static Column* new_xbuf_column(SType, size_t nrows, Py_buffer* pybuffer);
   static Column* new_mbuf_column(SType, MemoryRange&&);
 
   Column(const Column&) = delete;

--- a/c/column.h
+++ b/c/column.h
@@ -653,7 +653,7 @@ protected:
 
   friend Column;
   friend FreadReader;  // friend Column* alloc_column(SType, size_t, int);
-  friend Column* new_string_column(size_t, MemoryRange&&, MemoryRange&&);
+  friend OColumn new_string_column(size_t, MemoryRange&&, MemoryRange&&);
 };
 
 
@@ -662,7 +662,7 @@ protected:
  * It will create either StringColumn<uint32_t>* or StringColumn<uint64_t>*
  * depending on the size of the data.
  */
-Column* new_string_column(size_t n, MemoryRange&& data, MemoryRange&& str);
+OColumn new_string_column(size_t n, MemoryRange&& data, MemoryRange&& str);
 
 
 extern template class StringColumn<uint32_t>;

--- a/c/column.h
+++ b/c/column.h
@@ -201,8 +201,7 @@ public:
    * If you want the rowindices to be merged, you should merge them manually
    * and pass the merged rowindex to this method.
    */
-  virtual Column* shallowcopy(const RowIndex& new_rowindex) const;
-  Column* shallowcopy() const { return shallowcopy(RowIndex()); }
+  virtual Column* shallowcopy() const;
 
   /**
    * Factory method to cast the current column into the given `stype`. If a
@@ -628,7 +627,7 @@ public:
 
   CString mode() const;
 
-  Column* shallowcopy(const RowIndex& new_rowindex) const override;
+  Column* shallowcopy() const override;
   void replace_values(RowIndex at, const OColumn& with) override;
   StringStats<T>* get_stats() const override;
 

--- a/c/column.h
+++ b/c/column.h
@@ -310,8 +310,6 @@ protected:
   virtual void fill_na() = 0;
 
 private:
-  static Column* new_column(SType);
-
   // FIXME
   friend FreadReader;  // friend Column* realloc_column(Column *col, SType stype, size_t nrows, int j);
   friend class OColumn;
@@ -430,6 +428,7 @@ class OColumn
 template <typename T> class FwColumn : public Column
 {
 public:
+  FwColumn();
   FwColumn(size_t nrows);
   FwColumn(size_t nrows, MemoryRange&&);
   const T* elements_r() const;
@@ -452,7 +451,6 @@ protected:
   void rbind_impl(colvec& columns, size_t nrows, bool isempty) override;
   void fill_na() override;
 
-  FwColumn();
   friend Column;
 };
 
@@ -581,6 +579,7 @@ extern template class RealColumn<double>;
 class PyObjectColumn : public FwColumn<PyObject*>
 {
 public:
+  PyObjectColumn();
   PyObjectColumn(size_t nrows);
   PyObjectColumn(size_t nrows, MemoryRange&&);
   PyObjectStats* get_stats() const override;
@@ -588,7 +587,6 @@ public:
   bool get_element(size_t i, py::oobj* out) const override;
 
 protected:
-  PyObjectColumn();
 
   void rbind_impl(colvec& columns, size_t nrows, bool isempty) override;
 
@@ -611,6 +609,7 @@ template <typename T> class StringColumn : public Column
   MemoryRange strbuf;
 
 public:
+  StringColumn();
   StringColumn(size_t nrows);
 
   void materialize() override;
@@ -639,7 +638,6 @@ public:
   void fill_na_mask(int8_t* outmask, size_t row0, size_t row1) override;
 
 protected:
-  StringColumn();
   StringColumn(size_t nrows, MemoryRange&& offbuf, MemoryRange&& strbuf);
   void init_data() override;
 
@@ -672,6 +670,7 @@ extern template class StringColumn<uint64_t>;
 // unknown type. This column cannot be put into a DataTable.
 class VoidColumn : public Column {
   public:
+    VoidColumn();
     VoidColumn(size_t nrows);
     size_t data_nrows() const override;
     void materialize() override;
@@ -683,7 +682,6 @@ class VoidColumn : public Column {
     Stats* get_stats() const override;
     void fill_na_mask(int8_t* outmask, size_t row0, size_t row1) override;
   protected:
-    VoidColumn();
     void init_data() override;
     void fill_na() override;
 

--- a/c/column.h
+++ b/c/column.h
@@ -523,7 +523,6 @@ public:
 protected:
   using Column::stats;
   using Column::mbuf;
-  using Column::new_data_column;
   friend Column;
 };
 
@@ -555,7 +554,6 @@ public:
 
 protected:
   using Column::stats;
-  using Column::new_data_column;
   friend Column;
 };
 

--- a/c/column.h
+++ b/c/column.h
@@ -149,7 +149,6 @@ public:
   static Column* from_pylist(const py::olist& list, int stype0 = 0);
   static Column* from_pylist_of_tuples(const py::olist& list, size_t index, int stype0);
   static Column* from_pylist_of_dicts(const py::olist& list, py::robj name, int stype0);
-  static Column* from_buffer(const py::robj& buffer);
 
   Column(const Column&) = delete;
   Column(Column&&) = delete;
@@ -359,6 +358,7 @@ class OColumn
     OColumn& operator=(OColumn&&);
     ~OColumn();
 
+    static OColumn from_buffer(const py::robj& buffer);
     static OColumn from_range(int64_t start, int64_t stop, int64_t step, SType);
 
     // TODO: remove

--- a/c/column.h
+++ b/c/column.h
@@ -191,7 +191,7 @@ public:
    * NAs. The `mask` column must have the same number of rows as the current,
    * and neither of them can have a RowIndex.
    */
-  virtual void apply_na_mask(const BoolColumn* mask) = 0;
+  virtual void apply_na_mask(const OColumn& mask) = 0;
 
   /**
    * Create a shallow copy of this Column, possibly applying the provided
@@ -437,7 +437,7 @@ public:
 
   size_t data_nrows() const override;
   void resize_and_fill(size_t nrows) override;
-  void apply_na_mask(const BoolColumn* mask) override;
+  void apply_na_mask(const OColumn& mask) override;
   virtual void materialize() override;
   void replace_values(RowIndex at, const OColumn& with) override;
   void replace_values(const RowIndex& at, T with);
@@ -613,7 +613,7 @@ public:
 
   void materialize() override;
   void resize_and_fill(size_t nrows) override;
-  void apply_na_mask(const BoolColumn* mask) override;
+  void apply_na_mask(const OColumn& mask) override;
   RowIndex join(const Column* keycol) const override;
 
   MemoryRange str_buf() const { return strbuf; }
@@ -675,7 +675,7 @@ class VoidColumn : public Column {
     void materialize() override;
     void resize_and_fill(size_t) override;
     void rbind_impl(colvec&, size_t, bool) override;
-    void apply_na_mask(const BoolColumn*) override;
+    void apply_na_mask(const OColumn&) override;
     void replace_values(RowIndex, const OColumn&) override;
     RowIndex join(const Column* keycol) const override;
     Stats* get_stats() const override;

--- a/c/column.h
+++ b/c/column.h
@@ -155,8 +155,6 @@ public:
   Column(Column&&) = delete;
   virtual ~Column();
 
-  size_t elemsize() const { return info(_stype).elemsize(); }
-
   virtual bool get_element(size_t i, int32_t* out) const;
   virtual bool get_element(size_t i, int64_t* out) const;
   virtual bool get_element(size_t i, float* out) const;

--- a/c/column.h
+++ b/c/column.h
@@ -143,7 +143,6 @@ public:
   static constexpr size_t MAX_STR32_NROWS = 0x7FFFFFFF;
 
   static Column* new_data_column(SType, size_t nrows);
-  static Column* new_na_column(SType, size_t nrows);
   static Column* new_xbuf_column(SType, size_t nrows, Py_buffer* pybuffer);
   static Column* new_mbuf_column(SType, MemoryRange&&);
 
@@ -354,6 +353,7 @@ class OColumn
     OColumn& operator=(OColumn&&);
     ~OColumn();
 
+    static OColumn new_na_column(SType, size_t nrows);
     static OColumn from_buffer(const py::robj& buffer);
     static OColumn from_pylist(const py::olist& list, int stype0 = 0);
     static OColumn from_pylist_of_tuples(const py::olist& list, size_t index, int stype0);

--- a/c/column.h
+++ b/c/column.h
@@ -265,7 +265,7 @@ public:
   virtual void materialize() = 0;
 
 
-  virtual RowIndex join(const Column* keycol) const = 0;
+  virtual RowIndex join(const OColumn& keycol) const = 0;
 
   size_t countna() const;
   size_t nunique() const;
@@ -441,7 +441,7 @@ public:
   virtual void materialize() override;
   void replace_values(RowIndex at, const OColumn& with) override;
   void replace_values(const RowIndex& at, T with);
-  virtual RowIndex join(const Column* keycol) const override;
+  virtual RowIndex join(const OColumn& keycol) const override;
   void fill_na_mask(int8_t* outmask, size_t row0, size_t row1) override;
 
 protected:
@@ -614,7 +614,7 @@ public:
   void materialize() override;
   void resize_and_fill(size_t nrows) override;
   void apply_na_mask(const OColumn& mask) override;
-  RowIndex join(const Column* keycol) const override;
+  RowIndex join(const OColumn& keycol) const override;
 
   MemoryRange str_buf() const { return strbuf; }
   size_t datasize() const;
@@ -677,7 +677,7 @@ class VoidColumn : public Column {
     void rbind_impl(colvec&, size_t, bool) override;
     void apply_na_mask(const OColumn&) override;
     void replace_values(RowIndex, const OColumn&) override;
-    RowIndex join(const Column* keycol) const override;
+    RowIndex join(const OColumn& keycol) const override;
     Stats* get_stats() const override;
     void fill_na_mask(int8_t* outmask, size_t row0, size_t row1) override;
   protected:

--- a/c/column.h
+++ b/c/column.h
@@ -186,7 +186,7 @@ public:
    * column.
    */
   virtual void resize_and_fill(size_t nrows) = 0;
-  Column* repeat(size_t nreps) const;
+  OColumn repeat(size_t nreps) const;
 
   /**
    * Modify the Column, replacing values specified by the provided `mask` with

--- a/c/column.h
+++ b/c/column.h
@@ -143,7 +143,6 @@ public:
   static constexpr size_t MAX_STR32_NROWS = 0x7FFFFFFF;
 
   static Column* new_data_column(SType, size_t nrows);
-  static Column* new_mbuf_column(SType, MemoryRange&&);
 
   Column(const Column&) = delete;
   Column(Column&&) = delete;
@@ -353,6 +352,7 @@ class OColumn
     ~OColumn();
 
     static OColumn new_na_column(SType, size_t nrows);
+    static OColumn new_mbuf_column(SType, MemoryRange&&);
     static OColumn from_buffer(const py::robj& buffer);
     static OColumn from_pylist(const py::olist& list, int stype0 = 0);
     static OColumn from_pylist_of_tuples(const py::olist& list, size_t index, int stype0);

--- a/c/column_from_pylist.cc
+++ b/c/column_from_pylist.cc
@@ -541,7 +541,7 @@ static OColumn ocolumn_from_iterable(const iterable* il, int stype0)
   }
   if (stype == SType::STR32 || stype == SType::STR64) {
     size_t nrows = il->size();
-    return OColumn(new_string_column(nrows, std::move(membuf), std::move(strbuf)));
+    return new_string_column(nrows, std::move(membuf), std::move(strbuf));
   }
   else {
     if (stype == SType::OBJ) {

--- a/c/column_from_pylist.cc
+++ b/c/column_from_pylist.cc
@@ -584,13 +584,13 @@ template <typename T>
 static OColumn _make_range_column(
     int64_t start, int64_t length, int64_t step, SType stype)
 {
-  Column* col = Column::new_data_column(stype, static_cast<size_t>(length));
+  OColumn col = OColumn(Column::new_data_column(stype, static_cast<size_t>(length)));
   T* elems = static_cast<T*>(col->data_w());
   for (int64_t i = 0, j = start; i < length; ++i) {
     elems[i] = static_cast<T>(j);
     j += step;
   }
-  return OColumn(col);
+  return col;
 }
 
 

--- a/c/column_from_pylist.cc
+++ b/c/column_from_pylist.cc
@@ -594,6 +594,7 @@ static OColumn _make_range_column(
 }
 
 
+// TODO: create a special "range" column instead
 OColumn OColumn::from_range(
     int64_t start, int64_t stop, int64_t step, SType stype)
 {

--- a/c/column_from_pylist.cc
+++ b/c/column_from_pylist.cc
@@ -584,7 +584,7 @@ template <typename T>
 static OColumn _make_range_column(
     int64_t start, int64_t length, int64_t step, SType stype)
 {
-  OColumn col = OColumn(Column::new_data_column(stype, static_cast<size_t>(length)));
+  OColumn col = OColumn::new_data_column(stype, static_cast<size_t>(length));
   T* elems = static_cast<T*>(col->data_w());
   for (int64_t i = 0, j = start; i < length; ++i) {
     elems[i] = static_cast<T>(j);

--- a/c/column_from_pylist.cc
+++ b/c/column_from_pylist.cc
@@ -547,7 +547,7 @@ static OColumn ocolumn_from_iterable(const iterable* il, int stype0)
     if (stype == SType::OBJ) {
       membuf.set_pyobjects(/* clear_data = */ false);
     }
-    return OColumn(Column::new_mbuf_column(stype, std::move(membuf)));
+    return OColumn::new_mbuf_column(stype, std::move(membuf));
   }
 }
 

--- a/c/column_from_pylist.cc
+++ b/c/column_from_pylist.cc
@@ -495,7 +495,7 @@ static SType find_next_stype(SType curr_stype, int stype0) {
 
 
 
-Column* Column::from_py_iterable(const iterable* il, int stype0)
+static OColumn ocolumn_from_iterable(const iterable* il, int stype0)
 {
   MemoryRange membuf;
   MemoryRange strbuf;
@@ -541,36 +541,36 @@ Column* Column::from_py_iterable(const iterable* il, int stype0)
   }
   if (stype == SType::STR32 || stype == SType::STR64) {
     size_t nrows = il->size();
-    return new_string_column(nrows, std::move(membuf), std::move(strbuf));
+    return OColumn(new_string_column(nrows, std::move(membuf), std::move(strbuf)));
   }
   else {
     if (stype == SType::OBJ) {
       membuf.set_pyobjects(/* clear_data = */ false);
     }
-    return Column::new_mbuf_column(stype, std::move(membuf));
+    return OColumn(Column::new_mbuf_column(stype, std::move(membuf)));
   }
 }
 
 
-Column* Column::from_pylist(const py::olist& list, int stype0) {
+OColumn OColumn::from_pylist(const py::olist& list, int stype0) {
   ilist il(list);
-  return from_py_iterable(&il, stype0);
+  return ocolumn_from_iterable(&il, stype0);
 }
 
 
-Column* Column::from_pylist_of_tuples(
+OColumn OColumn::from_pylist_of_tuples(
     const py::olist& list, size_t index, int stype0)
 {
   ituplist il(list, index);
-  return from_py_iterable(&il, stype0);
+  return ocolumn_from_iterable(&il, stype0);
 }
 
 
-Column* Column::from_pylist_of_dicts(
+OColumn OColumn::from_pylist_of_dicts(
     const py::olist& list, py::robj name, int stype0)
 {
   idictlist il(list, name);
-  return from_py_iterable(&il, stype0);
+  return ocolumn_from_iterable(&il, stype0);
 }
 
 

--- a/c/column_fw.cc
+++ b/c/column_fw.cc
@@ -167,8 +167,9 @@ size_t FwColumn<T>::data_nrows() const {
 
 
 template <typename T>
-void FwColumn<T>::apply_na_mask(const BoolColumn* mask) {
-  const int8_t* maskdata = mask->elements_r();
+void FwColumn<T>::apply_na_mask(const OColumn& mask) {
+  xassert(mask.stype() == SType::BOOL);
+  auto maskdata = static_cast<const int8_t*>(mask->data());
   T* coldata = this->elements_w();
 
   dt::parallel_for_static(nrows,

--- a/c/column_fw.cc
+++ b/c/column_fw.cc
@@ -47,20 +47,6 @@ void FwColumn<T>::init_data() {
   mbuf.resize(nrows * sizeof(T));
 }
 
-template <typename T>
-void FwColumn<T>::init_xbuf(Py_buffer* pybuffer) {
-  xassert(!ri);
-  size_t exp_buf_len = nrows * sizeof(T);
-  if (static_cast<size_t>(pybuffer->len) != exp_buf_len) {
-    throw Error() << "PyBuffer cannot be used to create a column of " << nrows
-                  << " rows: buffer length is "
-                  << static_cast<size_t>(pybuffer->len)
-                  << ", expected " << exp_buf_len;
-  }
-  const void* ptr = pybuffer->buf;
-  mbuf = MemoryRange::external(ptr, exp_buf_len, pybuffer);
-}
-
 
 
 //==============================================================================

--- a/c/column_fw.cc
+++ b/c/column_fw.cc
@@ -256,17 +256,15 @@ static int32_t binsearch(const T* data, int32_t len, T value) {
 
 
 template <typename T>
-RowIndex FwColumn<T>::join(const Column* keycol) const {
-  xassert(_stype == keycol->_stype);
-
-  auto kcol = static_cast<const FwColumn<T>*>(keycol);
-  xassert(!kcol->ri);
+RowIndex FwColumn<T>::join(const OColumn& keycol) const {
+  xassert(_stype == keycol.stype());
+  xassert(!keycol->rowindex());
 
   arr32_t target_indices(nrows);
   int32_t* trg_indices = target_indices.data();
   const T* src_data = elements_r();
-  const T* search_data = kcol->elements_r();
-  int32_t search_n = static_cast<int32_t>(keycol->nrows);
+  const T* search_data = static_cast<const T*>(keycol->data());
+  int32_t search_n = static_cast<int32_t>(keycol.nrows());
 
   ri.iterate(0, nrows, 1,
     [&](size_t i, size_t j) {

--- a/c/column_fw.cc
+++ b/c/column_fw.cc
@@ -50,7 +50,7 @@ void FwColumn<T>::init_data() {
 template <typename T>
 void FwColumn<T>::init_xbuf(Py_buffer* pybuffer) {
   xassert(!ri);
-  size_t exp_buf_len = nrows * elemsize();
+  size_t exp_buf_len = nrows * sizeof(T);
   if (static_cast<size_t>(pybuffer->len) != exp_buf_len) {
     throw Error() << "PyBuffer cannot be used to create a column of " << nrows
                   << " rows: buffer length is "

--- a/c/column_pyobj.cc
+++ b/c/column_pyobj.cc
@@ -42,7 +42,7 @@ bool PyObjectColumn::get_element(size_t i, py::oobj* out) const {
 
 
 void PyObjectColumn::fill_na() {
-  // This is called from `Column::new_na_column()` only; and for a
+  // This is called from `OColumn::new_na_column()` only; and for a
   // PyObjectColumn the buffer is already created containing Py_None values,
   // thus we don't need to do anything extra.
   // Semantics of this function may be clarified in the future (specifically,

--- a/c/column_string.cc
+++ b/c/column_string.cc
@@ -109,8 +109,8 @@ void StringColumn<T>::init_data() {
 //==============================================================================
 
 template <typename T>
-Column* StringColumn<T>::shallowcopy(const RowIndex& new_rowindex) const {
-  Column* newcol = Column::shallowcopy(new_rowindex);
+Column* StringColumn<T>::shallowcopy() const {
+  Column* newcol = Column::shallowcopy();
   StringColumn<T>* col = static_cast<StringColumn<T>*>(newcol);
   col->strbuf = strbuf;
   return col;

--- a/c/column_string.cc
+++ b/c/column_string.cc
@@ -494,11 +494,11 @@ static int32_t binsearch(const uint8_t* strdata, const T* offsets, uint32_t len,
 
 
 template <typename T>
-RowIndex StringColumn<T>::join(const Column* keycol) const {
-  xassert(_stype == keycol->_stype);
+RowIndex StringColumn<T>::join(const OColumn& keycol) const {
+  xassert(_stype == keycol.stype());
+  xassert(!keycol->rowindex());
 
-  auto kcol = static_cast<const StringColumn<T>*>(keycol);
-  xassert(!kcol->ri);
+  auto kcol = static_cast<const StringColumn<T>*>(keycol.get());
 
   arr32_t target_indices(nrows);
   int32_t* trg_indices = target_indices.data();

--- a/c/column_string.cc
+++ b/c/column_string.cc
@@ -75,19 +75,19 @@ static MemoryRange _recode_offsets_to_u64(const MemoryRange& offsets) {
 }
 
 
-Column* new_string_column(size_t n, MemoryRange&& data, MemoryRange&& str) {
+OColumn new_string_column(size_t n, MemoryRange&& data, MemoryRange&& str) {
   size_t data_size = data.size();
   size_t strb_size = str.size();
 
   if (data_size == sizeof(uint32_t) * (n + 1)) {
     if (strb_size <= Column::MAX_STR32_BUFFER_SIZE &&
         n <= Column::MAX_STR32_NROWS) {
-      return new StringColumn<uint32_t>(n, std::move(data), std::move(str));
+      return OColumn(new StringColumn<uint32_t>(n, std::move(data), std::move(str)));
     }
     // Otherwise, offsets need to be recoded into a uint64_t array
     data = _recode_offsets_to_u64(data);
   }
-  return new StringColumn<uint64_t>(n, std::move(data), std::move(str));
+  return OColumn(new StringColumn<uint64_t>(n, std::move(data), std::move(str)));
 }
 
 

--- a/c/column_string.cc
+++ b/c/column_string.cc
@@ -388,8 +388,9 @@ void StringColumn<T>::resize_and_fill(size_t new_nrows)
 
 
 template <typename T>
-void StringColumn<T>::apply_na_mask(const BoolColumn* mask) {
-  const int8_t* maskdata = mask->elements_r();
+void StringColumn<T>::apply_na_mask(const OColumn& mask) {
+  xassert(mask.stype() == SType::BOOL);
+  auto maskdata = static_cast<const int8_t*>(mask->data());
   char* strdata = static_cast<char*>(strbuf.wptr());
   T* offsets = this->offsets_w();
 

--- a/c/column_string.cc
+++ b/c/column_string.cc
@@ -104,12 +104,6 @@ void StringColumn<T>::init_data() {
   mbuf.set_element<T>(0, 0);
 }
 
-// Not implemented (should it be?) see method signature in `Column` for
-// parameter definitions.
-template <typename T>
-void StringColumn<T>::init_xbuf(Py_buffer*) {
-  throw Error() << "String columns are incompatible with external buffers";
-}
 
 
 //==============================================================================

--- a/c/csv/reader.cc
+++ b/c/csv/reader.cc
@@ -833,7 +833,7 @@ dtptr GenericReader::makeDatatable() {
     SType stype = col.get_stype();
     ccols.push_back((stype == SType::STR32 || stype == SType::STR64)
       ? new_string_column(nrows, std::move(databuf), std::move(strbuf))
-      : OColumn(Column::new_mbuf_column(stype, std::move(databuf)))
+      : OColumn::new_mbuf_column(stype, std::move(databuf))
     );
   }
   py::olist names = freader.get_attr("_colnames").to_pylist();

--- a/c/csv/reader.cc
+++ b/c/csv/reader.cc
@@ -831,9 +831,9 @@ dtptr GenericReader::makeDatatable() {
     MemoryRange databuf = col.extract_databuf();
     MemoryRange strbuf = col.extract_strbuf();
     SType stype = col.get_stype();
-    ccols.emplace_back((stype == SType::STR32 || stype == SType::STR64)
+    ccols.push_back((stype == SType::STR32 || stype == SType::STR64)
       ? new_string_column(nrows, std::move(databuf), std::move(strbuf))
-      : Column::new_mbuf_column(stype, std::move(databuf))
+      : OColumn(Column::new_mbuf_column(stype, std::move(databuf)))
     );
   }
   py::olist names = freader.get_attr("_colnames").to_pylist();

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -41,7 +41,6 @@ struct RowColIndex {
   std::vector<size_t> colindices;
 };
 
-typedef Column* (Column::*colmakerfn)(void) const;
 using colvec = std::vector<OColumn>;
 using intvec = std::vector<size_t>;
 using strvec = std::vector<std::string>;
@@ -178,7 +177,6 @@ class DataTable {
     void _integrity_check_names() const;
     void _integrity_check_pynames() const;
 
-    DataTable* _statdt(colmakerfn f) const;
     void save_jay_impl(WritableBuffer*);
 
     #ifdef DTTEST

--- a/c/expr/expr_binaryop.cc
+++ b/c/expr/expr_binaryop.cc
@@ -377,7 +377,7 @@ static mapperfn resolve1(Op opcode, SType stype, OColumn* cols, size_t nrows, Op
   } else if (opcode == Op::DIVIDE && std::is_integral<VT>::value) {
     stype = SType::FLOAT64;
   }
-  cols[2] = OColumn(Column::new_data_column(stype, nrows));
+  cols[2] = OColumn::new_data_column(stype, nrows);
   switch (opcode) {
     case Op::PLUS:      return resolve2<LT, RT, VT, op_add<LT, RT, VT>>(mode);
     case Op::MINUS:     return resolve2<LT, RT, VT, op_sub<LT, RT, VT>>(mode);
@@ -410,7 +410,7 @@ static mapperfn resolve1str(Op opcode, OColumn* cols, size_t nrows, OpMode mode)
     mode = OpMode::N_to_One;
     std::swap(cols[0], cols[1]);
   }
-  cols[2] = OColumn(Column::new_data_column(SType::BOOL, nrows));
+  cols[2] = OColumn::new_data_column(SType::BOOL, nrows);
   switch (opcode) {
     case Op::EQ: return resolve2str<T0, T1, int8_t, strop_eq<T0, T1>>(mode);
     case Op::NE: return resolve2str<T0, T1, int8_t, strop_ne<T0, T1>>(mode);
@@ -425,7 +425,7 @@ static mapperfn resolve0(SType lhs_type, SType rhs_type, Op opcode, OColumn* col
   switch (lhs_type) {
     case SType::BOOL:
       if (rhs_type == SType::BOOL && (opcode == Op::AND || opcode == Op::OR)) {
-        cols[2] = OColumn(Column::new_data_column(SType::BOOL, nrows));
+        cols[2] = OColumn::new_data_column(SType::BOOL, nrows);
         if (opcode == Op::AND) return resolve2<int8_t, int8_t, int8_t, op_and>(mode);
         if (opcode == Op::OR)  return resolve2<int8_t, int8_t, int8_t, op_or>(mode);
       }

--- a/c/expr/expr_binaryop.cc
+++ b/c/expr/expr_binaryop.cc
@@ -66,7 +66,7 @@ enum OpMode {
   One_to_N = 3,
 };
 
-typedef void (*mapperfn)(int64_t row0, int64_t row1, void** params);
+using mapperfn = void(*)(size_t row0, size_t row1, OColumn* cols);
 
 
 
@@ -75,40 +75,31 @@ typedef void (*mapperfn)(int64_t row0, int64_t row1, void** params);
 //------------------------------------------------------------------------------
 
 template<typename LT, typename RT, typename VT, VT (*OP)(LT, RT)>
-static void map_n_to_n(int64_t row0, int64_t row1, void** params) {
-  Column* col0 = static_cast<Column*>(params[0]);
-  Column* col1 = static_cast<Column*>(params[1]);
-  Column* col2 = static_cast<Column*>(params[2]);
-  const LT* lhs_data = static_cast<const LT*>(col0->data());
-  const RT* rhs_data = static_cast<const RT*>(col1->data());
-  VT* res_data = static_cast<VT*>(col2->data_w());
-  for (int64_t i = row0; i < row1; ++i) {
+static void map_n_to_n(size_t row0, size_t row1, OColumn* cols) {
+  const LT* lhs_data = static_cast<const LT*>(cols[0]->data());
+  const RT* rhs_data = static_cast<const RT*>(cols[1]->data());
+  VT* res_data = static_cast<VT*>(cols[2]->data_w());
+  for (size_t i = row0; i < row1; ++i) {
     res_data[i] = OP(lhs_data[i], rhs_data[i]);
   }
 }
 
 template<typename LT, typename RT, typename VT, VT (*OP)(LT, RT)>
-static void map_n_to_1(int64_t row0, int64_t row1, void** params) {
-  Column* col0 = static_cast<Column*>(params[0]);
-  Column* col1 = static_cast<Column*>(params[1]);
-  Column* col2 = static_cast<Column*>(params[2]);
-  const LT* lhs_data = static_cast<const LT*>(col0->data());
-  RT rhs_value = static_cast<const RT*>(col1->data())[0];
-  VT* res_data = static_cast<VT*>(col2->data_w());
-  for (int64_t i = row0; i < row1; ++i) {
+static void map_n_to_1(size_t row0, size_t row1, OColumn* cols) {
+  const LT* lhs_data = static_cast<const LT*>(cols[0]->data());
+  RT rhs_value = static_cast<const RT*>(cols[1]->data())[0];
+  VT* res_data = static_cast<VT*>(cols[2]->data_w());
+  for (size_t i = row0; i < row1; ++i) {
     res_data[i] = OP(lhs_data[i], rhs_value);
   }
 }
 
 template<typename LT, typename RT, typename VT, VT (*OP)(LT, RT)>
-static void map_1_to_n(int64_t row0, int64_t row1, void** params) {
-  Column* col0 = static_cast<Column*>(params[0]);
-  Column* col1 = static_cast<Column*>(params[1]);
-  Column* col2 = static_cast<Column*>(params[2]);
-  LT lhs_value = static_cast<const LT*>(col0->data())[0];
-  const RT* rhs_data = static_cast<const RT*>(col1->data());
-  VT* res_data = static_cast<VT*>(col2->data_w());
-  for (int64_t i = row0; i < row1; ++i) {
+static void map_1_to_n(size_t row0, size_t row1, OColumn* cols) {
+  LT lhs_value = static_cast<const LT*>(cols[0]->data())[0];
+  const RT* rhs_data = static_cast<const RT*>(cols[1]->data());
+  VT* res_data = static_cast<VT*>(cols[2]->data_w());
+  for (size_t i = row0; i < row1; ++i) {
     res_data[i] = OP(lhs_value, rhs_data[i]);
   }
 }
@@ -116,18 +107,17 @@ static void map_1_to_n(int64_t row0, int64_t row1, void** params) {
 
 template<typename T0, typename T1, typename T2,
          T2 (*OP)(T0, T0, const char*, T1, T1, const char*)>
-static void strmap_n_to_n(int64_t row0, int64_t row1, void** params) {
-  auto col0 = static_cast<StringColumn<T0>*>(params[0]);
-  auto col1 = static_cast<StringColumn<T1>*>(params[1]);
-  auto col2 = static_cast<Column*>(params[2]);
+static void strmap_n_to_n(size_t row0, size_t row1, OColumn* cols) {
+  auto col0 = static_cast<StringColumn<T0>*>(const_cast<Column*>(cols[0].get()));
+  auto col1 = static_cast<StringColumn<T1>*>(const_cast<Column*>(cols[1].get()));
   const T0* offsets0 = col0->offsets();
   const T1* offsets1 = col1->offsets();
   const char* strdata0 = col0->strdata();
   const char* strdata1 = col1->strdata();
-  T2* res_data = static_cast<T2*>(col2->data_w());
+  T2* res_data = static_cast<T2*>(cols[2]->data_w());
   T0 str0start = offsets0[row0 - 1] & ~GETNA<T0>();
   T1 str1start = offsets1[row0 - 1] & ~GETNA<T1>();
-  for (int64_t i = row0; i < row1; ++i) {
+  for (size_t i = row0; i < row1; ++i) {
     T0 str0end = offsets0[i];
     T1 str1end = offsets1[i];
     res_data[i] = OP(str0start, str0end, strdata0,
@@ -140,10 +130,9 @@ static void strmap_n_to_n(int64_t row0, int64_t row1, void** params) {
 
 template<typename T0, typename T1, typename T2,
          T2 (*OP)(T0, T0, const char*, T1, T1, const char*)>
-static void strmap_n_to_1(int64_t row0, int64_t row1, void** params) {
-  auto col0 = static_cast<StringColumn<T0>*>(params[0]);
-  auto col1 = static_cast<StringColumn<T1>*>(params[1]);
-  auto col2 = static_cast<Column*>(params[2]);
+static void strmap_n_to_1(size_t row0, size_t row1, OColumn* cols) {
+  auto col0 = static_cast<StringColumn<T0>*>(const_cast<Column*>(cols[0].get()));
+  auto col1 = static_cast<StringColumn<T1>*>(const_cast<Column*>(cols[1].get()));
   const T0* offsets0 = col0->offsets();
   const T1* offsets1 = col1->offsets();
   const char* strdata0 = col0->strdata();
@@ -151,8 +140,8 @@ static void strmap_n_to_1(int64_t row0, int64_t row1, void** params) {
   T0 str0start = offsets0[row0 - 1] & ~GETNA<T0>();
   T1 str1start = 0;
   T1 str1end = offsets1[0];
-  T2* res_data = static_cast<T2*>(col2->data_w());
-  for (int64_t i = row0; i < row1; ++i) {
+  T2* res_data = static_cast<T2*>(cols[2]->data_w());
+  for (size_t i = row0; i < row1; ++i) {
     T0 str0end = offsets0[i];
     res_data[i] = OP(str0start, str0end, strdata0,
                      str1start, str1end, strdata1);
@@ -380,7 +369,7 @@ static mapperfn resolve2str(OpMode mode) {
 
 
 template<typename LT, typename RT, typename VT>
-static mapperfn resolve1(Op opcode, SType stype, void** params, size_t nrows, OpMode mode) {
+static mapperfn resolve1(Op opcode, SType stype, OColumn* cols, size_t nrows, OpMode mode) {
   if (static_cast<size_t>(opcode) >= static_cast<size_t>(Op::EQ) &&
       static_cast<size_t>(opcode) <= static_cast<size_t>(Op::GE)) {
     // override stype for relational operators
@@ -388,7 +377,7 @@ static mapperfn resolve1(Op opcode, SType stype, void** params, size_t nrows, Op
   } else if (opcode == Op::DIVIDE && std::is_integral<VT>::value) {
     stype = SType::FLOAT64;
   }
-  params[2] = Column::new_data_column(stype, nrows);
+  cols[2] = OColumn(Column::new_data_column(stype, nrows));
   switch (opcode) {
     case Op::PLUS:      return resolve2<LT, RT, VT, op_add<LT, RT, VT>>(mode);
     case Op::MINUS:     return resolve2<LT, RT, VT, op_sub<LT, RT, VT>>(mode);
@@ -411,34 +400,32 @@ static mapperfn resolve1(Op opcode, SType stype, void** params, size_t nrows, Op
 
     default: break;
   }
-  delete static_cast<Column*>(params[2]);
   return nullptr;
 }
 
 
 template<typename T0, typename T1>
-static mapperfn resolve1str(Op opcode, void** params, size_t nrows, OpMode mode) {
+static mapperfn resolve1str(Op opcode, OColumn* cols, size_t nrows, OpMode mode) {
   if (mode == OpMode::One_to_N) {
     mode = OpMode::N_to_One;
-    std::swap(params[0], params[1]);
+    std::swap(cols[0], cols[1]);
   }
-  params[2] = Column::new_data_column(SType::BOOL, nrows);
+  cols[2] = OColumn(Column::new_data_column(SType::BOOL, nrows));
   switch (opcode) {
     case Op::EQ: return resolve2str<T0, T1, int8_t, strop_eq<T0, T1>>(mode);
     case Op::NE: return resolve2str<T0, T1, int8_t, strop_ne<T0, T1>>(mode);
     default: break;
   }
-  delete static_cast<Column*>(params[2]);
   return nullptr;
 }
 
 
-static mapperfn resolve0(SType lhs_type, SType rhs_type, Op opcode, void** params, size_t nrows, OpMode mode) {
+static mapperfn resolve0(SType lhs_type, SType rhs_type, Op opcode, OColumn* cols, size_t nrows, OpMode mode) {
   if (mode == OpMode::Error) return nullptr;
   switch (lhs_type) {
     case SType::BOOL:
       if (rhs_type == SType::BOOL && (opcode == Op::AND || opcode == Op::OR)) {
-        params[2] = Column::new_data_column(SType::BOOL, nrows);
+        cols[2] = OColumn(Column::new_data_column(SType::BOOL, nrows));
         if (opcode == Op::AND) return resolve2<int8_t, int8_t, int8_t, op_and>(mode);
         if (opcode == Op::OR)  return resolve2<int8_t, int8_t, int8_t, op_or>(mode);
       }
@@ -447,12 +434,12 @@ static mapperfn resolve0(SType lhs_type, SType rhs_type, Op opcode, void** param
     case SType::INT8:
       switch (rhs_type) {
         case SType::BOOL:
-        case SType::INT8:    return resolve1<int8_t, int8_t, int8_t>(opcode, SType::INT8, params, nrows, mode);
-        case SType::INT16:   return resolve1<int8_t, int16_t, int16_t>(opcode, SType::INT16, params, nrows, mode);
-        case SType::INT32:   return resolve1<int8_t, int32_t, int32_t>(opcode, SType::INT32, params, nrows, mode);
-        case SType::INT64:   return resolve1<int8_t, int64_t, int64_t>(opcode, SType::INT64, params, nrows, mode);
-        case SType::FLOAT32: return resolve1<int8_t, float, float>(opcode, SType::FLOAT32, params, nrows, mode);
-        case SType::FLOAT64: return resolve1<int8_t, double, double>(opcode, SType::FLOAT64, params, nrows, mode);
+        case SType::INT8:    return resolve1<int8_t, int8_t, int8_t>(opcode, SType::INT8, cols, nrows, mode);
+        case SType::INT16:   return resolve1<int8_t, int16_t, int16_t>(opcode, SType::INT16, cols, nrows, mode);
+        case SType::INT32:   return resolve1<int8_t, int32_t, int32_t>(opcode, SType::INT32, cols, nrows, mode);
+        case SType::INT64:   return resolve1<int8_t, int64_t, int64_t>(opcode, SType::INT64, cols, nrows, mode);
+        case SType::FLOAT32: return resolve1<int8_t, float, float>(opcode, SType::FLOAT32, cols, nrows, mode);
+        case SType::FLOAT64: return resolve1<int8_t, double, double>(opcode, SType::FLOAT64, cols, nrows, mode);
         default: break;
       }
       break;
@@ -460,12 +447,12 @@ static mapperfn resolve0(SType lhs_type, SType rhs_type, Op opcode, void** param
     case SType::INT16:
       switch (rhs_type) {
         case SType::BOOL:
-        case SType::INT8:    return resolve1<int16_t, int8_t, int16_t>(opcode, SType::INT16, params, nrows, mode);
-        case SType::INT16:   return resolve1<int16_t, int16_t, int16_t>(opcode, SType::INT16, params, nrows, mode);
-        case SType::INT32:   return resolve1<int16_t, int32_t, int32_t>(opcode, SType::INT32, params, nrows, mode);
-        case SType::INT64:   return resolve1<int16_t, int64_t, int64_t>(opcode, SType::INT64, params, nrows, mode);
-        case SType::FLOAT32: return resolve1<int16_t, float, float>(opcode, SType::FLOAT32, params, nrows, mode);
-        case SType::FLOAT64: return resolve1<int16_t, double, double>(opcode, SType::FLOAT64, params, nrows, mode);
+        case SType::INT8:    return resolve1<int16_t, int8_t, int16_t>(opcode, SType::INT16, cols, nrows, mode);
+        case SType::INT16:   return resolve1<int16_t, int16_t, int16_t>(opcode, SType::INT16, cols, nrows, mode);
+        case SType::INT32:   return resolve1<int16_t, int32_t, int32_t>(opcode, SType::INT32, cols, nrows, mode);
+        case SType::INT64:   return resolve1<int16_t, int64_t, int64_t>(opcode, SType::INT64, cols, nrows, mode);
+        case SType::FLOAT32: return resolve1<int16_t, float, float>(opcode, SType::FLOAT32, cols, nrows, mode);
+        case SType::FLOAT64: return resolve1<int16_t, double, double>(opcode, SType::FLOAT64, cols, nrows, mode);
         default: break;
       }
       break;
@@ -473,12 +460,12 @@ static mapperfn resolve0(SType lhs_type, SType rhs_type, Op opcode, void** param
     case SType::INT32:
       switch (rhs_type) {
         case SType::BOOL:
-        case SType::INT8:    return resolve1<int32_t, int8_t, int32_t>(opcode, SType::INT32, params, nrows, mode);
-        case SType::INT16:   return resolve1<int32_t, int16_t, int32_t>(opcode, SType::INT32, params, nrows, mode);
-        case SType::INT32:   return resolve1<int32_t, int32_t, int32_t>(opcode, SType::INT32, params, nrows, mode);
-        case SType::INT64:   return resolve1<int32_t, int64_t, int64_t>(opcode, SType::INT64, params, nrows, mode);
-        case SType::FLOAT32: return resolve1<int32_t, float, float>(opcode, SType::FLOAT32, params, nrows, mode);
-        case SType::FLOAT64: return resolve1<int32_t, double, double>(opcode, SType::FLOAT64, params, nrows, mode);
+        case SType::INT8:    return resolve1<int32_t, int8_t, int32_t>(opcode, SType::INT32, cols, nrows, mode);
+        case SType::INT16:   return resolve1<int32_t, int16_t, int32_t>(opcode, SType::INT32, cols, nrows, mode);
+        case SType::INT32:   return resolve1<int32_t, int32_t, int32_t>(opcode, SType::INT32, cols, nrows, mode);
+        case SType::INT64:   return resolve1<int32_t, int64_t, int64_t>(opcode, SType::INT64, cols, nrows, mode);
+        case SType::FLOAT32: return resolve1<int32_t, float, float>(opcode, SType::FLOAT32, cols, nrows, mode);
+        case SType::FLOAT64: return resolve1<int32_t, double, double>(opcode, SType::FLOAT64, cols, nrows, mode);
         default: break;
       }
       break;
@@ -486,12 +473,12 @@ static mapperfn resolve0(SType lhs_type, SType rhs_type, Op opcode, void** param
     case SType::INT64:
       switch (rhs_type) {
         case SType::BOOL:
-        case SType::INT8:    return resolve1<int64_t, int8_t, int64_t>(opcode, SType::INT64, params, nrows, mode);
-        case SType::INT16:   return resolve1<int64_t, int16_t, int64_t>(opcode, SType::INT64, params, nrows, mode);
-        case SType::INT32:   return resolve1<int64_t, int32_t, int64_t>(opcode, SType::INT64, params, nrows, mode);
-        case SType::INT64:   return resolve1<int64_t, int64_t, int64_t>(opcode, SType::INT64, params, nrows, mode);
-        case SType::FLOAT32: return resolve1<int64_t, float, float>(opcode, SType::FLOAT32, params, nrows, mode);
-        case SType::FLOAT64: return resolve1<int64_t, double, double>(opcode, SType::FLOAT64, params, nrows, mode);
+        case SType::INT8:    return resolve1<int64_t, int8_t, int64_t>(opcode, SType::INT64, cols, nrows, mode);
+        case SType::INT16:   return resolve1<int64_t, int16_t, int64_t>(opcode, SType::INT64, cols, nrows, mode);
+        case SType::INT32:   return resolve1<int64_t, int32_t, int64_t>(opcode, SType::INT64, cols, nrows, mode);
+        case SType::INT64:   return resolve1<int64_t, int64_t, int64_t>(opcode, SType::INT64, cols, nrows, mode);
+        case SType::FLOAT32: return resolve1<int64_t, float, float>(opcode, SType::FLOAT32, cols, nrows, mode);
+        case SType::FLOAT64: return resolve1<int64_t, double, double>(opcode, SType::FLOAT64, cols, nrows, mode);
         default: break;
       }
       break;
@@ -499,12 +486,12 @@ static mapperfn resolve0(SType lhs_type, SType rhs_type, Op opcode, void** param
     case SType::FLOAT32:
       switch (rhs_type) {
         case SType::BOOL:
-        case SType::INT8:    return resolve1<float, int8_t, float>(opcode, SType::FLOAT32, params, nrows, mode);
-        case SType::INT16:   return resolve1<float, int16_t, float>(opcode, SType::FLOAT32, params, nrows, mode);
-        case SType::INT32:   return resolve1<float, int32_t, float>(opcode, SType::FLOAT32, params, nrows, mode);
-        case SType::INT64:   return resolve1<float, int64_t, float>(opcode, SType::FLOAT32, params, nrows, mode);
-        case SType::FLOAT32: return resolve1<float, float, float>(opcode, SType::FLOAT32, params, nrows, mode);
-        case SType::FLOAT64: return resolve1<float, double, double>(opcode, SType::FLOAT64, params, nrows, mode);
+        case SType::INT8:    return resolve1<float, int8_t, float>(opcode, SType::FLOAT32, cols, nrows, mode);
+        case SType::INT16:   return resolve1<float, int16_t, float>(opcode, SType::FLOAT32, cols, nrows, mode);
+        case SType::INT32:   return resolve1<float, int32_t, float>(opcode, SType::FLOAT32, cols, nrows, mode);
+        case SType::INT64:   return resolve1<float, int64_t, float>(opcode, SType::FLOAT32, cols, nrows, mode);
+        case SType::FLOAT32: return resolve1<float, float, float>(opcode, SType::FLOAT32, cols, nrows, mode);
+        case SType::FLOAT64: return resolve1<float, double, double>(opcode, SType::FLOAT64, cols, nrows, mode);
         default: break;
       }
       break;
@@ -512,28 +499,28 @@ static mapperfn resolve0(SType lhs_type, SType rhs_type, Op opcode, void** param
     case SType::FLOAT64:
       switch (rhs_type) {
         case SType::BOOL:
-        case SType::INT8:    return resolve1<double, int8_t, double>(opcode, SType::FLOAT64, params, nrows, mode);
-        case SType::INT16:   return resolve1<double, int16_t, double>(opcode, SType::FLOAT64, params, nrows, mode);
-        case SType::INT32:   return resolve1<double, int32_t, double>(opcode, SType::FLOAT64, params, nrows, mode);
-        case SType::INT64:   return resolve1<double, int64_t, double>(opcode, SType::FLOAT64, params, nrows, mode);
-        case SType::FLOAT32: return resolve1<double, float, double>(opcode, SType::FLOAT64, params, nrows, mode);
-        case SType::FLOAT64: return resolve1<double, double, double>(opcode, SType::FLOAT64, params, nrows, mode);
+        case SType::INT8:    return resolve1<double, int8_t, double>(opcode, SType::FLOAT64, cols, nrows, mode);
+        case SType::INT16:   return resolve1<double, int16_t, double>(opcode, SType::FLOAT64, cols, nrows, mode);
+        case SType::INT32:   return resolve1<double, int32_t, double>(opcode, SType::FLOAT64, cols, nrows, mode);
+        case SType::INT64:   return resolve1<double, int64_t, double>(opcode, SType::FLOAT64, cols, nrows, mode);
+        case SType::FLOAT32: return resolve1<double, float, double>(opcode, SType::FLOAT64, cols, nrows, mode);
+        case SType::FLOAT64: return resolve1<double, double, double>(opcode, SType::FLOAT64, cols, nrows, mode);
         default: break;
       }
       break;
 
     case SType::STR32:
       switch (rhs_type) {
-        case SType::STR32: return resolve1str<uint32_t, uint32_t>(opcode, params, nrows, mode);
-        case SType::STR64: return resolve1str<uint32_t, uint64_t>(opcode, params, nrows, mode);
+        case SType::STR32: return resolve1str<uint32_t, uint32_t>(opcode, cols, nrows, mode);
+        case SType::STR64: return resolve1str<uint32_t, uint64_t>(opcode, cols, nrows, mode);
         default: break;
       }
       break;
 
     case SType::STR64:
       switch (rhs_type) {
-        case SType::STR32: return resolve1str<uint64_t, uint32_t>(opcode, params, nrows, mode);
-        case SType::STR64: return resolve1str<uint64_t, uint64_t>(opcode, params, nrows, mode);
+        case SType::STR32: return resolve1str<uint64_t, uint32_t>(opcode, cols, nrows, mode);
+        case SType::STR64: return resolve1str<uint64_t, uint64_t>(opcode, cols, nrows, mode);
         default: break;
       }
       break;
@@ -550,28 +537,29 @@ static mapperfn resolve0(SType lhs_type, SType rhs_type, Op opcode, void** param
 // binaryop
 //------------------------------------------------------------------------------
 
-static Column* binaryop(Op opcode, Column* lhs, Column* rhs)
+static OColumn binaryop(Op opcode, OColumn& lhs, OColumn& rhs)
 {
-  lhs->materialize();
-  rhs->materialize();
-  size_t lhs_nrows = lhs->nrows;
-  size_t rhs_nrows = rhs->nrows;
+  // TODO: do not materialize, then `lhs` and `rhs` may be const
+  lhs.materialize();
+  rhs.materialize();
+  size_t lhs_nrows = lhs.nrows();
+  size_t rhs_nrows = rhs.nrows();
   if (lhs_nrows == 0 || rhs_nrows == 0) {
     lhs_nrows = rhs_nrows = 0;
   }
   size_t nrows = std::max(lhs_nrows, rhs_nrows);
-  SType lhs_type = lhs->_stype;
-  SType rhs_type = rhs->_stype;
-  void* params[3];
-  params[0] = lhs;
-  params[1] = rhs;
-  params[2] = nullptr;
+  auto mode = (lhs_nrows == rhs_nrows)? OpMode::N_to_N :
+              (rhs_nrows == 1)? OpMode::N_to_One :
+              (lhs_nrows == 1)? OpMode::One_to_N : OpMode::Error;
+  SType lhs_type = lhs.stype();
+  SType rhs_type = rhs.stype();
+
+  OColumn cols[3];
+  cols[0] = lhs;  // shallow copy
+  cols[1] = rhs;  // shallow copy
 
   mapperfn mapfn = nullptr;
-  mapfn = resolve0(lhs_type, rhs_type, opcode, params, nrows,
-                   lhs_nrows == rhs_nrows? OpMode::N_to_N :
-                   rhs_nrows == 1? OpMode::N_to_One :
-                   lhs_nrows == 1? OpMode::One_to_N : OpMode::Error);
+  mapfn = resolve0(lhs_type, rhs_type, opcode, cols, nrows, mode);
   if (!mapfn) {
     throw RuntimeError()
       << "Unable to apply op " << static_cast<size_t>(opcode)
@@ -579,9 +567,9 @@ static Column* binaryop(Op opcode, Column* lhs, Column* rhs)
       << ", nrows=" << lhs->nrows << ") and column2(stype=" << rhs_type
       << ", nrows=" << rhs->nrows << ")";
   }
-  (*mapfn)(0, static_cast<int64_t>(nrows), params);
+  (*mapfn)(0, nrows, cols);
 
-  return static_cast<Column*>(params[2]);
+  return std::move(cols[2]);
 }
 
 
@@ -624,9 +612,7 @@ GroupbyMode expr_binaryop::get_groupby_mode(const workframe& wf) const {
 OColumn expr_binaryop::evaluate_eager(workframe& wf) {
   auto lhs_res = lhs->evaluate_eager(wf);
   auto rhs_res = rhs->evaluate_eager(wf);
-  return OColumn(expr::binaryop(opcode,
-                               const_cast<Column*>(lhs_res.get()),
-                               const_cast<Column*>(rhs_res.get())));
+  return expr::binaryop(opcode, lhs_res, rhs_res);
 }
 
 

--- a/c/expr/expr_literal.cc
+++ b/c/expr/expr_literal.cc
@@ -27,7 +27,7 @@ namespace expr {
 expr_literal::expr_literal(py::robj v) {
   py::olist lst(1);
   lst.set(0, v);
-  col = OColumn(Column::from_pylist(lst, 0));
+  col = OColumn::from_pylist(lst, 0);
 }
 
 

--- a/c/expr/expr_reduce.cc
+++ b/c/expr/expr_reduce.cc
@@ -372,24 +372,24 @@ GroupbyMode expr_reduce0::get_groupby_mode(const workframe&) const {
 
 
 OColumn expr_reduce0::evaluate_eager(workframe& wf) {
-  Column* res = nullptr;
+  OColumn res;
   if (opcode == Op::COUNT0) {  // COUNT
     if (wf.has_groupby()) {
       const Groupby& grpby = wf.get_groupby();
       size_t ng = grpby.ngroups();
       const int32_t* offsets = grpby.offsets_r();
-      res = Column::new_data_column(SType::INT32, ng);
+      res = OColumn(Column::new_data_column(SType::INT32, ng));
       auto d_res = static_cast<int32_t*>(res->data_w());
       for (size_t i = 0; i < ng; ++i) {
         d_res[i] = offsets[i + 1] - offsets[i];
       }
     } else {
-      res = Column::new_data_column(SType::INT64, 1);
+      res = OColumn(Column::new_data_column(SType::INT64, 1));
       auto d_res = static_cast<int64_t*>(res->data_w());
       d_res[0] = static_cast<int64_t>(wf.nrows());
     }
   }
-  return OColumn(res);
+  return res;
 }
 
 

--- a/c/expr/expr_reduce.cc
+++ b/c/expr/expr_reduce.cc
@@ -79,7 +79,7 @@ static ReducerLibrary library;
 static OColumn reduce_first(const OColumn& col, const Groupby& groupby)
 {
   if (col.nrows() == 0) {
-    return OColumn(Column::new_data_column(col.stype(), 0));
+    return OColumn::new_data_column(col.stype(), 0);
   }
   size_t ngrps = groupby.ngroups();
   // groupby.offsets array has length `ngrps + 1` and contains offsets of the
@@ -322,7 +322,7 @@ OColumn expr_reduce1::evaluate_eager(workframe& wf)
   xassert(reducer);  // checked in .resolve()
 
   SType out_stype = reducer->output_stype;
-  auto res = OColumn(Column::new_data_column(out_stype, out_nrows));
+  auto res = OColumn::new_data_column(out_stype, out_nrows);
 
   RowIndex rowindex = input_col->rowindex();
   if (opcode == Op::MEDIAN && gb) {
@@ -378,13 +378,13 @@ OColumn expr_reduce0::evaluate_eager(workframe& wf) {
       const Groupby& grpby = wf.get_groupby();
       size_t ng = grpby.ngroups();
       const int32_t* offsets = grpby.offsets_r();
-      res = OColumn(Column::new_data_column(SType::INT32, ng));
+      res = OColumn::new_data_column(SType::INT32, ng);
       auto d_res = static_cast<int32_t*>(res->data_w());
       for (size_t i = 0; i < ng; ++i) {
         d_res[i] = offsets[i + 1] - offsets[i];
       }
     } else {
-      res = OColumn(Column::new_data_column(SType::INT64, 1));
+      res = OColumn::new_data_column(SType::INT64, 1);
       auto d_res = static_cast<int64_t*>(res->data_w());
       d_res[0] = static_cast<int64_t>(wf.nrows());
     }

--- a/c/expr/expr_reduce.cc
+++ b/c/expr/expr_reduce.cc
@@ -89,7 +89,8 @@ static OColumn reduce_first(const OColumn& col, const Groupby& groupby)
   arr32_t indices(ngrps, groupby.offsets_r());
   RowIndex ri = RowIndex(std::move(indices), true)
                 * col->rowindex();
-  auto res = OColumn(col->shallowcopy(ri));
+  OColumn res = col;  // copy
+  res->replace_rowindex(ri);
   if (ngrps == 1) res->materialize();
   return res;
 }

--- a/c/expr/expr_str.h
+++ b/c/expr/expr_str.h
@@ -44,7 +44,7 @@ class expr_string_match_re : public base_expr {
 
   private:
     template <typename T>
-    OColumn _compute(const Column* src);
+    OColumn _compute(const OColumn& src);
 };
 
 

--- a/c/expr/expr_unaryop.cc
+++ b/c/expr/expr_unaryop.cc
@@ -288,8 +288,8 @@ OColumn expr_unaryop::evaluate_eager(workframe& wf) {
     output_mbuf = MemoryRange::mem(out_elemsize * nrows);
     out = output_mbuf.xptr();
   }
-  auto output_column = OColumn(
-      Column::new_mbuf_column(ui.output_stype, std::move(output_mbuf)));
+  auto output_column =
+      OColumn::new_mbuf_column(ui.output_stype, std::move(output_mbuf));
 
   ui.vectorfn(nrows, inp, out);
 

--- a/c/expr/repl_node.cc
+++ b/c/expr/repl_node.cc
@@ -355,7 +355,7 @@ bool scalar_string_rn::valid_ltype(LType lt) const noexcept {
 
 OColumn scalar_string_rn::make_column(SType st, size_t nrows) const {
   if (nrows == 0) {
-    return OColumn(new StringColumn<uint32_t>(0));
+    return OColumn::new_data_column(SType::STR32, 0);
   }
   size_t len = value.size();
   SType rst = (st == SType::VOID)? SType::STR32 : st;

--- a/c/expr/repl_node.cc
+++ b/c/expr/repl_node.cc
@@ -368,11 +368,11 @@ OColumn scalar_string_rn::make_column(SType st, size_t nrows) const {
   }
   MemoryRange strbuf = MemoryRange::mem(len);
   std::memcpy(strbuf.xptr(), value.data(), len);
-  Column* col = new_string_column(1, std::move(offbuf), std::move(strbuf));
+  OColumn col = new_string_column(1, std::move(offbuf), std::move(strbuf));
   if (nrows > 1) {
     col->replace_rowindex(RowIndex(size_t(0), nrows, 0));
   }
-  return OColumn(col);
+  return col;
 }
 
 

--- a/c/expr/repl_node.cc
+++ b/c/expr/repl_node.cc
@@ -265,7 +265,7 @@ OColumn scalar_int_rn::make_column(SType st, size_t nrows) const {
                 rst == SType::FLOAT32? _make1<float>(rst) :
                 rst == SType::FLOAT64? _make1<double>(rst) : OColumn();
   xassert(col1);
-  return OColumn(col1->repeat(nrows));
+  return col1->repeat(nrows);
 }
 
 
@@ -323,7 +323,7 @@ OColumn scalar_float_rn::make_column(SType st, size_t nrows) const {
     static_cast<FwColumn<double>*>(const_cast<Column*>(col.get()))
         ->set_elem(0, value);
   }
-  return OColumn(col->repeat(nrows));
+  return col->repeat(nrows);
 }
 
 

--- a/c/expr/repl_node.cc
+++ b/c/expr/repl_node.cc
@@ -271,7 +271,7 @@ OColumn scalar_int_rn::make_column(SType st, size_t nrows) const {
 
 template <typename T>
 OColumn scalar_int_rn::_make1(SType st) const {
-  OColumn col = OColumn(Column::new_data_column(st, 1));
+  OColumn col = OColumn::new_data_column(st, 1);
   auto tcol = static_cast<FwColumn<T>*>(const_cast<Column*>(col.get()));
   tcol->set_elem(0, static_cast<T>(value));
   return col;
@@ -315,7 +315,7 @@ OColumn scalar_float_rn::make_column(SType st, size_t nrows) const {
   // to value truncation (value does not fit into float32).
   SType rst = st == SType::VOID || std::abs(value) > MAX
               ? SType::FLOAT64 : st;
-  OColumn col = OColumn(Column::new_data_column(rst, 1));
+  OColumn col = OColumn::new_data_column(rst, 1);
   if (rst == SType::FLOAT32) {
     static_cast<FwColumn<float>*>(const_cast<Column*>(col.get()))
         ->set_elem(0, static_cast<float>(value));

--- a/c/expr/repl_node.cc
+++ b/c/expr/repl_node.cc
@@ -100,7 +100,7 @@ void frame_rn::replace_values(workframe& wf, const intvec& indices) const {
     const OColumn& coli = dtr->get_ocolumn(rcols == 1? 0 : i);
     if (!dt0->get_ocolumn(j)) {
       dt0->set_ocolumn(j,
-          OColumn(Column::new_na_column(coli.stype(), dt0->nrows)));
+          OColumn::new_na_column(coli.stype(), dt0->nrows));
     }
     OColumn& colj = dt0->get_ocolumn(j);
     colj->replace_values(ri0, coli);
@@ -177,7 +177,7 @@ void scalar_rn::replace_values(workframe& wf, const intvec& indices) const {
     OColumn replcol = make_column(stype, 1);
     stype = replcol.stype();  // may change from VOID to BOOL, FIXME!
     if (!colj) {
-      dt0->set_ocolumn(j, OColumn(Column::new_na_column(stype, dt0->nrows)));
+      dt0->set_ocolumn(j, OColumn::new_na_column(stype, dt0->nrows));
     }
     else if (colj.stype() != stype) {
       dt0->set_ocolumn(j, colj.cast(stype));
@@ -213,7 +213,7 @@ bool scalar_na_rn::valid_ltype(LType) const noexcept {
 
 OColumn scalar_na_rn::make_column(SType st, size_t nrows) const {
   if (st == SType::VOID) st = SType::BOOL;
-  return OColumn(Column::new_na_column(st, nrows));
+  return OColumn::new_na_column(st, nrows);
 }
 
 

--- a/c/expr/repl_node.cc
+++ b/c/expr/repl_node.cc
@@ -271,10 +271,10 @@ OColumn scalar_int_rn::make_column(SType st, size_t nrows) const {
 
 template <typename T>
 OColumn scalar_int_rn::_make1(SType st) const {
-  Column* col = Column::new_data_column(st, 1);
-  auto tcol = static_cast<FwColumn<T>*>(col);
+  OColumn col = OColumn(Column::new_data_column(st, 1));
+  auto tcol = static_cast<FwColumn<T>*>(const_cast<Column*>(col.get()));
   tcol->set_elem(0, static_cast<T>(value));
-  return OColumn(col);
+  return col;
 }
 
 
@@ -315,11 +315,13 @@ OColumn scalar_float_rn::make_column(SType st, size_t nrows) const {
   // to value truncation (value does not fit into float32).
   SType rst = st == SType::VOID || std::abs(value) > MAX
               ? SType::FLOAT64 : st;
-  Column* col = Column::new_data_column(rst, 1);
+  OColumn col = OColumn(Column::new_data_column(rst, 1));
   if (rst == SType::FLOAT32) {
-    static_cast<FwColumn<float>*>(col)->set_elem(0, static_cast<float>(value));
+    static_cast<FwColumn<float>*>(const_cast<Column*>(col.get()))
+        ->set_elem(0, static_cast<float>(value));
   } else {
-    static_cast<FwColumn<double>*>(col)->set_elem(0, value);
+    static_cast<FwColumn<double>*>(const_cast<Column*>(col.get()))
+        ->set_elem(0, value);
   }
   return OColumn(col->repeat(nrows));
 }

--- a/c/expr/virtual_column.cc
+++ b/c/expr/virtual_column.cc
@@ -77,10 +77,10 @@ void virtual_column::compute(size_t, CString*) {
 //------------------------------------------------------------------------------
 
 template <typename T>
-void materialize_fw(virtual_column* self, Column* outcol) {
+void materialize_fw(virtual_column* self, OColumn& outcol) {
   T* out_data = static_cast<T*>(outcol->data_w());
   dt::parallel_for_static(
-    outcol->nrows,
+    outcol.nrows(),
     [&](size_t i) {
       self->compute(i, out_data + i);
     });
@@ -88,8 +88,7 @@ void materialize_fw(virtual_column* self, Column* outcol) {
 
 
 OColumn virtual_column::materialize() {
-  Column* out = Column::new_data_column(_stype, _nrows);
-  OColumn out_colptr(out);
+  OColumn out = OColumn(Column::new_data_column(_stype, _nrows));
   switch (_stype) {
     case SType::BOOL:
     case SType::INT8:    materialize_fw<int8_t> (this, out); break;
@@ -102,7 +101,7 @@ OColumn virtual_column::materialize() {
       throw NotImplError() << "virtual_column of stype " << _stype
           << " cannot be materialized";
   }
-  return out_colptr;
+  return out;
 }
 
 

--- a/c/expr/virtual_column.cc
+++ b/c/expr/virtual_column.cc
@@ -88,7 +88,7 @@ void materialize_fw(virtual_column* self, OColumn& outcol) {
 
 
 OColumn virtual_column::materialize() {
-  OColumn out = OColumn(Column::new_data_column(_stype, _nrows));
+  OColumn out = OColumn::new_data_column(_stype, _nrows);
   switch (_stype) {
     case SType::BOOL:
     case SType::INT8:    materialize_fw<int8_t> (this, out); break;

--- a/c/frame/__init__.cc
+++ b/c/frame/__init__.cc
@@ -234,8 +234,7 @@ class FrameInitializationManager {
       for (size_t j = 0; j < ncols; ++j) {
         py::robj name = nameslist[j];
         SType s = get_stype_for_column(j, &name);
-        Column* col = Column::from_pylist_of_dicts(srclist, name, int(s));
-        cols.emplace_back(col);
+        cols.push_back(OColumn::from_pylist_of_dicts(srclist, name, int(s)));
       }
       make_datatable(nameslist);
     }
@@ -267,7 +266,7 @@ class FrameInitializationManager {
       // Create the columns
       for (size_t j = 0; j < ncols; ++j) {
         SType s = get_stype_for_column(j);
-        cols.emplace_back(Column::from_pylist_of_tuples(srclist, j, int(s)));
+        cols.push_back(OColumn::from_pylist_of_tuples(srclist, j, int(s)));
       }
       if (names_arg || !item0.has_attr("_fields")) {
         make_datatable(names_arg);
@@ -596,7 +595,7 @@ class FrameInitializationManager {
         col = OColumn::from_buffer(colsrc);
       }
       else if (colsrc.is_list_or_tuple()) {
-        col = OColumn(Column::from_pylist(colsrc.to_pylist(), int(s)));
+        col = OColumn::from_pylist(colsrc.to_pylist(), int(s));
       }
       else if (colsrc.is_range()) {
         auto r = colsrc.to_orange();

--- a/c/frame/__init__.cc
+++ b/c/frame/__init__.cc
@@ -447,10 +447,9 @@ class FrameInitializationManager {
           auto colsrc  = npsrc.get_attr("data").get_item(col_key);
           auto masksrc = npsrc.get_attr("mask").get_item(col_key);
           make_column(colsrc, SType::VOID);
-          Column* maskcol = Column::from_buffer(masksrc);
-          xassert(maskcol->_stype == SType::BOOL);
-          cols.back()->apply_na_mask(static_cast<BoolColumn*>(maskcol));
-          delete maskcol;
+          OColumn maskcol = OColumn::from_buffer(masksrc);
+          xassert(maskcol.stype() == SType::BOOL);
+          cols.back()->apply_na_mask(static_cast<const BoolColumn*>(maskcol.get()));
         }
       } else {
         for (size_t i = 0; i < ncols; ++i) {
@@ -594,7 +593,7 @@ class FrameInitializationManager {
         col = srcdt->get_ocolumn(0);
       }
       else if (colsrc.is_buffer()) {
-        col = OColumn(Column::from_buffer(colsrc));
+        col = OColumn::from_buffer(colsrc);
       }
       else if (colsrc.is_list_or_tuple()) {
         col = OColumn(Column::from_pylist(colsrc.to_pylist(), int(s)));

--- a/c/frame/__init__.cc
+++ b/c/frame/__init__.cc
@@ -447,8 +447,7 @@ class FrameInitializationManager {
           auto masksrc = npsrc.get_attr("mask").get_item(col_key);
           make_column(colsrc, SType::VOID);
           OColumn maskcol = OColumn::from_buffer(masksrc);
-          xassert(maskcol.stype() == SType::BOOL);
-          cols.back()->apply_na_mask(static_cast<const BoolColumn*>(maskcol.get()));
+          cols.back()->apply_na_mask(maskcol);
         }
       } else {
         for (size_t i = 0; i < ncols; ++i) {

--- a/c/frame/__sizeof__.cc
+++ b/c/frame/__sizeof__.cc
@@ -62,7 +62,7 @@ void Frame::_init_sizeof(XTypeMaker& xt) {
 size_t DataTable::memory_footprint() const {
   size_t sz = 0;
   sz += sizeof(*this);
-  sz += sizeof(Column*) * columns.capacity();
+  sz += sizeof(OColumn) * columns.capacity();
   sz += sizeof(std::string) * names.capacity();
   for (size_t i = 0; i < ncols; ++i) {
     sz += columns[i]->memory_footprint();

--- a/c/frame/cast.cc
+++ b/c/frame/cast.cc
@@ -355,7 +355,7 @@ OColumn cast_manager::execute(const Column* src, MemoryRange&& target_mbuf,
     target_mbuf.set_pyobjects(/* clear = */ false);
   }
 
-  return OColumn(Column::new_mbuf_column(target_stype, std::move(target_mbuf)));
+  return OColumn::new_mbuf_column(target_stype, std::move(target_mbuf));
 }
 
 

--- a/c/frame/names.cc
+++ b/c/frame/names.cc
@@ -696,8 +696,8 @@ namespace dttest {
 
   void cover_names_integrity_checks() {
     DataTable* dt = new DataTable({
-                        OColumn(Column::new_data_column(SType::INT32, 1)),
-                        OColumn(Column::new_data_column(SType::FLOAT64, 1))
+                        OColumn::new_data_column(SType::INT32, 1),
+                        OColumn::new_data_column(SType::FLOAT64, 1)
                     });
 
     auto check1 = [dt]() { dt->_integrity_check_names(); };

--- a/c/frame/rbind.cc
+++ b/c/frame/rbind.cc
@@ -323,7 +323,7 @@ void OColumn::rbind(colvec& columns) {
   // filled with NAs; the current column; or a type-cast of the current column.
   OColumn newcol;
   if (col_empty) {
-    newcol = OColumn(Column::new_na_column(new_stype, nrows()));
+    newcol = OColumn::new_na_column(new_stype, nrows());
   } else if (stype() == new_stype) {
     newcol = std::move(*this);
   } else {

--- a/c/frame/rbind.cc
+++ b/c/frame/rbind.cc
@@ -277,7 +277,7 @@ void DataTable::rbind(
 
   columns.reserve(new_ncols);
   for (size_t i = ncols; i < new_ncols; ++i) {
-    columns.emplace_back(new VoidColumn(nrows));
+    columns.push_back(OColumn::new_data_column(SType::VOID, nrows));
   }
 
   size_t new_nrows = nrows;
@@ -290,7 +290,7 @@ void DataTable::rbind(
     for (size_t j = 0; j < dts.size(); ++j) {
       size_t k = col_indices[i][j];
       OColumn col = (k == INVALID_INDEX)
-                      ? OColumn(new VoidColumn(dts[j]->nrows))
+                      ? OColumn::new_data_column(SType::VOID, dts[j]->nrows)
                       : dts[j]->get_ocolumn(k);
       col.materialize();
       cols_to_append[j] = std::move(col);

--- a/c/frame/repeat.cc
+++ b/c/frame/repeat.cc
@@ -60,7 +60,7 @@ static RowIndex _make_repeat_rowindex(size_t nrows, size_t nreps) {
 Column* Column::repeat(size_t nreps) const {
   xassert(!info(_stype).is_varwidth());
   xassert(!ri);
-  size_t esize = elemsize();
+  size_t esize = info(_stype).elemsize();
   size_t new_nrows = nrows * nreps;
 
   Column* newcol = Column::new_data_column(_stype, new_nrows);

--- a/c/frame/repeat.cc
+++ b/c/frame/repeat.cc
@@ -64,7 +64,7 @@ OColumn Column::repeat(size_t nreps) const {
   size_t esize = info(_stype).elemsize();
   size_t new_nrows = nrows * nreps;
 
-  OColumn newcol = OColumn(Column::new_data_column(_stype, new_nrows));
+  OColumn newcol = OColumn::new_data_column(_stype, new_nrows);
   if (!new_nrows) {
     return newcol;
   }

--- a/c/frame/repeat.cc
+++ b/c/frame/repeat.cc
@@ -57,13 +57,14 @@ static RowIndex _make_repeat_rowindex(size_t nrows, size_t nreps) {
 }
 
 
-Column* Column::repeat(size_t nreps) const {
+// TODO: we could create a special "repeated" column here
+OColumn Column::repeat(size_t nreps) const {
   xassert(!info(_stype).is_varwidth());
   xassert(!ri);
   size_t esize = info(_stype).elemsize();
   size_t new_nrows = nrows * nreps;
 
-  Column* newcol = Column::new_data_column(_stype, new_nrows);
+  OColumn newcol = OColumn(Column::new_data_column(_stype, new_nrows));
   if (!new_nrows) {
     return newcol;
   }
@@ -116,7 +117,7 @@ static oobj repeat(const PKArgs& args) {
   // Single-colum fixed-width Frame:
   const OColumn& col0 = dt->get_ocolumn(0);
   if (dt->ncols == 1 && col0.is_fixedwidth() && !col0.is_virtual()) {
-    auto newcol = OColumn(col0->repeat(n));
+    auto newcol = col0->repeat(n);
     DataTable* newdt = new DataTable({std::move(newcol)}, dt);  // copy names from dt
     return Frame::oframe(newdt);
   }

--- a/c/frame/stats.cc
+++ b/c/frame/stats.cc
@@ -61,7 +61,7 @@ static OColumn _make_column_str(CString value) {
 }
 
 static OColumn _nacol(Stats*, const OColumn& col) {
-  return OColumn(Column::new_na_column(col.stype(), 1));
+  return OColumn::new_na_column(col.stype(), 1);
 }
 
 static oobj _naval(const OColumn&) {

--- a/c/frame/stats.cc
+++ b/c/frame/stats.cc
@@ -38,7 +38,7 @@ namespace py {
 
 template <typename T>
 static OColumn _make_column(SType stype, T value) {
-  OColumn col{ Column::new_data_column(stype, 1) };
+  OColumn col = OColumn(Column::new_data_column(stype, 1));
   static_cast<FwColumn<T>*>(const_cast<Column*>(col.get()))->set_elem(0, value);
   return col;
 }

--- a/c/frame/stats.cc
+++ b/c/frame/stats.cc
@@ -38,7 +38,7 @@ namespace py {
 
 template <typename T>
 static OColumn _make_column(SType stype, T value) {
-  OColumn col = OColumn(Column::new_data_column(stype, 1));
+  OColumn col = OColumn::new_data_column(stype, 1);
   static_cast<FwColumn<T>*>(const_cast<Column*>(col.get()))->set_elem(0, value);
   return col;
 }

--- a/c/frame/stats.cc
+++ b/c/frame/stats.cc
@@ -57,7 +57,7 @@ static OColumn _make_column_str(CString value) {
     mbuf.set_element<T>(0, 0);
     mbuf.set_element<T>(1, GETNA<T>());
   }
-  return OColumn(new_string_column(1, std::move(mbuf), std::move(strbuf)));
+  return new_string_column(1, std::move(mbuf), std::move(strbuf));
 }
 
 static OColumn _nacol(Stats*, const OColumn& col) {

--- a/c/frame/to_numpy.cc
+++ b/c/frame/to_numpy.cc
@@ -122,7 +122,7 @@ oobj Frame::to_numpy(const PKArgs& args) {
     size_t i0 = one_col? force_col : 0;
 
     size_t dtsize = ncols * dt->nrows;
-    OColumn mask_col = OColumn(Column::new_data_column(SType::BOOL, dtsize));
+    OColumn mask_col = OColumn::new_data_column(SType::BOOL, dtsize);
     int8_t* mask_data = static_cast<int8_t*>(mask_col->data_w());
 
     size_t n_row_chunks = std::max(dt->nrows / 100, size_t(1));

--- a/c/frame/to_numpy.cc
+++ b/c/frame/to_numpy.cc
@@ -122,7 +122,7 @@ oobj Frame::to_numpy(const PKArgs& args) {
     size_t i0 = one_col? force_col : 0;
 
     size_t dtsize = ncols * dt->nrows;
-    OColumn mask_col(Column::new_data_column(SType::BOOL, dtsize));
+    OColumn mask_col = OColumn(Column::new_data_column(SType::BOOL, dtsize));
     int8_t* mask_data = static_cast<int8_t*>(mask_col->data_w());
 
     size_t n_row_chunks = std::max(dt->nrows / 100, size_t(1));

--- a/c/jay/open_jay.cc
+++ b/c/jay/open_jay.cc
@@ -142,7 +142,7 @@ static OColumn column_from_jay(
     MemoryRange strbuf = extract_buffer(jaybuf, jcol->strdata());
     col = new_string_column(nrows, std::move(databuf), std::move(strbuf));
   } else {
-    col = OColumn(Column::new_mbuf_column(stype, std::move(databuf)));
+    col = OColumn::new_mbuf_column(stype, std::move(databuf));
   }
 
   Stats* stats = col->get_stats();

--- a/c/jay/open_jay.cc
+++ b/c/jay/open_jay.cc
@@ -14,7 +14,7 @@
 
 
 // Helper functions
-static Column* column_from_jay(size_t nrows,
+static OColumn column_from_jay(size_t nrows,
                                const jay::Column* jaycol,
                                const MemoryRange& jaybuf);
 
@@ -76,12 +76,12 @@ DataTable* open_jay_from_mbuf(const MemoryRange& mbuf)
   columns.reserve(ncols);
   size_t i = 0;
   for (const jay::Column* jcol : *msg_columns) {
-    Column* col = column_from_jay(nrows, jcol, mbuf);
-    if (col->nrows != nrows) {
-      throw IOError() << "Length of column " << i << " is " << col->nrows
+    OColumn col = column_from_jay(nrows, jcol, mbuf);
+    if (col.nrows() != nrows) {
+      throw IOError() << "Length of column " << i << " is " << col.nrows()
           << ", however the Frame contains " << nrows << " rows";
     }
-    columns.emplace_back(col);
+    columns.push_back(std::move(col));
     colnames.push_back(jcol->name()->str());
     ++i;
   }
@@ -118,7 +118,7 @@ static void initStats(Stats* stats, const jay::Column* jcol) {
 }
 
 
-static Column* column_from_jay(
+static OColumn column_from_jay(
     size_t nrows, const jay::Column* jcol, const MemoryRange& jaybuf)
 {
   jay::Type jtype = jcol->type();
@@ -136,13 +136,13 @@ static Column* column_from_jay(
     case jay::Type_Str64:   stype = SType::STR64; break;
   }
 
-  Column* col = nullptr;
+  OColumn col;
   MemoryRange databuf = extract_buffer(jaybuf, jcol->data());
   if (stype == SType::STR32 || stype == SType::STR64) {
     MemoryRange strbuf = extract_buffer(jaybuf, jcol->strdata());
     col = new_string_column(nrows, std::move(databuf), std::move(strbuf));
   } else {
-    col = Column::new_mbuf_column(stype, std::move(databuf));
+    col = OColumn(Column::new_mbuf_column(stype, std::move(databuf)));
   }
 
   Stats* stats = col->get_stats();

--- a/c/models/aggregator.cc
+++ b/c/models/aggregator.cc
@@ -234,7 +234,7 @@ void Aggregator<T>::aggregate(DataTable* dt_in,
   dt = dt_in;
   bool was_sampled = false;
 
-  OColumn col0(Column::new_data_column(SType::INT32, dt->nrows));
+  OColumn col0 = OColumn(Column::new_data_column(SType::INT32, dt->nrows));
   dt_members = dtptr(new DataTable({std::move(col0)}, {"exemplar_id"}));
 
   if (dt->nrows >= min_rows) {
@@ -400,9 +400,11 @@ void Aggregator<T>::aggregate_exemplars(bool was_sampled) {
   arr32_t exemplar_indices(n_exemplars);
 
   // Setting up a table for counts
-  Column* col = Column::new_data_column(SType::INT32, n_exemplars);
-  dtptr dt_counts = dtptr(new DataTable({OColumn(col)}, {"members_count"}));
-  auto d_counts = static_cast<int32_t*>(col->data_w());
+  auto dt_counts = dtptr(new DataTable(
+      {OColumn(Column::new_data_column(SType::INT32, n_exemplars))},
+      {"members_count"}
+  ));
+  auto d_counts = static_cast<int32_t*>(dt_counts->get_ocolumn(0)->data_w());
   std::memset(d_counts, 0, n_exemplars * sizeof(int32_t));
 
   // Setting up exemplar indices and counts

--- a/c/models/aggregator.cc
+++ b/c/models/aggregator.cc
@@ -234,7 +234,7 @@ void Aggregator<T>::aggregate(DataTable* dt_in,
   dt = dt_in;
   bool was_sampled = false;
 
-  OColumn col0 = OColumn(Column::new_data_column(SType::INT32, dt->nrows));
+  OColumn col0 = OColumn::new_data_column(SType::INT32, dt->nrows);
   dt_members = dtptr(new DataTable({std::move(col0)}, {"exemplar_id"}));
 
   if (dt->nrows >= min_rows) {
@@ -401,7 +401,7 @@ void Aggregator<T>::aggregate_exemplars(bool was_sampled) {
 
   // Setting up a table for counts
   auto dt_counts = dtptr(new DataTable(
-      {OColumn(Column::new_data_column(SType::INT32, n_exemplars))},
+      {OColumn::new_data_column(SType::INT32, n_exemplars)},
       {"members_count"}
   ));
   auto d_counts = static_cast<int32_t*>(dt_counts->get_ocolumn(0)->data_w());

--- a/c/models/dt_ftrl.cc
+++ b/c/models/dt_ftrl.cc
@@ -772,8 +772,9 @@ void Ftrl<T>::create_model() {
 
   colvec cols;
   cols.reserve(ncols);
+  constexpr SType stype = sizeof(T) == 4? SType::FLOAT32 : SType::FLOAT64;
   for (size_t i = 0; i < ncols; ++i) {
-    cols.emplace_back(new RealColumn<T>(nbins));
+    cols.push_back(OColumn::new_data_column(stype, nbins));
   }
   dt_model = dtptr(new DataTable(std::move(cols), DataTable::default_names));
   init_model();
@@ -807,7 +808,8 @@ void Ftrl<T>::adjust_model() {
   //   cols_new[1] = dt_model->get_ocolumn(1);
   // } else
   {
-    OColumn col(new RealColumn<T>(nbins));
+    constexpr SType stype = sizeof(T) == 4? SType::FLOAT32 : SType::FLOAT64;
+    OColumn col = OColumn::new_data_column(stype, nbins);
     auto data = static_cast<T*>(col->data_w());
     std::memset(data, 0, nbins * sizeof(T));
     newcol0 = col;
@@ -849,8 +851,9 @@ dtptr Ftrl<T>::create_p(size_t nrows) {
 
   colvec cols;
   cols.reserve(nlabels);
+  constexpr SType stype = sizeof(T) == 4? SType::FLOAT32 : SType::FLOAT64;
   for (size_t i = 0; i < nlabels; ++i) {
-    cols.emplace_back(new RealColumn<T>(nrows));
+    cols.push_back(OColumn::new_data_column(stype, nrows));
   }
 
   // dtptr dt_p = dtptr(new DataTable(std::move(cols), labels));
@@ -933,7 +936,8 @@ void Ftrl<T>::create_fi() {
   sb.order();
   sb.commit_and_start_new_chunk(nfeatures);
 
-  OColumn c_fi_values(new RealColumn<T>(nfeatures));
+  constexpr SType stype = sizeof(T) == 4? SType::FLOAT32 : SType::FLOAT64;
+  OColumn c_fi_values = OColumn::new_data_column(stype, nfeatures);
   dt_fi = dtptr(new DataTable({std::move(c_fi_names).to_ocolumn(), std::move(c_fi_values)},
                               {"feature_name", "feature_importance"})
                              );

--- a/c/models/kfold.cc
+++ b/c/models/kfold.cc
@@ -161,7 +161,7 @@ static oobj kfold(const PKArgs& args) {
     int64_t b1 = ii*n/k;
     int64_t b2 = (ii+1)*n/k;
     size_t colsize = static_cast<size_t>(b1 + n - b2);
-    OColumn col = OColumn(Column::new_data_column(SType::INT32, colsize));
+    OColumn col = OColumn::new_data_column(SType::INT32, colsize);
     DataTable* dt = new DataTable({std::move(col)}, DataTable::default_names);
     data.push_back(static_cast<int32_t*>(dt->get_ocolumn(0)->data_w()));
 
@@ -332,8 +332,8 @@ static oobj kfold_random(const PKArgs& args) {
   olist res(nsplits);
   for (size_t x = 0; x < nsplits; ++x) {
     size_t fold_size = (x + 1) * nrows / nsplits - x * nrows / nsplits;
-    OColumn col1 = OColumn(Column::new_data_column(S, nrows - fold_size));
-    OColumn col2 = OColumn(Column::new_data_column(S, fold_size));
+    OColumn col1 = OColumn::new_data_column(S, nrows - fold_size);
+    OColumn col2 = OColumn::new_data_column(S, fold_size);
     DataTable* dt1 = new DataTable({std::move(col1)}, DataTable::default_names);
     DataTable* dt2 = new DataTable({std::move(col2)}, DataTable::default_names);
     oobj train = Frame::oframe(dt1);

--- a/c/models/kfold.cc
+++ b/c/models/kfold.cc
@@ -161,7 +161,7 @@ static oobj kfold(const PKArgs& args) {
     int64_t b1 = ii*n/k;
     int64_t b2 = (ii+1)*n/k;
     size_t colsize = static_cast<size_t>(b1 + n - b2);
-    OColumn col{ Column::new_data_column(SType::INT32, colsize) };
+    OColumn col = OColumn(Column::new_data_column(SType::INT32, colsize));
     DataTable* dt = new DataTable({std::move(col)}, DataTable::default_names);
     data.push_back(static_cast<int32_t*>(dt->get_ocolumn(0)->data_w()));
 
@@ -332,8 +332,8 @@ static oobj kfold_random(const PKArgs& args) {
   olist res(nsplits);
   for (size_t x = 0; x < nsplits; ++x) {
     size_t fold_size = (x + 1) * nrows / nsplits - x * nrows / nsplits;
-    OColumn col1{ Column::new_data_column(S, nrows - fold_size) };
-    OColumn col2{ Column::new_data_column(S, fold_size) };
+    OColumn col1 = OColumn(Column::new_data_column(S, nrows - fold_size));
+    OColumn col2 = OColumn(Column::new_data_column(S, fold_size));
     DataTable* dt1 = new DataTable({std::move(col1)}, DataTable::default_names);
     DataTable* dt2 = new DataTable({std::move(col2)}, DataTable::default_names);
     oobj train = Frame::oframe(dt1);

--- a/c/models/label_encode.cc
+++ b/c/models/label_encode.cc
@@ -80,8 +80,8 @@ static void label_encode_bool(const OColumn& col, dtptr& dt_labels, dtptr& dt_en
   if (col.na_count() == col.nrows()) return;
 
   // Set up boolean labels and their corresponding ids.
-  OColumn ids_col(new BoolColumn(2));
-  OColumn labels_col(new BoolColumn(2));
+  OColumn ids_col = OColumn::new_data_column(SType::BOOL, 2);
+  OColumn labels_col = OColumn::new_data_column(SType::BOOL, 2);
   auto ids_data = static_cast<int8_t*>(ids_col->data_w());
   auto labels_data = static_cast<int8_t*>(labels_col->data_w());
   ids_data[0] = 0;

--- a/c/models/label_encode.h
+++ b/c/models/label_encode.h
@@ -35,8 +35,8 @@ void label_encode(const OColumn&, dtptr&, dtptr&, bool is_binomial = false);
 template <SType stype_from, SType stype_to>
 dtptr create_dt_labels_fw(const std::unordered_map<element_t<stype_from>, element_t<stype_to>>& labels_map) {
   size_t nlabels = labels_map.size();
-  OColumn labels_col = OColumn(Column::new_data_column(stype_from, nlabels));
-  OColumn ids_col = OColumn(Column::new_data_column(stype_to, nlabels));
+  OColumn labels_col = OColumn::new_data_column(stype_from, nlabels);
+  OColumn ids_col = OColumn::new_data_column(stype_to, nlabels);
 
   auto labels_data = static_cast<element_t<stype_from>*>(labels_col->data_w());
   auto ids_data = static_cast<element_t<stype_to>*>(ids_col->data_w());
@@ -57,7 +57,7 @@ dtptr create_dt_labels_fw(const std::unordered_map<element_t<stype_from>, elemen
 template <typename T, SType stype_to>
 dtptr create_dt_labels_str(const std::unordered_map<std::string, element_t<stype_to>>& labels_map) {
   size_t nlabels = labels_map.size();
-  OColumn ids_col = OColumn(Column::new_data_column(stype_to, nlabels));
+  OColumn ids_col = OColumn::new_data_column(stype_to, nlabels);
   auto ids_data = static_cast<element_t<stype_to>*>(ids_col->data_w());
   dt::writable_string_col c_label_names(nlabels);
   dt::writable_string_col::buffer_impl<T> sb(c_label_names);
@@ -102,7 +102,7 @@ void label_encode_fw(const OColumn& ocol, dtptr& dt_labels, dtptr& dt_encoded) {
   const size_t nrows = ocol.nrows();
   const RowIndex& ri = col->rowindex();
 
-  OColumn outcol = OColumn(Column::new_data_column(stype_to, nrows));
+  OColumn outcol = OColumn::new_data_column(stype_to, nrows);
   auto outdata = static_cast<T_to*>(outcol->data_w());
   std::unordered_map<T_from, T_to> labels_map;
   dt::shared_mutex shmutex;
@@ -159,7 +159,7 @@ void label_encode_str(const OColumn& ocol, dtptr& dt_labels, dtptr& dt_encoded) 
   const Column* col = ocol.get();
   const size_t nrows = ocol.nrows();
   const RowIndex& ri = col->rowindex();
-  OColumn outcol = OColumn(Column::new_data_column(stype_to, nrows));
+  OColumn outcol = OColumn::new_data_column(stype_to, nrows);
   auto outdata = static_cast<T_to*>(outcol->data_w());
   std::unordered_map<std::string, T_to> labels_map;
   dt::shared_mutex shmutex;

--- a/c/models/label_encode.h
+++ b/c/models/label_encode.h
@@ -35,8 +35,8 @@ void label_encode(const OColumn&, dtptr&, dtptr&, bool is_binomial = false);
 template <SType stype_from, SType stype_to>
 dtptr create_dt_labels_fw(const std::unordered_map<element_t<stype_from>, element_t<stype_to>>& labels_map) {
   size_t nlabels = labels_map.size();
-  OColumn labels_col(Column::new_data_column(stype_from, nlabels));
-  OColumn ids_col(Column::new_data_column(stype_to, nlabels));
+  OColumn labels_col = OColumn(Column::new_data_column(stype_from, nlabels));
+  OColumn ids_col = OColumn(Column::new_data_column(stype_to, nlabels));
 
   auto labels_data = static_cast<element_t<stype_from>*>(labels_col->data_w());
   auto ids_data = static_cast<element_t<stype_to>*>(ids_col->data_w());
@@ -57,7 +57,7 @@ dtptr create_dt_labels_fw(const std::unordered_map<element_t<stype_from>, elemen
 template <typename T, SType stype_to>
 dtptr create_dt_labels_str(const std::unordered_map<std::string, element_t<stype_to>>& labels_map) {
   size_t nlabels = labels_map.size();
-  OColumn ids_col(Column::new_data_column(stype_to, nlabels));
+  OColumn ids_col = OColumn(Column::new_data_column(stype_to, nlabels));
   auto ids_data = static_cast<element_t<stype_to>*>(ids_col->data_w());
   dt::writable_string_col c_label_names(nlabels);
   dt::writable_string_col::buffer_impl<T> sb(c_label_names);
@@ -102,7 +102,7 @@ void label_encode_fw(const OColumn& ocol, dtptr& dt_labels, dtptr& dt_encoded) {
   const size_t nrows = ocol.nrows();
   const RowIndex& ri = col->rowindex();
 
-  OColumn outcol(Column::new_data_column(stype_to, nrows));
+  OColumn outcol = OColumn(Column::new_data_column(stype_to, nrows));
   auto outdata = static_cast<T_to*>(outcol->data_w());
   std::unordered_map<T_from, T_to> labels_map;
   dt::shared_mutex shmutex;
@@ -159,7 +159,7 @@ void label_encode_str(const OColumn& ocol, dtptr& dt_labels, dtptr& dt_encoded) 
   const Column* col = ocol.get();
   const size_t nrows = ocol.nrows();
   const RowIndex& ri = col->rowindex();
-  OColumn outcol(Column::new_data_column(stype_to, nrows));
+  OColumn outcol = OColumn(Column::new_data_column(stype_to, nrows));
   auto outdata = static_cast<T_to*>(outcol->data_w());
   std::unordered_map<std::string, T_to> labels_map;
   dt::shared_mutex shmutex;

--- a/c/py_buffers.cc
+++ b/c/py_buffers.cc
@@ -415,10 +415,6 @@ void py::Frame::m__getbuffer__(Py_buffer* view, int flags) {
 
   // Construct the data buffer
   for (size_t i = 0; i < ncols; ++i) {
-    // either a shallow copy, or "materialized" column
-    // Column* col = dt->columns[i + i0]->shallowcopy();
-    // col->materialize();
-
     // xmb becomes a "view" on a portion of the buffer `mbuf`. An
     // ExternalMemBuf object is documented to be readonly; however in
     // practice it can still be written to, just not resized (this is

--- a/c/py_buffers.cc
+++ b/c/py_buffers.cc
@@ -27,7 +27,7 @@ namespace pybuffers {
 static void try_to_resolve_object_column(OColumn& col);
 static SType stype_from_format(const char *format, int64_t itemsize);
 static const char* format_from_stype(SType stype);
-static Column* convert_fwchararray_to_column(Py_buffer* view);
+static OColumn convert_fwchararray_to_column(Py_buffer* view);
 
 #define REQ_ND(flags)       ((flags & PyBUF_ND) == PyBUF_ND)
 #define REQ_FORMAT(flags)   ((flags & PyBUF_FORMAT) == PyBUF_FORMAT)
@@ -94,7 +94,7 @@ OColumn OColumn::from_buffer(const py::robj& pyobj)
 
   OColumn res;
   if (stype == SType::STR32) {
-    res = OColumn(convert_fwchararray_to_column(view));
+    res = convert_fwchararray_to_column(view);
   } else if (view->strides == nullptr) {
     Column* col = Column::new_column(stype);
     col->nrows = nrows;
@@ -136,7 +136,7 @@ OColumn OColumn::from_buffer(const py::robj& pyobj)
 }
 
 
-static Column* convert_fwchararray_to_column(Py_buffer* view)
+static OColumn convert_fwchararray_to_column(Py_buffer* view)
 {
   // Number of characters in each element
   size_t k = static_cast<size_t>(view->itemsize / 4);
@@ -246,7 +246,7 @@ static void try_to_resolve_object_column(OColumn& col)
 
     xassert(offset < strbuf.size());
     strbuf.resize(offset);
-    col = OColumn(new_string_column(nrows, std::move(offbuf), std::move(strbuf)));
+    col = new_string_column(nrows, std::move(offbuf), std::move(strbuf));
   }
 }
 

--- a/c/py_buffers.cc
+++ b/c/py_buffers.cc
@@ -101,7 +101,7 @@ OColumn OColumn::from_buffer(const py::robj& pyobj)
     col->init_xbuf(pview.release());
     res = OColumn(col);
   } else {
-    res = OColumn(Column::new_data_column(stype, nrows));
+    res = OColumn::new_data_column(stype, nrows);
     size_t stride = static_cast<size_t>(view->strides[0] / view->itemsize);
     if (view->itemsize == 8) {
       int64_t* out = static_cast<int64_t*>(res->data_w());

--- a/c/py_buffers.cc
+++ b/c/py_buffers.cc
@@ -46,7 +46,7 @@ static char strB[] = "B";
 // Construct a Column from a python object implementing Buffers protocol
 //------------------------------------------------------------------------------
 
-Column* Column::from_buffer(const py::robj& pyobj)
+OColumn OColumn::from_buffer(const py::robj& pyobj)
 {
   auto pview = std::unique_ptr<Py_buffer>(new Py_buffer());
   Py_buffer* view = pview.get();
@@ -56,11 +56,11 @@ Column* Column::from_buffer(const py::robj& pyobj)
     auto dtype = pyobj.get_attr("dtype");
     auto kind = dtype.get_attr("kind").to_string();
     if (kind == "M" || kind == "m") {
-      return Column::from_buffer(pyobj.invoke("astype", "(s)", "str"));
+      return from_buffer(pyobj.invoke("astype", "(s)", "str"));
     }
     auto fmt = dtype.get_attr("char").to_string();
     if (kind == "f" && fmt == "e") {  // float16
-      return Column::from_buffer(pyobj.invoke("astype", "(s)", "float32"));
+      return from_buffer(pyobj.invoke("astype", "(s)", "float32"));
     }
   }
 
@@ -129,7 +129,7 @@ Column* Column::from_buffer(const py::robj& pyobj)
   if (res->_stype == SType::OBJ) {
     res = try_to_resolve_object_column(res);
   }
-  return res;
+  return OColumn(res);
 }
 
 

--- a/c/py_buffers.cc
+++ b/c/py_buffers.cc
@@ -210,7 +210,7 @@ static void try_to_resolve_object_column(OColumn& col)
       PyObject* v = data[i];
       out[i] = v == Py_True? 1 : v == Py_False? 0 : GETNA<int8_t>();
     }
-    col = OColumn(new BoolColumn(nrows, std::move(mbuf)));
+    col = OColumn::new_mbuf_column(SType::BOOL, std::move(mbuf));
   }
 
   // All values were strings

--- a/c/set_funcs.cc
+++ b/c/set_funcs.cc
@@ -109,7 +109,7 @@ static sort_result sort_columns(ccolvec&& cv) {
     res.column = std::move(cv.columns[0]);
     res.column.materialize();
   } else {
-    res.column = OColumn(new VoidColumn(0));
+    res.column = OColumn::new_data_column(SType::VOID, 0);
     res.column.rbind(cv.columns);
   }
   res.ri = res.column->sort(&res.gb);

--- a/c/str/split_into_nhot.cc
+++ b/c/str/split_into_nhot.cc
@@ -165,11 +165,11 @@ DataTable* split_into_nhot(const OColumn& col, char sep,
               lock.exclusive_start();
               if (colsmap.count(s) == 0) {
                 colsmap[s] = outcols.size();
-                BoolColumn* newcol = new BoolColumn(nrows);
-                int8_t* data = newcol->elements_w();
+                auto newcol = OColumn::new_data_column(SType::BOOL, nrows);
+                int8_t* data = static_cast<int8_t*>(newcol->data_w());
                 std::memset(data, 0, nrows);
                 data[irow] = 1;
-                outcols.emplace_back(newcol);
+                outcols.push_back(std::move(newcol));
                 outdata.push_back(data);
                 outnames.push_back(s);
               } else {

--- a/c/wstringcol.cc
+++ b/c/wstringcol.cc
@@ -50,7 +50,7 @@ OColumn writable_string_col::to_ocolumn() && {
   } else {
     offdata.set_element<uint32_t>(0, 0);
   }
-  return OColumn(new_string_column(n, std::move(offdata), std::move(strbuf)));
+  return new_string_column(n, std::move(offdata), std::move(strbuf));
 }
 
 


### PR DESCRIPTION
This PR moves all factory methods from Column class into OColumn, several unused or rarely used methods removed. Most methods that were taking or returning Column* arguments, now use OColumns.

WIP for #1396 