### PR TITLE
Further transitioning towards OColumn class

### DIFF
--- a/c/column.cc
+++ b/c/column.cc
@@ -301,13 +301,6 @@ void OColumn::materialize() {
   pcol->materialize();
 }
 
-OColumn OColumn::cast(SType stype) const {
-  return OColumn(pcol->cast(stype));
-}
-
-OColumn OColumn::cast(SType stype, MemoryRange&& mem) const {
-  return OColumn(pcol->cast(stype, std::move(mem)));
-}
 
 
 

--- a/c/column.cc
+++ b/c/column.cc
@@ -105,7 +105,7 @@ bool Column::get_element(size_t, CString*) const {
     << "Cannot retrieve string values from a column of type " << _stype;
 }
 
-bool Column::get_element(size_t, py::oobj*) const {
+bool Column::get_element(size_t, py::robj*) const {
   throw NotImplError()
     << "Cannot retrieve object values from a column of type " << _stype;
 }
@@ -232,7 +232,7 @@ bool OColumn::is_fixedwidth() const noexcept {
 }
 
 bool OColumn::is_virtual() const noexcept {
-  return bool(pcol->rowindex());
+  return bool(pcol->ri);
 }
 
 size_t OColumn::elemsize() const noexcept {
@@ -253,7 +253,7 @@ bool OColumn::get_element(size_t i, int64_t*  out) const { return pcol->get_elem
 bool OColumn::get_element(size_t i, float*    out) const { return pcol->get_element(i, out); }
 bool OColumn::get_element(size_t i, double*   out) const { return pcol->get_element(i, out); }
 bool OColumn::get_element(size_t i, CString*  out) const { return pcol->get_element(i, out); }
-bool OColumn::get_element(size_t i, py::oobj* out) const { return pcol->get_element(i, out); }
+bool OColumn::get_element(size_t i, py::robj* out) const { return pcol->get_element(i, out); }
 
 
 static inline py::oobj wrap(int32_t x) { return py::oint(x); }
@@ -261,7 +261,7 @@ static inline py::oobj wrap(int64_t x) { return py::oint(x); }
 static inline py::oobj wrap(float x) { return py::ofloat(x); }
 static inline py::oobj wrap(double x) { return py::ofloat(x); }
 static inline py::oobj wrap(const CString& x) { return py::ostring(x); }
-static inline py::oobj wrap(const py::oobj& x) { return x; }
+static inline py::oobj wrap(const py::robj& x) { return py::oobj(x); }
 
 template <typename T>
 static inline py::oobj getelem(const OColumn& col, size_t i) {
@@ -285,7 +285,7 @@ py::oobj OColumn::get_element_as_pyobject(size_t i) const {
     case SType::FLOAT64: return getelem<double>(*this, i);
     case SType::STR32:
     case SType::STR64:   return getelem<CString>(*this, i);
-    case SType::OBJ:     return getelem<py::oobj>(*this, i);
+    case SType::OBJ:     return getelem<py::robj>(*this, i);
     default:
       throw NotImplError() << "Unable to convert elements of stype "
           << stype() << " into python objects";

--- a/c/column.h
+++ b/c/column.h
@@ -166,7 +166,7 @@ public:
   virtual bool get_element(size_t i, float* out) const;
   virtual bool get_element(size_t i, double* out) const;
   virtual bool get_element(size_t i, CString* out) const;
-  virtual bool get_element(size_t i, py::oobj* out) const;
+  virtual bool get_element(size_t i, py::robj* out) const;
 
   const RowIndex& rowindex() const noexcept { return ri; }
   RowIndex remove_rowindex();
@@ -416,7 +416,7 @@ class OColumn
     bool get_element(size_t i, float* out) const;
     bool get_element(size_t i, double* out) const;
     bool get_element(size_t i, CString* out) const;
-    bool get_element(size_t i, py::oobj* out) const;
+    bool get_element(size_t i, py::robj* out) const;
 
     // `get_element_as_pyobject(i)` returns the i-th element of the column
     // wrapped into a pyobject of the appropriate type. Use this function
@@ -601,7 +601,7 @@ public:
   PyObjectColumn(size_t nrows, MemoryRange&&);
   PyObjectStats* get_stats() const override;
 
-  bool get_element(size_t i, py::oobj* out) const override;
+  bool get_element(size_t i, py::robj* out) const override;
 
 protected:
 

--- a/c/column.h
+++ b/c/column.h
@@ -228,8 +228,6 @@ public:
    * creation of the resulting column (the Column will assume ownership of the
    * provided MemoryRange).
    */
-  OColumn cast(SType stype) const;
-  OColumn cast(SType stype, MemoryRange&& mr) const;
 
   /**
    * Replace values at positions given by the RowIndex `replace_at` with

--- a/c/column.h
+++ b/c/column.h
@@ -647,7 +647,7 @@ public:
 
   Column* shallowcopy() const override;
   void replace_values(RowIndex at, const OColumn& with) override;
-  StringStats<T>* get_stats() const override;
+  StringStats* get_stats() const override;
 
   void verify_integrity(const std::string& name) const override;
 

--- a/c/column.h
+++ b/c/column.h
@@ -82,20 +82,20 @@ template <> struct _elt<SType::OBJ>     { using t = PyObject*; };
 template <SType s>
 using element_t = typename _elt<s>::t;
 
-template <SType s> struct _gelt {};
-template <> struct _gelt<SType::BOOL>    { using t = int32_t; };
-template <> struct _gelt<SType::INT8>    { using t = int32_t; };
-template <> struct _gelt<SType::INT16>   { using t = int32_t; };
-template <> struct _gelt<SType::INT32>   { using t = int32_t; };
-template <> struct _gelt<SType::INT64>   { using t = int64_t; };
-template <> struct _gelt<SType::FLOAT32> { using t = float; };
-template <> struct _gelt<SType::FLOAT64> { using t = double; };
-template <> struct _gelt<SType::STR32>   { using t = CString; };
-template <> struct _gelt<SType::STR64>   { using t = CString; };
-template <> struct _gelt<SType::OBJ>     { using t = PyObject*; };
+template <typename T> struct _promote { using t = T; };
+template <> struct _promote<int8_t>  { using t = int32_t; };
+template <> struct _promote<int16_t> { using t = int32_t; };
+
+template <typename T>
+using promote = typename _promote<T>::t;
 
 template <SType s>
-using getelement_t = typename _gelt<s>::t;
+using getelement_t = promote<element_t<s>>;
+
+template <typename T>
+static inline T downcast(promote<T> v) {
+  return ISNA<promote<T>>(v)? GETNA<T>() : static_cast<T>(v);
+}
 
 
 
@@ -529,7 +529,7 @@ public:
   double kurt() const;
   int64_t min_int64() const override;
   int64_t max_int64() const override;
-  IntegerStats<T>* get_stats() const override;
+  IntegerStats<promote<T>>* get_stats() const override;
 
   bool get_element(size_t i, int32_t* out) const override;
   bool get_element(size_t i, int64_t* out) const override;

--- a/c/column_bool.cc
+++ b/c/column_bool.cc
@@ -39,9 +39,9 @@ BooleanStats* BoolColumn::get_stats() const {
   return static_cast<BooleanStats*>(stats);
 }
 
-int8_t  BoolColumn::min() const  { return get_stats()->min(this); }
-int8_t  BoolColumn::max() const  { return get_stats()->max(this); }
-int8_t  BoolColumn::mode() const { return get_stats()->mode(this); }
+int8_t  BoolColumn::min() const  { return downcast<int8_t>(get_stats()->min(this)); }
+int8_t  BoolColumn::max() const  { return downcast<int8_t>(get_stats()->max(this)); }
+int8_t  BoolColumn::mode() const { return downcast<int8_t>(get_stats()->mode(this)); }
 int64_t BoolColumn::sum() const  { return get_stats()->sum(this); }
 double  BoolColumn::mean() const { return get_stats()->mean(this); }
 double  BoolColumn::sd() const   { return get_stats()->stdev(this); }

--- a/c/column_from_pylist.cc
+++ b/c/column_from_pylist.cc
@@ -613,7 +613,7 @@ OColumn OColumn::from_range(
     case SType::INT64: return _make_range_column<int64_t>(start, length, step, stype);
     default: {
       OColumn col = _make_range_column<int64_t>(start, length, step, SType::INT64);
-      return col->cast(stype);
+      return col.cast(stype);
     }
   }
 }

--- a/c/column_fw.cc
+++ b/c/column_fw.cc
@@ -212,7 +212,7 @@ void FwColumn<T>::replace_values(
   }
   OColumn with = (replace_with.stype() == _stype)
                     ? replace_with  // copy
-                    : replace_with->cast(_stype);
+                    : replace_with.cast(_stype);
 
   if (with.nrows() == 1) {
     auto rcol = dynamic_cast<const FwColumn<T>*>(with.get());

--- a/c/column_int.cc
+++ b/c/column_int.cc
@@ -54,14 +54,14 @@ bool IntColumn<T>::get_element(size_t i, int64_t* out) const {
 //------------------------------------------------------------------------------
 
 template <typename T>
-IntegerStats<T>* IntColumn<T>::get_stats() const {
-  if (stats == nullptr) stats = new IntegerStats<T>();
-  return static_cast<IntegerStats<T>*>(stats);
+IntegerStats<promote<T>>* IntColumn<T>::get_stats() const {
+  if (stats == nullptr) stats = new IntegerStats<promote<T>>();
+  return static_cast<IntegerStats<promote<T>>*>(stats);
 }
 
-template <typename T> T       IntColumn<T>::min() const  { return get_stats()->min(this); }
-template <typename T> T       IntColumn<T>::max() const  { return get_stats()->max(this); }
-template <typename T> T       IntColumn<T>::mode() const { return get_stats()->mode(this); }
+template <typename T> T       IntColumn<T>::min() const  { return downcast<T>(get_stats()->min(this)); }
+template <typename T> T       IntColumn<T>::max() const  { return downcast<T>(get_stats()->max(this)); }
+template <typename T> T       IntColumn<T>::mode() const { return downcast<T>(get_stats()->mode(this)); }
 template <typename T> int64_t IntColumn<T>::sum() const  { return get_stats()->sum(this); }
 template <typename T> double  IntColumn<T>::mean() const { return get_stats()->mean(this); }
 template <typename T> double  IntColumn<T>::sd() const   { return get_stats()->stdev(this); }

--- a/c/column_pyobj.cc
+++ b/c/column_pyobj.cc
@@ -31,7 +31,7 @@ PyObjectColumn::PyObjectColumn(size_t nrows_, MemoryRange&& mb)
 
 
 
-bool PyObjectColumn::get_element(size_t i, py::oobj* out) const {
+bool PyObjectColumn::get_element(size_t i, py::robj* out) const {
   size_t j = (this->ri)[i];
   if (j == RowIndex::NA) return true;
   PyObject* x = this->elements_r()[j];

--- a/c/column_string.cc
+++ b/c/column_string.cc
@@ -536,9 +536,9 @@ void StringColumn<T>::fill_na_mask(int8_t* outmask, size_t row0, size_t row1) {
 //------------------------------------------------------------------------------
 
 template <typename T>
-StringStats<T>* StringColumn<T>::get_stats() const {
-  if (stats == nullptr) stats = new StringStats<T>();
-  return static_cast<StringStats<T>*>(stats);
+StringStats* StringColumn<T>::get_stats() const {
+  if (stats == nullptr) stats = new StringStats();
+  return static_cast<StringStats*>(stats);
 }
 
 template <typename T>

--- a/c/column_string.cc
+++ b/c/column_string.cc
@@ -277,7 +277,7 @@ void StringColumn<T>::replace_values(
   OColumn with;
   if (replace_with) {
     with = replace_with;  // copy
-    if (with.stype() != _stype) with = with->cast(_stype);
+    if (with.stype() != _stype) with = with.cast(_stype);
   }
   // This could be nullptr too
   auto repl_col = static_cast<const StringColumn<T>*>(with.get());

--- a/c/expr/expr_cast.cc
+++ b/c/expr/expr_cast.cc
@@ -47,7 +47,7 @@ GroupbyMode expr_cast::get_groupby_mode(const workframe& wf) const {
 
 OColumn expr_cast::evaluate_eager(workframe& wf) {
   auto arg_col = arg->evaluate_eager(wf);
-  return OColumn(arg_col->cast(stype));
+  return arg_col.cast(stype);
 }
 
 

--- a/c/expr/expr_unaryop.cc
+++ b/c/expr/expr_unaryop.cc
@@ -262,7 +262,7 @@ OColumn expr_unaryop::evaluate_eager(workframe& wf) {
   auto input_stype = input_column.stype();
   const auto& ui = unary_library.get_infox(opcode, input_stype);
   if (ui.cast_stype != SType::VOID) {
-    input_column = OColumn(input_column->cast(ui.cast_stype));
+    input_column = input_column.cast(ui.cast_stype);
   }
   if (ui.vectorfn == nullptr) {
     return input_column;

--- a/c/frame/cast.cc
+++ b/c/frame/cast.cc
@@ -555,13 +555,13 @@ void py::DatatableModule::init_casts()
 
 
 //------------------------------------------------------------------------------
-// Column (base methods)
+// OColumn (base methods)
 //------------------------------------------------------------------------------
 
-OColumn Column::cast(SType new_stype) const {
-  return cast(new_stype, MemoryRange());
+OColumn OColumn::cast(SType stype) const {
+  return casts.execute(pcol, MemoryRange(), stype);
 }
 
-OColumn Column::cast(SType new_stype, MemoryRange&& mr) const {
-  return casts.execute(this, std::move(mr), new_stype);
+OColumn OColumn::cast(SType stype, MemoryRange&& mem) const {
+  return casts.execute(pcol, std::move(mem), stype);
 }

--- a/c/frame/rbind.cc
+++ b/c/frame/rbind.cc
@@ -361,7 +361,7 @@ void StringColumn<T>::rbind_impl(colvec& columns, size_t new_nrows,
     OColumn& col = columns[i];
     if (col.stype() == SType::VOID) continue;
     if (col.stype() != _stype) {
-      col = OColumn(col->cast(_stype));
+      col = col.cast(_stype);
     }
     // TODO: replace with datasize(). But: what if col is not a string?
     new_strbuf_size += static_cast<const StringColumn<T>*>(col.get())->strbuf.size();
@@ -453,7 +453,7 @@ void FwColumn<T>::rbind_impl(colvec& columns, size_t new_nrows, bool col_empty)
         rows_to_fill = 0;
       }
       if (col.stype() != _stype) {
-        col = col->cast(_stype);
+        col = col.cast(_stype);
       }
       std::memcpy(resptr, col->data(), col->alloc_size());
       resptr += col->alloc_size();
@@ -492,10 +492,10 @@ void PyObjectColumn::rbind_impl(
   }
   for (auto& col : columns) {
     if (col.stype() == SType::VOID) {
-      dest_data += col->nrows;
+      dest_data += col.nrows();
     } else {
       if (col.stype() != SType::OBJ) {
-        col = col->cast(_stype);
+        col = col.cast(_stype);
       }
       auto src_data = static_cast<PyObject* const*>(col->data());
       for (size_t i = 0; i < col.nrows(); ++i) {

--- a/c/frame/stats.cc
+++ b/c/frame/stats.cc
@@ -76,37 +76,37 @@ static oobj _naval(const OColumn&) {
 template <typename T>
 static OColumn _mincol_num(Stats* stats, const OColumn& col) {
   return _make_column(col.stype(),
-                      static_cast<NumericalStats<T>*>(stats)->min(col.get()));
+                      downcast<T>(static_cast<NumericalStats<promote<T>>*>(stats)->min(col.get())));
 }
 
 template <typename T>
 static OColumn _maxcol_num(Stats* stats, const OColumn& col) {
   return _make_column(col.stype(),
-                      static_cast<NumericalStats<T>*>(stats)->max(col.get()));
+                      downcast<T>(static_cast<NumericalStats<promote<T>>*>(stats)->max(col.get())));
 }
 
 template <typename T>
 static OColumn _sumcol_num(Stats* stats, const OColumn& col) {
   return _make_column(std::is_integral<T>::value? SType::INT64 : SType::FLOAT64,
-                      static_cast<NumericalStats<T>*>(stats)->sum(col.get()));
+                      static_cast<NumericalStats<promote<T>>*>(stats)->sum(col.get()));
 }
 
 template <typename T>
 static OColumn _meancol_num(Stats* stats, const OColumn& col) {
   return _make_column(SType::FLOAT64,
-                      static_cast<NumericalStats<T>*>(stats)->mean(col.get()));
+                      static_cast<NumericalStats<promote<T>>*>(stats)->mean(col.get()));
 }
 
 template <typename T>
 static OColumn _sdcol_num(Stats* stats, const OColumn& col) {
   return _make_column(SType::FLOAT64,
-                      static_cast<NumericalStats<T>*>(stats)->stdev(col.get()));
+                      static_cast<NumericalStats<promote<T>>*>(stats)->stdev(col.get()));
 }
 
 template <typename T>
 static OColumn _modecol_num(Stats* stats, const OColumn& col) {
   return _make_column(col.stype(),
-                      static_cast<NumericalStats<T>*>(stats)->mode(col.get()));
+                      downcast<T>(static_cast<NumericalStats<promote<T>>*>(stats)->mode(col.get())));
 }
 
 template <typename T>

--- a/c/frame/stats.cc
+++ b/c/frame/stats.cc
@@ -111,7 +111,7 @@ static OColumn _modecol_num(Stats* stats, const OColumn& col) {
 
 template <typename T>
 static OColumn _modecol_str(Stats* stats, const OColumn& col) {
-  return _make_column_str<T>(static_cast<StringStats<T>*>(stats)->mode(col.get()));
+  return _make_column_str<T>(static_cast<StringStats*>(stats)->mode(col.get()));
 }
 
 static OColumn _countnacol(Stats* stats, const OColumn& col) {
@@ -154,8 +154,7 @@ static inline oobj pyvalue_real(void* ptr) {
 
 static inline oobj pyvalue_str(void* ptr) {
   CString& x = *reinterpret_cast<CString*>(ptr);
-  return x.size >= 0? ostring(x.ch, static_cast<size_t>(x.size))
-                    : None();
+  return x.isna()? None() : ostring(x);
 }
 
 template <SType s> oobj pyvalue(void* ptr);

--- a/c/jay/open_jay.cc
+++ b/c/jay/open_jay.cc
@@ -108,7 +108,7 @@ static MemoryRange extract_buffer(
 
 template <typename T, typename JStats>
 static void initStats(Stats* stats, const jay::Column* jcol) {
-  auto tstats = static_cast<NumericalStats<T>*>(stats);
+  auto tstats = static_cast<NumericalStats<promote<T>>*>(stats);
   auto jstats = static_cast<const JStats*>(jcol->stats());
   if (jstats) {
     tstats->set_countna(jcol->nullcount());

--- a/c/jay/save_jay.cc
+++ b/c/jay/save_jay.cc
@@ -203,8 +203,9 @@ static flatbuffers::Offset<void> saveStats(
   if (!stats ||
       !(stats->is_computed(Stat::Min) && stats->is_computed(Stat::Max)))
     return 0;
-  auto nstat = static_cast<NumericalStats<T>*>(stats);
-  StatBuilder ss(nstat->min(nullptr), nstat->max(nullptr));
+  auto nstat = static_cast<NumericalStats<promote<T>>*>(stats);
+  StatBuilder ss(downcast<T>(nstat->min(nullptr)),
+                 downcast<T>(nstat->max(nullptr)));
   flatbuffers::Offset<void> o = fbb.CreateStruct(ss).Union();
   return o;
 }

--- a/c/models/dt_ftrl.cc
+++ b/c/models/dt_ftrl.cc
@@ -834,19 +834,15 @@ dtptr Ftrl<T>::create_p(size_t nrows) {
   size_t nlabels = dt_labels->nrows;
   xassert(nlabels > 0);
 
-  OColumn col0_str64 = dt_labels->get_ocolumn(0)->cast(SType::STR64);
-  auto scol = static_cast<StringColumn<uint64_t>*>(const_cast<Column*>(col0_str64.get()));
-  const uint64_t* offsets = scol->offsets();
-  const char* strdata = scol->strdata();
+  OColumn col0_str64 = dt_labels->get_ocolumn(0).cast(SType::STR64);
 
   strvec labels_vec(nlabels);
 
   for (size_t i = 0; i < nlabels; ++i) {
-    const uint64_t strstart = offsets[i - 1] & ~GETNA<uint64_t>();
-    const char* c_str = strdata + strstart;
-    auto len = offsets[i] - strstart;
-    std::string str(c_str, len);
-    labels_vec[i] = std::move(str);
+    CString value;
+    bool isna = col0_str64.get_element(i, &value);
+    labels_vec[i] = isna? std::string()
+                        : std::string(value.ch, static_cast<size_t>(value.size));
   }
 
   colvec cols;

--- a/c/rowindex_array.cc
+++ b/c/rowindex_array.cc
@@ -169,13 +169,13 @@ ArrayRowIndexImpl::ArrayRowIndexImpl(const OColumn& col) {
   ascending = false;
   switch (col.stype()) {
     case SType::BOOL:
-      init_from_boolean_column(static_cast<const BoolColumn*>(col.get()));
+      init_from_boolean_column(col);
       break;
     case SType::INT8:
     case SType::INT16:
     case SType::INT32:
     case SType::INT64:
-      init_from_integer_column(col.get());
+      init_from_integer_column(col);
       break;
     default:
       throw ValueError() << "Column is not of boolean or integer type";
@@ -251,46 +251,49 @@ void ArrayRowIndexImpl::_set_min_max() {
 }
 
 
-void ArrayRowIndexImpl::init_from_boolean_column(const BoolColumn* col) {
-  const int8_t* tdata = col->elements_r();
-  length = static_cast<size_t>(col->sum());  // total # of 1s in the column
+void ArrayRowIndexImpl::init_from_boolean_column(const OColumn& col) {
+  xassert(col.stype() == SType::BOOL);
+  length = static_cast<size_t>(reinterpret_cast<const BoolColumn*>(col.get())->sum());  // total # of 1s in the column
 
   if (length == 0) {
     // no need to do anything: the data arrays already have 0 length
     type = RowIndexType::ARR32;
     return;
   }
-  if (length <= INT32_MAX && col->nrows <= INT32_MAX) {
+  int32_t value;
+  if (length <= INT32_MAX && col.nrows() <= INT32_MAX) {
     type = RowIndexType::ARR32;
     _resize_data();
     auto ind32 = static_cast<int32_t*>(data);
     size_t k = 0;
-    col->rowindex().iterate(0, col->nrows, 1,
-      [&](size_t, size_t j) {
-        if (tdata[j] == 1)
-          ind32[k++] = static_cast<int32_t>(j);
-      });
+    for (size_t i = 0; i < col.nrows(); ++i) {
+      bool isna = col.get_element(i, &value);
+      if (value && !isna) {
+        ind32[k++] = static_cast<int32_t>(i);
+      }
+    }
   } else {
     type = RowIndexType::ARR64;
     _resize_data();
     auto ind64 = static_cast<int64_t*>(data);
     size_t k = 0;
-    col->rowindex().iterate(0, col->nrows, 1,
-      [&](size_t, size_t j) {
-        if (tdata[j] == 1)
-          ind64[k++] = static_cast<int64_t>(j);
-      });
+    for (size_t i = 0; i < col.nrows(); ++i) {
+      bool isna = col.get_element(i, &value);
+      if (value && !isna) {
+        ind64[k++] = static_cast<int64_t>(i);
+      }
+    }
   }
   ascending = true;
   set_min_max();
 }
 
 
-void ArrayRowIndexImpl::init_from_integer_column(const Column* col) {
-  if (col->countna()) {
+void ArrayRowIndexImpl::init_from_integer_column(const OColumn& col) {
+  if (col.na_count()) {
     throw ValueError() << "RowIndex source column contains NA values.";
   }
-  if (col->nrows == 0) {
+  if (col.nrows() == 0) {
     min = max = RowIndex::NA;
   } else {
     int64_t imin = col->min_int64();
@@ -301,10 +304,10 @@ void ArrayRowIndexImpl::init_from_integer_column(const Column* col) {
     min = static_cast<size_t>(imin);
     max = static_cast<size_t>(imax);
   }
-  Column* col2 = col->shallowcopy();
-  col2->materialize();  // noop if col has no rowindex
+  OColumn col2 = col;  // copy
+  col2.materialize();
 
-  length = col->nrows;
+  length = col.nrows();
   if (length <= INT32_MAX && max <= INT32_MAX) {
     type = RowIndexType::ARR32;
     _resize_data();
@@ -314,16 +317,14 @@ void ArrayRowIndexImpl::init_from_integer_column(const Column* col) {
     // the column is destructed.
     MemoryRange xbuf = MemoryRange::external(data, length * sizeof(int32_t));
     xassert(xbuf.is_writable());
-    auto col3 = col2->cast(SType::INT32, std::move(xbuf));
+    auto col3 = col2.cast(SType::INT32, std::move(xbuf));
   } else {
     type = RowIndexType::ARR64;
     _resize_data();
     MemoryRange xbuf = MemoryRange::external(data, length * sizeof(int64_t));
     xassert(xbuf.is_writable());
-    auto col3 = col2->cast(SType::INT64, std::move(xbuf));
+    auto col3 = col2.cast(SType::INT64, std::move(xbuf));
   }
-
-  delete col2;
 }
 
 

--- a/c/rowindex_impl.h
+++ b/c/rowindex_impl.h
@@ -164,8 +164,8 @@ class ArrayRowIndexImpl : public RowIndexImpl {
     template <typename T> void _set_min_max();
 
     // Helpers for `ArrayRowIndexImpl(Column*)`
-    void init_from_boolean_column(const BoolColumn* col);
-    void init_from_integer_column(const Column* col);
+    void init_from_boolean_column(const OColumn& col);
+    void init_from_integer_column(const OColumn& col);
     void compactify();
 
     // Helper for `negate()`

--- a/c/stats.h
+++ b/c/stats.h
@@ -190,7 +190,7 @@ extern template class NumericalStats_<double, double>;
 template <typename T>
 class RealStats : public NumericalStats_<T, double> {
   protected:
-    virtual RealStats<T>* make() const override;
+    Stats* make() const override;
     void compute_numerical_stats(const Column*) override;
 };
 
@@ -209,7 +209,7 @@ extern template class RealStats<double>;
 template <typename T>
 class IntegerStats : public NumericalStats_<T, int64_t> {
   protected:
-    virtual IntegerStats<T>* make() const override;
+    Stats* make() const override;
 };
 
 extern template class IntegerStats<int32_t>;
@@ -228,7 +228,7 @@ extern template class IntegerStats<int64_t>;
  */
 class BooleanStats : public NumericalStats_<int32_t, int64_t> {
   protected:
-    virtual BooleanStats* make() const override;
+    Stats* make() const override;
     void compute_numerical_stats(const Column *col) override;
     void compute_sorted_stats(const Column*) override;
 };
@@ -243,7 +243,6 @@ class BooleanStats : public NumericalStats_<int32_t, int64_t> {
  * Stats for variable string columns. Uses a template type `T` to define the
  * integer type that is used to represent its offsets.
  */
-template <typename T>
 class StringStats : public Stats {
   private:
     CString _mode;
@@ -254,14 +253,12 @@ class StringStats : public Stats {
     CString mode(const Column*);
 
   protected:
-    StringStats<T>* make() const override;
+    Stats* make() const override;
     void compute_countna(const Column*) override;
     void compute_nunique(const Column*) override;
     void compute_sorted_stats(const Column*) override;
 };
 
-extern template class StringStats<uint32_t>;
-extern template class StringStats<uint64_t>;
 
 
 
@@ -274,7 +271,7 @@ class PyObjectStats : public Stats {
     virtual size_t memory_footprint() const override { return sizeof(*this); }
 
   protected:
-    PyObjectStats* make() const override;
+    Stats* make() const override;
     void compute_countna(const Column*) override;
     void compute_sorted_stats(const Column*) override;
 };

--- a/c/stats.h
+++ b/c/stats.h
@@ -173,8 +173,6 @@ template <> struct _A_from_T<double> { double value; };
 template <typename T>
 using NumericalStats = NumericalStats_<T, decltype(_A_from_T<T>::value)>;
 
-extern template class NumericalStats_<int8_t, int64_t>;
-extern template class NumericalStats_<int16_t, int64_t>;
 extern template class NumericalStats_<int32_t, int64_t>;
 extern template class NumericalStats_<int64_t, int64_t>;
 extern template class NumericalStats_<float, double>;
@@ -190,7 +188,7 @@ extern template class NumericalStats_<double, double>;
  * Child of NumericalStats that represents real-valued columns.
  */
 template <typename T>
-class RealStats : public NumericalStats<T> {
+class RealStats : public NumericalStats_<T, double> {
   protected:
     virtual RealStats<T>* make() const override;
     void compute_numerical_stats(const Column*) override;
@@ -209,13 +207,11 @@ extern template class RealStats<double>;
  * Child of NumericalStats that represents integer-valued columns.
  */
 template <typename T>
-class IntegerStats : public NumericalStats<T> {
+class IntegerStats : public NumericalStats_<T, int64_t> {
   protected:
     virtual IntegerStats<T>* make() const override;
 };
 
-extern template class IntegerStats<int8_t>;
-extern template class IntegerStats<int16_t>;
 extern template class IntegerStats<int32_t>;
 extern template class IntegerStats<int64_t>;
 
@@ -230,7 +226,7 @@ extern template class IntegerStats<int64_t>;
  * stype is treated as if it was `int8_t`, some optimizations can be achieved
  * if we know that the set of possible element values is {0, 1, NA}.
  */
-class BooleanStats : public NumericalStats<int8_t> {
+class BooleanStats : public NumericalStats_<int32_t, int64_t> {
   protected:
     virtual BooleanStats* make() const override;
     void compute_numerical_stats(const Column *col) override;


### PR DESCRIPTION
- Stats calculations now use OColumn::get_element(...) API;
- Reduced number of Stats classes;
- Column::cast() method moved to OColumn class;
- In Ftrl, create_p() method now uses get_element() API;
- Two methods in ArrayRowIndexImpl has been switched to OColumns.

WIP for #1396 