### PR TITLE
Replace stype with ltype check for validation target column

### DIFF
--- a/c/models/dt_ftrl.h
+++ b/c/models/dt_ftrl.h
@@ -83,7 +83,7 @@ class Ftrl : public dt::FtrlBase {
     const DataTable* dt_X_val;
     const DataTable* dt_y_val;
 
-    // Other temporary parameters that needed for validation.
+    // Other temporary parameters needed for validation.
     T nepochs_val;
     T val_error;
     size_t val_niters;
@@ -99,12 +99,13 @@ class Ftrl : public dt::FtrlBase {
     FtrlFitOutput fit_binomial();
     FtrlFitOutput fit_multinomial();
     template <typename U> FtrlFitOutput fit_regression();
-    template <typename U> FtrlFitOutput fit(T(*)(T), U(*)(U, size_t), T(*)(T, U));
+    template <typename U, typename V>
+    FtrlFitOutput fit(T(*)(T), U(*)(U, size_t), V(*)(V, size_t), T(*)(T, V));
     template <typename U>
     void update(const uint64ptr&, const tptr<T>&, T, U, size_t);
-    template <typename>
 
     // Predicting methods
+    template <typename>
     dtptr predict(const DataTable*);
     template <typename F> T predict_row(const uint64ptr&, tptr<T>&, size_t, F);
     dtptr create_p(size_t);

--- a/c/models/py_ftrl.cc
+++ b/c/models/py_ftrl.cc
@@ -332,13 +332,13 @@ oobj Ftrl::fit(const PKArgs& args) {
     }
 
 
-    SType stype = dt_y->get_ocolumn(0).stype();
-    SType stype_val = dt_y_val->get_ocolumn(0).stype();
+    LType ltype = dt_y->get_ocolumn(0).ltype();
+    LType ltype_val = dt_y_val->get_ocolumn(0).ltype();
 
-    if (info(stype).ltype() != info(stype_val).ltype()) {
+    if (ltype != ltype_val) {
       throw TypeError() << "Training and validation target columns must have "
-                        << "the same ltype, got: `" << info(stype).ltype_name()
-                        << "` and `" << info(stype_val).ltype_name() << "`";
+                        << "the same ltype, got: `" << info::ltype_name(ltype)
+                        << "` and `" << info::ltype_name(ltype_val) << "`";
     }
 
     if (dt_X_val->nrows != dt_y_val->nrows) {

--- a/c/models/py_ftrl.cc
+++ b/c/models/py_ftrl.cc
@@ -331,9 +331,14 @@ oobj Ftrl::fit(const PKArgs& args) {
                          << "one column";
     }
 
-    if (dt_y_val->get_ocolumn(0).stype() != dt_y->get_ocolumn(0).stype()) {
-      throw ValueError() << "Validation target frame must have the same "
-                            "stype as the target frame";
+
+    SType stype = dt_y->get_ocolumn(0).stype();
+    SType stype_val = dt_y_val->get_ocolumn(0).stype();
+
+    if (info(stype).ltype() != info(stype_val).ltype()) {
+      throw TypeError() << "Validation and training target columns must have "
+                         << "the same ltype, got: `" << info(stype_val).ltype_name()
+                         << "` and `" << info(stype).ltype_name() << "`";
     }
 
     if (dt_X_val->nrows != dt_y_val->nrows) {

--- a/c/models/py_ftrl.cc
+++ b/c/models/py_ftrl.cc
@@ -336,9 +336,9 @@ oobj Ftrl::fit(const PKArgs& args) {
     SType stype_val = dt_y_val->get_ocolumn(0).stype();
 
     if (info(stype).ltype() != info(stype_val).ltype()) {
-      throw TypeError() << "Validation and training target columns must have "
-                         << "the same ltype, got: `" << info(stype_val).ltype_name()
-                         << "` and `" << info(stype).ltype_name() << "`";
+      throw TypeError() << "Training and validation target columns must have "
+                        << "the same ltype, got: `" << info(stype).ltype_name()
+                        << "` and `" << info(stype_val).ltype_name() << "`";
     }
 
     if (dt_X_val->nrows != dt_y_val->nrows) {

--- a/c/types.cc
+++ b/c/types.cc
@@ -317,8 +317,7 @@ LType info::ltype() const {
   return stype_info[stype].ltype;
 }
 
-const char* info::ltype_name() const {
-  LType lt = ltype();
+const char* info::ltype_name(LType lt) {
   switch (lt) {
     case LType::MU:       return "void";
     case LType::BOOL:     return "bool";
@@ -330,6 +329,11 @@ const char* info::ltype_name() const {
     case LType::OBJECT:   return "obj";
   }
   throw RuntimeError() << "Unknown ltype " << int(lt); // LCOV_EXCL_LINE
+}
+
+const char* info::ltype_name() const {
+  LType lt = ltype();
+  return ltype_name(lt);
 }
 
 py::oobj info::py_ltype() const {

--- a/c/types.h
+++ b/c/types.h
@@ -336,6 +336,7 @@ class info {
   public:
     info(SType s);
     const char* name() const;
+    static const char* ltype_name(LType);
     const char* ltype_name() const;
     size_t elemsize() const;
     bool is_varwidth() const;

--- a/c/utils/exceptions.cc
+++ b/c/utils/exceptions.cc
@@ -146,6 +146,11 @@ Error& Error::operator<<(SType stype) {
   return *this;
 }
 
+Error& Error::operator<<(LType ltype) {
+  error << info::ltype_name(ltype);
+  return *this;
+}
+
 Error& Error::operator<<(char c) {
   uint8_t uc = static_cast<uint8_t>(c);
   if (uc < 0x20 || uc >= 0x80) {

--- a/c/utils/exceptions.h
+++ b/c/utils/exceptions.h
@@ -51,6 +51,7 @@ public:
   Error& operator<<(float);
   Error& operator<<(double);
   Error& operator<<(SType);
+  Error& operator<<(LType);
   Error& operator<<(const CErrno&);
   Error& operator<<(const py::_obj&);
   Error& operator<<(const py::ostring&);

--- a/tests/models/test_ftrl.py
+++ b/tests/models/test_ftrl.py
@@ -1090,6 +1090,27 @@ def test_ftrl_no_early_stopping():
     assert math.isnan(res.loss) == False
 
 
+def test_ftrl_early_stopping_different_stypes():
+    nepochs = 10000
+    nepochs_validation = 5
+    nbins = 10
+    ft = Ftrl(alpha = 0.5, nbins = nbins, nepochs = nepochs)
+    r = range(ft.nbins)
+    df_X = dt.Frame(r)
+    df_y = dt.Frame(r) # int32 stype
+    df_y_val = dt.Frame(list(r)) # int8 stype
+
+    res = ft.fit(df_X, df_y, df_X, df_y_val,
+                 nepochs_validation = nepochs_validation
+                 )
+    p = ft.predict(df_X)
+    delta = [abs(i - j) for i, j in zip(p.to_list()[0], list(r))]
+    assert res.epoch < nepochs
+    assert res.loss < epsilon
+    assert int(res.epoch) % nepochs_validation == 0
+    assert max(delta) < epsilon
+
+
 @pytest.mark.parametrize('validation_average_niterations', [1,5,10])
 def test_ftrl_early_stopping_int(validation_average_niterations):
     nepochs = 10000

--- a/tests/models/test_ftrl.py
+++ b/tests/models/test_ftrl.py
@@ -1022,6 +1022,24 @@ def test_ftrl_regression_fit():
 # Test early stopping
 #-------------------------------------------------------------------------------
 
+def test_ftrl_wrong_validation_target_type():
+    nepochs = 1234
+    nepochs_validation = 56
+    nbins = 78
+    ft = Ftrl(alpha = 0.5, nbins = nbins, nepochs = nepochs)
+    r = range(ft.nbins)
+    df_X = dt.Frame(r)
+    df_y = dt.Frame(r)
+    df_X_val = df_X
+    df_y_val = dt.Frame(["Some string data" for _ in r])
+
+    with pytest.raises(TypeError) as e:
+        res = ft.fit(df_X, df_y, df_X_val, df_y_val,
+                     nepochs_validation = 0)
+    assert ("Validation and training target columns must have the same ltype, "
+            "got: `str` and `int`" == str(e.value))
+
+
 def test_ftrl_wrong_validation_parameters():
     nepochs = 1234
     nepochs_validation = 56

--- a/tests/models/test_ftrl.py
+++ b/tests/models/test_ftrl.py
@@ -1036,8 +1036,8 @@ def test_ftrl_wrong_validation_target_type():
     with pytest.raises(TypeError) as e:
         res = ft.fit(df_X, df_y, df_X_val, df_y_val,
                      nepochs_validation = 0)
-    assert ("Validation and training target columns must have the same ltype, "
-            "got: `str` and `int`" == str(e.value))
+    assert ("Training and validation target columns must have the same ltype, "
+            "got: `int` and `str`" == str(e.value))
 
 
 def test_ftrl_wrong_validation_parameters():


### PR DESCRIPTION
- allow training and validation target columns to have different `stype`s, their `ltype`s must be identical though. Addresses https://github.com/h2oai/h2oai/issues/10593#issuecomment-522372576
- minor improvement of `LType`'s handling. 