### PR TITLE
Remove OColumn.get() method

### DIFF
--- a/c/api.cc
+++ b/c/api.cc
@@ -122,9 +122,9 @@ const char* DtFrame_ColumnStringDataR(PyObject* pydt, size_t i) {
   auto dt = _extract_dt(pydt);
   if (_column_index_oob(dt, i)) return nullptr;
   try {
-    const OColumn& col = dt->get_ocolumn(i);
+    OColumn& col = dt->get_ocolumn(i);
     if (col.ltype() == LType::STRING) {
-      return static_cast<const char*>(col.secondary_data());
+      return static_cast<const char*>(col.get_data_readonly(1));
     }
   } catch (const std::exception& e) {
     exception_to_python(e);

--- a/c/column.cc
+++ b/c/column.cc
@@ -3,7 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
-// © H2O.ai 2018
+// © H2O.ai 2018-2019
 //------------------------------------------------------------------------------
 #include <cstdlib>     // atoll
 #include "python/_all.h"
@@ -246,18 +246,11 @@ bool OColumn::get_element(size_t i, CString*  out) const { return pcol->get_elem
 bool OColumn::get_element(size_t i, py::robj* out) const { return pcol->get_element(i, out); }
 
 
-static inline py::oobj wrap(int32_t x) { return py::oint(x); }
-static inline py::oobj wrap(int64_t x) { return py::oint(x); }
-static inline py::oobj wrap(float x) { return py::ofloat(x); }
-static inline py::oobj wrap(double x) { return py::ofloat(x); }
-static inline py::oobj wrap(const CString& x) { return py::ostring(x); }
-static inline py::oobj wrap(const py::robj& x) { return py::oobj(x); }
-
 template <typename T>
 static inline py::oobj getelem(const OColumn& col, size_t i) {
   T x;
   bool r = col.get_element(i, &x);
-  return r? py::None() : wrap(x);
+  return r? py::None() : py::oobj::wrap(x);
 }
 
 py::oobj OColumn::get_element_as_pyobject(size_t i) const {
@@ -286,6 +279,9 @@ py::oobj OColumn::get_element_as_pyobject(size_t i) const {
 
 
 
+//------------------------------------------------------------------------------
+// OColumn : manipulation
+//------------------------------------------------------------------------------
 
 void OColumn::materialize() {
   pcol->materialize();

--- a/c/column.cc
+++ b/c/column.cc
@@ -223,14 +223,6 @@ OColumn::operator bool() const noexcept {
   return (pcol != nullptr);
 }
 
-const void* OColumn::secondary_data() const noexcept {
-  return pcol->data2();
-}
-
-size_t OColumn::secondary_size() const noexcept {
-  return pcol->data2_size();
-}
-
 
 
 
@@ -276,6 +268,22 @@ py::oobj OColumn::get_element_as_pyobject(size_t i) const {
 }
 
 
+const void* OColumn::get_data_readonly(size_t i) {
+  if (is_virtual()) pcol->materialize();
+  return i == 0 ? pcol->mbuf.rptr()
+                : pcol->data2();
+}
+
+void* OColumn::get_data_editable() {
+  if (is_virtual()) pcol->materialize();
+  return pcol->mbuf.wptr();
+}
+
+size_t OColumn::get_data_size(size_t i) {
+  if (is_virtual()) pcol->materialize();
+  return i == 0 ? pcol->mbuf.size()
+                : pcol->data2_size();
+}
 
 
 

--- a/c/column.h
+++ b/c/column.h
@@ -422,6 +422,10 @@ class OColumn
     //
     py::oobj get_element_as_pyobject(size_t i) const;
 
+    const void* get_data_readonly(size_t i = 0);
+    void* get_data_editable(size_t i = 0);
+    size_t get_data_size(size_t i = 0);
+
     const void* data_r() const { return pcol->mbuf.rptr(); }
     const void* data_with_nas_r() const { return pcol->mbuf.rptr(); }
 

--- a/c/column.h
+++ b/c/column.h
@@ -381,9 +381,6 @@ class OColumn
 
     operator bool() const noexcept;
 
-    // TEMP accessors to the underlying implementation
-    const Column* get() const { return pcol; }
-
     Column* operator->();
     const Column* operator->() const;
 

--- a/c/column.h
+++ b/c/column.h
@@ -419,11 +419,20 @@ class OColumn
     //
     py::oobj get_element_as_pyobject(size_t i) const;
 
+    // Access to the underlying column's data. If the column is virtual,
+    // it will be materialized first. The index `i` allows access to
+    // additional data buffers, depending on the column's type.
+    //
+    // For example, for string columns `get_data_readonly(0)` returns the
+    // array of 'start' offsets, while `get_data_readonly(1)` returns the
+    // raw character buffer.
+    //
+    // These methods are not marked const, because they may cause the
+    // column to become materialized.
+    //
     const void* get_data_readonly(size_t i = 0);
     void* get_data_editable();
     size_t get_data_size(size_t i = 0);
-
-    const void* data_r() const { return pcol->mbuf.rptr(); }
 
 
   //------------------------------------

--- a/c/column.h
+++ b/c/column.h
@@ -381,9 +381,6 @@ class OColumn
 
     operator bool() const noexcept;
 
-    const void* secondary_data() const noexcept;
-    size_t secondary_size() const noexcept;
-
     // TEMP accessors to the underlying implementation
     const Column* get() const { return pcol; }
 
@@ -423,11 +420,10 @@ class OColumn
     py::oobj get_element_as_pyobject(size_t i) const;
 
     const void* get_data_readonly(size_t i = 0);
-    void* get_data_editable(size_t i = 0);
+    void* get_data_editable();
     size_t get_data_size(size_t i = 0);
 
     const void* data_r() const { return pcol->mbuf.rptr(); }
-    const void* data_with_nas_r() const { return pcol->mbuf.rptr(); }
 
 
   //------------------------------------

--- a/c/frame/rbind.cc
+++ b/c/frame/rbind.cc
@@ -363,7 +363,7 @@ void StringColumn<T>::rbind_impl(colvec& columns, size_t new_nrows,
     if (col.stype() != _stype) {
       col = col.cast(_stype);
     }
-    new_strbuf_size += col.secondary_size();
+    new_strbuf_size += col.get_data_size(1);
   }
   size_t new_mbuf_size = sizeof(T) * (new_nrows + 1);
 

--- a/c/jay/save_jay.cc
+++ b/c/jay/save_jay.cc
@@ -3,7 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
-// © H2O.ai 2018
+// © H2O.ai 2018-2019
 //------------------------------------------------------------------------------
 #include "frame/py_frame.h"
 #include "jay/jay_generated.h"
@@ -17,9 +17,9 @@
 using WritableBufferPtr = std::unique_ptr<WritableBuffer>;
 static jay::Type stype_to_jaytype[DT_STYPES_COUNT];
 static flatbuffers::Offset<jay::Column> column_to_jay(
-    const OColumn& col, const std::string& name,
+    OColumn& col, const std::string& name,
     flatbuffers::FlatBufferBuilder& fbb, WritableBuffer* wb);
-static jay::Buffer saveMemoryRange(const MemoryRange*, WritableBuffer*);
+static jay::Buffer saveMemoryRange(const void*, size_t, WritableBuffer*);
 template <typename T, typename StatBuilder>
 static flatbuffers::Offset<void> saveStats(
     Stats* stats, flatbuffers::FlatBufferBuilder& fbb);
@@ -63,7 +63,7 @@ void DataTable::save_jay_impl(WritableBuffer* wb) {
 
   std::vector<flatbuffers::Offset<jay::Column>> msg_columns;
   for (size_t i = 0; i < ncols; ++i) {
-    const OColumn& col = get_ocolumn(i);
+    OColumn& col = get_ocolumn(i);
     if (col.stype() == SType::OBJ) {
       DatatableWarning() << "Column `" << names[i]
           << "` of type obj64 was not saved";
@@ -101,7 +101,7 @@ void DataTable::save_jay_impl(WritableBuffer* wb) {
 //------------------------------------------------------------------------------
 
 static flatbuffers::Offset<jay::Column> column_to_jay(
-    const OColumn& col,
+    OColumn& col,
     const std::string& name,
     flatbuffers::FlatBufferBuilder& fbb,
     WritableBuffer* wb)
@@ -148,24 +148,19 @@ static flatbuffers::Offset<jay::Column> column_to_jay(
   cbb.add_name(sname);
   cbb.add_nullcount(col.na_count());
 
-  MemoryRange mbuf = col->data_buf();  // shallow copy of col's `mbuf`
-  jay::Buffer saved_mbuf = saveMemoryRange(&mbuf, wb);
+  const void* data = col.get_data_readonly();
+  size_t size = col.get_data_size();
+  jay::Buffer saved_mbuf = saveMemoryRange(data, size, wb);
   cbb.add_data(&saved_mbuf);
   if (jsttype != jay::Stats_NONE) {
     cbb.add_stats_type(jsttype);
     cbb.add_stats(jsto);
   }
 
-  if (col.stype() == SType::STR32) {
-    auto scol = static_cast<const StringColumn<uint32_t>*>(col.get());
-    MemoryRange sbuf = scol->str_buf();
-    jay::Buffer saved_strbuf = saveMemoryRange(&sbuf, wb);
-    cbb.add_strdata(&saved_strbuf);
-  }
-  if (col.stype() == SType::STR64) {
-    auto scol = static_cast<const StringColumn<uint64_t>*>(col.get());
-    MemoryRange sbuf = scol->str_buf();
-    jay::Buffer saved_strbuf = saveMemoryRange(&sbuf, wb);
+  if (col.ltype() == LType::STRING) {
+    data = col.get_data_readonly(1);
+    size = col.get_data_size(1);
+    jay::Buffer saved_strbuf = saveMemoryRange(data, size, wb);
     cbb.add_strdata(&saved_strbuf);
   }
 
@@ -179,11 +174,8 @@ static flatbuffers::Offset<jay::Column> column_to_jay(
 //------------------------------------------------------------------------------
 
 static jay::Buffer saveMemoryRange(
-    const MemoryRange* mbuf, WritableBuffer* wb)
+    const void* data, size_t len, WritableBuffer* wb)
 {
-  if (!mbuf) return jay::Buffer();
-  size_t len = mbuf->size();
-  const void* data = mbuf->rptr();
   size_t pos = wb->prep_write(len, data);
   wb->write_at(pos, len, data);
   xassert(pos >= 8);
@@ -191,9 +183,9 @@ static jay::Buffer saveMemoryRange(
     uint64_t zero = 0;
     wb->write(8 - (len & 7), &zero);
   }
-
   return jay::Buffer(pos - 8, len);
 }
+
 
 
 template <typename T, typename StatBuilder>

--- a/c/jay/save_jay.cc
+++ b/c/jay/save_jay.cc
@@ -101,7 +101,9 @@ void DataTable::save_jay_impl(WritableBuffer* wb) {
 //------------------------------------------------------------------------------
 
 static flatbuffers::Offset<jay::Column> column_to_jay(
-    const OColumn& col, const std::string& name, flatbuffers::FlatBufferBuilder& fbb,
+    const OColumn& col,
+    const std::string& name,
+    flatbuffers::FlatBufferBuilder& fbb,
     WritableBuffer* wb)
 {
   jay::Stats jsttype = jay::Stats_NONE;
@@ -146,7 +148,7 @@ static flatbuffers::Offset<jay::Column> column_to_jay(
   cbb.add_name(sname);
   cbb.add_nullcount(col.na_count());
 
-  MemoryRange mbuf = col->data_buf();  // shallow copt of col's `mbuf`
+  MemoryRange mbuf = col->data_buf();  // shallow copy of col's `mbuf`
   jay::Buffer saved_mbuf = saveMemoryRange(&mbuf, wb);
   cbb.add_data(&saved_mbuf);
   if (jsttype != jay::Stats_NONE) {

--- a/c/python/obj.cc
+++ b/c/python/obj.cc
@@ -154,6 +154,7 @@ oobj oobj::wrap(size_t v)  { return py::oint(v); }
 oobj oobj::wrap(float v)   { return py::ofloat(v); }
 oobj oobj::wrap(double v)  { return py::ofloat(v); }
 oobj oobj::wrap(const CString& v) { return py::ostring(v); }
+oobj oobj::wrap(const robj& v) { return py::oobj(v); }
 
 
 

--- a/c/python/obj.h
+++ b/c/python/obj.h
@@ -318,6 +318,7 @@ class oobj : public _obj {
     static oobj wrap(float v);
     static oobj wrap(double v);
     static oobj wrap(const CString& v);
+    static oobj wrap(const py::robj& v);
 };
 
 

--- a/tests/munging/test_rbind.py
+++ b/tests/munging/test_rbind.py
@@ -306,6 +306,7 @@ def test_rbind_views2():
     dtr = dt.Frame({"A": [1, 5, 7, 3], "B": ["one", "two", None, "omega"]})
     assert_equals(dt1, dtr)
 
+
 def test_rbind_views3():
     # view + view
     dt0 = dt.Frame({"A": [129, 4, 73, 86],
@@ -318,6 +319,16 @@ def test_rbind_views3():
     dtr = dt.Frame({"A": [129, 73, -9, 365],
                     "B": ["eenie", "meenie", "miney", "mo"]})
     assert_equals(dt0, dtr)
+
+
+def test_rbind_view4():
+    DT = dt.Frame(A=list('abcdefghijklmnop'))
+    DTempty = dt.Frame(A=[])
+    DTempty.nrows = 2
+    assert_equals(dt.rbind(DT[:3, :], DT[:-4:-1, :]),
+                  dt.Frame(A=list('abcpon')))
+    assert_equals(dt.rbind(DT[2:4, :], DTempty, DT[2:5, :]),
+                  dt.Frame(A=['c', 'd', None, None, 'c', 'd', 'e']))
 
 
 def test_rbind_different_stypes1():
@@ -388,6 +399,15 @@ def test_rbind_different_stypes4():
     ]
 
 
+def test_rbind_str32_str64():
+    DT1 = dt.Frame(A=list('abcd'), stype=dt.str32)
+    DT2 = dt.Frame(A=list('efghij'), stype=dt.str64)
+    DT3 = dt.Frame(A=list('klm'), stype=dt.str32)
+    DTR = dt.rbind(DT1, DT2, DT3)
+    # It would be better if the result was str32
+    assert_equals(DTR, dt.Frame(A=list('abcdefghijklm'), stype=dt.str64))
+
+
 def test_rbind_all_stypes():
     sources = {
         dt.bool8: [True, False, True, None, False, None],
@@ -426,6 +446,12 @@ def test_rbind_modulefn():
     frame_integrity_check(f3)
     assert f3.to_list()[0] == f0.to_list()[0] + f1.to_list()[0]
 
+
+
+
+#-------------------------------------------------------------------------------
+# Issues
+#-------------------------------------------------------------------------------
 
 def test_issue1292():
     f0 = dt.Frame([None, None, None, "foo"])


### PR DESCRIPTION
The `.get()` method was used to provide access to the underlying implementation.
With this method removed, the implementation part is now properly encapsulated, which is a major step forward towards #1396.

WIP for #1396 