### PR TITLE
Remove deprecated Frame methods scalar(), append() and save()

### DIFF
--- a/c/frame/py_frame.cc
+++ b/c/frame/py_frame.cc
@@ -266,7 +266,7 @@ static PKArgs args___init__(1, 0, 3, false, true,
                             "__init__", nullptr);
 
 void Frame::impl_init_type(XTypeMaker& xt) {
-  xt.set_class_name("datatable.core.Frame");
+  xt.set_class_name("datatable.Frame");
   xt.set_class_doc(
     "Two-dimensional column-oriented table of data. Each column has its own\n"
     "name and type. Types may vary across columns but cannot vary within\n"
@@ -283,6 +283,7 @@ void Frame::impl_init_type(XTypeMaker& xt) {
   xt.add(METHOD__GETITEM__(&Frame::m__getitem__));
   xt.add(METHOD__SETITEM__(&Frame::m__setitem__));
   xt.add(BUFFERS(&Frame::m__getbuffer__, &Frame::m__releasebuffer__));
+  Frame_Type = reinterpret_cast<PyObject*>(&Frame::type);
 
   _init_cbind(xt);
   _init_key(xt);

--- a/datatable/__init__.py
+++ b/datatable/__init__.py
@@ -75,6 +75,3 @@ str32 = stype.str32
 str64 = stype.str64
 obj64 = stype.obj64
 DataTable = Frame
-
-
-Frame.__module__ = "datatable"

--- a/datatable/__init__.py
+++ b/datatable/__init__.py
@@ -56,7 +56,7 @@ __all__ = (
     "isna", "fread", "GenericReader", "stype", "ltype", "f", "g",
     "join", "by", "abs", "exp", "log", "log10",
     "TypeError", "ValueError", "DatatableWarning", "FreadWarning",
-    "DataTable", "options",
+    "options",
     "bool8", "int8", "int16", "int32", "int64",
     "float32", "float64", "str32", "str64", "obj64",
     "cbind", "rbind", "repeat", "sort",
@@ -74,4 +74,3 @@ float64 = stype.float64
 str32 = stype.str32
 str64 = stype.str64
 obj64 = stype.obj64
-DataTable = Frame

--- a/datatable/frame.py
+++ b/datatable/frame.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #-------------------------------------------------------------------------------
-# Copyright 2018 H2O.ai
+# Copyright 2018-2019 H2O.ai
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -20,62 +20,6 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 #-------------------------------------------------------------------------------
-import collections
-import datatable
-import time
-import warnings
-
-from datatable.lib import core
-from datatable.options import options
+from datatable.lib._datatable import Frame
 
 __all__ = ("Frame", )
-
-
-
-class Frame(core.Frame):
-    """
-    Two-dimensional column-oriented table of data. Each column has its own name
-    and type. Types may vary across columns (unlike in a Numpy array) but cannot
-    vary within each column (unlike in Pandas DataFrame).
-
-    Internally the data is stored as C primitives, and processed using
-    multithreaded native C++ code.
-
-    This is a primary data structure for datatable module.
-    """
-
-    #---------------------------------------------------------------------------
-    # Deprecated
-    #---------------------------------------------------------------------------
-
-    def scalar(self):
-        warnings.warn(
-            "Method `Frame.scalar()` is deprecated (will be removed in "
-            "0.10.0), please use `Frame[0, 0]` istead",
-            category=FutureWarning)
-        return self[0, 0]
-
-    def append(self):
-        warnings.warn(
-            "Method `Frame.append()` is deprecated (will be removed in "
-            "0.10.0), please use `Frame.rbind()` instead",
-            category=FutureWarning)
-
-    def save(self, path, format="jay", _strategy="auto"):
-        warnings.warn(
-            "Method `Frame.save()` is deprecated (will be removed in "
-            "0.10.0), please use `Frame.to_jay()` instead",
-            category=FutureWarning)
-        if format != "jay":
-            raise ValueError("Unknown `format` value: %s" % format)
-        return self.to_jay(path, _strategy=_strategy)
-
-
-
-
-#-------------------------------------------------------------------------------
-# Global settings
-#-------------------------------------------------------------------------------
-
-core._register_function(7, Frame)
-core._install_buffer_hooks(Frame)

--- a/tests/test_dt_create.py
+++ b/tests/test_dt_create.py
@@ -1157,17 +1157,3 @@ def test_duplicate_mangled():
         frame_integrity_check(DT)
         assert DT.names == (".", ".1", ".2", ".3", ".4")
     assert ("Duplicate column names found" in ws[0].message.args[0])
-
-
-
-
-#-------------------------------------------------------------------------------
-# Deprecated
-#-------------------------------------------------------------------------------
-
-def test_create_datatable():
-    """DataTable is old symbol for Frame."""
-    d = dt.DataTable([1, 2, 3])
-    frame_integrity_check(d)
-    assert d.__class__.__name__ == "Frame"
-    assert d.to_list() == [[1, 2, 3]]

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -31,9 +31,9 @@ from tests import same_iterables, assert_equals, isview
 
 
 def test_groups_internal2():
-    d0 = dt.DataTable([[1,   5,   3,   2,   1,    3,   1,   1,   None],
-                       ["a", "b", "c", "a", None, "f", "b", "h", "d"]],
-                      names=["A", "B"])
+    d0 = dt.Frame([[1,   5,   3,   2,   1,    3,   1,   1,   None],
+                   ["a", "b", "c", "a", None, "f", "b", "h", "d"]],
+                  names=["A", "B"])
     d1 = d0[:, :, by("A")]
     # gb = d1.internal.groupby
     # assert gb.ngroups == 5


### PR DESCRIPTION
These methods were scheduled for removal in v0.10.0