### PR TITLE
Sync when writing using mmap strategy

### DIFF
--- a/c/writebuf.cc
+++ b/c/writebuf.cc
@@ -299,3 +299,12 @@ void MmapWritableBuffer::realloc(size_t newsize)
   file.resize(newsize);
   map(file.descriptor(), newsize);
 }
+
+
+// Similar to realloc(), but does not re-map the file
+void MmapWritableBuffer::finalize() {
+  dt::shared_lock<dt::shared_mutex> lock(shmutex, /* exclusive = */ true);
+  unmap();
+  File file(filename, File::READWRITE);
+  file.resize(bytes_written);
+}

--- a/c/writebuf.h
+++ b/c/writebuf.h
@@ -181,6 +181,8 @@ public:
   MmapWritableBuffer(const std::string& path, size_t size);
   ~MmapWritableBuffer() override;
 
+  void finalize() override;
+
 private:
   void realloc(size_t newsize) override;
   void map(int fd, size_t size);


### PR DESCRIPTION
- Call `msync()` (http://man7.org/linux/man-pages/man2/msync.2.html) before unmapping. It is unclear from the docs whether this is required or not, but just in case.
- If an error occurs during `finalize()`, do not ignore it and throw an exception. This way if the file is not written properly, the user would be notified (assuming the OS reports error code correctly).

This may help with issues such as https://github.com/h2oai/h2oai/issues/10683