### PR TITLE
No warnings about duplicate names in DT[i,j]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ test_install:
 test:
 	rm -rf build/test-reports 2>/dev/null
 	mkdir -p build/test-reports/
-	$(PYTHON) -m pytest -ra --maxfail=10 $(PYTEST_FLAGS) \
+	$(PYTHON) -m pytest -ra --maxfail=10 -Werror $(PYTEST_FLAGS) \
 		--junit-prefix=$(PLATFORM) \
 		--junitxml=build/test-reports/TEST-datatable.xml \
 		tests

--- a/c/datatable.cc
+++ b/c/datatable.cc
@@ -50,16 +50,16 @@ DataTable::DataTable(colvec&& cols, DefaultNamesTag)
 }
 
 
-DataTable::DataTable(colvec&& cols, const py::olist& nn)
+DataTable::DataTable(colvec&& cols, const py::olist& nn, bool warn)
   : DataTable(std::move(cols))
 {
-  set_names(nn);
+  set_names(nn, warn);
 }
 
-DataTable::DataTable(colvec&& cols, const strvec& nn)
+DataTable::DataTable(colvec&& cols, const strvec& nn, bool warn)
   : DataTable(std::move(cols))
 {
-  set_names(nn);
+  set_names(nn, warn);
 }
 
 DataTable::DataTable(colvec&& cols, const DataTable* nn)

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -89,9 +89,9 @@ class DataTable {
 
     DataTable();
     DataTable(colvec&& cols, DefaultNamesTag);
-    DataTable(colvec&& cols, const strvec&);
+    DataTable(colvec&& cols, const strvec&, bool warn_duplicates = true);
+    DataTable(colvec&& cols, const py::olist&, bool warn_duplicates = true);
     DataTable(colvec&& cols, const DataTable*);
-    DataTable(colvec&& cols, const py::olist&);
     ~DataTable();
 
     void delete_columns(intvec&);
@@ -135,9 +135,9 @@ class DataTable {
     size_t xcolindex(int64_t index) const;
     void copy_names_from(const DataTable* other);
     void set_names_to_default();
-    void set_names(const py::olist& names_list);
-    void set_names(const strvec& names_list);
-    void replace_names(py::odict replacements);
+    void set_names(const py::olist& names_list, bool warn = true);
+    void set_names(const strvec& names_list, bool warn = true);
+    void replace_names(py::odict replacements, bool warn = true);
     void reorder_names(const intvec& col_indices);
 
     // Key
@@ -176,7 +176,7 @@ class DataTable {
     DataTable(colvec&& cols);
 
     void _init_pynames() const;
-    void _set_names_impl(NameProvider*);
+    void _set_names_impl(NameProvider*, bool warn);
     void _integrity_check_names() const;
     void _integrity_check_pynames() const;
 

--- a/c/expr/workframe.cc
+++ b/c/expr/workframe.cc
@@ -189,7 +189,7 @@ std::unique_ptr<DataTable> Workframe::convert_to_datatable() && {
     columns.emplace_back(std::move(record.column));
     names.emplace_back(std::move(record.name));
   }
-  return dtptr(new DataTable(std::move(columns), std::move(names)));
+  return dtptr(new DataTable(std::move(columns), std::move(names), false));
 }
 
 

--- a/c/frame/names.cc
+++ b/c/frame/names.cc
@@ -44,11 +44,12 @@ static Error _name_not_found_error(const DataTable* dt, const std::string& name)
 
 class NameProvider {
   public:
-    virtual ~NameProvider();  // LCOV_EXCL_LINE
+    virtual ~NameProvider() {}  // LCOV_EXCL_LINE
     virtual size_t size() const = 0;
     virtual CString item_as_cstring(size_t i) = 0;
     virtual py::oobj item_as_pyoobj(size_t i) = 0;
 };
+
 
 
 class pylistNP : public NameProvider {
@@ -56,11 +57,27 @@ class pylistNP : public NameProvider {
     const py::olist& names;
 
   public:
-    explicit pylistNP(const py::olist& arg) : names(arg) {}
-    virtual size_t size() const override;
-    virtual CString item_as_cstring(size_t i) override;
-    virtual py::oobj item_as_pyoobj(size_t i) override;
+    explicit pylistNP(const py::olist& arg)
+      : names(arg) {}
+
+    virtual size_t size() const override {
+      return names.size();
+    }
+
+    virtual CString item_as_cstring(size_t i) override {
+      py::robj name = names[i];
+      if (!name.is_string() && !name.is_none()) {
+        throw TypeError() << "Invalid `names` list: element " << i
+            << " is not a string";
+      }
+      return name.to_cstring();
+    }
+
+    virtual py::oobj item_as_pyoobj(size_t i) override {
+      return py::oobj(names[i]);
+    }
 };
+
 
 
 class strvecNP : public NameProvider {
@@ -68,47 +85,22 @@ class strvecNP : public NameProvider {
     const strvec& names;
 
   public:
-    explicit strvecNP(const std::vector<std::string>& arg) : names(arg) {}
-    virtual size_t size() const override;
-    virtual CString item_as_cstring(size_t i) override;
-    virtual py::oobj item_as_pyoobj(size_t i) override;
+    explicit strvecNP(const std::vector<std::string>& arg)
+      : names(arg) {}
+
+    virtual size_t size() const override {
+      return names.size();
+    }
+
+    virtual CString item_as_cstring(size_t i) override {
+      const std::string& name = names[i];
+      return CString { name.data(), static_cast<int64_t>(name.size()) };
+    }
+
+    virtual py::oobj item_as_pyoobj(size_t i) override {
+      return py::ostring(names[i]);
+    }
 };
-
-
-//------------------------------------------------------------------------------
-
-NameProvider::~NameProvider() {}
-
-size_t pylistNP::size() const {
-  return names.size();
-}
-
-CString pylistNP::item_as_cstring(size_t i) {
-  py::robj name = names[i];
-  if (!name.is_string() && !name.is_none()) {
-    throw TypeError() << "Invalid `names` list: element " << i
-        << " is not a string";
-  }
-  return name.to_cstring();
-}
-
-py::oobj pylistNP::item_as_pyoobj(size_t i) {
-  return py::oobj(names[i]);
-}
-
-
-size_t strvecNP::size() const {
-  return names.size();
-}
-
-CString strvecNP::item_as_cstring(size_t i) {
-  const std::string& name = names[i];
-  return CString { name.data(), static_cast<int64_t>(name.size()) };
-}
-
-py::oobj strvecNP::item_as_pyoobj(size_t i) {
-  return py::ostring(names[i]);
-}  // LCOV_EXCL_LINE
 
 
 
@@ -259,7 +251,7 @@ void py::Frame::init_names_options() {
 /**
  * Return DataTable column names as a C++ vector of strings.
  */
-const std::vector<std::string>& DataTable::get_names() const {
+const strvec& DataTable::get_names() const {
   return names;
 }
 

--- a/tests/test_dt_expr.py
+++ b/tests/test_dt_expr.py
@@ -420,3 +420,9 @@ def test_expr_reuse():
     df2 = df1[:, expr]
     frame_integrity_check(df2)
     assert df2.to_list() == [[False, True, True, True, True]]
+
+
+def test_expr_names():
+    # See issue #1963
+    DT = dt.Frame(A=range(5), B=range(5))
+    assert DT[:, [f.A, f.A + f.B]].names == ("A", "C0")


### PR DESCRIPTION
Expression `DT[i,j]` now suppresses warnings about duplicate column names.

Closes #2003