### PR TITLE
Properly treat the case when warnings are emitted as errors

### DIFF
--- a/c/frame/names.cc
+++ b/c/frame/names.cc
@@ -585,7 +585,7 @@ void DataTable::_set_names_impl(NameProvider* nameslist, bool warn_duplicates) {
           << replacements[i] << "'";
       }
     }
-    // as `w` goes out of scope, the warning is sent to Python
+    w.emit();
   }
 
   xassert(ncols == names.size());

--- a/c/jay/save_jay.cc
+++ b/c/jay/save_jay.cc
@@ -65,8 +65,9 @@ void DataTable::save_jay_impl(WritableBuffer* wb) {
   for (size_t i = 0; i < ncols; ++i) {
     Column& col = get_column(i);
     if (col.stype() == SType::OBJ) {
-      DatatableWarning() << "Column `" << names[i]
-          << "` of type obj64 was not saved";
+      auto w = DatatableWarning();
+      w << "Column `" << names[i] << "` of type obj64 was not saved";
+      w.emit();
     } else {
       auto saved_col = column_to_jay(col, names[i], fbb, wb);
       msg_columns.push_back(saved_col);

--- a/c/utils/exceptions.cc
+++ b/c/utils/exceptions.cc
@@ -255,9 +255,14 @@ void init_exceptions() {
 
 Warning::Warning(PyObject* cls) : Error(cls) {}
 
-Warning::~Warning() {
+void Warning::emit() {
   const std::string errstr = error.str();
-  PyErr_WarnEx(pycls, errstr.c_str(), 1);
+  // Normally, PyErr_WarnEx returns 0. However, when the `warnings` module is
+  // configured in such a way that all warnings are converted into errors,
+  // then PyErr_WarnEx will return -1. At that point we should throw
+  // an exception too, the error message is already set in Python.
+  int ret = PyErr_WarnEx(pycls, errstr.c_str(), 1);
+  if (ret) throw PyError();
 }
 
 

--- a/c/utils/exceptions.h
+++ b/c/utils/exceptions.h
@@ -119,7 +119,8 @@ class Warning : public Error {
   public:
     Warning(PyObject* cls);
     Warning(const Warning&) = default;
-    ~Warning() override;
+
+    void emit();
 };
 
 Warning DatatableWarning();

--- a/datatable/utils/typechecks.py
+++ b/datatable/utils/typechecks.py
@@ -41,9 +41,13 @@ TImportError.__name__ = "ImportError"
 #-------------------------------------------------------------------------------
 
 class DatatableWarning(UserWarning):
-    def _handle_(self):
-        print(term.color("yellow", self.__class__.__name__ + ": ") +
-              term.color("bright_black", str(self)))
+    def _handle_(self, *exc_args):
+        if exc_args:
+            # Warning was converted into an exception
+            TTypeError._handle_(self, *exc_args)
+        else:
+            print(term.color("yellow", self.__class__.__name__ + ": ") +
+                  term.color("bright_black", str(self)))
 
 
 def dtwarn(message):

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -77,7 +77,7 @@ def assert_valueerror(frame, rows, error_message):
 
 
 #-------------------------------------------------------------------------------
-# Run the tests
+# Generic tests
 #-------------------------------------------------------------------------------
 
 def test_platform():
@@ -377,6 +377,19 @@ def test_issue1406(dt0):
     with pytest.raises(ValueError) as e:
         noop(dt0[3,])
     assert "Invalid tuple of size 1 used as a frame selector" in str(e.value)
+
+
+def test_warnings_as_errors():
+    # See issue #2005
+    import warnings
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        try:
+            dt.fread("A,A,A\n1,2,3")
+        except dt.DatatableWarning as e:
+            assert "Duplicate column names found" in str(e)
+            assert "SystemError" not in str(e)
+            assert e.__cause__ is None
 
 
 


### PR DESCRIPTION
Python can be configured to treat warnings as errors. In that case datatable's warnings should behave properly and also throw exceptions.

Closes #2005