### PR TITLE
Fix a bug in infinity check when fitting FTRL model

### DIFF
--- a/c/models/dt_ftrl.cc
+++ b/c/models/dt_ftrl.cc
@@ -545,9 +545,7 @@ FtrlFitOutput Ftrl<T>::fit(T(*linkfn)(T),
           size_t ii = (iteration_start + i) % dt_X_train->nrows;
           const size_t j0 = ri[0][ii];
 
-          if (j0 != RowIndex::NA && !ISNA<U>(data_y[0][j0])
-              && !std::isinf(data_y[0][j0]))
-          {
+          if (is_data_valid(data_y[0], j0)) {
             hash_row(x, hashers, ii);
             for (size_t k = 0; k < label_ids_train.size(); ++k) {
               const size_t j = ri[0][ii];
@@ -585,9 +583,7 @@ FtrlFitOutput Ftrl<T>::fit(T(*linkfn)(T),
           dt::nested_for_static(dt_X_val->nrows, [&](size_t i) {
             const size_t j0 = ri_val[0][i];
 
-            if (j0 != RowIndex::NA && !ISNA<V>(data_y_val[0][j0])
-                && !std::isinf(data_y[0][j0]))
-            {
+            if (is_data_valid(data_y_val[0], j0)) {
               hash_row(x, hashers_val, i);
               for (size_t k = 0; k < label_ids_val.size(); ++k) {
                 const size_t j = ri_val[0][i];
@@ -830,6 +826,19 @@ void Ftrl<T>::fill_ri_data(const DataTable* dt,
     data.push_back(static_cast<const U*>(col->data()));
     ri.push_back(col->rowindex());
   }
+}
+
+
+/**
+ *  Check if `data[i]` is valid data for training.
+ */
+template <typename T>
+template <typename U /* column data type */>
+bool Ftrl<T>::is_data_valid(const U* data, size_t i) {
+  bool res = i!= RowIndex::NA &&
+             !ISNA<U>(data[i]) &&
+             !std::isinf(data[i]);
+  return res;
 }
 
 

--- a/c/models/dt_ftrl.h
+++ b/c/models/dt_ftrl.h
@@ -137,6 +137,8 @@ class Ftrl : public dt::FtrlBase {
     void fill_ri_data(const DataTable*,
                       std::vector<RowIndex>&,
                       std::vector<const U*>&);
+    template <typename U>
+    static bool is_data_valid(const U*, size_t);
 
   public:
     Ftrl();


### PR DESCRIPTION
We don't train FTRL model when target is infinite, and do an infinity check for both training and validation targets. In this PR we fix a bug in the infinity check for validation targets. This could cause an incorrect behavior of FTRL algo, and in some cases could even lead to a crash. 