### PR TITLE
Add library name in locate command failure

### DIFF
--- a/ci/setup_utils.py
+++ b/ci/setup_utils.py
@@ -643,8 +643,9 @@ def find_linked_dynamic_libraries():
                 else:
                     log.fatal("Cannot locate dynamic library `%s`" % libname)
             else:
-                log.fatal("`locate` command returned the following error:\n%s"
-                          % stderr.decode())
+                print("%s :::: %d :::: %s" % (libname, proc.returncode, stdout.decode()))
+                log.fatal("`locate` command returned the following error while looking for %s:\n%s"
+                          % (libname, stderr.decode()))
         return resolved
 
 


### PR DESCRIPTION
This helps in debugging when the locate command fails.