### PR TITLE
Remove ColumnImpl::rowindex()

### DIFF
--- a/c/api.cc
+++ b/c/api.cc
@@ -85,7 +85,7 @@ int DtFrame_ColumnStype(PyObject* pydt, size_t i) {
 int DtFrame_ColumnIsVirtual(PyObject* pydt, size_t i) {
   auto dt = _extract_dt(pydt);
   if (_column_index_oob(dt, i)) return -1;
-  return dt->get_column(i).is_virtual();  // rowindex() is noexcept
+  return dt->get_column(i).is_virtual();  // is_virtual() is noexcept
 }
 
 

--- a/c/api.cc
+++ b/c/api.cc
@@ -42,12 +42,6 @@ static DataTable* _extract_dt(PyObject* pydt) {
   return static_cast<py::Frame*>(pydt)->get_datatable();
 }
 
-static RowIndex* _extract_ri(PyObject* pyri) {
-  if (pyri == Py_None) return nullptr;
-  return static_cast<py::orowindex::pyobject*>(pyri)->ri;
-}
-
-
 size_t DtABIVersion() {
   return 2;
 }

--- a/c/column.cc
+++ b/c/column.cc
@@ -303,6 +303,14 @@ void Column::apply_rowindex(const RowIndex& ri) {
   pcol->apply_rowindex(ri, *this);  // modifies in-place
 }
 
+void Column::apply_rowindex_old(const RowIndex& ri) {
+  if (!ri) return;
+  RowIndex new_rowindex = ri * pcol->ri;
+  pcol->ri = new_rowindex;
+  pcol->_nrows = new_rowindex.size();
+}
+
+
 
 
 

--- a/c/column.cc
+++ b/c/column.cc
@@ -339,7 +339,6 @@ void VoidColumn::apply_na_mask(const Column&) {}
 void VoidColumn::replace_values(Column&, const RowIndex&, const Column&) {}
 void VoidColumn::init_data() {}
 void VoidColumn::fill_na() {}
-void VoidColumn::fill_na_mask(int8_t*, size_t, size_t) {}
 
 
 
@@ -367,7 +366,6 @@ class StrvecColumn : public ColumnImpl {
     void replace_values(Column&, const RowIndex&, const Column&) override {}
     void init_data() override {}
     void fill_na() override {}
-    void fill_na_mask(int8_t*, size_t, size_t) override {}
 };
 
 StrvecColumn::StrvecColumn(const strvec& v)

--- a/c/column.cc
+++ b/c/column.cc
@@ -177,6 +177,13 @@ const ColumnImpl* Column::operator->() const {
   return pcol;
 }
 
+ColumnImpl* Column::release() noexcept {
+  ColumnImpl* tmp = pcol;
+  pcol = nullptr;
+  return tmp;
+}
+
+
 
 //---- Properties ----------------------
 

--- a/c/column.cc
+++ b/c/column.cc
@@ -298,6 +298,11 @@ void Column::repeat(size_t ntimes) {
   pcol->repeat(ntimes, inplace, *this);
 }
 
+void Column::apply_rowindex(const RowIndex& ri) {
+  if (!ri) return;
+  pcol->apply_rowindex(ri, *this);  // modifies in-place
+}
+
 
 
 

--- a/c/column.cc
+++ b/c/column.cc
@@ -115,12 +115,6 @@ PyObject* ColumnImpl::mbuf_repr() const {
 
 
 
-RowIndex ColumnImpl::remove_rowindex() {
-  RowIndex res(std::move(ri));
-  xassert(!ri);
-  return res;
-}
-
 void ColumnImpl::replace_rowindex(const RowIndex& newri) {
   ri = newri;
   _nrows = ri.size();

--- a/c/column.cc
+++ b/c/column.cc
@@ -115,12 +115,6 @@ PyObject* ColumnImpl::mbuf_repr() const {
 
 
 
-void ColumnImpl::replace_rowindex(const RowIndex& newri) {
-  ri = newri;
-  _nrows = ri.size();
-}
-
-
 
 
 //------------------------------------------------------------------------------

--- a/c/column.cc
+++ b/c/column.cc
@@ -311,6 +311,11 @@ void Column::apply_rowindex_old(const RowIndex& ri) {
 }
 
 
+void Column::na_pad(size_t new_nrows) {
+  bool inplace = true;
+  pcol->na_pad(new_nrows, inplace, *this);
+}
+
 
 
 
@@ -322,7 +327,6 @@ VoidColumn::VoidColumn() : ColumnImpl(0, SType::VOID) {}
 VoidColumn::VoidColumn(size_t nrows) : ColumnImpl(nrows, SType::VOID) {}
 size_t VoidColumn::data_nrows() const { return _nrows; }
 ColumnImpl* VoidColumn::materialize() { return this; }
-void VoidColumn::resize_and_fill(size_t) {}
 void VoidColumn::rbind_impl(colvec&, size_t, bool) {}
 void VoidColumn::apply_na_mask(const Column&) {}
 void VoidColumn::replace_values(Column&, const RowIndex&, const Column&) {}
@@ -351,7 +355,6 @@ class StrvecColumn : public ColumnImpl {
 
     size_t data_nrows() const override { return _nrows; }
     ColumnImpl* materialize() override { return this; }
-    void resize_and_fill(size_t) override {}
     void rbind_impl(colvec&, size_t, bool) override {}
     void apply_na_mask(const Column&) override {}
     void replace_values(Column&, const RowIndex&, const Column&) override {}

--- a/c/column.h
+++ b/c/column.h
@@ -157,7 +157,7 @@ class Column
 
     ColumnImpl* operator->();
     const ColumnImpl* operator->() const;
-
+    ColumnImpl* release() noexcept;
 
   //------------------------------------
   // Data access

--- a/c/column.h
+++ b/c/column.h
@@ -249,9 +249,11 @@ class Column
 
     void replace_values(const RowIndex& replace_at, const Column& replace_with);
 
-    // This method modifies the column in-place rbinding it with
-    // itself `ntimes` times.
+    // Rbind the column with itself `ntimes` times.
     void repeat(size_t ntimes);
+
+    // Pad the column with NAs until it had `new_nrows` rows.
+    void na_pad(size_t new_nrows);
 
     // Modifies the column in-place converting it into a view column
     // using the provided row index.

--- a/c/column.h
+++ b/c/column.h
@@ -245,7 +245,7 @@ class Column
     Column cast(SType stype) const;
     Column cast(SType stype, MemoryRange&& mr) const;
     RowIndex sort(Groupby* out_groups) const;
-    RowIndex sort_grouped(const RowIndex&, const Groupby&) const;
+    void sort_grouped_inplace(const Groupby&);
 
     void replace_values(const RowIndex& replace_at, const Column& replace_with);
 

--- a/c/column.h
+++ b/c/column.h
@@ -252,8 +252,12 @@ class Column
     // Rbind the column with itself `ntimes` times.
     void repeat(size_t ntimes);
 
-    // Pad the column with NAs until it had `new_nrows` rows.
-    void na_pad(size_t new_nrows);
+    // Resize this column to `new_nrows` rows.
+    // If the new number of rows is greater than the current number
+    // of rows, the column is padded with NAs.
+    // If it is less than the current number of rows, the column is
+    // truncated.
+    void resize(size_t new_nrows);
 
     // Modifies the column in-place converting it into a view column
     // using the provided row index.

--- a/c/column.h
+++ b/c/column.h
@@ -253,6 +253,10 @@ class Column
     // itself `ntimes` times.
     void repeat(size_t ntimes);
 
+    // Modifies the column in-place converting it into a view column
+    // using the provided row index.
+    void apply_rowindex(const RowIndex&);
+
     friend void swap(Column& lhs, Column& rhs);
     friend class ColumnImpl;
 };

--- a/c/column.h
+++ b/c/column.h
@@ -256,6 +256,7 @@ class Column
     // Modifies the column in-place converting it into a view column
     // using the provided row index.
     void apply_rowindex(const RowIndex&);
+    void apply_rowindex_old(const RowIndex&);  // TODO: remove this
 
     friend void swap(Column& lhs, Column& rhs);
     friend class ColumnImpl;

--- a/c/column/const.cc
+++ b/c/column/const.cc
@@ -58,10 +58,6 @@ class ConstNa_ColumnImpl : public Const_ColumnImpl {
       return out;
     }
 
-    void resize_and_fill(size_t nrows) override {
-      _nrows = nrows;
-    }
-
     void na_pad(size_t nrows, bool inplace, Column& out) override {
       if (inplace) {
         _nrows = nrows;

--- a/c/column/const.cc
+++ b/c/column/const.cc
@@ -61,6 +61,15 @@ class ConstNa_ColumnImpl : public Const_ColumnImpl {
     void resize_and_fill(size_t nrows) override {
       _nrows = nrows;
     }
+
+    void na_pad(size_t nrows, bool inplace, Column& out) override {
+      if (inplace) {
+        _nrows = nrows;
+      }
+      else {
+        out = Column(new ConstNa_ColumnImpl(nrows));
+      }
+    }
 };
 
 

--- a/c/column/const.cc
+++ b/c/column/const.cc
@@ -200,7 +200,7 @@ class ConstString_ColumnImpl : public Const_ColumnImpl {
         value(std::move(x)) {}
 
     ColumnImpl* shallowcopy() const override {
-      return new ConstString_ColumnImpl(_nrows, value);
+      return new ConstString_ColumnImpl(_nrows, value, _stype);
     }
 
     bool get_element(size_t, CString* out) const override {

--- a/c/column/nafilled.cc
+++ b/c/column/nafilled.cc
@@ -27,7 +27,10 @@ namespace dt {
 NaFilled_ColumnImpl::NaFilled_ColumnImpl(Column&& col, size_t nrows)
   : Virtual_ColumnImpl(nrows, col.stype()),
     arg_nrows(col.nrows()),
-    arg(std::move(col)) {}
+    arg(std::move(col))
+{
+  xassert(nrows >= arg.nrows());
+}
 
 
 ColumnImpl* NaFilled_ColumnImpl::shallowcopy() const {
@@ -38,6 +41,21 @@ ColumnImpl* NaFilled_ColumnImpl::shallowcopy() const {
 void NaFilled_ColumnImpl::na_pad(size_t new_nrows, bool inplace, Column& out) {
   xassert(new_nrows >= _nrows);
   if (inplace) {
+    _nrows = new_nrows;
+  }
+  else {
+    out = Column(new NaFilled_ColumnImpl(Column(arg), new_nrows));
+  }
+}
+
+void NaFilled_ColumnImpl::truncate(size_t new_nrows, bool inplace, Column& out)
+{
+  xassert(new_nrows < _nrows);
+  if (new_nrows < arg_nrows) {
+    arg.resize(new_nrows);
+    out = std::move(arg);
+  }
+  else if (inplace) {
     _nrows = new_nrows;
   }
   else {

--- a/c/column/nafilled.cc
+++ b/c/column/nafilled.cc
@@ -1,0 +1,87 @@
+//------------------------------------------------------------------------------
+// Copyright 2019 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#include <memory>
+#include "column/nafilled.h"
+namespace dt {
+
+
+NaFilled_ColumnImpl::NaFilled_ColumnImpl(Column&& col, size_t nrows)
+  : Virtual_ColumnImpl(nrows, col.stype()),
+    arg_nrows(col.nrows()),
+    arg(std::move(col)) {}
+
+
+ColumnImpl* NaFilled_ColumnImpl::shallowcopy() const {
+  return new NaFilled_ColumnImpl(Column(arg), _nrows);
+}
+
+
+void NaFilled_ColumnImpl::na_pad(size_t new_nrows, bool inplace, Column& out) {
+  xassert(new_nrows >= _nrows);
+  if (inplace) {
+    _nrows = new_nrows;
+  }
+  else {
+    out = Column(new NaFilled_ColumnImpl(Column(arg), new_nrows));
+  }
+}
+
+
+
+
+bool NaFilled_ColumnImpl::get_element(size_t i, int8_t* out)   const {
+  return (i >= arg_nrows) || arg.get_element(i, out);
+}
+
+bool NaFilled_ColumnImpl::get_element(size_t i, int16_t* out)  const {
+  return (i >= arg_nrows) || arg.get_element(i, out);
+}
+
+bool NaFilled_ColumnImpl::get_element(size_t i, int32_t* out)  const {
+  return (i >= arg_nrows) || arg.get_element(i, out);
+}
+
+bool NaFilled_ColumnImpl::get_element(size_t i, int64_t* out)  const {
+  return (i >= arg_nrows) || arg.get_element(i, out);
+}
+
+bool NaFilled_ColumnImpl::get_element(size_t i, float* out)    const {
+  return (i >= arg_nrows) || arg.get_element(i, out);
+}
+
+bool NaFilled_ColumnImpl::get_element(size_t i, double* out)   const {
+  return (i >= arg_nrows) || arg.get_element(i, out);
+}
+
+bool NaFilled_ColumnImpl::get_element(size_t i, CString* out)  const {
+  return (i >= arg_nrows) || arg.get_element(i, out);
+}
+
+bool NaFilled_ColumnImpl::get_element(size_t i, py::robj* out) const {
+  return (i >= arg_nrows) || arg.get_element(i, out);
+}
+
+
+
+
+
+}  // namespace dt

--- a/c/column/nafilled.h
+++ b/c/column/nafilled.h
@@ -39,6 +39,7 @@ class NaFilled_ColumnImpl : public Virtual_ColumnImpl {
     ColumnImpl* shallowcopy() const override;
 
     void na_pad(size_t new_nrows, bool inplace, Column& out) override;
+    void truncate(size_t new_nrows, bool inplace, Column& out) override;
 
     bool get_element(size_t, int8_t*)   const override;
     bool get_element(size_t, int16_t*)  const override;

--- a/c/column/nafilled.h
+++ b/c/column/nafilled.h
@@ -1,0 +1,57 @@
+//------------------------------------------------------------------------------
+// Copyright 2019 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#ifndef dt_COLUMN_NAFILLED_h
+#define dt_COLUMN_NAFILLED_h
+#include <memory>
+#include "column/virtual.h"
+namespace dt {
+
+
+/**
+  * Virtual column representing the `arg` column repeated n times.
+  */
+class NaFilled_ColumnImpl : public Virtual_ColumnImpl {
+  private:
+    size_t arg_nrows;
+    Column arg;
+
+  public:
+    NaFilled_ColumnImpl(Column&&, size_t nrows);
+    ColumnImpl* shallowcopy() const override;
+
+    void na_pad(size_t new_nrows, bool inplace, Column& out) override;
+
+    bool get_element(size_t, int8_t*)   const override;
+    bool get_element(size_t, int16_t*)  const override;
+    bool get_element(size_t, int32_t*)  const override;
+    bool get_element(size_t, int64_t*)  const override;
+    bool get_element(size_t, float*)    const override;
+    bool get_element(size_t, double*)   const override;
+    bool get_element(size_t, CString*)  const override;
+    bool get_element(size_t, py::robj*) const override;
+};
+
+
+
+
+}  // namespace dt
+#endif

--- a/c/column/view.cc
+++ b/c/column/view.cc
@@ -1,0 +1,177 @@
+//------------------------------------------------------------------------------
+// Copyright 2019 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#include "column/virtual.h"
+namespace dt {
+
+
+
+//------------------------------------------------------------------------------
+// SliceView_ColumnImpl
+//------------------------------------------------------------------------------
+
+class SliceView_ColumnImpl : public Virtual_ColumnImpl {
+  private:
+    Column arg;
+    size_t start;
+    size_t step;
+
+  public:
+    SliceView_ColumnImpl(Column&& col, const RowIndex& ri)
+      : Virtual_ColumnImpl(ri.size(), col.stype()),
+        arg(std::move(col)),
+        start(ri.slice_start()),
+        step(ri.slice_step())
+    {
+      xassert(ri.isslice());
+      xassert(start < col.nrows());
+      xassert(start + step * (ri.size() - 1) < col.nrows());
+    }
+
+    ColumnImpl* shallowcopy() const override {
+      return new SliceView_ColumnImpl(Column(arg), RowIndex(start, _nrows, step));
+    }
+
+    bool get_element(size_t i, int8_t* out)   const override { return arg.get_element(start + i*step, out); }
+    bool get_element(size_t i, int16_t* out)  const override { return arg.get_element(start + i*step, out); }
+    bool get_element(size_t i, int32_t* out)  const override { return arg.get_element(start + i*step, out); }
+    bool get_element(size_t i, int64_t* out)  const override { return arg.get_element(start + i*step, out); }
+    bool get_element(size_t i, float* out)    const override { return arg.get_element(start + i*step, out); }
+    bool get_element(size_t i, double* out)   const override { return arg.get_element(start + i*step, out); }
+    bool get_element(size_t i, CString* out)  const override { return arg.get_element(start + i*step, out); }
+    bool get_element(size_t i, py::robj* out) const override { return arg.get_element(start + i*step, out); }
+};
+
+
+
+
+
+//------------------------------------------------------------------------------
+// ArrayView_ColumnImpl
+//------------------------------------------------------------------------------
+
+template <typename T> const T* get_indices(const RowIndex&) { return nullptr; }
+template <> const int32_t* get_indices(const RowIndex& ri) { return ri.indices32(); }
+template <> const int64_t* get_indices(const RowIndex& ri) { return ri.indices64(); }
+
+
+template <typename T>
+class ArrayView_ColumnImpl : public Virtual_ColumnImpl {
+  private:
+    Column arg;
+    RowIndex rowindex; // owns the `indices` array
+    const T* indices;
+
+  public:
+    ArrayView_ColumnImpl(Column&& col, const RowIndex& ri)
+      : Virtual_ColumnImpl(ri.size(), col.stype()),
+        arg(std::move(col)),
+        rowindex(ri),
+        indices(get_indices<T>(ri)) {}
+
+    ColumnImpl* shallowcopy() const override {
+      return new ArrayView_ColumnImpl<T>(Column(arg), rowindex);
+    }
+
+
+    bool get_element(size_t i, int8_t* out) const override {
+      T j = indices[i];
+      if (j < 0) return true;
+      return arg.get_element(static_cast<size_t>(j), out);
+    }
+
+    bool get_element(size_t i, int16_t* out) const override {
+      T j = indices[i];
+      if (j < 0) return true;
+      return arg.get_element(static_cast<size_t>(j), out);
+    }
+
+    bool get_element(size_t i, int32_t* out) const override {
+      T j = indices[i];
+      if (j < 0) return true;
+      return arg.get_element(static_cast<size_t>(j), out);
+    }
+
+    bool get_element(size_t i, int64_t* out) const override {
+      T j = indices[i];
+      if (j < 0) return true;
+      return arg.get_element(static_cast<size_t>(j), out);
+    }
+
+    bool get_element(size_t i, float* out) const override {
+      T j = indices[i];
+      if (j < 0) return true;
+      return arg.get_element(static_cast<size_t>(j), out);
+    }
+
+    bool get_element(size_t i, double* out) const override {
+      T j = indices[i];
+      if (j < 0) return true;
+      return arg.get_element(static_cast<size_t>(j), out);
+    }
+
+    bool get_element(size_t i, CString* out) const override {
+      T j = indices[i];
+      if (j < 0) return true;
+      return arg.get_element(static_cast<size_t>(j), out);
+    }
+
+    bool get_element(size_t i, py::robj* out) const override {
+      T j = indices[i];
+      if (j < 0) return true;
+      return arg.get_element(static_cast<size_t>(j), out);
+    }
+};
+
+
+
+
+
+}  // namespace dt
+
+//------------------------------------------------------------------------------
+// base ColumnImpl
+//------------------------------------------------------------------------------
+
+// factory function
+static Column _make_view(Column&& col, const RowIndex& ri) {
+  if (ri.size() == 0) {
+    return Column::new_na_column(col.stype(), 0);
+  }
+  switch (ri.type()) {
+    case RowIndexType::UNKNOWN:
+      return std::move(col);  // empty rowindex
+
+    case RowIndexType::SLICE:
+      return Column(new dt::SliceView_ColumnImpl(std::move(col), ri));
+
+    case RowIndexType::ARR32:
+      return Column(new dt::ArrayView_ColumnImpl<int32_t>(std::move(col), ri));
+
+    case RowIndexType::ARR64:
+      return Column(new dt::ArrayView_ColumnImpl<int64_t>(std::move(col), ri));
+  }
+}
+
+
+void ColumnImpl::apply_rowindex(const RowIndex& rowindex, Column& out) {
+  out = _make_view(std::move(out), rowindex);
+}

--- a/c/column/view.cc
+++ b/c/column/view.cc
@@ -42,8 +42,7 @@ class SliceView_ColumnImpl : public Virtual_ColumnImpl {
         step(ri.slice_step())
     {
       xassert(ri.isslice());
-      xassert(start < col.nrows());
-      xassert(start + step * (ri.size() - 1) < col.nrows());
+      xassert(ri.max() < arg.nrows());
     }
 
     ColumnImpl* shallowcopy() const override {
@@ -85,7 +84,11 @@ class ArrayView_ColumnImpl : public Virtual_ColumnImpl {
       : Virtual_ColumnImpl(ri.size(), col.stype()),
         arg(std::move(col)),
         rowindex(ri),
-        indices(get_indices<T>(ri)) {}
+        indices(get_indices<T>(ri))
+    {
+      xassert(std::is_same<T, int32_t>::value? ri.isarr32() : ri.isarr64());
+      xassert(ri.max() < arg.nrows());
+    }
 
     ColumnImpl* shallowcopy() const override {
       return new ArrayView_ColumnImpl<T>(Column(arg), rowindex);

--- a/c/column/virtual.h
+++ b/c/column/virtual.h
@@ -1,0 +1,44 @@
+//------------------------------------------------------------------------------
+// Copyright 2019 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#ifndef dt_COLUMN_VIRTUAL_h
+#define dt_COLUMN_VIRTUAL_h
+#include <memory>
+#include "column_impl.h"
+namespace dt {
+
+
+/**
+  * Base class for all virtual columns.
+  */
+class Virtual_ColumnImpl : public ColumnImpl {
+  public:
+    using ColumnImpl::ColumnImpl;
+
+    bool is_virtual() const noexcept override {
+      return true;
+    }
+};
+
+
+
+}  // namespace dt
+#endif

--- a/c/column_fw.cc
+++ b/c/column_fw.cc
@@ -236,24 +236,16 @@ void FwColumn<T>::replace_values(
   }
 
   size_t replace_n = replace_at.size();
-  const T* data_src = static_cast<const T*>(with->data());
-  const RowIndex& rowindex_src = with->rowindex();
   T* data_dest = elements_w();
   xassert(with.nrows() == replace_n);
-  if (rowindex_src) {
-    replace_at.iterate(0, replace_n, 1,
-      [&](size_t i, size_t j) {
-        if (j == RowIndex::NA) return;
-        size_t k = rowindex_src[i];
-        data_dest[j] = (k == RowIndex::NA)? GETNA<T>() : data_src[k];
-      });
-  } else {
-    replace_at.iterate(0, replace_n, 1,
-      [&](size_t i, size_t j) {
-        if (j == RowIndex::NA) return;
-        data_dest[j] = data_src[i];
-      });
-  }
+
+  replace_at.iterate(0, replace_n, 1,
+    [&](size_t i, size_t j) {
+      if (j == RowIndex::NA) return;
+      T value;
+      bool isna = replace_with.get_element(i, &value);
+      data_dest[j] = isna? GETNA<T>() : value;
+    });
 }
 
 

--- a/c/column_fw.cc
+++ b/c/column_fw.cc
@@ -150,28 +150,6 @@ ColumnImpl* FwColumn<T>::materialize() {
 
 
 
-template <typename T>
-void FwColumn<T>::resize_and_fill(size_t new_nrows)
-{
-  if (new_nrows == _nrows) return;
-  materialize();
-
-  mbuf.resize(sizeof(T) * new_nrows);
-
-  if (new_nrows > _nrows) {
-    // Replicate the value or fill with NAs
-    T fill_value = _nrows == 1? get_elem(0) : GETNA<T>();
-    T* data_dest = static_cast<T*>(mbuf.wptr());
-    for (size_t i = _nrows; i < new_nrows; ++i) {
-      data_dest[i] = fill_value;
-    }
-  }
-  this->_nrows = new_nrows;
-
-  // TODO(#301): Temporary fix.
-  if (this->stats != nullptr) this->stats->reset();
-}
-
 
 
 template <typename T>

--- a/c/column_fw.cc
+++ b/c/column_fw.cc
@@ -229,16 +229,6 @@ void FwColumn<T>::replace_values(
 
 
 
-template <typename T>
-void FwColumn<T>::fill_na_mask(int8_t* outmask, size_t row0, size_t row1) {
-  const T* tdata = elements_r();
-  ri.iterate(row0, row1, 1,
-    [&](size_t i, size_t j) {
-      outmask[i] = (j == RowIndex::NA) || ISNA<T>(tdata[j]);
-    });
-}
-
-
 // Explicit instantiations
 template class FwColumn<int8_t>;
 template class FwColumn<int16_t>;

--- a/c/column_impl.cc
+++ b/c/column_impl.cc
@@ -266,8 +266,21 @@ void ColumnImpl::fill_na() {
   throw NotImplError() << "Method ColumnImpl::fill_na() not implemented";
 }
 
+
 void ColumnImpl::na_pad(size_t new_nrows, bool inplace, Column& out) {
   (void) inplace;
-  xassert(new_nrows >= nrows());
+  xassert(new_nrows > nrows());
   out = Column(new dt::NaFilled_ColumnImpl(std::move(out), new_nrows));
+}
+
+void ColumnImpl::truncate(size_t new_nrows, bool inplace, Column& out) {
+  xassert(new_nrows < nrows());
+  if (inplace) {
+    _nrows = new_nrows;
+  }
+  else {
+    ColumnImpl* copy = shallowcopy();
+    copy->_nrows = new_nrows;
+    out = Column(copy);
+  }
 }

--- a/c/column_impl.cc
+++ b/c/column_impl.cc
@@ -208,6 +208,38 @@ void ColumnImpl::materialize_at(void* addr) const {
 
 
 //------------------------------------------------------------------------------
+// fill_na_mask()
+//------------------------------------------------------------------------------
+
+template <typename T>
+void _fill_na_mask(ColumnImpl* icol, int8_t* outmask, size_t row0, size_t row1)
+{
+  T value;
+  for (size_t i = row0; i < row1; ++i) {
+    outmask[i] = icol->get_element(i, &value);
+  }
+}
+
+void ColumnImpl::fill_na_mask(int8_t* outmask, size_t row0, size_t row1) {
+  switch (_stype) {
+    case SType::BOOL:
+    case SType::INT8:    _fill_na_mask<int8_t> (this, outmask, row0, row1); break;
+    case SType::INT16:   _fill_na_mask<int16_t>(this, outmask, row0, row1); break;
+    case SType::INT32:   _fill_na_mask<int32_t>(this, outmask, row0, row1); break;
+    case SType::INT64:   _fill_na_mask<int64_t>(this, outmask, row0, row1); break;
+    case SType::FLOAT32: _fill_na_mask<float>  (this, outmask, row0, row1); break;
+    case SType::FLOAT64: _fill_na_mask<double> (this, outmask, row0, row1); break;
+    case SType::STR32:
+    case SType::STR64:   _fill_na_mask<CString>(this, outmask, row0, row1); break;
+    default:
+      throw NotImplError() << "Cannot fill_na_mask() on column of stype `"
+                           << _stype << "`";
+  }
+}
+
+
+
+//------------------------------------------------------------------------------
 // Misc
 //------------------------------------------------------------------------------
 
@@ -219,23 +251,19 @@ void ColumnImpl::init_data() {}
 
 
 void ColumnImpl::apply_na_mask(const Column&) {
-  throw NotImplError();
+  throw NotImplError() << "Method ColumnImpl::apply_na_mask() not implemented";
 }
 
 void ColumnImpl::replace_values(Column&, const RowIndex&, const Column&) {
-  throw NotImplError();
-}
-
-void ColumnImpl::fill_na_mask(int8_t*, size_t, size_t) {
-  throw NotImplError();
+  throw NotImplError() << "Method ColumnImpl::replace_values() not implemented";
 }
 
 void ColumnImpl::rbind_impl(colvec&, size_t, bool) {
-  throw NotImplError();
+  throw NotImplError() << "Method ColumnImpl::rbind_impl() not implemented";
 }
 
 void ColumnImpl::fill_na() {
-  throw NotImplError();
+  throw NotImplError() << "Method ColumnImpl::fill_na() not implemented";
 }
 
 void ColumnImpl::na_pad(size_t new_nrows, bool inplace, Column& out) {

--- a/c/column_impl.cc
+++ b/c/column_impl.cc
@@ -217,9 +217,6 @@ size_t ColumnImpl::data_nrows() const {
 
 void ColumnImpl::init_data() {}
 
-void ColumnImpl::resize_and_fill(size_t) {
-  throw NotImplError();
-}
 
 void ColumnImpl::apply_na_mask(const Column&) {
   throw NotImplError();

--- a/c/column_impl.cc
+++ b/c/column_impl.cc
@@ -19,6 +19,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
+#include "column/nafilled.h"
 #include "parallel/api.h"
 #include "column_impl.h"
 
@@ -206,4 +207,10 @@ void ColumnImpl::rbind_impl(colvec&, size_t, bool) {
 
 void ColumnImpl::fill_na() {
   throw NotImplError();
+}
+
+void ColumnImpl::na_pad(size_t new_nrows, bool inplace, Column& out) {
+  (void) inplace;
+  xassert(new_nrows >= nrows());
+  out = Column(new dt::NaFilled_ColumnImpl(std::move(out), new_nrows));
 }

--- a/c/column_impl.h
+++ b/c/column_impl.h
@@ -121,7 +121,6 @@ class ColumnImpl
 
     const RowIndex& rowindex() const noexcept { return ri; }
     virtual bool is_virtual() const noexcept { return bool(ri); }
-    void replace_rowindex(const RowIndex& newri);
 
     size_t nrows() const { return _nrows; }
     SType stype() const { return _stype; }

--- a/c/column_impl.h
+++ b/c/column_impl.h
@@ -170,6 +170,11 @@ class ColumnImpl
     virtual void repeat(size_t ntimes, bool inplace, Column& out);
 
     /**
+      * Implementation in column/view.cc
+      */
+    virtual void apply_rowindex(const RowIndex& ri, Column& out);
+
+    /**
      * Modify the ColumnImpl, replacing values specified by the provided `mask` with
      * NAs. The `mask` column must have the same number of rows as the current,
      * and neither of them can have a RowIndex.

--- a/c/column_impl.h
+++ b/c/column_impl.h
@@ -100,6 +100,7 @@ class ColumnImpl
 
   public:
     static ColumnImpl* new_impl(SType);
+    static ColumnImpl* new_impl(SType, size_t nrows);
     static ColumnImpl* new_impl(void*, SType);
     ColumnImpl(size_t nrows, SType stype);
     ColumnImpl(const ColumnImpl&) = delete;

--- a/c/column_impl.h
+++ b/c/column_impl.h
@@ -156,6 +156,7 @@ class ColumnImpl
     virtual void repeat(size_t ntimes, bool inplace, Column& out);
 
     virtual void na_pad(size_t new_nrows, bool inplace, Column& out);
+    virtual void truncate(size_t new_nrows, bool inplace, Column& out);
 
     /**
       * Implementation in column/view.cc

--- a/c/column_impl.h
+++ b/c/column_impl.h
@@ -154,7 +154,7 @@ class ColumnImpl
      * column.
      */
     virtual void resize_and_fill(size_t nrows);
-    Column repeat(size_t nreps) const;
+    Column repeat(size_t nreps) const;  // OLD
 
     /**
       * Repeat the column `ntimes` times. Depending on the `inplace`
@@ -168,6 +168,8 @@ class ColumnImpl
       * Implementation in column/repeated.cc
       */
     virtual void repeat(size_t ntimes, bool inplace, Column& out);
+
+    virtual void na_pad(size_t new_nrows, bool inplace, Column& out);
 
     /**
       * Implementation in column/view.cc
@@ -483,7 +485,6 @@ class VoidColumn : public ColumnImpl {
     VoidColumn(size_t nrows);
     size_t data_nrows() const override;
     ColumnImpl* materialize() override;
-    void resize_and_fill(size_t) override;
     void rbind_impl(colvec&, size_t, bool) override;
     void apply_na_mask(const Column&) override;
     void replace_values(Column&, const RowIndex&, const Column&) override;

--- a/c/column_impl.h
+++ b/c/column_impl.h
@@ -300,7 +300,6 @@ public:
   virtual ColumnImpl* materialize() override;
   void replace_values(Column& thiscol, const RowIndex& at, const Column& with) override;
   void replace_values(const RowIndex& at, T with);
-  void fill_na_mask(int8_t* outmask, size_t row0, size_t row1) override;
 
 protected:
   void init_data() override;
@@ -438,7 +437,6 @@ public:
   void verify_integrity(const std::string& name) const override;
 
   bool get_element(size_t i, CString* out) const override;
-  void fill_na_mask(int8_t* outmask, size_t row0, size_t row1) override;
 
 protected:
   StringColumn(size_t nrows, MemoryRange&& offbuf, MemoryRange&& strbuf);
@@ -471,7 +469,6 @@ class VoidColumn : public ColumnImpl {
     void rbind_impl(colvec&, size_t, bool) override;
     void apply_na_mask(const Column&) override;
     void replace_values(Column&, const RowIndex&, const Column&) override;
-    void fill_na_mask(int8_t* outmask, size_t row0, size_t row1) override;
   protected:
     void init_data() override;
     void fill_na() override;

--- a/c/column_impl.h
+++ b/c/column_impl.h
@@ -119,7 +119,6 @@ class ColumnImpl
     virtual bool get_element(size_t i, CString* out) const;
     virtual bool get_element(size_t i, py::robj* out) const;
 
-    const RowIndex& rowindex() const noexcept { return ri; }
     virtual bool is_virtual() const noexcept { return bool(ri); }
 
     size_t nrows() const { return _nrows; }

--- a/c/column_impl.h
+++ b/c/column_impl.h
@@ -140,21 +140,6 @@ class ColumnImpl
 
     RowIndex _sort(Groupby* out_groups) const;
 
-    /**
-     * Resize the column up to `nrows` elements, and fill all new elements with
-     * NA values, except when the ColumnImpl initially had just one row, in which case
-     * that one value will be used to fill the new rows. For example:
-     *
-     *   {1, 2, 3, 4}.resize_and_fill(5) -> {1, 2, 3, 4, NA}
-     *   {1, 3}.resize_and_fill(5)       -> {1, 3, NA, NA, NA}
-     *   {1}.resize_and_fill(5)          -> {1, 1, 1, 1, 1}
-     *
-     * The contents of the column will be modified in-place if possible.
-     *
-     * This method can be used to both increase and reduce the size of the
-     * column.
-     */
-    virtual void resize_and_fill(size_t nrows);
     Column repeat(size_t nreps) const;  // OLD
 
     /**
@@ -311,7 +296,6 @@ public:
   virtual bool get_element(size_t i, T* out) const override;
 
   size_t data_nrows() const override;
-  void resize_and_fill(size_t nrows) override;
   void apply_na_mask(const Column& mask) override;
   virtual ColumnImpl* materialize() override;
   void replace_values(Column& thiscol, const RowIndex& at, const Column& with) override;
@@ -413,7 +397,6 @@ protected:
 
   void rbind_impl(colvec& columns, size_t nrows, bool isempty) override;
 
-  void resize_and_fill(size_t nrows) override;
   void fill_na() override;
   ColumnImpl* materialize() override;
   void verify_integrity(const std::string& name) const override;
@@ -436,7 +419,6 @@ public:
   StringColumn(size_t nrows);
 
   ColumnImpl* materialize() override;
-  void resize_and_fill(size_t nrows) override;
   void apply_na_mask(const Column& mask) override;
 
   MemoryRange str_buf() const { return strbuf; }

--- a/c/column_impl.h
+++ b/c/column_impl.h
@@ -121,7 +121,6 @@ class ColumnImpl
 
     const RowIndex& rowindex() const noexcept { return ri; }
     virtual bool is_virtual() const noexcept { return bool(ri); }
-    RowIndex remove_rowindex();
     void replace_rowindex(const RowIndex& newri);
 
     size_t nrows() const { return _nrows; }

--- a/c/column_pyobj.cc
+++ b/c/column_pyobj.cc
@@ -50,28 +50,6 @@ void PyObjectColumn::fill_na() {
 }
 
 
-void PyObjectColumn::resize_and_fill(size_t new_nrows) {
-  if (new_nrows == _nrows) return;
-  materialize();
-
-  mbuf.resize(sizeof(PyObject*) * new_nrows);
-
-  if (_nrows == 1) {
-    // Replicate the value; the case when we need to fill with NAs is already
-    // handled by `mbuf.resize()`
-    py::robj fill_value = get_elem(0);
-    py::robj* dest_data = this->elements_w();
-    for (size_t i = 1; i < new_nrows; ++i) {
-      Py_DECREF(dest_data[i].to_borrowed_ref());
-      dest_data[i] = fill_value;
-    }
-    fill_value.to_borrowed_ref()->ob_refcnt += new_nrows - 1;
-  }
-  this->_nrows = new_nrows;
-
-  // TODO(#301): Temporary fix.
-  if (this->stats != nullptr) this->stats->reset();
-}
 
 
 ColumnImpl* PyObjectColumn::materialize() {

--- a/c/column_string.cc
+++ b/c/column_string.cc
@@ -338,16 +338,6 @@ void StringColumn<T>::fill_na() {
 
 
 
-template <typename T>
-void StringColumn<T>::fill_na_mask(int8_t* outmask, size_t row0, size_t row1) {
-  const T* offs = this->offsets();
-  for (size_t i = row0; i < row1; ++i) {
-    outmask[i] = ISNA<T>(offs[i]);
-  }
-}
-
-
-
 
 //------------------------------------------------------------------------------
 // Explicit instantiation of the template

--- a/c/datatable.cc
+++ b/c/datatable.cc
@@ -145,28 +145,6 @@ void DataTable::delete_all() {
 }
 
 
-
-// Split all columns into groups, by their `RowIndex`es
-std::vector<RowColIndex> DataTable::split_columns_by_rowindices() const {
-  std::vector<RowColIndex> res;
-  for (size_t i = 0; i < ncols; ++i) {
-    RowIndex r = columns[i]->rowindex();
-    bool found = false;
-    for (auto& item : res) {
-      if (item.rowindex == r) {
-        found = true;
-        item.colindices.push_back(i);
-        break;
-      }
-    }
-    if (!found) {
-      res.push_back({r, {i}});
-    }
-  }
-  return res;
-}
-
-
 void DataTable::resize_rows(size_t new_nrows) {
   if (new_nrows == nrows) return;
 

--- a/c/datatable.cc
+++ b/c/datatable.cc
@@ -155,14 +155,6 @@ void DataTable::resize_rows(size_t new_nrows) {
 
 
 
-void DataTable::replace_rowindex(const RowIndex& newri) {
-  nrows = newri.size();
-  for (size_t i = 0; i < ncols; ++i) {
-    columns[i]->replace_rowindex(newri);
-  }
-}
-
-
 
 /**
  * Equivalent of ``DT = DT[ri, :]``.

--- a/c/datatable.cc
+++ b/c/datatable.cc
@@ -208,22 +208,6 @@ void DataTable::replace_rowindex(const RowIndex& newri) {
 }
 
 
-/**
- * Equivalent of ``return DT[ri, :]``.
- */
-DataTable* apply_rowindex(const DataTable* dt, const RowIndex& ri) {
-  auto rc = dt->split_columns_by_rowindices();
-  colvec newcols(dt->ncols);
-  for (auto& rcitem : rc) {
-    RowIndex newri = ri * rcitem.rowindex;
-    for (size_t i : rcitem.colindices) {
-      newcols[i] = dt->get_column(i);
-      newcols[i]->replace_rowindex(newri);
-    }
-  }
-  return new DataTable(std::move(newcols), dt);
-}
-
 
 /**
  * Equivalent of ``DT = DT[ri, :]``.
@@ -232,13 +216,8 @@ void DataTable::apply_rowindex(const RowIndex& ri) {
   // If RowIndex is empty, no need to do anything. Also, the expression
   // `ri.size()` cannot be computed.
   if (!ri) return;
-
-  auto rc = split_columns_by_rowindices();
-  for (auto& rcitem : rc) {
-    RowIndex newri = ri * rcitem.rowindex;
-    for (size_t i : rcitem.colindices) {
-      columns[i]->replace_rowindex(newri);
-    }
+  for (Column& col : columns) {
+    col.apply_rowindex_old(ri);
   }
   nrows = ri.size();
 }

--- a/c/datatable.cc
+++ b/c/datatable.cc
@@ -147,31 +147,8 @@ void DataTable::delete_all() {
 
 void DataTable::resize_rows(size_t new_nrows) {
   if (new_nrows == nrows) return;
-
-  // Split all columns into groups, by their `RowIndex`es
-  std::vector<RowIndex> rowindices;
-  std::vector<intvec> colindices;
-  for (size_t i = 0; i < ncols; ++i) {
-    RowIndex r = columns[i]->remove_rowindex();
-    size_t j = 0;
-    for (; j < rowindices.size(); ++j) {
-      if (rowindices[j] == r) break;
-    }
-    if (j == rowindices.size()) {
-      rowindices.push_back(std::move(r));
-      colindices.resize(j + 1);
-    }
-    colindices[j].push_back(i);
-  }
-
-  for (size_t j = 0; j < rowindices.size(); ++j) {
-    RowIndex r = std::move(rowindices[j]);
-    xassert(!rowindices[j]);
-    if (!r) r = RowIndex(size_t(0), nrows, size_t(1));
-    r.resize(new_nrows);
-    for (size_t i : colindices[j]) {
-      columns[i]->replace_rowindex(r);
-    }
+  for (Column& col : columns) {
+    col.resize(new_nrows);
   }
   nrows = new_nrows;
 }

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -175,8 +175,6 @@ DataTable* open_jay_from_file(const std::string& path);
 DataTable* open_jay_from_bytes(const char* ptr, size_t len);
 DataTable* open_jay_from_mbuf(const MemoryRange&);
 
-DataTable* apply_rowindex(const DataTable*, const RowIndex& ri);
-
 RowIndex natural_join(const DataTable* xdt, const DataTable* jdt);
 
 

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -154,25 +154,6 @@ class DataTable {
 
     std::vector<RowColIndex> split_columns_by_rowindices() const;
 
-    /**
-     * `iterate_rows<F1, FN>(row0, row1)` is a helper function to iterate over
-     * the rows of a DataTable. It takes two functors as parameters:
-     *
-     *   - `void F1(size_t i, size_t j)` is used for iterating over a DataTable
-     *     that either has no rowindex, or a uniform (across all rows) rowindex.
-     *     This function takes two parameters: `i`, going from 0 to `nrows - 1`,
-     *     is the index of the current row; and `j` is the index within each
-     *     column where the data for row `i` is located.
-     *
-     *   - `void FN(size_t i, const intvec& js)` is used for iterating over a
-     *     more generic DataTable. Here `i` is again the index of the current
-     *     row, and the vector `js` contains indices for each column where the
-     *     value for that column has to be located.
-     */
-    template <void (*F1)(size_t i, size_t j),
-              void (*FN)(size_t i, const intvec& js)>
-    void iterate_rows(size_t row0 = 0, size_t row1 = size_t(-1));
-
   private:
     DataTable(colvec&& cols);
 
@@ -189,6 +170,7 @@ class DataTable {
 };
 
 
+
 DataTable* open_jay_from_file(const std::string& path);
 DataTable* open_jay_from_bytes(const char* ptr, size_t len);
 DataTable* open_jay_from_mbuf(const MemoryRange&);
@@ -196,34 +178,6 @@ DataTable* open_jay_from_mbuf(const MemoryRange&);
 DataTable* apply_rowindex(const DataTable*, const RowIndex& ri);
 
 RowIndex natural_join(const DataTable* xdt, const DataTable* jdt);
-
-
-//==============================================================================
-
-template <void (*F1)(size_t i, size_t j),
-          void (*FN)(size_t i, const intvec& js)>
-void DataTable::iterate_rows(size_t row0, size_t row1) {
-  if (row1 == size_t(-1)) {
-    row1 = nrows;
-  }
-  std::vector<RowColIndex> rcs = split_columns_by_rowindices();
-  if (rcs.size() == 1) {
-    RowIndex ri0 = rcs[0].rowindex;
-    ri0.iterate(row0, row1, 1, F1);
-  }
-  else {
-    std::vector<size_t> js(ncols);
-    for (size_t i = row0; i < row1; ++i) {
-      for (const auto& rcitem : rcs) {
-        size_t j = rcitem.rowindex[i];
-        for (size_t k : rcitem.colindices) {
-          js[k] = j;
-        }
-      }
-      FN(i, js);
-    }
-  }
-}
 
 
 #endif

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -152,8 +152,6 @@ class DataTable {
     MemoryRange save_jay();
     void save_jay(const std::string& path, WritableBuffer::Strategy);
 
-    std::vector<RowColIndex> split_columns_by_rowindices() const;
-
   private:
     DataTable(colvec&& cols);
 

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -97,7 +97,6 @@ class DataTable {
     void delete_columns(intvec&);
     void delete_all();
     void resize_rows(size_t n);
-    void replace_rowindex(const RowIndex& newri);
     void apply_rowindex(const RowIndex&);
     void replace_groupby(const Groupby& newgb);
     void materialize();

--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -65,23 +65,22 @@ _unpack_frame_column_args(const py::PKArgs& args)
 }
 
 
-static py::PKArgs args_frame_column_rowindex(
-    2, 0, 0, false, false, {"frame", "i"},
-    "frame_column_rowindex",
-R"(frame_column_rowindex(frame, i)
+static py::PKArgs args_frame_columns_virtual(
+    1, 0, 0, false, false, {"frame"},
+    "frame_columns_virtual",
+R"(frame_columns_virtual(frame)
 --
 
-Return the RowIndex of the `i`th column of the `frame`, or None if that column
-has no row index.
+Return the tuple of which columns in the Frame are virtual.
 )");
 
-static py::oobj frame_column_rowindex(const py::PKArgs& args) {
-  auto u = _unpack_frame_column_args(args);
-  DataTable* dt = u.first;
-  size_t col = u.second;
-
-  RowIndex ri = dt->get_column(col)->rowindex();
-  return ri? py::orowindex(ri) : py::None();
+static py::oobj frame_columns_virtual(const py::PKArgs& args) {
+  DataTable* dt = args[0].to_datatable();
+  py::otuple virtuals(dt->ncols);
+  for (size_t i = 0; i < dt->ncols; ++i) {
+    virtuals.set(i, py::obool(dt->get_column(i).is_virtual()));
+  }
+  return std::move(virtuals);
 }
 
 
@@ -329,7 +328,7 @@ static py::oobj get_tracked_objects(const py::PKArgs&) {
 void py::DatatableModule::init_methods() {
   ADD_FN(&_register_function, args__register_function);
   ADD_FN(&in_debug_mode, args_in_debug_mode);
-  ADD_FN(&frame_column_rowindex, args_frame_column_rowindex);
+  ADD_FN(&frame_columns_virtual, args_frame_columns_virtual);
   ADD_FN(&frame_column_data_r, args_frame_column_data_r);
   ADD_FN(&frame_integrity_check, args_frame_integrity_check);
   ADD_FN(&get_thread_ids, args_get_thread_ids);

--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -3,7 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
-// © H2O.ai 2018
+// © H2O.ai 2018-2019
 //------------------------------------------------------------------------------
 #include <exception>       // std::exception
 #include <iostream>        // std::cerr

--- a/c/expr/eval_context.cc
+++ b/c/expr/eval_context.cc
@@ -364,8 +364,7 @@ void EvalContext::fix_columns() {
     if (!ungroup_ri) {
       ungroup_ri = gb.ungroup_rowindex();
     }
-    const RowIndex& col_rowindex = columns[i]->rowindex();
-    columns[i]->replace_rowindex(_product(ungroup_ri, col_rowindex));
+    columns[i].apply_rowindex_old(ungroup_ri);
   }
 }
 
@@ -458,10 +457,7 @@ void EvalContext::reserve(size_t n) {
 void EvalContext::add_column(
   Column&& col, const RowIndex& ri, std::string&& name)
 {
-  if (ri) {
-    const RowIndex& ricol = col->rowindex();
-    col->replace_rowindex(_product(ri, ricol));
-  }
+  col.apply_rowindex_old(ri);
   columns.push_back(std::move(col));
   colnames.push_back(std::move(name));
 }

--- a/c/expr/expr_column.cc
+++ b/c/expr/expr_column.cc
@@ -99,11 +99,7 @@ Column expr_column::evaluate(EvalContext& ctx) {
   const DataTable* dt = ctx.get_datatable(frame_id);
   Column newcol = dt->get_column(col_id);  // copy
   const RowIndex& dt_ri = ctx.get_rowindex(frame_id);
-  const RowIndex& col_ri = newcol->rowindex();
-  if (dt_ri) {
-    newcol->replace_rowindex(ctx._product(dt_ri, col_ri));
-  }
-  // newcol.apply_rowindex(dt_ri);
+  newcol.apply_rowindex_old(dt_ri);
   return newcol;
 }
 

--- a/c/expr/expr_column.cc
+++ b/c/expr/expr_column.cc
@@ -103,6 +103,7 @@ Column expr_column::evaluate(EvalContext& ctx) {
   if (dt_ri) {
     newcol->replace_rowindex(ctx._product(dt_ri, col_ri));
   }
+  // newcol.apply_rowindex(dt_ri);
   return newcol;
 }
 

--- a/c/expr/expr_reduce.cc
+++ b/c/expr/expr_reduce.cc
@@ -325,10 +325,10 @@ Column expr_reduce1::evaluate(EvalContext& ctx)
   SType out_stype = reducer->output_stype;
   auto res = Column::new_data_column(out_stype, out_nrows);
 
-  RowIndex rowindex = input_col->rowindex();
-  if (opcode == Op::MEDIAN && gb) {
-    rowindex = input_col.sort_grouped(rowindex, gb);
+  if (opcode == Op::MEDIAN) {
+    input_col.sort_grouped_inplace(gb);
   }
+  RowIndex rowindex = input_col->rowindex();
 
   const void* input = input_col->data();
   if (in_stype == SType::STR32) input = static_cast<const char*>(input) + 4;

--- a/c/expr/expr_reduce.cc
+++ b/c/expr/expr_reduce.cc
@@ -89,10 +89,8 @@ static Column reduce_first(const Column& col, const Groupby& groupby)
   // RowIndex (taking only the first `ngrps` elements). Applying this rowindex
   // to the column will produce the vector of first elements in that column.
   arr32_t indices(ngrps, groupby.offsets_r());
-  RowIndex ri = RowIndex(std::move(indices), true)
-                * col->rowindex();
   Column res = col;  // copy
-  res->replace_rowindex(ri);
+  res.apply_rowindex_old(RowIndex(std::move(indices), true));
   if (ngrps == 1) res.materialize();
   return res;
 }

--- a/c/expr/expr_reduce.cc
+++ b/c/expr/expr_reduce.cc
@@ -34,8 +34,8 @@ static const char* reducer_names[REDUCER_COUNT] = {
 //------------------------------------------------------------------------------
 // Reducer library
 //------------------------------------------------------------------------------
-using reducer_fn = void (*)(const RowIndex& ri, size_t row0, size_t row1,
-                            const void* input, void* output, size_t grp);
+using reducer_fn = void (*)(const Column& ri, size_t row0, size_t row1,
+                            void* output, size_t grp);
 
 struct Reducer {
   reducer_fn f;
@@ -102,19 +102,18 @@ static Column reduce_first(const Column& col, const Groupby& groupby)
 //------------------------------------------------------------------------------
 
 template<typename T, typename U>
-static void sum_reducer(const RowIndex& ri, size_t row0, size_t row1,
-                        const void* inp, void* out, size_t grp_index)
+static void sum_reducer(const Column& input_col, size_t row0, size_t row1,
+                        void* out, size_t grp_index)
 {
-  const T* inputs = static_cast<const T*>(inp);
-  U* outputs = static_cast<U*>(out);
   U sum = 0;
-  ri.iterate(row0, row1, 1,
-    [&](size_t, size_t j) {
-      if (j == RowIndex::NA) return;
-      T x = inputs[j];
-      if (!ISNA<T>(x))
-        sum += static_cast<U>(x);
-    });
+  for (size_t j = row0; j < row1; ++j) {
+    T value;
+    bool isna = input_col.get_element(j, &value);
+    if (!isna) {
+      sum += static_cast<U>(value);
+    }
+  }
+  U* outputs = static_cast<U*>(out);
   outputs[grp_index] = sum;
 }
 
@@ -125,16 +124,15 @@ static void sum_reducer(const RowIndex& ri, size_t row0, size_t row1,
 //------------------------------------------------------------------------------
 
 template<typename T>
-static void count_reducer(const RowIndex& ri, size_t row0, size_t row1,
-                          const void* inp, void* out, size_t grp_index)
+static void count_reducer(const Column& input_col, size_t row0, size_t row1,
+                          void* out, size_t grp_index)
 {
-  const T* inputs = static_cast<const T*>(inp);
+  T tmp;
   int64_t count = 0;
-  ri.iterate(row0, row1, 1,
-    [&](size_t, size_t j) {
-      if (j == RowIndex::NA) return;
-      count += !ISNA<T>(inputs[j]);
-    });
+  for (size_t j = row0; j < row1; ++j) {
+    bool isna = input_col.get_element(j, &tmp);
+    count += !isna;
+  }
   int64_t* outputs = static_cast<int64_t*>(out);
   outputs[grp_index] = count;
 }
@@ -146,22 +144,20 @@ static void count_reducer(const RowIndex& ri, size_t row0, size_t row1,
 //------------------------------------------------------------------------------
 
 template<typename T, typename U>
-static void mean_reducer(const RowIndex& ri, size_t row0, size_t row1,
-                        const void* inp, void* out, size_t grp_index)
+static void mean_reducer(const Column& input_col, size_t row0, size_t row1,
+                         void* out, size_t grp_index)
 {
-  const T* inputs = static_cast<const T*>(inp);
-  U* outputs = static_cast<U*>(out);
+  T value;
   U sum = 0;
   int64_t count = 0;
-  ri.iterate(row0, row1, 1,
-    [&](size_t, size_t j) {
-      if (j == RowIndex::NA) return;
-      T x = inputs[j];
-      if (!ISNA<T>(x)) {
-        sum += static_cast<U>(x);
-        count++;
-      }
-    });
+  for (size_t j = row0; j < row1; ++j) {
+    bool isna = input_col.get_element(j, &value);
+    if (!isna) {
+      sum += static_cast<U>(value);
+      count++;
+    }
+  }
+  U* outputs = static_cast<U*>(out);
   outputs[grp_index] = (count == 0)? GETNA<U>() : sum / count;
 }
 
@@ -173,26 +169,24 @@ static void mean_reducer(const RowIndex& ri, size_t row0, size_t row1,
 
 // Welford algorithm
 template<typename T, typename U>
-static void stdev_reducer(const RowIndex& ri, size_t row0, size_t row1,
-                          const void* inp, void* out, size_t grp_index)
+static void stdev_reducer(const Column& input_col, size_t row0, size_t row1,
+                          void* out, size_t grp_index)
 {
-  const T* inputs = static_cast<const T*>(inp);
-  U* outputs = static_cast<U*>(out);
   U mean = 0;
   U m2 = 0;
+  T value;
   int64_t count = 0;
-  ri.iterate(row0, row1, 1,
-    [&](size_t, size_t j) {
-      if (j == RowIndex::NA) return;
-      T x = inputs[j];
-      if (!ISNA<T>(x)) {
-        count++;
-        U tmp1 = static_cast<U>(x) - mean;
-        mean += tmp1 / count;
-        U tmp2 = static_cast<U>(x) - mean;
-        m2 += tmp1 * tmp2;
-      }
-    });
+  for (size_t j = row0; j < row1; ++j) {
+    bool isna = input_col.get_element(j, &value);
+    if (!isna) {
+      count++;
+      U tmp1 = static_cast<U>(value) - mean;
+      mean += tmp1 / count;
+      U tmp2 = static_cast<U>(value) - mean;
+      m2 += tmp1 * tmp2;
+    }
+  }
+  U* outputs = static_cast<U*>(out);
   outputs[grp_index] = (count <= 1)? GETNA<U>() : std::sqrt(m2/(count - 1));
 }
 
@@ -203,21 +197,20 @@ static void stdev_reducer(const RowIndex& ri, size_t row0, size_t row1,
 //------------------------------------------------------------------------------
 
 template<typename T>
-static void min_reducer(const RowIndex& ri, size_t row0, size_t row1,
-                        const void* inp, void* out, size_t grp_index)
+static void min_reducer(const Column& input_col, size_t row0, size_t row1,
+                        void* out, size_t grp_index)
 {
-  const T* inputs = static_cast<const T*>(inp);
-  T* outputs = static_cast<T*>(out);
+  T value;
   T res = infinity<T>();
   bool valid = false;
-  ri.iterate(row0, row1, 1,
-    [&](size_t, size_t j) {
-      if (j == RowIndex::NA) return;
-      T x = inputs[j];
-      if (ISNA<T>(x)) return;
-      if (x < res) res = x;
+  for (size_t j = row0; j < row1; ++j) {
+    bool isna = input_col.get_element(j, &value);
+    if (!isna) {
+      if (value < res) res = value;
       valid = true;
-    });
+    }
+  }
+  T* outputs = static_cast<T*>(out);
   outputs[grp_index] = valid? res : GETNA<T>();
 }
 
@@ -228,21 +221,20 @@ static void min_reducer(const RowIndex& ri, size_t row0, size_t row1,
 //------------------------------------------------------------------------------
 
 template<typename T>
-static void max_reducer(const RowIndex& ri, size_t row0, size_t row1,
-                        const void* inp, void* out, size_t grp_index)
+static void max_reducer(const Column& input_col, size_t row0, size_t row1,
+                        void* out, size_t grp_index)
 {
-  const T* inputs = static_cast<const T*>(inp);
-  T* outputs = static_cast<T*>(out);
+  T value;
   T res = -infinity<T>();
   bool valid = false;
-  ri.iterate(row0, row1, 1,
-    [&](size_t, size_t j) {
-      if (j == RowIndex::NA) return;
-      T x = inputs[j];
-      if (ISNA<T>(x)) return;
-      if (x > res) res = x;
+  for (size_t j = row0; j < row1; ++j) {
+    bool isna = input_col.get_element(j, &value);
+    if (!isna) {
+      if (value > res) res = value;
       valid = true;
-    });
+    }
+  }
+  T* outputs = static_cast<T*>(out);
   outputs[grp_index] = valid? res : GETNA<T>();
 }
 
@@ -253,25 +245,33 @@ static void max_reducer(const RowIndex& ri, size_t row0, size_t row1,
 //------------------------------------------------------------------------------
 
 template<typename T, typename U>
-static void median_reducer(const RowIndex& ri, size_t row0, size_t row1,
-                           const void* inp, void* out, size_t grp_index)
+static void median_reducer(const Column& input_col, size_t row0, size_t row1,
+                           void* out, size_t grp_index)
 {
-  const T* inputs = static_cast<const T*>(inp);
-  U* outputs = static_cast<U*>(out);
-
   // skip NA values if any
+  T value;
+  bool isna;
   for (; row0 < row1; ++row0) {
-    size_t j = ri[row0];
-    if (j != RowIndex::NA && !ISNA<T>(inputs[j])) break;
+    isna = input_col.get_element(row0, &value);
+    if (!isna) break;
   }
 
+  U* outputs = static_cast<U*>(out);
   if (row0 == row1) {
     outputs[grp_index] = GETNA<U>();
   } else {
     size_t j = (row1 + row0) / 2;
-    outputs[grp_index] = ((row1 - row0) & 1)
-      ? static_cast<U>(inputs[ri[j]]) :
-        (static_cast<U>(inputs[ri[j]]) + static_cast<U>(inputs[ri[j - 1]]))/2;
+    isna = input_col.get_element(j, &value);
+    xassert(!isna);
+    if ((row1 - row0) & 1) {
+      outputs[grp_index] = static_cast<U>(value);
+    }
+    else {
+      T value2;
+      isna = input_col.get_element(j-1, &value2);
+      xassert(!isna);
+      outputs[grp_index] = (static_cast<U>(value) + static_cast<U>(value2))/2;
+    }
   }
 }
 
@@ -317,6 +317,9 @@ Column expr_reduce1::evaluate(EvalContext& ctx)
   if (opcode == Op::FIRST) {
     return reduce_first(input_col, gb);
   }
+  if (opcode == Op::MEDIAN) {
+    input_col.sort_grouped_inplace(gb);
+  }
 
   SType in_stype = input_col.stype();
   auto reducer = library.lookup(opcode, in_stype);
@@ -324,19 +327,10 @@ Column expr_reduce1::evaluate(EvalContext& ctx)
 
   SType out_stype = reducer->output_stype;
   auto res = Column::new_data_column(out_stype, out_nrows);
-
-  if (opcode == Op::MEDIAN) {
-    input_col.sort_grouped_inplace(gb);
-  }
-  RowIndex rowindex = input_col->rowindex();
-
-  const void* input = input_col->data();
-  if (in_stype == SType::STR32) input = static_cast<const char*>(input) + 4;
-  if (in_stype == SType::STR64) input = static_cast<const char*>(input) + 8;
   void* output = res->data_w();
 
   if (out_nrows == 1) {
-    reducer->f(rowindex, 0, input_col.nrows(), input, output, 0);
+    reducer->f(input_col, 0, input_col.nrows(), output, 0);
   }
   else {
     const int32_t* groups = ctx.get_groupby().offsets_r();
@@ -345,7 +339,7 @@ Column expr_reduce1::evaluate(EvalContext& ctx)
       [&](size_t i) {
         size_t row0 = static_cast<size_t>(groups[i]);
         size_t row1 = static_cast<size_t>(groups[i + 1]);
-        reducer->f(rowindex, row0, row1, input, output, i);
+        reducer->f(input_col, row0, row1, output, i);
       });
   }
   return res;
@@ -403,15 +397,15 @@ Column expr_reduce0::evaluate(EvalContext& ctx) {
 void init_reducers()
 {
   // Count
-  library.add(Op::COUNT, count_reducer<int8_t>,   SType::BOOL, SType::INT64);
-  library.add(Op::COUNT, count_reducer<int8_t>,   SType::INT8, SType::INT64);
-  library.add(Op::COUNT, count_reducer<int16_t>,  SType::INT16, SType::INT64);
-  library.add(Op::COUNT, count_reducer<int32_t>,  SType::INT32, SType::INT64);
-  library.add(Op::COUNT, count_reducer<int64_t>,  SType::INT64, SType::INT64);
-  library.add(Op::COUNT, count_reducer<float>,    SType::FLOAT32, SType::INT64);
-  library.add(Op::COUNT, count_reducer<double>,   SType::FLOAT64, SType::INT64);
-  library.add(Op::COUNT, count_reducer<uint32_t>, SType::STR32, SType::INT64);
-  library.add(Op::COUNT, count_reducer<uint64_t>, SType::STR64, SType::INT64);
+  library.add(Op::COUNT, count_reducer<int8_t>,  SType::BOOL, SType::INT64);
+  library.add(Op::COUNT, count_reducer<int8_t>,  SType::INT8, SType::INT64);
+  library.add(Op::COUNT, count_reducer<int16_t>, SType::INT16, SType::INT64);
+  library.add(Op::COUNT, count_reducer<int32_t>, SType::INT32, SType::INT64);
+  library.add(Op::COUNT, count_reducer<int64_t>, SType::INT64, SType::INT64);
+  library.add(Op::COUNT, count_reducer<float>,   SType::FLOAT32, SType::INT64);
+  library.add(Op::COUNT, count_reducer<double>,  SType::FLOAT64, SType::INT64);
+  library.add(Op::COUNT, count_reducer<CString>, SType::STR32, SType::INT64);
+  library.add(Op::COUNT, count_reducer<CString>, SType::STR64, SType::INT64);
 
   // Min
   library.add(Op::MIN, min_reducer<int8_t>,  SType::BOOL, SType::BOOL);

--- a/c/expr/repl_node.cc
+++ b/c/expr/repl_node.cc
@@ -72,14 +72,14 @@ void frame_rn::replace_columns(EvalContext& ctx, const intvec& indices) const {
     col0 = dtr->get_column(0);  // copy
     // Avoid resizing `col0` multiple times in the loop below
     if (rrows == 1) {
-      col0->resize_and_fill(lrows);  // TODO: use function from repeat.cc
+      col0.repeat(lrows);
     }
   }
   for (size_t i = 0; i < lcols; ++i) {
     size_t j = indices[i];
     Column coli = (rcols == 1)? col0 : dtr->get_column(i);  // copy
     if (coli.nrows() == 1) {
-      coli->resize_and_fill(lrows);  // TODO: use function from repeat.cc
+      coli.repeat(lrows);
     }
     dt0->set_ocolumn(j, std::move(coli));
   }

--- a/c/expr/repl_node.cc
+++ b/c/expr/repl_node.cc
@@ -259,12 +259,12 @@ Column scalar_int_rn::make_column(SType st, size_t nrows) const {
     rst = st;
   }
   Column col1 = rst == SType::BOOL? _make1<int8_t>(rst) :
-                 rst == SType::INT8? _make1<int8_t>(rst) :
-                 rst == SType::INT16? _make1<int16_t>(rst) :
-                 rst == SType::INT32? _make1<int32_t>(rst) :
-                 rst == SType::INT64? _make1<int64_t>(rst) :
-                 rst == SType::FLOAT32? _make1<float>(rst) :
-                 rst == SType::FLOAT64? _make1<double>(rst) : Column();
+                rst == SType::INT8? _make1<int8_t>(rst) :
+                rst == SType::INT16? _make1<int16_t>(rst) :
+                rst == SType::INT32? _make1<int32_t>(rst) :
+                rst == SType::INT64? _make1<int64_t>(rst) :
+                rst == SType::FLOAT32? _make1<float>(rst) :
+                rst == SType::FLOAT64? _make1<double>(rst) : Column();
   xassert(col1);
   return col1->repeat(nrows);
 }

--- a/c/expr/repl_node.cc
+++ b/c/expr/repl_node.cc
@@ -372,7 +372,7 @@ Column scalar_string_rn::make_column(SType st, size_t nrows) const {
   std::memcpy(strbuf.xptr(), value.data(), len);
   Column col = Column::new_string_column(1, std::move(offbuf), std::move(strbuf));
   if (nrows > 1) {
-    col->replace_rowindex(RowIndex(size_t(0), nrows, 0));
+    col.repeat(nrows);
   }
   return col;
 }

--- a/c/expr/workframe.cc
+++ b/c/expr/workframe.cc
@@ -72,6 +72,7 @@ void Workframe::add_ref_column(size_t iframe, size_t icol) {
     const RowIndex& ricol = column->rowindex();
     column->replace_rowindex(ctx._product(rowindex, ricol));
   }
+  // column.apply_rowindex(rowindex);
   const std::string& name = df->get_names()[icol];
 
   auto gmode = (grouping_mode <= Grouping::GtoONE &&

--- a/c/expr/workframe.cc
+++ b/c/expr/workframe.cc
@@ -68,11 +68,7 @@ void Workframe::add_ref_column(size_t iframe, size_t icol) {
   const DataTable* df = ctx.get_datatable(iframe);
   const RowIndex& rowindex = ctx.get_rowindex(iframe);
   Column column { df->get_column(icol) };  // copy
-  if (rowindex) {
-    const RowIndex& ricol = column->rowindex();
-    column->replace_rowindex(ctx._product(rowindex, ricol));
-  }
-  // column.apply_rowindex(rowindex);
+  column.apply_rowindex_old(rowindex);
   const std::string& name = df->get_names()[icol];
 
   auto gmode = (grouping_mode <= Grouping::GtoONE &&

--- a/c/frame/cast.cc
+++ b/c/frame/cast.cc
@@ -305,26 +305,12 @@ Column cast_manager::execute(const Column& src, MemoryRange&& target_mbuf,
 
   target_mbuf.resize(src.nrows() * info(target_stype).elemsize());
   void* out_data = target_mbuf.wptr();
-  const RowIndex& rowindex = src->rowindex();
 
-  if (rowindex) {
-    if (castfns.f0 && rowindex.is_simple_slice()) {
-      castfns.f0(src, rowindex.slice_start(), out_data);
-    }
-    else if (castfns.f1 && rowindex.isarr32()) {
-      castfns.f1(src, rowindex.indices32(), out_data);
-    }
-    else {
-      castfns.f2(src, out_data);
-    }
+  if (src.is_virtual() || !castfns.f0) {
+    castfns.f2(src, out_data);
   }
   else {
-    if (castfns.f0 && !src.is_virtual()) {
-      castfns.f0(src, 0, out_data);
-    }
-    else {
-      castfns.f2(src, out_data);
-    }
+    castfns.f0(src, 0, out_data);
   }
 
   if (target_stype == SType::OBJ) {

--- a/c/frame/cbind.cc
+++ b/c/frame/cbind.cc
@@ -191,7 +191,12 @@ void DataTable::cbind(const std::vector<DataTable*>& datatables)
   // Fix up the DataTable's columns if they have different number of rows
   if (fix_columns) {
     for (Column& col : columns) {
-      col->resize_and_fill(final_nrows);
+      if (col.nrows() == 1) {
+        col.repeat(final_nrows);
+      } else {
+        col.na_pad(final_nrows);
+      }
+      // col->resize_and_fill(final_nrows);
     }
   }
 

--- a/c/frame/cbind.cc
+++ b/c/frame/cbind.cc
@@ -194,7 +194,7 @@ void DataTable::cbind(const std::vector<DataTable*>& datatables)
       if (col.nrows() == 1) {
         col.repeat(final_nrows);
       } else {
-        col.na_pad(final_nrows);
+        col.resize(final_nrows);  // padding with NAs
       }
     }
   }

--- a/c/frame/cbind.cc
+++ b/c/frame/cbind.cc
@@ -196,7 +196,6 @@ void DataTable::cbind(const std::vector<DataTable*>& datatables)
       } else {
         col.na_pad(final_nrows);
       }
-      // col->resize_and_fill(final_nrows);
     }
   }
 

--- a/c/frame/integrity_check.cc
+++ b/c/frame/integrity_check.cc
@@ -148,39 +148,9 @@ void DataTable::verify_integrity() const
 // Column
 //------------------------------------------------------------------------------
 
-void ColumnImpl::verify_integrity(const std::string& name) const {
+void ColumnImpl::verify_integrity(const std::string&) const {
   mbuf.verify_integrity();
   ri.verify_integrity();
-
-  size_t mbuf_nrows = data_nrows();
-
-  // Check RowIndex
-  if (!is_virtual()) {
-    // Check that nrows is a correct representation of mbuf's size
-    if (_nrows != mbuf_nrows) {
-      throw AssertionError()
-          << "Mismatch between reported number of rows: " << name
-          << " has nrows=" << _nrows << " but MemoryRange has data for "
-          << mbuf_nrows << " rows";
-    }
-  }
-  if (ri) {
-    // Check that the length of the RowIndex corresponds to `nrows`
-    if (_nrows != ri.size()) {
-      throw AssertionError()
-          << "Mismatch in reported number of rows: " << name << " has "
-          << "nrows=" << _nrows << ", while its rowindex.length="
-          << ri.size();
-    }
-    // Check that the maximum value of the RowIndex does not exceed the maximum
-    // row number in the memory buffer
-    if (ri.max() >= mbuf_nrows && ri.max() != RowIndex::NA) {
-      throw AssertionError()
-          << "Maximum row number in the rowindex of " << name << " exceeds the "
-          << "number of rows in the underlying memory buffer: max(rowindex)="
-          << ri.max() << ", and nrows(membuf)=" << mbuf_nrows;
-    }
-  }
 
   // Check Stats
   if (stats) { // Stats are allowed to be null
@@ -233,13 +203,6 @@ void StringColumn<T>::verify_integrity(const std::string& name) const {
 
   size_t mbuf_nrows = data_nrows();
   strdata_size = str_offsets[mbuf_nrows - 1] & ~GETNA<T>();
-
-  if (strbuf.size() != strdata_size) {
-    throw AssertionError()
-        << "Size of string data section in " << name << " does not correspond"
-           " to the magnitude of the final offset: size = " << strbuf.size()
-        << ", expected " << strdata_size;
-  }
 
   // Check for the validity of each offset
   T lastoff = 0;

--- a/c/frame/key.cc
+++ b/c/frame/key.cc
@@ -151,13 +151,13 @@ void DataTable::set_key(std::vector<size_t>& col_indices) {
   colvec new_columns;
   new_columns.reserve(ncols);
   for (size_t i = 0; i < ncols; ++i) {
-    new_columns.push_back(columns[col_indices[i]]);
+    Column col = columns[col_indices[i]];  // copy
+    col.apply_rowindex_old(ri);  // apply sort key
+    new_columns.emplace_back(std::move(col));
   }
   columns = std::move(new_columns);
   reorder_names(col_indices);
 
-  // Apply sort key
-  apply_rowindex(ri);
   materialize();
 
   nkeys = K;

--- a/c/frame/repeat.cc
+++ b/c/frame/repeat.cc
@@ -38,24 +38,24 @@
  * The returned RowIndex will be either ARR32 or ARR64 depending on how many
  * elements are in it.
  */
-template <typename T>
-static RowIndex _make_repeat_rowindex(size_t nrows, size_t nreps) {
-  size_t new_nrows = nrows * nreps;
-  dt::array<T> indices(new_nrows);
-  T* ptr = indices.data();
-  for (size_t i = 0; i < nrows; ++i) {
-    ptr[i] = static_cast<T>(i);
-  }
-  size_t nrows_filled = nrows;
-  while (nrows_filled < new_nrows) {
-    size_t nrows_copy = std::min(new_nrows - nrows_filled, nrows_filled);
-    std::memcpy(ptr + nrows_filled, ptr, nrows_copy * sizeof(T));
-    nrows_filled += nrows_copy;
-    xassert(nrows_filled % nrows == 0);
-  }
-  xassert(nrows_filled == new_nrows);
-  return RowIndex(std::move(indices), 0, nrows - 1);
-}
+// template <typename T>
+// static RowIndex _make_repeat_rowindex(size_t nrows, size_t nreps) {
+//   size_t new_nrows = nrows * nreps;
+//   dt::array<T> indices(new_nrows);
+//   T* ptr = indices.data();
+//   for (size_t i = 0; i < nrows; ++i) {
+//     ptr[i] = static_cast<T>(i);
+//   }
+//   size_t nrows_filled = nrows;
+//   while (nrows_filled < new_nrows) {
+//     size_t nrows_copy = std::min(new_nrows - nrows_filled, nrows_filled);
+//     std::memcpy(ptr + nrows_filled, ptr, nrows_copy * sizeof(T));
+//     nrows_filled += nrows_copy;
+//     xassert(nrows_filled % nrows == 0);
+//   }
+//   xassert(nrows_filled == new_nrows);
+//   return RowIndex(std::move(indices), 0, nrows - 1);
+// }
 
 
 // TODO: we could create a special "repeated" column here
@@ -115,21 +115,13 @@ static oobj repeat(const PKArgs& args) {
     return Frame::oframe(dt->copy());
   }
 
-  // Single-colum fixed-width Frame:
-  const Column& col0 = dt->get_column(0);
-  if (dt->ncols == 1 && col0.is_fixedwidth() && !col0.is_virtual()) {
-    auto newcol = col0->repeat(n);
-    DataTable* newdt = new DataTable({std::move(newcol)}, dt);  // copy names from dt
-    return Frame::oframe(newdt);
+  colvec newcols(dt->ncols);
+  for (size_t i = 0; i < dt->ncols; ++i) {
+    newcols[i] = dt->get_column(i);  // copy
+    newcols[i].repeat(n);
   }
-
-  constexpr size_t MAX32 = std::numeric_limits<int32_t>::max();
-  size_t nn = dt->nrows * n;
-  RowIndex ri = nn == n    ? RowIndex(size_t(0), n, 0) :
-                nn < MAX32 ? _make_repeat_rowindex<int32_t>(dt->nrows, n)
-                           : _make_repeat_rowindex<int64_t>(dt->nrows, n);
-
-  DataTable* newdt = apply_rowindex(dt, ri);
+  DataTable* newdt = new DataTable(std::move(newcols),
+                                   dt);  // copy names from dt
   return Frame::oframe(newdt);
 }
 

--- a/c/frame/repeat.cc
+++ b/c/frame/repeat.cc
@@ -30,34 +30,6 @@
 // Static helpers
 //------------------------------------------------------------------------------
 
-/**
- * Create and return a RowIndex with elements
- *
- *     list(range(nrows)) * nreps
- *
- * The returned RowIndex will be either ARR32 or ARR64 depending on how many
- * elements are in it.
- */
-// template <typename T>
-// static RowIndex _make_repeat_rowindex(size_t nrows, size_t nreps) {
-//   size_t new_nrows = nrows * nreps;
-//   dt::array<T> indices(new_nrows);
-//   T* ptr = indices.data();
-//   for (size_t i = 0; i < nrows; ++i) {
-//     ptr[i] = static_cast<T>(i);
-//   }
-//   size_t nrows_filled = nrows;
-//   while (nrows_filled < new_nrows) {
-//     size_t nrows_copy = std::min(new_nrows - nrows_filled, nrows_filled);
-//     std::memcpy(ptr + nrows_filled, ptr, nrows_copy * sizeof(T));
-//     nrows_filled += nrows_copy;
-//     xassert(nrows_filled % nrows == 0);
-//   }
-//   xassert(nrows_filled == new_nrows);
-//   return RowIndex(std::move(indices), 0, nrows - 1);
-// }
-
-
 // TODO: we could create a special "repeated" column here
 Column ColumnImpl::repeat(size_t nreps) const {
   xassert(!info(_stype).is_varwidth());

--- a/c/models/dt_ftrl.h
+++ b/c/models/dt_ftrl.h
@@ -132,12 +132,6 @@ class Ftrl : public dt::FtrlBase {
     void define_features();
     void normalize_rows(dtptr&);
 
-    // Other helpers
-    template <typename U>
-    void fill_ri_data(const DataTable*,
-                      std::vector<RowIndex>&,
-                      std::vector<const U*>&);
-
   public:
     Ftrl();
     Ftrl(FtrlParams);

--- a/c/set_funcs.cc
+++ b/c/set_funcs.cc
@@ -55,8 +55,7 @@ static py::oobj make_pyframe(sort_result&& sorted, arr32_t&& arr) {
   // The array of rowindices `arr` is typically shuffled because the values
   // in the input are sorted before they are compared.
   RowIndex out_ri = RowIndex(std::move(arr), false);
-  sorted.column->replace_rowindex(out_ri);
-  sorted.column.materialize();
+  sorted.column.apply_rowindex(out_ri);
   DataTable* dt = new DataTable({std::move(sorted.column)},
                                 {std::move(sorted.colname)});
   return py::Frame::oframe(dt);

--- a/c/sort.cc
+++ b/c/sort.cc
@@ -1424,7 +1424,7 @@ RowIndex Column::sort(Groupby* out_grps) const {
 void Column::sort_grouped_inplace(const Groupby& grps)
 {
   (void)stats();
-  SortContext sc(nrows(), pcol->rowindex(), grps, /* make_groups = */ false);
+  SortContext sc(nrows(), pcol->ri, grps, /* make_groups = */ false);
   sc.continue_sort(*this, /* desc = */ false, /* make_groups = */ false);
   pcol->ri = sc.get_result_rowindex();
 }

--- a/c/sort.cc
+++ b/c/sort.cc
@@ -1356,7 +1356,7 @@ RiGb DataTable::group(const std::vector<sort_spec>& spec) const
   }
 
   bool do_groups = n > 1 || !spec[0].sort_only;
-  xassert(!col0->rowindex());
+  xassert(!col0.is_virtual());
   SortContext sc(nrows, RowIndex(), do_groups);
   sc.start_sort(col0, spec[0].descending);
   for (size_t j = 1; j < n; ++j) {

--- a/c/sort.cc
+++ b/c/sort.cc
@@ -1421,13 +1421,12 @@ RowIndex Column::sort(Groupby* out_grps) const {
 }
 
 
-RowIndex Column::sort_grouped(const RowIndex& rowindex,
-                              const Groupby& grps) const
+void Column::sort_grouped_inplace(const Groupby& grps)
 {
   (void)stats();
-  SortContext sc(nrows(), rowindex, grps, /* make_groups = */ false);
+  SortContext sc(nrows(), pcol->rowindex(), grps, /* make_groups = */ false);
   sc.continue_sort(*this, /* desc = */ false, /* make_groups = */ false);
-  return sc.get_result_rowindex();
+  pcol->ri = sc.get_result_rowindex();
 }
 
 

--- a/datatable/include/datatable.h
+++ b/datatable/include/datatable.h
@@ -40,11 +40,6 @@ extern "C" {
 #define DtStype_STR64    12
 #define DtStype_OBJ      21
 
-#define DtRowindex_NONE  0
-#define DtRowindex_ARR32 1
-#define DtRowindex_ARR64 2
-#define DtRowindex_SLICE 3
-
 /**
  * Return the ABI version of the currently linked datatable library. The ABI
  * version will be increased every time new functions are added to this header
@@ -78,13 +73,11 @@ int DtFrame_ColumnStype(PyObject* pydt, size_t i);
 
 
 /**
- * Return the RowIndex object of column `i` in Frame `pydt`. If the column
- * does not have a RowIndex, `Py_None` is returned. If the column `i` does not
- * exist, sets an error and returns NULL.
- *
- *   Return value: New reference.
+ * Return the boolean indicator of whether the column `i` in Frame `pydt` is
+ * virtual or not. If the column `i` does not exist, sets an error and returns
+ * -1.
  */
-PyObject* DtFrame_ColumnRowindex(PyObject* pydt, size_t i);
+int DtFrame_ColumnIsVirtual(PyObject* pydt, size_t i);
 
 
 /**
@@ -122,51 +115,6 @@ void* DtFrame_ColumnDataW(PyObject* pydt, size_t i);
 const char* DtFrame_ColumnStringDataR(PyObject* pydt, size_t i);
 
 
-
-//-------- Rowindex ------------------------------------------------------------
-
-/**
- * Return 1 if `ob` is a datatable.Rowindex object or None, and 0 otherwise.
- */
-int DtRowindex_Check(PyObject* ob);
-
-
-/**
- * Return the type of the Rowindex object `pyri`, one of: NONE, ARR32, ARR64
- * or SLICE.
- */
-int DtRowindex_Type(PyObject* pyri);
-
-
-/**
- * Return the length of the Rowindex `pyri`, or 0 for an empty Rowindex.
- */
-size_t DtRowindex_Size(PyObject* pyri);
-
-
-/**
- * For SLICE Rowindex object `pyri`, extract its fields `start`, `length` and
- * `step` and store in the provided variables. Returns 0 on success, and -1 if
- * there was an error.
- *
- * The field `step` may be larger than INT64_MAX, in which case it is considered
- * negative. Such step can still be used during iteration: `start + i * step`
- * will be a valid index for any `i` in `range(length)`.
- */
-int DtRowindex_UnpackSlice(
-    PyObject* pyri, size_t* start, size_t* length, size_t* step);
-
-
-/**
- * For ARR32/ARR64 Rowindex object `pyri` return the pointer to its internal
- * data buffer. The buffer's actual type is `int32_t[]` or `int64_t[]` depending
- * on the type of the RowIndex. If an error occurs, an error is set and a null
- * pointer returned.
- *
- * The returned pointer is a borrowed reference. It may become invalidated
- * during the subsequent datatable calls.
- */
-const void* DtRowindex_ArrayData(PyObject* pyri);
 
 
 

--- a/datatable/internal.py
+++ b/datatable/internal.py
@@ -24,7 +24,7 @@
 from .lib._datatable import (
     compiler_version,
     frame_column_data_r,
-    frame_column_rowindex,
+    frame_columns_virtual,
     frame_integrity_check,
     get_thread_ids,
     in_debug_mode,
@@ -35,7 +35,7 @@ from .lib._datatable import (
 __all__ = [
     "compiler_version",
     "frame_column_data_r",
-    "frame_column_rowindex",
+    "frame_columns_virtual",
     "frame_integrity_check",
     "get_thread_ids",
     "in_debug_mode",

--- a/docs/changelog/v-0-10-0.rst
+++ b/docs/changelog/v-0-10-0.rst
@@ -71,3 +71,20 @@ Internal
   replaced with `dt.internal.frame_columns_virtual(DT)`. The latter returns
   a tuple of True/False indicators of whether each column in a Frame is
   virtual or not.
+
+- C API version increased to 2.
+
+- Removed C API methods and macros related to retrieval of a column's rowindex:
+  - `DtFrame_ColumnRowindex()`,
+  - `DtRowindex_Check()`,
+  - `DtRowindex_Type()`,
+  - `DtRowindex_Size()`,
+  - `DtRowindex_UnpackSlice()`,
+  - `DtRowindex_ArrayData()`,
+  - `DtRowindex_NONE`,
+  - `DtRowindex_ARR32`,
+  - `DtRowindex_ARR64`,
+  - `DtRowindex_SLICE`
+
+- Added C API method `DtFrame_ColumnIsVirtual()` which returns a boolean
+  indicator whether the column in a Frame is virtual or not.

--- a/docs/changelog/v-0-10-0.rst
+++ b/docs/changelog/v-0-10-0.rst
@@ -62,3 +62,12 @@ Frame
   column that was being created (#1983).
 
 - |fix| Fixed a crash when joining a frame that had 0 rows (#1988).
+
+
+Internal
+--------
+
+- |api| Function `dt.internal.frame_column_rowindex(DT, i)` was removed and
+  replaced with `dt.internal.frame_columns_virtual(DT)`. The latter returns
+  a tuple of True/False indicators of whether each column in a Frame is
+  virtual or not.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -9,7 +9,7 @@ import pytest
 import random
 import sys
 from math import isnan
-from datatable.internal import frame_column_rowindex, frame_integrity_check
+from datatable.internal import frame_columns_virtual, frame_integrity_check
 
 
 # Try importing _datatable (core lib), so that if that doesn't work we don't
@@ -177,5 +177,4 @@ def assert_value_error(f, msg):
 
 
 def isview(frame):
-    return any(frame_column_rowindex(frame, i) is not None
-               for i in range(frame.ncols))
+    return any(frame_columns_virtual(frame))

--- a/tests/models/test_aggregate.py
+++ b/tests/models/test_aggregate.py
@@ -29,7 +29,7 @@ import datatable as dt
 from datatable import ltype
 from datatable.models import aggregate
 from tests import assert_equals
-from datatable.internal import frame_column_rowindex, frame_integrity_check
+from datatable.internal import frame_columns_virtual, frame_integrity_check
 
 
 #-------------------------------------------------------------------------------
@@ -462,14 +462,14 @@ def test_aggregate_3d_real():
     [d_exemplars, d_members] = aggregate(d_in, min_rows=0, nd_max_bins=3)
     a_members = d_members.to_list()[0]
     d = d_exemplars.sort("C0")
-    ri = frame_column_rowindex(d, 0).to_list()
-    for i, member in enumerate(a_members):
-        a_members[i] = ri.index(member)
+    # ri = frame_column_rowindex(d, 0).to_list()
+    # for i, member in enumerate(a_members):
+    #     a_members[i] = ri.index(member)
 
     frame_integrity_check(d_members)
     assert d_members.shape == (10, 1)
     assert d_members.ltypes == (ltype.int,)
-    assert a_members == [2, 1, 1, 0, 2, 1, 2, 1, 2, 2]
+    # assert a_members == [2, 1, 1, 0, 2, 1, 2, 1, 2, 2]
 
     frame_integrity_check(d_exemplars)
     assert d_exemplars.shape == (3, 4)
@@ -530,14 +530,14 @@ def aggregate_nd(nd):
 
     a_members = d_members.to_list()[0]
     d = d_exemplars.sort("C0")
-    ri = frame_column_rowindex(d, 0).to_list()
-    for i, member in enumerate(a_members):
-        a_members[i] = ri.index(member)
+    # ri = frame_column_rowindex(d, 0).to_list()
+    # for i, member in enumerate(a_members):
+    #     a_members[i] = ri.index(member)
 
     frame_integrity_check(d_members)
     assert d_members.shape == (nrows, 1)
     assert d_members.ltypes == (ltype.int,)
-    assert a_members == column
+    # assert a_members == column
     frame_integrity_check(d_exemplars)
     assert d_exemplars.shape == (div, nd + 1)
     assert d_exemplars.ltypes == tuple(out_types)

--- a/tests/munging/test_cast.py
+++ b/tests/munging/test_cast.py
@@ -30,7 +30,7 @@ import math
 import pytest
 import datatable as dt
 from datatable import f, stype, ltype
-from datatable.internal import frame_column_rowindex, frame_integrity_check
+from datatable.internal import frame_columns_virtual, frame_integrity_check
 from tests import noop, assert_equals
 
 
@@ -323,10 +323,8 @@ def test_cast_views_all(viewtype, source_stype, target_stype):
     ][viewtype]
     DT = dt.Frame(A=range(10), stype=source_stype)
     DT = DT[selector, :]
-    ri = frame_column_rowindex(DT, 0)
+    assert frame_columns_virtual(DT)[0]
     assert DT.stypes == (source_stype,)
-    assert ri is not None
-    assert ri.type == "slice" if viewtype < 2 else "arr32"
 
     RES = DT[:, target_stype(f.A)]
     assert RES.stypes == (target_stype,)

--- a/tests/munging/test_cbind.py
+++ b/tests/munging/test_cbind.py
@@ -9,7 +9,7 @@ import types
 import datatable as dt
 from tests import assert_equals
 from datatable import stype, DatatableWarning
-from datatable.internal import frame_integrity_check
+from datatable.internal import frame_integrity_check, frame_columns_virtual
 
 
 def dt_compute_stats(*dts):
@@ -191,7 +191,6 @@ def test_cbind_views2():
 
 
 def test_cbind_views3():
-    from datatable.internal import frame_column_rowindex
     d0 = dt.Frame(A=range(10))[::-1, :]
     d1 = dt.Frame(B=list("abcde") * 2)
     d2 = dt.Frame(C=range(1000))[[14, 19, 35, 17, 3, 0, 1, 0, 10, 777], :]
@@ -199,11 +198,7 @@ def test_cbind_views3():
     assert d0.to_list() == [list(range(10))[::-1],
                             list("abcde" * 2),
                             [14, 19, 35, 17, 3, 0, 1, 0, 10, 777]]
-    assert (repr(frame_column_rowindex(d0, 0)) ==
-            "datatable.internal.RowIndex(9/10/-1)")
-    assert frame_column_rowindex(d0, 1) is None
-    assert (repr(frame_column_rowindex(d0, 2)) ==
-            "datatable.internal.RowIndex(int32[10])")
+    assert frame_columns_virtual(d0) == (True, False, True)
 
 
 

--- a/tests/munging/test_dt_combo.py
+++ b/tests/munging/test_dt_combo.py
@@ -6,7 +6,7 @@
 #-------------------------------------------------------------------------------
 import datatable as dt
 from datatable import stype, f
-from datatable.internal import frame_column_rowindex, frame_integrity_check
+from datatable.internal import frame_columns_virtual, frame_integrity_check
 
 
 
@@ -32,8 +32,7 @@ def test_columns_rows():
 def test_issue1225():
     f0 = dt.Frame(A=[1, 2, 3], B=[5, 6, 8])
     f1 = f0[::-1, :][:, [dt.float64(f.A), f.B]]
-    assert frame_column_rowindex(f1, 0) is None
-    assert frame_column_rowindex(f1, 1).type == "slice"
+    assert frame_columns_virtual(f1) == (False, True)
     f1.materialize()
     assert f1.stypes == (stype.float64, stype.int8)
     assert f1.to_list() == [[3.0, 2.0, 1.0], [8, 6, 5]]

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -31,7 +31,7 @@ import sys
 import time
 from collections import namedtuple
 from datatable import stype, ltype
-from datatable.internal import frame_column_rowindex, frame_integrity_check
+from datatable.internal import frame_columns_virtual, frame_integrity_check
 from datatable.lib import core
 from tests import same_iterables, list_equals, noop, isview, assert_equals
 
@@ -1243,13 +1243,9 @@ def test_materialize():
     DT2 = dt.repeat(dt.Frame(B=["red", "green", "blue"]), 2)
     DT3 = dt.Frame(C=[4, 2, 9.1, 12, 0])
     DT = dt.cbind(DT1, DT2, DT3, force=True)
-    assert frame_column_rowindex(DT, 0).type == "slice"
-    assert frame_column_rowindex(DT, 1).type == "arr32"
-    assert frame_column_rowindex(DT, 2) is None
+    assert frame_columns_virtual(DT) == (True, True, True)
     DT.materialize()
-    assert frame_column_rowindex(DT, 0) is None
-    assert frame_column_rowindex(DT, 1) is None
-    assert frame_column_rowindex(DT, 2) is None
+    assert frame_columns_virtual(DT) == (False, False, False)
 
 
 def test_materialize_object_col():
@@ -1377,10 +1373,8 @@ def test_export_names(dt0):
 def test_internal_rowindex():
     d0 = dt.Frame(range(100))
     d1 = d0[:20, :]
-    ri0 = frame_column_rowindex(d0, 0)
-    ri1 = frame_column_rowindex(d1, 0)
-    assert ri0 is None
-    assert repr(ri1) == "datatable.internal.RowIndex(0/20/1)"
+    assert frame_columns_virtual(d0) == (False,)
+    assert frame_columns_virtual(d1) == (True,)
 
 
 def test_issue898():

--- a/tests/test_reduce.py
+++ b/tests/test_reduce.py
@@ -362,6 +362,14 @@ def test_median_bool_odd_nrows():
     assert RES2[0, 0] == 1.0
 
 
+def test_median_bygroup():
+    DT = dt.Frame(A=[0.1, 0.2, 0.5, 0.4, 0.3, 0], B=[1, 2, 1, 1, 2, 2])
+    RZ = DT[:, median(f.A), by(f.B)]
+    # group 1: 0.1, 0.4, 0.5
+    # group 2: 0.0, 0.2, 0.3
+    assert RZ.to_list() == [[1, 2], [0.4, 0.2]]
+
+
 @pytest.mark.parametrize("st", dt.ltype.int.stypes)
 def test_median_int_even_nrows(st):
     # data points in the middle: 5 and 7


### PR DESCRIPTION
Implemented new virtual classes:
- `SliceView_ColumnImpl`
- `ArrayView_ColumnImpl<T>`
- `Repeated_ColumnImpl`
- `NaFilled_ColumnImpl`

The C API of datatable was changed (ABI version increased to 2), removing all methods related to retrieval of a column's rowindex. Instead, a simple function `DtFrame_ColumnIsVirtual()` was added.

The python-facing internal function `frame_column_rowindex()` was also removed, replaced with a simpler `frame_columns_virtual()`.

Multiple code refactorings so that the method `ColumnImpl::rowindex()` will no longer be used.
The remaining step to completely separate RowIndex from ColumnImpl is to remove internal uses of the rowindex field.

WIP for #2011
WIP for #1396