### PR TITLE
Forbid increasing the number of rows on a keyed Frame

### DIFF
--- a/c/datatable.cc
+++ b/c/datatable.cc
@@ -147,6 +147,9 @@ void DataTable::delete_all() {
 
 void DataTable::resize_rows(size_t new_nrows) {
   if (new_nrows == nrows) return;
+  if (new_nrows > nrows && nkeys > 0) {
+    throw ValueError() << "Cannot increase the number of rows in a keyed frame";
+  }
   for (Column& col : columns) {
     col.resize(new_nrows);
   }

--- a/c/frame/py_frame.cc
+++ b/c/frame/py_frame.cc
@@ -253,6 +253,7 @@ void Frame::set_nrows(const Arg& nr) {
 }
 
 
+
 static GSArgs args_shape(
   "shape",
   "Tuple with (nrows, ncols) dimensions of the Frame\n");

--- a/docs/changelog/v-0-10-0.rst
+++ b/docs/changelog/v-0-10-0.rst
@@ -63,6 +63,9 @@ Frame
 
 - |fix| Fixed a crash when joining a frame that had 0 rows (#1988).
 
+- |fix| Increasing the number of rows in a keyed Frame was documented as
+  invalid, but didn't actually throw any errors. Now it does (#2021).
+
 
 Internal
 --------

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -163,3 +163,14 @@ def test_key_after_group():
     tmp.key = "A"
     assert tmp.to_list()[0] == ["a", "b", "c", "d"]
     assert sum(tmp.to_list()[1]) == n
+
+
+def test_setnrows_for_keyed_frame():
+    DT = dt.Frame(A=range(100))
+    DT.key = "A"
+    DT.nrows = 50
+    frame_integrity_check(DT)
+    assert DT.to_list() == [list(range(50))]
+    with pytest.raises(ValueError) as e:
+        DT.nrows = 70
+    assert "Cannot increase the number of rows" in str(e.value)


### PR DESCRIPTION
In a keyed frame, the values in key columns must be unique. On the other hand, increasing the number of rows in a frame adds new rows filled with NAs, which is not legal for a keyed frame (because the values in the key column will stop being unique).

Closes #2021