### PR TITLE
Added Frame property .stype

### DIFF
--- a/c/frame/py_frame.h
+++ b/c/frame/py_frame.h
@@ -92,6 +92,7 @@ class Frame : public XObject<Frame> {
     oobj get_ndims() const;
     oobj get_shape() const;
     oobj get_stypes() const;
+    oobj get_stype() const;
     oobj get_ltypes() const;
     oobj get_names() const;
     oobj get_key() const;

--- a/docs/changelog/v-0-10-0.rst
+++ b/docs/changelog/v-0-10-0.rst
@@ -57,6 +57,11 @@ Frame
   The variables are created in the global scope because python's locals cannot
   be manipulated programmatically.
 
+- |new| Added frame property :meth:`.stype <datatable.Frame.stype>` which is
+  similar to :meth:`.stypes <datatable.Frame.stypes>` except that it returns
+  a single stype instead of a tuple. This method can only be used on a frame
+  where all columns have the same stype, or there is only one column.
+
 - |fix| Fixed a bug where creating a new column via assignment would crash if
   the RHS of the assignment contained an expression that tried to use the
   column that was being created (#1983).

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -394,6 +394,25 @@ def test_warnings_as_errors():
 
 
 #-------------------------------------------------------------------------------
+# Stype
+#-------------------------------------------------------------------------------
+
+def test_dt_stype(dt0):
+    assert dt0[0].stype == stype.int8
+    assert dt0[1].stype == stype.bool8
+    assert dt0[:, [1, 2, 4, 5]].stype == stype.bool8
+    assert dt0[-1].stype == stype.str32
+
+
+def test_dt_stype_heterogenous(dt0):
+    with pytest.raises(ValueError) as e:
+        noop(dt0.stype)
+    assert ("The stype of column 'B' is `bool8`, which is different "
+            "from the stype of the previous column" in str(e.value))
+
+
+
+#-------------------------------------------------------------------------------
 # Colindex
 #-------------------------------------------------------------------------------
 


### PR DESCRIPTION
The new property is convenient in situations when you either have a single-column Frame, or when you know that all columns in your Frame have the same stype.

Closes #2020