### PR TITLE
Fix rbinding of resized frames

### DIFF
--- a/c/column.cc
+++ b/c/column.cc
@@ -105,8 +105,8 @@ ColumnImpl* ColumnImpl::shallowcopy() const {
 }
 
 
-size_t ColumnImpl::alloc_size() const {
-  return mbuf.size();
+size_t ColumnImpl::alloc_size() const {  // TODO: remove
+  return _nrows * info(_stype).elemsize();
 }
 
 PyObject* ColumnImpl::mbuf_repr() const {

--- a/c/frame/rbind.cc
+++ b/c/frame/rbind.cc
@@ -465,7 +465,7 @@ void FwColumn<T>::rbind_impl(colvec& columns, size_t new_nrows, bool col_empty)
         rows_to_fill = 0;
       }
       if (col.stype() != _stype) {
-        col = col.cast(_stype);
+        col.cast_inplace(_stype);
       }
       std::memcpy(resptr, col->data(), col->alloc_size());
       resptr += col->alloc_size();

--- a/tests/munging/test_rbind.py
+++ b/tests/munging/test_rbind.py
@@ -480,3 +480,13 @@ def test_issue1607():
     DT.rbind(DT, DT)
     frame_integrity_check(DT)
     assert DT.shape == (0, 3)
+
+
+def test_issue2026():
+    DT = dt.Frame(A=range(10))
+    DT.rbind(DT)
+    DT.nrows = 8
+    DT.rbind(DT)
+    frame_integrity_check(DT)
+    assert DT.to_list() == [[0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7]]
+


### PR DESCRIPTION
After a column was resized, its `mbuf.size()` may be bigger than the amount of data actually used. This was causing problems with rbind, which used incorrect definition of column's size when copying the data.

The bug was introduced in yesterday's commit, so not a critical issue.
Closes #2026