### PR TITLE
Fix broken aggregator tests

### DIFF
--- a/tests/models/test_aggregate.py
+++ b/tests/models/test_aggregate.py
@@ -452,6 +452,7 @@ def test_aggregate_3d_categorical():
     assert_equals(d_in, d_in_copy)
 
 
+# Single thread test, due to small number of rows
 def test_aggregate_3d_real():
     d_in = dt.Frame([
         [0.95, 0.50, 0.55, 0.10, 0.90, 0.50, 0.90, 0.50, 0.90, 1.00],
@@ -460,25 +461,22 @@ def test_aggregate_3d_real():
     ])
     d_in_copy = dt.Frame(d_in)
     [d_exemplars, d_members] = aggregate(d_in, min_rows=0, nd_max_bins=3)
-    a_members = d_members.to_list()[0]
-    d = d_exemplars.sort("C0")
-    # ri = frame_column_rowindex(d, 0).to_list()
-    # for i, member in enumerate(a_members):
-    #     a_members[i] = ri.index(member)
-
-    frame_integrity_check(d_members)
-    assert d_members.shape == (10, 1)
-    assert d_members.ltypes == (ltype.int,)
-    # assert a_members == [2, 1, 1, 0, 2, 1, 2, 1, 2, 2]
 
     frame_integrity_check(d_exemplars)
     assert d_exemplars.shape == (3, 4)
     assert d_exemplars.ltypes == (ltype.real, ltype.real, ltype.real, ltype.int)
-    assert d.to_list() == [[0.10, 0.50, 0.95],
-                           [0.05, 0.55, 1.00],
-                           [0.00, 0.50, 0.90],
-                           [1, 4, 5]]
+    assert d_exemplars.to_list() == [[0.95, 0.50, 0.10],
+                                     [1.00, 0.55, 0.05],
+                                     [0.90, 0.50, 0.00],
+                                     [5, 4, 1]]
+
+    frame_integrity_check(d_members)
+    assert d_members.shape == (10, 1)
+    assert d_members.ltypes == (ltype.int,)
+    assert d_members.to_list() == [[0, 1, 1, 2, 0, 1, 0, 1, 0, 0]]
+
     assert_equals(d_in, d_in_copy)
+
 
 
 def test_aggregate_nd_direct():
@@ -514,7 +512,6 @@ def aggregate_nd(nd):
                                      min_duration=0):
         [d_exemplars, d_members] = aggregate(d_in, min_rows=0,
                                              nd_max_bins=div, seed=1)
-
         messages = ("", "Preparing", "Aggregating", "Sampling", "Finalizing")
         message_index = 0
         for i, p in enumerate(progress_reports):

--- a/tests/models/test_aggregate.py
+++ b/tests/models/test_aggregate.py
@@ -525,20 +525,16 @@ def aggregate_nd(nd):
         assert progress_reports[-1].status == "finished"
         assert progress_reports[-1].message == "Finalizing"
 
-    a_members = d_members.to_list()[0]
-    d = d_exemplars.sort("C0")
-    # ri = frame_column_rowindex(d, 0).to_list()
-    # for i, member in enumerate(a_members):
-    #     a_members[i] = ri.index(member)
-
     frame_integrity_check(d_members)
     assert d_members.shape == (nrows, 1)
     assert d_members.ltypes == (ltype.int,)
-    # assert a_members == column
+    for i in range(nrows) :
+        assert(i % div == d_exemplars[d_members[i, 0], 0])
+
     frame_integrity_check(d_exemplars)
     assert d_exemplars.shape == (div, nd + 1)
     assert d_exemplars.ltypes == tuple(out_types)
-    assert d.to_list() == out_value
+    assert d_exemplars.sort("C0").to_list() == out_value
     assert_equals(d_in, d_in_copy)
 
 


### PR DESCRIPTION
Fix aggregator tests broken due to the Python rowindex removal in #2018.

Closes #2019