### PR TITLE
Buffer refactoring

### DIFF
--- a/c/buffer.h
+++ b/c/buffer.h
@@ -241,14 +241,9 @@ class MemoryRange
 
     // Utility functions
     //
-    // pyrepr()
-    //   Return PyObject* containing `repr()` string of this object. [Not sure
-    //   if this function ought to exist].
-    //
     // verify_integrity()
     //   Check internal validity of this object.
     //
-    PyObject* pyrepr() const;
     void verify_integrity() const;
 
   private:

--- a/c/buffer.h
+++ b/c/buffer.h
@@ -237,6 +237,9 @@ class MemoryRange
     MemoryRange& set_pyobjects(bool clear_data);
     MemoryRange& resize(size_t newsize, bool keep_data = true);
 
+    void acquire_shared();
+    void release_shared();
+
     // Utility functions
     //
     // pyrepr()

--- a/c/buffer.h
+++ b/c/buffer.h
@@ -244,7 +244,7 @@ class MemoryRange
     void verify_integrity() const;
 
   private:
-    explicit MemoryRange(BufferImpl* impl);
+    explicit MemoryRange(BufferImpl*&& impl);
 
     // Helper function for dealing with non-writeable objects. It will replace
     // the current `impl` with a new `MemoryMRI` object of size `newsize`,

--- a/c/buffer.h
+++ b/c/buffer.h
@@ -128,6 +128,7 @@ class MemoryRange
     static MemoryRange mem(size_t n);
     static MemoryRange mem(int64_t n);
     static MemoryRange acquire(void* ptr, size_t n);
+    static MemoryRange external(void* ptr, size_t n);
     static MemoryRange external(const void* ptr, size_t n);
     static MemoryRange external(const void* ptr, size_t n, Py_buffer* pybuf);
     static MemoryRange view(const MemoryRange& src, size_t n, size_t offset);

--- a/c/buffer.h
+++ b/c/buffer.h
@@ -236,9 +236,6 @@ class MemoryRange
     MemoryRange& set_pyobjects(bool clear_data);
     MemoryRange& resize(size_t newsize, bool keep_data = true);
 
-    void acquire_shared();
-    void release_shared();
-
     // Utility functions
     //
     // verify_integrity()

--- a/c/column.cc
+++ b/c/column.cc
@@ -108,10 +108,6 @@ size_t ColumnImpl::alloc_size() const {  // TODO: remove
   return _nrows * info(_stype).elemsize();
 }
 
-PyObject* ColumnImpl::mbuf_repr() const {
-  return mbuf.pyrepr();
-}
-
 
 
 
@@ -293,7 +289,7 @@ const void* Column::get_data_readonly(size_t k) const {
                 : pcol->data2();
 }
 
-void* Column::get_data_editable(size_t k) {
+void* Column::get_data_editable(size_t) {
   if (is_virtual()) materialize();
   return pcol->mbuf.wptr();
 }

--- a/c/column.cc
+++ b/c/column.cc
@@ -38,7 +38,7 @@ Column Column::new_na_column(SType stype, size_t nrows) {
 }
 
 
-Column Column::new_mbuf_column(SType stype, MemoryRange&& mbuf) {
+Column Column::new_mbuf_column(SType stype, Buffer&& mbuf) {
   size_t elemsize = info(stype).elemsize();
   ColumnImpl* col = ColumnImpl::new_impl(stype);
   xassert(mbuf.size() % elemsize == 0);
@@ -51,9 +51,9 @@ Column Column::new_mbuf_column(SType stype, MemoryRange&& mbuf) {
 }
 
 
-static MemoryRange _recode_offsets_to_u64(const MemoryRange& offsets) {
+static Buffer _recode_offsets_to_u64(const Buffer& offsets) {
   // TODO: make this parallel
-  MemoryRange off64 = MemoryRange::mem(offsets.size() * 2);
+  Buffer off64 = Buffer::mem(offsets.size() * 2);
   auto data64 = static_cast<uint64_t*>(off64.xptr());
   auto data32 = static_cast<const uint32_t*>(offsets.rptr());
   data64[0] = 0;
@@ -73,7 +73,7 @@ static MemoryRange _recode_offsets_to_u64(const MemoryRange& offsets) {
 
 
 Column Column::new_string_column(
-    size_t n, MemoryRange&& data, MemoryRange&& str)
+    size_t n, Buffer&& data, Buffer&& str)
 {
   size_t data_size = data.size();
   size_t strb_size = str.size();

--- a/c/column.h
+++ b/c/column.h
@@ -31,7 +31,7 @@ class BitMask;
 class Column;
 class ColumnImpl;
 class Groupby;
-class MemoryRange;
+class Buffer;
 using colvec = std::vector<Column>;
 using strvec = std::vector<std::string>;
 
@@ -136,8 +136,8 @@ class Column
 
     static Column new_data_column(SType, size_t nrows);
     static Column new_na_column(SType, size_t nrows);
-    static Column new_mbuf_column(SType, MemoryRange&&);
-    static Column new_string_column(size_t n, MemoryRange&& data, MemoryRange&& str);
+    static Column new_mbuf_column(SType, Buffer&&);
+    static Column new_string_column(size_t n, Buffer&& data, Buffer&& str);
     static Column from_buffer(const py::robj& buffer);
     static Column from_pylist(const py::olist& list, int stype0 = 0);
     static Column from_pylist_of_tuples(const py::olist& list, size_t index, int stype0);
@@ -268,7 +268,7 @@ class Column
     void materialize() const;
     void cast_inplace(SType stype);
     Column cast(SType stype) const;
-    Column cast(SType stype, MemoryRange&& mr) const;
+    Column cast(SType stype, Buffer&& mr) const;
     RowIndex sort(Groupby* out_groups) const;
     void sort_grouped(const Groupby&);
 

--- a/c/column_bool.cc
+++ b/c/column_bool.cc
@@ -14,7 +14,7 @@ BoolColumn::BoolColumn(size_t nrows) : FwColumn<int8_t>(nrows) {
   _stype = SType::BOOL;
 }
 
-BoolColumn::BoolColumn(size_t nrows, MemoryRange&& mem)
+BoolColumn::BoolColumn(size_t nrows, Buffer&& mem)
   : FwColumn<int8_t>(nrows, std::move(mem)) {
   _stype = SType::BOOL;
 }

--- a/c/column_from_pylist.cc
+++ b/c/column_from_pylist.cc
@@ -119,7 +119,7 @@ py::robj idictlist::item(size_t i) const {
  * pythonic `False` or number 0 as "false" values, and pythonic `None` as NA.
  * If any other value is encountered, the parse will fail.
  */
-static bool parse_as_bool(const iterable* list, MemoryRange& membuf, size_t& from)
+static bool parse_as_bool(const iterable* list, Buffer& membuf, size_t& from)
 {
   size_t nrows = list->size();
   membuf.resize(nrows);
@@ -151,7 +151,7 @@ static bool parse_as_bool(const iterable* list, MemoryRange& membuf, size_t& fro
  * fails for any reason (for example, method `__bool__()` raised an exception)
  * then the value will be converted into NA.
  */
-static void force_as_bool(const iterable* list, MemoryRange& membuf)
+static void force_as_bool(const iterable* list, Buffer& membuf)
 {
   size_t nrows = list->size();
   membuf.resize(nrows);
@@ -181,7 +181,7 @@ static void force_as_bool(const iterable* list, MemoryRange& membuf)
  * parser will fail if the `int` value does not fit into the range of type `T`.
  */
 template <typename T>
-static bool parse_as_int(const iterable* list, MemoryRange& membuf, size_t& from)
+static bool parse_as_int(const iterable* list, Buffer& membuf, size_t& from)
 {
   size_t nrows = list->size();
   membuf.resize(nrows * sizeof(T));
@@ -222,7 +222,7 @@ static bool parse_as_int(const iterable* list, MemoryRange& membuf, size_t& from
  * as C++'s `static_cast<T>`).
  */
 template <typename T>
-static void force_as_int(const iterable* list, MemoryRange& membuf)
+static void force_as_int(const iterable* list, Buffer& membuf)
 {
   size_t nrows = list->size();
   membuf.resize(nrows * sizeof(T));
@@ -250,7 +250,7 @@ static void force_as_int(const iterable* list, MemoryRange& membuf)
  * as doubles, and it's extremely hard to determine whether that number should
  * have been a float instead...
  */
-static bool parse_as_double(const iterable* list, MemoryRange& membuf, size_t& from)
+static bool parse_as_double(const iterable* list, Buffer& membuf, size_t& from)
 {
   size_t nrows = list->size();
   membuf.resize(nrows * sizeof(double));
@@ -286,7 +286,7 @@ static bool parse_as_double(const iterable* list, MemoryRange& membuf, size_t& f
 
 
 template <typename T>
-static void force_as_real(const iterable* list, MemoryRange& membuf)
+static void force_as_real(const iterable* list, Buffer& membuf)
 {
   size_t nrows = list->size();
   membuf.resize(nrows * sizeof(T));
@@ -318,8 +318,8 @@ static void force_as_real(const iterable* list, MemoryRange& membuf)
 //------------------------------------------------------------------------------
 
 template <typename T>
-static bool parse_as_str(const iterable* list, MemoryRange& offbuf,
-                         MemoryRange& strbuf)
+static bool parse_as_str(const iterable* list, Buffer& offbuf,
+                         Buffer& strbuf)
 {
   size_t nrows = list->size();
   offbuf.resize((nrows + 1) * sizeof(T));
@@ -391,8 +391,8 @@ static bool parse_as_str(const iterable* list, MemoryRange& offbuf,
  * `int32_t`.
  */
 template <typename T>
-static void force_as_str(const iterable* list, MemoryRange& offbuf,
-                         MemoryRange& strbuf)
+static void force_as_str(const iterable* list, Buffer& offbuf,
+                         Buffer& strbuf)
 {
   size_t nrows = list->size();
   if (nrows > std::numeric_limits<T>::max()) {
@@ -454,7 +454,7 @@ static void force_as_str(const iterable* list, MemoryRange& offbuf,
 // Object
 //------------------------------------------------------------------------------
 
-static bool parse_as_pyobj(const iterable* list, MemoryRange& membuf)
+static bool parse_as_pyobj(const iterable* list, Buffer& membuf)
 {
   size_t nrows = list->size();
   membuf.resize(nrows * sizeof(PyObject*));
@@ -499,8 +499,8 @@ static SType find_next_stype(SType curr_stype, int stype0) {
 
 static Column ocolumn_from_iterable(const iterable* il, int stype0)
 {
-  MemoryRange membuf;
-  MemoryRange strbuf;
+  Buffer membuf;
+  Buffer strbuf;
   SType stype = find_next_stype(SType::VOID, stype0);
   size_t i = 0;
   while (stype != SType::VOID) {

--- a/c/column_fw.cc
+++ b/c/column_fw.cc
@@ -42,7 +42,7 @@ FwColumn<T>::FwColumn(size_t nrows_)
 
 
 template <typename T>
-FwColumn<T>::FwColumn(size_t nrows_, MemoryRange&& mr)
+FwColumn<T>::FwColumn(size_t nrows_, Buffer&& mr)
   : ColumnImpl(nrows_, stype_for<T>())
 {
   size_t req_size = sizeof(T) * nrows_;

--- a/c/column_impl.h
+++ b/c/column_impl.h
@@ -125,7 +125,6 @@ class ColumnImpl
       assert(!is_virtual());
       return mbuf.wptr();
     }
-    PyObject* mbuf_repr() const;
     size_t alloc_size() const;
 
     virtual size_t data_nrows() const;

--- a/c/column_pyobj.cc
+++ b/c/column_pyobj.cc
@@ -22,7 +22,7 @@ PyObjectColumn::PyObjectColumn(size_t nrows_) : FwColumn<py::robj>(nrows_) {
   mbuf.set_pyobjects(/*clear_data = */ true);
 }
 
-PyObjectColumn::PyObjectColumn(size_t nrows_, MemoryRange&& mb)
+PyObjectColumn::PyObjectColumn(size_t nrows_, Buffer&& mb)
     : FwColumn<py::robj>(nrows_, std::move(mb))
 {
   _stype = SType::OBJ;

--- a/c/column_string.cc
+++ b/c/column_string.cc
@@ -27,7 +27,7 @@ template <typename T>
 StringColumn<T>::StringColumn(size_t n)
   : ColumnImpl(n, stype_for<T>())
 {
-  mbuf = MemoryRange::mem(sizeof(T) * (n + 1));
+  mbuf = Buffer::mem(sizeof(T) * (n + 1));
   mbuf.set_element<T>(0, 0);
 }
 
@@ -40,7 +40,7 @@ StringColumn<T>::StringColumn()
 
 // private: use `new_string_column(n, &&mb, &&sb)` instead
 template <typename T>
-StringColumn<T>::StringColumn(size_t n, MemoryRange&& mb, MemoryRange&& sb)
+StringColumn<T>::StringColumn(size_t n, Buffer&& mb, Buffer&& sb)
   : ColumnImpl(n, stype_for<T>())
 {
   xassert(mb);
@@ -61,7 +61,7 @@ StringColumn<T>::StringColumn(size_t n, MemoryRange&& mb, MemoryRange&& sb)
 
 template <typename T>
 void StringColumn<T>::init_data() {
-  mbuf = MemoryRange::mem((_nrows + 1) * sizeof(T));
+  mbuf = Buffer::mem((_nrows + 1) * sizeof(T));
   mbuf.set_element<T>(0, 0);
 }
 
@@ -147,7 +147,7 @@ void StringColumn<T>::replace_values(
       bool isvalid = with.get_element(0, &repl_value);
       if (!isvalid) repl_value = CString();
     }
-    MemoryRange mask = replace_at.as_boolean_mask(_nrows);
+    Buffer mask = replace_at.as_boolean_mask(_nrows);
     auto mask_indices = static_cast<const int8_t*>(mask.rptr());
     rescol = dt::map_str2str(thiscol,
       [=](size_t i, CString& value, dt::string_buf* sb) {
@@ -155,7 +155,7 @@ void StringColumn<T>::replace_values(
       });
   }
   else {
-    MemoryRange mask = replace_at.as_integer_mask(_nrows);
+    Buffer mask = replace_at.as_integer_mask(_nrows);
     auto mask_indices = static_cast<const int32_t*>(mask.rptr());
     rescol = dt::map_str2str(thiscol,
       [=](size_t i, CString& value, dt::string_buf* sb) {

--- a/c/csv/reader.cc
+++ b/c/csv/reader.cc
@@ -534,7 +534,7 @@ void GenericReader::open_input() {
   size_t extra_byte = 0;
   if (fileno > 0) {
     const char* src = src_arg.to_cstring().ch;
-    input_mbuf = MemoryRange::overmap(src, /* extra = */ 1, fileno);
+    input_mbuf = Buffer::overmap(src, /* extra = */ 1, fileno);
     size_t sz = input_mbuf.size();
     if (sz > 0) {
       sz--;
@@ -545,12 +545,12 @@ void GenericReader::open_input() {
 
   } else if ((text = text_arg.to_cstring())) {
     size_t size = static_cast<size_t>(text.size);
-    input_mbuf = MemoryRange::external(text.ch, size + 1);
+    input_mbuf = Buffer::external(text.ch, size + 1);
     extra_byte = 1;
     input_is_string = true;
 
   } else if ((filename = file_arg.to_cstring().ch)) {
-    input_mbuf = MemoryRange::overmap(filename, /* extra = */ 1);
+    input_mbuf = Buffer::overmap(filename, /* extra = */ 1);
     size_t sz = input_mbuf.size();
     if (sz > 0) {
       sz--;
@@ -780,7 +780,7 @@ void GenericReader::decode_utf16() {
 
   // `buf` is a borrowed ref, belongs to PyObject* `t`
   const char* buf = PyUnicode_AsUTF8AndSize(t, &ssize);
-  input_mbuf = MemoryRange::external(
+  input_mbuf = Buffer::external(
                   const_cast<void*>(static_cast<const void*>(buf)),
                   static_cast<size_t>(ssize) + 1);
   sof = static_cast<char*>(input_mbuf.wptr());
@@ -830,8 +830,8 @@ dtptr GenericReader::makeDatatable() {
   for (size_t i = 0; i < ncols; ++i) {
     dt::read::Column& col = columns[i];
     if (!col.is_in_output()) continue;
-    MemoryRange databuf = col.extract_databuf();
-    MemoryRange strbuf = col.extract_strbuf();
+    Buffer databuf = col.extract_databuf();
+    Buffer strbuf = col.extract_strbuf();
     SType stype = col.get_stype();
     ccols.push_back((stype == SType::STR32 || stype == SType::STR64)
       ? Column::new_string_column(nrows, std::move(databuf), std::move(strbuf))

--- a/c/csv/reader.h
+++ b/c/csv/reader.h
@@ -8,7 +8,7 @@
 #ifndef dt_CSV_READER_h
 #define dt_CSV_READER_h
 #include <memory>           // std::unique_ptr, std::shared_ptr
-#include "buffer.h"       // MemoryRange
+#include "buffer.h"       // Buffer
 #include "progress/work.h"  // dt::progress::work
 #include "python/obj.h"     // py::robj, py::oobj
 #include "read/columns.h"   // dt::read::Columns
@@ -82,7 +82,7 @@ class GenericReader
     static constexpr size_t WORK_REREAD = 60;
     static constexpr size_t WORK_DECODE_UTF16 = 50;
     std::shared_ptr<dt::progress::work> job; // owned
-    MemoryRange input_mbuf;
+    Buffer input_mbuf;
     const char* sof;
     const char* eof;
     size_t line;

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -148,7 +148,7 @@ class DataTable {
 
     void verify_integrity() const;
 
-    MemoryRange save_jay();
+    Buffer save_jay();
     void save_jay(const std::string& path, WritableBuffer::Strategy);
 
   private:
@@ -170,7 +170,7 @@ class DataTable {
 
 DataTable* open_jay_from_file(const std::string& path);
 DataTable* open_jay_from_bytes(const char* ptr, size_t len);
-DataTable* open_jay_from_mbuf(const MemoryRange&);
+DataTable* open_jay_from_mbuf(const Buffer&);
 
 RowIndex natural_join(const DataTable* xdt, const DataTable* jdt);
 

--- a/c/expr/expr_reduce.cc
+++ b/c/expr/expr_reduce.cc
@@ -89,7 +89,7 @@ static Column reduce_first(const Column& col, const Groupby& groupby)
   // RowIndex (taking only the first `ngrps` elements). Applying this rowindex
   // to the column will produce the vector of first elements in that column.
   arr32_t indices(ngrps);
-  // TODO: Groupby should use MemoryRange, then data copying can be shallow
+  // TODO: Groupby should use Buffer, then data copying can be shallow
   std::memcpy(indices.data(), groupby.offsets_r(), ngrps * 4);
   Column res = col;  // copy
   res.apply_rowindex(RowIndex(std::move(indices), true));

--- a/c/expr/expr_unaryop.cc
+++ b/c/expr/expr_unaryop.cc
@@ -315,10 +315,10 @@ Column expr_unaryop::evaluate(EvalContext& ctx) {
   input_column.materialize();
 
   size_t nrows = input_column.nrows();
-  const MemoryRange& input_mbuf = input_column->data_buf();
+  const Buffer& input_mbuf = input_column->data_buf();
   const void* inp = input_mbuf.rptr();
 
-  MemoryRange output_mbuf;
+  Buffer output_mbuf;
   void* out = nullptr;
   size_t out_elemsize = info(ui.output_stype).elemsize();
   if (input_mbuf.is_writable() &&
@@ -327,10 +327,10 @@ Column expr_unaryop::evaluate(EvalContext& ctx) {
     // The address `out` must be taken *before* `output_mbuf` is initialized,
     // since the `.xptr()` method checks that the reference counter is 1.
     out = input_mbuf.xptr();
-    output_mbuf = MemoryRange(input_mbuf);
+    output_mbuf = Buffer(input_mbuf);
   }
   else {
-    output_mbuf = MemoryRange::mem(out_elemsize * nrows);
+    output_mbuf = Buffer::mem(out_elemsize * nrows);
     out = output_mbuf.xptr();
   }
   auto output_column =

--- a/c/expr/i_node.cc
+++ b/c/expr/i_node.cc
@@ -166,7 +166,7 @@ void slice_in::execute_grouped(EvalContext& ctx) {
 
   size_t ri_size = istep == 0? ng * static_cast<size_t>(istop) : ctx.nrows();
   arr32_t out_ri_array(ri_size);
-  MemoryRange out_groups = MemoryRange::mem((ng + 1) * sizeof(int32_t));
+  Buffer out_groups = Buffer::mem((ng + 1) * sizeof(int32_t));
   int32_t* out_rowindices = out_ri_array.data();
   int32_t* out_offsets = static_cast<int32_t*>(out_groups.xptr()) + 1;
   out_offsets[-1] = 0;

--- a/c/expr/repl_node.cc
+++ b/c/expr/repl_node.cc
@@ -272,7 +272,7 @@ Column scalar_int_rn::make_column(SType st, size_t nrows) const {
 
 template <typename T>
 Column scalar_int_rn::_make1(SType stype) const {
-  MemoryRange mbuf = MemoryRange::mem(sizeof(T));
+  Buffer mbuf = Buffer::mem(sizeof(T));
   mbuf.set_element<T>(0, static_cast<T>(value));
   return Column::new_mbuf_column(stype, std::move(mbuf));
 }
@@ -317,7 +317,7 @@ Column scalar_float_rn::make_column(SType st, size_t nrows) const {
                 std::abs(value) > MAX);
   SType result_stype = res64? SType::FLOAT64 : SType::FLOAT32;
 
-  MemoryRange mbuf = MemoryRange::mem(res64? sizeof(double) : sizeof(float));
+  Buffer mbuf = Buffer::mem(res64? sizeof(double) : sizeof(float));
   if (res64) {
     mbuf.set_element<double>(0, value);
   } else {
@@ -360,7 +360,7 @@ Column scalar_string_rn::make_column(SType st, size_t nrows) const {
   size_t len = value.size();
   SType rst = (st == SType::VOID)? SType::STR32 : st;
   size_t elemsize = (rst == SType::STR32)? 4 : 8;
-  MemoryRange offbuf = MemoryRange::mem(2 * elemsize);
+  Buffer offbuf = Buffer::mem(2 * elemsize);
   if (elemsize == 4) {
     offbuf.set_element<uint32_t>(0, 0);
     offbuf.set_element<uint32_t>(1, static_cast<uint32_t>(len));
@@ -368,7 +368,7 @@ Column scalar_string_rn::make_column(SType st, size_t nrows) const {
     offbuf.set_element<uint64_t>(0, 0);
     offbuf.set_element<uint64_t>(1, len);
   }
-  MemoryRange strbuf = MemoryRange::mem(len);
+  Buffer strbuf = Buffer::mem(len);
   std::memcpy(strbuf.xptr(), value.data(), len);
   Column col = Column::new_string_column(1, std::move(offbuf), std::move(strbuf));
   if (nrows > 1) {

--- a/c/frame/__init__.cc
+++ b/c/frame/__init__.cc
@@ -694,7 +694,7 @@ static PKArgs fn___setstate__(
 
 // TODO: add py::obytes object
 oobj Frame::m__getstate__(const PKArgs&) {
-  MemoryRange mr = dt->save_jay();
+  Buffer mr = dt->save_jay();
   auto data = static_cast<const char*>(mr.xptr());
   auto size = static_cast<Py_ssize_t>(mr.size());
   return oobj::from_new_reference(PyBytes_FromStringAndSize(data, size));

--- a/c/groupby.cc
+++ b/c/groupby.cc
@@ -12,7 +12,7 @@
 Groupby::Groupby() : n(0) {}
 
 
-Groupby::Groupby(size_t _n, MemoryRange&& _offs) {
+Groupby::Groupby(size_t _n, Buffer&& _offs) {
   if (_offs.size() < sizeof(int32_t) * (_n + 1)) {
     throw RuntimeError() << "Cannot create groupby for " << _n << " groups "
         "from memory buffer of size " << _offs.size();
@@ -27,7 +27,7 @@ Groupby::Groupby(size_t _n, MemoryRange&& _offs) {
 
 
 Groupby Groupby::single_group(size_t nrows) {
-  MemoryRange mr = MemoryRange::mem(2 * sizeof(int32_t));
+  Buffer mr = Buffer::mem(2 * sizeof(int32_t));
   mr.set_element<int32_t>(0, 0);
   mr.set_element<int32_t>(1, static_cast<int32_t>(nrows));
   return Groupby(1, std::move(mr));

--- a/c/groupby.h
+++ b/c/groupby.h
@@ -13,12 +13,12 @@
 
 class Groupby {
   private:
-    MemoryRange offsets;
+    Buffer offsets;
     size_t n;
 
   public:
     Groupby();
-    Groupby(size_t _n, MemoryRange&& _offs);
+    Groupby(size_t _n, Buffer&& _offs);
     Groupby(const Groupby&) = default;
     Groupby(Groupby&&) = default;
     Groupby& operator=(const Groupby&) = default;

--- a/c/jay/save_jay.cc
+++ b/c/jay/save_jay.cc
@@ -45,7 +45,7 @@ void DataTable::save_jay(const std::string& path,
 /**
  * Save Frame in Jay format to memory,
  */
-MemoryRange DataTable::save_jay() {
+Buffer DataTable::save_jay() {
   auto wb = std::unique_ptr<MemoryWritableBuffer>(
                 new MemoryWritableBuffer(memory_footprint()));
   save_jay_impl(wb.get());
@@ -263,7 +263,7 @@ oobj Frame::to_jay(const PKArgs& args) {
   }
 
   if (filename.empty()) {
-    MemoryRange mr = dt->save_jay();
+    Buffer mr = dt->save_jay();
     auto data = static_cast<const char*>(mr.xptr());
     auto size = static_cast<Py_ssize_t>(mr.size());
     return oobj::from_new_reference(PyBytes_FromStringAndSize(data, size));

--- a/c/parallel/string_utils.cc
+++ b/c/parallel/string_utils.cc
@@ -28,7 +28,7 @@ namespace dt {
 
 Column generate_string_column(function<void(size_t, string_buf*)> fn,
                               size_t nrows,
-                              MemoryRange&& offsets_buffer,
+                              Buffer&& offsets_buffer,
                               bool force_str64,
                               bool force_single_threaded)
 {

--- a/c/parallel/string_utils.h
+++ b/c/parallel/string_utils.h
@@ -32,7 +32,7 @@ using string_buf = writable_string_col::buffer;
 
 Column generate_string_column(dt::function<void(size_t, string_buf*)> fn,
                               size_t n,
-                              MemoryRange&& offsets_buffer = MemoryRange(),
+                              Buffer&& offsets_buffer = Buffer(),
                               bool force_str64 = false,
                               bool force_single_threaded = false);
 

--- a/c/read/column.cc
+++ b/c/read/column.cc
@@ -66,12 +66,12 @@ WritableBuffer* Column::strdata_w() {
   return strbuf;
 }
 
-MemoryRange Column::extract_databuf() {
+Buffer Column::extract_databuf() {
   return std::move(databuf);
 }
 
-MemoryRange Column::extract_strbuf() {
-  if (!(strbuf && is_string())) return MemoryRange();
+Buffer Column::extract_strbuf() {
+  if (!(strbuf && is_string())) return Buffer();
   strbuf->finalize();
   return strbuf->get_mbuf();
 }

--- a/c/read/column.h
+++ b/c/read/column.h
@@ -8,7 +8,7 @@
 #ifndef dt_READ_COLUMN_h
 #define dt_READ_COLUMN_h
 #include <string>
-#include "buffer.h"     // MemoryRange
+#include "buffer.h"     // Buffer
 #include "python/obj.h"   // py::oobj
 #include "writebuf.h"     // WritableBuffer
 
@@ -34,7 +34,7 @@ namespace read {
 class Column {
   private:
     std::string name;
-    MemoryRange databuf;
+    Buffer databuf;
     MemoryWritableBuffer* strbuf;
     PT ptype;
     RT rtype;
@@ -68,8 +68,8 @@ class Column {
     void allocate(size_t nrows);
     void* data_w();
     WritableBuffer* strdata_w();
-    MemoryRange extract_databuf();
-    MemoryRange extract_strbuf();
+    Buffer extract_databuf();
+    Buffer extract_strbuf();
 
     // Column's name
     const std::string& get_name() const noexcept;

--- a/c/rowindex.cc
+++ b/c/rowindex.cc
@@ -232,8 +232,8 @@ RowIndex operator *(const RowIndex& ri1, const RowIndex& ri2) {
 }
 
 
-MemoryRange RowIndex::as_boolean_mask(size_t nrows) const {
-  MemoryRange res = MemoryRange::mem(nrows);
+Buffer RowIndex::as_boolean_mask(size_t nrows) const {
+  Buffer res = Buffer::mem(nrows);
   int8_t* data = static_cast<int8_t*>(res.xptr());
   if (isabsent()) {
     // No RowIndex is equivalent to having RowIndex over all rows, i.e. we
@@ -250,8 +250,8 @@ MemoryRange RowIndex::as_boolean_mask(size_t nrows) const {
 }
 
 
-MemoryRange RowIndex::as_integer_mask(size_t nrows) const {
-  MemoryRange res = MemoryRange::mem(nrows * 4);
+Buffer RowIndex::as_integer_mask(size_t nrows) const {
+  Buffer res = Buffer::mem(nrows * 4);
   int32_t* data = static_cast<int32_t*>(res.xptr());
   // NA index is -1 in byte, and also -1 in int32
   std::memset(data, -1, nrows * 4);

--- a/c/rowindex.h
+++ b/c/rowindex.h
@@ -123,14 +123,14 @@ class RowIndex {
      * is either 1 or 0 depending whether that element is selected by the
      * current RowIndex or not.
      */
-    MemoryRange as_boolean_mask(size_t nrows) const;
+    Buffer as_boolean_mask(size_t nrows) const;
 
     /**
      * Convert the RowIndex into an array `int32_t[nrows]`, where entries not
      * selected by this RowIndex are -1, and the selected entries are
      * consecutive integers 0, 1, ..., size()-1.
      */
-    MemoryRange as_integer_mask(size_t nrows) const;
+    Buffer as_integer_mask(size_t nrows) const;
 
     /**
      * Return a RowIndex which is the negation of the current, when applied

--- a/c/rowindex_array.cc
+++ b/c/rowindex_array.cc
@@ -27,7 +27,7 @@
 #include "utils/exceptions.h"  // ValueError, RuntimeError
 #include "utils/assert.h"
 #include "column.h"            // Column, BoolColumn
-#include "buffer.h"          // MemoryRange
+#include "buffer.h"          // Buffer
 #include "rowindex.h"
 #include "rowindex_impl.h"
 
@@ -316,13 +316,13 @@ void ArrayRowIndexImpl::init_from_integer_column(const Column& col) {
     // will be written into `xbuf`, which is just a view onto `ind32`. Also,
     // since `xbuf` is ExternalMemBuf, its memory won't be reclaimed when
     // the column is destructed.
-    MemoryRange xbuf = MemoryRange::external(data, length * sizeof(int32_t));
+    Buffer xbuf = Buffer::external(data, length * sizeof(int32_t));
     xassert(xbuf.is_writable());
     auto col3 = col2.cast(SType::INT32, std::move(xbuf));
   } else {
     type = RowIndexType::ARR64;
     _resize_data();
-    MemoryRange xbuf = MemoryRange::external(data, length * sizeof(int64_t));
+    Buffer xbuf = Buffer::external(data, length * sizeof(int64_t));
     xassert(xbuf.is_writable());
     auto col3 = col2.cast(SType::INT64, std::move(xbuf));
   }

--- a/c/sort.cc
+++ b/c/sort.cc
@@ -577,7 +577,7 @@ class SortContext {
     size_t ng = gg.size();
     xassert(groups.size() > ng);
     size_t memsize = (ng + 1) * sizeof(int32_t);
-    MemoryRange mr = MemoryRange::mem(memsize);
+    Buffer mr = Buffer::mem(memsize);
     std::memcpy(mr.xptr(), groups.data(), memsize);
     return Groupby(ng, std::move(mr));
   }

--- a/c/stats.cc
+++ b/c/stats.cc
@@ -1198,7 +1198,7 @@ py::oobj Stats::get_stat_as_pyobject(Stat stat) {
 
 template <typename T>
 static Column _make_column(SType stype, T value) {
-  MemoryRange mbuf = MemoryRange::mem(sizeof(T));
+  Buffer mbuf = Buffer::mem(sizeof(T));
   mbuf.set_element<T>(0, value);
   Column res = Column::new_mbuf_column(stype, std::move(mbuf));
   xassert(res.nrows() == 1);
@@ -1211,8 +1211,8 @@ static Column _make_nacol(SType stype) {
 
 static Column _make_column_str(CString value) {
   using T = uint32_t;
-  MemoryRange mbuf = MemoryRange::mem(sizeof(T) * 2);
-  MemoryRange strbuf;
+  Buffer mbuf = Buffer::mem(sizeof(T) * 2);
+  Buffer strbuf;
   if (value.size >= 0) {
     size_t len = static_cast<size_t>(value.size);
     mbuf.set_element<T>(0, 0);

--- a/c/utils/alloc.cc
+++ b/c/utils/alloc.cc
@@ -41,8 +41,6 @@ void* _realloc(void* ptr, size_t n) {
       // another thread picks up that address emitting an error that the address
       // is in use (because the first thread hadn't had the chance to untrack it
       // yet).
-      // if (ptr) UNTRACK(ptr);
-      // TRACK(newptr, n, "malloc");
       return newptr;
     }
     if (errno == 12 && attempts--) {

--- a/c/utils/array.h
+++ b/c/utils/array.h
@@ -82,13 +82,13 @@ template <typename T> class array
       return res;
     }
 
-    MemoryRange to_memoryrange() {
+    Buffer to_memoryrange() {
       void* ptr = x;
       size_t size = sizeof(T) * n;
       x = nullptr;
       n = 0;
-      if (owned) return MemoryRange::acquire(ptr, size);
-      else       return MemoryRange::external(ptr, size);
+      if (owned) return Buffer::acquire(ptr, size);
+      else       return Buffer::external(ptr, size);
     }
 
     // Standard operators

--- a/c/utils/assert.h
+++ b/c/utils/assert.h
@@ -18,10 +18,11 @@
 // may add it as a default compilation flag, so in order to combat this we have
 // defined a new `DTDEBUG` macro. This macro may be passed from the Makefile,
 // and if declared it means to ignore the NDEBUG macro even if it is present.
-#if defined(DTDEBUG) && defined(NDEBUG)
-  #undef NDEBUG
-#endif
-#if !defined(DTDEBUG) && !defined(NDEBUG)
+#undef NDEBUG
+#ifdef DTDEBUG
+  #undef DTDEBUG
+  #define DTDEBUG 1
+#else
   #define NDEBUG 1
 #endif
 
@@ -31,10 +32,7 @@
 
 // Here we also define the `xassert` macro, which behaves similarly to `assert`,
 // however it throws exceptions instead of terminating the program
-#ifdef NDEBUG
-  #define wassert(EXPRESSION)
-  #define xassert(EXPRESSION)
-#else
+#if DTDEBUG
   #define wassert(EXPRESSION) \
     if (!(EXPRESSION)) { \
       (AssertionError() << "Assertion '" #EXPRESSION "' failed in " \
@@ -46,7 +44,20 @@
       throw AssertionError() << "Assertion '" #EXPRESSION "' failed in " \
           << __FILE__ << ", line " << __LINE__; \
     }
+#else
+  #define wassert(EXPRESSION)
+  #define xassert(EXPRESSION)
 #endif
+
+
+// XAssert() macro is similar to xassert(), except it works both in
+// debug and in production.
+#define XAssert(EXPRESSION) \
+  if (!(EXPRESSION)) { \
+    throw AssertionError() << "Assertion '" #EXPRESSION "' failed in " \
+        << __FILE__ << ", line " << __LINE__; \
+  }
+
 
 
 #ifdef static_assert

--- a/c/writebuf.cc
+++ b/c/writebuf.cc
@@ -167,8 +167,11 @@ size_t ThreadsafeWritableBuffer::prep_write(size_t n, const void*) {
 
 
 void ThreadsafeWritableBuffer::write_at(size_t pos, size_t n, const void* src) {
+  // When n==0, the `buffer` pointer may remain unallocated, and it
+  // is invalid to `memcpy` 0 bytes into a null pointer.
+  if (n == 0) return;
   if (pos + n > allocsize) {
-    throw RuntimeError() << "Attempt to write at pos=" << pos << " chunk of "
+    throw AssertionError() << "Attempt to write at pos=" << pos << " chunk of "
       "length " << n << ", however the buffer is allocated for " << allocsize
       << " bytes only";
   }

--- a/c/writebuf.cc
+++ b/c/writebuf.cc
@@ -222,10 +222,10 @@ void* MemoryWritableBuffer::get_cptr()
 }
 
 
-MemoryRange MemoryWritableBuffer::get_mbuf() {
+Buffer MemoryWritableBuffer::get_mbuf() {
   size_t size = allocsize;
   void* ptr = get_cptr();
-  return MemoryRange::acquire(ptr, size);
+  return Buffer::acquire(ptr, size);
 }
 
 

--- a/c/writebuf.h
+++ b/c/writebuf.h
@@ -13,7 +13,7 @@
 #include "utils/file.h"
 using std::size_t;
 
-class MemoryRange;
+class Buffer;
 
 
 
@@ -162,7 +162,7 @@ public:
    * it will be the responsibility of the caller to handle it.
    */
   void* get_cptr();
-  MemoryRange get_mbuf();
+  Buffer get_mbuf();
   std::string get_string();
 
 private:

--- a/c/wstringcol.cc
+++ b/c/wstringcol.cc
@@ -27,11 +27,11 @@ namespace dt {
 
 writable_string_col::writable_string_col(size_t nrows, bool str64_)
   : strdata(nrows),
-    offdata(MemoryRange::mem((nrows + 1) * 4 * (1 + str64_))),
+    offdata(Buffer::mem((nrows + 1) * 4 * (1 + str64_))),
     n(nrows),
     str64(str64_) {}
 
-writable_string_col::writable_string_col(MemoryRange&& offsets, size_t nrows,
+writable_string_col::writable_string_col(Buffer&& offsets, size_t nrows,
                                          bool str64_)
   : strdata(nrows),
     offdata(std::move(offsets)),

--- a/c/wstringcol.h
+++ b/c/wstringcol.h
@@ -16,7 +16,7 @@
 #ifndef dt_WSTRINGCOL_h
 #define dt_WSTRINGCOL_h
 #include <memory>           // std::unique_ptr
-#include "buffer.h"       // MemoryRange
+#include "buffer.h"       // Buffer
 #include "column.h"
 #include "types.h"          // CString
 #include "utils/array.h"    // dt::array
@@ -40,14 +40,14 @@ namespace dt {
 class writable_string_col {
   private:
     MemoryWritableBuffer strdata;
-    MemoryRange offdata;
+    Buffer offdata;
     size_t n;
     bool str64;
     size_t : 56;
 
   public:
     writable_string_col(size_t nrows, bool str64_ = false);
-    writable_string_col(MemoryRange&& offsets, size_t nrows,
+    writable_string_col(Buffer&& offsets, size_t nrows,
                         bool str64_ = false);
     Column to_ocolumn() &&;
 


### PR DESCRIPTION
- Class `MemoryRange` renamed into `Buffer`
- The structure of `Buffer` class significantly simplified: it no longer contains a `shared_ptr<struct{unique_ptr<Buffer_Impl>}>`, instead we have a simple `Buffer_Impl*` pointer, with manual shared-ptr-like semantics via a built-in reference-counter. This not only save allocation of an extra object on a heap, but also makes it more simple to inspect the data in a debugger.
- Multiple clean-ups and better organization of the implementation code.
- Added macro `XAssert`, which is similar to `xassert` but works also in production builds.