### PR TITLE
Column refactoring

### DIFF
--- a/c/api.cc
+++ b/c/api.cc
@@ -92,7 +92,7 @@ const void* DtFrame_ColumnDataR(PyObject* pydt, size_t i) {
   auto dt = _extract_dt(pydt);
   if (_column_index_oob(dt, i)) return nullptr;
   try {
-    return dt->get_column(i)->data();
+    return dt->get_column(i).get_data_readonly();
   } catch (const std::exception& e) {
     exception_to_python(e);
     return nullptr;

--- a/c/api.cc
+++ b/c/api.cc
@@ -103,7 +103,7 @@ void* DtFrame_ColumnDataW(PyObject* pydt, size_t i) {
   auto dt = _extract_dt(pydt);
   if (_column_index_oob(dt, i)) return nullptr;
   try {
-    return dt->get_column(i)->data_w();
+    return dt->get_column(i).get_data_editable();
   } catch (const std::exception& e) {
     exception_to_python(e);
     return nullptr;

--- a/c/buffer.cc
+++ b/c/buffer.cc
@@ -263,11 +263,13 @@ class External_BufferImpl : public BufferImpl
     Py_buffer* pybufinfo_;
 
   public:
-    External_BufferImpl(const void* ptr, size_t n, Py_buffer* pybuf) {
+    External_BufferImpl(const void* ptr, size_t n,
+                        std::unique_ptr<Py_buffer>&& pybuf)
+    {
       XAssert(ptr || n == 0);
       data_ = const_cast<void*>(ptr);
       size_ = n;
-      pybufinfo_ = pybuf;
+      pybufinfo_ = pybuf.release();
       resizable_ = false;
       writable_ = false;
     }
@@ -746,8 +748,10 @@ class Overmap_BufferImpl : public Mmap_BufferImpl {
     return Buffer(new External_BufferImpl(ptr, n));
   }
 
-  Buffer Buffer::external(const void* ptr, size_t n, Py_buffer* pb) {
-    return Buffer(new External_BufferImpl(ptr, n, pb));
+  Buffer Buffer::external(const void* ptr, size_t n,
+                          std::unique_ptr<Py_buffer>&& pb)
+  {
+    return Buffer(new External_BufferImpl(ptr, n, std::move(pb)));
   }
 
   Buffer Buffer::view(const Buffer& src, size_t n, size_t offset) {

--- a/c/buffer.h
+++ b/c/buffer.h
@@ -120,7 +120,8 @@ class Buffer
     static Buffer acquire(void* ptr, size_t n);
     static Buffer external(void* ptr, size_t n);
     static Buffer external(const void* ptr, size_t n);
-    static Buffer external(const void* ptr, size_t n, Py_buffer* pybuf);
+    static Buffer external(const void* ptr, size_t n,
+                           std::unique_ptr<Py_buffer>&& pybuf);
     static Buffer view(const Buffer& src, size_t n, size_t offset);
     static Buffer mmap(const std::string& path);
     static Buffer mmap(const std::string& path, size_t n, int fd = -1);

--- a/c/column.cc
+++ b/c/column.cc
@@ -104,11 +104,6 @@ ColumnImpl* ColumnImpl::shallowcopy() const {
 }
 
 
-size_t ColumnImpl::alloc_size() const {  // TODO: remove
-  return _nrows * info(_stype).elemsize();
-}
-
-
 
 
 

--- a/c/column.cc
+++ b/c/column.cc
@@ -92,20 +92,6 @@ Column Column::new_string_column(
 
 
 
-/**
- * Create a shallow copy of the column; possibly applying the provided rowindex.
- */
-ColumnImpl* ColumnImpl::shallowcopy() const {
-  ColumnImpl* col = ColumnImpl::new_impl(_stype);
-  col->_nrows = _nrows;
-  col->mbuf = mbuf;
-  // TODO: also copy Stats object
-  return col;
-}
-
-
-
-
 
 //------------------------------------------------------------------------------
 // Column

--- a/c/column.h
+++ b/c/column.h
@@ -205,6 +205,10 @@ class Column
   // Data buffers
   //------------------------------------
   public:
+    // Return the method that this column uses to encode NAs. See
+    // the description of `NaStorage` enum for details.
+    NaStorage get_na_storage_method() const;
+
     // A Column may be comprised of multiple data buffers. For virtual
     // columns this property returns 0.
     size_t get_num_data_buffers() const;
@@ -214,10 +218,6 @@ class Column
     // specifies which buffer the function is applied to.
     // Correspondingly, the methods below are not applicable to
     // virtual columns and will raise an exception.
-
-    // Return the method that this column uses to encode NAs. See
-    // the description of `NaStorage` enum for details.
-    NaStorage get_na_storage_method(size_t k = 0) const;
 
     // Return true if data buffer can be edited as-is, without
     // creating any extra copies.

--- a/c/column.h
+++ b/c/column.h
@@ -138,7 +138,7 @@ class Column
     static Column new_na_column(SType, size_t nrows);
     static Column new_mbuf_column(SType, Buffer&&);
     static Column new_string_column(size_t n, Buffer&& data, Buffer&& str);
-    static Column from_buffer(const py::robj& buffer);
+    static Column from_pybuffer(const py::robj& buffer);
     static Column from_pylist(const py::olist& list, int stype0 = 0);
     static Column from_pylist_of_tuples(const py::olist& list, size_t index, int stype0);
     static Column from_pylist_of_dicts(const py::olist& list, py::robj name, int stype0);

--- a/c/column/const.cc
+++ b/c/column/const.cc
@@ -151,13 +151,10 @@ class ConstFloat_ColumnImpl : public Const_ColumnImpl {
     double value;
 
   public:
-    ConstFloat_ColumnImpl(size_t nrows, double x)
-      : Const_ColumnImpl(nrows, SType::FLOAT64), value(x) {}
-
-    ConstFloat_ColumnImpl(size_t nrows, float x, SType stype)
+    ConstFloat_ColumnImpl(size_t nrows, float x, SType stype = SType::FLOAT32)
       : Const_ColumnImpl(nrows, stype), value(static_cast<double>(x)) {}
 
-    ConstFloat_ColumnImpl(size_t nrows, double x, SType stype)
+    ConstFloat_ColumnImpl(size_t nrows, double x, SType stype = SType::FLOAT64)
       : Const_ColumnImpl(nrows, stype), value(x) {}
 
     ColumnImpl* shallowcopy() const override {
@@ -229,8 +226,8 @@ Column Const_ColumnImpl::make_int_column(size_t nrows, int64_t x) {
   return Column(new ConstInt_ColumnImpl(nrows, x));
 }
 
-Column Const_ColumnImpl::make_float_column(size_t nrows, double x) {
-  return Column(new ConstFloat_ColumnImpl(nrows, x));
+Column Const_ColumnImpl::make_float_column(size_t nrows, double x, SType st) {
+  return Column(new ConstFloat_ColumnImpl(nrows, x, st));
 }
 
 Column Const_ColumnImpl::make_string_column(size_t nrows, CString x) {

--- a/c/column/const.cc
+++ b/c/column/const.cc
@@ -46,7 +46,7 @@ class ConstNa_ColumnImpl : public Const_ColumnImpl {
     // TODO: override cast()
 
     ColumnImpl* shallowcopy() const override {
-      return new ConstNa_ColumnImpl(_nrows);
+      return new ConstNa_ColumnImpl(_nrows, _stype);
     }
 
     // VOID column materializes into BOOL stype
@@ -99,7 +99,7 @@ class ConstInt_ColumnImpl : public Const_ColumnImpl {
       : Const_ColumnImpl(nrows, stype), value(x) {}
 
     ColumnImpl* shallowcopy() const override {
-      return new ConstInt_ColumnImpl(_nrows, value);
+      return new ConstInt_ColumnImpl(_nrows, value, _stype);
     }
 
     bool get_element(size_t, int8_t* out) const override {
@@ -161,7 +161,7 @@ class ConstFloat_ColumnImpl : public Const_ColumnImpl {
       : Const_ColumnImpl(nrows, stype), value(x) {}
 
     ColumnImpl* shallowcopy() const override {
-      return new ConstFloat_ColumnImpl(_nrows, value);
+      return new ConstFloat_ColumnImpl(_nrows, value, _stype);
     }
 
     bool get_element(size_t, float* out) const override {

--- a/c/column/const.h
+++ b/c/column/const.h
@@ -31,7 +31,8 @@ class Const_ColumnImpl : public Virtual_ColumnImpl {
     static Column make_na_column(size_t nrows);
     static Column make_bool_column(size_t nrows, bool value);
     static Column make_int_column(size_t nrows, int64_t value);
-    static Column make_float_column(size_t nrows, double value);
+    static Column make_float_column(size_t nrows, double value,
+                                    SType stype = SType::FLOAT64);
     static Column make_string_column(size_t nrows, CString value);
     static Column from_1row_column(const Column& col);
 

--- a/c/column/const.h
+++ b/c/column/const.h
@@ -30,10 +30,9 @@ class Const_ColumnImpl : public Virtual_ColumnImpl {
     using Virtual_ColumnImpl::Virtual_ColumnImpl;
     static Column make_na_column(size_t nrows);
     static Column make_bool_column(size_t nrows, bool value);
-    static Column make_int_column(size_t nrows, int64_t value);
-    static Column make_float_column(size_t nrows, double value,
-                                    SType stype = SType::FLOAT64);
-    static Column make_string_column(size_t nrows, CString value);
+    static Column make_int_column(size_t nrows, int64_t value, SType stype = SType::VOID);
+    static Column make_float_column(size_t nrows, double value, SType stype = SType::FLOAT64);
+    static Column make_string_column(size_t nrows, CString value, SType stype = SType::STR32);
     static Column from_1row_column(const Column& col);
 
     void repeat(size_t ntimes, bool inplace, Column& out) override;

--- a/c/column/view.cc
+++ b/c/column/view.cc
@@ -29,8 +29,8 @@ namespace dt {
 //------------------------------------------------------------------------------
 
 SliceView_ColumnImpl::SliceView_ColumnImpl(
-    Column&& col, const RowIndex& ri, size_t nrows)
-  : Virtual_ColumnImpl(nrows, col.stype()),
+    Column&& col, const RowIndex& ri)
+  : Virtual_ColumnImpl(ri.size(), col.stype()),
     arg(std::move(col)),
     start(ri.slice_start()),
     step(ri.slice_step())
@@ -42,7 +42,7 @@ SliceView_ColumnImpl::SliceView_ColumnImpl(
 
 ColumnImpl* SliceView_ColumnImpl::shallowcopy() const {
   return new SliceView_ColumnImpl(
-                Column(arg), RowIndex(start, _nrows, step), _nrows);
+                Column(arg), RowIndex(start, _nrows, step));
 }
 
 
@@ -175,8 +175,7 @@ static Column _make_view(Column&& col, const RowIndex& ri) {
   }
   switch (ri.type()) {
     case RowIndexType::SLICE:
-      return Column(new dt::SliceView_ColumnImpl(
-                      std::move(col), ri, ri.size()));
+      return Column(new dt::SliceView_ColumnImpl(std::move(col), ri));
 
     case RowIndexType::ARR32:
       return Column(new dt::ArrayView_ColumnImpl<int32_t>(

--- a/c/column/view.h
+++ b/c/column/view.h
@@ -37,7 +37,7 @@ class SliceView_ColumnImpl : public Virtual_ColumnImpl {
     size_t step;
 
   public:
-    SliceView_ColumnImpl(Column&& col, const RowIndex& ri, size_t nrows);
+    SliceView_ColumnImpl(Column&& col, const RowIndex& ri);
     ColumnImpl* shallowcopy() const override;
 
     bool get_element(size_t i, int8_t* out)   const override;

--- a/c/column_fw.cc
+++ b/c/column_fw.cc
@@ -110,7 +110,7 @@ size_t FwColumn<T>::data_nrows() const {
 template <typename T>
 void FwColumn<T>::apply_na_mask(const Column& mask) {
   xassert(mask.stype() == SType::BOOL);
-  auto maskdata = static_cast<const int8_t*>(mask->data());
+  auto maskdata = static_cast<const int8_t*>(mask.get_data_readonly());
   T* coldata = this->elements_w();
 
   dt::parallel_for_static(_nrows,

--- a/c/column_fw.cc
+++ b/c/column_fw.cc
@@ -55,6 +55,22 @@ FwColumn<T>::FwColumn(size_t nrows_, Buffer&& mr)
 }
 
 
+/**
+ * Create a shallow copy of the column; possibly applying the provided rowindex.
+ */
+template <typename T>
+ColumnImpl* FwColumn<T>::shallowcopy() const {
+  ColumnImpl* col = ColumnImpl::new_impl(_stype);
+  auto fwcol = dynamic_cast<FwColumn<T>*>(col);
+  xassert(fwcol);
+  fwcol->_nrows = _nrows;
+  fwcol->mbuf = mbuf;
+  // TODO: also copy Stats object
+  return col;
+}
+
+
+
 //==============================================================================
 // Initialization methods
 //==============================================================================

--- a/c/column_impl.h
+++ b/c/column_impl.h
@@ -133,8 +133,6 @@ class ColumnImpl
     RowIndex _sort(Groupby* out_groups) const;
     virtual void sort_grouped(const Groupby&, bool inplace, Column& out);
 
-    Column repeat(size_t nreps) const;  // OLD
-
     /**
       * Repeat the column `ntimes` times. Depending on the `inplace`
       * flag, this method is either allowed to modify the current

--- a/c/column_impl.h
+++ b/c/column_impl.h
@@ -168,7 +168,7 @@ class ColumnImpl
      * If you want the rowindices to be merged, you should merge them manually
      * and pass the merged rowindex to this method.
      */
-    virtual ColumnImpl* shallowcopy() const;
+    virtual ColumnImpl* shallowcopy() const = 0;
 
     /**
      * Factory method to cast the current column into the given `stype`. If a
@@ -285,6 +285,7 @@ public:
   T get_elem(size_t i) const;
 
   virtual bool get_element(size_t i, T* out) const override;
+  ColumnImpl* shallowcopy() const override;
 
   size_t data_nrows() const override;
   void apply_na_mask(const Column& mask) override;
@@ -459,6 +460,7 @@ class VoidColumn : public ColumnImpl {
     VoidColumn(size_t nrows);
     size_t data_nrows() const override;
     ColumnImpl* materialize() override;
+    ColumnImpl* shallowcopy() const override { return new VoidColumn(_nrows); }
     void apply_na_mask(const Column&) override;
     void replace_values(Column&, const RowIndex&, const Column&) override;
   protected:

--- a/c/column_impl.h
+++ b/c/column_impl.h
@@ -125,7 +125,6 @@ class ColumnImpl
       xassert(!is_virtual());
       return mbuf.wptr();
     }
-    size_t alloc_size() const;
 
     virtual size_t data_nrows() const;
     virtual size_t memory_footprint() const;

--- a/c/column_string.cc
+++ b/c/column_string.cc
@@ -44,9 +44,9 @@ StringColumn<T>::StringColumn(size_t n, Buffer&& mb, Buffer&& sb)
   : ColumnImpl(n, stype_for<T>())
 {
   xassert(mb);
-  xassert(mb.size() == sizeof(T) * (n + 1));
+  xassert(mb.size() >= sizeof(T) * (n + 1));
   xassert(mb.get_element<T>(0) == 0);
-  xassert(sb.size() == (mb.get_element<T>(n) & ~GETNA<T>()));
+  xassert(sb.size() >= (mb.get_element<T>(n) & ~GETNA<T>()));
   mbuf = std::move(mb);
   strbuf = std::move(sb);
 }
@@ -71,10 +71,7 @@ void StringColumn<T>::init_data() {
 
 template <typename T>
 ColumnImpl* StringColumn<T>::shallowcopy() const {
-  ColumnImpl* newcol = ColumnImpl::shallowcopy();
-  StringColumn<T>* col = static_cast<StringColumn<T>*>(newcol);
-  col->strbuf = strbuf;
-  return col;
+  return new StringColumn<T>(_nrows, Buffer(mbuf), Buffer(strbuf));
 }
 
 

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -114,7 +114,7 @@ class DataTable {
       xassert(i < columns.size());
       return columns[i];
     }
-    void set_ocolumn(size_t i, Column&& newcol) {
+    void set_column(size_t i, Column&& newcol) {
       xassert(i < columns.size());
       xassert(newcol.nrows() == nrows);
       columns[i] = std::move(newcol);

--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -99,7 +99,8 @@ static py::oobj frame_column_data_r(const py::PKArgs& args) {
   auto u = _unpack_frame_column_args(args);
   DataTable* dt = u.first;
   size_t col = u.second;
-  size_t iptr = reinterpret_cast<size_t>(dt->get_column(col)->data());
+  size_t iptr = reinterpret_cast<size_t>(
+                    dt->get_column(col).get_data_readonly());
   return c_void_p.call({py::oint(iptr)});
 }
 

--- a/c/expr/eval_context.cc
+++ b/c/expr/eval_context.cc
@@ -292,7 +292,7 @@ void EvalContext::evaluate_update_columns() {
   typecheck_for_update(replacement, indices);
 
   for (size_t i = 0; i < lcols; ++i) {
-    dt0->set_ocolumn(indices[i], replacement.retrieve_column(i));
+    dt0->set_column(indices[i], replacement.retrieve_column(i));
   }
 }
 

--- a/c/expr/expr_binaryop.cc
+++ b/c/expr/expr_binaryop.cc
@@ -77,32 +77,54 @@ using mapperfn = void(*)(size_t row0, size_t row1, Column* cols);
 
 template<typename LT, typename RT, typename VT, VT (*OP)(LT, RT)>
 static void map_n_to_n(size_t row0, size_t row1, Column* cols) {
-  const LT* lhs_data = static_cast<const LT*>(cols[0]->data());
-  const RT* rhs_data = static_cast<const RT*>(cols[1]->data());
+  const Column& col0 = cols[0];
+  const Column& col1 = cols[1];
+  LT lhs_value;
+  RT rhs_value;
+  bool lhs_valid, rhs_valid;
+
   VT* res_data = static_cast<VT*>(cols[2].get_data_editable());
   for (size_t i = row0; i < row1; ++i) {
-    res_data[i] = OP(lhs_data[i], rhs_data[i]);
+    lhs_valid = col0.get_element(i, &lhs_value);
+    rhs_valid = col1.get_element(i, &rhs_value);
+    res_data[i] = OP(lhs_value, rhs_value);
   }
+  (void) lhs_valid;  // FIXME
+  (void) rhs_valid;
 }
 
 template<typename LT, typename RT, typename VT, VT (*OP)(LT, RT)>
 static void map_n_to_1(size_t row0, size_t row1, Column* cols) {
-  const LT* lhs_data = static_cast<const LT*>(cols[0]->data());
-  RT rhs_value = static_cast<const RT*>(cols[1]->data())[0];
+  const Column& col0 = cols[0];
+  LT lhs_value;
+  RT rhs_value;
+  bool lhs_valid, rhs_valid;
+
+  rhs_valid = cols[1].get_element(0, &rhs_value);
   VT* res_data = static_cast<VT*>(cols[2].get_data_editable());
   for (size_t i = row0; i < row1; ++i) {
-    res_data[i] = OP(lhs_data[i], rhs_value);
+    lhs_valid = col0.get_element(i, &lhs_value);
+    res_data[i] = OP(lhs_value, rhs_value);
   }
+  (void) lhs_valid;  // FIXME
+  (void) rhs_valid;
 }
 
 template<typename LT, typename RT, typename VT, VT (*OP)(LT, RT)>
 static void map_1_to_n(size_t row0, size_t row1, Column* cols) {
-  LT lhs_value = static_cast<const LT*>(cols[0]->data())[0];
-  const RT* rhs_data = static_cast<const RT*>(cols[1]->data());
+  const Column& col1 = cols[1];
+  LT lhs_value;
+  RT rhs_value;
+  bool lhs_valid, rhs_valid;
+
+  lhs_valid = cols[0].get_element(0, &lhs_value);
   VT* res_data = static_cast<VT*>(cols[2].get_data_editable());
   for (size_t i = row0; i < row1; ++i) {
-    res_data[i] = OP(lhs_value, rhs_data[i]);
+    rhs_valid = col1.get_element(i, &rhs_value);
+    res_data[i] = OP(lhs_value, rhs_value);
   }
+  (void) lhs_valid;  // FIXME
+  (void) rhs_valid;
 }
 
 
@@ -587,7 +609,8 @@ bool expr_binaryop::check_for_operation_with_literal_na(const EvalContext& ctx) 
     if (pliteral->resolve(ctx) != SType::BOOL) return false;
     Column ocol = pliteral->evaluate(const_cast<EvalContext&>(ctx));
     if (ocol.nrows() != 1) return false;
-    return ISNA<int8_t>(reinterpret_cast<const int8_t*>(ocol->data())[0]);
+    int8_t tmp;
+    return !ocol.get_element(0, &tmp);
   };
   if (check_operand(rhs)) {
     SType lhs_stype = lhs->resolve(ctx);

--- a/c/expr/expr_binaryop.cc
+++ b/c/expr/expr_binaryop.cc
@@ -79,7 +79,7 @@ template<typename LT, typename RT, typename VT, VT (*OP)(LT, RT)>
 static void map_n_to_n(size_t row0, size_t row1, Column* cols) {
   const LT* lhs_data = static_cast<const LT*>(cols[0]->data());
   const RT* rhs_data = static_cast<const RT*>(cols[1]->data());
-  VT* res_data = static_cast<VT*>(cols[2]->data_w());
+  VT* res_data = static_cast<VT*>(cols[2].get_data_editable());
   for (size_t i = row0; i < row1; ++i) {
     res_data[i] = OP(lhs_data[i], rhs_data[i]);
   }
@@ -89,7 +89,7 @@ template<typename LT, typename RT, typename VT, VT (*OP)(LT, RT)>
 static void map_n_to_1(size_t row0, size_t row1, Column* cols) {
   const LT* lhs_data = static_cast<const LT*>(cols[0]->data());
   RT rhs_value = static_cast<const RT*>(cols[1]->data())[0];
-  VT* res_data = static_cast<VT*>(cols[2]->data_w());
+  VT* res_data = static_cast<VT*>(cols[2].get_data_editable());
   for (size_t i = row0; i < row1; ++i) {
     res_data[i] = OP(lhs_data[i], rhs_value);
   }
@@ -99,7 +99,7 @@ template<typename LT, typename RT, typename VT, VT (*OP)(LT, RT)>
 static void map_1_to_n(size_t row0, size_t row1, Column* cols) {
   LT lhs_value = static_cast<const LT*>(cols[0]->data())[0];
   const RT* rhs_data = static_cast<const RT*>(cols[1]->data());
-  VT* res_data = static_cast<VT*>(cols[2]->data_w());
+  VT* res_data = static_cast<VT*>(cols[2].get_data_editable());
   for (size_t i = row0; i < row1; ++i) {
     res_data[i] = OP(lhs_value, rhs_data[i]);
   }
@@ -110,7 +110,7 @@ template<typename TR, TR (*OP)(const CString&, bool, const CString&, bool)>
 static void strmap_n_to_n(size_t row0, size_t row1, Column* cols) {
   const Column& col0 = cols[0];
   const Column& col1 = cols[1];
-  auto res_data = static_cast<TR*>(cols[2]->data_w());
+  auto res_data = static_cast<TR*>(cols[2].get_data_editable());
   CString val0, val1;
   bool valid0, valid1;
   for (size_t i = row0; i < row1; ++i) {
@@ -125,7 +125,7 @@ template<typename TR, TR (*OP)(const CString&, bool, const CString&, bool)>
 static void strmap_n_to_1(size_t row0, size_t row1, Column* cols) {
   const Column& col0 = cols[0];
   const Column& col1 = cols[1];
-  auto res_data = static_cast<TR*>(cols[2]->data_w());
+  auto res_data = static_cast<TR*>(cols[2].get_data_editable());
   CString val0, val1;
   bool valid0;
   bool valid1 = col1.get_element(0, &val1);

--- a/c/expr/expr_reduce.cc
+++ b/c/expr/expr_reduce.cc
@@ -329,7 +329,7 @@ Column expr_reduce1::evaluate(EvalContext& ctx)
 
   SType out_stype = reducer->output_stype;
   auto res = Column::new_data_column(out_stype, out_nrows);
-  void* output = res->data_w();
+  void* output = res.get_data_editable();
 
   if (out_nrows == 1) {
     reducer->f(input_col, 0, input_col.nrows(), output, 0);
@@ -376,13 +376,13 @@ Column expr_reduce0::evaluate(EvalContext& ctx) {
       size_t ng = grpby.ngroups();
       const int32_t* offsets = grpby.offsets_r();
       res = Column::new_data_column(SType::INT32, ng);
-      auto d_res = static_cast<int32_t*>(res->data_w());
+      auto d_res = static_cast<int32_t*>(res.get_data_editable());
       for (size_t i = 0; i < ng; ++i) {
         d_res[i] = offsets[i + 1] - offsets[i];
       }
     } else {
       res = Column::new_data_column(SType::INT64, 1);
-      auto d_res = static_cast<int64_t*>(res->data_w());
+      auto d_res = static_cast<int64_t*>(res.get_data_editable());
       d_res[0] = static_cast<int64_t>(ctx.nrows());
     }
   }

--- a/c/expr/expr_str.cc
+++ b/c/expr/expr_str.cc
@@ -104,7 +104,7 @@ Column expr_string_match_re::evaluate(EvalContext& ctx) {
   size_t nrows = src.nrows();
 
   Column trg = Column::new_data_column(SType::BOOL, nrows);
-  int8_t* trg_data = static_cast<int8_t*>(trg->data_w());
+  int8_t* trg_data = static_cast<int8_t*>(trg.get_data_editable());
 
   dt::parallel_for_dynamic(nrows,
     [&](size_t i) {

--- a/c/expr/head_func_other.cc
+++ b/c/expr/head_func_other.cc
@@ -20,6 +20,7 @@
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #include <cstring>                 // std::memcmp
+#include "column/virtual.h"
 #include "expr/expr.h"
 #include "expr/head_func_other.h"
 #include "expr/workframe.h"
@@ -36,18 +37,20 @@ namespace expr {
 // Head_Func_Re_Match
 //------------------------------------------------------------------------------
 
-class re_match_vcol : public ColumnImpl {
+class re_match_vcol : public Virtual_ColumnImpl {
   private:
     Column arg;
     std::regex regex;
 
   public:
     re_match_vcol(Column&& col, const std::regex& rx)
-      : ColumnImpl(col.nrows(), SType::BOOL),
+      : Virtual_ColumnImpl(col.nrows(), SType::BOOL),
         arg(std::move(col)),
         regex(rx) {}
 
-    bool is_virtual() const noexcept override { return true; }
+    ColumnImpl* shallowcopy() const override {
+      return new re_match_vcol(Column(arg), regex);
+    }
 
     bool get_element(size_t i, int8_t* out) const override {
       CString x;

--- a/c/expr/head_reduce_nullary.cc
+++ b/c/expr/head_reduce_nullary.cc
@@ -42,7 +42,7 @@ static Column _count0(EvalContext& ctx)
     size_t ng = grpby.ngroups();
     const int32_t* offsets = grpby.offsets_r();
     Column col = Column::new_data_column(SType::INT64, ng);
-    auto d_res = static_cast<int64_t*>(col->data_w());
+    auto d_res = static_cast<int64_t*>(col.get_data_editable());
     for (size_t i = 0; i < ng; ++i) {
       d_res[i] = offsets[i + 1] - offsets[i];
     }

--- a/c/expr/repl_node.cc
+++ b/c/expr/repl_node.cc
@@ -20,6 +20,7 @@
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #include <unordered_map>
+#include "column/const.h"
 #include "expr/expr.h"
 #include "expr/collist.h"
 #include "expr/repl_node.h"
@@ -317,14 +318,16 @@ Column scalar_float_rn::make_column(SType st, size_t nrows) const {
   bool res64 = (st == SType::FLOAT64 || st == SType::VOID ||
                 std::abs(value) > MAX);
   SType result_stype = res64? SType::FLOAT64 : SType::FLOAT32;
+  return Const_ColumnImpl::make_float_column(nrows, value, result_stype);
+  // return Column(new )
 
-  Buffer mbuf = Buffer::mem(res64? sizeof(double) : sizeof(float));
-  if (res64) {
-    mbuf.set_element<double>(0, value);
-  } else {
-    mbuf.set_element<float>(0, static_cast<float>(value));
-  }
-  return Column::new_mbuf_column(result_stype, std::move(mbuf))->repeat(nrows);
+  // Buffer mbuf = Buffer::mem(res64? sizeof(double) : sizeof(float));
+  // if (res64) {
+  //   mbuf.set_element<double>(0, value);
+  // } else {
+  //   mbuf.set_element<float>(0, static_cast<float>(value));
+  // }
+  // return Column::new_mbuf_column(result_stype, std::move(mbuf))->repeat(nrows);
 }
 
 

--- a/c/expr/repl_node.cc
+++ b/c/expr/repl_node.cc
@@ -227,57 +227,27 @@ Column scalar_na_rn::make_column(SType st, size_t nrows) const {
 
 class scalar_int_rn : public scalar_rn {
   int64_t value;
+  bool isbool;
+  size_t : 56;
 
   public:
-    explicit scalar_int_rn(int64_t x) : value(x) {}
+    explicit scalar_int_rn(int64_t x) : value(x), isbool(false) {}
+    explicit scalar_int_rn(bool x)    : value(x), isbool(true) {}
 
   protected:
-    const char* value_type() const noexcept override;
-    bool valid_ltype(LType) const noexcept override;
-    Column make_column(SType st, size_t nrows) const override;
-    template <typename T> Column _make1(SType st) const;
+    const char* value_type() const noexcept override { return "integer"; }
+
+    bool valid_ltype(LType lt) const noexcept override {
+      return lt == LType::INT || lt == LType::REAL ||
+             (lt == LType::BOOL && (value == 0 || value == 1));
+    }
+
+    Column make_column(SType st, size_t nrows) const override {
+      return (isbool && (st == SType::VOID || st == SType::BOOL))
+                ? Const_ColumnImpl::make_bool_column(nrows, bool(value))
+                : Const_ColumnImpl::make_int_column(nrows, value, st);
+    }
 };
-
-
-const char* scalar_int_rn::value_type() const noexcept {
-  return "integer";
-}
-
-
-bool scalar_int_rn::valid_ltype(LType lt) const noexcept {
-  return lt == LType::INT || lt == LType::REAL ||
-         (lt == LType::BOOL && (value == 0 || value == 1));
-}
-
-
-Column scalar_int_rn::make_column(SType st, size_t nrows) const {
-  int64_t av = std::abs(value);
-  SType rst = value == 0 || value == 1? SType::BOOL :
-              av <= 127? SType::INT8 :
-              av <= 32767? SType::INT16 :
-              av <= 2147483647? SType::INT32 : SType::INT64;
-  if (static_cast<size_t>(st) > static_cast<size_t>(rst)) {
-    rst = st;
-  }
-  Column col1 = rst == SType::BOOL? _make1<int8_t>(rst) :
-                rst == SType::INT8? _make1<int8_t>(rst) :
-                rst == SType::INT16? _make1<int16_t>(rst) :
-                rst == SType::INT32? _make1<int32_t>(rst) :
-                rst == SType::INT64? _make1<int64_t>(rst) :
-                rst == SType::FLOAT32? _make1<float>(rst) :
-                rst == SType::FLOAT64? _make1<double>(rst) : Column();
-  xassert(col1);
-  col1.repeat(nrows);
-  return col1;
-}
-
-
-template <typename T>
-Column scalar_int_rn::_make1(SType stype) const {
-  Buffer mbuf = Buffer::mem(sizeof(T));
-  mbuf.set_element<T>(0, static_cast<T>(value));
-  return Column::new_mbuf_column(stype, std::move(mbuf));
-}
 
 
 
@@ -319,15 +289,6 @@ Column scalar_float_rn::make_column(SType st, size_t nrows) const {
                 std::abs(value) > MAX);
   SType result_stype = res64? SType::FLOAT64 : SType::FLOAT32;
   return Const_ColumnImpl::make_float_column(nrows, value, result_stype);
-  // return Column(new )
-
-  // Buffer mbuf = Buffer::mem(res64? sizeof(double) : sizeof(float));
-  // if (res64) {
-  //   mbuf.set_element<double>(0, value);
-  // } else {
-  //   mbuf.set_element<float>(0, static_cast<float>(value));
-  // }
-  // return Column::new_mbuf_column(result_stype, std::move(mbuf))->repeat(nrows);
 }
 
 
@@ -358,27 +319,11 @@ bool scalar_string_rn::valid_ltype(LType lt) const noexcept {
 }
 
 Column scalar_string_rn::make_column(SType st, size_t nrows) const {
+  if (st == SType::VOID) st = SType::STR32;
   if (nrows == 0) {
     return Column::new_data_column(SType::STR32, 0);
   }
-  size_t len = value.size();
-  SType rst = (st == SType::VOID)? SType::STR32 : st;
-  size_t elemsize = (rst == SType::STR32)? 4 : 8;
-  Buffer offbuf = Buffer::mem(2 * elemsize);
-  if (elemsize == 4) {
-    offbuf.set_element<uint32_t>(0, 0);
-    offbuf.set_element<uint32_t>(1, static_cast<uint32_t>(len));
-  } else {
-    offbuf.set_element<uint64_t>(0, 0);
-    offbuf.set_element<uint64_t>(1, len);
-  }
-  Buffer strbuf = Buffer::mem(len);
-  std::memcpy(strbuf.xptr(), value.data(), len);
-  Column col = Column::new_string_column(1, std::move(offbuf), std::move(strbuf));
-  if (nrows > 1) {
-    col.repeat(nrows);
-  }
-  return col;
+  return Const_ColumnImpl::make_string_column(nrows, CString(value), st);
 }
 
 
@@ -492,7 +437,7 @@ repl_node_ptr repl_node::make(EvalContext& ctx, py::oobj src) {
 
   if (src.is_frame())       res = new frame_rn(src.to_datatable());
   else if (src.is_none())   res = new scalar_na_rn();
-  else if (src.is_bool())   res = new scalar_int_rn(src.to_bool());
+  else if (src.is_bool())   res = new scalar_int_rn(bool(src.to_bool()));
   else if (src.is_int())    res = new scalar_int_rn(src.to_int64());
   else if (src.is_float())  res = new scalar_float_rn(src.to_double());
   else if (src.is_string()) res = new scalar_string_rn(src.to_string());

--- a/c/expr/repl_node.cc
+++ b/c/expr/repl_node.cc
@@ -82,7 +82,7 @@ void frame_rn::replace_columns(EvalContext& ctx, const intvec& indices) const {
     if (coli.nrows() == 1) {
       coli.repeat(lrows);
     }
-    dt0->set_ocolumn(j, std::move(coli));
+    dt0->set_column(j, std::move(coli));
   }
 }
 
@@ -101,7 +101,7 @@ void frame_rn::replace_values(EvalContext& ctx, const intvec& indices) const {
     size_t j = indices[i];
     const Column& coli = dtr->get_column(rcols == 1? 0 : i);
     if (!dt0->get_column(j)) {
-      dt0->set_ocolumn(j,
+      dt0->set_column(j,
           Column::new_na_column(coli.stype(), dt0->nrows));
     }
     Column& colj = dt0->get_column(j);
@@ -163,7 +163,7 @@ void scalar_rn::replace_columns(EvalContext& ctx, const intvec& indices) const {
       new_columns[stype] = make_column(stype, dt0->nrows);
     }
     Column newcol = new_columns[stype];  // copy
-    dt0->set_ocolumn(j, std::move(newcol));
+    dt0->set_column(j, std::move(newcol));
   }
 }
 
@@ -179,10 +179,10 @@ void scalar_rn::replace_values(EvalContext& ctx, const intvec& indices) const {
     Column replcol = make_column(stype, 1);
     stype = replcol.stype();  // may change from VOID to BOOL, FIXME!
     if (!colj) {
-      dt0->set_ocolumn(j, Column::new_na_column(stype, dt0->nrows));
+      dt0->set_column(j, Column::new_na_column(stype, dt0->nrows));
     }
     else if (colj.stype() != stype) {
-      dt0->set_ocolumn(j, colj.cast(stype));
+      dt0->set_column(j, colj.cast(stype));
     }
     Column& ocol = dt0->get_column(j);
     ocol.replace_values(ri0, replcol);
@@ -407,7 +407,7 @@ void exprlist_rn::replace_columns(EvalContext& ctx, const intvec& indices) const
     Column col = (i < rcols)? exprs[i]->evaluate(ctx)
                             : dt0->get_column(indices[0]);
     xassert(col.nrows() == dt0->nrows);
-    dt0->set_ocolumn(j, std::move(col));
+    dt0->set_column(j, std::move(col));
   }
 }
 

--- a/c/expr/repl_node.cc
+++ b/c/expr/repl_node.cc
@@ -266,7 +266,8 @@ Column scalar_int_rn::make_column(SType st, size_t nrows) const {
                 rst == SType::FLOAT32? _make1<float>(rst) :
                 rst == SType::FLOAT64? _make1<double>(rst) : Column();
   xassert(col1);
-  return col1->repeat(nrows);
+  col1.repeat(nrows);
+  return col1;
 }
 
 

--- a/c/frame/__init__.cc
+++ b/c/frame/__init__.cc
@@ -450,7 +450,7 @@ class FrameInitializationManager {
           auto colsrc  = npsrc.get_attr("data").get_item(col_key);
           auto masksrc = npsrc.get_attr("mask").get_item(col_key);
           make_column(colsrc, SType::VOID);
-          Column maskcol = Column::from_buffer(masksrc);
+          Column maskcol = Column::from_pybuffer(masksrc);
           cols.back()->apply_na_mask(maskcol);
         }
       } else {
@@ -595,7 +595,7 @@ class FrameInitializationManager {
         col = srcdt->get_column(0);
       }
       else if (colsrc.is_buffer()) {
-        col = Column::from_buffer(colsrc);
+        col = Column::from_pybuffer(colsrc);
       }
       else if (colsrc.is_list_or_tuple()) {
         col = Column::from_pylist(colsrc.to_pylist(), int(s));

--- a/c/frame/__sizeof__.cc
+++ b/c/frame/__sizeof__.cc
@@ -84,10 +84,8 @@ size_t DataTable::memory_footprint() const {
 
 
 /**
- * Get the total size of the memory occupied by the Column. This is different
- * from `column->alloc_size`, which in general reports byte size of the `data`
- * portion of the column.
- */
+  * Get the total size of the memory occupied by the Column.
+  */
 size_t ColumnImpl::memory_footprint() const {
   size_t sz = sizeof(*this);
   sz += mbuf.memory_footprint();

--- a/c/frame/cast.cc
+++ b/c/frame/cast.cc
@@ -112,7 +112,7 @@ static inline void obj_str(py::robj x, dt::string_buf* buf) {
 template <typename T, typename U, U(*CAST_OP)(T)>
 static void cast_fw0(const Column& col, size_t start, void* out_data)
 {
-  auto inp = static_cast<const T*>(col->data()) + start;
+  auto inp = static_cast<const T*>(col.get_data_readonly()) + start;
   auto out = static_cast<U*>(out_data);
   dt::parallel_for_static(col.nrows(),
     [=](size_t i) {

--- a/c/frame/rbind.cc
+++ b/c/frame/rbind.cc
@@ -441,7 +441,7 @@ void FwColumn<T>::rbind_impl(colvec& columns, size_t new_nrows, bool col_empty)
 
   // Reallocate the column's data buffer
   size_t old_nrows = _nrows;
-  size_t old_alloc_size = alloc_size();
+  size_t old_alloc_size = sizeof(T) * old_nrows;
   size_t new_alloc_size = sizeof(T) * new_nrows;
   mbuf.resize(new_alloc_size);
   _nrows = new_nrows;
@@ -467,8 +467,9 @@ void FwColumn<T>::rbind_impl(colvec& columns, size_t new_nrows, bool col_empty)
       if (col.stype() != _stype) {
         col.cast_inplace(_stype);
       }
-      std::memcpy(resptr, col->data(), col->alloc_size());
-      resptr += col->alloc_size();
+      size_t col_data_size = sizeof(T) * col.nrows();
+      std::memcpy(resptr, col.get_data_readonly(), col_data_size);
+      resptr += col_data_size;
     }
   }
   if (rows_to_fill) {

--- a/c/frame/rbind.cc
+++ b/c/frame/rbind.cc
@@ -510,7 +510,8 @@ void PyObjectColumn::rbind_impl(
       if (col.stype() != SType::OBJ) {
         col = col.cast(_stype);
       }
-      auto src_data = static_cast<PyObject* const*>(col->data());
+      auto src_data = static_cast<PyObject* const*>(
+                        col.get_data_readonly());
       for (size_t i = 0; i < col.nrows(); ++i) {
         Py_INCREF(src_data[i]);
         Py_DECREF(*dest_data);

--- a/c/frame/repeat.cc
+++ b/c/frame/repeat.cc
@@ -19,43 +19,16 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
-#include "datatablemodule.h"
+#include "column/repeated.h"
 #include "frame/py_frame.h"
 #include "python/args.h"
-#include "rowindex.h"
 #include "column_impl.h"  // TODO: remove
+#include "datatablemodule.h"
+#include "rowindex.h"
 
 
-//------------------------------------------------------------------------------
-// Static helpers
-//------------------------------------------------------------------------------
-
-// TODO: we could create a special "repeated" column here
 Column ColumnImpl::repeat(size_t nreps) const {
-  xassert(!info(_stype).is_varwidth());
-  size_t esize = info(_stype).elemsize();
-  size_t new_nrows = _nrows * nreps;
-
-  Column newcol = Column::new_data_column(_stype, new_nrows);
-  if (!new_nrows) {
-    return newcol;
-  }
-  const void* olddata = data();
-  void* newdata = newcol->data_w();
-
-  std::memcpy(newdata, olddata, _nrows * esize);
-  size_t nrows_filled = _nrows;
-  while (nrows_filled < new_nrows) {
-    size_t nrows_copy = std::min(new_nrows - nrows_filled, nrows_filled);
-    std::memcpy(static_cast<char*>(newdata) + nrows_filled * esize,
-                newdata,
-                nrows_copy * esize);
-    nrows_filled += nrows_copy;
-    xassert(nrows_filled % _nrows == 0);
-  }
-  xassert(nrows_filled == new_nrows);
-
-  return newcol;
+  return Column(new dt::Repeated_ColumnImpl(Column(this->shallowcopy()), nreps));
 }
 
 

--- a/c/frame/repeat.cc
+++ b/c/frame/repeat.cc
@@ -25,18 +25,13 @@
 #include "column_impl.h"  // TODO: remove
 #include "datatablemodule.h"
 #include "rowindex.h"
-
-
-Column ColumnImpl::repeat(size_t nreps) const {
-  return Column(new dt::Repeated_ColumnImpl(Column(this->shallowcopy()), nreps));
-}
+namespace py {
 
 
 
 //------------------------------------------------------------------------------
 // datatable.repeat()
 //------------------------------------------------------------------------------
-namespace py {
 
 static PKArgs args_repeat(
     2, 0, 0, false, false, {"frame", "n"},
@@ -71,8 +66,11 @@ static oobj repeat(const PKArgs& args) {
 
 
 
+
 void DatatableModule::init_methods_repeat() {
   ADD_FN(&repeat, args_repeat);
 }
+
+
 
 } // namespace py

--- a/c/frame/replace.cc
+++ b/c/frame/replace.cc
@@ -493,7 +493,7 @@ void ReplaceAgent::process_int_column(size_t colidx) {
   if (maxy) {
     SType new_stype = (maxy > std::numeric_limits<int32_t>::max())
                       ? SType::INT64 : SType::INT32;
-    dt->set_ocolumn(colidx, col.cast(new_stype));
+    dt->set_column(colidx, col.cast(new_stype));
     columns_cast = true;
     if (new_stype == SType::INT64) {
       process_int_column<int64_t>(colidx);
@@ -549,7 +549,7 @@ void ReplaceAgent::process_real_column(size_t colidx) {
     }
   }
   if (std::is_same<T, float>::value && maxy > 0) {
-    dt->set_ocolumn(colidx, col.cast(SType::FLOAT64));
+    dt->set_column(colidx, col.cast(SType::FLOAT64));
     columns_cast = true;
     process_real_column<double>(colidx);
   } else {
@@ -572,7 +572,7 @@ void ReplaceAgent::process_str_column(size_t colidx) {
   }
   Column newcol = replace_str(x_str.size(), x_str.data(), y_str.data(), col);
   columns_cast = (newcol.stype() != col.stype());
-  dt->set_ocolumn(colidx, std::move(newcol));
+  dt->set_column(colidx, std::move(newcol));
 }
 
 

--- a/c/frame/replace.cc
+++ b/c/frame/replace.cc
@@ -446,7 +446,7 @@ void ReplaceAgent::process_bool_column(size_t colidx) {
   if (x_bool.empty()) return;
   Column& col = dt->get_column(colidx);
   col.materialize();
-  int8_t* coldata = static_cast<int8_t*>(col->data_w());
+  int8_t* coldata = static_cast<int8_t*>(col.get_data_editable());
   size_t n = x_bool.size();
   xassert(n == y_bool.size());
   if (n == 0) return;
@@ -504,7 +504,7 @@ void ReplaceAgent::process_int_column(size_t colidx) {
     size_t n = xfilt.size();
     xassert(n == yfilt.size());
     if (n == 0) return;
-    T* coldata = static_cast<T*>(col->data_w());
+    T* coldata = static_cast<T*>(col.get_data_editable());
     replace_fw<T>(xfilt.data(), yfilt.data(), col.nrows(), coldata, n);
     col.reset_stats();
   }
@@ -556,7 +556,7 @@ void ReplaceAgent::process_real_column(size_t colidx) {
     size_t n = xfilt.size();
     xassert(n == yfilt.size());
     if (n == 0) return;
-    T* coldata = static_cast<T*>(col->data_w());
+    T* coldata = static_cast<T*>(col.get_data_editable());
     replace_fw<T>(xfilt.data(), yfilt.data(), col.nrows(), coldata, n);
     col.reset_stats();
   }

--- a/c/frame/to_numpy.cc
+++ b/c/frame/to_numpy.cc
@@ -124,7 +124,7 @@ oobj Frame::to_numpy(const PKArgs& args) {
 
     size_t dtsize = ncols * dt->nrows;
     Column mask_col = Column::new_data_column(SType::BOOL, dtsize);
-    int8_t* mask_data = static_cast<int8_t*>(mask_col->data_w());
+    int8_t* mask_data = static_cast<int8_t*>(mask_col.get_data_editable());
 
     size_t n_row_chunks = std::max(dt->nrows / 100, size_t(1));
     size_t rows_per_chunk = dt->nrows / n_row_chunks;

--- a/c/models/aggregator.cc
+++ b/c/models/aggregator.cc
@@ -350,7 +350,7 @@ bool Aggregator<T>::sample_exemplars(size_t max_bins, size_t n_na_bins)
   // for the additional N/A bins that may appear during grouping.
   if (gb_members.ngroups() > max_bins + n_na_bins) {
     const int32_t* offsets = gb_members.offsets_r();
-    auto d_members = static_cast<int32_t*>(dt_members->get_column(0)->data_w());
+    auto d_members = static_cast<int32_t*>(dt_members->get_column(0).get_data_editable());
 
     // First, set all `exemplar_id`s to `N/A`.
     for (size_t i = 0; i < dt_members->nrows; ++i) {
@@ -412,11 +412,11 @@ void Aggregator<T>::aggregate_exemplars(bool was_sampled) {
       {Column::new_data_column(SType::INT32, n_exemplars)},
       {"members_count"}
   ));
-  auto d_counts = static_cast<int32_t*>(dt_counts->get_column(0)->data_w());
+  auto d_counts = static_cast<int32_t*>(dt_counts->get_column(0).get_data_editable());
   std::memset(d_counts, 0, n_exemplars * sizeof(int32_t));
 
   // Setting up exemplar indices and counts
-  auto d_members = static_cast<int32_t*>(dt_members->get_column(0)->data_w());
+  auto d_members = static_cast<int32_t*>(dt_members->get_column(0).get_data_editable());
   for (size_t i = was_sampled; i < ngroups; ++i) {
     size_t i_sampled = i - was_sampled;
     size_t off_i = static_cast<size_t>(offsets[i]);
@@ -458,7 +458,7 @@ void Aggregator<T>::group_0d() {
     auto res = dt->group(spec);
     RowIndex ri_exemplars = std::move(res.first);
 
-    auto d_members = static_cast<int32_t*>(dt_members->get_column(0)->data_w());
+    auto d_members = static_cast<int32_t*>(dt_members->get_column(0).get_data_editable());
     ri_exemplars.iterate(0, dt->nrows, 1,
       [&](size_t i, size_t j) {
         d_members[j] = static_cast<int32_t>(i);
@@ -511,7 +511,7 @@ void Aggregator<T>::group_2d() {
  */
 template <typename T>
 void Aggregator<T>::group_1d_continuous() {
-  auto d_members = static_cast<int32_t*>(dt_members->get_column(0)->data_w());
+  auto d_members = static_cast<int32_t*>(dt_members->get_column(0).get_data_editable());
   T norm_factor, norm_shift;
   set_norm_coeffs(norm_factor, norm_shift, contconvs[0]->get_min(), contconvs[0]->get_max(), n_bins);
 
@@ -532,7 +532,7 @@ void Aggregator<T>::group_1d_continuous() {
  */
 template <typename T>
 void Aggregator<T>::group_2d_continuous() {
-  auto d_members = static_cast<int32_t*>(dt_members->get_column(0)->data_w());
+  auto d_members = static_cast<int32_t*>(dt_members->get_column(0).get_data_editable());
 
   T normx_factor, normx_shift;
   T normy_factor, normy_shift;
@@ -565,7 +565,7 @@ void Aggregator<T>::group_1d_categorical() {
   RowIndex ri0 = std::move(res.first);
   Groupby grpby0 = std::move(res.second);
 
-  auto d_members = static_cast<int32_t*>(dt_members->get_column(0)->data_w());
+  auto d_members = static_cast<int32_t*>(dt_members->get_column(0).get_data_editable());
   const int32_t* offsets0 = grpby0.offsets_r();
 
   dt::parallel_for_dynamic(grpby0.ngroups(),
@@ -592,7 +592,7 @@ void Aggregator<T>::group_2d_categorical()
   RowIndex ri = std::move(res.first);
   Groupby grpby = std::move(res.second);
 
-  auto d_members = static_cast<int32_t*>(dt_members->get_column(0)->data_w());
+  auto d_members = static_cast<int32_t*>(dt_members->get_column(0).get_data_editable());
   const int32_t* offsets = grpby.offsets_r();
 
   const Column& col0 = dt_cat->get_column(0);
@@ -642,7 +642,7 @@ void Aggregator<T>::group_2d_mixed()
   RowIndex ri_cat = std::move(res.first);
   Groupby grpby = std::move(res.second);
 
-  auto d_members = static_cast<int32_t*>(dt_members->get_column(0)->data_w());
+  auto d_members = static_cast<int32_t*>(dt_members->get_column(0).get_data_editable());
   const int32_t* offsets_cat = grpby.offsets_r();
 
   T normx_factor, normx_shift;
@@ -709,7 +709,7 @@ void Aggregator<T>::group_nd() {
   size_t nexemplars = 0;
   size_t ncoprimes = 0;
 
-  auto d_members = static_cast<int32_t*>(dt_members->get_column(0)->data_w());
+  auto d_members = static_cast<int32_t*>(dt_members->get_column(0).get_data_editable());
   tptr<T> pmatrix;
   bool do_projection = ncols > max_dimensions;
   if (do_projection) pmatrix = generate_pmatrix(ncols);
@@ -892,7 +892,7 @@ void Aggregator<T>::adjust_delta(T& delta, std::vector<exptr>& exemplars,
 template <typename T>
 void Aggregator<T>::adjust_members(std::vector<size_t>& ids) {
 
-  auto d_members = static_cast<int32_t*>(dt_members->get_column(0)->data_w());
+  auto d_members = static_cast<int32_t*>(dt_members->get_column(0).get_data_editable());
   auto map = std::unique_ptr<size_t[]>(new size_t[ids.size()]);
   auto nids = ids.size();
 

--- a/c/models/dt_ftrl.cc
+++ b/c/models/dt_ftrl.cc
@@ -208,8 +208,10 @@ void Ftrl<T>::create_y_binomial(const DataTable* dt,
     RowIndex ri_join = natural_join(dt_labels_in.get(), dt_labels.get());
     size_t nlabels = dt_labels->nrows;
     xassert(nlabels != 0 && nlabels < 3);
-    auto data_label_ids_in = static_cast<int8_t*>(dt_labels_in->get_column(1).get_data_editable());
-    auto data_label_ids = static_cast<const int8_t*>(dt_labels->get_column(1)->data());
+    auto data_label_ids_in = static_cast<int8_t*>(
+                              dt_labels_in->get_column(1).get_data_editable());
+    auto data_label_ids = static_cast<const int8_t*>(
+                              dt_labels->get_column(1).get_data_readonly());
 
 
     switch (nlabels) {
@@ -389,7 +391,8 @@ void Ftrl<T>::create_y_multinomial(const DataTable* dt,
   // If we only got NA targets, return to stop training.
   if (dt_labels_in == nullptr) return;
 
-  auto data_label_ids_in = static_cast<const int32_t*>(dt_labels_in->get_column(1)->data());
+  auto data_label_ids_in = static_cast<const int32_t*>(
+                              dt_labels_in->get_column(1).get_data_readonly());
   size_t nlabels_in = dt_labels_in->nrows;
 
   // When we only start training, all the incoming labels become the model
@@ -405,7 +408,8 @@ void Ftrl<T>::create_y_multinomial(const DataTable* dt,
     // When we already have some labels, and got new ones, we first
     // set up mapping in such a way, so that models will train
     // on all the negatives.
-    auto data_label_ids = static_cast<const int32_t*>(dt_labels->get_column(1)->data());
+    auto data_label_ids = static_cast<const int32_t*>(
+                            dt_labels->get_column(1).get_data_readonly());
     RowIndex ri_join = natural_join(dt_labels_in.get(), dt_labels.get());
     size_t nlabels = dt_labels->nrows;
 
@@ -732,7 +736,8 @@ dtptr Ftrl<T>::predict(const DataTable* dt_X) {
   // Create datatable for predictions and obtain column data pointers.
   size_t nlabels = dt_labels->nrows;
 
-  auto data_label_ids = static_cast<const U*>(dt_labels->get_column(1)->data());
+  auto data_label_ids = static_cast<const U*>(
+                            dt_labels->get_column(1).get_data_readonly());
 
   dtptr dt_p = create_p(dt_X->nrows);
   std::vector<T*> data_p(nlabels);

--- a/c/models/kfold.cc
+++ b/c/models/kfold.cc
@@ -164,7 +164,7 @@ static oobj kfold(const PKArgs& args) {
     size_t colsize = static_cast<size_t>(b1 + n - b2);
     Column col = Column::new_data_column(SType::INT32, colsize);
     DataTable* dt = new DataTable({std::move(col)}, DataTable::default_names);
-    data.push_back(static_cast<int32_t*>(dt->get_column(0)->data_w()));
+    data.push_back(static_cast<int32_t*>(dt->get_column(0).get_data_editable()));
 
     res.set(static_cast<size_t>(ii),
             otuple(Frame::oframe(dt), orange(b1, b2)));
@@ -339,8 +339,8 @@ static oobj kfold_random(const PKArgs& args) {
     DataTable* dt2 = new DataTable({std::move(col2)}, DataTable::default_names);
     oobj train = Frame::oframe(dt1);
     oobj test  = Frame::oframe(dt2);
-    train_folds[x] = static_cast<T*>(dt1->get_column(0)->data_w());
-    test_folds[x] = static_cast<T*>(dt2->get_column(0)->data_w());
+    train_folds[x] = static_cast<T*>(dt1->get_column(0).get_data_editable());
+    test_folds[x] = static_cast<T*>(dt2->get_column(0).get_data_editable());
     res.set(x, otuple{ train, test });
   }
 

--- a/c/models/label_encode.cc
+++ b/c/models/label_encode.cc
@@ -82,8 +82,8 @@ static void label_encode_bool(const Column& col, dtptr& dt_labels, dtptr& dt_enc
   // Set up boolean labels and their corresponding ids.
   Column ids_col = Column::new_data_column(SType::BOOL, 2);
   Column labels_col = Column::new_data_column(SType::BOOL, 2);
-  auto ids_data = static_cast<int8_t*>(ids_col->data_w());
-  auto labels_data = static_cast<int8_t*>(labels_col->data_w());
+  auto ids_data = static_cast<int8_t*>(ids_col.get_data_editable());
+  auto labels_data = static_cast<int8_t*>(labels_col.get_data_editable());
   ids_data[0] = 0;
   ids_data[1] = 1;
   labels_data[0] = 0;

--- a/c/models/label_encode.h
+++ b/c/models/label_encode.h
@@ -43,8 +43,8 @@ dtptr create_dt_labels_fw(const std::unordered_map<element_t<stype_from>,
   Column labels_col = Column::new_data_column(stype_from, nlabels);
   Column ids_col = Column::new_data_column(stype_to, nlabels);
 
-  auto labels_data = static_cast<Tfrom*>(labels_col->data_w());
-  auto ids_data = static_cast<Tto*>(ids_col->data_w());
+  auto labels_data = static_cast<Tfrom*>(labels_col.get_data_editable());
+  auto ids_data = static_cast<Tto*>(ids_col.get_data_editable());
 
   for (auto& label : labels_map) {
     labels_data[label.second] = static_cast<Tfrom>(label.first);
@@ -63,7 +63,7 @@ template <typename T, SType stype_to>
 dtptr create_dt_labels_str(const std::unordered_map<std::string, element_t<stype_to>>& labels_map) {
   size_t nlabels = labels_map.size();
   Column ids_col = Column::new_data_column(stype_to, nlabels);
-  auto ids_data = static_cast<element_t<stype_to>*>(ids_col->data_w());
+  auto ids_data = static_cast<element_t<stype_to>*>(ids_col.get_data_editable());
   dt::writable_string_col c_label_names(nlabels);
   dt::writable_string_col::buffer_impl<T> sb(c_label_names);
   sb.commit_and_start_new_chunk(0);
@@ -90,7 +90,7 @@ dtptr create_dt_labels_str(const std::unordered_map<std::string, element_t<stype
 template <typename T>
 void set_ids(Column& col, T i0) {
   col.materialize();
-  auto data = static_cast<T*>(col->data_w());
+  auto data = static_cast<T*>(col.get_data_editable());
   for (T i = 0; i < static_cast<T>(col.nrows()); ++i) {
     data[i] = i0 + i;
   }
@@ -107,7 +107,7 @@ void label_encode_fw(const Column& ocol, dtptr& dt_labels, dtptr& dt_encoded) {
   const size_t nrows = ocol.nrows();
 
   Column outcol = Column::new_data_column(stype_to, nrows);
-  auto outdata = static_cast<T_to*>(outcol->data_w());
+  auto outdata = static_cast<T_to*>(outcol.get_data_editable());
   std::unordered_map<T_from, T_to> labels_map;
   dt::shared_mutex shmutex;
 
@@ -158,7 +158,7 @@ void label_encode_str(const Column& ocol, dtptr& dt_labels, dtptr& dt_encoded) {
   using T_to = element_t<stype_to>;
   const size_t nrows = ocol.nrows();
   Column outcol = Column::new_data_column(stype_to, nrows);
-  auto outdata = static_cast<T_to*>(outcol->data_w());
+  auto outdata = static_cast<T_to*>(outcol.get_data_editable());
   std::unordered_map<std::string, T_to> labels_map;
   dt::shared_mutex shmutex;
 

--- a/c/py_buffers.cc
+++ b/c/py_buffers.cc
@@ -113,25 +113,25 @@ Column Column::from_buffer(const py::robj& pyobj)
     res = Column::new_data_column(stype, nrows);
     size_t stride = static_cast<size_t>(view->strides[0] / view->itemsize);
     if (view->itemsize == 8) {
-      int64_t* out = static_cast<int64_t*>(res->data_w());
+      int64_t* out = static_cast<int64_t*>(res.get_data_editable());
       int64_t* inp = static_cast<int64_t*>(view->buf);
       for (size_t j = 0; j < nrows; ++j) {
         out[j] = inp[j * stride];
       }
     } else if (view->itemsize == 4) {
-      int32_t* out = static_cast<int32_t*>(res->data_w());
+      int32_t* out = static_cast<int32_t*>(res.get_data_editable());
       int32_t* inp = static_cast<int32_t*>(view->buf);
       for (size_t j = 0; j < nrows; ++j) {
         out[j] = inp[j * stride];
       }
     } else if (view->itemsize == 2) {
-      int16_t* out = static_cast<int16_t*>(res->data_w());
+      int16_t* out = static_cast<int16_t*>(res.get_data_editable());
       int16_t* inp = static_cast<int16_t*>(view->buf);
       for (size_t j = 0; j < nrows; ++j) {
         out[j] = inp[j * stride];
       }
     } else if (view->itemsize == 1) {
-      int8_t* out = static_cast<int8_t*>(res->data_w());
+      int8_t* out = static_cast<int8_t*>(res.get_data_editable());
       int8_t* inp = static_cast<int8_t*>(view->buf);
       for (size_t j = 0; j < nrows; ++j) {
         out[j] = inp[j * stride];

--- a/c/py_buffers.cc
+++ b/c/py_buffers.cc
@@ -111,9 +111,9 @@ Column Column::from_pybuffer(const py::robj& pyobj)
                 << ", expected " << buffer_len_expected;
     }
 
-    pview.release();
+    void* ptr = pview->buf;
     res = Column::new_mbuf_column(stype,
-              Buffer::external(view->buf, buffer_len * stride_len, view)
+              Buffer::external(ptr, buffer_len * stride_len, std::move(pview))
           );
     if (strided) {
       res = Column(

--- a/c/py_buffers.cc
+++ b/c/py_buffers.cc
@@ -429,16 +429,11 @@ void py::Frame::m__getbuffer__(Py_buffer* view, int flags) {
     {
       Column newcol = dt->get_column(i + i0).cast(stype, std::move(xmb));
       newcol.materialize();
-      xassert(newcol->alloc_size() == colsize);
       // We can now delete the new column: this will delete `xmb` as well,
-      // however an ExternalMemBuf object does not attempt to free its
-      // memory buffer. The converted data that was written to `mbuf` will
-      // thus remain intact. No need to delete `xmb` either.
+      // however a "view buffer" object does not attempt to free its
+      // memory. The converted data that was written to `xmb` will
+      // thus remain intact.
     }
-
-    // Delete the `col` pointer, which was extracted from the i-th column
-    // of the DataTable.
-    // delete col;
   }
   if (stype == SType::OBJ) {
     memr.set_pyobjects(/*clear=*/ false);

--- a/c/sort.cc
+++ b/c/sort.cc
@@ -646,7 +646,7 @@ class SortContext {
    */
   template <bool ASC>
   void _initB() {
-    const uint8_t* xi = static_cast<const uint8_t*>(column->data());
+    const uint8_t* xi = static_cast<const uint8_t*>(column.get_data_readonly());
     elemsize = 1;
     nsigbits = 2;
     allocate_x();
@@ -693,7 +693,7 @@ class SortContext {
   void _initI_impl(T edge) {
     TI una = static_cast<TI>(GETNA<T>());
     TI uedge = static_cast<TI>(edge);
-    const TI* xi = static_cast<const TI*>(column->data());
+    const TI* xi = static_cast<const TI*>(column.get_data_readonly());
     elemsize = sizeof(TO);
     allocate_x();
     TO* xo = x.data<TO>();
@@ -749,7 +749,7 @@ class SortContext {
    */
   template <bool ASC, typename TO>
   void _initF() {
-    const TO* xi = static_cast<const TO*>(column->data());
+    const TO* xi = static_cast<const TO*>(column.get_data_readonly());
     elemsize = sizeof(TO);
     nsigbits = elemsize * 8;
     allocate_x();

--- a/c/str/split_into_nhot.cc
+++ b/c/str/split_into_nhot.cc
@@ -85,7 +85,7 @@ static void encode_nones(const Column& col, colvec& outcols) {
   size_t nrows = outcols[0].nrows();
   std::vector<int8_t*> coldata(ncols);
   for (size_t i = 0; i < ncols; ++i) {
-    coldata[i] = static_cast<int8_t*>(outcols[i]->data_w());
+    coldata[i] = static_cast<int8_t*>(outcols[i].get_data_editable());
   }
 
   dt::parallel_for_dynamic(nrows,
@@ -125,7 +125,7 @@ static void sort_colnames(colvec& outcols, strvec& outnames) {
 DataTable* split_into_nhot(const Column& col, char sep,
                            bool sort /* = false */)
 {
-  xassert((col.stype() == SType::STR32) || (col.stype() == SType::STR64));
+  xassert(col.ltype() == LType::STRING);
 
   size_t nrows = col.nrows();
   std::unordered_map<std::string, size_t> colsmap;
@@ -168,7 +168,7 @@ DataTable* split_into_nhot(const Column& col, char sep,
               if (colsmap.count(s) == 0) {
                 colsmap[s] = outcols.size();
                 auto newcol = Column::new_data_column(SType::BOOL, nrows);
-                int8_t* data = static_cast<int8_t*>(newcol->data_w());
+                int8_t* data = static_cast<int8_t*>(newcol.get_data_editable());
                 std::memset(data, 0, nrows);
                 data[irow] = 1;
                 outcols.push_back(std::move(newcol));


### PR DESCRIPTION
- `ColumnImpl::shallowcopy()` is made pure virtual;
- Fixed shallowcopying of const columns so that  it preserves types;
- `ColumnImpl::repeat(n)` removed (there is another `repeat()` method that remains);
- Refactored mappers in expr_binaryop.cc  to use new Column API;
- Simplified classes `sclar_int_rn`, `scalar_float_rn`, `scalar_string_rn`;
- Eliminate certain instances where `Column::operator->` was used;
- When converting from a strided external buffer we now avoid copying and create a virtual column instead.

WIP for #2012 
WIP for #1396