### PR TITLE
ColumnImpl::Mbuf relocated

### DIFF
--- a/c/buffer.cc
+++ b/c/buffer.cc
@@ -325,7 +325,7 @@ class View_BufferImpl : public BufferImpl
       XAssert(offs + n <= src->size());
       parent_ = src->acquire_shared();
       offset_ = offs;
-      data_ = static_cast<char*>(src->data()) + offset_;
+      data_ = n? static_cast<char*>(src->data()) + offset_ : nullptr;
       size_ = n;
       resizable_ = false;
       writable_ = src->is_writable();
@@ -343,8 +343,10 @@ class View_BufferImpl : public BufferImpl
 
     void verify_integrity() const override {
       BufferImpl::verify_integrity();
+      auto parent_data = static_cast<const char*>(parent_->data());
       XAssert(!resizable_);
-      XAssert(data_ == static_cast<const char*>(parent_->data()) + offset_);
+      XAssert(size_? data_ == parent_data + offset_
+                   : data_ == nullptr);
     }
 };
 

--- a/c/column.cc
+++ b/c/column.cc
@@ -267,10 +267,10 @@ void Column::materialize() const {
 }
 
 void Column::replace_values(const RowIndex& replace_at,
-                             const Column& replace_with)
+                            const Column& replace_with)
 {
   materialize();
-  pcol->replace_values(*this, replace_at, replace_with);
+  pcol->replace_values(replace_at, replace_with, *this);
 }
 
 

--- a/c/column.cc
+++ b/c/column.cc
@@ -219,32 +219,41 @@ py::oobj Column::get_element_as_pyobject(size_t i) const {
 // Column : data buffers
 //------------------------------------------------------------------------------
 
+NaStorage Column::get_na_storage_method() const noexcept {
+  return pcol->get_na_storage_method();
+}
+
+
+size_t Column::get_num_data_buffers() const noexcept {
+  return pcol->get_num_data_buffers();
+}
+
+
 bool Column::is_data_editable(size_t k) const {
-  if (k != 0) return false;
-  return pcol->mbuf.is_writable();
+  return pcol->is_data_editable(k);
 }
 
-const void* Column::get_data_readonly(size_t k) const {
-  if (is_virtual()) materialize();
-  return k == 0 ? pcol->mbuf.rptr()
-                : pcol->data2();
-}
-
-void* Column::get_data_editable(size_t) {
-  if (is_virtual()) materialize();
-  return pcol->mbuf.wptr();
-}
-
-Buffer Column::get_data_buffer(size_t) const {
-  if (is_virtual()) materialize();
-  return pcol->mbuf;
-}
 
 size_t Column::get_data_size(size_t k) const {
-  if (is_virtual()) materialize();
-  return k == 0 ? pcol->mbuf.size()
-                : pcol->data2_size();
+  return pcol->get_data_size(k);
 }
+
+
+const void* Column::get_data_readonly(size_t k) const {
+  return pcol->get_data_readonly(k);
+}
+
+
+void* Column::get_data_editable(size_t k) {
+  return pcol->get_data_editable(k);
+}
+
+
+Buffer Column::get_data_buffer(size_t k) const {
+  return pcol->get_data_buffer(k);
+
+}
+
 
 
 

--- a/c/column.h
+++ b/c/column.h
@@ -37,7 +37,7 @@ using strvec = std::vector<std::string>;
 
 enum class NaStorage : uint8_t {
   NONE,
-  INLINE,
+  SENTINEL,
   BITMASK,
   VIRTUAL,
 };
@@ -207,11 +207,11 @@ class Column
   public:
     // Return the method that this column uses to encode NAs. See
     // the description of `NaStorage` enum for details.
-    NaStorage get_na_storage_method() const;
+    NaStorage get_na_storage_method() const noexcept;
 
     // A Column may be comprised of multiple data buffers. For virtual
     // columns this property returns 0.
-    size_t get_num_data_buffers() const;
+    size_t get_num_data_buffers() const noexcept;
 
     // Since the Column contains `n = get_n_data_buffers()` buffers,
     // each of the methods below takes the parameter `k < n` that
@@ -228,10 +228,10 @@ class Column
     // "editable" method will allow the data to be both read and
     // written. The latter method may need to create a copy of the
     // data buffer.
-    size_t get_data_size(size_t k = 0) const;
+    size_t      get_data_size(size_t k = 0) const;
     const void* get_data_readonly(size_t k = 0) const;
     void*       get_data_editable(size_t k = 0);
-    Buffer      get_data_buffer(size_t  k = 0) const;
+    Buffer      get_data_buffer(size_t k = 0) const;
 
 
   //------------------------------------

--- a/c/column/latent.cc
+++ b/c/column/latent.cc
@@ -43,13 +43,9 @@ CHECK_SIZE(PyObjectColumn);
 
 
 Latent_ColumnImpl::Latent_ColumnImpl(ColumnImpl* pcol)
-  : ColumnImpl(pcol->nrows(), pcol->stype()),
+  : Virtual_ColumnImpl(pcol->nrows(), pcol->stype()),
     column(pcol) {}
 
-
-bool Latent_ColumnImpl::is_virtual() const noexcept {
-  return true;
-}
 
 
 ColumnImpl* Latent_ColumnImpl::shallowcopy() const {

--- a/c/column/latent.h
+++ b/c/column/latent.h
@@ -22,7 +22,7 @@
 #ifndef dt_COLUMN_LATENT_h
 #define dt_COLUMN_LATENT_h
 #include <memory>
-#include "column_impl.h"
+#include "column/virtual.h"
 namespace dt {
 
 
@@ -41,7 +41,7 @@ namespace dt {
   *     manifest; hidden or concealed.
   *
   */
-class Latent_ColumnImpl : public ColumnImpl {
+class Latent_ColumnImpl : public Virtual_ColumnImpl {
   private:
     mutable std::unique_ptr<ColumnImpl> column;
     size_t : 64;
@@ -49,7 +49,6 @@ class Latent_ColumnImpl : public ColumnImpl {
   public:
     Latent_ColumnImpl(ColumnImpl*);
 
-    bool is_virtual() const noexcept override;
     ColumnImpl* shallowcopy() const override;
     ColumnImpl* materialize() override;
 

--- a/c/column/repeated.cc
+++ b/c/column/repeated.cc
@@ -30,17 +30,13 @@ namespace dt {
 //------------------------------------------------------------------------------
 
 Repeated_ColumnImpl::Repeated_ColumnImpl(Column&& col, size_t ntimes)
-  : ColumnImpl(col.nrows() * ntimes, col.stype()),
+  : Virtual_ColumnImpl(col.nrows() * ntimes, col.stype()),
     mod(col.nrows()),
     arg(std::move(col))
 {
   if (mod == 0) mod = 1;
 }
 
-
-bool Repeated_ColumnImpl::is_virtual() const noexcept {
-  return true;
-}
 
 ColumnImpl* Repeated_ColumnImpl::shallowcopy() const {
   return new Repeated_ColumnImpl(Column(arg), nrows_ / mod);

--- a/c/column/repeated.h
+++ b/c/column/repeated.h
@@ -22,14 +22,14 @@
 #ifndef dt_COLUMN_REPEATED_h
 #define dt_COLUMN_REPEATED_h
 #include <memory>
-#include "column_impl.h"
+#include "column/virtual.h"
 namespace dt {
 
 
 /**
   * Virtual column representing the `arg` column repeated n times.
   */
-class Repeated_ColumnImpl : public ColumnImpl {
+class Repeated_ColumnImpl : public Virtual_ColumnImpl {
   private:
     size_t mod;
     Column arg;  // arg.nrows() == mod
@@ -37,10 +37,8 @@ class Repeated_ColumnImpl : public ColumnImpl {
   public:
     Repeated_ColumnImpl(Column&&, size_t ntimes);
 
-    bool is_virtual() const noexcept override;
     ColumnImpl* shallowcopy() const override;
     void repeat(size_t ntimes, Column& out) override;
-    // ColumnImpl* materialize() override;
 
     bool get_element(size_t, int8_t*)   const override;
     bool get_element(size_t, int16_t*)  const override;

--- a/c/column/sentinel.cc
+++ b/c/column/sentinel.cc
@@ -115,6 +115,12 @@ bool Sentinel_ColumnImpl::is_virtual() const noexcept {
   return false;
 }
 
+NaStorage Sentinel_ColumnImpl::get_na_storage_method() const noexcept {
+  return NaStorage::SENTINEL;
+}
+
+
+
 
 
 }  // namespace dt

--- a/c/column/sentinel_fw.h
+++ b/c/column/sentinel_fw.h
@@ -53,7 +53,7 @@ class FwColumn : public dt::Sentinel_ColumnImpl
     void*       get_data_editable(size_t k) override;
     Buffer      get_data_buffer(size_t k) const override;
 
-    void replace_values(Column& thiscol, const RowIndex& at, const Column& with) override;
+    void replace_values(const RowIndex& at, const Column& with, Column&) override;
     void replace_values(const RowIndex& at, T with);
     size_t memory_footprint() const noexcept override;
     void verify_integrity() const override;

--- a/c/column/sentinel_fw.h
+++ b/c/column/sentinel_fw.h
@@ -110,7 +110,7 @@ class IntColumn : public FwColumn<T>
     bool get_element(size_t i, int64_t* out) const override;
 
   protected:
-    using ColumnImpl::stats;
+    using ColumnImpl::stats_;
     friend ColumnImpl;
 };
 

--- a/c/column/sentinel_fw.h
+++ b/c/column/sentinel_fw.h
@@ -29,28 +29,39 @@
 template <typename T>
 class FwColumn : public dt::Sentinel_ColumnImpl
 {
-public:
-  FwColumn();
-  FwColumn(ColumnImpl*&&);
-  FwColumn(size_t nrows);
-  FwColumn(size_t nrows, Buffer&&);
+  protected:
+    Buffer mbuf;
 
-  const T* elements_r() const;
-  T* elements_w();
-  T get_elem(size_t i) const;
+  public:
+    FwColumn();
+    FwColumn(ColumnImpl*&&);
+    FwColumn(size_t nrows);
+    FwColumn(size_t nrows, Buffer&&);
 
-  virtual bool get_element(size_t i, T* out) const override;
+    const T* elements_r() const;
+    T* elements_w();
+    T get_elem(size_t i) const;
 
-  virtual ColumnImpl* shallowcopy() const override;
-  virtual ColumnImpl* materialize() override;
+    virtual bool get_element(size_t i, T* out) const override;
 
-  void replace_values(Column& thiscol, const RowIndex& at, const Column& with) override;
-  void replace_values(const RowIndex& at, T with);
+    virtual ColumnImpl* shallowcopy() const override;
+    virtual ColumnImpl* materialize() override;
+    size_t get_num_data_buffers() const noexcept override;
+    bool is_data_editable(size_t k) const override;
+    size_t get_data_size(size_t k) const override;
+    const void* get_data_readonly(size_t k) const override;
+    void*       get_data_editable(size_t k) override;
+    Buffer      get_data_buffer(size_t k) const override;
 
-protected:
-  void rbind_impl(colvec& columns, size_t nrows, bool isempty) override;
+    void replace_values(Column& thiscol, const RowIndex& at, const Column& with) override;
+    void replace_values(const RowIndex& at, T with);
+    size_t memory_footprint() const noexcept override;
+    void verify_integrity() const override;
 
-  friend ColumnImpl;
+  protected:
+    void rbind_impl(colvec& columns, size_t nrows, bool isempty) override;
+
+    friend ColumnImpl;
 };
 
 
@@ -80,7 +91,6 @@ class BoolColumn : public FwColumn<int8_t>
   protected:
     void verify_integrity() const override;
 
-    using ColumnImpl::mbuf;
     friend ColumnImpl;
 };
 
@@ -101,7 +111,6 @@ class IntColumn : public FwColumn<T>
 
   protected:
     using ColumnImpl::stats;
-    using ColumnImpl::mbuf;
     friend ColumnImpl;
 };
 

--- a/c/column/sentinel_str.h
+++ b/c/column/sentinel_str.h
@@ -56,7 +56,7 @@ class StringColumn : public dt::Sentinel_ColumnImpl
     T* offsets_w();
     size_t memory_footprint() const noexcept override;
 
-    void replace_values(Column& thiscol, const RowIndex& at, const Column& with) override;
+    void replace_values(const RowIndex& at, const Column& with, Column&) override;
 
     void verify_integrity() const override;
 

--- a/c/column/sentinel_str.h
+++ b/c/column/sentinel_str.h
@@ -28,39 +28,43 @@
 template <typename T>
 class StringColumn : public dt::Sentinel_ColumnImpl
 {
-  Buffer strbuf;
+  private:
+    Buffer mbuf;
+    Buffer strbuf;
 
-public:
-  StringColumn();
-  StringColumn(size_t nrows);
-  StringColumn(size_t nrows, Buffer&& offbuf, Buffer&& strbuf);
+  public:
+    StringColumn();
+    StringColumn(size_t nrows);
+    StringColumn(size_t nrows, Buffer&& offbuf, Buffer&& strbuf);
 
-  ColumnImpl* materialize() override;
+    ColumnImpl* shallowcopy() const override;
+    ColumnImpl* materialize() override;
 
-  Buffer str_buf() const { return strbuf; }
-  size_t datasize() const;
-  const char* strdata() const;
-  const uint8_t* ustrdata() const;
-  const T* offsets() const;
-  T* offsets_w();
-  size_t memory_footprint() const noexcept override;
-  const void* data2() const override { return strbuf.rptr(); }
-  size_t data2_size() const override {
-    return static_cast<const T*>(mbuf.rptr())[nrows_] & ~GETNA<T>();
-  }
+    bool get_element(size_t i, CString* out) const override;
 
-  ColumnImpl* shallowcopy() const override;
-  void replace_values(Column& thiscol, const RowIndex& at, const Column& with) override;
+    size_t get_num_data_buffers() const noexcept override;
+    bool is_data_editable(size_t k) const override;
+    size_t get_data_size(size_t k) const override;
+    const void* get_data_readonly(size_t k) const override;
+    void* get_data_editable(size_t k) override;
+    Buffer get_data_buffer(size_t k) const override;
 
-  void verify_integrity() const override;
+    size_t datasize() const;
+    const char* strdata() const;
+    const uint8_t* ustrdata() const;
+    const T* offsets() const;
+    T* offsets_w();
+    size_t memory_footprint() const noexcept override;
 
-  bool get_element(size_t i, CString* out) const override;
+    void replace_values(Column& thiscol, const RowIndex& at, const Column& with) override;
 
-protected:
-  void rbind_impl(colvec& columns, size_t nrows, bool isempty) override;
+    void verify_integrity() const override;
 
-  friend ColumnImpl;
-  friend Column;
+  protected:
+    void rbind_impl(colvec& columns, size_t nrows, bool isempty) override;
+
+    friend ColumnImpl;
+    friend Column;
 };
 
 

--- a/c/column/virtual.cc
+++ b/c/column/virtual.cc
@@ -31,6 +31,11 @@ bool Virtual_ColumnImpl::is_virtual() const noexcept {
   return true;
 }
 
+size_t Virtual_ColumnImpl::memory_footprint() const noexcept {
+  return sizeof(*this);
+}
+
+
 
 NaStorage Virtual_ColumnImpl::get_na_storage_method() const noexcept {
   return NaStorage::VIRTUAL;

--- a/c/column/virtual.cc
+++ b/c/column/virtual.cc
@@ -19,32 +19,54 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
-#ifndef dt_COLUMN_SENTINEL_h
-#define dt_COLUMN_SENTINEL_h
-#include <memory>
-#include "column_impl.h"
+#include "column/virtual.h"
 namespace dt {
 
 
-/**
-  * Base class for all material columns that use sentinel values
-  * in order to encode NAs.
-  */
-class Sentinel_ColumnImpl : public ColumnImpl
-{
-  public:
-  	static ColumnImpl* make_column(size_t nrows, SType);
-    static ColumnImpl* make_fw_column(size_t nrows, SType, Buffer&&);
-    static ColumnImpl* make_str_column(size_t nrows, Buffer&&, Buffer&&);
+Virtual_ColumnImpl::Virtual_ColumnImpl(size_t nrows, SType stype)
+  : ColumnImpl(nrows, stype) {}
 
-    bool is_virtual() const noexcept override;
-    NaStorage get_na_storage_method() const noexcept override;
 
-  protected:
-    Sentinel_ColumnImpl(size_t nrows, SType stype);
-};
+bool Virtual_ColumnImpl::is_virtual() const noexcept {
+  return true;
+}
+
+
+NaStorage Virtual_ColumnImpl::get_na_storage_method() const noexcept {
+  return NaStorage::VIRTUAL;
+}
+
+
+size_t Virtual_ColumnImpl::get_num_data_buffers() const noexcept {
+  return 0;
+}
+
+
+bool Virtual_ColumnImpl::is_data_editable(size_t) const {
+  throw RuntimeError() << "Invalid data access for a virtual column";
+}
+
+
+size_t Virtual_ColumnImpl::get_data_size(size_t) const {
+  throw RuntimeError() << "Invalid data access for a virtual column";
+}
+
+
+const void* Virtual_ColumnImpl::get_data_readonly(size_t) const {
+  throw RuntimeError() << "Invalid data access for a virtual column";
+}
+
+
+void* Virtual_ColumnImpl::get_data_editable(size_t) {
+  throw RuntimeError() << "Invalid data access for a virtual column";
+}
+
+
+Buffer Virtual_ColumnImpl::get_data_buffer(size_t) const {
+  throw RuntimeError() << "Invalid data access for a virtual column";
+}
+
 
 
 
 }  // namespace dt
-#endif

--- a/c/column/virtual.h
+++ b/c/column/virtual.h
@@ -35,6 +35,8 @@ class Virtual_ColumnImpl : public ColumnImpl
     Virtual_ColumnImpl(size_t nrows, SType stype);
 
     bool is_virtual() const noexcept override;
+    size_t memory_footprint() const noexcept override;
+
     NaStorage get_na_storage_method() const noexcept override;
     size_t get_num_data_buffers() const noexcept override;
     bool is_data_editable(size_t) const override;

--- a/c/column/virtual.h
+++ b/c/column/virtual.h
@@ -29,14 +29,20 @@ namespace dt {
 /**
   * Base class for all virtual columns.
   */
-class Virtual_ColumnImpl : public ColumnImpl {
+class Virtual_ColumnImpl : public ColumnImpl
+{
   public:
-    Virtual_ColumnImpl(size_t nrows, SType stype)
-      : ColumnImpl(nrows, stype) {}
+    Virtual_ColumnImpl(size_t nrows, SType stype);
 
-    bool is_virtual() const noexcept override {
-      return true;
-    }
+    bool is_virtual() const noexcept override;
+    NaStorage get_na_storage_method() const noexcept override;
+    size_t get_num_data_buffers() const noexcept override;
+    bool is_data_editable(size_t) const override;
+    size_t get_data_size(size_t) const override;
+    const void* get_data_readonly(size_t k) const override;
+    void* get_data_editable(size_t k) override;
+    Buffer get_data_buffer(size_t k) const override;
+
 };
 
 

--- a/c/column_fw.cc
+++ b/c/column_fw.cc
@@ -41,7 +41,7 @@ FwColumn<T>::FwColumn(ColumnImpl*&& other)
   auto fwother = dynamic_cast<FwColumn<T>*>(other);
   xassert(fwother != nullptr);
   mbuf = std::move(fwother->mbuf);
-  stats = std::move(fwother->stats);
+  stats_ = std::move(fwother->stats_);
 }
 
 
@@ -164,7 +164,7 @@ void FwColumn<T>::replace_values(const RowIndex& replace_at, T replace_with) {
     [&](size_t, size_t j) {
       data[j] = replace_with;
     });
-  if (stats) stats->reset();
+  if (stats_) stats_->reset();
 }
 
 
@@ -202,7 +202,7 @@ void FwColumn<T>::replace_values(
 
 template <typename T>
 size_t FwColumn<T>::memory_footprint() const noexcept {
-  return sizeof(*this) + (stats? stats->memory_footprint() : 0)
+  return sizeof(*this) + (stats_? stats_->memory_footprint() : 0)
                        + mbuf.memory_footprint();
 }
 

--- a/c/column_fw.cc
+++ b/c/column_fw.cc
@@ -170,9 +170,8 @@ void FwColumn<T>::replace_values(const RowIndex& replace_at, T replace_with) {
 
 template <typename T>
 void FwColumn<T>::replace_values(
-    Column&, const RowIndex& replace_at, const Column& replace_with)
+    const RowIndex& replace_at, const Column& replace_with, Column&)
 {
-  materialize();
   if (!replace_with) {
     return replace_values(replace_at, GETNA<T>());
   }

--- a/c/column_fw.cc
+++ b/c/column_fw.cc
@@ -112,6 +112,49 @@ ColumnImpl* FwColumn<T>::materialize() {
 }
 
 
+template <typename T>
+size_t FwColumn<T>::get_num_data_buffers() const noexcept {
+  return 1;
+}
+
+
+template <typename T>
+bool FwColumn<T>::is_data_editable(size_t k) const {
+  xassert(k == 0);
+  return mbuf.is_writable();
+}
+
+
+template <typename T>
+size_t FwColumn<T>::get_data_size(size_t k) const {
+  xassert(k == 0);
+  xassert(mbuf.size() >= nrows_ * sizeof(T));
+  return nrows_ * sizeof(T);
+}
+
+
+template <typename T>
+const void* FwColumn<T>::get_data_readonly(size_t k) const {
+  xassert(k == 0);
+  return mbuf.rptr();
+}
+
+
+template <typename T>
+void* FwColumn<T>::get_data_editable(size_t k) {
+  xassert(k == 0);
+  return mbuf.wptr();
+}
+
+
+template <typename T>
+Buffer FwColumn<T>::get_data_buffer(size_t k) const {
+  xassert(k == 0);
+  return Buffer(mbuf);
+}
+
+
+
 
 
 template <typename T>
@@ -157,6 +200,18 @@ void FwColumn<T>::replace_values(
     });
 }
 
+
+template <typename T>
+size_t FwColumn<T>::memory_footprint() const noexcept {
+  return sizeof(*this) + (stats? stats->memory_footprint() : 0)
+                       + mbuf.memory_footprint();
+}
+
+template <typename T>
+void FwColumn<T>::verify_integrity() const {
+  Sentinel_ColumnImpl::verify_integrity();
+  mbuf.verify_integrity();
+}
 
 
 

--- a/c/column_impl.cc
+++ b/c/column_impl.cc
@@ -201,7 +201,7 @@ void ColumnImpl::fill_npmask(bool* outmask, size_t row0, size_t row1) const {
 // Misc
 //------------------------------------------------------------------------------
 
-void ColumnImpl::replace_values(Column&, const RowIndex&, const Column&) {
+void ColumnImpl::replace_values(const RowIndex&, const Column&, Column&) {
   throw NotImplError() << "Method ColumnImpl::replace_values() not implemented";
 }
 

--- a/c/column_impl.cc
+++ b/c/column_impl.cc
@@ -174,7 +174,7 @@ void ColumnImpl::_fill_npmask(bool* outmask, size_t row0, size_t row1) const {
 }
 
 void ColumnImpl::fill_npmask(bool* outmask, size_t row0, size_t row1) const {
-  if (stats && stats->is_computed(Stat::NaCount) && stats->nacount() == 0) {
+  if (stats_ && stats_->is_computed(Stat::NaCount) && stats_->nacount() == 0) {
     std::fill(outmask + row0, outmask + row1, false);
     return;
   }

--- a/c/column_impl.cc
+++ b/c/column_impl.cc
@@ -35,8 +35,6 @@ ColumnImpl::ColumnImpl(size_t nrows, SType stype)
   : nrows_(nrows),
     stype_(stype) {}
 
-ColumnImpl::~ColumnImpl() {}
-
 
 // TODO: replace these with ref-counting semantics
 
@@ -84,7 +82,7 @@ ColumnImpl* ColumnImpl::_materialize_fw() {
   assert_compatible_type<T>(inp_stype);
   ColumnImpl* output_column
       = dt::Sentinel_ColumnImpl::make_column(inp_nrows, inp_stype);
-  auto out_data = static_cast<T*>(output_column->mbuf.wptr());
+  auto out_data = static_cast<T*>(output_column->get_data_editable(0));
 
   dt::parallel_for_static(
     inp_nrows,
@@ -104,7 +102,7 @@ ColumnImpl* ColumnImpl::_materialize_obj() {
 
   ColumnImpl* output_column
       = dt::Sentinel_ColumnImpl::make_column(inp_nrows, SType::OBJ);
-  auto out_data = static_cast<py::oobj*>(output_column->mbuf.wptr());
+  auto out_data = static_cast<py::oobj*>(output_column->get_data_editable(0));
 
   // Writing output array as `py::oobj` will ensure that the elements
   // will be properly INCREF-ed.

--- a/c/column_impl.h
+++ b/c/column_impl.h
@@ -84,7 +84,7 @@ class ColumnImpl
     size_t nrows_;
     SType  stype_;
     size_t : 56;
-    mutable std::unique_ptr<Stats> stats;
+    mutable std::unique_ptr<Stats> stats_;
 
   //------------------------------------
   // Constructors
@@ -124,7 +124,7 @@ class ColumnImpl
     size_t nrows() const noexcept { return nrows_; }
     SType  stype() const noexcept { return stype_; }
     virtual bool is_virtual() const noexcept = 0;
-    virtual size_t memory_footprint() const noexcept;
+    virtual size_t memory_footprint() const noexcept = 0;
 
 
   //------------------------------------

--- a/c/column_impl.h
+++ b/c/column_impl.h
@@ -21,62 +21,20 @@
 //------------------------------------------------------------------------------
 #ifndef dt_COLUMN_IMPL_h
 #define dt_COLUMN_IMPL_h
-#include <string>
-#include <vector>
-#include "python/list.h"
-#include "python/obj.h"
-#include "column.h"
-#include "groupby.h"
-#include "buffer.h"     // Buffer
-#include "rowindex.h"
-#include "stats.h"
-#include "types.h"
+#include <memory>        // std::unique_ptr
+#include "python/obj.h"  // py::robj
+#include "column.h"      // Column, NaStorage, colvec
+#include "groupby.h"     // Groupby
+#include "buffer.h"      // Buffer
+#include "stats.h"       // Stats
+#include "types.h"       // SType, CString
 
-class DataTable;
-class BoolColumn;
-class PyObjectColumn;
-namespace dt {
-  class ConstNa_ColumnImpl;
-}
-template <typename T> class IntColumn;
-template <typename T> class StringColumn;
-
-using colvec = std::vector<Column>;
-using strvec = std::vector<std::string>;
-using pimpl = std::unique_ptr<ColumnImpl>;
-
-
-
-//==============================================================================
 
 /**
  * A single column within a DataTable.
  *
- * A ColumnImpl is a self-sufficient object, i.e. it may exist outside of a
- * DataTable too. This usually happens when a DataTable is being transformed,
- * then new ColumnImpl objects will be created, manipulated, and eventually bundled
- * into a new DataTable object.
- *
- * The main "payload" of this class is the data buffer `mbuf`, which contains
- * a contiguous memory region with the column's data in NFF format. Columns
- * of "string" type carry an additional buffer `strbuf` that stores the column's
- * character data (while `mbuf` stores the offsets).
- *
- * The data buffer `mbuf` may be shared across multiple columns: this enables
- * light-weight "shallow" copying of ColumnImpl objects. A ColumnImpl may also reference
- * another ColumnImpl's `mbuf` applying a RowIndex `ri` to it. When a RowIndex is
- * present, it selects a subset of elements from `mbuf`, and only those
- * sub-elements are considered to be the actual values in the ColumnImpl.
- *
- * Parameters
- * ----------
- * nrows_
- *     Number of elements in this column. If the ColumnImpl has a rowindex, then
- *     this number will be the same as the number of elements in the rowindex.
- *
- * stats
- *     Auxiliary structure that contains stat values about this column, if
- *     they were computed.
+ * This class serves as the base in the hierarchy of different
+ * column implementation classes.
  */
 class ColumnImpl
 {
@@ -143,6 +101,7 @@ class ColumnImpl
   //------------------------------------
   // Column manipulation
   //------------------------------------
+  public:
     virtual void fill_npmask(bool* outmask, size_t row0, size_t row1) const;
     virtual RowIndex sort(Groupby* out_groups) const;
     virtual void sort_grouped(const Groupby&, Column& out);
@@ -167,7 +126,6 @@ class ColumnImpl
     void _fill_npmask(bool* outmask, size_t row0, size_t row1) const;
 
     friend class Column;
-    friend class dt::ConstNa_ColumnImpl;
 };
 
 

--- a/c/column_int.cc
+++ b/c/column_int.cc
@@ -13,7 +13,7 @@
 
 template <typename T>
 ColumnImpl* IntColumn<T>::shallowcopy() const {
-  return new IntColumn<T>(this->nrows_, Buffer(mbuf));
+  return new IntColumn<T>(this->nrows_, Buffer(this->mbuf));
 }
 
 

--- a/c/column_string.cc
+++ b/c/column_string.cc
@@ -163,7 +163,7 @@ ColumnImpl* StringColumn<T>::materialize() {
 
 template <typename T>
 void StringColumn<T>::replace_values(
-    Column& thiscol, const RowIndex& replace_at, const Column& replace_with)
+    const RowIndex& replace_at, const Column& replace_with, Column& out)
 {
   Column rescol;
   Column with;
@@ -180,7 +180,7 @@ void StringColumn<T>::replace_values(
     }
     Buffer mask = replace_at.as_boolean_mask(nrows_);
     auto mask_indices = static_cast<const int8_t*>(mask.rptr());
-    rescol = dt::map_str2str(thiscol,
+    rescol = dt::map_str2str(out,
       [=](size_t i, CString& value, dt::string_buf* sb) {
         sb->write(mask_indices[i]? repl_value : value);
       });
@@ -188,7 +188,7 @@ void StringColumn<T>::replace_values(
   else {
     Buffer mask = replace_at.as_integer_mask(nrows_);
     auto mask_indices = static_cast<const int32_t*>(mask.rptr());
-    rescol = dt::map_str2str(thiscol,
+    rescol = dt::map_str2str(out,
       [=](size_t i, CString& value, dt::string_buf* sb) {
         int ir = mask_indices[i];
         if (ir == -1) {
@@ -210,7 +210,7 @@ void StringColumn<T>::replace_values(
     throw NotImplError() << "When replacing string values, the size of the "
       "resulting column exceeds the maximum for str32";
   }
-  thiscol = std::move(rescol);
+  out = std::move(rescol);
 }
 
 

--- a/c/column_string.cc
+++ b/c/column_string.cc
@@ -65,6 +65,54 @@ ColumnImpl* StringColumn<T>::shallowcopy() const {
   return new StringColumn<T>(nrows_, Buffer(mbuf), Buffer(strbuf));
 }
 
+template <typename T>
+size_t StringColumn<T>::get_num_data_buffers() const noexcept {
+  return 2;
+}
+
+template <typename T>
+bool StringColumn<T>::is_data_editable(size_t k) const {
+  xassert(k <= 1);
+  return false;
+}
+
+template <typename T>
+size_t StringColumn<T>::get_data_size(size_t k) const {
+  xassert(k <= 1);
+  if (k == 0) {
+    xassert(mbuf.size() >= (nrows_ + 1) * sizeof(T));
+    return (nrows_ + 1) * sizeof(T);
+  }
+  else {
+    size_t sz = this->offsets()[nrows_ - 1] & ~GETNA<T>();
+    xassert(sz <= strbuf.size());
+    return sz;
+  }
+}
+
+
+template <typename T>
+const void* StringColumn<T>::get_data_readonly(size_t k) const {
+  xassert(k <= 1);
+  return (k == 0)? mbuf.rptr() : strbuf.rptr();
+}
+
+
+template <typename T>
+void* StringColumn<T>::get_data_editable(size_t k) {
+  xassert(k <= 1);
+  return (k == 0)? mbuf.xptr() : strbuf.xptr();
+}
+
+
+template <typename T>
+Buffer StringColumn<T>::get_data_buffer(size_t k) const {
+  xassert(k <= 1);
+  return (k == 0)? Buffer(mbuf) : Buffer(strbuf);
+}
+
+
+
 
 template <typename T>
 bool StringColumn<T>::get_element(size_t i, CString* out) const {

--- a/c/frame/__sizeof__.cc
+++ b/c/frame/__sizeof__.cc
@@ -89,7 +89,6 @@ size_t DataTable::memory_footprint() const noexcept {
   */
 size_t ColumnImpl::memory_footprint() const noexcept {
   size_t sz = sizeof(*this);
-  sz += mbuf.memory_footprint();
   if (stats) sz += stats->memory_footprint();
   return sz;
 }
@@ -97,7 +96,10 @@ size_t ColumnImpl::memory_footprint() const noexcept {
 
 template <typename T>
 size_t StringColumn<T>::memory_footprint() const noexcept {
-  return ColumnImpl::memory_footprint() + strbuf.memory_footprint();
+  return sizeof(*this)
+         + mbuf.memory_footprint()
+         + strbuf.memory_footprint()
+         + (stats? stats->memory_footprint() : 0);
 }
 
 

--- a/c/frame/__sizeof__.cc
+++ b/c/frame/__sizeof__.cc
@@ -84,22 +84,12 @@ size_t DataTable::memory_footprint() const noexcept {
 }
 
 
-/**
-  * Get the total size of the memory occupied by the Column.
-  */
-size_t ColumnImpl::memory_footprint() const noexcept {
-  size_t sz = sizeof(*this);
-  if (stats) sz += stats->memory_footprint();
-  return sz;
-}
-
-
 template <typename T>
 size_t StringColumn<T>::memory_footprint() const noexcept {
   return sizeof(*this)
          + mbuf.memory_footprint()
          + strbuf.memory_footprint()
-         + (stats? stats->memory_footprint() : 0);
+         + (stats_? stats_->memory_footprint() : 0);
 }
 
 

--- a/c/frame/integrity_check.cc
+++ b/c/frame/integrity_check.cc
@@ -158,8 +158,8 @@ void DataTable::verify_integrity() const
 //------------------------------------------------------------------------------
 
 void ColumnImpl::verify_integrity() const {
-  if (stats) { // Stats are allowed to be null
-    stats->verify_integrity();
+  if (stats_) { // Stats are allowed to be null
+    stats_->verify_integrity();
   }
 }
 

--- a/c/frame/integrity_check.cc
+++ b/c/frame/integrity_check.cc
@@ -132,7 +132,7 @@ void DataTable::verify_integrity() const
     }
     catch (Error& e) {
       e = std::move(AssertionError() << "in column " << i
-                    << " '" << col_name << "': " << e.what());
+                    << " '" << col_name << "': " << e.to_string());
       throw;
     }
   }
@@ -158,9 +158,6 @@ void DataTable::verify_integrity() const
 //------------------------------------------------------------------------------
 
 void ColumnImpl::verify_integrity() const {
-  mbuf.verify_integrity();
-
-  // Check Stats
   if (stats) { // Stats are allowed to be null
     stats->verify_integrity();
   }
@@ -196,7 +193,9 @@ void BoolColumn::verify_integrity() const {
 
 template <typename T>
 void StringColumn<T>::verify_integrity() const {
-  ColumnImpl::verify_integrity();
+  Sentinel_ColumnImpl::verify_integrity();
+  mbuf.verify_integrity();
+  strbuf.verify_integrity();
 
   size_t strdata_size = 0;
   //*_utf8 functions use unsigned char*

--- a/c/sort.cc
+++ b/c/sort.cc
@@ -1397,7 +1397,7 @@ static RowIndex sort_tiny(const Column& col, Groupby* out_grps) {
 }
 
 
-RowIndex ColumnImpl::_sort(Groupby* out_grps) const {
+RowIndex ColumnImpl::sort(Groupby* out_grps) const {
   Column ocol(this->shallowcopy());
   return ocol.sort(out_grps);
 }

--- a/c/stats.cc
+++ b/c/stats.cc
@@ -893,7 +893,7 @@ void Stats::compute_sorted_stats() {
 template <typename T>
 void NumericStats<T>::compute_sorted_stats() {
   Groupby grpby;
-  RowIndex ri = column->_sort(&grpby);
+  RowIndex ri = column->sort(&grpby);
   const int32_t* groups = grpby.offsets_r();
   size_t n_groups = grpby.ngroups();
   xassert(n_groups >= 1);
@@ -932,7 +932,7 @@ void NumericStats<T>::compute_sorted_stats() {
 
 void StringStats::compute_sorted_stats() {
   Groupby grpby;
-  RowIndex ri = column->_sort(&grpby);
+  RowIndex ri = column->sort(&grpby);
   const int32_t* groups = grpby.offsets_r();
   size_t n_groups = grpby.ngroups();
   xassert(n_groups >= 1);

--- a/c/stats.cc
+++ b/c/stats.cc
@@ -1065,12 +1065,12 @@ static std::unique_ptr<Stats> _make_stats(ColumnImpl* col) {
 }
 
 Stats* Column::stats() const {
-  if (!pcol->stats) pcol->stats = _make_stats(pcol);
-  return pcol->stats.get();
+  if (!pcol->stats_) pcol->stats_ = _make_stats(pcol);
+  return pcol->stats_.get();
 }
 
 Stats* Column::get_stats_if_exist() const {
-  return pcol->stats.get();
+  return pcol->stats_.get();
 }
 
 

--- a/c/utils/exceptions.cc
+++ b/c/utils/exceptions.cc
@@ -82,8 +82,12 @@ Error& Error::operator=(Error&& other) {
   return *this;
 }
 
-void Error::to_stderr() {
+void Error::to_stderr() const {
   std::cerr << error.str() << "\n";
+}
+
+std::string Error::to_string() const {
+  return error.str();
 }
 
 

--- a/c/utils/exceptions.h
+++ b/c/utils/exceptions.h
@@ -63,7 +63,8 @@ public:
     Error& operator<<(ssize_t);
   #endif
 
-  void to_stderr();
+  void to_stderr() const;
+  std::string to_string() const;
 
   /**
    * Translate this exception into a Python error by calling PyErr_SetString


### PR DESCRIPTION
- `ColumnImpl::mbuf` field moved into `FwColumn` / `StringColumn` classes;
- cleaned up API of `ColumnImpl` class.

Closes #2052