### PR TITLE
Fixed incorrect cloning of resized virtual columns

### DIFF
--- a/c/column/npmasked.cc
+++ b/c/column/npmasked.cc
@@ -35,7 +35,9 @@ NpMasked_ColumnImpl::NpMasked_ColumnImpl(Column&& arg, Buffer&& mask)
 
 
 ColumnImpl* NpMasked_ColumnImpl::clone() const {
-  return new NpMasked_ColumnImpl(Column(arg_), Buffer(mask_));
+  auto res = new NpMasked_ColumnImpl(Column(arg_), Buffer(mask_));
+  res->nrows_ = nrows_;
+  return res;
 }
 
 

--- a/c/column/rbound.cc
+++ b/c/column/rbound.cc
@@ -58,7 +58,9 @@ Rbound_ColumnImpl::Rbound_ColumnImpl(const colvec& columns)
 
 
 ColumnImpl* Rbound_ColumnImpl::clone() const {
-  return new Rbound_ColumnImpl(columns_);
+  auto res = new Rbound_ColumnImpl(columns_);
+  res->nrows_ = nrows_;
+  return res;
 }
 
 

--- a/c/column/repeated.cc
+++ b/c/column/repeated.cc
@@ -39,7 +39,9 @@ Repeated_ColumnImpl::Repeated_ColumnImpl(Column&& col, size_t ntimes)
 
 
 ColumnImpl* Repeated_ColumnImpl::clone() const {
-  return new Repeated_ColumnImpl(Column(arg), nrows_ / mod);
+  auto res = new Repeated_ColumnImpl(Column(arg), nrows_ / mod);
+  res->nrows_ = nrows_;
+  return res;
 }
 
 void Repeated_ColumnImpl::repeat(size_t ntimes, Column&) {

--- a/c/column/strvec.h
+++ b/c/column/strvec.h
@@ -52,7 +52,9 @@ class Strvec_ColumnImpl : public Virtual_ColumnImpl {
     }
 
     ColumnImpl* clone() const override {
-      return new Strvec_ColumnImpl(vec);
+      auto res = new Strvec_ColumnImpl(vec);
+      res->nrows_ = nrows_;
+      return res;
     }
 };
 

--- a/tests/munging/test_dt_rows.py
+++ b/tests/munging/test_dt_rows.py
@@ -900,6 +900,17 @@ def test_issue1602():
     assert DT.to_list() == [[None]]
 
 
+def test_issue2055(numpy):
+    DT = dt.cbind(
+        dt.Frame(A=[1, 2]),
+        dt.Frame(numpy.ma.array([True, True], mask=[False, False]))
+    )
+    DT.nrows = 1
+    DT = DT.copy()
+    frame_integrity_check(DT)
+    assert DT.to_list() == [[1], [True]]
+
+
 
 #-------------------------------------------------------------------------------
 # (i=slice) + by


### PR DESCRIPTION
Certain virtual ColumnImpl classes were not propagating the `nrows_` property correctly during cloning after being resized.  `NpMasked_ColumnImpl` was one of such classes.

Closes #2055