### PR TITLE
Column class now uses ref-count semantics for its impl

### DIFF
--- a/c/column.cc
+++ b/c/column.cc
@@ -22,7 +22,7 @@
 
 
 Column Column::new_data_column(size_t nrows, SType stype) {
-  return Column(dt::Sentinel_ColumnImpl::make_column(nrows, stype));
+  return dt::Sentinel_ColumnImpl::make_column(nrows, stype);
 }
 
 
@@ -32,16 +32,15 @@ Column Column::new_na_column(size_t nrows, SType stype) {
 
 
 Column Column::new_mbuf_column(size_t nrows, SType stype, Buffer&& mbuf) {
-  return Column(dt::Sentinel_ColumnImpl::make_fw_column(
-                    nrows, stype, std::move(mbuf)));
+  return dt::Sentinel_ColumnImpl::make_fw_column(nrows, stype, std::move(mbuf));
 }
 
 
 Column Column::new_string_column(
     size_t nrows, Buffer&& data, Buffer&& str)
 {
-  return Column(dt::Sentinel_ColumnImpl::make_str_column(
-                      nrows, std::move(data), std::move(str)));
+  return dt::Sentinel_ColumnImpl::make_str_column(
+                      nrows, std::move(data), std::move(str));
 }
 
 

--- a/c/column.cc
+++ b/c/column.cc
@@ -50,46 +50,69 @@ Column Column::new_string_column(
 //------------------------------------------------------------------------------
 
 void swap(Column& lhs, Column& rhs) {
-  std::swap(lhs.pcol, rhs.pcol);
+  std::swap(lhs.impl_, rhs.impl_);
 }
 
-Column::Column()
-  : pcol(nullptr) {}
+Column::Column() noexcept
+  : impl_(nullptr) {}
 
-Column::Column(dt::ColumnImpl*&& col)
-  : pcol(col) {}
+Column::Column(dt::ColumnImpl*&& col) noexcept
+  : impl_(col) {}
 
-Column::Column(const Column& other)
-  : pcol(other.pcol->acquire_instance()) {}
+Column::Column(const Column& other) noexcept {
+  _acquire_impl(other.impl_);
+}
 
 Column::Column(Column&& other) noexcept : Column() {
-  std::swap(pcol, other.pcol);
+  std::swap(impl_, other.impl_);
 }
 
 Column& Column::operator=(const Column& other) {
-  auto old = pcol;
-  pcol = other.pcol->acquire_instance();
-  if (old) old->release_instance();
+  auto old = impl_;
+  _acquire_impl(other.impl_);
+  _release_impl(old);
   return *this;
 }
 
 Column& Column::operator=(Column&& other) noexcept {
-  auto old = pcol;
-  pcol = other.pcol;
-  other.pcol = nullptr;
-  if (old) old->release_instance();
+  auto old = impl_;
+  impl_ = other.impl_;
+  other.impl_ = nullptr;
+  _release_impl(old);
   return *this;
 }
 
 Column::~Column() {
-  if (pcol) pcol->release_instance();
+  _release_impl(impl_);
 }
 
 
-dt::ColumnImpl* Column::release() && noexcept {
-  dt::ColumnImpl* tmp = pcol;
-  pcol = nullptr;
+dt::ColumnImpl* Column::release() && {
+  xassert(impl_->refcount_ == 1);
+  dt::ColumnImpl* tmp = _get_mutable_impl();
+  impl_ = nullptr;
   return tmp;
+}
+
+void Column::_acquire_impl(const dt::ColumnImpl* impl) {
+  impl_ = impl;
+  ++impl->refcount_;
+}
+
+void Column::_release_impl(const dt::ColumnImpl* impl) {
+  if (!impl) return;
+  if ((--impl->refcount_) == 0) {
+    delete impl;
+  }
+}
+
+dt::ColumnImpl* Column::_get_mutable_impl() {
+  if (impl_->refcount_ > 1) {
+    --impl_->refcount_;
+    impl_ = impl_->clone();
+  }
+  xassert(impl_->refcount_ == 1);
+  return const_cast<dt::ColumnImpl*>(impl_);
 }
 
 
@@ -99,7 +122,7 @@ dt::ColumnImpl* Column::release() && noexcept {
 //------------------------------------------------------------------------------
 
 size_t Column::nrows() const noexcept {
-  return pcol->nrows_;
+  return impl_->nrows_;
 }
 
 size_t Column::na_count() const {
@@ -107,31 +130,31 @@ size_t Column::na_count() const {
 }
 
 SType Column::stype() const noexcept {
-  return pcol->stype_;
+  return impl_->stype_;
 }
 
 LType Column::ltype() const noexcept {
-  return info(pcol->stype_).ltype();
+  return info(impl_->stype_).ltype();
 }
 
 bool Column::is_fixedwidth() const noexcept {
-  return !info(pcol->stype_).is_varwidth();
+  return !info(impl_->stype_).is_varwidth();
 }
 
 bool Column::is_virtual() const noexcept {
-  return pcol->is_virtual();
+  return impl_->is_virtual();
 }
 
 size_t Column::elemsize() const noexcept {
-  return info(pcol->stype_).elemsize();
+  return info(impl_->stype_).elemsize();
 }
 
 Column::operator bool() const noexcept {
-  return (pcol != nullptr);
+  return (impl_ != nullptr);
 }
 
 size_t Column::memory_footprint() const noexcept {
-  return sizeof(Column) + (pcol? pcol->memory_footprint() : 0);
+  return sizeof(Column) + (impl_? impl_->memory_footprint() : 0);
 }
 
 
@@ -142,42 +165,42 @@ size_t Column::memory_footprint() const noexcept {
 
 bool Column::get_element(size_t i, int8_t* out) const {
   xassert(i < nrows());
-  return pcol->get_element(i, out);
+  return impl_->get_element(i, out);
 }
 
 bool Column::get_element(size_t i, int16_t* out) const {
   xassert(i < nrows());
-  return pcol->get_element(i, out);
+  return impl_->get_element(i, out);
 }
 
 bool Column::get_element(size_t i, int32_t* out) const {
   xassert(i < nrows());
-  return pcol->get_element(i, out);
+  return impl_->get_element(i, out);
 }
 
 bool Column::get_element(size_t i, int64_t* out) const {
   xassert(i < nrows());
-  return pcol->get_element(i, out);
+  return impl_->get_element(i, out);
 }
 
 bool Column::get_element(size_t i, float* out) const {
   xassert(i < nrows());
-  return pcol->get_element(i, out);
+  return impl_->get_element(i, out);
 }
 
 bool Column::get_element(size_t i, double* out) const {
   xassert(i < nrows());
-  return pcol->get_element(i, out);
+  return impl_->get_element(i, out);
 }
 
 bool Column::get_element(size_t i, CString* out) const {
   xassert(i < nrows());
-  return pcol->get_element(i, out);
+  return impl_->get_element(i, out);
 }
 
 bool Column::get_element(size_t i, py::robj* out) const {
   xassert(i < nrows());
-  return pcol->get_element(i, out);
+  return impl_->get_element(i, out);
 }
 
 
@@ -218,38 +241,38 @@ py::oobj Column::get_element_as_pyobject(size_t i) const {
 //------------------------------------------------------------------------------
 
 NaStorage Column::get_na_storage_method() const noexcept {
-  return pcol->get_na_storage_method();
+  return impl_->get_na_storage_method();
 }
 
 
 size_t Column::get_num_data_buffers() const noexcept {
-  return pcol->get_num_data_buffers();
+  return impl_->get_num_data_buffers();
 }
 
 
 bool Column::is_data_editable(size_t k) const {
-  return pcol->is_data_editable(k);
+  return impl_->is_data_editable(k);
 }
 
 
 size_t Column::get_data_size(size_t k) const {
-  return pcol->get_data_size(k);
+  return impl_->get_data_size(k);
 }
 
 
 const void* Column::get_data_readonly(size_t k) const {
-  return pcol->get_data_readonly(k);
+  return impl_->get_data_readonly(k);
 }
 
 
 void* Column::get_data_editable(size_t k) {
+  auto pcol = _get_mutable_impl();
   return pcol->get_data_editable(k);
 }
 
 
 Buffer Column::get_data_buffer(size_t k) const {
-  return pcol->get_data_buffer(k);
-
+  return impl_->get_data_buffer(k);
 }
 
 
@@ -259,29 +282,33 @@ Buffer Column::get_data_buffer(size_t k) const {
 // Column : manipulation
 //------------------------------------------------------------------------------
 
-void Column::materialize() const {
-  auto self = const_cast<Column*>(this);
-  self->pcol->materialize(*self);
+void Column::materialize() {
+  auto pcol = _get_mutable_impl();
+  pcol->materialize(*this);
 }
 
 void Column::replace_values(const RowIndex& replace_at,
                             const Column& replace_with)
 {
   materialize();
+  auto pcol = _get_mutable_impl();
   pcol->replace_values(replace_at, replace_with, *this);
 }
 
 
 void Column::repeat(size_t ntimes) {
+  auto pcol = _get_mutable_impl();
   pcol->repeat(ntimes, *this);
 }
 
 void Column::apply_rowindex(const RowIndex& ri) {
   if (!ri) return;
+  auto pcol = _get_mutable_impl();
   pcol->apply_rowindex(ri, *this);  // modifies in-place
 }
 
 void Column::resize(size_t new_nrows) {
+  auto pcol = _get_mutable_impl();
   size_t curr_nrows = nrows();
   if (new_nrows > curr_nrows) pcol->na_pad(new_nrows, *this);
   if (new_nrows < curr_nrows) pcol->truncate(new_nrows, *this);
@@ -289,15 +316,16 @@ void Column::resize(size_t new_nrows) {
 
 
 void Column::sort_grouped(const Groupby& grps) {
+  auto pcol = _get_mutable_impl();
   pcol->sort_grouped(grps, *this);
 }
 
 
 void Column::verify_integrity() const {
-  pcol->verify_integrity();
+  impl_->verify_integrity();
 }
 
 
 void Column::fill_npmask(bool* out_mask, size_t row0, size_t row1) const {
-  pcol->fill_npmask(out_mask, row0, row1);
+  impl_->fill_npmask(out_mask, row0, row1);
 }

--- a/c/column/column_impl.cc
+++ b/c/column/column_impl.cc
@@ -29,23 +29,13 @@ namespace dt {
 
 
 //------------------------------------------------------------------------------
-// Basic constructors
+// Constructor
 //------------------------------------------------------------------------------
 
 ColumnImpl::ColumnImpl(size_t nrows, SType stype)
   : nrows_(nrows),
-    stype_(stype) {}
-
-
-// TODO: replace these with ref-counting semantics
-
-ColumnImpl* ColumnImpl::acquire_instance() const {
-  return this->clone();
-}
-
-void ColumnImpl::release_instance() noexcept {
-  delete this;
-}
+    stype_(stype),
+    refcount_(1) {}
 
 
 

--- a/c/column/column_impl.h
+++ b/c/column/column_impl.h
@@ -54,7 +54,8 @@ class ColumnImpl
   protected:
     size_t nrows_;
     SType  stype_;
-    size_t : 56;
+    size_t : 24;
+    mutable uint32_t refcount_;
     mutable std::unique_ptr<Stats> stats_;
 
   //------------------------------------
@@ -65,9 +66,6 @@ class ColumnImpl
     ColumnImpl(const ColumnImpl&) = delete;
     ColumnImpl(ColumnImpl&&) = delete;
     virtual ~ColumnImpl() = default;
-
-    ColumnImpl* acquire_instance() const;
-    void release_instance() noexcept;
 
     virtual ColumnImpl* clone() const = 0;
     virtual void materialize(Column& out);

--- a/c/datatable.cc
+++ b/c/datatable.cc
@@ -35,7 +35,7 @@ DataTable::DataTable(colvec&& cols) : DataTable()
   columns = std::move(cols);
   ncols = columns.size();
   nrows = columns[0].nrows();
-  #ifndef NDEBUG
+  #if DTDEBUG
     for (const auto& col : columns) {
       xassert(col && col.nrows() == nrows);
     }

--- a/c/frame/integrity_check.cc
+++ b/c/frame/integrity_check.cc
@@ -162,6 +162,7 @@ namespace dt {
 void ColumnImpl::verify_integrity() const {
   XAssert(static_cast<int64_t>(nrows_) >= 0);
   XAssert(static_cast<size_t>(stype_) < DT_STYPES_COUNT);
+  XAssert(refcount_ > 0 && refcount_ < uint32_t(-100));
   if (stats_) { // Stats are allowed to be null
     stats_->verify_integrity();
   }

--- a/c/frame/rbind.cc
+++ b/c/frame/rbind.cc
@@ -305,6 +305,7 @@ void DataTable::rbind(
 //------------------------------------------------------------------------------
 
 void Column::rbind(colvec& columns) {
+  _get_mutable_impl();
   // Is the current column "empty" ?
   bool col_empty = (stype() == SType::VOID);
   if (!col_empty) this->materialize();
@@ -336,10 +337,10 @@ void Column::rbind(colvec& columns) {
 
   // Use the appropriate strategy to continue appending the columns.
   newcol.materialize();
-  newcol.pcol->rbind_impl(columns, new_nrows, col_empty);
+  newcol._get_mutable_impl()->rbind_impl(columns, new_nrows, col_empty);
 
   // Replace current column's impl with the newcol's
-  std::swap(pcol, newcol.pcol);
+  std::swap(impl_, newcol.impl_);
 }
 
 

--- a/c/stats.cc
+++ b/c/stats.cc
@@ -53,7 +53,7 @@ static const char* stat_name(Stat s) {
 // main Stats class
 //------------------------------------------------------------------------------
 
-Stats::Stats(dt::ColumnImpl* col) : column(col) {
+Stats::Stats(const dt::ColumnImpl* col) : column(col) {
   xassert(col);
 }
 
@@ -1044,7 +1044,7 @@ void BooleanStats::compute_all_stats() {
 // Column's API
 //------------------------------------------------------------------------------
 
-static std::unique_ptr<Stats> _make_stats(dt::ColumnImpl* col) {
+static std::unique_ptr<Stats> _make_stats(const dt::ColumnImpl* col) {
   using StatsPtr = std::unique_ptr<Stats>;
   switch (col->stype()) {
     case SType::BOOL:    return StatsPtr(new BooleanStats(col));
@@ -1065,12 +1065,12 @@ static std::unique_ptr<Stats> _make_stats(dt::ColumnImpl* col) {
 }
 
 Stats* Column::stats() const {
-  if (!pcol->stats_) pcol->stats_ = _make_stats(pcol);
-  return pcol->stats_.get();
+  if (!impl_->stats_) impl_->stats_ = _make_stats(impl_);
+  return impl_->stats_.get();
 }
 
 Stats* Column::get_stats_if_exist() const {
-  return pcol->stats_.get();
+  return impl_->stats_.get();
 }
 
 

--- a/c/stats.h
+++ b/c/stats.h
@@ -123,7 +123,7 @@ constexpr uint8_t NSTATS = 14;
 class Stats
 {
   protected:
-    dt::ColumnImpl* column;
+    const dt::ColumnImpl* column;
     std::bitset<NSTATS> _computed;
     std::bitset<NSTATS> _valid;
     size_t _countna;
@@ -132,7 +132,7 @@ class Stats
 
   //---- Generic properties ------------
   public:
-    explicit Stats(dt::ColumnImpl* col);
+    explicit Stats(const dt::ColumnImpl* col);
     Stats(const Stats&) = delete;
     Stats(Stats&&) = delete;
     virtual ~Stats();


### PR DESCRIPTION
- fix constructors `Column::new_data_column()` etc. (they were creating an unnecessary copy);
- `Column::pcol` renamed into `impl_`;
- methods `_acquire_impl` and `_release_impl` moved into the `Column` class;

Closes #2010 