### PR TITLE
Cleanup of DataTable class

### DIFF
--- a/c/api.cc
+++ b/c/api.cc
@@ -31,7 +31,7 @@ extern "C" {
 //------------------------------------------------------------------------------
 
 static int _column_index_oob(DataTable* dt, size_t i) {
-  if (i < dt->ncols) return 0;
+  if (i < dt->ncols()) return 0;
   PyErr_Format(PyExc_IndexError, "Column %zu does not exist in the Frame", i);
   return -1;
 }
@@ -64,12 +64,12 @@ int DtFrame_Check(PyObject* ob) {
 
 size_t DtFrame_NColumns(PyObject* pydt) {
   auto dt = _extract_dt(pydt);
-  return dt->ncols;
+  return dt->ncols();
 }
 
 size_t DtFrame_NRows(PyObject* pydt) {
   auto dt = _extract_dt(pydt);
-  return dt->nrows;
+  return dt->nrows();
 }
 
 

--- a/c/api.cc
+++ b/c/api.cc
@@ -114,7 +114,7 @@ const char* DtFrame_ColumnStringDataR(PyObject* pydt, size_t i) {
   auto dt = _extract_dt(pydt);
   if (_column_index_oob(dt, i)) return nullptr;
   try {
-    Column& col = dt->get_column(i);
+    const Column& col = dt->get_column(i);
     if (col.ltype() == LType::STRING) {
       return static_cast<const char*>(col.get_data_readonly(1));
     }

--- a/c/datatable.cc
+++ b/c/datatable.cc
@@ -145,8 +145,8 @@ void DataTable::delete_columns(intvec& cols_to_remove) {
   ncols_ = j;
   columns_.resize(j);
   names_.resize(j);
-  py_names  = py::otuple();
-  py_inames = py::odict();
+  py_names_  = py::otuple();
+  py_inames_ = py::odict();
 }
 
 
@@ -156,8 +156,8 @@ void DataTable::delete_all() {
   nkeys_ = 0;
   columns_.resize(0);
   names_.resize(0);
-  py_names  = py::otuple();
-  py_inames = py::odict();
+  py_names_  = py::otuple();
+  py_inames_ = py::odict();
 }
 
 

--- a/c/datatable.cc
+++ b/c/datatable.cc
@@ -61,7 +61,7 @@ DataTable::DataTable(colvec&& cols, const strvec& nn, bool warn)
   set_names(nn, warn);
 }
 
-DataTable::DataTable(colvec&& cols, const DataTable* nn)
+DataTable::DataTable(colvec&& cols, const DataTable& nn)
   : DataTable(std::move(cols))
 {
   copy_names_from(nn);
@@ -108,7 +108,7 @@ size_t DataTable::xcolindex(int64_t index) const {
  */
 DataTable* DataTable::copy() const {
   colvec newcols = columns_;  // copy the vector
-  DataTable* res = new DataTable(std::move(newcols), this);
+  DataTable* res = new DataTable(std::move(newcols), *this);
   res->nkeys_ = nkeys_;
   return res;
 }

--- a/c/datatable.cc
+++ b/c/datatable.cc
@@ -172,15 +172,6 @@ void DataTable::apply_rowindex(const RowIndex& rowindex) {
 }
 
 
-void DataTable::replace_groupby(const Groupby& newgb) {
-  int32_t last_offset = newgb.offsets_r()[newgb.ngroups()];
-  if (static_cast<size_t>(last_offset) != nrows) {
-    throw ValueError() << "Cannot apply Groupby of " << last_offset << " rows "
-      "to a Frame with " << nrows << " rows";
-  }
-  groupby = newgb;
-}
-
 
 
 /**

--- a/c/datatable.cc
+++ b/c/datatable.cc
@@ -19,7 +19,7 @@
 //------------------------------------------------------------------------------
 
 DataTable::DataTable()
-  : nrows_(0), ncols_(0), nkeys(0)
+  : nrows_(0), ncols_(0), nkeys_(0)
 {
   TRACK(this, sizeof(*this), "DataTable");
 }
@@ -92,7 +92,7 @@ size_t DataTable::xcolindex(int64_t index) const {
 DataTable* DataTable::copy() const {
   colvec newcols = columns;  // copy the vector
   DataTable* res = new DataTable(std::move(newcols), this);
-  res->nkeys = nkeys;
+  res->nkeys_ = nkeys_;
   return res;
 }
 
@@ -136,7 +136,7 @@ void DataTable::delete_columns(intvec& cols_to_remove) {
 void DataTable::delete_all() {
   ncols_ = 0;
   nrows_ = 0;
-  nkeys = 0;
+  nkeys_ = 0;
   columns.resize(0);
   names.resize(0);
   py_names  = py::otuple();
@@ -146,7 +146,7 @@ void DataTable::delete_all() {
 
 void DataTable::resize_rows(size_t new_nrows) {
   if (new_nrows == nrows_) return;
-  if (new_nrows > nrows_ && nkeys > 0) {
+  if (new_nrows > nrows_ && nkeys_ > 0) {
     throw ValueError() << "Cannot increase the number of rows in a keyed frame";
   }
   for (Column& col : columns) {

--- a/c/datatable.cc
+++ b/c/datatable.cc
@@ -156,6 +156,12 @@ void DataTable::resize_rows(size_t new_nrows) {
 }
 
 
+void DataTable::resize_columns(const strvec& new_names) {
+  ncols_ = new_names.size();
+  columns.resize(ncols_);
+  set_names(new_names);
+}
+
 
 
 /**

--- a/c/datatable.cc
+++ b/c/datatable.cc
@@ -106,17 +106,17 @@ size_t DataTable::xcolindex(int64_t index) const {
 /**
  * Make a shallow copy of the current DataTable.
  */
-DataTable* DataTable::copy() const {
+DataTable DataTable::copy() const {
   colvec newcols = columns_;  // copy the vector
-  DataTable* res = new DataTable(std::move(newcols), *this);
-  res->nkeys_ = nkeys_;
+  DataTable res(std::move(newcols), *this);
+  res.nkeys_ = nkeys_;
   return res;
 }
 
 
-DataTable* DataTable::extract_column(size_t i) const {
+DataTable DataTable::extract_column(size_t i) const {
   xassert(i < ncols_);
-  return new DataTable({columns_[i]}, {names_[i]});
+  return DataTable({columns_[i]}, {names_[i]});
 }
 
 

--- a/c/datatable.cc
+++ b/c/datatable.cc
@@ -28,7 +28,7 @@ DataTable::~DataTable() {
   UNTRACK(this);
 }
 
-// Private constructor, initializes only columns but not names
+// Private constructor, initializes only columns but not names_
 DataTable::DataTable(colvec&& cols) : DataTable()
 {
   if (cols.empty()) return;
@@ -116,7 +116,7 @@ DataTable* DataTable::copy() const {
 
 DataTable* DataTable::extract_column(size_t i) const {
   xassert(i < ncols_);
-  return new DataTable({columns_[i]}, {names[i]});
+  return new DataTable({columns_[i]}, {names_[i]});
 }
 
 
@@ -138,13 +138,13 @@ void DataTable::delete_columns(intvec& cols_to_remove) {
     }
     if (i != j) {
       std::swap(columns_[j], columns_[i]);
-      std::swap(names[j], names[i]);
+      std::swap(names_[j], names_[i]);
     }
     ++j;
   }
   ncols_ = j;
   columns_.resize(j);
-  names.resize(j);
+  names_.resize(j);
   py_names  = py::otuple();
   py_inames = py::odict();
 }
@@ -155,7 +155,7 @@ void DataTable::delete_all() {
   nrows_ = 0;
   nkeys_ = 0;
   columns_.resize(0);
-  names.resize(0);
+  names_.resize(0);
   py_names  = py::otuple();
   py_inames = py::odict();
 }

--- a/c/datatable.cc
+++ b/c/datatable.cc
@@ -103,17 +103,6 @@ size_t DataTable::xcolindex(int64_t index) const {
 }
 
 
-/**
- * Make a shallow copy of the current DataTable.
- */
-DataTable DataTable::copy() const {
-  colvec newcols = columns_;  // copy the vector
-  DataTable res(std::move(newcols), *this);
-  res.nkeys_ = nkeys_;
-  return res;
-}
-
-
 DataTable DataTable::extract_column(size_t i) const {
   xassert(i < ncols_);
   return DataTable({columns_[i]}, {names_[i]});

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -44,7 +44,6 @@ struct RowColIndex {
 using colvec = std::vector<Column>;
 using intvec = std::vector<size_t>;
 using strvec = std::vector<std::string>;
-using dtptr  = std::unique_ptr<DataTable>;
 
 
 //==============================================================================

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -77,7 +77,7 @@ class DataTable {
     size_t  ncols_;
     size_t  nkeys_;
     colvec  columns_;
-    strvec  names;
+    strvec  names_;
     mutable py::otuple py_names;   // memoized tuple of column names
     mutable py::odict  py_inames;  // memoized dict of {column name: index}
 

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -75,8 +75,8 @@ class DataTable {
   private:
     size_t  nrows_;
     size_t  ncols_;
+    size_t  nkeys_;
     colvec  columns;
-    size_t  nkeys;
     strvec  names;
     mutable py::otuple py_names;   // memoized tuple of column names
     mutable py::odict  py_inames;  // memoized dict of {column name: index}

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -36,10 +36,6 @@ struct sort_spec {
     : col_index(i), descending(desc), na_last(nalast), sort_only(sort) {}
 };
 
-struct RowColIndex {
-  RowIndex rowindex;
-  std::vector<size_t> colindices;
-};
 
 using colvec = std::vector<Column>;
 using intvec = std::vector<size_t>;
@@ -49,27 +45,27 @@ using strvec = std::vector<std::string>;
 //==============================================================================
 
 /**
- * The DataTable
- *
- * Properties
- * ----------
- * nrows_
- * ncols_
- *     Data dimensions: number of rows and columns in the datatable. We do not
- *     support more than 2 dimensions (as Numpy or TensorFlow do).
- *     The maximum number of rows is 2**63 - 1. The maximum number of columns
- *     is 2**31 - 1 (even though `ncols_` is declared as `size_t`).
- *
- * nkeys_
- *     The number of columns that together constitute the primary key of this
- *     data frame. The key columns are always located at the beginning of the
- *     `columns_` list. The key values are unique, and the frame is sorted by
- *     these values.
- *
- * columns_
- *     The array of columns within the datatable. This array contains `ncols_`
- *     elements, and each column has the same number of rows: `nrows_`.
- */
+  * The DataTable
+  *
+  * Properties
+  * ----------
+  * nrows_
+  * ncols_
+  *     Data dimensions: number of rows and columns in the datatable. We do not
+  *     support more than 2 dimensions (as Numpy or TensorFlow do).
+  *     The maximum number of rows is 2**63 - 1. The maximum number of columns
+  *     is 2**31 - 1 (even though `ncols_` is declared as `size_t`).
+  *
+  * nkeys_
+  *     The number of columns that together constitute the primary key of this
+  *     data frame. The key columns are always located at the beginning of the
+  *     `columns_` list. The key values are unique, and the frame is sorted by
+  *     these values.
+  *
+  * columns_
+  *     The array of columns within the datatable. This array contains `ncols_`
+  *     elements, and each column has the same number of rows: `nrows_`.
+  */
 class DataTable {
   private:
     size_t  nrows_;
@@ -84,7 +80,7 @@ class DataTable {
     static struct DefaultNamesTag {} default_names;
 
     DataTable();
-    DataTable(const DataTable&) = delete;
+    DataTable(const DataTable&) = default;
     DataTable(DataTable&&) = default;
     DataTable(colvec&& cols, DefaultNamesTag);
     DataTable(colvec&& cols, const strvec&, bool warn_duplicates = true);
@@ -104,7 +100,6 @@ class DataTable {
     void materialize();
     void rbind(const std::vector<DataTable*>&, const std::vector<intvec>&);
     void cbind(const std::vector<DataTable*>&);
-    DataTable copy() const;
     DataTable extract_column(size_t i) const;
     size_t memory_footprint() const noexcept;
 

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -3,7 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
-// © H2O.ai 2018
+// © H2O.ai 2018-2019
 //------------------------------------------------------------------------------
 #ifndef dt_DATATABLE_h
 #define dt_DATATABLE_h
@@ -88,7 +88,7 @@ class DataTable {
     DataTable(colvec&& cols, DefaultNamesTag);
     DataTable(colvec&& cols, const strvec&, bool warn_duplicates = true);
     DataTable(colvec&& cols, const py::olist&, bool warn_duplicates = true);
-    DataTable(colvec&& cols, const DataTable*);
+    DataTable(colvec&& cols, const DataTable&);
     ~DataTable();
 
     size_t nrows() const noexcept { return nrows_; }
@@ -124,7 +124,7 @@ class DataTable {
     int64_t colindex(const py::_obj& pyname) const;
     size_t xcolindex(const py::_obj& pyname) const;
     size_t xcolindex(int64_t index) const;
-    void copy_names_from(const DataTable* other);
+    void copy_names_from(const DataTable& other);
     void set_names_to_default();
     void set_names(const py::olist& names_list, bool warn = true);
     void set_names(const strvec& names_list, bool warn = true);
@@ -162,7 +162,7 @@ DataTable* open_jay_from_file(const std::string& path);
 DataTable* open_jay_from_bytes(const char* ptr, size_t len);
 DataTable* open_jay_from_mbuf(const Buffer&);
 
-RowIndex natural_join(const DataTable* xdt, const DataTable* jdt);
+RowIndex natural_join(const DataTable& xdt, const DataTable& jdt);
 
 
 #endif

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -73,13 +73,13 @@ using dtptr  = std::unique_ptr<DataTable>;
  */
 class DataTable {
   public:
-    size_t   nrows;
-    size_t   ncols;
+    size_t  nrows_;
+    size_t  ncols_;
 
   private:
     colvec  columns;
-    size_t   nkeys;
-    strvec   names;
+    size_t  nkeys;
+    strvec  names;
     mutable py::otuple py_names;   // memoized tuple of column names
     mutable py::odict  py_inames;  // memoized dict of {column name: index}
 
@@ -92,6 +92,9 @@ class DataTable {
     DataTable(colvec&& cols, const py::olist&, bool warn_duplicates = true);
     DataTable(colvec&& cols, const DataTable*);
     ~DataTable();
+
+    size_t nrows() const noexcept { return nrows_; }
+    size_t ncols() const noexcept { return ncols_; }
 
     void delete_columns(intvec&);
     void delete_all();
@@ -114,7 +117,7 @@ class DataTable {
     }
     void set_column(size_t i, Column&& newcol) {
       xassert(i < columns.size());
-      xassert(newcol.nrows() == nrows);
+      xassert(newcol.nrows() == nrows_);
       columns[i] = std::move(newcol);
     }
 

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -76,7 +76,7 @@ class DataTable {
     size_t  nrows_;
     size_t  ncols_;
     size_t  nkeys_;
-    colvec  columns;
+    colvec  columns_;
     strvec  names;
     mutable py::otuple py_names;   // memoized tuple of column names
     mutable py::odict  py_inames;  // memoized dict of {column name: index}
@@ -106,19 +106,9 @@ class DataTable {
     DataTable* extract_column(size_t i) const;
     size_t memory_footprint() const noexcept;
 
-    const Column& get_column(size_t i) const {
-      xassert(i < columns.size());
-      return columns[i];
-    }
-    Column& get_column(size_t i) {
-      xassert(i < columns.size());
-      return columns[i];
-    }
-    void set_column(size_t i, Column&& newcol) {
-      xassert(i < columns.size());
-      xassert(newcol.nrows() == nrows_);
-      columns[i] = std::move(newcol);
-    }
+    const Column& get_column(size_t i) const;
+    Column& get_column(size_t i);
+    void set_column(size_t i, Column&& newcol);
 
     /**
      * Sort the DataTable by specified columns, and return the corresponding

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -85,6 +85,8 @@ class DataTable {
     static struct DefaultNamesTag {} default_names;
 
     DataTable();
+    DataTable(const DataTable&) = delete;
+    DataTable(DataTable&&) = default;
     DataTable(colvec&& cols, DefaultNamesTag);
     DataTable(colvec&& cols, const strvec&, bool warn_duplicates = true);
     DataTable(colvec&& cols, const py::olist&, bool warn_duplicates = true);
@@ -103,8 +105,8 @@ class DataTable {
     void materialize();
     void rbind(const std::vector<DataTable*>&, const std::vector<intvec>&);
     void cbind(const std::vector<DataTable*>&);
-    DataTable* copy() const;
-    DataTable* extract_column(size_t i) const;
+    DataTable copy() const;
+    DataTable extract_column(size_t i) const;
     size_t memory_footprint() const noexcept;
 
     const Column& get_column(size_t i) const;

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -78,8 +78,8 @@ class DataTable {
     size_t  nkeys_;
     colvec  columns_;
     strvec  names_;
-    mutable py::otuple py_names;   // memoized tuple of column names
-    mutable py::odict  py_inames;  // memoized dict of {column name: index}
+    mutable py::otuple py_names_;   // memoized tuple of column names
+    mutable py::odict  py_inames_;  // memoized dict of {column name: index}
 
   public:
     static struct DefaultNamesTag {} default_names;

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -54,22 +54,22 @@ using dtptr  = std::unique_ptr<DataTable>;
  *
  * Properties
  * ----------
- * nrows
- * ncols
+ * nrows_
+ * ncols_
  *     Data dimensions: number of rows and columns in the datatable. We do not
  *     support more than 2 dimensions (as Numpy or TensorFlow do).
  *     The maximum number of rows is 2**63 - 1. The maximum number of columns
- *     is 2**31 - 1 (even though `ncols` is declared as `size_t`).
+ *     is 2**31 - 1 (even though `ncols_` is declared as `size_t`).
  *
- * nkeys
+ * nkeys_
  *     The number of columns that together constitute the primary key of this
  *     data frame. The key columns are always located at the beginning of the
- *     `column` list. The key values are unique, and the frame is sorted by
+ *     `columns_` list. The key values are unique, and the frame is sorted by
  *     these values.
  *
- * columns
- *     The array of columns within the datatable. This array contains `ncols`
- *     elements, and each column has the same number of rows: `nrows`.
+ * columns_
+ *     The array of columns within the datatable. This array contains `ncols_`
+ *     elements, and each column has the same number of rows: `nrows_`.
  */
 class DataTable {
   private:
@@ -93,6 +93,7 @@ class DataTable {
 
     size_t nrows() const noexcept { return nrows_; }
     size_t ncols() const noexcept { return ncols_; }
+    size_t nkeys() const noexcept { return nkeys_; }
 
     void delete_columns(intvec&);
     void delete_all();
@@ -131,7 +132,6 @@ class DataTable {
     void reorder_names(const intvec& col_indices);
 
     // Key
-    size_t get_nkeys() const;
     void set_key(intvec& col_indices);
     void clear_key();
     void set_nkeys_unsafe(size_t K);

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -72,11 +72,9 @@ using dtptr  = std::unique_ptr<DataTable>;
  *     elements, and each column has the same number of rows: `nrows`.
  */
 class DataTable {
-  public:
+  private:
     size_t  nrows_;
     size_t  ncols_;
-
-  private:
     colvec  columns;
     size_t  nkeys;
     strvec  names;
@@ -99,6 +97,7 @@ class DataTable {
     void delete_columns(intvec&);
     void delete_all();
     void resize_rows(size_t n);
+    void resize_columns(const strvec& new_names);
     void apply_rowindex(const RowIndex&);
     void materialize();
     void rbind(const std::vector<DataTable*>&, const std::vector<intvec>&);

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -75,7 +75,6 @@ class DataTable {
   public:
     size_t   nrows;
     size_t   ncols;
-    Groupby  groupby;
 
   private:
     colvec  columns;
@@ -98,7 +97,6 @@ class DataTable {
     void delete_all();
     void resize_rows(size_t n);
     void apply_rowindex(const RowIndex&);
-    void replace_groupby(const Groupby& newgb);
     void materialize();
     void rbind(const std::vector<DataTable*>&, const std::vector<intvec>&);
     void cbind(const std::vector<DataTable*>&);

--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -58,7 +58,7 @@ _unpack_frame_column_args(const py::PKArgs& args)
   size_t col    = args[1].to_size_t();
 
   if (!dt) throw TypeError() << "First parameter should be a Frame";
-  if (col >= dt->ncols) throw ValueError() << "Index out of bounds";
+  if (col >= dt->ncols()) throw ValueError() << "Index out of bounds";
   return std::make_pair(dt, col);
 }
 
@@ -74,8 +74,8 @@ Return the tuple of which columns in the Frame are virtual.
 
 static py::oobj frame_columns_virtual(const py::PKArgs& args) {
   DataTable* dt = args[0].to_datatable();
-  py::otuple virtuals(dt->ncols);
-  for (size_t i = 0; i < dt->ncols; ++i) {
+  py::otuple virtuals(dt->ncols());
+  for (size_t i = 0; i < dt->ncols(); ++i) {
     virtuals.set(i, py::obool(dt->get_column(i).is_virtual()));
   }
   return std::move(virtuals);

--- a/c/expr/collist.cc
+++ b/c/expr/collist.cc
@@ -127,11 +127,11 @@ class collist_maker
       }
 
       // Finalize
-      if (type == list_type::BOOL && k != dt0->ncols) {
+      if (type == list_type::BOOL && k != dt0->ncols()) {
         throw ValueError()
             << "The length of boolean list in " << srcname
             << " does not match the number of columns in the Frame: "
-            << k << " vs " << dt0->ncols;
+            << k << " vs " << dt0->ncols();
       }
     }
 
@@ -176,7 +176,7 @@ class collist_maker
     void _process_element_int(py::robj elem) {
       _set_type(list_type::INT);
       int64_t i = elem.to_int64_strict();
-      int64_t icols = static_cast<int64_t>(dt0->ncols);
+      int64_t icols = static_cast<int64_t>(dt0->ncols());
       if (i < -icols || i >= icols) {
         throw ValueError()
             << "Column index `" << i << "` is invalid for a Frame with "
@@ -241,7 +241,7 @@ class collist_maker
 
     void _process_element_numslice(py::oslice ssrc) {
       _set_type(list_type::INT);
-      size_t len = dt0->ncols;
+      size_t len = dt0->ncols();
       size_t start, count, step;
       ssrc.normalize(len, &start, &count, &step);
       indices.reserve(indices.size() + count);
@@ -258,7 +258,7 @@ class collist_maker
       size_t start, end;
       if (strict) {
         start = ostart.is_none()? 0 : dt0->xcolindex(ostart);
-        end = ostop.is_none()? dt0->ncols - 1 : dt0->xcolindex(ostop);
+        end = ostop.is_none()? dt0->ncols() - 1 : dt0->xcolindex(ostop);
       } else {
         // Note: colindex() may return -1 indicating the column was not found
         int64_t s = ostart.is_none()? -2 : dt0->colindex(ostart);
@@ -266,7 +266,7 @@ class collist_maker
         // If both ends of a range are not valid, the slice is considered empty
         if ((s + e == -3) || (s == e && s == -1)) return;
         start = (s < 0)? 0 : static_cast<size_t>(s);
-        end = (e < 0)? dt0->ncols - 1 : static_cast<size_t>(e);
+        end = (e < 0)? dt0->ncols() - 1 : static_cast<size_t>(e);
       }
       size_t len = start <= end? end - start + 1 : start - end + 1;
       indices.reserve(len);
@@ -318,7 +318,7 @@ class collist_maker
     }
 
     void _select_types(const std::vector<SType>& stypes) {
-      size_t ncols = dt0->ncols;
+      size_t ncols = dt0->ncols();
       for (size_t i = 0; i < ncols; ++i) {
         SType st = dt0->get_column(i).stype();
         for (SType s : stypes) {

--- a/c/expr/eval_context.cc
+++ b/c/expr/eval_context.cc
@@ -170,7 +170,7 @@ intvec EvalContext::evaluate_j_as_column_index() {
     if (jres.is_placeholder_column(i)) {
       // If allow_new is false, no placeholder columns should be generated
       xassert(allow_new);
-      indices[i] = dt0->ncols + newnames.size();
+      indices[i] = dt0->ncols() + newnames.size();
       newnames.emplace_back(jres.retrieve_name(i));
     }
     if (jres.is_computed_column(i)) {
@@ -187,7 +187,7 @@ void EvalContext::create_placeholder_columns() {
   DataTable* dt0 = frames[0].dt;
   const strvec& oldnames = dt0->get_names();
   newnames.insert(newnames.begin(), oldnames.begin(), oldnames.end());
-  dt0->ncols = newnames.size();
+  dt0->ncols_ = newnames.size();
   dt0->set_names(newnames);
 }
 
@@ -222,7 +222,7 @@ void EvalContext::evaluate_delete_rows() {
   DataTable* dt0 = frames[0].dt;
   const RowIndex& ri0 = frames[0].ri;
   if (ri0) {
-    RowIndex ri_neg = ri0.negate(dt0->nrows);
+    RowIndex ri_neg = ri0.negate(dt0->nrows());
     dt0->apply_rowindex(ri_neg);
   } else {
     dt0->delete_all();
@@ -373,11 +373,11 @@ py::oobj EvalContext::get_result() {
     DataTable* result =
         out_datatable? out_datatable.release()
                      : new DataTable(std::move(columns), std::move(colnames));
-    if (result->ncols == 0) {
+    if (result->ncols() == 0) {
       // When selecting a 0-column subset, make sure the number of rows is the
       // same as if some of the columns were selected.
-      result->nrows = frames[0].ri? frames[0].ri.size()
-                                  : frames[0].dt->nrows;
+      result->nrows_ = frames[0].ri? frames[0].ri.size()
+                                  : frames[0].dt->nrows();
     }
     return py::Frame::oframe(result);
   }
@@ -421,7 +421,7 @@ size_t EvalContext::nframes() const {
 
 size_t EvalContext::nrows() const {
   const RowIndex& ri0 = frames[0].ri;
-  return ri0? ri0.size() : frames[0].dt->nrows;
+  return ri0? ri0.size() : frames[0].dt->nrows();
 }
 
 

--- a/c/expr/eval_context.cc
+++ b/c/expr/eval_context.cc
@@ -187,8 +187,7 @@ void EvalContext::create_placeholder_columns() {
   DataTable* dt0 = frames[0].dt;
   const strvec& oldnames = dt0->get_names();
   newnames.insert(newnames.begin(), oldnames.begin(), oldnames.end());
-  dt0->ncols_ = newnames.size();
-  dt0->set_names(newnames);
+  dt0->resize_columns(newnames);
 }
 
 
@@ -376,8 +375,8 @@ py::oobj EvalContext::get_result() {
     if (result->ncols() == 0) {
       // When selecting a 0-column subset, make sure the number of rows is the
       // same as if some of the columns were selected.
-      result->nrows_ = frames[0].ri? frames[0].ri.size()
-                                  : frames[0].dt->nrows();
+      result->resize_rows(frames[0].ri? frames[0].ri.size()
+                                      : frames[0].dt->nrows());
     }
     return py::Frame::oframe(result);
   }

--- a/c/expr/eval_context.cc
+++ b/c/expr/eval_context.cc
@@ -104,7 +104,7 @@ void EvalContext::evaluate() {
   DataTable* xdt = frames[0].dt;
   for (size_t i = 1; i < frames.size(); ++i) {
     DataTable* jdt = frames[i].dt;
-    frames[i].ri = natural_join(xdt, jdt);
+    frames[i].ri = natural_join(*xdt, *jdt);
   }
 
   // Compute groupby

--- a/c/expr/eval_context.h
+++ b/c/expr/eval_context.h
@@ -96,7 +96,7 @@ class EvalContext {
     strvec colnames;
     struct ritriple { RowIndex ab, bc, ac; };
     std::vector<ritriple> all_ri;
-    dtptr  out_datatable;
+    std::unique_ptr<DataTable> out_datatable;
 
   public:
     EvalContext(DataTable*, EvalMode);

--- a/c/expr/expr_column.cc
+++ b/c/expr/expr_column.cc
@@ -57,7 +57,7 @@ size_t expr_column::get_col_index(const EvalContext& ctx, bool strict) {
     const DataTable* dt = ctx.get_datatable(get_col_frame(ctx));
     if (col_selector.is_int()) {
       int64_t icolid = col_selector.to_int64_strict();
-      int64_t incols = static_cast<int64_t>(dt->ncols);
+      int64_t incols = static_cast<int64_t>(dt->ncols());
       if (icolid < -incols || icolid >= incols) {
         if (strict) {
           throw ValueError() << "Column index " << icolid << " is invalid for "
@@ -67,7 +67,7 @@ size_t expr_column::get_col_index(const EvalContext& ctx, bool strict) {
       } else {
         if (icolid < 0) icolid += incols;
         col_id = static_cast<size_t>(icolid);
-        xassert(col_id < dt->ncols);
+        xassert(col_id < dt->ncols());
       }
     }
     else {

--- a/c/expr/expr_unaryop.cc
+++ b/c/expr/expr_unaryop.cc
@@ -348,7 +348,7 @@ static py::oobj process_frame(Op opcode, py::robj arg) {
 
   py::oobj res = frame->m__getitem__(py::otuple{ py::None(), columns });
   DataTable* res_dt = res.to_datatable();
-  res_dt->copy_names_from(dt);
+  res_dt->copy_names_from(*dt);
   return res;
 }
 

--- a/c/expr/expr_unaryop.cc
+++ b/c/expr/expr_unaryop.cc
@@ -338,8 +338,8 @@ static py::oobj process_frame(Op opcode, py::robj arg) {
   auto frame = static_cast<py::Frame*>(arg.to_borrowed_ref());
   DataTable* dt = frame->get_datatable();
 
-  py::olist columns(dt->ncols);
-  for (size_t i = 0; i < dt->ncols; ++i) {
+  py::olist columns(dt->ncols());
+  for (size_t i = 0; i < dt->ncols(); ++i) {
     py::oobj col_selector = make_pyexpr(Op::COL,
                                         py::otuple{py::oint(i)},
                                         py::otuple{py::oint(0)});

--- a/c/expr/head_frame.cc
+++ b/c/expr/head_frame.cc
@@ -60,15 +60,15 @@ Workframe Head_Frame::evaluate_n(const vecExpr& args, EvalContext& ctx) const {
   (void) args;
   xassert(args.size() == 0);
 
-  if (!(dt->nrows == ctx.nrows() || dt->nrows == 1)) {
-    throw ValueError() << "Frame has " << dt->nrows << " rows, and "
+  if (!(dt->nrows() == ctx.nrows() || dt->nrows() == 1)) {
+    throw ValueError() << "Frame has " << dt->nrows() << " rows, and "
         "cannot be used in an expression where " << ctx.nrows()
         << " are expected";
   }
-  Grouping grouplevel = (dt->nrows == 1)? Grouping::GtoONE
-                                        : Grouping::GtoALL;
+  Grouping grouplevel = (dt->nrows() == 1)? Grouping::GtoONE
+                                          : Grouping::GtoALL;
   Workframe res(ctx);
-  for (size_t i = 0; i < dt->ncols; ++i) {
+  for (size_t i = 0; i < dt->ncols(); ++i) {
     res.add_column(
         Column(dt->get_column(i)),
         ignore_names? std::string() : std::string(dt->get_names()[i]),

--- a/c/expr/head_list.cc
+++ b/c/expr/head_list.cc
@@ -121,11 +121,11 @@ static Kind _resolve_list_kind(const vecExpr& inputs) {
 
 static Workframe _evaluate_bool_list(const vecExpr& inputs, EvalContext& ctx) {
   DataTable* df = ctx.get_datatable(0);
-  if (inputs.size() != df->ncols) {
+  if (inputs.size() != df->ncols()) {
     throw ValueError()
         << "The length of boolean list in j selector does not match the "
            "number of columns in the Frame: "
-        << inputs.size() << " vs " << df->ncols;
+        << inputs.size() << " vs " << df->ncols();
   }
   Workframe outputs(ctx);
   for (size_t i = 0; i < inputs.size(); ++i) {

--- a/c/expr/head_literal_int.cc
+++ b/c/expr/head_literal_int.cc
@@ -46,7 +46,7 @@ Workframe Head_Literal_Int::evaluate_f(
 {
   auto df = ctx.get_datatable(frame_id);
   Workframe outputs(ctx);
-  int64_t icols = static_cast<int64_t>(df->ncols);
+  int64_t icols = static_cast<int64_t>(df->ncols());
   if (value < -icols || value >= icols) {
     if (!(allow_new && value > 0)) {
       throw ValueError()

--- a/c/expr/head_literal_none.cc
+++ b/c/expr/head_literal_none.cc
@@ -41,7 +41,7 @@ Workframe Head_Literal_None::evaluate_n(const vecExpr&, EvalContext& ctx) const 
 Workframe Head_Literal_None::evaluate_j(
     const vecExpr&, EvalContext& ctx, bool) const
 {
-  size_t n = ctx.get_datatable(0)->ncols;
+  size_t n = ctx.get_datatable(0)->ncols();
   Workframe outputs(ctx);
   for (size_t i = 0; i < n; ++i) {
     outputs.add_ref_column(0, i);

--- a/c/expr/head_literal_sliceall.cc
+++ b/c/expr/head_literal_sliceall.cc
@@ -41,7 +41,7 @@ Workframe Head_Literal_SliceAll::evaluate_n(const vecExpr&, EvalContext&) const 
 Workframe Head_Literal_SliceAll::evaluate_f(
     EvalContext& ctx, size_t frame_id, bool) const
 {
-  size_t ncols = ctx.get_datatable(frame_id)->ncols;
+  size_t ncols = ctx.get_datatable(frame_id)->ncols();
   Workframe outputs(ctx);
   for (size_t i = 0; i < ncols; ++i) {
     outputs.add_ref_column(frame_id, i);
@@ -64,7 +64,7 @@ Workframe Head_Literal_SliceAll::evaluate_j(
     const DataTable* dti = ctx.get_datatable(i);
     size_t j0 = ctx.is_naturally_joined(i)? dti->get_nkeys() : 0;
     const by_node& by = ctx.get_by_node();
-    for (size_t j = j0; j < dti->ncols; ++j) {
+    for (size_t j = j0; j < dti->ncols(); ++j) {
       if (by.has_group_column(j)) continue;
       outputs.add_ref_column(i, j);
     }

--- a/c/expr/head_literal_sliceall.cc
+++ b/c/expr/head_literal_sliceall.cc
@@ -62,7 +62,7 @@ Workframe Head_Literal_SliceAll::evaluate_j(
   Workframe outputs(ctx);
   for (size_t i = 0; i < ctx.nframes(); ++i) {
     const DataTable* dti = ctx.get_datatable(i);
-    size_t j0 = ctx.is_naturally_joined(i)? dti->get_nkeys() : 0;
+    size_t j0 = ctx.is_naturally_joined(i)? dti->nkeys() : 0;
     const by_node& by = ctx.get_by_node();
     for (size_t j = j0; j < dti->ncols(); ++j) {
       if (by.has_group_column(j)) continue;

--- a/c/expr/head_literal_sliceint.cc
+++ b/c/expr/head_literal_sliceint.cc
@@ -45,7 +45,7 @@ Workframe Head_Literal_SliceInt::evaluate_n(const vecExpr&, EvalContext&) const 
 Workframe Head_Literal_SliceInt::evaluate_f(
     EvalContext& ctx, size_t frame_id, bool) const
 {
-  size_t len = ctx.get_datatable(frame_id)->ncols;
+  size_t len = ctx.get_datatable(frame_id)->ncols();
   size_t start, count, step;
   value.normalize(len, &start, &count, &step);
   Workframe outputs(ctx);

--- a/c/expr/head_literal_slicestr.cc
+++ b/c/expr/head_literal_slicestr.cc
@@ -50,7 +50,7 @@ Workframe Head_Literal_SliceStr::evaluate_f(
 {
   DataTable* df = ctx.get_datatable(frame_id);
   size_t istart = start.is_none()? 0 : df->xcolindex(start);
-  size_t iend = end.is_none()? df->ncols - 1 : df->xcolindex(end);
+  size_t iend = end.is_none()? df->ncols() - 1 : df->xcolindex(end);
 
   Workframe outputs(ctx);
   size_t di = (istart <= iend)? 1 : size_t(-1);

--- a/c/expr/head_literal_type.cc
+++ b/c/expr/head_literal_type.cc
@@ -44,7 +44,7 @@ static Workframe _select_types(
 {
   const DataTable* df = ctx.get_datatable(frame_id);
   Workframe outputs(ctx);
-  for (size_t i = 0; i < df->ncols; ++i) {
+  for (size_t i = 0; i < df->ncols(); ++i) {
     SType st = df->get_column(i).stype();
     for (SType s : stypes) {
       if (s == st) {
@@ -61,7 +61,7 @@ static Workframe _select_type(EvalContext& ctx, size_t frame_id, SType stype0)
 {
   const DataTable* df = ctx.get_datatable(frame_id);
   Workframe outputs(ctx);
-  for (size_t i = 0; i < df->ncols; ++i) {
+  for (size_t i = 0; i < df->ncols(); ++i) {
     SType stypei = df->get_column(i).stype();
     if (stypei == stype0) {
       outputs.add_ref_column(frame_id, i);

--- a/c/expr/i_node.cc
+++ b/c/expr/i_node.cc
@@ -315,9 +315,9 @@ class frame_in : public i_node {
 
 frame_in::frame_in(py::robj src) : dtobj(src) {
   dt = src.to_datatable();
-  if (dt->ncols != 1) {
+  if (dt->ncols() != 1) {
     throw ValueError() << "Only a single-column Frame may be used as `i` "
-        "selector, instead got a Frame with " << dt->ncols << " columns";
+        "selector, instead got a Frame with " << dt->ncols() << " columns";
   }
   SType st = dt->get_column(0).stype();
   if (!(st == SType::BOOL || info(st).ltype() == LType::INT)) {

--- a/c/expr/j_node.cc
+++ b/c/expr/j_node.cc
@@ -82,7 +82,7 @@ void allcols_jnode::select(EvalContext& ctx) {
     const DataTable* dti = ctx.get_datatable(i);
     const RowIndex& rii = ctx.get_rowindex(i);
     const strvec& dti_column_names = dti->get_names();
-    size_t ncolsi = dti->ncols;
+    size_t ncolsi = dti->ncols();
 
     size_t j0 = ctx.is_naturally_joined(i)? dti->get_nkeys() : 0;
     ctx.reserve(ncolsi - j0);
@@ -101,7 +101,7 @@ void allcols_jnode::delete_(EvalContext& ctx) {
   DataTable* dt0 = ctx.get_datatable(0);
   const RowIndex& ri0 = ctx.get_rowindex(0);
   if (ri0) {
-    RowIndex ri_neg = ri0.negate(dt0->nrows);
+    RowIndex ri_neg = ri0.negate(dt0->nrows());
     dt0->apply_rowindex(ri_neg);
   } else {
     dt0->delete_all();
@@ -112,8 +112,8 @@ void allcols_jnode::delete_(EvalContext& ctx) {
 void allcols_jnode::update(EvalContext& ctx, repl_node* repl) {
   DataTable* dt0 = ctx.get_datatable(0);
   const RowIndex& ri0 = ctx.get_rowindex(0);
-  size_t ncols = dt0->ncols;
-  size_t nrows = ri0? ri0.size() : dt0->nrows;
+  size_t ncols = dt0->ncols();
+  size_t nrows = ri0? ri0.size() : dt0->nrows();
   repl->check_compatibility(nrows, ncols);
 
   std::vector<size_t> indices(ncols);
@@ -223,10 +223,10 @@ void simplelist_jnode::update(EvalContext& ctx, repl_node* repl) {
   DataTable* dt0 = ctx.get_datatable(0);
   const RowIndex& ri0 = ctx.get_rowindex(0);
   size_t lcols = indices.size();
-  size_t lrows = ri0? ri0.size() : dt0->nrows;
+  size_t lrows = ri0? ri0.size() : dt0->nrows();
   repl->check_compatibility(lrows, lcols);
 
-  size_t ncols = dt0->ncols;
+  size_t ncols = dt0->ncols();
   strvec new_names{ dt0->get_names() };  // copy names
   try {
     size_t num_new_columns = 0;
@@ -243,7 +243,7 @@ void simplelist_jnode::update(EvalContext& ctx, repl_node* repl) {
           new_names.push_back(names[i]);
         }
       }
-      dt0->ncols = new_names.size();
+      dt0->ncols_ = new_names.size();
       dt0->set_names(new_names);
     }
 
@@ -254,7 +254,7 @@ void simplelist_jnode::update(EvalContext& ctx, repl_node* repl) {
     }
   } catch (...) {
     new_names.resize(ncols);
-    dt0->ncols = ncols;
+    dt0->ncols_ = ncols;
     dt0->set_names(new_names);
     throw;
   }

--- a/c/expr/j_node.cc
+++ b/c/expr/j_node.cc
@@ -243,8 +243,7 @@ void simplelist_jnode::update(EvalContext& ctx, repl_node* repl) {
           new_names.push_back(names[i]);
         }
       }
-      dt0->ncols_ = new_names.size();
-      dt0->set_names(new_names);
+      dt0->resize_columns(new_names);
     }
 
     if (ri0) {
@@ -254,8 +253,7 @@ void simplelist_jnode::update(EvalContext& ctx, repl_node* repl) {
     }
   } catch (...) {
     new_names.resize(ncols);
-    dt0->ncols_ = ncols;
-    dt0->set_names(new_names);
+    dt0->resize_columns(new_names);
     throw;
   }
 }

--- a/c/expr/j_node.cc
+++ b/c/expr/j_node.cc
@@ -84,7 +84,7 @@ void allcols_jnode::select(EvalContext& ctx) {
     const strvec& dti_column_names = dti->get_names();
     size_t ncolsi = dti->ncols();
 
-    size_t j0 = ctx.is_naturally_joined(i)? dti->get_nkeys() : 0;
+    size_t j0 = ctx.is_naturally_joined(i)? dti->nkeys() : 0;
     ctx.reserve(ncolsi - j0);
     const by_node& by = ctx.get_by_node();
     for (size_t j = j0; j < ncolsi; ++j) {

--- a/c/expr/join_node.cc
+++ b/c/expr/join_node.cc
@@ -42,7 +42,7 @@ void ojoin::pyobj::m__init__(const PKArgs& args) {
     throw TypeError() << "The argument to join() must be a Frame";
   }
   DataTable* jdt = join_frame.to_datatable();
-  if (jdt->get_nkeys() == 0) {
+  if (jdt->nkeys() == 0) {
     throw ValueError() << "The join frame is not keyed";
   }
 }

--- a/c/expr/repl_node.cc
+++ b/c/expr/repl_node.cc
@@ -47,8 +47,8 @@ class frame_rn : public repl_node {
 
 
 void frame_rn::check_compatibility(size_t lrows, size_t lcols) const {
-  size_t rrows = dtr->nrows;
-  size_t rcols = dtr->ncols;
+  size_t rrows = dtr->nrows();
+  size_t rcols = dtr->ncols();
   if ((rrows == lrows || rrows == 1) && (rcols == lcols || rcols == 1)) return;
   if (rcols == 0 && lcols == 0 && rrows == 0) return;
   throw ValueError() << "Invalid replacement Frame: expected [" <<
@@ -58,13 +58,13 @@ void frame_rn::check_compatibility(size_t lrows, size_t lcols) const {
 
 
 void frame_rn::replace_columns(EvalContext& ctx, const intvec& indices) const {
-  size_t rcols = dtr->ncols;
-  size_t rrows = dtr->nrows;
+  size_t rcols = dtr->ncols();
+  size_t rrows = dtr->nrows();
   if (rcols == 0) return;
 
   DataTable* dt0 = ctx.get_datatable(0);
   size_t lcols = indices.size();
-  size_t lrows = dt0->nrows;
+  size_t lrows = dt0->nrows();
   xassert(rcols == 1 || rcols == lcols);  // enforced in `check_compatibility()`
 
   Column col0;
@@ -87,8 +87,8 @@ void frame_rn::replace_columns(EvalContext& ctx, const intvec& indices) const {
 
 
 void frame_rn::replace_values(EvalContext& ctx, const intvec& indices) const {
-  size_t rcols = dtr->ncols;
-  size_t rrows = dtr->nrows;
+  size_t rcols = dtr->ncols();
+  size_t rrows = dtr->nrows();
   if (rcols == 0 || rrows == 0) return;
 
   DataTable* dt0 = ctx.get_datatable(0);
@@ -101,7 +101,7 @@ void frame_rn::replace_values(EvalContext& ctx, const intvec& indices) const {
     const Column& coli = dtr->get_column(rcols == 1? 0 : i);
     if (!dt0->get_column(j)) {
       dt0->set_column(j,
-          Column::new_na_column(dt0->nrows, coli.stype()));
+          Column::new_na_column(dt0->nrows(), coli.stype()));
     }
     Column& colj = dt0->get_column(j);
     colj.replace_values(ri0, coli);
@@ -159,7 +159,7 @@ void scalar_rn::replace_columns(EvalContext& ctx, const intvec& indices) const {
     const Column& col = dt0->get_column(j);
     SType stype = col? col.stype() : SType::VOID;
     if (new_columns.count(stype) == 0) {
-      new_columns[stype] = make_column(stype, dt0->nrows);
+      new_columns[stype] = make_column(stype, dt0->nrows());
     }
     Column newcol = new_columns[stype];  // copy
     dt0->set_column(j, std::move(newcol));
@@ -178,7 +178,7 @@ void scalar_rn::replace_values(EvalContext& ctx, const intvec& indices) const {
     Column replcol = make_column(stype, 1);
     stype = replcol.stype();  // may change from VOID to BOOL, FIXME!
     if (!colj) {
-      dt0->set_column(j, Column::new_na_column(dt0->nrows, stype));
+      dt0->set_column(j, Column::new_na_column(dt0->nrows(), stype));
     }
     else if (colj.stype() != stype) {
       dt0->set_column(j, colj.cast(stype));
@@ -405,7 +405,7 @@ void exprlist_rn::replace_columns(EvalContext& ctx, const intvec& indices) const
     size_t j = indices[i];
     Column col = (i < rcols)? exprs[i]->evaluate(ctx)
                             : dt0->get_column(indices[0]);
-    xassert(col.nrows() == dt0->nrows);
+    xassert(col.nrows() == dt0->nrows());
     dt0->set_column(j, std::move(col));
   }
 }

--- a/c/expr/workframe.cc
+++ b/c/expr/workframe.cc
@@ -223,7 +223,8 @@ std::unique_ptr<DataTable> Workframe::convert_to_datatable() && {
     columns.emplace_back(std::move(record.column));
     names.emplace_back(std::move(record.name));
   }
-  return dtptr(new DataTable(std::move(columns), std::move(names), false));
+  return std::unique_ptr<DataTable>(
+            new DataTable(std::move(columns), std::move(names), false));
 }
 
 

--- a/c/frame/__getitem__.cc
+++ b/c/frame/__getitem__.cc
@@ -152,7 +152,7 @@ oobj Frame::_main_getset(robj item, robj value) {
     bool a1int = arg1.is_int();
     if (a0int && (a1int || arg1.is_string())) {
       int64_t irow = arg0.to_int64_strict();
-      int64_t nrows = static_cast<int64_t>(dt->nrows);
+      int64_t nrows = static_cast<int64_t>(dt->nrows());
       if (irow < -nrows || irow >= nrows) {
         throw ValueError() << "Row `" << irow << "` is invalid for a frame "
             "with " << nrows << " row" << (nrows == 1? "" : "s");

--- a/c/frame/__init__.cc
+++ b/c/frame/__init__.cc
@@ -648,7 +648,7 @@ class FrameInitializationManager {
     }
 
     void make_datatable(const DataTable* names_src) {
-      frame->dt = new DataTable(std::move(cols), names_src);
+      frame->dt = new DataTable(std::move(cols), *names_src);
     }
 
 

--- a/c/frame/__init__.cc
+++ b/c/frame/__init__.cc
@@ -335,7 +335,7 @@ class FrameInitializationManager {
 
     void init_from_frame() {
       DataTable* srcdt = src.to_datatable();
-      size_t ncols = srcdt->ncols;
+      size_t ncols = srcdt->ncols();
       check_names_count(ncols);
       if (stypes_arg || stype_arg) {
         // TODO: allow this use case
@@ -592,9 +592,9 @@ class FrameInitializationManager {
       Column col;
       if (colsrc.is_frame()) {
         DataTable* srcdt = colsrc.to_datatable();
-        if (srcdt->ncols != 1) {
+        if (srcdt->ncols() != 1) {
           throw ValueError() << "A column cannot be constructed from a Frame "
-              "with " << srcdt->ncols << " columns";
+              "with " << srcdt->ncols() << " columns";
         }
         col = srcdt->get_column(0);
       }

--- a/c/frame/__init__.cc
+++ b/c/frame/__init__.cc
@@ -350,8 +350,8 @@ class FrameInitializationManager {
       } else {
         make_datatable(srcdt);
       }
-      if (srcdt->get_nkeys()) {
-        frame->dt->set_nkeys_unsafe(srcdt->get_nkeys());
+      if (srcdt->nkeys()) {
+        frame->dt->set_nkeys_unsafe(srcdt->nkeys());
       }
     }
 

--- a/c/frame/__iter__.cc
+++ b/c/frame/__iter__.cc
@@ -50,16 +50,16 @@ class FrameIterator : public XObject<FrameIterator>
     // See PEP-424
     // Note: the underlying DataTable may get modified while iterating
     oobj m__length_hint__() {
-      if (iteration_index >= dt->ncols) return oint(0);
-      return oint(dt->ncols - iteration_index);
+      if (iteration_index >= dt->ncols()) return oint(0);
+      return oint(dt->ncols() - iteration_index);
     }
 
     oobj m__next__() {
-      if (iteration_index >= dt->ncols) {
+      if (iteration_index >= dt->ncols()) {
         return oobj();
       }
       size_t i = (iteration_index++);
-      if (reverse) i = dt->ncols - i - 1;
+      if (reverse) i = dt->ncols() - i - 1;
       return Frame::oframe(dt->extract_column(i));
     }
 

--- a/c/frame/__repr__.cc
+++ b/c/frame/__repr__.cc
@@ -88,8 +88,8 @@ class HtmlWidget {
       const size_t maxcols = 15;  // TODO: make configurable
       const size_t maxrows = 15;
       dt = dt_;
-      ncols = dt->ncols;
-      nrows = dt->nrows;
+      ncols = dt->ncols();
+      nrows = dt->nrows();
       cols0 = ncols <= maxcols ? ncols : maxcols * 2 / 3;
       cols1 = ncols <= maxcols ? 0 : maxcols - cols0;
       rows0 = nrows <= maxrows ? nrows : maxrows * 2 / 3;
@@ -396,8 +396,8 @@ bool HtmlWidget::styles_emitted = false;
 namespace py {
 
 oobj Frame::m__repr__() const {
-  size_t nrows = dt->nrows;
-  size_t ncols = dt->ncols;
+  size_t nrows = dt->nrows();
+  size_t ncols = dt->ncols();
   std::ostringstream out;
   out << "<Frame [" << nrows << " row" << (nrows == 1? "" : "s")
       << " x " << ncols << " col" << (ncols == 1? "" : "s") << "]>";

--- a/c/frame/__sizeof__.cc
+++ b/c/frame/__sizeof__.cc
@@ -76,9 +76,6 @@ size_t DataTable::memory_footprint() const noexcept {
       sz += py_names[i].get_sizeof();
     }
   }
-  if (groupby) {
-    sz += (groupby.ngroups() + 1) * sizeof(int32_t);
-  }
   return sz;
 }
 

--- a/c/frame/__sizeof__.cc
+++ b/c/frame/__sizeof__.cc
@@ -63,10 +63,10 @@ void Frame::_init_sizeof(XTypeMaker& xt) {
 size_t DataTable::memory_footprint() const noexcept {
   size_t sz = 0;
   sz += sizeof(*this);
-  sz += sizeof(Column) * columns.capacity();
+  sz += sizeof(Column) * columns_.capacity();
   sz += sizeof(std::string) * names.capacity();
   for (size_t i = 0; i < ncols_; ++i) {
-    sz += columns[i].memory_footprint();
+    sz += columns_[i].memory_footprint();
     sz += names[i].size();
   }
   if (py_names) {

--- a/c/frame/__sizeof__.cc
+++ b/c/frame/__sizeof__.cc
@@ -69,11 +69,11 @@ size_t DataTable::memory_footprint() const noexcept {
     sz += columns_[i].memory_footprint();
     sz += names_[i].size();
   }
-  if (py_names) {
-    sz += py_names.get_sizeof();
-    sz += py_inames.get_sizeof();
+  if (py_names_) {
+    sz += py_names_.get_sizeof();
+    sz += py_inames_.get_sizeof();
     for (size_t i = 0; i < ncols_; ++i) {
-      sz += py_names[i].get_sizeof();
+      sz += py_names_[i].get_sizeof();
     }
   }
   return sz;

--- a/c/frame/__sizeof__.cc
+++ b/c/frame/__sizeof__.cc
@@ -65,14 +65,14 @@ size_t DataTable::memory_footprint() const noexcept {
   sz += sizeof(*this);
   sz += sizeof(Column) * columns.capacity();
   sz += sizeof(std::string) * names.capacity();
-  for (size_t i = 0; i < ncols; ++i) {
+  for (size_t i = 0; i < ncols_; ++i) {
     sz += columns[i].memory_footprint();
     sz += names[i].size();
   }
   if (py_names) {
     sz += py_names.get_sizeof();
     sz += py_inames.get_sizeof();
-    for (size_t i = 0; i < ncols; ++i) {
+    for (size_t i = 0; i < ncols_; ++i) {
       sz += py_names[i].get_sizeof();
     }
   }

--- a/c/frame/__sizeof__.cc
+++ b/c/frame/__sizeof__.cc
@@ -64,10 +64,10 @@ size_t DataTable::memory_footprint() const noexcept {
   size_t sz = 0;
   sz += sizeof(*this);
   sz += sizeof(Column) * columns_.capacity();
-  sz += sizeof(std::string) * names.capacity();
+  sz += sizeof(std::string) * names_.capacity();
   for (size_t i = 0; i < ncols_; ++i) {
     sz += columns_[i].memory_footprint();
-    sz += names[i].size();
+    sz += names_[i].size();
   }
   if (py_names) {
     sz += py_names.get_sizeof();

--- a/c/frame/cbind.cc
+++ b/c/frame/cbind.cc
@@ -166,7 +166,7 @@ void DataTable::cbind(const std::vector<DataTable*>& datatables)
   }
 
   bool fix_columns = (nrows_ < final_nrows);
-  strvec newnames = names;
+  strvec newnames = names_;
   columns_.reserve(final_ncols);
 
   // NOTE: when appending a DataTable to itself, the following happens:
@@ -180,7 +180,7 @@ void DataTable::cbind(const std::vector<DataTable*>& datatables)
     for (size_t ii = 0; ii < dt->ncols(); ++ii) {
       columns_.push_back(dt->columns_[ii]);
     }
-    const auto& namesi = dt->names;
+    const strvec& namesi = dt->get_names();
     xassert(namesi.size() == dt->ncols());
     newnames.insert(newnames.end(), namesi.begin(), namesi.end());
   }

--- a/c/frame/cbind.cc
+++ b/c/frame/cbind.cc
@@ -167,7 +167,7 @@ void DataTable::cbind(const std::vector<DataTable*>& datatables)
 
   bool fix_columns = (nrows_ < final_nrows);
   strvec newnames = names;
-  columns.reserve(final_ncols);
+  columns_.reserve(final_ncols);
 
   // NOTE: when appending a DataTable to itself, the following happens:
   // we start changing `this->columns` vector, which thus becomes
@@ -178,18 +178,18 @@ void DataTable::cbind(const std::vector<DataTable*>& datatables)
   for (auto dt : datatables) {
     fix_columns |= (dt->nrows() < final_nrows);
     for (size_t ii = 0; ii < dt->ncols(); ++ii) {
-      columns.push_back(dt->columns[ii]);
+      columns_.push_back(dt->columns_[ii]);
     }
     const auto& namesi = dt->names;
     xassert(namesi.size() == dt->ncols());
     newnames.insert(newnames.end(), namesi.begin(), namesi.end());
   }
-  xassert(columns.size() == final_ncols);
+  xassert(columns_.size() == final_ncols);
   xassert(newnames.size() == final_ncols);
 
   // Fix up the DataTable's columns if they have different number of rows
   if (fix_columns) {
-    for (Column& col : columns) {
+    for (Column& col : columns_) {
       if (col.nrows() == 1) {
         col.repeat(final_nrows);
       } else {

--- a/c/frame/integrity_check.cc
+++ b/c/frame/integrity_check.cc
@@ -86,7 +86,7 @@ void py::Frame::integrity_check() {
 void DataTable::verify_integrity() const
 {
   XAssert(nkeys_ <= ncols_);
-  XAssert(columns.size() == ncols_);
+  XAssert(columns_.size() == ncols_);
   XAssert(names.size() == ncols_);
 
   _integrity_check_names();
@@ -102,7 +102,7 @@ void DataTable::verify_integrity() const
    */
   for (size_t i = 0; i < ncols_; ++i) {
     const std::string& col_name = names[i];
-    const Column& col = columns[i];
+    const Column& col = columns_[i];
     if (!col) {
       throw AssertionError() << col_name << " of Frame is empty";
     }

--- a/c/frame/integrity_check.cc
+++ b/c/frame/integrity_check.cc
@@ -87,7 +87,7 @@ void DataTable::verify_integrity() const
 {
   XAssert(nkeys_ <= ncols_);
   XAssert(columns_.size() == ncols_);
-  XAssert(names.size() == ncols_);
+  XAssert(names_.size() == ncols_);
 
   _integrity_check_names();
   _integrity_check_pynames();
@@ -101,7 +101,7 @@ void DataTable::verify_integrity() const
    * are equal to those of each column.
    */
   for (size_t i = 0; i < ncols_; ++i) {
-    const std::string& col_name = names[i];
+    const std::string& col_name = names_[i];
     const Column& col = columns_[i];
     if (!col) {
       throw AssertionError() << col_name << " of Frame is empty";
@@ -123,7 +123,7 @@ void DataTable::verify_integrity() const
   }
 
   for (size_t i = 0; i < ncols_; ++i) {
-    const std::string& name = names[i];
+    const std::string& name = names_[i];
     if (name.empty()) {
       throw AssertionError() << "Column " << i << " has empty name";
     }

--- a/c/frame/integrity_check.cc
+++ b/c/frame/integrity_check.cc
@@ -38,11 +38,11 @@ void py::Frame::integrity_check() {
       throw AssertionError() << "py::Frame.stypes is not a tuple";
     }
     auto stypes_tuple = py::robj(stypes).to_otuple();
-    if (stypes_tuple.size() != dt->ncols) {
+    if (stypes_tuple.size() != dt->ncols()) {
       throw AssertionError() << "len(.stypes) = " << stypes_tuple.size()
-          << " is different from .ncols = " << dt->ncols;
+          << " is different from .ncols = " << dt->ncols();
     }
-    for (size_t i = 0; i < dt->ncols; ++i) {
+    for (size_t i = 0; i < dt->ncols(); ++i) {
       SType col_stype = dt->get_column(i).stype();
       auto elem = stypes_tuple[i];
       auto eexp = info(col_stype).py_stype();
@@ -57,11 +57,11 @@ void py::Frame::integrity_check() {
       throw AssertionError() << "py::Frame.ltypes is not a tuple";
     }
     auto ltypes_tuple = py::robj(ltypes).to_otuple();
-    if (ltypes_tuple.size() != dt->ncols) {
+    if (ltypes_tuple.size() != dt->ncols()) {
       throw AssertionError() << "len(.ltypes) = " << ltypes_tuple.size()
-          << " is different from .ncols = " << dt->ncols;
+          << " is different from .ncols = " << dt->ncols();
     }
-    for (size_t i = 0; i < dt->ncols; ++i) {
+    for (size_t i = 0; i < dt->ncols(); ++i) {
       SType col_stype = dt->get_column(i).stype();
       auto elem = ltypes_tuple[i];
       auto eexp = info(col_stype).py_ltype();
@@ -85,10 +85,10 @@ void py::Frame::integrity_check() {
  */
 void DataTable::verify_integrity() const
 {
-  if (nkeys > ncols) {
+  if (nkeys > ncols_) {
     throw AssertionError()
         << "Number of keys is greater than the number of columns in the Frame: "
-        << nkeys << " > " << ncols;
+        << nkeys << " > " << ncols_;
   }
 
   _integrity_check_names();
@@ -96,15 +96,15 @@ void DataTable::verify_integrity() const
 
   // Check the number of columns; the number of allocated columns should be
   // equal to `ncols`.
-  if (columns.size() != ncols) {
+  if (columns.size() != ncols_) {
     throw AssertionError()
         << "DataTable.columns array size is " << columns.size()
-        << " whereas ncols = " << ncols;
+        << " whereas ncols = " << ncols_;
   }
-  if (names.size() != ncols) {
+  if (names.size() != ncols_) {
     throw AssertionError()
         << "Number of column names, " << names.size() << ", is not equal "
-           "to the number of columns in the Frame: " << ncols;
+           "to the number of columns in the Frame: " << ncols_;
   }
 
   /**
@@ -114,17 +114,17 @@ void DataTable::verify_integrity() const
    * nrows of each column, so we will just check that the datatable's values
    * are equal to those of each column.
    */
-  for (size_t i = 0; i < ncols; ++i) {
+  for (size_t i = 0; i < ncols_; ++i) {
     const std::string& col_name = names[i];
     const Column& col = columns[i];
     if (!col) {
       throw AssertionError() << col_name << " of Frame is empty";
     }
     // Make sure the column and the datatable have the same value for `nrows`
-    if (nrows != col.nrows()) {
+    if (nrows_ != col.nrows()) {
       throw AssertionError()
           << "Mismatch in `nrows`: " << col_name << ".nrows = " << col.nrows()
-          << ", while the Frame has nrows=" << nrows;
+          << ", while the Frame has nrows=" << nrows_;
     }
     try {
       col.verify_integrity();
@@ -136,7 +136,7 @@ void DataTable::verify_integrity() const
     }
   }
 
-  for (size_t i = 0; i < ncols; ++i) {
+  for (size_t i = 0; i < ncols_; ++i) {
     const std::string& name = names[i];
     if (name.empty()) {
       throw AssertionError() << "Column " << i << " has empty name";

--- a/c/frame/integrity_check.cc
+++ b/c/frame/integrity_check.cc
@@ -85,27 +85,13 @@ void py::Frame::integrity_check() {
  */
 void DataTable::verify_integrity() const
 {
-  if (nkeys > ncols_) {
-    throw AssertionError()
-        << "Number of keys is greater than the number of columns in the Frame: "
-        << nkeys << " > " << ncols_;
-  }
+  XAssert(nkeys_ <= ncols_);
+  XAssert(columns.size() == ncols_);
+  XAssert(names.size() == ncols_);
 
   _integrity_check_names();
   _integrity_check_pynames();
 
-  // Check the number of columns; the number of allocated columns should be
-  // equal to `ncols`.
-  if (columns.size() != ncols_) {
-    throw AssertionError()
-        << "DataTable.columns array size is " << columns.size()
-        << " whereas ncols = " << ncols_;
-  }
-  if (names.size() != ncols_) {
-    throw AssertionError()
-        << "Number of column names, " << names.size() << ", is not equal "
-           "to the number of columns in the Frame: " << ncols_;
-  }
 
   /**
    * Check the structure and contents of the column array.

--- a/c/frame/join.cc
+++ b/c/frame/join.cc
@@ -408,15 +408,6 @@ RowIndex natural_join(const DataTable* xdt, const DataTable* jdt) {
     jcols.push_back(i);
   }
 
-  // For now, we materialize the join columns. Later, we can add an ability
-  // to operate on the view columns as well, via the `as_view` flag (similar
-  // to the `group()` function). A frame can only be joined as a view if all
-  // its columns have the same rowindex (or at least all columns needed to
-  // compute the result).
-  for (size_t j : xcols) {
-    const_cast<DataTable*>(xdt)->get_column(j).materialize();
-  }
-
   arr32_t arr_result_indices(xdt->nrows);
   if (xdt->nrows) {
     int32_t* result_indices = arr_result_indices.data();

--- a/c/frame/join.cc
+++ b/c/frame/join.cc
@@ -392,7 +392,7 @@ static size_t binsearch(Cmp* cmp, size_t nrows) {
 
 // declared in datatable.h
 RowIndex natural_join(const DataTable* xdt, const DataTable* jdt) {
-  size_t k = jdt->get_nkeys();  // Number of join columns
+  size_t k = jdt->nkeys();  // Number of join columns
   xassert(k > 0);
 
   // Determine how key columns in `jdt` match the columns in `xdt`

--- a/c/frame/join.cc
+++ b/c/frame/join.cc
@@ -408,15 +408,15 @@ RowIndex natural_join(const DataTable* xdt, const DataTable* jdt) {
     jcols.push_back(i);
   }
 
-  arr32_t arr_result_indices(xdt->nrows);
-  if (xdt->nrows) {
+  arr32_t arr_result_indices(xdt->nrows());
+  if (xdt->nrows()) {
     int32_t* result_indices = arr_result_indices.data();
-    size_t nchunks = std::min(std::max(xdt->nrows / 200, size_t(1)),
+    size_t nchunks = std::min(std::max(xdt->nrows() / 200, size_t(1)),
                               dt::num_threads_in_pool());
     xassert(nchunks);
 
-    if (jdt->nrows == 0) {
-      dt::parallel_for_static(xdt->nrows,
+    if (jdt->nrows() == 0) {
+      dt::parallel_for_static(xdt->nrows(),
         [&](size_t i) {
           result_indices[i] = -1;
         });
@@ -427,11 +427,11 @@ RowIndex natural_join(const DataTable* xdt, const DataTable* jdt) {
           // Creating the comparator may fail if xcols and jcols are incompatible
           cmpptr comparator = _make_comparator(xdt, jdt, xcols, jcols);
 
-          dt::nested_for_static(xdt->nrows,
+          dt::nested_for_static(xdt->nrows(),
             [&](size_t i) {
               int r = comparator->set_xrow(i);
               if (r == 0) {
-                size_t j = binsearch(comparator.get(), jdt->nrows);
+                size_t j = binsearch(comparator.get(), jdt->nrows());
                 result_indices[i] = static_cast<int32_t>(j);
               } else {
                 result_indices[i] = -1;

--- a/c/frame/key.cc
+++ b/c/frame/key.cc
@@ -43,7 +43,7 @@ will be sorted. The values in the key columns must be unique.
 
 
 oobj Frame::get_key() const {
-  otuple key(dt->get_nkeys());
+  otuple key(dt->nkeys());
   otuple names = get_names().to_otuple();
   for (size_t i = 0; i < key.size(); ++i) {
     key.set(i, names[i]);
@@ -94,10 +94,6 @@ void Frame::_init_key(XTypeMaker& xt) {
 //------------------------------------------------------------------------------
 // DataTable API
 //------------------------------------------------------------------------------
-
-size_t DataTable::get_nkeys() const {
-  return nkeys_;
-}
 
 void DataTable::clear_key() {
   nkeys_ = 0;

--- a/c/frame/key.cc
+++ b/c/frame/key.cc
@@ -114,7 +114,7 @@ void DataTable::set_key(std::vector<size_t>& col_indices) {
   for (size_t i = 0; i < K; ++i) {
     for (size_t j = i + 1; j < K; ++j) {
       if (col_indices[i] == col_indices[j]) {
-        throw ValueError() << "Column `" << names[col_indices[i]] << "` is "
+        throw ValueError() << "Column `" << names_[col_indices[i]] << "` is "
           "specified multiple times within the key";
       }
     }

--- a/c/frame/key.cc
+++ b/c/frame/key.cc
@@ -96,17 +96,17 @@ void Frame::_init_key(XTypeMaker& xt) {
 //------------------------------------------------------------------------------
 
 size_t DataTable::get_nkeys() const {
-  return nkeys;
+  return nkeys_;
 }
 
 void DataTable::clear_key() {
-  nkeys = 0;
+  nkeys_ = 0;
 }
 
 
 void DataTable::set_key(std::vector<size_t>& col_indices) {
   if (col_indices.empty()) {
-    nkeys = 0;
+    nkeys_ = 0;
     return;
   }
   // Check that col_indices are unique
@@ -160,10 +160,10 @@ void DataTable::set_key(std::vector<size_t>& col_indices) {
 
   materialize();
 
-  nkeys = K;
+  nkeys_ = K;
 }
 
 
 void DataTable::set_nkeys_unsafe(size_t K) {
-  nkeys = K;
+  nkeys_ = K;
 }

--- a/c/frame/key.cc
+++ b/c/frame/key.cc
@@ -127,9 +127,9 @@ void DataTable::set_key(std::vector<size_t>& col_indices) {
   }
   auto res = group(ss);
   RowIndex ri = res.first;
-  xassert(ri.size() == nrows);
+  xassert(ri.size() == nrows_);
   // Note: it's possible to have ngroups > nrows, when grouping a 0-row Frame
-  if (res.second.ngroups() < nrows) {
+  if (res.second.ngroups() < nrows_) {
     throw ValueError() << "Cannot set a key: the values are not unique";
   }
 
@@ -140,17 +140,17 @@ void DataTable::set_key(std::vector<size_t>& col_indices) {
     }
     return false;
   };
-  for (size_t i = 0; i < ncols; ++i) {
+  for (size_t i = 0; i < ncols_; ++i) {
     if (!is_key_column(i)) {
       col_indices.push_back(i);
     }
   }
-  xassert(col_indices.size() == ncols);
+  xassert(col_indices.size() == ncols_);
 
   // Reorder the columns
   colvec new_columns;
-  new_columns.reserve(ncols);
-  for (size_t i = 0; i < ncols; ++i) {
+  new_columns.reserve(ncols_);
+  for (size_t i = 0; i < ncols_; ++i) {
     Column col = columns[col_indices[i]];  // copy
     col.apply_rowindex(ri);  // apply sort key
     new_columns.emplace_back(std::move(col));

--- a/c/frame/key.cc
+++ b/c/frame/key.cc
@@ -151,11 +151,11 @@ void DataTable::set_key(std::vector<size_t>& col_indices) {
   colvec new_columns;
   new_columns.reserve(ncols_);
   for (size_t i = 0; i < ncols_; ++i) {
-    Column col = columns[col_indices[i]];  // copy
+    Column col = columns_[col_indices[i]];  // copy
     col.apply_rowindex(ri);  // apply sort key
     new_columns.emplace_back(std::move(col));
   }
-  columns = std::move(new_columns);
+  columns_ = std::move(new_columns);
   reorder_names(col_indices);
 
   materialize();

--- a/c/frame/names.cc
+++ b/c/frame/names.cc
@@ -327,9 +327,9 @@ void DataTable::set_names(const py::olist& names_list, bool warn) {
 
 
 void DataTable::set_names(const strvec& names_list, bool warn) {
+  xassert(names_list.size() == ncols_);
   strvecNP np(names_list);
   _set_names_impl(&np, warn);
-  columns.resize(names.size());
 }
 
 

--- a/c/frame/names.cc
+++ b/c/frame/names.cc
@@ -295,11 +295,10 @@ size_t DataTable::xcolindex(const py::_obj& pyname) const {
  * Copy names without checking for validity, since we know they were already
  * verified in DataTable `other`.
  */
-void DataTable::copy_names_from(const DataTable* other) {
-  xassert(other);
-  names_ = other->names_;
-  py_names_ = other->py_names_;
-  py_inames_ = other->py_inames_;
+void DataTable::copy_names_from(const DataTable& other) {
+  names_ = other.names_;
+  py_names_ = other.py_names_;
+  py_inames_ = other.py_inames_;
 }
 
 

--- a/c/frame/names.cc
+++ b/c/frame/names.cc
@@ -322,7 +322,7 @@ void DataTable::set_names(const py::olist& names_list, bool warn) {
   if (!names_list) return set_names_to_default();
   pylistNP np(names_list);
   _set_names_impl(&np, warn);
-  columns.resize(names.size());
+  columns_.resize(names.size());
 }
 
 

--- a/c/frame/py_frame.cc
+++ b/c/frame/py_frame.cc
@@ -43,7 +43,7 @@ Return the first `n` rows of the frame, same as ``self[:n, :]``.
 
 oobj Frame::head(const PKArgs& args) {
   size_t n = std::min(args.get<size_t>(0, 10),
-                      dt->nrows);
+                      dt->nrows());
   return m__getitem__(otuple(oslice(0, static_cast<int64_t>(n), 1),
                              None()));
 }
@@ -61,9 +61,9 @@ Return the last `n` rows of the frame, same as ``self[-n:, :]``.
 
 oobj Frame::tail(const PKArgs& args) {
   size_t n = std::min(args.get<size_t>(0, 10),
-                      dt->nrows);
+                      dt->nrows());
   // Note: usual slice `-n::` doesn't work as expected when `n = 0`
-  int64_t start = static_cast<int64_t>(dt->nrows - n);
+  int64_t start = static_cast<int64_t>(dt->nrows() - n);
   return m__getitem__(otuple(oslice(start, oslice::NA, 1),
                              None()));
 }
@@ -136,7 +136,7 @@ void Frame::export_names(const PKArgs&) {
   py::oobj f = py::oobj::import("datatable", "f");
   py::odict globals = py::robj(PyEval_GetGlobals()).to_pydict();
   py::otuple names = dt->get_pynames();
-  for (size_t i = 0; i < dt->ncols; ++i) {
+  for (size_t i = 0; i < dt->ncols(); ++i) {
     py::robj name = names[i];
     globals.set(name, f.get_item(name));
   }
@@ -221,7 +221,7 @@ static GSArgs args_ncols(
   "Number of columns in the Frame\n");
 
 oobj Frame::get_ncols() const {
-  return py::oint(dt->ncols);
+  return py::oint(dt->ncols());
 }
 
 
@@ -237,7 +237,7 @@ Increasing the number of rows of a keyed Frame is not allowed.
 )");
 
 oobj Frame::get_nrows() const {
-  return py::oint(dt->nrows);
+  return py::oint(dt->nrows());
 }
 
 void Frame::set_nrows(const Arg& nr) {
@@ -278,7 +278,7 @@ static GSArgs args_stypes(
 
 oobj Frame::get_stypes() const {
   if (stypes == nullptr) {
-    py::otuple ostypes(dt->ncols);
+    py::otuple ostypes(dt->ncols());
     for (size_t i = 0; i < ostypes.size(); ++i) {
       SType st = dt->get_column(i).stype();
       ostypes.set(i, info(st).py_stype());
@@ -298,9 +298,9 @@ static GSArgs args_stype(
   "returns None.\n");
 
 oobj Frame::get_stype() const {
-  if (dt->ncols == 0) return None();
+  if (dt->ncols() == 0) return None();
   SType stype = dt->get_column(0).stype();
-  for (size_t i = 1; i < dt->ncols; ++i) {
+  for (size_t i = 1; i < dt->ncols(); ++i) {
     SType col_stype = dt->get_column(i).stype();
     if (col_stype != stype) {
       throw ValueError() << "The stype of column '" << dt->get_names()[i]
@@ -319,7 +319,7 @@ static GSArgs args_ltypes(
 
 oobj Frame::get_ltypes() const {
   if (ltypes == nullptr) {
-    py::otuple oltypes(dt->ncols);
+    py::otuple oltypes(dt->ncols());
     for (size_t i = 0; i < oltypes.size(); ++i) {
       SType st = dt->get_column(i).stype();
       oltypes.set(i, info(st).py_ltype());

--- a/c/frame/py_frame.cc
+++ b/c/frame/py_frame.cc
@@ -91,7 +91,7 @@ it was deep-copied.)"
 );
 
 oobj Frame::copy(const PKArgs&) {
-  oobj res = Frame::oframe(dt->copy());
+  oobj res = Frame::oframe(new DataTable(*dt));  // copy dt
   Frame* newframe = static_cast<Frame*>(res.to_borrowed_ref());
   newframe->stypes = stypes;  Py_XINCREF(stypes);
   newframe->ltypes = ltypes;  Py_XINCREF(ltypes);

--- a/c/frame/py_frame.cc
+++ b/c/frame/py_frame.cc
@@ -162,6 +162,10 @@ oobj Frame::oframe(DataTable* dt) {
   return oobj::from_new_reference(frame);
 }
 
+oobj Frame::oframe(DataTable&& dt) {
+  return oframe(new DataTable(std::move(dt)));
+}
+
 
 oobj Frame::oframe(robj src) {
   return robj(Frame_Type).call(otuple{src});

--- a/c/frame/py_frame.h
+++ b/c/frame/py_frame.h
@@ -61,6 +61,7 @@ class Frame : public XObject<Frame> {
     // Internal "constructor" of Frame objects. We do not use real constructors
     // because Frame objects must be allocated/initialized by Python.
     static oobj oframe(DataTable* dt);
+    static oobj oframe(DataTable&& dt);
 
     // Convert python object `src` into a py::Frame object. This is exactly
     // equivalent to calling `dt.Frame(src)` in python.

--- a/c/frame/rbind.cc
+++ b/c/frame/rbind.cc
@@ -112,7 +112,7 @@ void Frame::rbind(const PKArgs& args) {
     std::function<void(py::robj)> process_arg = [&](py::robj arg) {
       if (arg.is_frame()) {
         DataTable* df = arg.to_datatable();
-        if (df->nrows) dts.push_back(df);
+        if (df->nrows()) dts.push_back(df);
         ++j;
       }
       else if (arg.is_iterable()) {
@@ -136,7 +136,7 @@ void Frame::rbind(const PKArgs& args) {
   if (dts.empty()) return;
 
   strvec final_names = dt->get_names();  // copy the names
-  size_t n = dt->ncols;
+  size_t n = dt->ncols();
   if (n == 0) {
     final_names = dts[0]->get_names();
     n = final_names.size();
@@ -160,7 +160,7 @@ void Frame::rbind(const PKArgs& args) {
     }
     i = 0;
     for (DataTable* df : dts) {
-      if (!force) _check_ncols(n, df->ncols);
+      if (!force) _check_ncols(n, df->ncols());
       const strvec& dfnames = df->get_names();
       size_t j = 0;
       for (const auto& name : dfnames) {
@@ -193,18 +193,18 @@ void Frame::rbind(const PKArgs& args) {
   else {
     size_t i = 0;
     for (DataTable* df : dts) {
-      if (n != df->ncols) {
-        if (!force) _check_ncols(n, df->ncols);
-        if (n < df->ncols) {
+      if (n != df->ncols()) {
+        if (!force) _check_ncols(n, df->ncols());
+        if (n < df->ncols()) {
           const strvec& dfnames = df->get_names();
-          for (size_t j = n; j < df->ncols; ++j) {
+          for (size_t j = n; j < df->ncols(); ++j) {
             final_names.push_back(dfnames[j]);
             cols.push_back(intvec(dts.size(), INVALID_INDEX));
           }
-          n = df->ncols;
+          n = df->ncols();
         }
       }
-      for (size_t j = 0; j < df->ncols; ++j) {
+      for (size_t j = 0; j < df->ncols(); ++j) {
         cols[j][i] = j;
       }
       ++i;
@@ -270,16 +270,16 @@ void DataTable::rbind(
     const std::vector<intvec>& col_indices)
 {
   size_t new_ncols = col_indices.size();
-  xassert(new_ncols >= ncols);
+  xassert(new_ncols >= ncols_);
 
   columns.reserve(new_ncols);
-  for (size_t i = ncols; i < new_ncols; ++i) {
-    columns.push_back(Column::new_na_column(nrows));
+  for (size_t i = ncols_; i < new_ncols; ++i) {
+    columns.push_back(Column::new_na_column(nrows_));
   }
 
-  size_t new_nrows = this->nrows;
+  size_t new_nrows = nrows_;
   for (auto dt : dts) {
-    new_nrows += dt->nrows;
+    new_nrows += dt->nrows();
   }
 
   colvec cols_to_append(dts.size());
@@ -287,14 +287,14 @@ void DataTable::rbind(
     for (size_t j = 0; j < dts.size(); ++j) {
       size_t k = col_indices[i][j];
       Column col = (k == INVALID_INDEX)
-                      ? Column::new_na_column(dts[j]->nrows)
+                      ? Column::new_na_column(dts[j]->nrows())
                       : dts[j]->get_column(k);
       cols_to_append[j] = std::move(col);
     }
     columns[i].rbind(cols_to_append);
   }
-  ncols = new_ncols;
-  nrows = new_nrows;
+  ncols_ = new_ncols;
+  nrows_ = new_nrows;
 }
 
 

--- a/c/frame/rbind.cc
+++ b/c/frame/rbind.cc
@@ -272,9 +272,9 @@ void DataTable::rbind(
   size_t new_ncols = col_indices.size();
   xassert(new_ncols >= ncols_);
 
-  columns.reserve(new_ncols);
+  columns_.reserve(new_ncols);
   for (size_t i = ncols_; i < new_ncols; ++i) {
-    columns.push_back(Column::new_na_column(nrows_));
+    columns_.push_back(Column::new_na_column(nrows_));
   }
 
   size_t new_nrows = nrows_;
@@ -291,7 +291,7 @@ void DataTable::rbind(
                       : dts[j]->get_column(k);
       cols_to_append[j] = std::move(col);
     }
-    columns[i].rbind(cols_to_append);
+    columns_[i].rbind(cols_to_append);
   }
   ncols_ = new_ncols;
   nrows_ = new_nrows;

--- a/c/frame/repeat.cc
+++ b/c/frame/repeat.cc
@@ -49,12 +49,12 @@ static oobj repeat(const PKArgs& args) {
   size_t n = args[1].to_size_t();
 
   // Empty Frame: repeating is a noop
-  if (dt->ncols == 0 || dt->nrows == 0) {
+  if (dt->ncols() == 0 || dt->nrows() == 0) {
     return Frame::oframe(dt->copy());
   }
 
-  colvec newcols(dt->ncols);
-  for (size_t i = 0; i < dt->ncols; ++i) {
+  colvec newcols(dt->ncols());
+  for (size_t i = 0; i < dt->ncols(); ++i) {
     newcols[i] = dt->get_column(i);  // copy
     newcols[i].repeat(n);
   }

--- a/c/frame/repeat.cc
+++ b/c/frame/repeat.cc
@@ -50,7 +50,7 @@ static oobj repeat(const PKArgs& args) {
 
   // Empty Frame: repeating is a noop
   if (dt->ncols() == 0 || dt->nrows() == 0) {
-    return Frame::oframe(dt->copy());
+    return Frame::oframe(new DataTable(*dt));
   }
 
   colvec newcols(dt->ncols());

--- a/c/frame/repeat.cc
+++ b/c/frame/repeat.cc
@@ -59,7 +59,7 @@ static oobj repeat(const PKArgs& args) {
     newcols[i].repeat(n);
   }
   DataTable* newdt = new DataTable(std::move(newcols),
-                                   dt);  // copy names from dt
+                                   *dt);  // copy names from dt
   return Frame::oframe(newdt);
 }
 

--- a/c/frame/replace.cc
+++ b/c/frame/replace.cc
@@ -157,7 +157,7 @@ void Frame::replace(const PKArgs& args) {
   ra.parse_x_y(x, y);
   ra.split_x_y_by_type();
 
-  for (size_t i = 0; i < dt->ncols; ++i) {
+  for (size_t i = 0; i < dt->ncols(); ++i) {
     // If a column is a view, then: for a fixed-width column it gets
     // materialized when we request `col->elements_w()`; on the other hand,
     // a string column remains a view, however the iterator `dt::map_str2str`
@@ -260,7 +260,7 @@ void ReplaceAgent::split_x_y_by_type() {
        done_real = false,
        done_bool = false,
        done_str = false;
-  for (size_t i = 0; i < dt->ncols; ++i) {
+  for (size_t i = 0; i < dt->ncols(); ++i) {
     SType s = dt->get_column(i).stype();
     switch (s) {
       case SType::BOOL: {

--- a/c/frame/replace.cc
+++ b/c/frame/replace.cc
@@ -565,12 +565,12 @@ void ReplaceAgent::process_real_column(size_t colidx) {
 
 void ReplaceAgent::process_str_column(size_t colidx) {
   if (x_str.empty()) return;
-  Column& col = dt->get_column(colidx);
+  const Column& col = dt->get_column(colidx);
   if (x_str.size() == 1 && x_str[0].isna()) {
     if (col.na_count() == 0) return;
   }
   Column newcol = replace_str(x_str.size(), x_str.data(), y_str.data(), col);
-  columns_cast = (newcol.stype() != col.stype());
+  columns_cast |= (newcol.stype() != col.stype());
   dt->set_column(colidx, std::move(newcol));
 }
 

--- a/c/frame/stats.cc
+++ b/c/frame/stats.cc
@@ -45,7 +45,7 @@ static DataTable* _make_frame(DataTable* dt, Stat stat) {
     const Column& dtcol = dt->get_column(i);
     out_cols.push_back(dtcol.stats()->get_stat_as_column(stat));
   }
-  return new DataTable(std::move(out_cols), dt);
+  return new DataTable(std::move(out_cols), *dt);
 }
 
 

--- a/c/frame/stats.cc
+++ b/c/frame/stats.cc
@@ -40,8 +40,8 @@ static std::unordered_map<const PKArgs*, Stat> stat_from_args;
 
 static DataTable* _make_frame(DataTable* dt, Stat stat) {
   colvec out_cols;
-  out_cols.reserve(dt->ncols);
-  for (size_t i = 0; i < dt->ncols; ++i) {
+  out_cols.reserve(dt->ncols());
+  for (size_t i = 0; i < dt->ncols(); ++i) {
     const Column& dtcol = dt->get_column(i);
     out_cols.push_back(dtcol.stats()->get_stat_as_column(stat));
   }
@@ -82,7 +82,7 @@ static PKArgs args_nmodal1(0, 0, 0, false, false, {}, "nmodal1", nullptr);
 static PKArgs args_nunique1(0, 0, 0, false, false, {}, "nunique1", nullptr);
 
 oobj Frame::stat1(const PKArgs& args) {
-  if (dt->ncols != 1) {
+  if (dt->ncols() != 1) {
     throw ValueError() << "This method can only be applied to a 1-column Frame";
   }
   const Column& col0 = dt->get_column(0);

--- a/c/frame/to_numpy.cc
+++ b/c/frame/to_numpy.cc
@@ -138,7 +138,7 @@ oobj Frame::to_numpy(const PKArgs& args) {
         size_t row0 = irow * rows_per_chunk;
         size_t row1 = irow == n_row_chunks-1? dt->nrows : row0 + rows_per_chunk;
         bool* mask_ptr = mask_data + icol * dt->nrows;
-        Column& col = dt->get_column(icol + i0);
+        const Column& col = dt->get_column(icol + i0);
         col.fill_npmask(mask_ptr, row0, row1);
       });
 

--- a/c/frame/to_python.cc
+++ b/c/frame/to_python.cc
@@ -54,17 +54,17 @@ Examples
 
 oobj Frame::to_tuples(const PKArgs&) {
   std::vector<py::otuple> list_of_tuples;
-  for (size_t i = 0; i < dt->nrows; ++i) {
-    list_of_tuples.push_back(py::otuple(dt->ncols));
+  for (size_t i = 0; i < dt->nrows(); ++i) {
+    list_of_tuples.push_back(py::otuple(dt->ncols()));
   }
-  for (size_t j = 0; j < dt->ncols; ++j) {
+  for (size_t j = 0; j < dt->ncols(); ++j) {
     const Column& col = dt->get_column(j);
-    for (size_t i = 0; i < dt->nrows; ++i) {
+    for (size_t i = 0; i < dt->nrows(); ++i) {
       list_of_tuples[i].set(j, col.get_element_as_pyobject(i));
     }
   }
-  py::olist res(dt->nrows);
-  for (size_t i = 0; i < dt->nrows; ++i) {
+  py::olist res(dt->nrows());
+  for (size_t i = 0; i < dt->nrows(); ++i) {
     res.set(i, std::move(list_of_tuples[i]));
   }
   return std::move(res);
@@ -92,11 +92,11 @@ Examples
 )");
 
 oobj Frame::to_list(const PKArgs&) {
-  py::olist res(dt->ncols);
-  for (size_t j = 0; j < dt->ncols; ++j) {
-    py::olist pycol(dt->nrows);
+  py::olist res(dt->ncols());
+  for (size_t j = 0; j < dt->ncols(); ++j) {
+    py::olist pycol(dt->nrows());
     const Column& col = dt->get_column(j);
-    for (size_t i = 0; i < dt->nrows; ++i) {
+    for (size_t i = 0; i < dt->nrows(); ++i) {
       pycol.set(i, col.get_element_as_pyobject(i));
     }
     res.set(j, std::move(pycol));
@@ -128,10 +128,10 @@ Examples
 oobj Frame::to_dict(const PKArgs&) {
   py::otuple names = dt->get_pynames();
   py::odict res;
-  for (size_t j = 0; j < dt->ncols; ++j) {
-    py::olist pycol(dt->nrows);
+  for (size_t j = 0; j < dt->ncols(); ++j) {
+    py::olist pycol(dt->nrows());
     const Column& col = dt->get_column(j);
-    for (size_t i = 0; i < dt->nrows; ++i) {
+    for (size_t i = 0; i < dt->nrows(); ++i) {
       pycol.set(i, col.get_element_as_pyobject(i));
     }
     res.set(names[j], pycol);

--- a/c/jay/save_jay.cc
+++ b/c/jay/save_jay.cc
@@ -66,10 +66,10 @@ void DataTable::save_jay_impl(WritableBuffer* wb) {
     const Column& col = get_column(i);
     if (col.stype() == SType::OBJ) {
       auto w = DatatableWarning();
-      w << "Column `" << names[i] << "` of type obj64 was not saved";
+      w << "Column `" << names_[i] << "` of type obj64 was not saved";
       w.emit();
     } else {
-      auto saved_col = column_to_jay(col, names[i], fbb, wb);
+      auto saved_col = column_to_jay(col, names_[i], fbb, wb);
       msg_columns.push_back(saved_col);
     }
   }

--- a/c/jay/save_jay.cc
+++ b/c/jay/save_jay.cc
@@ -17,7 +17,7 @@
 using WritableBufferPtr = std::unique_ptr<WritableBuffer>;
 static jay::Type stype_to_jaytype[DT_STYPES_COUNT];
 static flatbuffers::Offset<jay::Column> column_to_jay(
-    Column& col, const std::string& name,
+    const Column& col, const std::string& name,
     flatbuffers::FlatBufferBuilder& fbb, WritableBuffer* wb);
 static jay::Buffer saveMemoryRange(const void*, size_t, WritableBuffer*);
 template <typename T, typename StatBuilder>
@@ -63,7 +63,7 @@ void DataTable::save_jay_impl(WritableBuffer* wb) {
 
   std::vector<flatbuffers::Offset<jay::Column>> msg_columns;
   for (size_t i = 0; i < ncols; ++i) {
-    Column& col = get_column(i);
+    const Column& col = get_column(i);
     if (col.stype() == SType::OBJ) {
       auto w = DatatableWarning();
       w << "Column `" << names[i] << "` of type obj64 was not saved";
@@ -102,7 +102,7 @@ void DataTable::save_jay_impl(WritableBuffer* wb) {
 //------------------------------------------------------------------------------
 
 static flatbuffers::Offset<jay::Column> column_to_jay(
-    Column& col,
+    const Column& col,
     const std::string& name,
     flatbuffers::FlatBufferBuilder& fbb,
     WritableBuffer* wb)

--- a/c/jay/save_jay.cc
+++ b/c/jay/save_jay.cc
@@ -78,7 +78,7 @@ void DataTable::save_jay_impl(WritableBuffer* wb) {
   auto frame = jay::CreateFrameDirect(fbb,
                   nrows_,
                   msg_columns.size(),
-                  static_cast<int>(nkeys),
+                  static_cast<int>(nkeys_),
                   &msg_columns);
   fbb.Finish(frame);
 

--- a/c/jay/save_jay.cc
+++ b/c/jay/save_jay.cc
@@ -62,7 +62,7 @@ void DataTable::save_jay_impl(WritableBuffer* wb) {
   flatbuffers::FlatBufferBuilder fbb(1024);
 
   std::vector<flatbuffers::Offset<jay::Column>> msg_columns;
-  for (size_t i = 0; i < ncols; ++i) {
+  for (size_t i = 0; i < ncols_; ++i) {
     const Column& col = get_column(i);
     if (col.stype() == SType::OBJ) {
       auto w = DatatableWarning();
@@ -76,7 +76,7 @@ void DataTable::save_jay_impl(WritableBuffer* wb) {
   xassert((wb->size() & 7) == 0);
 
   auto frame = jay::CreateFrameDirect(fbb,
-                  nrows,
+                  nrows_,
                   msg_columns.size(),
                   static_cast<int>(nkeys),
                   &msg_columns);

--- a/c/models/aggregator.cc
+++ b/c/models/aggregator.cc
@@ -310,7 +310,7 @@ void Aggregator<T>::aggregate(DataTable* dt_in,
 
   // Do not aggregate `dt` in-place, instead, make a shallow copy
   // and apply rowindex based on the `exemplar_id`s gathered in `dt_members`.
-  dt_exemplars = dtptr(dt->copy());
+  dt_exemplars = dtptr(new DataTable(dt->copy()));
   {
     job.set_message("Finalizing");
     dt::progress::subtask subjob(job, WORK_FINALIZE);

--- a/c/models/aggregator.cc
+++ b/c/models/aggregator.cc
@@ -234,13 +234,13 @@ void Aggregator<T>::aggregate(DataTable* dt_in,
   dt = dt_in;
   bool was_sampled = false;
 
-  Column col0 = Column::new_data_column(dt->nrows, SType::INT32);
+  Column col0 = Column::new_data_column(dt->nrows(), SType::INT32);
   dt_members = dtptr(new DataTable({std::move(col0)}, {"exemplar_id"}));
 
-  if (dt->nrows >= min_rows) {
+  if (dt->nrows() >= min_rows) {
     colvec catcols;
     size_t ncols, max_bins;
-    contconvs.reserve(dt->ncols);
+    contconvs.reserve(dt->ncols());
     ccptr<T> contconv;
 
     // Number of possible `N/A` bins for a particular aggregator.
@@ -248,7 +248,7 @@ void Aggregator<T>::aggregate(DataTable* dt_in,
 
     // Create a column convertor for each numeric columns,
     // and create a vector of categoricals.
-    for (size_t i = 0; i < dt->ncols; ++i) {
+    for (size_t i = 0; i < dt->ncols(); ++i) {
       bool is_continuous = true;
       const Column& col = dt->get_column(i);
       switch (col.stype()) {
@@ -259,7 +259,7 @@ void Aggregator<T>::aggregate(DataTable* dt_in,
         case SType::INT64:   contconv = ccptr<T>(new ColumnConvertorReal<int64_t, T>(col)); break;
         case SType::FLOAT32: contconv = ccptr<T>(new ColumnConvertorReal<float, T>(col)); break;
         case SType::FLOAT64: contconv = ccptr<T>(new ColumnConvertorReal<double, T>(col)); break;
-        default:             if (dt->ncols < 3) {
+        default:             if (dt->ncols() < 3) {
                                is_continuous = false;
                                catcols.push_back(dt->get_column(i));
                              }
@@ -270,7 +270,7 @@ void Aggregator<T>::aggregate(DataTable* dt_in,
     }
 
     dt_cat = dtptr(new DataTable(std::move(catcols), DataTable::default_names));
-    ncols = contconvs.size() + dt_cat->ncols;
+    ncols = contconvs.size() + dt_cat->ncols();
     job.add_done_amount(WORK_PREPARE);
 
     // Depending on number of columns call a corresponding aggregating method.
@@ -352,7 +352,7 @@ bool Aggregator<T>::sample_exemplars(size_t max_bins, size_t n_na_bins)
     auto d_members = static_cast<int32_t*>(dt_members->get_column(0).get_data_editable());
 
     // First, set all `exemplar_id`s to `N/A`.
-    for (size_t i = 0; i < dt_members->nrows; ++i) {
+    for (size_t i = 0; i < dt_members->nrows(); ++i) {
       d_members[i] = GETNA<int32_t>();
     }
 
@@ -452,13 +452,13 @@ void Aggregator<T>::aggregate_exemplars(bool was_sampled) {
  */
 template <typename T>
 void Aggregator<T>::group_0d() {
-  if (dt->ncols > 0) {
+  if (dt->ncols() > 0) {
     std::vector<sort_spec> spec = {sort_spec(0, false, false, true)};
     auto res = dt->group(spec);
     RowIndex ri_exemplars = std::move(res.first);
 
     auto d_members = static_cast<int32_t*>(dt_members->get_column(0).get_data_editable());
-    ri_exemplars.iterate(0, dt->nrows, 1,
+    ri_exemplars.iterate(0, dt->nrows(), 1,
       [&](size_t i, size_t j) {
         d_members[j] = static_cast<int32_t>(i);
       });
@@ -900,7 +900,7 @@ void Aggregator<T>::adjust_members(std::vector<size_t>& ids) {
       map[i] = (ids[i] == i) ? i : calculate_map(ids, i);
     });
 
-  dt::parallel_for_static(dt_members->nrows,
+  dt::parallel_for_static(dt_members->nrows(),
     [&](size_t i) {
       auto j = static_cast<size_t>(d_members[i]);
       d_members[i] = static_cast<int32_t>(map[j]);

--- a/c/models/aggregator.cc
+++ b/c/models/aggregator.cc
@@ -310,7 +310,7 @@ void Aggregator<T>::aggregate(DataTable* dt_in,
 
   // Do not aggregate `dt` in-place, instead, make a shallow copy
   // and apply rowindex based on the `exemplar_id`s gathered in `dt_members`.
-  dt_exemplars = dtptr(new DataTable(dt->copy()));
+  dt_exemplars = dtptr(new DataTable(*dt));
   {
     job.set_message("Finalizing");
     dt::progress::subtask subjob(job, WORK_FINALIZE);

--- a/c/models/aggregator.h
+++ b/c/models/aggregator.h
@@ -32,6 +32,7 @@ using ccptr = typename std::unique_ptr<ColumnConvertor<T>>;
 template <typename T>
 using ccptrvec = typename std::vector<ccptr<T>>;
 
+using dtptr = std::unique_ptr<DataTable>;
 
 /**
  *  Aggregator base class.

--- a/c/models/dt_ftrl.cc
+++ b/c/models/dt_ftrl.cc
@@ -191,7 +191,7 @@ void Ftrl<T>::create_y_binomial(const DataTable* dt,
 
   // If we only got NA targets, return to stop training.
   if (dt_labels_in == nullptr) return;
-  size_t nlabels_in = dt_labels_in->nrows;
+  size_t nlabels_in = dt_labels_in->nrows();
 
   if (nlabels_in > 2) {
     throw ValueError() << "For binomial regression target column should have "
@@ -206,7 +206,7 @@ void Ftrl<T>::create_y_binomial(const DataTable* dt,
   } else {
 
     RowIndex ri_join = natural_join(dt_labels_in.get(), dt_labels.get());
-    size_t nlabels = dt_labels->nrows;
+    size_t nlabels = dt_labels->nrows();
     xassert(nlabels != 0 && nlabels < 3);
     auto data_label_ids_in = static_cast<int8_t*>(
                               dt_labels_in->get_column(1).get_data_editable());
@@ -286,7 +286,7 @@ inline U itarget(U y, size_t label_indicator) {
 template <typename T>
 template <typename U>
 FtrlFitOutput Ftrl<T>::fit_regression() {
-  xassert(dt_y_train->ncols == 1);
+  xassert(dt_y_train->ncols() == 1);
   if (is_model_trained() && model_type != FtrlModelType::REGRESSION) {
     throw TypeError() << "This model has already been trained in a "
                          "mode different from regression. To train it "
@@ -393,7 +393,7 @@ void Ftrl<T>::create_y_multinomial(const DataTable* dt,
 
   auto data_label_ids_in = static_cast<const int32_t*>(
                               dt_labels_in->get_column(1).get_data_readonly());
-  size_t nlabels_in = dt_labels_in->nrows;
+  size_t nlabels_in = dt_labels_in->nrows();
 
   // When we only start training, all the incoming labels become the model
   // labels. Mapping is trivial in this case.
@@ -411,7 +411,7 @@ void Ftrl<T>::create_y_multinomial(const DataTable* dt,
     auto data_label_ids = static_cast<const int32_t*>(
                             dt_labels->get_column(1).get_data_readonly());
     RowIndex ri_join = natural_join(dt_labels_in.get(), dt_labels.get());
-    size_t nlabels = dt_labels->nrows;
+    size_t nlabels = dt_labels->nrows();
 
     for (size_t i = 0; i < nlabels; ++i) {
       label_ids.push_back(std::numeric_limits<size_t>::max());
@@ -448,7 +448,7 @@ void Ftrl<T>::create_y_multinomial(const DataTable* dt,
       new_label_indices.resize(n_new_labels);
       RowIndex ri_labels(std::move(new_label_indices));
       dt_labels_in->apply_rowindex(ri_labels);
-      set_ids(dt_labels_in->get_column(1), static_cast<int32_t>(dt_labels->nrows));
+      set_ids(dt_labels_in->get_column(1), static_cast<int32_t>(dt_labels->nrows()));
       dt_labels->rbind({ dt_labels_in.get() }, {{ 0 } , { 1 }});
 
       // It is necessary to re-key the column, because there is no guarantee
@@ -488,7 +488,7 @@ FtrlFitOutput Ftrl<T>::fit(T(*linkfn)(T),
   // Training settings. By default each training iteration consists of
   // `dt_X_train->nrows` rows.
   size_t niterations = nepochs;
-  size_t iteration_nrows = dt_X_train->nrows;
+  size_t iteration_nrows = dt_X_train->nrows();
   size_t total_nrows = niterations * iteration_nrows;
   size_t iteration_end;
 
@@ -505,7 +505,7 @@ FtrlFitOutput Ftrl<T>::fit(T(*linkfn)(T),
                                             : target_col0_train;  // whatever
   if (validation) {
     hashers_val = create_hashers(dt_X_val);
-    iteration_nrows = static_cast<size_t>(nepochs_val * dt_X_train->nrows);
+    iteration_nrows = static_cast<size_t>(nepochs_val * dt_X_train->nrows());
     niterations = total_nrows / iteration_nrows;
     loss_history.resize(val_niters, 0.0);
   }
@@ -518,7 +518,7 @@ FtrlFitOutput Ftrl<T>::fit(T(*linkfn)(T),
   // validation.
   size_t work_total = (niterations - 1) * get_work_amount(iteration_nrows);
   work_total += get_work_amount(total_nrows - (niterations - 1) * iteration_nrows);
-  if (validation) work_total += niterations * get_work_amount(dt_X_val->nrows);
+  if (validation) work_total += niterations * get_work_amount(dt_X_val->nrows());
 
   // Set work amount to be reported by the zero thread.
   dt::progress::work job(work_total);
@@ -540,7 +540,7 @@ FtrlFitOutput Ftrl<T>::fit(T(*linkfn)(T),
 
         // Training.
         dt::nested_for_static(iteration_size, ChunkSize(MIN_ROWS_PER_THREAD), [&](size_t i) {
-          size_t ii = (iteration_start + i) % dt_X_train->nrows;
+          size_t ii = (iteration_start + i) % dt_X_train->nrows();
           U value;
           bool isvalid = target_col0_train.get_element(ii, &value);
 
@@ -577,7 +577,7 @@ FtrlFitOutput Ftrl<T>::fit(T(*linkfn)(T),
           dt::atomic<T> loss_global {0.0};
           T loss_local = 0.0;
 
-          dt::nested_for_static(dt_X_val->nrows, ChunkSize(MIN_ROWS_PER_THREAD), [&](size_t i) {
+          dt::nested_for_static(dt_X_val->nrows(), ChunkSize(MIN_ROWS_PER_THREAD), [&](size_t i) {
             V value;
             bool isvalid = target_col0_val.get_element(i, &value);
 
@@ -607,7 +607,7 @@ FtrlFitOutput Ftrl<T>::fit(T(*linkfn)(T),
           // more than `val_error`, sets `loss_old` to `NaN` -> this will stop
           // all the threads after `barrier()`.
           if (dt::this_thread_index() == 0) {
-            T loss_current = loss_global.load() / (dt_X_val->nrows * dt_y_val->ncols);
+            T loss_current = loss_global.load() / (dt_X_val->nrows() * dt_y_val->ncols());
             loss_history[iter % val_niters] = loss_current / val_niters;
             loss = std::accumulate(loss_history.begin(), loss_history.end(), T_ZERO);
             T loss_diff = (loss_old - loss) / loss_old;
@@ -642,7 +642,7 @@ FtrlFitOutput Ftrl<T>::fit(T(*linkfn)(T),
   // in `py::Validator::has_negatives()` during unpickling.
   reset_model_stats();
 
-  double epoch_stopped = static_cast<double>(iteration_end) / dt_X_train->nrows;
+  double epoch_stopped = static_cast<double>(iteration_end) / dt_X_train->nrows();
   FtrlFitOutput res = {epoch_stopped, static_cast<double>(loss)};
 
   return res;
@@ -734,12 +734,12 @@ dtptr Ftrl<T>::predict(const DataTable* dt_X) {
   auto hashers = create_hashers(dt_X);
 
   // Create datatable for predictions and obtain column data pointers.
-  size_t nlabels = dt_labels->nrows;
+  size_t nlabels = dt_labels->nrows();
 
   auto data_label_ids = static_cast<const U*>(
                             dt_labels->get_column(1).get_data_readonly());
 
-  dtptr dt_p = create_p(dt_X->nrows);
+  dtptr dt_p = create_p(dt_X->nrows());
   std::vector<T*> data_p(nlabels);
   for (size_t i = 0; i < nlabels; ++i) {
     data_p[i] = static_cast<T*>(dt_p->get_column(i).get_data_editable());
@@ -757,12 +757,12 @@ dtptr Ftrl<T>::predict(const DataTable* dt_X) {
                                  << "the model was trained in an unknown mode";
   }
 
-  size_t nthreads = get_nthreads(dt_X->nrows);
+  size_t nthreads = get_nthreads(dt_X->nrows());
   nthreads = std::min(std::max(nthreads, 1lu), dt::num_threads_in_pool());
   bool k_binomial;
 
   // Set progress reporting
-  size_t work_total = dt_X->nrows / nthreads;
+  size_t work_total = dt_X->nrows() / nthreads;
   dt::progress::work job(work_total);
   job.set_message("Predicting");
 
@@ -770,7 +770,7 @@ dtptr Ftrl<T>::predict(const DataTable* dt_X) {
     uint64ptr x = uint64ptr(new uint64_t[nfeatures]);
     tptr<T> w = tptr<T>(new T[nfeatures]);
 
-    dt::nested_for_static(dt_X->nrows, [&](size_t i) {
+    dt::nested_for_static(dt_X->nrows(), [&](size_t i) {
       // Predicting for all the `nlabels`
       hash_row(x, hashers, i);
       for (size_t k = 0; k < nlabels; ++k) {
@@ -792,7 +792,7 @@ dtptr Ftrl<T>::predict(const DataTable* dt_X) {
   job.done();
 
   if (model_type == FtrlModelType::BINOMIAL) {
-    dt::parallel_for_static(dt_X->nrows, [&](size_t i){
+    dt::parallel_for_static(dt_X->nrows(), [&](size_t i){
       data_p[k_binomial][i] = T_ONE - data_p[!k_binomial][i];
     });
   }
@@ -811,8 +811,8 @@ dtptr Ftrl<T>::predict(const DataTable* dt_X) {
  */
 template <typename T>
 void Ftrl<T>::normalize_rows(dtptr& dt) {
-  size_t nrows = dt->nrows;
-  size_t ncols = dt->ncols;
+  size_t nrows = dt->nrows();
+  size_t ncols = dt->ncols();
 
   std::vector<T*> data(ncols);
   for (size_t j = 0; j < ncols; ++j) {
@@ -837,7 +837,7 @@ void Ftrl<T>::normalize_rows(dtptr& dt) {
  */
 template <typename T>
 void Ftrl<T>::create_model() {
-  size_t nlabels = (dt_labels == nullptr)? 0 : dt_labels->nrows;
+  size_t nlabels = (dt_labels == nullptr)? 0 : dt_labels->nrows();
   size_t ncols = (model_type == FtrlModelType::BINOMIAL)? 2 : 2 * nlabels;
 
   colvec cols;
@@ -859,8 +859,8 @@ void Ftrl<T>::create_model() {
  */
 template <typename T>
 void Ftrl<T>::adjust_model() {
-  size_t ncols_model = dt_model->ncols;
-  size_t ncols_model_new = 2 * dt_labels->nrows;
+  size_t ncols_model = dt_model->ncols();
+  size_t ncols_model_new = 2 * dt_labels->nrows();
   xassert(ncols_model_new > ncols_model)
 
   colvec cols;
@@ -901,7 +901,7 @@ void Ftrl<T>::adjust_model() {
  */
 template <typename T>
 dtptr Ftrl<T>::create_p(size_t nrows) {
-  size_t nlabels = dt_labels->nrows;
+  size_t nlabels = dt_labels->nrows();
   xassert(nlabels > 0);
 
   Column col0_str64 = dt_labels->get_column(0).cast(SType::STR64);
@@ -947,7 +947,7 @@ void Ftrl<T>::reset() {
 template <typename T>
 void Ftrl<T>::init_model() {
   if (dt_model == nullptr) return;
-  for (size_t i = 0; i < dt_model->ncols; ++i) {
+  for (size_t i = 0; i < dt_model->ncols(); ++i) {
     auto data = static_cast<T*>(dt_model->get_column(i).get_data_editable());
     std::memset(data, 0, nbins * sizeof(T));
   }
@@ -960,7 +960,7 @@ void Ftrl<T>::init_model() {
  template <typename T>
  void Ftrl<T>::reset_model_stats() {
   if (dt_model == nullptr) return;
-  for (size_t i = 0; i < dt_model->ncols; ++i) {
+  for (size_t i = 0; i < dt_model->ncols(); ++i) {
     (dt_model->get_column(i)).reset_stats();
   }
 }
@@ -971,7 +971,7 @@ void Ftrl<T>::init_model() {
  */
 template <typename T>
 void Ftrl<T>::init_weights() {
-  size_t model_ncols = dt_model->ncols;
+  size_t model_ncols = dt_model->ncols();
   xassert(model_ncols % 2 == 0);
   size_t nlabels = model_ncols / 2;
   z.clear();
@@ -1039,7 +1039,7 @@ void Ftrl<T>::init_fi() {
  */
 template <typename T>
 void Ftrl<T>::define_features() {
-  nfeatures = dt_X_train->ncols + interactions.size();
+  nfeatures = dt_X_train->ncols() + interactions.size();
 }
 
 
@@ -1050,10 +1050,10 @@ template <typename T>
 std::vector<hasherptr> Ftrl<T>::create_hashers(const DataTable* dt) {
   std::vector<hasherptr> hashers;
   hashers.clear();
-  hashers.reserve(dt->ncols);
+  hashers.reserve(dt->ncols());
 
   // Create hashers.
-  for (size_t i = 0; i < dt->ncols; ++i) {
+  for (size_t i = 0; i < dt->ncols(); ++i) {
     const Column& col = dt->get_column(i);
     hashers.push_back(create_hasher(col));
   }
@@ -1061,8 +1061,8 @@ std::vector<hasherptr> Ftrl<T>::create_hashers(const DataTable* dt) {
   // Hash column names.
   const std::vector<std::string>& c_names = dt->get_names();
   colname_hashes.clear();
-  colname_hashes.reserve(dt->ncols);
-  for (size_t i = 0; i < dt->ncols; i++) {
+  colname_hashes.reserve(dt->ncols());
+  for (size_t i = 0; i < dt->ncols(); i++) {
     uint64_t h = hash_murmur2(c_names[i].c_str(),
                              c_names[i].length() * sizeof(char));
     colname_hashes.push_back(h);
@@ -1281,7 +1281,7 @@ DataTable* Ftrl<T>::get_labels() {
 template <typename T>
 void Ftrl<T>::set_model(DataTable* dt_model_in) {
   dt_model = dtptr(dt_model_in->copy());
-  set_nbins(dt_model->nrows);
+  set_nbins(dt_model->nrows());
   nfeatures = 0;
 }
 
@@ -1301,7 +1301,7 @@ void Ftrl<T>::set_model_type_trained(FtrlModelType model_type_trained_in) {
 template <typename T>
 void Ftrl<T>::set_fi(DataTable* dt_fi_in) {
   dt_fi = dtptr(dt_fi_in->copy());
-  nfeatures = dt_fi->nrows;
+  nfeatures = dt_fi->nrows();
 }
 
 

--- a/c/models/dt_ftrl.cc
+++ b/c/models/dt_ftrl.cc
@@ -1138,7 +1138,7 @@ bool Ftrl<T>::is_model_trained() {
 template <typename T>
 py::oobj Ftrl<T>::get_model() {
   if (dt_model == nullptr) return py::None();
-  return py::Frame::oframe(dt_model->copy());
+  return py::Frame::oframe(new DataTable(*dt_model));
 }
 
 
@@ -1171,7 +1171,7 @@ template <typename T>
 py::oobj Ftrl<T>::get_fi(bool normalize /* = true */) {
   if (dt_fi == nullptr) return py::None();
 
-  auto dt_fi_copy = dt_fi->copy();
+  DataTable dt_fi_copy { *dt_fi };  // copy
   if (normalize) {
     Column& col = dt_fi_copy.get_column(1);
     bool max_isna;
@@ -1274,13 +1274,13 @@ FtrlParams Ftrl<T>::get_params() {
 template <typename T>
 py::oobj Ftrl<T>::get_labels() {
   if (dt_labels == nullptr) return py::None();
-  return py::Frame::oframe(dt_labels->copy());
+  return py::Frame::oframe(new DataTable(*dt_labels));
 }
 
 
 template <typename T>
-void Ftrl<T>::set_model(DataTable* dt_model_in) {
-  dt_model = dtptr(new DataTable(dt_model_in->copy()));
+void Ftrl<T>::set_model(const DataTable& dt_model_in) {
+  dt_model = dtptr(new DataTable(dt_model_in));
   set_nbins(dt_model->nrows());
   nfeatures = 0;
 }
@@ -1299,8 +1299,8 @@ void Ftrl<T>::set_model_type_trained(FtrlModelType model_type_trained_in) {
 
 
 template <typename T>
-void Ftrl<T>::set_fi(DataTable* dt_fi_in) {
-  dt_fi = dtptr(new DataTable(dt_fi_in->copy()));
+void Ftrl<T>::set_fi(const DataTable& dt_fi_in) {
+  dt_fi = dtptr(new DataTable(dt_fi_in));
   nfeatures = dt_fi->nrows();
 }
 
@@ -1369,8 +1369,8 @@ void Ftrl<T>::set_negative_class(bool negative_class_in) {
 
 
 template <typename T>
-void Ftrl<T>::set_labels(DataTable* dt_labels_in) {
-  dt_labels = dtptr(new DataTable(dt_labels_in->copy()));
+void Ftrl<T>::set_labels(const DataTable& dt_labels_in) {
+  dt_labels = dtptr(new DataTable(dt_labels_in));
 }
 
 

--- a/c/models/dt_ftrl.cc
+++ b/c/models/dt_ftrl.cc
@@ -205,7 +205,7 @@ void Ftrl<T>::create_y_binomial(const DataTable* dt,
     dt_labels = std::move(dt_labels_in);
   } else {
 
-    RowIndex ri_join = natural_join(dt_labels_in.get(), dt_labels.get());
+    RowIndex ri_join = natural_join(*dt_labels_in.get(), *dt_labels.get());
     size_t nlabels = dt_labels->nrows();
     xassert(nlabels != 0 && nlabels < 3);
     auto data_label_ids_in = static_cast<int8_t*>(
@@ -410,7 +410,7 @@ void Ftrl<T>::create_y_multinomial(const DataTable* dt,
     // on all the negatives.
     auto data_label_ids = static_cast<const int32_t*>(
                             dt_labels->get_column(1).get_data_readonly());
-    RowIndex ri_join = natural_join(dt_labels_in.get(), dt_labels.get());
+    RowIndex ri_join = natural_join(*dt_labels_in.get(), *dt_labels.get());
     size_t nlabels = dt_labels->nrows();
 
     for (size_t i = 0; i < nlabels; ++i) {

--- a/c/models/dt_ftrl.h
+++ b/c/models/dt_ftrl.h
@@ -149,8 +149,8 @@ class Ftrl : public dt::FtrlBase {
     bool is_model_trained() override;
 
     // Getters
-    DataTable* get_model() override;
-    DataTable* get_fi(bool normalize = true) override;
+    py::oobj get_model() override;
+    py::oobj get_fi(bool normalize = true) override;
     FtrlModelType get_model_type() override;
     FtrlModelType get_model_type_trained() override;
     size_t get_nfeatures() override;
@@ -166,7 +166,7 @@ class Ftrl : public dt::FtrlBase {
     const std::vector<intvec>& get_interactions() override;
     bool get_negative_class() override;
     FtrlParams get_params() override;
-    DataTable* get_labels() override;
+    py::oobj get_labels() override;
 
     // Setters
     void set_model(DataTable*) override;

--- a/c/models/dt_ftrl.h
+++ b/c/models/dt_ftrl.h
@@ -169,8 +169,8 @@ class Ftrl : public dt::FtrlBase {
     py::oobj get_labels() override;
 
     // Setters
-    void set_model(DataTable*) override;
-    void set_fi(DataTable*) override;
+    void set_model(const DataTable&) override;
+    void set_fi(const DataTable&) override;
     void set_model_type(FtrlModelType) override;
     void set_model_type_trained(FtrlModelType) override;
     void set_alpha(double) override;
@@ -182,7 +182,7 @@ class Ftrl : public dt::FtrlBase {
     void set_nepochs(size_t) override;
     void set_interactions(std::vector<intvec>) override;
     void set_negative_class(bool) override;
-    void set_labels(DataTable*) override;
+    void set_labels(const DataTable&) override;
 
     // Some useful constants:
     static constexpr T T_NAN = std::numeric_limits<T>::quiet_NaN();

--- a/c/models/dt_ftrl_base.h
+++ b/c/models/dt_ftrl_base.h
@@ -73,6 +73,7 @@ struct FtrlFitOutput {
     double loss;
 };
 
+using dtptr = std::unique_ptr<DataTable>;
 
 /**
  *  An abstract dt::FtrlBase class that declares all the virtual functions

--- a/c/models/dt_ftrl_base.h
+++ b/c/models/dt_ftrl_base.h
@@ -93,10 +93,10 @@ class FtrlBase {
     virtual bool is_model_trained() = 0;
 
     // Getters
-    virtual DataTable* get_model() = 0;
+    virtual py::oobj get_model() = 0;
     virtual FtrlModelType get_model_type() = 0;
     virtual FtrlModelType get_model_type_trained() = 0;
-    virtual DataTable* get_fi(bool normaliza = true) = 0;
+    virtual py::oobj get_fi(bool normaliza = true) = 0;
     virtual size_t get_nfeatures() = 0;
     virtual size_t get_ncols() = 0;
     virtual const std::vector<uint64_t>& get_colname_hashes() = 0;
@@ -110,7 +110,7 @@ class FtrlBase {
     virtual const std::vector<intvec>& get_interactions() = 0;
     virtual bool get_negative_class() = 0;
     virtual FtrlParams get_params() = 0;
-    virtual DataTable* get_labels() = 0;
+    virtual py::oobj get_labels() = 0;
     static size_t get_nthreads(size_t);
     static size_t get_work_amount(size_t);
 

--- a/c/models/dt_ftrl_base.h
+++ b/c/models/dt_ftrl_base.h
@@ -116,8 +116,8 @@ class FtrlBase {
     static size_t get_work_amount(size_t);
 
     // Setters
-    virtual void set_model(DataTable*) = 0;
-    virtual void set_fi(DataTable*) = 0;
+    virtual void set_model(const DataTable&) = 0;
+    virtual void set_fi(const DataTable&) = 0;
     virtual void set_model_type(FtrlModelType) = 0;
     virtual void set_model_type_trained(FtrlModelType) = 0;
     virtual void set_alpha(double) = 0;
@@ -129,7 +129,7 @@ class FtrlBase {
     virtual void set_nepochs(size_t) = 0;
     virtual void set_interactions(std::vector<intvec>) = 0;
     virtual void set_negative_class(bool) = 0;
-    virtual void set_labels(DataTable*) = 0;
+    virtual void set_labels(const DataTable&) = 0;
 
     // Number of mantissa bits in a double number.
     static constexpr unsigned char DOUBLE_MANTISSA_NBITS = 52;

--- a/c/models/kfold.cc
+++ b/c/models/kfold.cc
@@ -162,8 +162,8 @@ static oobj kfold(const PKArgs& args) {
     int64_t b2 = (ii+1)*n/k;
     size_t colsize = static_cast<size_t>(b1 + n - b2);
     Column col = Column::new_data_column(colsize, SType::INT32);
+    data.push_back(static_cast<int32_t*>(col.get_data_editable()));
     DataTable* dt = new DataTable({std::move(col)}, DataTable::default_names);
-    data.push_back(static_cast<int32_t*>(dt->get_column(0).get_data_editable()));
 
     res.set(static_cast<size_t>(ii),
             otuple(Frame::oframe(dt), orange(b1, b2)));
@@ -334,12 +334,12 @@ static oobj kfold_random(const PKArgs& args) {
     size_t fold_size = (x + 1) * nrows / nsplits - x * nrows / nsplits;
     Column col1 = Column::new_data_column(nrows - fold_size, S);
     Column col2 = Column::new_data_column(fold_size, S);
+    train_folds[x] = static_cast<T*>(col1.get_data_editable());
+    test_folds[x] = static_cast<T*>(col2.get_data_editable());
     DataTable* dt1 = new DataTable({std::move(col1)}, DataTable::default_names);
     DataTable* dt2 = new DataTable({std::move(col2)}, DataTable::default_names);
     oobj train = Frame::oframe(dt1);
     oobj test  = Frame::oframe(dt2);
-    train_folds[x] = static_cast<T*>(dt1->get_column(0).get_data_editable());
-    test_folds[x] = static_cast<T*>(dt2->get_column(0).get_data_editable());
     res.set(x, otuple{ train, test });
   }
 

--- a/c/models/py_ftrl.cc
+++ b/c/models/py_ftrl.cc
@@ -495,10 +495,7 @@ static GSArgs args_labels(
 
 
 oobj Ftrl::get_labels() const {
-  DataTable* dt_labels = dtft->get_labels();
-  if (dt_labels ==nullptr) return py::None();
-  py::oobj df_labels = py::Frame::oframe(dt_labels);
-  return df_labels;
+  return dtft->get_labels();
 }
 
 
@@ -515,10 +512,7 @@ contain z model coefficients, and even columns n model coefficients.)");
 
 oobj Ftrl::get_model() const {
   if (!dtft->is_model_trained()) return py::None();
-
-  DataTable* dt_model = dtft->get_model();
-  py::oobj df_model = py::Frame::oframe(dt_model);
-  return df_model;
+  return dtft->get_model();
 }
 
 
@@ -575,10 +569,7 @@ oobj Ftrl::get_fi() const {
 
 oobj Ftrl::get_normalized_fi(bool normalize) const {
   if (!dtft->is_model_trained()) return py::None();
-
-  DataTable* dt_fi = dtft->get_fi(normalize);
-  py::oobj df_fi = py::Frame::oframe(dt_fi);
-  return df_fi;
+  return dtft->get_fi(normalize);
 }
 
 

--- a/c/models/py_ftrl.cc
+++ b/c/models/py_ftrl.cc
@@ -269,19 +269,19 @@ oobj Ftrl::fit(const PKArgs& args) {
 
   if (dt_X_train == nullptr || dt_y == nullptr) return py::None();
 
-  if (dt_X_train->ncols == 0) {
+  if (dt_X_train->ncols() == 0) {
     throw ValueError() << "Training frame must have at least one column";
   }
 
-  if (dt_X_train->nrows == 0) {
+  if (dt_X_train->nrows() == 0) {
     throw ValueError() << "Training frame cannot be empty";
   }
 
-  if (dt_y->ncols != 1) {
+  if (dt_y->ncols() != 1) {
     throw ValueError() << "Target frame must have exactly one column";
   }
 
-  if (dt_X_train->nrows != dt_y->nrows) {
+  if (dt_X_train->nrows() != dt_y->nrows()) {
     throw ValueError() << "Target column must have the same number of rows "
                        << "as the training frame";
   }
@@ -312,7 +312,7 @@ oobj Ftrl::fit(const PKArgs& args) {
     dt_X_val = arg_X_validation.to_datatable();
     dt_y_val = arg_y_validation.to_datatable();
 
-    if (dt_X_val->ncols != dt_X_train->ncols) {
+    if (dt_X_val->ncols() != dt_X_train->ncols()) {
       throw ValueError() << "Validation frame must have the same number of "
                          << "columns as the training frame";
     }
@@ -322,11 +322,11 @@ oobj Ftrl::fit(const PKArgs& args) {
                          << "names as the training frame";
     }
 
-    if (dt_X_val->nrows == 0) {
+    if (dt_X_val->nrows() == 0) {
       throw ValueError() << "Validation frame cannot be empty";
     }
 
-    if (dt_y_val->ncols != 1) {
+    if (dt_y_val->ncols() != 1) {
       throw ValueError() << "Validation target frame must have exactly "
                          << "one column";
     }
@@ -341,7 +341,7 @@ oobj Ftrl::fit(const PKArgs& args) {
                         << "` and `" << info::ltype_name(ltype_val) << "`";
     }
 
-    if (dt_X_val->nrows != dt_y_val->nrows) {
+    if (dt_X_val->nrows() != dt_y_val->nrows()) {
       throw ValueError() << "Validation target frame must have the same "
                          << "number of rows as the validation frame itself";
     }
@@ -428,7 +428,7 @@ oobj Ftrl::predict(const PKArgs& args) {
   }
 
   size_t ncols = dtft->get_ncols();
-  if (dt_X->ncols != ncols && ncols != 0) {
+  if (dt_X->ncols() != ncols && ncols != 0) {
     throw ValueError() << "Can only predict on a frame that has " << ncols
                        << " column" << (ncols == 1? "" : "s")
                        << ", i.e. has the same number of features as "
@@ -526,16 +526,16 @@ void Ftrl::set_model(robj model) {
   DataTable* dt_model = model.to_datatable();
   if (dt_model == nullptr) return;
 
-  size_t ncols = dt_model->ncols;
-  if (dt_model->nrows != dtft->get_nbins() || dt_model->ncols%2 != 0) {
+  size_t ncols = dt_model->ncols();
+  if (dt_model->nrows() != dtft->get_nbins() || dt_model->ncols()%2 != 0) {
     throw ValueError() << "Model frame must have " << dtft->get_nbins()
                        << " rows, and an even number of columns, "
                        << "whereas your frame has "
-                       << dt_model->nrows << " row"
-                       << (dt_model->nrows == 1? "": "s")
+                       << dt_model->nrows() << " row"
+                       << (dt_model->nrows() == 1? "": "s")
                        << " and "
-                       << dt_model->ncols << " column"
-                       << (dt_model->ncols == 1? "": "s");
+                       << dt_model->ncols() << " column"
+                       << (dt_model->ncols() == 1? "": "s");
 
   }
 

--- a/c/models/py_ftrl.cc
+++ b/c/models/py_ftrl.cc
@@ -550,7 +550,7 @@ void Ftrl::set_model(robj model) {
       throw ValueError() << "Column " << i << " cannot have negative values";
     }
   }
-  dtft->set_model(dt_model);
+  dtft->set_model(*dt_model);
 }
 
 
@@ -1104,11 +1104,11 @@ void Ftrl::m__setstate__(const PKArgs& args) {
   set_params_tuple(pickle[1]);
   set_model(pickle[2]);
   if (pickle[3].is_frame()) {
-    dtft->set_fi(pickle[3].to_datatable());
+    dtft->set_fi(*pickle[3].to_datatable());
   }
 
   if (pickle[4].is_frame()) {
-    dtft->set_labels(pickle[4].to_datatable());
+    dtft->set_labels(*pickle[4].to_datatable());
   }
   set_colnames(pickle[5]);
 

--- a/c/py_buffers.cc
+++ b/c/py_buffers.cc
@@ -348,8 +348,8 @@ static void getbuffer_1_col(py::Frame* self, Py_buffer* view, int flags)
 
 void py::Frame::m__getbuffer__(Py_buffer* view, int flags) {
   XInfo* xinfo = nullptr;
-  size_t ncols = dt->ncols;
-  size_t nrows = dt->nrows;
+  size_t ncols = dt->ncols();
+  size_t nrows = dt->nrows();
   size_t i0 = 0;
   bool one_col = (pybuffers::single_col != size_t(-1));
   if (one_col) {

--- a/c/set_funcs.cc
+++ b/c/set_funcs.cc
@@ -66,10 +66,10 @@ static named_colvec columns_from_args(const py::PKArgs& args) {
   std::function<void(py::robj)> process_arg = [&](py::robj arg) {
     if (arg.is_frame()) {
       DataTable* dt = arg.to_datatable();
-      if (dt->ncols == 0) return;
-      if (dt->ncols > 1) {
+      if (dt->ncols() == 0) return;
+      if (dt->ncols() > 1) {
         throw ValueError() << "Only single-column Frames are allowed, "
-            "but received a Frame with " << dt->ncols << " columns";
+            "but received a Frame with " << dt->ncols() << " columns";
       }
       Column col = dt->get_column(0);  // copy
       col.materialize();
@@ -170,10 +170,10 @@ static py::oobj unique(const py::PKArgs& args) {
   DataTable* dt = args[0].to_datatable();
 
   named_colvec ncv;
-  for (size_t i = 0; i < dt->ncols; ++i) {
+  for (size_t i = 0; i < dt->ncols(); ++i) {
     ncv.columns.push_back(dt->get_column(i));
   }
-  if (dt->ncols == 1) {
+  if (dt->ncols() == 1) {
     ncv.name = dt->get_names()[0];
   }
   return _union(std::move(ncv));

--- a/c/sort.cc
+++ b/c/sort.cc
@@ -1341,14 +1341,14 @@ RiGb DataTable::group(const std::vector<sort_spec>& spec) const
 
   // For a 0-row Frame we return a rowindex of size 0, and the
   // Groupby containing a single group (also of size 0).
-  if (nrows <= 1) {
-    arr32_t indices(nrows);
-    if (nrows) {
+  if (nrows_ <= 1) {
+    arr32_t indices(nrows_);
+    if (nrows_) {
       indices[0] = 0;
     }
     result.first = RowIndex(std::move(indices), true);
     if (!spec[0].sort_only) {
-      result.second = Groupby::single_group(nrows);
+      result.second = Groupby::single_group(nrows_);
     }
     return result;
   }
@@ -1359,7 +1359,7 @@ RiGb DataTable::group(const std::vector<sort_spec>& spec) const
 
   bool do_groups = n > 1 || !spec[0].sort_only;
   xassert(!col0.is_virtual());
-  SortContext sc(nrows, RowIndex(), do_groups);
+  SortContext sc(nrows_, RowIndex(), do_groups);
   sc.start_sort(col0, spec[0].descending);
   for (size_t j = 1; j < n; ++j) {
     if (spec[j].sort_only && !spec[j - 1].sort_only) {
@@ -1474,8 +1474,8 @@ py::oobj py::Frame::sort(const PKArgs& args) {
   dt::EvalContext ctx(dt, dt::EvalMode::SELECT);
 
   if (args.num_vararg_args() == 0) {
-    py::otuple all_cols(dt->ncols);
-    for (size_t i = 0; i < dt->ncols; ++i) {
+    py::otuple all_cols(dt->ncols());
+    for (size_t i = 0; i < dt->ncols(); ++i) {
       all_cols.set(i, py::oint(i));
     }
     ctx.add_sortby(py::osort(all_cols));

--- a/c/sort.cc
+++ b/c/sort.cc
@@ -1336,7 +1336,7 @@ RiGb DataTable::group(const std::vector<sort_spec>& spec) const
   size_t n = spec.size();
   xassert(n > 0);
 
-  const Column& col0 = columns[spec[0].col_index];
+  const Column& col0 = columns_[spec[0].col_index];
   col0.stats();  // instantiate Stats object; TODO: remove this
 
   // For a 0-row Frame we return a rowindex of size 0, and the
@@ -1354,7 +1354,7 @@ RiGb DataTable::group(const std::vector<sort_spec>& spec) const
   }
 
   for (auto& s : spec) {
-    const_cast<DataTable*>(this)->columns[s.col_index].materialize();
+    const_cast<DataTable*>(this)->columns_[s.col_index].materialize();
   }
 
   bool do_groups = n > 1 || !spec[0].sort_only;
@@ -1368,7 +1368,7 @@ RiGb DataTable::group(const std::vector<sort_spec>& spec) const
     if (j == n - 1 && spec[j].sort_only) {
       do_groups = false;
     }
-    const Column& colj = columns[spec[j].col_index];
+    const Column& colj = columns_[spec[j].col_index];
     colj.stats();  // TODO: remove this
     sc.continue_sort(colj, spec[j].descending, do_groups);
   }

--- a/c/str/py_str.cc
+++ b/c/str/py_str.cc
@@ -40,10 +40,10 @@ static oobj split_into_nhot(const PKArgs& args) {
   std::string sep = args[1]? args[1].to_string() : ",";
   bool sort = args[2]? args[2].to_bool_strict() : false;
 
-  if (dt->ncols != 1) {
+  if (dt->ncols() != 1) {
     throw ValueError() << "Function split_into_nhot() may only be applied to "
       "a single-column Frame of type string;" << " got frame with "
-      << dt->ncols << " columns";
+      << dt->ncols() << " columns";
   }
   const Column& col0 = dt->get_column(0);
   SType st = col0.stype();

--- a/c/write/csv_writer.cc
+++ b/c/write/csv_writer.cc
@@ -53,8 +53,8 @@ std::string csv_writer::get_job_name() const {
  *
  */
 void csv_writer::estimate_output_size() {
-  size_t nrows = dt->nrows;
-  size_t ncols = dt->ncols;
+  size_t nrows = dt->nrows();
+  size_t ncols = dt->ncols();
   const strvec& column_names = dt->get_names();
 
   size_t total_columns_size = 0;
@@ -84,15 +84,15 @@ void csv_writer::write_preamble() {
 
   Column names_as_col = Column(new Strvec_ColumnImpl(column_names));
   auto writer = value_writer::create(names_as_col, options);
-  writing_context ctx { 3*dt->ncols, 1, options.compress_zlib };
+  writing_context ctx { 3*dt->ncols(), 1, options.compress_zlib };
 
   if (options.quoting_mode == Quoting::ALL) {
-    for (size_t i = 0; i < dt->ncols; ++i) {
+    for (size_t i = 0; i < dt->ncols(); ++i) {
       writer->write_quoted(i, ctx);
       *ctx.ch++ = ',';
     }
   } else {
-    for (size_t i = 0; i < dt->ncols; ++i) {
+    for (size_t i = 0; i < dt->ncols(); ++i) {
       writer->write_normal(i, ctx);
       *ctx.ch++ = ',';
     }

--- a/c/write/write_manager.cc
+++ b/c/write/write_manager.cc
@@ -88,7 +88,7 @@ void write_manager::write_main()
   chronicler.checkpoint_preamble_done();
   job.add_done_amount(WRITE_PREPARE);
 
-  if (dt->nrows > 0 && dt->ncols > 0) {
+  if (dt->nrows() > 0 && dt->ncols() > 0) {
     job.add_tentative_amount(WRITE_MAIN);
     write_rows();
   }
@@ -109,13 +109,13 @@ void write_manager::write_main()
 void write_manager::write_rows()
 {
   // Check that `nchunks * nrows` doesn't overflow
-  size_t nrows = dt->nrows;
+  size_t nrows = dt->nrows();
   xassert(nchunks <= size_t(-1) / nrows);
 
   parallel_for_ordered(
     nchunks,  // number of iterations
     [&](ordered* o) {
-      size_t nrows_per_chunk =  dt->nrows / nchunks;
+      size_t nrows_per_chunk =  dt->nrows() / nchunks;
       writing_context ctx(fixed_size_per_row, nrows_per_chunk,
                           options.compress_zlib);
       size_t th_write_at = 0;
@@ -161,7 +161,7 @@ py::oobj write_manager::get_result() {
 //------------------------------------------------------------------------------
 
 void write_manager::create_column_writers() {
-  for (size_t i = 0; i < dt->ncols; ++i) {
+  for (size_t i = 0; i < dt->ncols(); ++i) {
     const Column& col = dt->get_column(i);
     columns.push_back(value_writer::create(col, options));
   }
@@ -183,8 +183,8 @@ void write_manager::create_output_target() {
  */
 void write_manager::determine_chunking_strategy()
 {
-  size_t nrows = dt->nrows;
-  if (nrows == 0 || dt->ncols == 0) return;
+  size_t nrows = dt->nrows();
+  if (nrows == 0 || dt->ncols() == 0) return;
   xassert(estimated_output_size > 0)
   const double bytes_per_row = 1.0 * estimated_output_size / nrows;
 


### PR DESCRIPTION
- Do not materialize DataTable during join operation (this will result in a speedup);
- In some cases when `Column&` was requested changed the code to work with `const Column&`;
- DataTable properties renamed to have `_` at the end and made private;
- `DataTable::nrows()` and `DataTable::ncols()` are now getter functions;
- In certain places `DataTable` is now used by-reference rather than by pointer. Eventually we should transition the code to use by-value DataTable objects everywhere.