### PR TITLE
Fix 'removing untracked pointer' error

### DIFF
--- a/c/datatable.cc
+++ b/c/datatable.cc
@@ -19,14 +19,8 @@
 //------------------------------------------------------------------------------
 
 DataTable::DataTable()
-  : nrows_(0), ncols_(0), nkeys_(0)
-{
-  TRACK(this, sizeof(*this), "DataTable");
-}
+  : nrows_(0), ncols_(0), nkeys_(0) {}
 
-DataTable::~DataTable() {
-  UNTRACK(this);
-}
 
 // Private constructor, initializes only columns but not names_
 DataTable::DataTable(colvec&& cols) : DataTable()

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -86,7 +86,6 @@ class DataTable {
     DataTable(colvec&& cols, const strvec&, bool warn_duplicates = true);
     DataTable(colvec&& cols, const py::olist&, bool warn_duplicates = true);
     DataTable(colvec&& cols, const DataTable&);
-    ~DataTable();
 
     size_t nrows() const noexcept { return nrows_; }
     size_t ncols() const noexcept { return ncols_; }

--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -290,9 +290,10 @@ void UNTRACK(void* ptr) {
 
   if (tracked_objects.count(ptr) == 0) {
     // UNTRACK() is usually called from a destructor, so cannot throw any
-    // exceptions there :(
-    std::cerr << "ERROR: Trying to remove pointer " << ptr
-              << " which is not tracked\n";
+    // exceptions there. However, calling PyErr_*() will cause the python
+    // to raise SystemError once the control reaches python.
+    PyErr_SetString(PyExc_RuntimeError,
+                    "ERROR: Trying to remove pointer which is not tracked");
   }
   tracked_objects.erase(ptr);
 }

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -270,6 +270,13 @@ def test_dt_getitem2(dt0):
     assert_equals(dt0[1], dt0[:, 1])
 
 
+def test_dt_getitem3():
+    DT = dt.Frame([3])
+    a = DT[0]
+    assert a.to_list() == [[3]]
+    del a  # should not emit an error
+
+
 def test_frame_as_iterable(dt0):
     assert iter(dt0)
     assert iter(dt0).__length_hint__() == dt0.ncols


### PR DESCRIPTION
The error was introduced in the latest PR: when DataTable uses default copy-construction, the `TRACK()` macro isn't called. The easiest solution is not to call these macros for `DataTable` at all.

Closes #2062