### PR TITLE
Close all files opened with open() in python

### DIFF
--- a/datatable/fread.py
+++ b/datatable/fread.py
@@ -380,21 +380,21 @@ class GenericReader(object):
 
         elif ext == ".bz2":
             import bz2
-            zf = bz2.open(filename, mode="rb")
-            if self._verbose:
-                self.logger.debug("Extracting %s into memory" % filename)
-            self._text = zf.read()
-            if self._verbose:
-                self.logger.debug("Extracted: size = %d" % len(self._text))
+            with bz2.open(filename, mode="rb") as zf:
+                if self._verbose:
+                    self.logger.debug("Extracting %s into memory" % filename)
+                self._text = zf.read()
+                if self._verbose:
+                    self.logger.debug("Extracted: size = %d" % len(self._text))
 
         elif ext == ".xz":
             import lzma
-            zf = lzma.open(filename, mode="rb")
-            if self._verbose:
-                self.logger.debug("Extracting %s into memory" % filename)
-            self._text = zf.read()
-            if self._verbose:
-                self.logger.debug("Extracted: size = %d" % len(self._text))
+            with lzma.open(filename, mode="rb") as zf:
+                if self._verbose:
+                    self.logger.debug("Extracting %s into memory" % filename)
+                self._text = zf.read()
+                if self._verbose:
+                    self.logger.debug("Extracted: size = %d" % len(self._text))
 
         elif ext == ".xlsx" or ext == ".xls":
             self._result = read_xls_workbook(filename, subpath)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,7 +37,8 @@ except ImportError:
     verfile = os.path.abspath(os.path.join(os.path.dirname(__file__),
                               "../datatable/__version__.py"))
     if os.path.isfile(verfile):
-        txt = open(verfile, "rt").read()
+        with open(verfile, "rt") as inp:
+            txt = inp.read()
     else:
         txt = ""
     mm = re.search(r'version = "(.*)"', txt)

--- a/tests/fread/test_fread_large.py
+++ b/tests/fread/test_fread_large.py
@@ -82,7 +82,8 @@ def get_file_list(*path, skip=None):
                 if f + ".gz" in out:
                     out.remove(f + ".gz")
                 try:
-                    open(f, "rb")
+                    with open(f, "rb"):
+                        pass
                     out.add(param(f))
                 except Exception as e:
                     out.add(skipped("%s: '%s'" % (e.__class__.__name__, f), id=f))

--- a/tests/random_attack.py
+++ b/tests/random_attack.py
@@ -731,5 +731,9 @@ if __name__ == "__main__":
         python_output.write("from datatable import f\n")
         python_output.write("from datatable.internal import frame_integrity_check\n\n")
 
-    ra = Attacker(args.seed)
-    ra.attack()
+    try:
+        ra = Attacker(args.seed)
+        ra.attack()
+    finally:
+        if python_output:
+            python_output.close()

--- a/tests/test_dt_sort.py
+++ b/tests/test_dt_sort.py
@@ -684,7 +684,8 @@ def test_strXX_large6(st):
     for dirname, _, files in os.walk(rootdir):
         for filename in files:
             f = os.path.join(dirname, filename)
-            txt = open(f, "r", encoding="utf-8").read()
+            with open(f, "r", encoding="utf-8") as inp:
+                txt = inp.read()
             words.extend(txt.split())
     dt0 = dt.Frame(words, stype=st)
     assert dt0.stypes == (st, )

--- a/tests/test_tocsv.py
+++ b/tests/test_tocsv.py
@@ -107,7 +107,8 @@ def test_issue507(tempfile, col, scol):
     d = dt.Frame({col: [-0.006492080633259916]})
     d.to_csv(tempfile)
     exp_text = scol + "\n-0.006492080633259916\n"
-    assert open(tempfile, "rb").read() == exp_text.encode()
+    with open(tempfile, "rb") as inp:
+        assert inp.read() == exp_text.encode()
 
 
 def test_view_to_csv():


### PR DESCRIPTION
Occasionally python emits ResourceWarnings in our test suit, such as
```
Exception ignored in: <_io.FileIO name='/tmp/tmp21vyfziy' mode='rb' closefd=True>
ResourceWarning: unclosed file <_io.BufferedReader name='/tmp/tmp21vyfziy'>
```
These, however, are not regular warnings, and can neither be detected nor captured by `pytest`. They do not reproduce reliably, and we can't write any test to check for their presence/absence.

After a bit of googling, it appears that these warnings are caused by file handlers that are not closed explicitly. Thus, in this PR I'm fixing several instances where we used to have un-closed file handles, in hope that the warnings will go away.
