### PR TITLE
Range column improvements

### DIFF
--- a/c/column/range.cc
+++ b/c/column/range.cc
@@ -25,6 +25,11 @@
 namespace dt {
 
 
+
+//------------------------------------------------------------------------------
+// Constructors
+//------------------------------------------------------------------------------
+
 static size_t compute_nrows(int64_t start, int64_t stop, int64_t step) {
   xassert(step != 0);
   int64_t length = (step > 0) ? (stop - start + step - 1) / step
@@ -34,12 +39,12 @@ static size_t compute_nrows(int64_t start, int64_t stop, int64_t step) {
 
 static SType compute_stype(int64_t start, int64_t stop, SType stype) {
   if (stype == SType::VOID) {
-    bool start_fits_int32 = (start == static_cast<int32_t>(start));
-    bool stop_fits_int32  = (stop == static_cast<int32_t>(stop));
-    return (start_fits_int32 && stop_fits_int32) ? SType::INT32 : SType::INT64;
+    bool start_is_int32 = (start == static_cast<int32_t>(start));
+    bool stop_is_int32  = (stop == static_cast<int32_t>(stop));
+    return (start_is_int32 && stop_is_int32) ? SType::INT32 : SType::INT64;
   }
   auto ltype = info(stype).ltype();
-  if (ltype == LType::INT || ltype == LType::REAL || ltype == LType::BOOL) {
+  if (ltype == LType::INT || ltype == LType::REAL) {
     return stype;
   }
   throw ValueError() << "Invalid stype " << stype << " for a range column";
@@ -55,7 +60,8 @@ Range_ColumnImpl::Range_ColumnImpl(int64_t start, int64_t stop, int64_t step,
     step_(step) {}
 
 
-Range_ColumnImpl::Range_ColumnImpl(SType stype, size_t nrows, int64_t start,
+// private constructor (used for cloning)
+Range_ColumnImpl::Range_ColumnImpl(size_t nrows, SType stype, int64_t start,
                                    int64_t step)
   : Virtual_ColumnImpl(nrows, stype),
     start_(start),
@@ -64,42 +70,39 @@ Range_ColumnImpl::Range_ColumnImpl(SType stype, size_t nrows, int64_t start,
 
 
 ColumnImpl* Range_ColumnImpl::clone() const {
-  return new Range_ColumnImpl(stype_, nrows_, start_, step_);
+  return new Range_ColumnImpl(nrows_, stype_, start_, step_);
 }
 
 
 
-bool Range_ColumnImpl::get_element(size_t i, int8_t* out)  const {
-  *out = static_cast<int8_t>(start_ + static_cast<int64_t>(i) * step_);
+
+//------------------------------------------------------------------------------
+// Element access
+//------------------------------------------------------------------------------
+
+template <typename T>
+inline bool Range_ColumnImpl::_get(size_t i, T* out) const {
+  *out = static_cast<T>(start_ + static_cast<int64_t>(i) * step_);
   return true;
 }
 
-bool Range_ColumnImpl::get_element(size_t i, int16_t* out) const {
-  *out = static_cast<int16_t>(start_ + static_cast<int64_t>(i) * step_);
-  return true;
-}
-
-bool Range_ColumnImpl::get_element(size_t i, int32_t* out) const {
-  *out = static_cast<int32_t>(start_ + static_cast<int64_t>(i) * step_);
-  return true;
-}
-
-bool Range_ColumnImpl::get_element(size_t i, int64_t* out) const {
-  *out = static_cast<int64_t>(start_ + static_cast<int64_t>(i) * step_);
-  return true;
-}
-
-bool Range_ColumnImpl::get_element(size_t i, float* out)   const {
-  *out = static_cast<float>(start_ + static_cast<int64_t>(i) * step_);
-  return true;
-}
-
-bool Range_ColumnImpl::get_element(size_t i, double* out)  const {
-  *out = static_cast<double>(start_ + static_cast<int64_t>(i) * step_);
-  return true;
-}
+bool Range_ColumnImpl::get_element(size_t i, int8_t* out)  const { return _get(i, out); }
+bool Range_ColumnImpl::get_element(size_t i, int16_t* out) const { return _get(i, out); }
+bool Range_ColumnImpl::get_element(size_t i, int32_t* out) const { return _get(i, out); }
+bool Range_ColumnImpl::get_element(size_t i, int64_t* out) const { return _get(i, out); }
+bool Range_ColumnImpl::get_element(size_t i, float* out)   const { return _get(i, out); }
+bool Range_ColumnImpl::get_element(size_t i, double* out)  const { return _get(i, out); }
 
 
+
+
+//------------------------------------------------------------------------------
+// Materialization
+//------------------------------------------------------------------------------
+
+// void Range_ColumnImpl::materialize(Column& out) {
+
+// }
 
 
 

--- a/c/column/range.h
+++ b/c/column/range.h
@@ -46,7 +46,9 @@ class Range_ColumnImpl : public Virtual_ColumnImpl {
                      SType stype = SType::VOID);
 
     ColumnImpl* clone() const override;
+    size_t memory_footprint() const noexcept override;
     void materialize(Column&) override;
+    void verify_integrity() const override;
 
     bool get_element(size_t, int8_t*)  const override;
     bool get_element(size_t, int16_t*) const override;
@@ -54,6 +56,9 @@ class Range_ColumnImpl : public Virtual_ColumnImpl {
     bool get_element(size_t, int64_t*) const override;
     bool get_element(size_t, float*)   const override;
     bool get_element(size_t, double*)  const override;
+
+    void fill_npmask(bool* outmask, size_t row0, size_t row1) const override;
+    void apply_rowindex(const RowIndex& ri, Column& out) override;
 
   private:
     Range_ColumnImpl(size_t, SType, int64_t, int64_t);  // for cloning

--- a/c/column/range.h
+++ b/c/column/range.h
@@ -27,7 +27,14 @@ namespace dt {
 
 
 /**
-  * Virtual column representing the `arg` column repeated n times.
+  * Virtual column corresponding to Python `range()` object. This
+  * column is created when a `range` object is passed into Frame
+  * constructor.
+  *
+  * By default, this column will take stype INT32. However, if the
+  * range is sufficiently large, the stype will become INT64. However,
+  * we do not support further promotion into FLOAT64 stype for even
+  * larger integers.
   */
 class Range_ColumnImpl : public Virtual_ColumnImpl {
   private:
@@ -39,6 +46,7 @@ class Range_ColumnImpl : public Virtual_ColumnImpl {
                      SType stype = SType::VOID);
 
     ColumnImpl* clone() const override;
+    // void materialize(Column&) override;
 
     bool get_element(size_t, int8_t*)  const override;
     bool get_element(size_t, int16_t*) const override;
@@ -48,7 +56,10 @@ class Range_ColumnImpl : public Virtual_ColumnImpl {
     bool get_element(size_t, double*)  const override;
 
   private:
-    Range_ColumnImpl(SType, size_t, int64_t, int64_t);  // for cloning
+    Range_ColumnImpl(size_t, SType, int64_t, int64_t);  // for cloning
+
+    // Helper for get_element() accessors
+    template <typename T> inline bool _get(size_t, T*) const;
 };
 
 

--- a/c/column/range.h
+++ b/c/column/range.h
@@ -46,7 +46,7 @@ class Range_ColumnImpl : public Virtual_ColumnImpl {
                      SType stype = SType::VOID);
 
     ColumnImpl* clone() const override;
-    // void materialize(Column&) override;
+    void materialize(Column&) override;
 
     bool get_element(size_t, int8_t*)  const override;
     bool get_element(size_t, int16_t*) const override;
@@ -60,6 +60,9 @@ class Range_ColumnImpl : public Virtual_ColumnImpl {
 
     // Helper for get_element() accessors
     template <typename T> inline bool _get(size_t, T*) const;
+
+    // Helper for materialize()
+    template <typename T> void _materialize(Column&) const;
 };
 
 

--- a/c/column_from_pylist.cc
+++ b/c/column_from_pylist.cc
@@ -584,7 +584,9 @@ Column Column::from_pylist_of_dicts(
 Column Column::from_range(
     int64_t start, int64_t stop, int64_t step, SType stype)
 {
-  if (stype == SType::STR32 || stype == SType::STR64 || stype == SType::OBJ) {
+  if (stype == SType::STR32 || stype == SType::STR64 ||
+      stype == SType::OBJ || stype == SType::BOOL)
+  {
     Column col = Column(new dt::Range_ColumnImpl(start, stop, step));
     col.cast_inplace(stype);
     return col;

--- a/c/expr/head_literal_sliceint.cc
+++ b/c/expr/head_literal_sliceint.cc
@@ -74,6 +74,7 @@ RowIndex Head_Literal_SliceInt::evaluate_i(const vecExpr&, EvalContext& ctx) con
 static size_t _estimate_iby_nrows(size_t nrows, size_t ngroups,
                                   int64_t istart, int64_t istop, int64_t istep)
 {
+  (void) istart;
   // if (istep < 0) istep = -istep;
   // if (istep == 1) {
   //   if (istart == py::oslice::NA) istart = 0;

--- a/tests/random_attack.py
+++ b/tests/random_attack.py
@@ -243,6 +243,23 @@ class Attacker:
         if python_output:
             python_output.write("DT.cbind(DTNP)\n")
 
+    def add_range_column(self, frame):
+        start = int(random.expovariate(0.05) - 5)
+        step = 0
+        while step == 0:
+            step = int(1 + random.random() * 3)
+        stop = start + step * frame.nrows
+        rangeobj = range(start, stop, step)
+        print("[12] Adding a range column %r -> ncols = %d"
+              % (rangeobj, frame.ncols + 1))
+        name = Frame0.random_name()
+        if python_output:
+            python_output.write("DT.cbind(dt.Frame(%s=%r))\n"
+                                % (name, rangeobj))
+        frame.add_range_column(name, rangeobj)
+
+
+
     #---------------------------------------------------------------------------
     # Helpers
     #---------------------------------------------------------------------------
@@ -284,6 +301,7 @@ class Attacker:
         replace_nas_in_column: 1,
         sort_column: 1,
         cbind_numpy_column: 1,
+        add_range_column: 1,
     }
     ATTACK_WEIGHTS = list(itertools.accumulate(ATTACK_METHODS.values()))
     ATTACK_METHODS = list(ATTACK_METHODS.keys())
@@ -676,6 +694,14 @@ class Frame0:
         self.types += [coltype]
         self.names += names
         self.dedup_names()
+
+    def add_range_column(self, name, rangeobj):
+        self.data += [list(rangeobj)]
+        self.names += [name]
+        self.types += [int]
+        self.dedup_names()
+        self.df.cbind(dt.Frame(rangeobj, names=[name]))
+
 
     #---------------------------------------------------------------------------
     # Helpers


### PR DESCRIPTION
- `Range_ColumnImpl` no longer allows BOOL stype;
- Simplified `get_element()` functions;
- Added specialized `materialize()` method;
- Also added `fill_np_mask()` and `apply_rowindex()`;
- Added range column to the suite of random attack tests.