### PR TITLE
Fix missing import in setup_utils.py

### DIFF
--- a/ci/setup_utils.py
+++ b/ci/setup_utils.py
@@ -23,6 +23,7 @@
 #-------------------------------------------------------------------------------
 import os
 import re
+import shutil
 import subprocess
 import sys
 import sysconfig


### PR DESCRIPTION
Library `shutil` was used in "setup_utils.py" (on a rare path) but never imported.

Closes #2070