### PR TITLE
Adjust NA handling in FTRL

### DIFF
--- a/c/column.cc
+++ b/c/column.cc
@@ -215,7 +215,7 @@ static inline py::oobj getelem(const Column& col, size_t i) {
 py::oobj Column::get_element_as_pyobject(size_t i) const {
   switch (stype()) {
     case SType::BOOL: {
-      int32_t x;
+      int8_t x;
       bool isvalid = get_element(i, &x);
       return isvalid? py::obool(x) : py::None();
     }

--- a/c/frame/__repr__.cc
+++ b/c/frame/__repr__.cc
@@ -195,8 +195,8 @@ class HtmlWidget {
         const Column& col = dt->get_column(j);
         switch (col.stype()) {
           case SType::BOOL:
-          case SType::INT8:
-          case SType::INT16:
+          case SType::INT8:    render_fw_value<int8_t>(col, i); break;
+          case SType::INT16:   render_fw_value<int16_t>(col, i); break;
           case SType::INT32:   render_fw_value<int32_t>(col, i); break;
           case SType::INT64:   render_fw_value<int64_t>(col, i); break;
           case SType::FLOAT32: render_fw_value<float>(col, i); break;
@@ -261,7 +261,8 @@ class HtmlWidget {
           html << "&minus;";
           val = -val;
         }
-        html << val;
+        html << +val; // "+" ensures that `int8_t` vals are rendered as numbers
+
       } else {
         render_na();
       }

--- a/c/models/column_hasher.h
+++ b/c/models/column_hasher.h
@@ -45,7 +45,6 @@ using hasherptr = std::unique_ptr<Hasher>;
 /**
  *  Template class to hash booleans & integers.
  */
-template <typename T>
 class HasherInt : public Hasher {
   public:
     using Hasher::Hasher;
@@ -56,7 +55,6 @@ class HasherInt : public Hasher {
 /**
  *  Template class to hash floats.
  */
-template <typename T>
 class HasherFloat : public Hasher {
   private:
     const int shift_nbits;
@@ -75,13 +73,6 @@ class HasherString : public Hasher {
     using Hasher::Hasher;
     uint64_t hash(size_t row) const override;
 };
-
-
-extern template class HasherInt<int32_t>;
-extern template class HasherInt<int64_t>;
-extern template class HasherFloat<float>;
-extern template class HasherFloat<double>;
-
 
 
 #endif

--- a/c/models/column_hasher.h
+++ b/c/models/column_hasher.h
@@ -43,8 +43,9 @@ using hasherptr = std::unique_ptr<Hasher>;
 
 
 /**
- *  Template class to hash booleans & integers.
+ *  Template class to hash booleans and integers.
  */
+template <typename T>
 class HasherInt : public Hasher {
   public:
     using Hasher::Hasher;
@@ -55,6 +56,7 @@ class HasherInt : public Hasher {
 /**
  *  Template class to hash floats.
  */
+template <typename T>
 class HasherFloat : public Hasher {
   private:
     const int shift_nbits;
@@ -74,5 +76,11 @@ class HasherString : public Hasher {
     uint64_t hash(size_t row) const override;
 };
 
+extern template class HasherInt<int8_t>;
+extern template class HasherInt<int16_t>;
+extern template class HasherInt<int32_t>;
+extern template class HasherInt<int64_t>;
+extern template class HasherFloat<float>;
+extern template class HasherFloat<double>;
 
 #endif

--- a/c/models/dt_ftrl.cc
+++ b/c/models/dt_ftrl.cc
@@ -923,7 +923,6 @@ dtptr Ftrl<T>::create_p(size_t nrows) {
     cols.push_back(Column::new_data_column(nrows, stype));
   }
 
-  // dtptr dt_p = dtptr(new DataTable(std::move(cols), labels));
   dtptr dt_p = dtptr(new DataTable(std::move(cols), std::move(labels_vec)));
   return dt_p;
 }
@@ -1083,10 +1082,10 @@ hasherptr Ftrl<T>::create_hasher(const Column& col) {
     case SType::BOOL:
     case SType::INT8:
     case SType::INT16:
-    case SType::INT32:   return hasherptr(new HasherInt<int32_t>(col));
-    case SType::INT64:   return hasherptr(new HasherInt<int64_t>(col));
-    case SType::FLOAT32: return hasherptr(new HasherFloat<float>(col, shift_nbits));
-    case SType::FLOAT64: return hasherptr(new HasherFloat<double>(col, shift_nbits));
+    case SType::INT32:
+    case SType::INT64:   return hasherptr(new HasherInt(col));
+    case SType::FLOAT32:
+    case SType::FLOAT64: return hasherptr(new HasherFloat(col, shift_nbits));
     case SType::STR32:
     case SType::STR64:   return hasherptr(new HasherString(col));
     default:             throw  TypeError() << "Cannot hash a column of type "

--- a/c/models/dt_ftrl.cc
+++ b/c/models/dt_ftrl.cc
@@ -1080,12 +1080,12 @@ hasherptr Ftrl<T>::create_hasher(const Column& col) {
   int shift_nbits = DOUBLE_MANTISSA_NBITS - mantissa_nbits;
   switch (col.stype()) {
     case SType::BOOL:
-    case SType::INT8:
-    case SType::INT16:
-    case SType::INT32:
-    case SType::INT64:   return hasherptr(new HasherInt(col));
-    case SType::FLOAT32:
-    case SType::FLOAT64: return hasherptr(new HasherFloat(col, shift_nbits));
+    case SType::INT8:    return hasherptr(new HasherInt<int8_t>(col));
+    case SType::INT16:   return hasherptr(new HasherInt<int16_t>(col));
+    case SType::INT32:   return hasherptr(new HasherInt<int32_t>(col));
+    case SType::INT64:   return hasherptr(new HasherInt<int64_t>(col));
+    case SType::FLOAT32: return hasherptr(new HasherFloat<float>(col, shift_nbits));
+    case SType::FLOAT64: return hasherptr(new HasherFloat<double>(col, shift_nbits));
     case SType::STR32:
     case SType::STR64:   return hasherptr(new HasherString(col));
     default:             throw  TypeError() << "Cannot hash a column of type "

--- a/tests/random_driver.py
+++ b/tests/random_driver.py
@@ -10,6 +10,7 @@
 #     python tests/random_driver.py --help
 #
 #-------------------------------------------------------------------------------
+import sys; sys.path.insert(0, '.'); sys.path.insert(0, '..')
 import os
 import subprocess
 import random

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -1342,6 +1342,7 @@ def test_html_repr_joined_frame():
     DT = L_dt[:, :, dt.join(R_dt)]
     html = DT._repr_html_()
     hr = parse_html_repr(html)
+    print(hr)
     assert hr.names == ("A", "B", "yhat")
     assert hr.shape == (4, 3)
     assert hr.data == [['5', '7', '1'],

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -1342,7 +1342,6 @@ def test_html_repr_joined_frame():
     DT = L_dt[:, :, dt.join(R_dt)]
     html = DT._repr_html_()
     hr = parse_html_repr(html)
-    print(hr)
     assert hr.names == ("A", "B", "yhat")
     assert hr.shape == (4, 3)
     assert hr.data == [['5', '7', '1'],


### PR DESCRIPTION
- to avoid confusions and to increase compatibility with DAI, FTRL hashers will hash `NA`'s to  `NA_S8`, that is `uint64_t(1) << 63`, for all the supported column types; 
- minor adjustment to frame rendering and tests.