### PR TITLE
Add a function to set key columns to random attacker

### DIFF
--- a/c/column.cc
+++ b/c/column.cc
@@ -312,6 +312,7 @@ void Column::resize(size_t new_nrows) {
   size_t curr_nrows = nrows();
   if (new_nrows > curr_nrows) pcol->na_pad(new_nrows, *this);
   if (new_nrows < curr_nrows) pcol->truncate(new_nrows, *this);
+  if (new_nrows != curr_nrows) reset_stats();
 }
 
 

--- a/c/column.cc
+++ b/c/column.cc
@@ -112,6 +112,7 @@ dt::ColumnImpl* Column::_get_mutable_impl() {
     impl_ = impl_->clone();
   }
   xassert(impl_->refcount_ == 1);
+  reset_stats();
   return const_cast<dt::ColumnImpl*>(impl_);
 }
 
@@ -308,11 +309,11 @@ void Column::apply_rowindex(const RowIndex& ri) {
 }
 
 void Column::resize(size_t new_nrows) {
-  auto pcol = _get_mutable_impl();
   size_t curr_nrows = nrows();
+  if (new_nrows == curr_nrows) return;
+  auto pcol = _get_mutable_impl();
   if (new_nrows > curr_nrows) pcol->na_pad(new_nrows, *this);
   if (new_nrows < curr_nrows) pcol->truncate(new_nrows, *this);
-  if (new_nrows != curr_nrows) reset_stats();
 }
 
 

--- a/tests/random_attack.py
+++ b/tests/random_attack.py
@@ -605,7 +605,6 @@ class Frame0:
     #---------------------------------------------------------------------------
 
     def resize_rows(self, nrows):
-        import unittest
         curr_nrows = self.nrows
         if len(self.df.key) and nrows > curr_nrows:
             with pytest.raises(ValueError, match="Cannot increase the number "

--- a/tests/random_attack.py
+++ b/tests/random_attack.py
@@ -145,10 +145,10 @@ class Attacker:
             if res:
                 python_output.write("DT.nrows = %d\n" % new_nrows)
             else:
-                python_output.write("with pytest.raises(ValueError) as e:\n"
-                                    "    DT.nrows = %d\n"
-                                    "assert str(e.value) == 'Cannot increase the "
-                                    "number of rows in a keyed frame'\n\n"
+                python_output.write("with pytest.raises(ValueError, "
+                                    "match='Cannot increase the number of rows "
+                                    "in a keyed frame'):\n"
+                                    "    DT.nrows = %d\n\n"
                                     % new_nrows)
 
     def slice_rows(self, frame):
@@ -287,10 +287,10 @@ class Attacker:
             if res:
                 python_output.write("DT.key = %r\n" % names)
             else:
-                python_output.write("with pytest.raises(ValueError) as e:\n"
-                                    "    DT.key = %r\n"
-                                    "assert str(e.value) == 'Cannot set a key: "
-                                    "the values are not unique'\n\n"
+                python_output.write("with pytest.raises(ValueError, "
+                                    "match='Cannot set a key: the values are "
+                                    "not unique'):\n"
+                                    "    DT.key = %r\n\n"
                                     % names)
 
 
@@ -604,11 +604,12 @@ class Frame0:
     #---------------------------------------------------------------------------
 
     def resize_rows(self, nrows):
+        import unittest
         curr_nrows = self.nrows
         if len(self.df.key) and nrows > curr_nrows:
-            with pytest.raises(ValueError) as e:
+            with pytest.raises(ValueError, match="Cannot increase the number "
+                               "of rows in a keyed frame"):
                 self.df.nrows = nrows
-            assert str(e.value) == "Cannot increase the number of rows in a keyed frame"
             return False
         else:
             self.df.nrows = nrows
@@ -755,9 +756,9 @@ class Frame0:
         # if ngroups == self.nrows:
         #     self.df.key = names
         # else:
-        #     with pytest.raises(ValueError) as e:
+        #     with pytest.raises(ValueError, match="Cannot set a key: the "
+        #                        "values are not unique"):
         #         self.df.key = names
-        #     assert str(e.value) == "Cannot set a key: the values are not unique"
         #     return False
         try:
             self.df.key = names

--- a/tests/random_attack.py
+++ b/tests/random_attack.py
@@ -230,14 +230,13 @@ class Attacker:
     def sort_columns(self, frame):
         if frame.ncols == 0:
             return
-        ncols_sort = random.randint(1,5)
-        a = self.random_array(frame.ncols, newn=ncols_sort, positive=True)
+        ncols_sort = random.randint(1, frame.ncols)
+        a = random.sample(range(0, frame.ncols), ncols_sort)
 
-        print("[10] Sorting %s: %r in ascending order"
+        print("[10] Sorting %s in ascending order: %r"
               % (plural(len(a), "column"), a))
         if python_output:
             python_output.write("DT = DT.sort(%r)\n" % a)
-        frame.sort_columns(a)
 
     def cbind_numpy_column(self, frame):
         print("[11] Cbinding frame with a numpy column -> ncols = %d"
@@ -261,6 +260,18 @@ class Attacker:
             python_output.write("DT.cbind(dt.Frame(%s=%r))\n"
                                 % (name, rangeobj))
         frame.add_range_column(name, rangeobj)
+
+    def set_key_columns(self, frame):
+        if frame.ncols == 0:
+            return
+        ncols_key = random.randint(1, frame.ncols)
+        a = random.sample(range(0, frame.ncols), ncols_key)
+
+        print("[13] Setting %s: %r"
+              % (plural(len(a), "key column"), a))
+        if python_output:
+            python_output.write("DT = DT.key(%r)\n" % a)
+        frame.set_key_columns(a)
 
 
 
@@ -307,6 +318,8 @@ class Attacker:
         sort_columns: 1,
         cbind_numpy_column: 1,
         add_range_column: 1,
+        set_key_columns: 0,
+        # cbind_unique_columns: 0,
     }
     ATTACK_WEIGHTS = list(itertools.accumulate(ATTACK_METHODS.values()))
     ATTACK_METHODS = list(ATTACK_METHODS.keys())
@@ -707,6 +720,14 @@ class Frame0:
         self.dedup_names()
         self.df.cbind(dt.Frame(rangeobj, names=[name]))
 
+    def set_key_columns(self, a):
+        colnames = self.df.names
+        key_colnames = [colnames[i] for i in a]
+        self.df.key = key_colnames
+        if (len(self.data[0])):
+            data = list(zip(*self.data))
+            data.sort(key=lambda x: [(x[i] is not None, x[i]) for i in a])
+            self.data = list(map(list, zip(*data)))
 
     #---------------------------------------------------------------------------
     # Helpers

--- a/tests/random_attack.py
+++ b/tests/random_attack.py
@@ -110,7 +110,6 @@ class Attacker:
             frame = Frame0()
         print("Launching an attack for %d rounds" % rounds)
         for _ in range(rounds):
-            print(":", end='', flush=True)
             self.attack_frame(frame)
             if exhaustive_checks:
                 frame.check()

--- a/tests/random_attack.py
+++ b/tests/random_attack.py
@@ -4,7 +4,7 @@
 #   License, v. 2.0. If a copy of the MPL was not distributed with this
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #-------------------------------------------------------------------------------
-import sys; sys.path += ('.', '..')
+import sys; sys.path = ['.', '..'] + sys.path
 import copy
 import datatable as dt
 import itertools
@@ -236,7 +236,7 @@ class Attacker:
     def sort_columns(self, frame):
         if frame.ncols == 0:
             return
-        ncols_sort = random.randint(1, frame.ncols)
+        ncols_sort = min(int(random.expovariate(1.0)) + 1, frame.ncols)
         a = random.sample(range(0, frame.ncols), ncols_sort)
 
         print("[10] Sorting %s in ascending order: %r"
@@ -270,7 +270,7 @@ class Attacker:
     def set_key_columns(self, frame):
         if frame.ncols == 0:
             return
-        nkeys = random.randint(1, frame.ncols)
+        nkeys = min(int(random.expovariate(1.0)) + 1, frame.ncols)
         keys = random.sample(range(0, frame.ncols), nkeys)
         names = [frame.names[i] for i in keys]
 
@@ -746,16 +746,17 @@ class Frame0:
             assert str(e) == "Cannot set a key: the values are not unique"
             return
 
-        nonkeys = sorted(list(set(range(len(self.data))) - set(keys)))
+        nonkeys = sorted(set(range(len(self.data))) - set(keys))
+        new_col_order = keys + nonkeys
 
-        self.types = [self.types[i] for i in keys] + [self.types[i] for i in nonkeys]
-        self.names = [self.names[i] for i in keys] + [self.names[i] for i in nonkeys]
+        self.types = [self.types[i] for i in new_col_order]
+        self.names = [self.names[i] for i in new_col_order]
 
         if (len(self.data[0])):
             data = list(zip(*self.data))
             data.sort(key=lambda x: [(x[i] is not None, x[i]) for i in keys])
             self.data = list(map(list, zip(*data)))
-            self.data = [self.data[i] for i in keys] + [self.data[i] for i in nonkeys]
+            self.data = [self.data[i] for i in new_col_order]
 
     #---------------------------------------------------------------------------
     # Helpers
@@ -806,11 +807,11 @@ if __name__ == "__main__":
                                str(args.seed) + ".py")
         python_output = open(outfile, "wt")
         python_output.write("#!/usr/bin/env python\n")
-        python_output.write("import sys; sys.path += ('.', '..')\n")
+        python_output.write("import sys; sys.path = ['.', '..'] + sys.path\n")
         python_output.write("import datatable as dt\n")
         python_output.write("import numpy as np\n")
         python_output.write("from datatable import f\n")
-        python_output.write("from datatable.internal import frame_integrity_check\n")
+        python_output.write("from datatable.internal import frame_integrity_check\n\n")
 
     try:
         ra = Attacker(args.seed)

--- a/tests/random_attack.py
+++ b/tests/random_attack.py
@@ -504,10 +504,12 @@ class Frame0:
 
     @property
     def nrows(self):
+        assert self.df.nrows == len(self.data[0])
         return self.df.nrows
 
     @property
     def ncols(self):
+        assert self.df.ncols == len(self.data)
         return self.df.ncols
 
 
@@ -691,7 +693,7 @@ class Frame0:
 
     def sort_columns(self, a):
         self.df = self.df.sort(a)
-        if (len(self.data[0])):
+        if (self.nrows):
             data = list(zip(*self.data))
             data.sort(key=lambda x: [(x[i] is not None, x[i]) for i in a])
             self.data = list(map(list, zip(*data)))
@@ -746,13 +748,13 @@ class Frame0:
             assert str(e) == "Cannot set a key: the values are not unique"
             return
 
-        nonkeys = sorted(set(range(len(self.data))) - set(keys))
+        nonkeys = sorted(set(range(self.ncols)) - set(keys))
         new_col_order = keys + nonkeys
 
         self.types = [self.types[i] for i in new_col_order]
         self.names = [self.names[i] for i in new_col_order]
 
-        if (len(self.data[0])):
+        if (self.nrows):
             data = list(zip(*self.data))
             data.sort(key=lambda x: [(x[i] is not None, x[i]) for i in keys])
             self.data = list(map(list, zip(*data)))

--- a/tests/random_attack.py
+++ b/tests/random_attack.py
@@ -4,7 +4,7 @@
 #   License, v. 2.0. If a copy of the MPL was not distributed with this
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #-------------------------------------------------------------------------------
-import sys; sys.path.insert(0, '.'); sys.path.insert(0, '..')
+import sys; sys.path += ('.', '..')
 import copy
 import datatable as dt
 import itertools
@@ -141,7 +141,8 @@ class Attacker:
             python_output.write("\ntry:\n"
                                 "   DT.nrows = %d\n"
                                 "except ValueError as e:\n"
-                                "   assert str(e) == 'Cannot increase the number of rows in a keyed frame'\n\n"
+                                "   assert str(e) == 'Cannot increase the "
+                                "number of rows in a keyed frame'\n"
                                 % new_nrows)
 
         frame.resize_rows(new_nrows)
@@ -280,7 +281,8 @@ class Attacker:
             python_output.write("\ntry:\n"
                                 "   DT.key = %r\n"
                                 "except ValueError as e:\n"
-                                "   assert str(e) == 'Cannot set a key: the values are not unique'\n"
+                                "   assert str(e) == 'Cannot set a key: the "
+                                "values are not unique'\n"
                                 % names)
 
         frame.set_key_columns(keys, names)
@@ -388,7 +390,7 @@ class Frame0:
                                 "              names=%r,\n"
                                 "              stypes=%s)\n"
                                 % (repr_data(data, 14), names, repr_types(types)))
-            python_output.write("assert DT.shape == (%d, %d)\n\n" % (nrows, ncols))
+            python_output.write("assert DT.shape == (%d, %d)\n" % (nrows, ncols))
 
 
     def random_type(self):
@@ -599,7 +601,7 @@ class Frame0:
         try:
             self.df.nrows = nrows
         except ValueError as e:
-            assert(str(e) == "Cannot increase the number of rows in a keyed frame")
+            assert str(e) == "Cannot increase the number of rows in a keyed frame"
             return
 
         if curr_nrows < nrows:
@@ -713,12 +715,12 @@ class Frame0:
             python_output.write("DTNP = dt.Frame(np.ma.array(%s,\n"
                                 "                mask=%s,\n"
                                 "                dtype=np.dtype(%s)).T,\n"
-                                "                names=%r)\n\n"
+                                "                names=%r)\n"
                                 % (repr_data([data], 14),
                                    repr_data([mmask], 14),
                                    coltype.__name__,
                                    names))
-            python_output.write("assert DTNP.shape == (%d, %d)\n\n"
+            python_output.write("assert DTNP.shape == (%d, %d)\n"
                                 % (self.nrows, 1))
 
         for i in range(self.nrows):
@@ -741,11 +743,10 @@ class Frame0:
         try:
             self.df.key = names
         except ValueError as e:
-            assert(str(e) == "Cannot set a key: the values are not unique")
+            assert str(e) == "Cannot set a key: the values are not unique"
             return
 
-        nonkeys = list(set(range(len(self.data))) - set(keys))
-        nonkeys.sort()
+        nonkeys = sorted(list(set(range(len(self.data))) - set(keys)))
 
         self.types = [self.types[i] for i in keys] + [self.types[i] for i in nonkeys]
         self.names = [self.names[i] for i in keys] + [self.names[i] for i in nonkeys]
@@ -805,11 +806,11 @@ if __name__ == "__main__":
                                str(args.seed) + ".py")
         python_output = open(outfile, "wt")
         python_output.write("#!/usr/bin/env python\n")
-        python_output.write("import sys; sys.path.insert(0, '.'); sys.path.insert(0, '..')\n")
+        python_output.write("import sys; sys.path += ('.', '..')\n")
         python_output.write("import datatable as dt\n")
         python_output.write("import numpy as np\n")
         python_output.write("from datatable import f\n")
-        python_output.write("from datatable.internal import frame_integrity_check\n\n")
+        python_output.write("from datatable.internal import frame_integrity_check\n")
 
     try:
         ra = Attacker(args.seed)

--- a/tests/random_attack.py
+++ b/tests/random_attack.py
@@ -270,20 +270,20 @@ class Attacker:
         if frame.ncols == 0:
             return
         nkeys = random.randint(1, frame.ncols)
-        colids = random.sample(range(0, frame.ncols), nkeys)
-        colnames = [frame.names[i] for i in colids]
+        keys = random.sample(range(0, frame.ncols), nkeys)
+        names = [frame.names[i] for i in keys]
 
         print("[13] Setting %s: %r"
-              % (plural(nkeys, "key column"), colids))
+              % (plural(nkeys, "key column"), keys))
 
         if python_output:
             python_output.write("\ntry:\n"
                                 "   DT.key = %r\n"
                                 "except ValueError as e:\n"
                                 "   assert str(e) == 'Cannot set a key: the values are not unique'\n"
-                                % colnames)
+                                % names)
 
-        frame.set_key_columns(colids, colnames)
+        frame.set_key_columns(keys, names)
 
 
 
@@ -330,7 +330,6 @@ class Attacker:
         cbind_numpy_column: 1,
         add_range_column: 1,
         set_key_columns: 1,
-        # cbind_unique_columns: 0,
     }
     ATTACK_WEIGHTS = list(itertools.accumulate(ATTACK_METHODS.values()))
     ATTACK_METHODS = list(ATTACK_METHODS.keys())
@@ -600,7 +599,6 @@ class Frame0:
         try:
             self.df.nrows = nrows
         except ValueError as e:
-            pass
             assert(str(e) == "Cannot increase the number of rows in a keyed frame")
             return
 
@@ -749,14 +747,14 @@ class Frame0:
         nonkeys = list(set(range(len(self.data))) - set(keys))
         nonkeys.sort()
 
+        self.types = [self.types[i] for i in keys] + [self.types[i] for i in nonkeys]
+        self.names = [self.names[i] for i in keys] + [self.names[i] for i in nonkeys]
+
         if (len(self.data[0])):
             data = list(zip(*self.data))
             data.sort(key=lambda x: [(x[i] is not None, x[i]) for i in keys])
             self.data = list(map(list, zip(*data)))
             self.data = [self.data[i] for i in keys] + [self.data[i] for i in nonkeys]
-
-        self.types = [self.types[i] for i in keys] + [self.types[i] for i in nonkeys]
-        self.names = [self.names[i] for i in keys] + [self.names[i] for i in nonkeys]
 
     #---------------------------------------------------------------------------
     # Helpers

--- a/tests/random_attack.py
+++ b/tests/random_attack.py
@@ -510,12 +510,12 @@ class Frame0:
     @property
     def nrows(self):
         assert self.df.nrows == len(self.data[0])
-        return self.df.nrows
+        return len(self.data[0])
 
     @property
     def ncols(self):
         assert self.df.ncols == len(self.data)
-        return self.df.ncols
+        return len(self.data)
 
 
     #---------------------------------------------------------------------------
@@ -751,19 +751,14 @@ class Frame0:
         self.df.cbind(dt.Frame(rangeobj, names=[name]))
 
     def set_key_columns(self, keys, names):
-        # from datatable import by, count
-        # ngroups = self.df[:, count(f[0]), by(*names)].nrows
-        # if ngroups == self.nrows:
-        #     self.df.key = names
-        # else:
-        #     with pytest.raises(ValueError, match="Cannot set a key: the "
-        #                        "values are not unique"):
-        #         self.df.key = names
-        #     return False
-        try:
+        key_data = [self.data[i] for i in keys]
+        unique_rows = set(list(zip(*key_data)))
+        if len(unique_rows) == self.nrows:
             self.df.key = names
-        except ValueError as e:
-            assert str(e) == "Cannot set a key: the values are not unique"
+        else:
+            with pytest.raises(ValueError, match="Cannot set a key: the values "
+                               "are not unique"):
+                self.df.key = names
             return False
 
         nonkeys = sorted(set(range(self.ncols)) - set(keys))

--- a/tests/random_attack.py
+++ b/tests/random_attack.py
@@ -752,7 +752,7 @@ class Frame0:
 
     def set_key_columns(self, keys, names):
         key_data = [self.data[i] for i in keys]
-        unique_rows = set(list(zip(*key_data)))
+        unique_rows = set(zip(*key_data))
         if len(unique_rows) == self.nrows:
             self.df.key = names
         else:

--- a/tests/random_attack.py
+++ b/tests/random_attack.py
@@ -509,8 +509,9 @@ class Frame0:
 
     @property
     def nrows(self):
-        assert self.df.nrows == len(self.data[0])
-        return len(self.data[0])
+        nrows = len(self.data[0]) if self.data else 0
+        assert self.df.nrows == nrows
+        return nrows
 
     @property
     def ncols(self):

--- a/tests/random_attack.py
+++ b/tests/random_attack.py
@@ -515,8 +515,9 @@ class Frame0:
 
     @property
     def ncols(self):
-        assert self.df.ncols == len(self.data)
-        return len(self.data)
+        ncols = len(self.data)
+        assert self.df.ncols == ncols
+        return ncols
 
 
     #---------------------------------------------------------------------------

--- a/tests/random_driver.py
+++ b/tests/random_driver.py
@@ -10,10 +10,11 @@
 #     python tests/random_driver.py --help
 #
 #-------------------------------------------------------------------------------
-import sys; sys.path += ('.', '..')
+import sys; sys.path = ['.', '..'] + sys.path
 import os
 import subprocess
 import random
+import datatable
 from datatable.utils.terminal import term
 
 skip_successful_seeds = False

--- a/tests/random_driver.py
+++ b/tests/random_driver.py
@@ -10,7 +10,7 @@
 #     python tests/random_driver.py --help
 #
 #-------------------------------------------------------------------------------
-import sys; sys.path.insert(0, '.'); sys.path.insert(0, '..')
+import sys; sys.path += ('.', '..')
 import os
 import subprocess
 import random

--- a/tests/random_driver.py
+++ b/tests/random_driver.py
@@ -10,6 +10,7 @@
 #     python tests/random_driver.py --help
 #
 #-------------------------------------------------------------------------------
+import sys; sys.path.insert(0, '.'); sys.path.insert(0, '..')
 import os
 import subprocess
 import random

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -608,6 +608,12 @@ def test_resize_issue1527(patched_terminal, capsys):
             in out)
 
 
+def test_resize_invalidates_stats():
+    f0 = dt.Frame([3, 1, 4, 1, 5, 9, 2, 6])
+    assert_equals(f0.max(), dt.Frame([9]))
+    f0.nrows = 3
+    frame_integrity_check(f0)
+    assert_equals(f0.max(), dt.Frame([4]))
 
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
- set key columns in a random attacker;
- fix numpy python output;
- invalidate stats when mutable column implementation is requested;
- minor cleaning.

Closes #2075.