### PR TITLE
Add delete columns operation to random attacker

### DIFF
--- a/c/column.cc
+++ b/c/column.cc
@@ -112,6 +112,7 @@ dt::ColumnImpl* Column::_get_mutable_impl() {
     impl_ = impl_->clone();
   }
   xassert(impl_->refcount_ == 1);
+  reset_stats();
   return const_cast<dt::ColumnImpl*>(impl_);
 }
 
@@ -308,8 +309,9 @@ void Column::apply_rowindex(const RowIndex& ri) {
 }
 
 void Column::resize(size_t new_nrows) {
-  auto pcol = _get_mutable_impl();
   size_t curr_nrows = nrows();
+  if (new_nrows == curr_nrows) return;
+  auto pcol = _get_mutable_impl();
   if (new_nrows > curr_nrows) pcol->na_pad(new_nrows, *this);
   if (new_nrows < curr_nrows) pcol->truncate(new_nrows, *this);
 }

--- a/tests/random_attack.py
+++ b/tests/random_attack.py
@@ -646,15 +646,26 @@ class Frame0:
                 self.data[i] = [col[j] for j in s]
 
     def delete_rows(self, s):
+        assert isinstance(s, slice) or isinstance(s, list)
         nrows = self.nrows
         del self.df[s, :]
         if isinstance(s, slice):
             s = list(range(nrows))[s]
-        if isinstance(s, list):
-            index = sorted(set(range(nrows)) - set(s))
-            for i in range(self.ncols):
-                col = self.data[i]
-                self.data[i] = [col[j] for j in index]
+        index = sorted(set(range(nrows)) - set(s))
+        for i in range(self.ncols):
+            col = self.data[i]
+            self.data[i] = [col[j] for j in index]
+
+    def delete_columns(self, s):
+        assert isinstance(s, slice) or isinstance(s, list)
+        ncols = self.ncols
+        del self.df[:, s]
+        if isinstance(s, slice):
+            s = list(range(ncols))[s]
+        index = sorted(set(range(ncols)) - set(s))
+        self.data = [self.data[i] for i in index]
+        self.names = [self.names[i] for i in index]
+        self.types = [self.types[i] for i in index]
 
     def slice_cols(self, s):
         self.df = self.df[:, s]
@@ -695,16 +706,6 @@ class Frame0:
         self.data = [[value for i, value in enumerate(column) if filter_col[i]]
                      for column in self.data]
         self.df = self.df[f[icol], :]
-
-    def delete_columns(self, s):
-        ncols = self.ncols
-        del self.df[:, s]
-        if isinstance(s, slice):
-            s = list(range(ncols))[s]
-        new_column_ids = sorted(set(range(ncols)) - set(s))
-        self.data = [self.data[i] for i in new_column_ids]
-        self.names = [self.names[i] for i in new_column_ids]
-        self.types = [self.types[i] for i in new_column_ids]
 
     def replace_nas_in_column(self, icol, replacement_value):
         assert 0 <= icol < self.ncols

--- a/tests/random_attack.py
+++ b/tests/random_attack.py
@@ -296,7 +296,6 @@ class Attacker:
         if frame.ncols < 2:
             return
         s = self.random_array(frame.ncols - 1, positive=True)
-        s = sorted(set(s))
         print("[14] Removing columns %r -> ncols = %d"
               % (s, frame.ncols - len(s)))
         if python_output:

--- a/tests/random_attack.py
+++ b/tests/random_attack.py
@@ -215,9 +215,7 @@ class Attacker:
               % (filter_column, frame.names[filter_column]))
         if python_output:
             python_output.write("DT = DT[f[%d], :]\n" % filter_column)
-            python_output.write("del DT[:, %d]\n" % filter_column)
         frame.filter_on_bool_column(filter_column)
-        frame.delete_column(filter_column)
 
     def replace_nas_in_column(self, frame):
         icol = random.randint(0, frame.ncols - 1)
@@ -292,6 +290,19 @@ class Attacker:
                                     "    DT.key = %r\n\n"
                                     % names)
 
+    def delete_columns_array(self, frame):
+        # datatable supports a shape of n x 0 for non-zero n's, while
+        # python doesn't, so we never remove all the columns from a Frame.
+        if frame.ncols < 2:
+            return
+        s = self.random_array(frame.ncols - 1, positive=True)
+        s = sorted(set(s))
+        print("[14] Removing columns %r -> ncols = %d"
+              % (s, frame.ncols - len(s)))
+        if python_output:
+            python_output.write("del DT[:, %r]\n" % (s,))
+        frame.delete_columns(s)
+
 
     #---------------------------------------------------------------------------
     # Helpers
@@ -336,6 +347,7 @@ class Attacker:
         cbind_numpy_column: 1,
         add_range_column: 1,
         set_key_columns: 1,
+        delete_columns_array: 1,
     }
     ATTACK_WEIGHTS = list(itertools.accumulate(ATTACK_METHODS.values()))
     ATTACK_METHODS = list(ATTACK_METHODS.keys())
@@ -634,7 +646,6 @@ class Frame0:
                 self.data[i] = [col[j] for j in s]
 
     def delete_rows(self, s):
-        self.check_shape()
         nrows = self.nrows
         del self.df[s, :]
         if isinstance(s, slice):
@@ -685,11 +696,15 @@ class Frame0:
                      for column in self.data]
         self.df = self.df[f[icol], :]
 
-    def delete_column(self, icol):
-        del self.data[icol]
-        del self.names[icol]
-        del self.types[icol]
-        del self.df[icol]
+    def delete_columns(self, s):
+        ncols = self.ncols
+        del self.df[:, s]
+        if isinstance(s, slice):
+            s = list(range(ncols))[s]
+        new_column_ids = sorted(set(range(ncols)) - set(s))
+        self.data = [self.data[i] for i in new_column_ids]
+        self.names = [self.names[i] for i in new_column_ids]
+        self.types = [self.types[i] for i in new_column_ids]
 
     def replace_nas_in_column(self, icol, replacement_value):
         assert 0 <= icol < self.ncols
@@ -824,6 +839,7 @@ if __name__ == "__main__":
                                str(args.seed) + ".py")
         python_output = open(outfile, "wt")
         python_output.write("#!/usr/bin/env python\n")
+        python_output.write("#seed: %s\n" % args.seed)
         python_output.write("import sys; sys.path = ['.', '..'] + sys.path\n")
         python_output.write("import datatable as dt\n")
         python_output.write("import numpy as np\n")

--- a/tests/random_attack.py
+++ b/tests/random_attack.py
@@ -300,7 +300,7 @@ class Attacker:
         print("[14] Removing columns %r -> ncols = %d"
               % (s, frame.ncols - len(s)))
         if python_output:
-            python_output.write("del DT[:, %r]\n" % (s,))
+            python_output.write("del DT[:, %r]\n" % s)
         frame.delete_columns(s)
 
 

--- a/tests/random_driver.py
+++ b/tests/random_driver.py
@@ -10,10 +10,11 @@
 #     python tests/random_driver.py --help
 #
 #-------------------------------------------------------------------------------
-import sys; sys.path.insert(0, '.'); sys.path.insert(0, '..')
+import sys; sys.path = ['.', '..'] + sys.path
 import os
 import subprocess
 import random
+import datatable
 from datatable.utils.terminal import term
 
 skip_successful_seeds = False

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -608,6 +608,12 @@ def test_resize_issue1527(patched_terminal, capsys):
             in out)
 
 
+def test_resize_invalidates_stats():
+    f0 = dt.Frame([3, 1, 4, 1, 5, 9, 2, 6])
+    assert_equals(f0.max(), dt.Frame([9]))
+    f0.nrows = 3
+    frame_integrity_check(f0)
+    assert_equals(f0.max(), dt.Frame([4]))
 
 
 #-------------------------------------------------------------------------------

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -352,7 +352,7 @@ def test_names_deduplication():
 
 # To pick up attacks based on the corresponding weights, random attacker
 # uses random.choices(), introduced in Python 3.6.
-@pytest.mark.usefixtures("py36")
+@pytest.mark.usefixtures("py36", "numpy")
 def test_random_attack():
     import subprocess
     cmd_run = "./tests/random_driver.py"


### PR DESCRIPTION
- add delete column operation to random attacker;
- don't delete boolean column in `select_rows_with_boolean_column()`;
- minor other adjustments to the unit tests.

Helped to reveal #2083.
