### PR TITLE
Add join operation to random attacker

### DIFF
--- a/c/frame/rbind.cc
+++ b/c/frame/rbind.cc
@@ -295,6 +295,7 @@ void DataTable::rbind(
   }
   ncols_ = new_ncols;
   nrows_ = new_nrows;
+  nkeys_ = 0; // this will drop key columns, if they existed
 }
 
 

--- a/c/frame/rbind.cc
+++ b/c/frame/rbind.cc
@@ -295,7 +295,7 @@ void DataTable::rbind(
   }
   ncols_ = new_ncols;
   nrows_ = new_nrows;
-  nkeys_ = 0; // this will drop keys, if they was previously set
+  nkeys_ = 0; // this will drop all the keys, if there were any
 }
 
 

--- a/c/frame/rbind.cc
+++ b/c/frame/rbind.cc
@@ -295,7 +295,7 @@ void DataTable::rbind(
   }
   ncols_ = new_ncols;
   nrows_ = new_nrows;
-  nkeys_ = 0; // this will drop key columns, if they existed
+  nkeys_ = 0; // this will drop keys, if they was previously set
 }
 
 

--- a/tests/munging/test_rbind.py
+++ b/tests/munging/test_rbind.py
@@ -447,7 +447,13 @@ def test_rbind_modulefn():
     assert f3.to_list()[0] == f0.to_list()[0] + f1.to_list()[0]
 
 
-
+def test_rbind_keyed_frame():
+    f0 = dt.Frame([1, 2, 3])
+    f1 = dt.Frame([100, 500, 900])
+    f0.key = "C0"
+    f0.rbind(f1)
+    assert len(f0.key) == 0
+    assert f0.shape == (6, 1)
 
 #-------------------------------------------------------------------------------
 # Issues

--- a/tests/random_attack.py
+++ b/tests/random_attack.py
@@ -731,7 +731,8 @@ class Frame0:
                 assert self.names[j] == iframe.names[j]
                 newdata[j] += iframe.data[j]
         self.data = newdata
-        self.nkeys = 0
+        if self.nrows:
+            self.nkeys = 0
 
     def filter_on_bool_column(self, icol):
         assert self.types[icol] is bool

--- a/tests/random_attack.py
+++ b/tests/random_attack.py
@@ -244,6 +244,7 @@ class Attacker:
               % (plural(len(a), "column"), a))
         if python_output:
             python_output.write("DT = DT.sort(%r)\n" % a)
+        frame.sort_columns(a)
 
     def cbind_numpy_column(self, frame):
         print("[11] Cbinding frame with a numpy column -> ncols = %d"

--- a/tests/random_attack.py
+++ b/tests/random_attack.py
@@ -731,6 +731,7 @@ class Frame0:
                 assert self.names[j] == iframe.names[j]
                 newdata[j] += iframe.data[j]
         self.data = newdata
+        self.nkeys = 0
 
     def filter_on_bool_column(self, icol):
         assert self.types[icol] is bool

--- a/tests/random_attack.py
+++ b/tests/random_attack.py
@@ -687,13 +687,14 @@ class Frame0:
         del self.df[:, s]
         if isinstance(s, slice):
             s = list(range(ncols))[s]
-        new_column_order = sorted(set(range(ncols)) - set(s))
-        self.data = [self.data[i] for i in new_column_order]
-        self.names = [self.names[i] for i in new_column_order]
-        self.types = [self.types[i] for i in new_column_order]
 
+        new_column_ids = sorted(set(range(ncols)) - set(s))
+        self.data = [self.data[i] for i in new_column_ids]
+        self.names = [self.names[i] for i in new_column_ids]
+        self.types = [self.types[i] for i in new_column_ids]
         if (min(s) < self.nkeys):
             self.nkeys = 0
+
 
     def slice_cols(self, s):
         self.df = self.df[:, s]

--- a/tests/random_attack.py
+++ b/tests/random_attack.py
@@ -272,6 +272,7 @@ class Attacker:
     def set_key_columns(self, frame):
         if frame.ncols == 0:
             return
+
         nkeys = min(int(random.expovariate(1.0)) + 1, frame.ncols)
         keys = random.sample(range(0, frame.ncols), nkeys)
         names = [frame.names[i] for i in keys]
@@ -754,6 +755,7 @@ class Frame0:
             data = list(zip(*self.data))
             data.sort(key=lambda x: [(x[i] is not None, x[i]) for i in a])
             self.data = list(map(list, zip(*data)))
+        self.nkeys = 0
 
     def cbind_numpy_column(self):
         coltype = self.random_type()

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -352,6 +352,7 @@ def test_names_deduplication():
 
 # To pick up attacks based on the corresponding weights, random attacker
 # uses random.choices(), introduced in Python 3.6.
+@pytest.mark.skip(reason="See #2090")
 @pytest.mark.usefixtures("py36", "numpy")
 def test_random_attack():
     import subprocess

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -352,7 +352,6 @@ def test_names_deduplication():
 
 # To pick up attacks based on the corresponding weights, random attacker
 # uses random.choices(), introduced in Python 3.6.
-@pytest.mark.skip(reason="See #2090")
 @pytest.mark.usefixtures("py36", "numpy")
 def test_random_attack():
     import subprocess


### PR DESCRIPTION
- add join-frame-with-itself operation to random attacker;
- add key check to make sure number of keys is the same between python and datatable;
- restore frame sorting operation that was accidentally deleted in one of the previous PRs;
- drop keys after `rbind()` operation.

Adding key checks revealed a problem that we don't preserve key columns in many cases when we could: row slicing, join, etc. 

Closes #2090