### PR TITLE
Display

### DIFF
--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -239,6 +239,7 @@ static void initialize_options(const py::PKArgs& args) {
   dt::thread_pool::init_options();
   dt::progress::init_options();
   py::Frame::init_names_options();
+  py::Frame::init_display_options();
   GenericReader::init_options();
   sort_init_options();
 }

--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -33,6 +33,7 @@
 #include "python/string.h"
 #include "utils/assert.h"
 #include "utils/macros.h"
+#include "utils/terminal.h"
 #include "datatablemodule.h"
 #include "options.h"
 #include "sort.h"
@@ -383,6 +384,7 @@ PyMODINIT_FUNC PyInit__datatable() noexcept
     py::oby::init(m);
     py::ojoin::init(m);
     py::osort::init(m);
+    dt::Terminal::standard_terminal().initialize();
 
   } catch (const std::exception& e) {
     exception_to_python(e);

--- a/c/frame/__repr__.cc
+++ b/c/frame/__repr__.cc
@@ -23,17 +23,12 @@
 #include <sstream>
 #include "frame/py_frame.h"
 #include "frame/repr/repr_options.h"
+#include "frame/repr/terminal_widget.h"
 #include "frame/repr/text_column.h"
 #include "frame/repr/widget.h"
 #include "python/string.h"
 #include "options.h"
 #include "types.h"
-
-
-//------------------------------------------------------------------------------
-// Display options
-//------------------------------------------------------------------------------
-
 
 
 
@@ -403,85 +398,6 @@ bool HtmlWidget::styles_emitted = false;
 
 
 //------------------------------------------------------------------------------
-// TerminalWidget
-//------------------------------------------------------------------------------
-
-/**
-  * This class is responsible for rendering a Frame into a terminal
-  * as a text.
-  */
-class TerminalWidget : public dt::Widget {
-  private:
-    std::ostringstream out_;
-    std::vector<dt::TextColumn> text_columns_;
-
-  public:
-    TerminalWidget(DataTable* dt, dt::Widget::SplitViewTag)
-      : Widget(dt, split_view_tag) {}
-
-    py::oobj to_python() {
-      render_all();
-      const std::string outstr = out_.str();
-      return py::ostring(outstr);
-    }
-
-  protected:
-    void _render() override {
-      _prerender_columns();
-      _render_column_names();
-      _render_header_separator();
-      _render_data();
-      _render_footer();
-    }
-
-  private:
-    void _prerender_columns() {
-      // size_t nkeys = dt_->nkeys();
-      const auto& names = dt_->get_names();
-      text_columns_.reserve(colindices_.size());
-      for (size_t j : colindices_) {
-        text_columns_.emplace_back(names[j], dt_->get_column(j), rowindices_);
-      }
-    }
-
-    void _render_column_names() {
-      for (const auto& col : text_columns_) {
-        col.print_name(out_);
-      }
-      out_ << '\n';
-    }
-
-    void _render_header_separator() {
-      for (const auto& col : text_columns_) {
-        col.print_separator(out_);
-      }
-      out_ << '\n';
-    }
-
-    void _render_data() {
-      for (size_t k = 0; k < rowindices_.size(); ++k) {
-        for (const auto& col : text_columns_) {
-          col.print_value(out_, k);
-        }
-        out_ << '\n';
-      }
-    }
-
-    void _render_footer() {
-      size_t nrows = dt_->nrows();
-      size_t ncols = dt_->ncols();
-      out_ << '\n';
-      out_ << "[" << nrows << " row" << (nrows==1? "" : "s") << " x ";
-      out_ << ncols << " column" << (ncols==1? "" : "s") << "]";
-      out_ << '\n';
-    }
-};
-
-
-
-
-
-//------------------------------------------------------------------------------
 // py::Frame interface
 //------------------------------------------------------------------------------
 namespace py {
@@ -539,7 +455,7 @@ void Frame::view(const PKArgs& args) {
 static PKArgs args_newview(0,0,0,false,false,{},"v",nullptr);
 
 oobj Frame::newview(const PKArgs& args) {
-  TerminalWidget widget(dt, dt::Widget::split_view_tag);
+  dt::TerminalWidget widget(dt, dt::Widget::split_view_tag);
   return widget.to_python();
 }
 

--- a/c/frame/__repr__.cc
+++ b/c/frame/__repr__.cc
@@ -402,6 +402,7 @@ bool HtmlWidget::styles_emitted = false;
 //------------------------------------------------------------------------------
 namespace py {
 
+
 oobj Frame::m__repr__() const {
   size_t nrows = dt->nrows();
   size_t ncols = dt->ncols();
@@ -411,11 +412,12 @@ oobj Frame::m__repr__() const {
   return ostring(out.str());
 }
 
+
 oobj Frame::m__str__() const {
-  oobj DFWidget = oobj::import("datatable")
-                  .get_attr("widget")
-                  .get_attr("DataFrameWidget");
-  return DFWidget.call({oobj(this)}).invoke("as_string");
+  dt::TerminalWidget widget(dt,
+                            &dt::Terminal::plain_terminal(),
+                            dt::Widget::split_view_tag);
+  return widget.to_python();
 }
 
 
@@ -452,12 +454,6 @@ void Frame::view(const PKArgs& args) {
 }
 
 
-static PKArgs args_newview(0,0,0,false,false,{},"v",nullptr);
-
-oobj Frame::newview(const PKArgs& args) {
-  dt::TerminalWidget widget(dt, dt::Widget::split_view_tag);
-  return widget.to_python();
-}
 
 
 void Frame::_init_repr(XTypeMaker& xt) {
@@ -466,7 +462,6 @@ void Frame::_init_repr(XTypeMaker& xt) {
   xt.add(METHOD(&Frame::_repr_html_, args__repr_html_));
   xt.add(METHOD(&Frame::_repr_pretty_, args__repr_pretty_));
   xt.add(METHOD(&Frame::view, args_view));
-  xt.add(METHOD(&Frame::newview, args_newview));
 }
 
 

--- a/c/frame/__repr__.cc
+++ b/c/frame/__repr__.cc
@@ -22,7 +22,7 @@
 #include <ctime>
 #include <sstream>
 #include "frame/py_frame.h"
-#include "frame/repr/repr.h"
+#include "frame/repr/text_column.h"
 #include "python/string.h"
 #include "options.h"
 #include "types.h"

--- a/c/frame/__repr__.cc
+++ b/c/frame/__repr__.cc
@@ -443,10 +443,11 @@ oobj Frame::_repr_pretty_(const PKArgs&) {
 
 
 static PKArgs args_view(
-  0, 1, 0, false, false, {"interactive"}, "view", nullptr);
+  0, 2, 0, false, false, {"interactive", "plain"}, "view", nullptr);
 
 void Frame::view(const PKArgs& args) {
   bool interactive = true;  // default when `interactive` is omitted entirely
+  bool plain = args[1].to<bool>(false);
   if (args[0].is_none()) interactive = dt::display_interactive;
   if (args[0].is_bool()) interactive = args[0].to_bool_strict();
   if (interactive && !dt::Terminal::standard_terminal().is_jupyter()) {
@@ -458,9 +459,9 @@ void Frame::view(const PKArgs& args) {
                     .get_attr("DataFrameWidget");
     DFWidget.call({oobj(this), obool(interactive)}).invoke("render");
   } else {
-    dt::TerminalWidget widget(dt,
-                              &dt::Terminal::standard_terminal(),
-                              dt::Widget::split_view_tag);
+    auto terminal = plain? &dt::Terminal::plain_terminal()
+                         : &dt::Terminal::standard_terminal();
+    dt::TerminalWidget widget(dt, terminal, dt::Widget::split_view_tag);
     widget.to_stdout();
   }
 }

--- a/c/frame/py_frame.h
+++ b/c/frame/py_frame.h
@@ -87,6 +87,7 @@ class Frame : public XObject<Frame> {
     oobj _repr_html_(const PKArgs&);
     oobj _repr_pretty_(const PKArgs&);
     void view(const PKArgs&);
+    oobj newview(const PKArgs&);
 
     oobj get_ncols() const;
     oobj get_nrows() const;

--- a/c/frame/py_frame.h
+++ b/c/frame/py_frame.h
@@ -132,6 +132,7 @@ class Frame : public XObject<Frame> {
 
     // Called once during module start-up
     static void init_names_options();
+    static void init_display_options();
 
   private:
     static bool internal_construction;

--- a/c/frame/repr/repr.h
+++ b/c/frame/repr/repr.h
@@ -1,0 +1,68 @@
+//------------------------------------------------------------------------------
+// Copyright 2019 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#include <iostream>
+#include <string>
+#include <vector>
+#include "column.h"
+namespace dt {
+using std::size_t;
+using std::string;
+using std::ostringstream;
+using intvec = std::vector<size_t>;
+
+enum Align : int { LEFT, RIGHT, DOT };
+
+static constexpr size_t NA_index = size_t(-1);
+
+
+class TextColumn {
+  private:
+    strvec data_;
+    string name_;
+    size_t width_;
+    size_t width_left_;
+    Align  alignment_;
+    bool   margin_left_;
+    bool   margin_right_;
+    int : 16;
+
+  public:
+    TextColumn(const string& name, const Column& col, const intvec& indices);
+    TextColumn(const TextColumn&) = default;
+    TextColumn(TextColumn&&) = default;
+
+    void print_name(ostringstream&) const;
+    void print_separator(ostringstream&) const;
+    void print_value(ostringstream&, size_t i) const;
+
+  private:
+    void _render_all_data(const Column& col, const intvec& indices);
+    void _print_aligned_value(ostringstream&, const string& value) const;
+    void _print_whitespace(ostringstream&, size_t n) const;
+    void _align_at_dot();
+};
+
+
+
+
+
+}  // namespace dt

--- a/c/frame/repr/repr_options.cc
+++ b/c/frame/repr/repr_options.cc
@@ -28,9 +28,9 @@ namespace dt {
 
 
 static constexpr size_t NA_size_t = size_t(-1);
-size_t display_max_nrows = 50;
-size_t display_head_nrows = 20;
-size_t display_tail_nrows = 10;
+size_t display_max_nrows = 30;
+size_t display_head_nrows = 15;
+size_t display_tail_nrows = 5;
 bool   display_interactive = false;
 
 

--- a/c/frame/repr/repr_options.cc
+++ b/c/frame/repr/repr_options.cc
@@ -1,0 +1,95 @@
+//------------------------------------------------------------------------------
+// Copyright 2019 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#include "frame/repr/repr_options.h"
+#include "frame/py_frame.h"
+#include "python/_all.h"
+#include "python/arg.h"
+#include "options.h"
+namespace dt {
+
+
+static constexpr size_t NA_size_t = size_t(-1);
+size_t display_max_nrows = 50;
+size_t display_head_nrows = 20;
+size_t display_tail_nrows = 10;
+
+
+
+static void _init_options() {
+  dt::register_option(
+    "display.max_nrows",
+    []{
+      return (display_max_nrows == NA_size_t)? py::None()
+                                             : py::oint(display_max_nrows);
+    },
+    [](const py::Arg& value) {
+      if (value.is_none()) {
+        display_max_nrows = NA_size_t;
+      } else {
+        int64_t n = value.to_int64_strict();
+        display_max_nrows = (n < 0)? NA_size_t : static_cast<size_t>(n);
+      }
+    },
+    "A frame with more rows than this will be displayed truncated\n"
+    "when the frame is printed to the console: only its first `head_nrows`\n"
+    "and last `tail_nrows` rows will be printed. It is recommended to have\n"
+    "`head_nrows + tail_nrows <= max_nrows`.\n"
+    "Setting this option to None (or a negative value) will cause all\n"
+    "rows in a frame to be printed, which may cause the console to become\n"
+    "unresponsive.\n"
+  );
+
+  register_option(
+    "display.head_nrows",
+    []{
+      return py::oint(display_head_nrows);
+    },
+    [](const py::Arg& value) {
+      display_head_nrows = value.to_size_t();
+    },
+    "The number of rows from the top of a frame to be displayed when\n"
+    "the frame's output is truncated due to the total number of frame's\n"
+    "rows exceeding `max_nrows` value.\n"
+  );
+
+  register_option(
+    "display.tail_nrows",
+    []{
+      return py::oint(display_tail_nrows);
+    },
+    [](const py::Arg& value) {
+      display_tail_nrows = value.to_size_t();
+    },
+    "The number of rows from the bottom of a frame to be displayed when\n"
+    "the frame's output is truncated due to the total number of frame's\n"
+    "rows exceeding `max_nrows` value.\n"
+  );
+}
+
+
+
+
+}  // namespace dt
+
+void py::Frame::init_display_options() {
+  dt::_init_options();
+}

--- a/c/frame/repr/repr_options.cc
+++ b/c/frame/repr/repr_options.cc
@@ -31,11 +31,25 @@ static constexpr size_t NA_size_t = size_t(-1);
 size_t display_max_nrows = 50;
 size_t display_head_nrows = 20;
 size_t display_tail_nrows = 10;
+bool   display_interactive = false;
 
 
+static void _init_options()
+{
+  register_option(
+    "display.interactive",
+    []{ return py::obool(display_interactive); },
+    [](const py::Arg& value) {
+      display_interactive = value.to_bool_strict();
+    },
+    "This option controls the behavior of a Frame when it is viewed in a\n"
+    "text console. When True, the Frame will be shown in the interactove\n"
+    "mode, allowing you to navigate the rows/columns with keyboard.\n"
+    "When False, the Frame will be shown in regular, non-interactive mode\n"
+    "(you can still call DT.view() to enter the interactive mode manually.\n"
+  );
 
-static void _init_options() {
-  dt::register_option(
+  register_option(
     "display.max_nrows",
     []{
       return (display_max_nrows == NA_size_t)? py::None()

--- a/c/frame/repr/repr_options.h
+++ b/c/frame/repr/repr_options.h
@@ -1,0 +1,35 @@
+//------------------------------------------------------------------------------
+// Copyright 2019 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#ifndef dt_FRAME_REPR_OPTIONS_h
+#define dt_FRAME_REPR_OPTIONS_h
+#include <cstddef>
+namespace dt {
+using std::size_t;
+
+
+extern size_t display_max_nrows;
+extern size_t display_head_nrows;
+extern size_t display_tail_nrows;
+
+
+} // namespace dt
+#endif

--- a/c/frame/repr/repr_options.h
+++ b/c/frame/repr/repr_options.h
@@ -29,7 +29,7 @@ using std::size_t;
 extern size_t display_max_nrows;
 extern size_t display_head_nrows;
 extern size_t display_tail_nrows;
-
+extern bool   display_interactive;
 
 } // namespace dt
 #endif

--- a/c/frame/repr/sstring.cc
+++ b/c/frame/repr/sstring.cc
@@ -1,0 +1,101 @@
+//------------------------------------------------------------------------------
+// Copyright 2019 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#include "frame/repr/sstring.h"
+namespace dt {
+using std::size_t;
+
+
+
+//------------------------------------------------------------------------------
+// Constructors
+//------------------------------------------------------------------------------
+
+sstring::sstring()
+  : str_(),
+    size_(0) {}
+
+
+sstring::sstring(const std::string& s)
+  : str_(s),
+    size_(_compute_string_size(str_)) {}
+
+
+sstring::sstring(std::string&& s)
+  : str_(std::move(s)),
+    size_(_compute_string_size(str_)) {}
+
+
+sstring::sstring(const std::string& s, size_t n)
+  : str_(s),
+    size_(n) {}
+
+
+sstring::sstring(std::string&& s, size_t n)
+  : str_(std::move(s)),
+    size_(n) {}
+
+
+
+//------------------------------------------------------------------------------
+// Private helpers
+//------------------------------------------------------------------------------
+
+static inline bool isdigit(char c) {
+  // Compiles to: (uint8_t)(c - '0') <= 9;
+  return (c >= '0') && (c <= '9');
+}
+
+static inline bool isalpha(char c) {
+  // Compiles to: (uint8_t)((c&~32) - 'A') <= 25;
+  return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+}
+
+
+size_t sstring::_compute_string_size(const std::string& str) {
+  size_t n = str.size();
+  size_t sz = 0;
+  for (size_t i = 0; i < n; ++i) {
+    auto c = static_cast<unsigned char>(str[i]);
+    // Ecma-48 terminal control sequences
+    if (c == 0x1B && i < n-2 && str[i+1] == '[') {
+      size_t j = i + 2;
+      while (j < n && isdigit(str[j])) j++;
+      if (j < n && isalpha(str[j])) {
+        i = j;  // i will be incremented by the loop too
+        continue;
+      }
+    }
+    // UTF-8 continuation sequences
+    if (c >= 0xC0) {
+      if ((c & 0xE0) == 0xC0)      i += 1;
+      else if ((c & 0xF0) == 0xE0) i += 2;
+      else if ((c & 0xF8) == 0xF0) i += 3;
+    }
+    sz++;
+  }
+  return sz;
+}
+
+
+
+
+}  // namespace dt

--- a/c/frame/repr/sstring.h
+++ b/c/frame/repr/sstring.h
@@ -49,6 +49,7 @@ class sstring {
     sstring(const sstring&) = default;
     sstring(sstring&&) noexcept = default;
     sstring& operator=(sstring&&) = default;
+    sstring& operator=(const sstring&) = default;
 
     sstring(const std::string&);
     sstring(std::string&&);

--- a/c/frame/repr/sstring.h
+++ b/c/frame/repr/sstring.h
@@ -19,50 +19,50 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
-#include <iostream>
 #include <string>
-#include <vector>
-#include "column.h"
+#ifndef dt_FRAME_REPR_SSTRING_h
+#define dt_FRAME_REPR_SSTRING_h
 namespace dt {
 using std::size_t;
-using std::string;
-using std::ostringstream;
-using intvec = std::vector<size_t>;
-
-enum Align : int { LEFT, RIGHT, DOT };
-
-static constexpr size_t NA_index = size_t(-1);
 
 
-class TextColumn {
+/**
+  * This class represents a string whose display size in terminal
+  * is different from the string's byte-size. The difference could
+  * be due to:
+  *
+  *   - string containing unicode characters which are encoded as
+  *     multi-byte UTF-8 sequences, yet are displayed as a single
+  *     character on screen;
+  *
+  *   - string containing special terminal codes that affect the
+  *     color of the text, yet are not visible in the output;
+  *
+  */
+class sstring {
   private:
-    strvec data_;
-    string name_;
-    size_t width_;
-    size_t width_left_;
-    Align  alignment_;
-    bool   margin_left_;
-    bool   margin_right_;
-    int : 16;
+    std::string str_;
+    size_t      size_;
 
   public:
-    TextColumn(const string& name, const Column& col, const intvec& indices);
-    TextColumn(const TextColumn&) = default;
-    TextColumn(TextColumn&&) = default;
+    sstring();
+    sstring(const sstring&) = default;
+    sstring(sstring&&) noexcept = default;
+    sstring& operator=(sstring&&) = default;
 
-    void print_name(ostringstream&) const;
-    void print_separator(ostringstream&) const;
-    void print_value(ostringstream&, size_t i) const;
+    sstring(const std::string&);
+    sstring(std::string&&);
+    sstring(const std::string&, size_t n);
+    sstring(std::string&&, size_t n);
+
+    inline size_t size() const noexcept { return size_; }
+    inline const std::string& str() const noexcept { return str_; }
 
   private:
-    void _render_all_data(const Column& col, const intvec& indices);
-    void _print_aligned_value(ostringstream&, const string& value) const;
-    void _print_whitespace(ostringstream&, size_t n) const;
-    void _align_at_dot();
+    static size_t _compute_string_size(const std::string&);
 };
 
 
 
-
-
 }  // namespace dt
+#endif

--- a/c/frame/repr/terminal_widget.cc
+++ b/c/frame/repr/terminal_widget.cc
@@ -26,8 +26,11 @@ namespace dt {
 
 
 
-TerminalWidget::TerminalWidget(DataTable* dt, SplitViewTag)
-  : Widget(dt, split_view_tag) {}
+TerminalWidget::TerminalWidget(DataTable* dt, Terminal* term, SplitViewTag)
+  : Widget(dt, split_view_tag)
+{
+  TextColumn::setup(term);
+}
 
 
 py::oobj TerminalWidget::to_python() {
@@ -71,6 +74,7 @@ void TerminalWidget::_prerender_columns() {
     text_columns_.emplace_back(std::move(textcol));
   }
   text_columns_.front().unset_left_margin();
+  text_columns_.back().unset_right_margin();
 }
 
 

--- a/c/frame/repr/terminal_widget.cc
+++ b/c/frame/repr/terminal_widget.cc
@@ -19,6 +19,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
+#include "column/range.h"
 #include "frame/repr/terminal_widget.h"
 #include "python/string.h"
 namespace dt {
@@ -52,9 +53,15 @@ void TerminalWidget::_render() {
 
 
 void TerminalWidget::_prerender_columns() {
-  // size_t nkeys = dt_->nkeys();
+  size_t nkeys = dt_->nkeys();
+  size_t nrows = dt_->nrows();
   const auto& names = dt_->get_names();
-  text_columns_.reserve(colindices_.size());
+  text_columns_.reserve(colindices_.size() + 1);
+  if (nkeys == 0) {
+    Column ri_col(new Range_ColumnImpl(0, static_cast<int64_t>(nrows), 1));
+    TextColumn ri_textcol("", ri_col, rowindices_, /*is_key_column=*/true);
+    text_columns_.emplace_back(std::move(ri_textcol));
+  }
   for (size_t j : colindices_) {
     text_columns_.emplace_back(names[j], dt_->get_column(j), rowindices_);
   }

--- a/c/frame/repr/terminal_widget.cc
+++ b/c/frame/repr/terminal_widget.cc
@@ -1,0 +1,102 @@
+//------------------------------------------------------------------------------
+// Copyright 2019 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#include "frame/repr/terminal_widget.h"
+#include "python/string.h"
+namespace dt {
+
+
+
+TerminalWidget::TerminalWidget(DataTable* dt, SplitViewTag)
+  : Widget(dt, split_view_tag) {}
+
+
+py::oobj TerminalWidget::to_python() {
+  render_all();
+  const std::string outstr = out_.str();
+  return py::ostring(outstr);
+}
+
+
+
+
+//------------------------------------------------------------------------------
+// Rendering
+//------------------------------------------------------------------------------
+
+void TerminalWidget::_render() {
+  _prerender_columns();
+  _render_column_names();
+  _render_header_separator();
+  _render_data();
+  _render_footer();
+}
+
+
+void TerminalWidget::_prerender_columns() {
+  // size_t nkeys = dt_->nkeys();
+  const auto& names = dt_->get_names();
+  text_columns_.reserve(colindices_.size());
+  for (size_t j : colindices_) {
+    text_columns_.emplace_back(names[j], dt_->get_column(j), rowindices_);
+  }
+}
+
+
+void TerminalWidget::_render_column_names() {
+  for (const auto& col : text_columns_) {
+    col.print_name(out_);
+  }
+  out_ << '\n';
+}
+
+
+void TerminalWidget::_render_header_separator() {
+  for (const auto& col : text_columns_) {
+    col.print_separator(out_);
+  }
+  out_ << '\n';
+}
+
+
+void TerminalWidget::_render_data() {
+  for (size_t k = 0; k < rowindices_.size(); ++k) {
+    for (const auto& col : text_columns_) {
+      col.print_value(out_, k);
+    }
+    out_ << '\n';
+  }
+}
+
+
+void TerminalWidget::_render_footer() {
+  size_t nrows = dt_->nrows();
+  size_t ncols = dt_->ncols();
+  out_ << '\n';
+  out_ << "[" << nrows << " row" << (nrows==1? "" : "s") << " x ";
+  out_ << ncols << " column" << (ncols==1? "" : "s") << "]";
+  out_ << '\n';
+}
+
+
+
+
+}  // namespace dt

--- a/c/frame/repr/terminal_widget.cc
+++ b/c/frame/repr/terminal_widget.cc
@@ -59,12 +59,18 @@ void TerminalWidget::_prerender_columns() {
   text_columns_.reserve(colindices_.size() + 1);
   if (nkeys == 0) {
     Column ri_col(new Range_ColumnImpl(0, static_cast<int64_t>(nrows), 1));
-    TextColumn ri_textcol("", ri_col, rowindices_, /*is_key_column=*/true);
-    text_columns_.emplace_back(std::move(ri_textcol));
+    TextColumn textcol("", ri_col, rowindices_, /*is_key_column=*/true);
+    textcol.set_right_border();
+    text_columns_.emplace_back(std::move(textcol));
   }
   for (size_t j : colindices_) {
-    text_columns_.emplace_back(names[j], dt_->get_column(j), rowindices_);
+    const auto& col = dt_->get_column(j);
+    bool iskey = (j < nkeys);
+    TextColumn textcol(names[j], col, rowindices_, iskey);
+    if (j == nkeys - 1) textcol.set_right_border();
+    text_columns_.emplace_back(std::move(textcol));
   }
+  text_columns_.front().unset_left_margin();
 }
 
 

--- a/c/frame/repr/terminal_widget.cc
+++ b/c/frame/repr/terminal_widget.cc
@@ -39,6 +39,11 @@ py::oobj TerminalWidget::to_python() {
   return py::ostring(outstr);
 }
 
+void TerminalWidget::to_stdout() {
+  render_all();
+  const std::string outstr = out_.str();
+  py::write_to_stdout(outstr);
+}
 
 
 

--- a/c/frame/repr/terminal_widget.h
+++ b/c/frame/repr/terminal_widget.h
@@ -39,7 +39,7 @@ class TerminalWidget : public Widget {
     std::vector<TextColumn> text_columns_;
 
   public:
-    TerminalWidget(DataTable* dt, SplitViewTag);
+    TerminalWidget(DataTable* dt, Terminal* term, SplitViewTag);
     py::oobj to_python();
 
   protected:

--- a/c/frame/repr/terminal_widget.h
+++ b/c/frame/repr/terminal_widget.h
@@ -40,7 +40,9 @@ class TerminalWidget : public Widget {
 
   public:
     TerminalWidget(DataTable* dt, Terminal* term, SplitViewTag);
+
     py::oobj to_python();
+    void     to_stdout();
 
   protected:
     void _render() override;

--- a/c/frame/repr/terminal_widget.h
+++ b/c/frame/repr/terminal_widget.h
@@ -1,0 +1,60 @@
+//------------------------------------------------------------------------------
+// Copyright 2019 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#ifndef dt_FRAME_REPR_TERMINAL_WIDGET_h
+#define dt_FRAME_REPR_TERMINAL_WIDGET_h
+#include <iostream>
+#include <vector>
+#include "frame/repr/text_column.h"
+#include "frame/repr/widget.h"
+#include "python/_all.h"
+namespace dt {
+
+
+/**
+  * This class is responsible for rendering a Frame into a terminal
+  * as a text.
+  */
+class TerminalWidget : public Widget {
+  private:
+    std::ostringstream out_;
+    std::vector<TextColumn> text_columns_;
+
+  public:
+    TerminalWidget(DataTable* dt, SplitViewTag);
+    py::oobj to_python();
+
+  protected:
+    void _render() override;
+
+  private:
+    void _prerender_columns();
+    void _render_column_names();
+    void _render_header_separator();
+    void _render_data();
+    void _render_footer();
+};
+
+
+
+
+}  // namespace dt
+#endif

--- a/c/frame/repr/text_column.cc
+++ b/c/frame/repr/text_column.cc
@@ -24,21 +24,22 @@
 namespace dt {
 
 
-
-//------------------------------------------------------------------------------
-// Construction
-//------------------------------------------------------------------------------
-Terminal* TextColumn::term_ = nullptr;
+const Terminal* TextColumn::term_ = nullptr;
 sstring TextColumn::ellipsis_;
 sstring TextColumn::na_value_;
 
 void TextColumn::setup(const Terminal* terminal) {
   term_ = terminal;
+  na_value_ = term_->dim("NA");
   ellipsis_ = term_->unicode_allowed()? term_->dim("\xE2\x80\xA6")  // '…'
                                       : term_->dim("...");
-  na_value_ = term_->dim("NA");
 }
 
+
+
+//------------------------------------------------------------------------------
+// Construction
+//------------------------------------------------------------------------------
 
 TextColumn::TextColumn(const std::string& name, const Column& col,
                        const intvec& indices, bool is_key_column)

--- a/c/frame/repr/text_column.cc
+++ b/c/frame/repr/text_column.cc
@@ -1,0 +1,172 @@
+//------------------------------------------------------------------------------
+// Copyright 2019 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#include "frame/repr/repr.h"
+#include "utils/assert.h"
+namespace dt {
+
+
+
+TextColumn::TextColumn(const string& name, const Column& col,
+                       const intvec& indices)
+  : name_(name),
+    width_(name.size())
+{
+  LType ltype = col.ltype();
+  alignment_ = (ltype == LType::BOOL)? Align::RIGHT :
+               (ltype == LType::INT) ? Align::RIGHT :
+               (ltype == LType::REAL)? Align::DOT :
+                                       Align::LEFT;
+  margin_left_ = true;
+  margin_right_ = true;
+  _render_all_data(col, indices);
+  _align_at_dot();
+}
+
+
+
+//------------------------------------------------------------------------------
+// Print data to the output stream
+//------------------------------------------------------------------------------
+
+void TextColumn::print_name(ostringstream& out) const {
+  _print_aligned_value(out, name_);
+}
+
+
+void TextColumn::print_separator(ostringstream& out) const {
+  if (margin_left_) out << ' ';
+  for (size_t i = 0; i < width_; ++i) {
+    out << '-';
+  }
+  if (margin_right_) out << ' ';
+}
+
+
+void TextColumn::print_value(ostringstream& out, size_t i) const {
+  _print_aligned_value(out, data_[i]);
+}
+
+
+void TextColumn::_print_aligned_value(ostringstream& out,
+                                      const string& value) const
+{
+  if (margin_left_) out << ' ';
+  if (alignment_ == Align::LEFT) {
+    out << value;
+    _print_whitespace(out, width_ - value.size());
+  }
+  if (alignment_ == Align::RIGHT) {
+    _print_whitespace(out, width_ - value.size());
+    out << value;
+  }
+  if (alignment_ == Align::DOT) {
+    size_t i = 0;
+    for (; i < value.size() && value[i] != '.'; ++i) {}
+    _print_whitespace(out, width_left_ - i);
+    out << value;
+    _print_whitespace(out, width_ - value.size() - width_left_ + i);
+  }
+  if (margin_right_) out << ' ';
+}
+
+
+void TextColumn::_print_whitespace(ostringstream& out, size_t n) const {
+  xassert(n < 10000);
+  for (size_t i = 0; i < n; ++i) out << ' ';
+}
+
+
+
+//------------------------------------------------------------------------------
+// Data rendering
+//------------------------------------------------------------------------------
+
+static string _render_value_bool(const Column& col, size_t i) {
+  int8_t value;
+  bool isvalid = col.get_element(i, &value);
+  if (!isvalid) return "";
+  return value? "1" : "0";
+}
+
+template <typename T>
+static string _render_value_int(const Column& col, size_t i) {
+  T value;
+  bool isvalid = col.get_element(i, &value);
+  if (!isvalid) return "";
+  return std::to_string(value);
+}
+
+template <typename T>
+static string _render_value_float(const Column& col, size_t i) {
+  T value;
+  bool isvalid = col.get_element(i, &value);
+  if (!isvalid) return "";
+  ostringstream out;
+  out << value;
+  return out.str();
+}
+
+
+static std::string _render_value(const Column& col, size_t i) {
+  switch (col.stype()) {
+    case SType::BOOL:    return _render_value_bool(col, i);
+    case SType::INT8:    return _render_value_int<int8_t>(col, i);
+    case SType::INT16:   return _render_value_int<int16_t>(col, i);
+    case SType::INT32:   return _render_value_int<int32_t>(col, i);
+    case SType::INT64:   return _render_value_int<int64_t>(col, i);
+    case SType::FLOAT32: return _render_value_float<float>(col, i);
+    case SType::FLOAT64: return _render_value_float<double>(col, i);
+    default: return "(?)";
+  }
+}
+
+
+
+
+void TextColumn::_render_all_data(const Column& col, const intvec& indices) {
+  data_.reserve(indices.size());
+  for (size_t i : indices) {
+    if (i == NA_index) {
+      data_.push_back("...");
+    } else {
+      data_.push_back(_render_value(col, i));
+    }
+    size_t w = data_.back().size();
+    if (width_ < w) width_ = w;
+  }
+}
+
+
+void TextColumn::_align_at_dot() {
+  if (alignment_ != Align::DOT) return;
+  width_left_ = 0;
+  for (const auto& val : data_) {
+    size_t i = 0;
+    for (; i < val.size() && val[i] != '.'; ++i) {}
+    if (i > width_left_) width_left_ = i;
+  }
+}
+
+
+
+
+}  // namespace dt

--- a/c/frame/repr/text_column.cc
+++ b/c/frame/repr/text_column.cc
@@ -31,7 +31,7 @@ const Terminal& TextColumn::term = Terminal::get_instance();
 
 
 TextColumn::TextColumn(const std::string& name, const Column& col,
-                       const intvec& indices)
+                       const intvec& indices, bool is_key_column)
   : name_(name)
 {
   width_ = std::max(name_.size(), size_t(2));
@@ -41,6 +41,7 @@ TextColumn::TextColumn(const std::string& name, const Column& col,
                  (ltype == LType::REAL);
   margin_left_ = true;
   margin_right_ = true;
+  is_key_column_ = is_key_column;
   _render_all_data(col, indices);
   if (ltype == LType::REAL) {
     _align_at_dot();
@@ -156,7 +157,11 @@ void TextColumn::_render_all_data(const Column& col, const intvec& indices) {
     if (i == NA_index) {
       data_.push_back(sstring("...", 3));
     } else {
-      data_.push_back(_render_value(col, i));
+      auto rendered_value = _render_value(col, i);
+      if (is_key_column_) {
+        rendered_value = sstring(term.grey(rendered_value.str()));
+      }
+      data_.push_back(std::move(rendered_value));
     }
     size_t w = data_.back().size();
     if (width_ < w) width_ = w;

--- a/c/frame/repr/text_column.cc
+++ b/c/frame/repr/text_column.cc
@@ -19,17 +19,22 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
-#include "frame/repr/repr.h"
+#include "frame/repr/text_column.h"
 #include "utils/assert.h"
 namespace dt {
 
 
+//------------------------------------------------------------------------------
+// Construction
+//------------------------------------------------------------------------------
+const Terminal& TextColumn::term = Terminal::get_instance();
 
-TextColumn::TextColumn(const string& name, const Column& col,
+
+TextColumn::TextColumn(const std::string& name, const Column& col,
                        const intvec& indices)
-  : name_(name),
-    width_(name.size())
+  : name_(name)
 {
+  width_ = std::max(name_.size(), size_t(2));
   LType ltype = col.ltype();
   alignment_ = (ltype == LType::BOOL)? Align::RIGHT :
                (ltype == LType::INT) ? Align::RIGHT :
@@ -38,8 +43,11 @@ TextColumn::TextColumn(const string& name, const Column& col,
   margin_left_ = true;
   margin_right_ = true;
   _render_all_data(col, indices);
-  _align_at_dot();
+  if (ltype == LType::REAL) {
+    _align_at_dot();
+  }
 }
+
 
 
 
@@ -48,42 +56,43 @@ TextColumn::TextColumn(const string& name, const Column& col,
 //------------------------------------------------------------------------------
 
 void TextColumn::print_name(ostringstream& out) const {
-  _print_aligned_value(out, name_);
+  _print_aligned_value(out, term.bold(name_.str()));
 }
 
 
 void TextColumn::print_separator(ostringstream& out) const {
   if (margin_left_) out << ' ';
-  for (size_t i = 0; i < width_; ++i) {
-    out << '-';
-  }
+  out << term.grey(std::string(width_, '-'));
   if (margin_right_) out << ' ';
 }
 
 
 void TextColumn::print_value(ostringstream& out, size_t i) const {
-  _print_aligned_value(out, data_[i]);
+  _print_aligned_value(out, data_[i].str());
 }
 
 
 void TextColumn::_print_aligned_value(ostringstream& out,
-                                      const string& value) const
+                                      const sstring& value) const
 {
+  const auto& value_str = value.str();
   if (margin_left_) out << ' ';
   if (alignment_ == Align::LEFT) {
-    out << value;
+    out << value_str;
     _print_whitespace(out, width_ - value.size());
   }
   if (alignment_ == Align::RIGHT) {
     _print_whitespace(out, width_ - value.size());
-    out << value;
+    out << value_str;
   }
   if (alignment_ == Align::DOT) {
-    size_t i = 0;
-    for (; i < value.size() && value[i] != '.'; ++i) {}
-    _print_whitespace(out, width_left_ - i);
-    out << value;
-    _print_whitespace(out, width_ - value.size() - width_left_ + i);
+    _print_whitespace(out, width_ - value.size());
+    out << value_str;
+    // size_t i = 0;
+    // for (; i < value_str.size() && value_str[i] != '.'; ++i) {}
+    // _print_whitespace(out, width_left_ - i);
+    // out << value_str;
+    // _print_whitespace(out, width_ - value.size() - width_left_ + i);
   }
   if (margin_right_) out << ' ';
 }
@@ -100,33 +109,41 @@ void TextColumn::_print_whitespace(ostringstream& out, size_t n) const {
 // Data rendering
 //------------------------------------------------------------------------------
 
-static string _render_value_bool(const Column& col, size_t i) {
+static sstring _render_value_bool(const Column& col, size_t i) {
   int8_t value;
   bool isvalid = col.get_element(i, &value);
-  if (!isvalid) return "";
-  return value? "1" : "0";
+  if (!isvalid) return sstring();
+  return value? sstring("1", 1)
+              : sstring("0", 1);
 }
 
 template <typename T>
-static string _render_value_int(const Column& col, size_t i) {
+static sstring _render_value_int(const Column& col, size_t i) {
   T value;
   bool isvalid = col.get_element(i, &value);
-  if (!isvalid) return "";
-  return std::to_string(value);
+  if (!isvalid) return sstring();
+  return sstring(std::to_string(value));
 }
 
 template <typename T>
-static string _render_value_float(const Column& col, size_t i) {
+static sstring _render_value_float(const Column& col, size_t i) {
   T value;
   bool isvalid = col.get_element(i, &value);
-  if (!isvalid) return "";
+  if (!isvalid) return sstring();
   ostringstream out;
   out << value;
-  return out.str();
+  return sstring(out.str());
+}
+
+static sstring _render_value_string(const Column& col, size_t i) {
+  CString value;
+  bool isvalid = col.get_element(i, &value);
+  if (!isvalid) return sstring("NA", 2);
+  return sstring(std::string(value.ch, static_cast<size_t>(value.size)));
 }
 
 
-static std::string _render_value(const Column& col, size_t i) {
+static sstring _render_value(const Column& col, size_t i) {
   switch (col.stype()) {
     case SType::BOOL:    return _render_value_bool(col, i);
     case SType::INT8:    return _render_value_int<int8_t>(col, i);
@@ -135,7 +152,9 @@ static std::string _render_value(const Column& col, size_t i) {
     case SType::INT64:   return _render_value_int<int64_t>(col, i);
     case SType::FLOAT32: return _render_value_float<float>(col, i);
     case SType::FLOAT64: return _render_value_float<double>(col, i);
-    default: return "(?)";
+    case SType::STR32:
+    case SType::STR64:   return _render_value_string(col, i);
+    default: return sstring("", 0);
   }
 }
 
@@ -146,7 +165,7 @@ void TextColumn::_render_all_data(const Column& col, const intvec& indices) {
   data_.reserve(indices.size());
   for (size_t i : indices) {
     if (i == NA_index) {
-      data_.push_back("...");
+      data_.push_back(sstring("...", 3));
     } else {
       data_.push_back(_render_value(col, i));
     }
@@ -157,12 +176,27 @@ void TextColumn::_render_all_data(const Column& col, const intvec& indices) {
 
 
 void TextColumn::_align_at_dot() {
-  if (alignment_ != Align::DOT) return;
-  width_left_ = 0;
-  for (const auto& val : data_) {
-    size_t i = 0;
-    for (; i < val.size() && val[i] != '.'; ++i) {}
-    if (i > width_left_) width_left_ = i;
+  size_t n = data_.size();
+  std::vector<size_t> right_widths;
+  right_widths.reserve(n);
+
+  size_t max_right_width = 0;
+  for (size_t i = 0; i < n; ++i) {
+    const auto& str = data_[i].str();
+    size_t k = str.size();
+    for (; k > 0 && str[k-1] != '.'; --k) {}
+    k = str.size() - k;
+    if (k > max_right_width) max_right_width = k;
+    right_widths.push_back(k);
+  }
+
+  for (size_t i = 0; i < n; ++i) {
+    if (right_widths[i] < max_right_width) {
+      size_t nspaces = max_right_width - right_widths[i];
+      data_[i] = sstring(std::string(data_[i].str())
+                         .insert(data_[i].str().size(), nspaces, ' '));
+      width_ = std::max(width_, data_[i].size());
+    }
   }
 }
 

--- a/c/frame/repr/text_column.h
+++ b/c/frame/repr/text_column.h
@@ -49,11 +49,13 @@ class TextColumn {
     bool    is_key_column_;
     int : 24;
 
-    static const Terminal& term;
+    static const Terminal* term_;
     static sstring ellipsis_;
     static sstring na_value_;
 
   public:
+    static void setup(const Terminal*);
+
     TextColumn(const std::string& name,
                const Column& col,
                const intvec& indices,
@@ -62,6 +64,7 @@ class TextColumn {
     TextColumn(TextColumn&&) = default;
 
     void unset_left_margin();
+    void unset_right_margin();
     void set_right_border();
 
     void print_name(ostringstream&) const;

--- a/c/frame/repr/text_column.h
+++ b/c/frame/repr/text_column.h
@@ -35,10 +35,6 @@ using sstrvec = std::vector<sstring>;
 
 static constexpr size_t NA_index = size_t(-1);
 
-enum Align : int { LEFT, RIGHT, DOT };
-
-
-
 
 
 class TextColumn {
@@ -46,10 +42,10 @@ class TextColumn {
     sstrvec data_;
     sstring name_;
     size_t  width_;
-    Align   alignment_;
+    bool    align_right_;
     bool    margin_left_;
     bool    margin_right_;
-    int : 16;
+    size_t : 40;
 
     static const Terminal& term;
 
@@ -68,6 +64,14 @@ class TextColumn {
     void _print_aligned_value(ostringstream&, const sstring& value) const;
     void _print_whitespace(ostringstream&, size_t n) const;
     void _align_at_dot();
+
+    sstring _render_value(const Column&, size_t i) const;
+    template <typename T>
+    sstring _render_value_float(const Column& col, size_t i) const;
+    template <typename T>
+    sstring _render_value_int(const Column& col, size_t i) const;
+    sstring _render_value_bool(const Column&, size_t i) const;
+    sstring _render_value_string(const Column&, size_t i) const;
 };
 
 

--- a/c/frame/repr/text_column.h
+++ b/c/frame/repr/text_column.h
@@ -1,0 +1,78 @@
+//------------------------------------------------------------------------------
+// Copyright 2019 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#ifndef dt_FRAME_REPR_TEXT_COLUMN_h
+#define dt_FRAME_REPR_TEXT_COLUMN_h
+#include <iostream>
+#include <string>
+#include <vector>
+#include "frame/repr/sstring.h"
+#include "utils/terminal.h"
+#include "column.h"
+namespace dt {
+using std::size_t;
+using std::ostringstream;
+using intvec = std::vector<size_t>;
+using sstrvec = std::vector<sstring>;
+
+static constexpr size_t NA_index = size_t(-1);
+
+enum Align : int { LEFT, RIGHT, DOT };
+
+
+
+
+
+class TextColumn {
+  private:
+    sstrvec data_;
+    sstring name_;
+    size_t  width_;
+    Align   alignment_;
+    bool    margin_left_;
+    bool    margin_right_;
+    int : 16;
+
+    static const Terminal& term;
+
+  public:
+    TextColumn(const std::string& name, const Column& col,
+               const intvec& indices);
+    TextColumn(const TextColumn&) = default;
+    TextColumn(TextColumn&&) = default;
+
+    void print_name(ostringstream&) const;
+    void print_separator(ostringstream&) const;
+    void print_value(ostringstream&, size_t i) const;
+
+  private:
+    void _render_all_data(const Column& col, const intvec& indices);
+    void _print_aligned_value(ostringstream&, const sstring& value) const;
+    void _print_whitespace(ostringstream&, size_t n) const;
+    void _align_at_dot();
+};
+
+
+
+
+
+}  // namespace dt
+#endif

--- a/c/frame/repr/text_column.h
+++ b/c/frame/repr/text_column.h
@@ -45,10 +45,13 @@ class TextColumn {
     bool    align_right_;
     bool    margin_left_;
     bool    margin_right_;
+    bool    border_right_;
     bool    is_key_column_;
-    int : 32;
+    int : 24;
 
     static const Terminal& term;
+    static sstring ellipsis_;
+    static sstring na_value_;
 
   public:
     TextColumn(const std::string& name,
@@ -57,6 +60,9 @@ class TextColumn {
                bool is_key_column = false);
     TextColumn(const TextColumn&) = default;
     TextColumn(TextColumn&&) = default;
+
+    void unset_left_margin();
+    void set_right_border();
 
     void print_name(ostringstream&) const;
     void print_separator(ostringstream&) const;

--- a/c/frame/repr/text_column.h
+++ b/c/frame/repr/text_column.h
@@ -45,13 +45,16 @@ class TextColumn {
     bool    align_right_;
     bool    margin_left_;
     bool    margin_right_;
-    size_t : 40;
+    bool    is_key_column_;
+    int : 32;
 
     static const Terminal& term;
 
   public:
-    TextColumn(const std::string& name, const Column& col,
-               const intvec& indices);
+    TextColumn(const std::string& name,
+               const Column& col,
+               const intvec& indices,
+               bool is_key_column = false);
     TextColumn(const TextColumn&) = default;
     TextColumn(TextColumn&&) = default;
 

--- a/c/frame/repr/widget.cc
+++ b/c/frame/repr/widget.cc
@@ -1,0 +1,130 @@
+//------------------------------------------------------------------------------
+// Copyright 2019 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#include <string>
+#include "frame/repr/repr_options.h"
+#include "frame/repr/widget.h"
+namespace dt {
+
+constexpr size_t Widget::NA_index;
+
+
+//------------------------------------------------------------------------------
+// Construction
+//------------------------------------------------------------------------------
+
+Widget::Widget(DataTable* dt) {
+  dt_ = dt;
+  ncols_ = dt->ncols();
+  nrows_ = dt->nrows();
+  nkeys_ = dt->nkeys();
+  render_row_indices_ = true;
+}
+
+
+Widget::Widget(DataTable* dt, SplitViewTag) : Widget(dt)
+{
+  startcol_ = NA_index;
+  startrow_ = NA_index;
+
+  constexpr size_t maxcols = 15;
+  cols0_ = (ncols_ <= maxcols) ? ncols_ : maxcols * 2 / 3;
+  cols1_ = (ncols_ <= maxcols) ? 0 : maxcols - cols0_;
+  cols0_ = std::max(cols0_, dt->nkeys());
+
+  size_t max_nrows = std::max(display_max_nrows,
+                              display_head_nrows + display_tail_nrows);
+  rows0_ = (nrows_ > max_nrows) ? display_head_nrows : nrows_;
+  rows1_ = (nrows_ > max_nrows) ? display_tail_nrows : 0;
+}
+
+
+Widget::Widget(DataTable* dt, WindowedTag) : Widget(dt)
+{
+  startcol_ = 0;
+  startrow_ = 0;
+  cols0_ = 15;
+  rows0_ = 30;
+}
+
+
+
+
+//------------------------------------------------------------------------------
+// Rendering
+//------------------------------------------------------------------------------
+
+void Widget::render_all() {
+  _generate_column_indices();
+  _generate_row_indices();
+  _render();
+}
+
+
+void Widget::_generate_column_indices() {
+  colindices_.clear();
+  if (startcol_ == NA_index) {
+    colindices_.reserve(cols0_ + cols1_ + 1);
+    for (size_t i = 0; i < ncols_; ++i) {
+      if (i == cols0_) {
+        colindices_.push_back(NA_index);
+        i = ncols_ - cols1_;
+      }
+      colindices_.push_back(i);
+    }
+  } else {
+    colindices_.reserve(nkeys_ + cols0_);
+    for (size_t i = 0; i < nkeys_; ++i) {
+      colindices_.push_back(i);
+    }
+    for (size_t i = 0; i < cols0_; ++i) {
+      colindices_.push_back(i + startcol_);
+    }
+  }
+}
+
+
+// Populate array `rowindices_` with indices of the rows that shall be
+// rendered. The array may also contain `NA_index`, which indicates an
+// "ellipsis" row.
+void Widget::_generate_row_indices() {
+  rowindices_.clear();
+  if (startrow_ == NA_index) {
+    rowindices_.reserve(rows0_ + rows1_ + 1);
+    for (size_t i = 0; i < nrows_; ++i) {
+      if (i == rows0_) {
+        rowindices_.push_back(NA_index);
+        i = nrows_ - rows1_;
+      }
+      rowindices_.push_back(i);
+    }
+  } else {
+    rowindices_.reserve(rows0_);
+    for (size_t i = 0; i < rows0_; ++i) {
+      rowindices_.push_back(i + startrow_);
+    }
+  }
+}
+
+
+
+
+}  // namespace dt

--- a/c/frame/repr/widget.h
+++ b/c/frame/repr/widget.h
@@ -1,0 +1,70 @@
+//------------------------------------------------------------------------------
+// Copyright 2019 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#include <vector>
+#include "datatable.h"
+#ifndef dt_FRAME_REPR_WIDGET_h
+#define dt_FRAME_REPR_WIDGET_h
+namespace dt {
+using std::size_t;
+
+
+
+class Widget {
+  private:
+    size_t ncols_, nrows_, nkeys_;
+    size_t startcol_, startrow_;
+    size_t cols0_, cols1_;
+    size_t rows0_, rows1_;
+
+  protected:
+    DataTable* dt_;
+    std::vector<size_t> colindices_;
+    std::vector<size_t> rowindices_;
+    bool render_row_indices_;
+    size_t : 56;
+
+  public:
+    static constexpr size_t NA_index = size_t(-1);
+    static struct SplitViewTag {} split_view_tag;
+    static struct WindowedTag {} windowed_tag;
+
+    Widget(DataTable* dt, SplitViewTag);
+    Widget(DataTable* dt, WindowedTag);
+    virtual ~Widget() = default;
+
+    void render_all();
+
+  protected:
+    virtual void _render() = 0;
+
+  private:
+    explicit Widget(DataTable* dt);
+
+    void _generate_column_indices();
+    void _generate_row_indices();
+};
+
+
+
+
+}  // namespace dt
+#endif

--- a/c/python/obj.cc
+++ b/c/python/obj.cc
@@ -19,7 +19,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
-#include "python/obj.h"
+#include <iostream>
 #include <cstdint>         // INT32_MAX
 #include "expr/by_node.h"
 #include "expr/join_node.h"
@@ -27,6 +27,7 @@
 #include "frame/py_frame.h"
 #include "python/_all.h"
 #include "python/list.h"
+#include "python/obj.h"
 #include "python/string.h"
 
 namespace py {
@@ -39,6 +40,9 @@ static void init_numpy();
 
 // Set from datatablemodule.cc
 PyObject* Expr_Type = nullptr;
+
+_Py_IDENTIFIER(stdout);
+_Py_IDENTIFIER(write);
 
 
 
@@ -807,8 +811,39 @@ oobj None()     { return oobj(Py_None); }
 oobj True()     { return oobj(Py_True); }
 oobj False()    { return oobj(Py_False); }
 oobj Ellipsis() { return oobj(Py_Ellipsis); }
-robj stdout()   { return robj(PySys_GetObject("stdout")); }
 robj rnone()    { return robj(Py_None); }
+
+robj stdout() {
+  return robj(
+    #ifndef Py_LIMITED_API
+      _PySys_GetObjectId(&PyId_stdout)  // borrowed ref
+    #else
+      PySys_GetObject("stdout")         // borrowed ref
+    #endif
+  );
+}
+
+void write_to_stdout(const std::string& str) {
+  PyObject* py_stdout = stdout().to_borrowed_ref();
+  oobj writer;
+  if (py_stdout && py_stdout != Py_None) {
+    writer = oobj::from_new_reference(
+      #ifndef Py_LIMITED_API
+        _PyObject_GetAttrId(py_stdout, &PyId_write)  // new ref
+      #else
+        PyObject_GetAttrString(py_stdout, "write")   // new ref
+      #endif
+    );
+    if (!writer) PyErr_Clear();
+  }
+  if (writer) {
+    writer.call({ ostring(str) });
+  }
+  else {
+    std::cout << str;
+  }
+}
+
 
 
 //------------------------------------------------------------------------------

--- a/c/python/obj.h
+++ b/c/python/obj.h
@@ -144,6 +144,7 @@ class _obj {
     oobj call(otuple args, odict kws) const;
     ostring str() const;
     PyTypeObject* typeobj() const noexcept;  // borrowed ref
+    std::string typestr() const;
     size_t get_sizeof() const;
 
     explicit operator bool() const noexcept;  // opposite of is_undefined()
@@ -341,6 +342,7 @@ oobj None();
 oobj True();
 oobj False();
 oobj Ellipsis();
+robj stdin();
 robj stdout();
 robj rnone();
 
@@ -350,6 +352,9 @@ robj rnone();
   * write to the standard C++ output stream `sys::cout`.
   */
 void write_to_stdout(const std::string& str);
+
+
+oobj get_module(const char* name);
 
 
 extern PyObject* Expr_Type;

--- a/c/python/obj.h
+++ b/c/python/obj.h
@@ -335,14 +335,21 @@ class oobj : public _obj {
 
 
 /**
- * Return python constants None, True, False wrapped as `oobj`s.
- */
+  * Return python constants None, True, False wrapped as `oobj`s.
+  */
 oobj None();
 oobj True();
 oobj False();
 oobj Ellipsis();
 robj stdout();
 robj rnone();
+
+
+/**
+  * Write the string to python's `sys.stdout`, or if it is absent,
+  * write to the standard C++ output stream `sys::cout`.
+  */
+void write_to_stdout(const std::string& str);
 
 
 extern PyObject* Expr_Type;

--- a/c/read/py_read.cc
+++ b/c/read/py_read.cc
@@ -171,6 +171,7 @@ static bool _has_control_characters(const CString& text) {
 }
 
 
+#if 0
 static bool _looks_like_url(const CString& text) {
   size_t n = static_cast<size_t>(text.size);
   const char* ch = text.ch;
@@ -193,10 +194,11 @@ static bool _looks_like_glob(const CString& text) {
   }
   return false;
 }
-
+#endif
 
 
 static ReadSource _resolve_source_any(const py::Arg& src, GenericReader& gr) {
+  (void)gr;
   xassert(src.is_defined());
   auto srcobj = src.to_oobj();
   if (src.is_string() || src.is_bytes()) {

--- a/c/utils/terminal.cc
+++ b/c/utils/terminal.cc
@@ -1,0 +1,121 @@
+//------------------------------------------------------------------------------
+// Copyright 2019 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#include "utils/assert.h"
+#include "utils/terminal.h"
+namespace dt {
+
+
+
+//------------------------------------------------------------------------------
+// Constructors
+//------------------------------------------------------------------------------
+
+Terminal& Terminal::get_instance() {
+  static Terminal term;
+  return term;
+}
+
+Terminal::Terminal() {
+  allow_unicode_ = true;
+  enable_colors_ = true; // false;
+  enable_ecma48_ = true; // false;
+  enable_keyboard_ = false;
+  is_jupyter_ = false;
+  is_ipython_ = false;
+  if (!enable_ecma48_) xassert(!enable_colors_);
+}
+
+Terminal::~Terminal() = default;
+
+
+
+std::string Terminal::blue(const std::string& s) const {
+  return enable_colors_? "\x1B[34m" + s + "\x1B[m" : s;
+}
+
+std::string Terminal::blueB(const std::string& s) const {
+  return enable_colors_? "\x1B[94m" + s + "\x1B[m" : s;
+}
+
+std::string Terminal::bold(const std::string& s) const {
+  return enable_colors_? "\x1B[1m" + s + "\x1B[m" : s;
+}
+
+std::string Terminal::cyan(const std::string& s) const {
+  return enable_colors_? "\x1B[36m" + s + "\x1B[m" : s;
+}
+
+std::string Terminal::cyanB(const std::string& s) const {
+  return enable_colors_? "\x1B[96m" + s + "\x1B[m" : s;
+}
+
+std::string Terminal::dim(const std::string& s) const {
+  return enable_colors_? "\x1B[2m" + s + "\x1B[m" : s;
+}
+
+std::string Terminal::green(const std::string& s) const {
+  return enable_colors_? "\x1B[32m" + s + "\x1B[m" : s;
+}
+
+std::string Terminal::greenB(const std::string& s) const {
+  return enable_colors_? "\x1B[92m" + s + "\x1B[m" : s;
+}
+
+std::string Terminal::grey(const std::string& s) const {
+  return enable_colors_? "\x1B[90m" + s + "\x1B[m" : s;
+}
+
+std::string Terminal::magenta(const std::string& s) const {
+  return enable_colors_? "\x1B[35m" + s + "\x1B[m" : s;
+}
+
+std::string Terminal::magentaB(const std::string& s) const {
+  return enable_colors_? "\x1B[95m" + s + "\x1B[m" : s;
+}
+
+std::string Terminal::red(const std::string& s) const {
+  return enable_colors_? "\x1B[31m" + s + "\x1B[m" : s;
+}
+
+std::string Terminal::redB(const std::string& s) const {
+  return enable_colors_? "\x1B[91m" + s + "\x1B[m" : s;
+}
+
+std::string Terminal::white(const std::string& s) const {
+  return enable_colors_? "\x1B[37m" + s + "\x1B[m" : s;
+}
+
+std::string Terminal::whiteB(const std::string& s) const {
+  return enable_colors_? "\x1B[97m" + s + "\x1B[m" : s;
+}
+
+std::string Terminal::yellow(const std::string& s) const {
+  return enable_colors_? "\x1B[33m" + s + "\x1B[m" : s;
+}
+
+std::string Terminal::yellowB(const std::string& s) const {
+  return enable_colors_? "\x1B[93m" + s + "\x1B[m" : s;
+}
+
+
+
+}  // namespace dt

--- a/c/utils/terminal.cc
+++ b/c/utils/terminal.cc
@@ -19,6 +19,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
+#include <iostream>
 #include "utils/assert.h"
 #include "utils/terminal.h"
 namespace dt {
@@ -50,6 +51,47 @@ Terminal::Terminal(bool is_plain) {
 }
 
 Terminal::~Terminal() = default;
+
+
+void Terminal::initialize() {
+  py::robj stdin = py::stdin();
+  py::robj stdout = py::stdout();
+  if (!stdout || !stdin || stdout.is_none() || stdin.is_none()) {
+    enable_keyboard_ = false;
+    enable_colors_ = false;
+    enable_ecma48_ = false;
+    allow_unicode_ = true;
+  }
+  else {
+    // allow_unicode_ = false;
+    enable_keyboard_ = true;
+    enable_colors_ = true;
+    enable_ecma48_ = true;
+    // check  encoding?
+    _check_ipython();
+  }
+}
+
+/**
+  * When running inside a Jupyter notebook, IPython and ipykernel will
+  * already be preloaded (in sys.modules). We don't want to try to
+  * import them, because it adds unnecessary startup delays.
+  */
+void Terminal::_check_ipython() {
+  py::oobj ipython = py::get_module("IPython");
+  if (ipython) {
+    auto ipy = ipython.invoke("get_ipython");
+    std::string ipy_type = ipy.typestr();
+    if (ipy_type.find("ZMQInteractiveShell") != std::string::npos) {
+      allow_unicode_ = true;
+      is_jupyter_ = true;
+    }
+    if (ipy_type.find("TerminalInteractiveShell") != std::string::npos) {
+      is_ipython_ = true;
+    }
+  }
+}
+
 
 
 

--- a/c/utils/terminal.cc
+++ b/c/utils/terminal.cc
@@ -48,16 +48,42 @@ Terminal::~Terminal() = default;
 
 
 
+//------------------------------------------------------------------------------
+// Text formatting
+//------------------------------------------------------------------------------
+
+std::string Terminal::bold(const std::string& s) const {
+  return enable_colors_? "\x1B[1m" + s + "\x1B[m" : s;
+}
+
+std::string Terminal::dim(const std::string& s) const {
+  return enable_colors_? "\x1B[2m" + s + "\x1B[m" : s;
+}
+
+std::string Terminal::italic(const std::string& s) const {
+  return enable_colors_? "\x1B[3m" + s + "\x1B[m" : s;
+}
+
+std::string Terminal::underline(const std::string& s) const {
+  return enable_colors_? "\x1B[4m" + s + "\x1B[m" : s;
+}
+
+std::string Terminal::invert(const std::string& s) const {
+  return enable_colors_? "\x1B[7m" + s + "\x1B[m" : s;
+}
+
+
+
+//------------------------------------------------------------------------------
+// Colors
+//------------------------------------------------------------------------------
+
 std::string Terminal::blue(const std::string& s) const {
   return enable_colors_? "\x1B[34m" + s + "\x1B[m" : s;
 }
 
 std::string Terminal::blueB(const std::string& s) const {
   return enable_colors_? "\x1B[94m" + s + "\x1B[m" : s;
-}
-
-std::string Terminal::bold(const std::string& s) const {
-  return enable_colors_? "\x1B[1m" + s + "\x1B[m" : s;
 }
 
 std::string Terminal::cyan(const std::string& s) const {
@@ -68,8 +94,8 @@ std::string Terminal::cyanB(const std::string& s) const {
   return enable_colors_? "\x1B[96m" + s + "\x1B[m" : s;
 }
 
-std::string Terminal::dim(const std::string& s) const {
-  return enable_colors_? "\x1B[2m" + s + "\x1B[m" : s;
+std::string Terminal::cyanD(const std::string& s) const {
+  return enable_colors_? "\x1B[2;96m" + s + "\x1B[m" : s;
 }
 
 std::string Terminal::green(const std::string& s) const {

--- a/c/utils/terminal.cc
+++ b/c/utils/terminal.cc
@@ -29,15 +29,20 @@ namespace dt {
 // Constructors
 //------------------------------------------------------------------------------
 
-Terminal& Terminal::get_instance() {
-  static Terminal term;
+Terminal& Terminal::standard_terminal() {
+  static Terminal term(false);
   return term;
 }
 
-Terminal::Terminal() {
+Terminal& Terminal::plain_terminal() {
+  static Terminal term(true);
+  return term;
+}
+
+Terminal::Terminal(bool is_plain) {
   allow_unicode_ = true;
-  enable_colors_ = true; // false;
-  enable_ecma48_ = true; // false;
+  enable_colors_ = !is_plain;
+  enable_ecma48_ = !is_plain;
   enable_keyboard_ = false;
   is_jupyter_ = false;
   is_ipython_ = false;
@@ -45,6 +50,34 @@ Terminal::Terminal() {
 }
 
 Terminal::~Terminal() = default;
+
+
+
+//------------------------------------------------------------------------------
+// Properties
+//------------------------------------------------------------------------------
+
+bool Terminal::is_jupyter() const noexcept {
+  return is_jupyter_;
+}
+
+bool Terminal::is_ipython() const noexcept {
+  return is_ipython_;
+}
+
+bool Terminal::colors_enabled() const noexcept {
+  return enable_colors_;
+}
+
+bool Terminal::unicode_allowed() const noexcept {
+  return allow_unicode_;
+}
+
+
+void Terminal::use_colors(bool f) {
+  enable_colors_ = f;
+}
+
 
 
 

--- a/c/utils/terminal.h
+++ b/c/utils/terminal.h
@@ -27,6 +27,16 @@ namespace dt {
 using std::size_t;
 
 
+/**
+  * Class that controls adorned output to a terminal. This class
+  * supports setting basic text attributes (such as bold/italic),
+  * and printing in different colors.
+  *
+  * In addition, this class has setting to fall back to regular
+  * (non-colored) output if the terminal does not support it.
+  *
+  * This is a replacement for "terminal.py"
+  */
 class Terminal {
   using string = std::string;
   private:
@@ -41,23 +51,28 @@ class Terminal {
   public:
     static Terminal& get_instance();
 
-    string blue    (const string&) const;
-    string blueB   (const string&) const;
-    string bold    (const string&) const;
-    string cyan    (const string&) const;
-    string cyanB   (const string&) const;
-    string dim     (const string&) const;
-    string green   (const string&) const;
-    string greenB  (const string&) const;
-    string grey    (const string&) const;
-    string magenta (const string&) const;
-    string magentaB(const string&) const;
-    string red     (const string&) const;
-    string redB    (const string&) const;
-    string white   (const string&) const;
-    string whiteB  (const string&) const;
-    string yellow  (const string&) const;
-    string yellowB (const string&) const;
+    string bold     (const string&) const;
+    string dim      (const string&) const;
+    string italic   (const string&) const;
+    string underline(const string&) const;
+    string invert   (const string&) const;
+
+    string blue     (const string&) const;
+    string blueB    (const string&) const;
+    string cyan     (const string&) const;
+    string cyanB    (const string&) const;
+    string cyanD    (const string&) const;
+    string green    (const string&) const;
+    string greenB   (const string&) const;
+    string grey     (const string&) const;
+    string magenta  (const string&) const;
+    string magentaB (const string&) const;
+    string red      (const string&) const;
+    string redB     (const string&) const;
+    string white    (const string&) const;
+    string whiteB   (const string&) const;
+    string yellow   (const string&) const;
+    string yellowB  (const string&) const;
 
     inline bool is_jupyter() const { return is_jupyter_; }
     inline bool is_ipython() const { return is_ipython_; }

--- a/c/utils/terminal.h
+++ b/c/utils/terminal.h
@@ -49,7 +49,8 @@ class Terminal {
     int : 16;
 
   public:
-    static Terminal& get_instance();
+    static Terminal& standard_terminal();
+    static Terminal& plain_terminal();
 
     string bold     (const string&) const;
     string dim      (const string&) const;
@@ -74,11 +75,15 @@ class Terminal {
     string yellow   (const string&) const;
     string yellowB  (const string&) const;
 
-    inline bool is_jupyter() const { return is_jupyter_; }
-    inline bool is_ipython() const { return is_ipython_; }
+    bool is_jupyter() const noexcept;
+    bool is_ipython() const noexcept;
+    bool colors_enabled() const noexcept;
+    bool unicode_allowed() const noexcept;
+
+    void use_colors(bool f);
 
   private:
-    Terminal();
+    Terminal(bool is_plain);
     Terminal(const Terminal&) = delete;
     Terminal(Terminal&&) = delete;
     ~Terminal();

--- a/c/utils/terminal.h
+++ b/c/utils/terminal.h
@@ -51,6 +51,7 @@ class Terminal {
   public:
     static Terminal& standard_terminal();
     static Terminal& plain_terminal();
+    void initialize();
 
     string bold     (const string&) const;
     string dim      (const string&) const;
@@ -87,6 +88,8 @@ class Terminal {
     Terminal(const Terminal&) = delete;
     Terminal(Terminal&&) = delete;
     ~Terminal();
+
+    void _check_ipython();
 };
 
 

--- a/c/utils/terminal.h
+++ b/c/utils/terminal.h
@@ -1,0 +1,75 @@
+//------------------------------------------------------------------------------
+// Copyright 2019 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#ifndef dt_UTILS_TERMINAL_h
+#define dt_UTILS_TERMINAL_h
+#include <memory>
+#include <string>
+namespace dt {
+using std::size_t;
+
+
+class Terminal {
+  using string = std::string;
+  private:
+    bool allow_unicode_;
+    bool enable_colors_;
+    bool enable_ecma48_;
+    bool enable_keyboard_;
+    bool is_jupyter_;
+    bool is_ipython_;
+    int : 16;
+
+  public:
+    static Terminal& get_instance();
+
+    string blue    (const string&) const;
+    string blueB   (const string&) const;
+    string bold    (const string&) const;
+    string cyan    (const string&) const;
+    string cyanB   (const string&) const;
+    string dim     (const string&) const;
+    string green   (const string&) const;
+    string greenB  (const string&) const;
+    string grey    (const string&) const;
+    string magenta (const string&) const;
+    string magentaB(const string&) const;
+    string red     (const string&) const;
+    string redB    (const string&) const;
+    string white   (const string&) const;
+    string whiteB  (const string&) const;
+    string yellow  (const string&) const;
+    string yellowB (const string&) const;
+
+    inline bool is_jupyter() const { return is_jupyter_; }
+    inline bool is_ipython() const { return is_ipython_; }
+
+  private:
+    Terminal();
+    Terminal(const Terminal&) = delete;
+    Terminal(Terminal&&) = delete;
+    ~Terminal();
+};
+
+
+
+}  // namespace dt
+#endif

--- a/datatable/widget.py
+++ b/datatable/widget.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# © H2O.ai 2018; -*- encoding: utf-8 -*-
+# © H2O.ai 2018-2019; -*- encoding: utf-8 -*-
 #   This Source Code Form is subject to the terms of the Mozilla Public
 #   License, v. 2.0. If a copy of the MPL was not distributed with this
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -114,7 +114,7 @@ class DataFrameWidget(object):
         self._view_col0 = 0
         self._view_row0 = 0
         self._view_ncols = 30
-        self._view_nrows = DataFrameWidget.VIEW_NROWS_MAX
+        self._view_nrows = options.display.max_nrows
 
         # Largest allowed values for ``self._view_(col|row)0``
         self._max_row0 = 0

--- a/datatable/widget.py
+++ b/datatable/widget.py
@@ -138,16 +138,6 @@ class DataFrameWidget(object):
             self._interact()
 
 
-    def as_string(self):
-        self._interactive = False
-        self._show_navbar = False
-        colors = term.using_colors()
-        term.use_colors(False)
-        out = self._draw(to_string=True)
-        term.use_colors(colors)
-        return out
-
-
     #---------------------------------------------------------------------------
     # Private
     #---------------------------------------------------------------------------

--- a/datatable/widget.py
+++ b/datatable/widget.py
@@ -557,8 +557,3 @@ options.register_option(
     doc="Display navigation hint at the bottom of a Frame when viewing "
         "its contents in the console.")
 
-options.register_option(
-    name="display.interactive",
-    default=False,
-    xtype=bool,
-    doc="Show datatable Frame interactively in a Python console.")

--- a/docs/changelog/v-0-10-0.rst
+++ b/docs/changelog/v-0-10-0.rst
@@ -62,6 +62,14 @@ Frame
   a single stype instead of a tuple. This method can only be used on a frame
   where all columns have the same stype, or there is only one column.
 
+- |new| When a frame is displayed in a console, it will now display the first
+  15 + the last 5 rows, similarly to how it is rendered in Jupyter notebook.
+  Also, if the frame is 30 rows or less, it will be shown in full.
+
+  These parameters are configurable via the options
+  ``dt.options.display.head_nrows``, ``dt.options.display.tail_nrows`` and
+  ``dt.options.display.max_nrows``.
+
 - |api| The name deduplication algorithm now starts looking for candidate names
   starting from ``name + dt.options.frame.name_auto_index``. For example, if
   you're creating a Frame with column names `["A", "A", "A"]`, then those names

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -240,12 +240,12 @@ def test_dt_view_keyed(patched_terminal, capsys):
 
 
 def test_stringify(dt0):
-    assert ("     A   B   C     D   E   F  G    \n"
-            "--  --  --  --  ----  --  --  -----\n"
-            " 0   2   1   1   0.1       0  1    \n"
-            " 1   7   0   1   2         0  2    \n"
-            " 2   0   0   1  -4         0  hello\n"
-            " 3   0   1   1   4.4       0  world\n"
+    assert ("   |  A   B   C     D   E   F  G    \n"
+            "---+ --  --  --  ----  --  --  -----\n"
+            " 0 |  2   1   1   0.1  NA   0  1    \n"
+            " 1 |  7   0   1   2    NA   0  2    \n"
+            " 2 |  0   0   1  -4    NA   0  hello\n"
+            " 3 |  0   1   1   4.4  NA   0  world\n"
             "\n"
             "[4 rows x 7 columns]\n"
             == str(dt0))

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -60,14 +60,6 @@ def dt0():
     ], names=list("ABCDEFG"))
 
 
-@pytest.fixture()
-def patched_terminal():
-    dt.utils.terminal.term._width = 100
-    dt.utils.terminal.term.use_colors(False)
-    dt.utils.terminal.term.use_keyboard(False)
-    dt.utils.terminal.term.use_terminal_codes(False)
-
-
 def assert_valueerror(frame, rows, error_message):
     with pytest.raises(ValueError) as e:
         noop(frame[rows, :])
@@ -206,25 +198,25 @@ def test_internal_compiler_version():
     assert ver != "Unknown"
 
 
-def test_dt_view(dt0, patched_terminal, capsys):
-    dt0.view(interactive=False)
+def test_dt_view(dt0, capsys):
+    dt0.view(interactive=False, plain=True)
     out, err = capsys.readouterr()
     assert not err
-    assert ("     A   B   C     D   E   F  G    \n"
-            "--  --  --  --  ----  --  --  -----\n"
-            " 0   2   1   1   0.1       0  1    \n"
-            " 1   7   0   1   2         0  2    \n"
-            " 2   0   0   1  -4         0  hello\n"
-            " 3   0   1   1   4.4       0  world\n"
+    assert ("   |  A   B   C     D   E   F  G    \n"
+            "---+ --  --  --  ----  --  --  -----\n"
+            " 0 |  2   1   1   0.1  NA   0  1    \n"
+            " 1 |  7   0   1   2    NA   0  2    \n"
+            " 2 |  0   0   1  -4    NA   0  hello\n"
+            " 3 |  0   1   1   4.4  NA   0  world\n"
             "\n"
             "[4 rows x 7 columns]\n"
-            in out)
+            == out)
 
 
-def test_dt_view_keyed(patched_terminal, capsys):
+def test_dt_view_keyed(capsys):
     DT = dt.Frame(A=range(5), B=list("cdbga"))
     DT.key = "B"
-    DT.view(interactive=False)
+    DT.view(interactive=False, plain=True)
     out, err = capsys.readouterr()
     assert not err
     assert ("B  |  A\n"
@@ -586,26 +578,26 @@ def test_resize_bad():
             in str(e.value))
 
 
-def test_resize_issue1527(patched_terminal, capsys):
+def test_resize_issue1527(capsys):
     f0 = dt.Frame(A=[])
     assert f0.nrows == 0
     f0.nrows = 5
     assert f0.nrows == 5
     assert f0.to_list() == [[None] * 5]
 
-    f0.view(interactive=False)
+    f0.view(interactive=False, plain=True)
     out, err = capsys.readouterr()
     assert not err
-    assert ("     A\n"
-            "--  --\n"
-            " 0    \n"
-            " 1    \n"
-            " 2    \n"
-            " 3    \n"
-            " 4    \n"
+    assert ("   |  A\n"
+            "---+ --\n"
+            " 0 | NA\n"
+            " 1 | NA\n"
+            " 2 | NA\n"
+            " 3 | NA\n"
+            " 4 | NA\n"
             "\n"
             "[5 rows x 1 column]\n"
-            in out)
+            == out)
 
 
 def test_resize_invalidates_stats():

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -32,8 +32,11 @@ def test_options_all():
     }
     assert set(dir(dt.options.display)) == {
         "allow_unicode",
+        "head_nrows",
         "interactive",
         "interactive_hint",
+        "max_nrows",
+        "tail_nrows",
         "use_colors"
     }
     assert set(dir(dt.options.frame)) == {


### PR DESCRIPTION
- created C++ `Terminal` class, which can replace the python `Terminal` at some point. This class allows producing proper colored output from C++;
- Re-implemented text widget rendering in C++ (to replace `DataFrameWidget` in "widget.py"). This  ensures that Frame rendering into HTML and text can  share common functionality;
- Added display options `display.max_nrows`, `display.head_nrows` and `display.tail_nrows` to control the  appearance of the  widget in the console/HTML.
- Slight adjustments to styling of the output frame, in particular all NA values are now displayed as "NA" (previously they were rendered  as empty strings).

Closes #2087 
WIP for #1677 