### PR TITLE
Fix setting a key on a copied frame

### DIFF
--- a/c/datatable.cc
+++ b/c/datatable.cc
@@ -22,6 +22,20 @@ DataTable::DataTable()
   : nrows_(0), ncols_(0), nkeys_(0) {}
 
 
+// Default copy is not suitable because `py_inames` has no CoW semantics, and
+// its default copy-by-reference will cause shared state between Frames.
+DataTable::DataTable(const DataTable& other)
+  : nrows_(other.nrows_),
+    ncols_(other.ncols_),
+    nkeys_(other.nkeys_),
+    columns_(other.columns_),
+    names_(other.names_)
+{
+  if (other.py_names_)  py_names_ = other.py_names_;
+  if (other.py_inames_) py_inames_ = other.py_inames_.copy();
+}
+
+
 // Private constructor, initializes only columns but not names_
 DataTable::DataTable(colvec&& cols) : DataTable()
 {

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -80,7 +80,7 @@ class DataTable {
     static struct DefaultNamesTag {} default_names;
 
     DataTable();
-    DataTable(const DataTable&) = default;
+    DataTable(const DataTable&);
     DataTable(DataTable&&) = default;
     DataTable(colvec&& cols, DefaultNamesTag);
     DataTable(colvec&& cols, const strvec&, bool warn_duplicates = true);

--- a/c/python/dict.cc
+++ b/c/python/dict.cc
@@ -37,8 +37,14 @@ odict::odict() {
 }
 
 // private constructors
+odict::odict(oobj&& src) : oobj(std::move(src)) {}
 odict::odict(const robj& src) : oobj(src) {}
 rdict::rdict(const robj& src) : robj(src) {}
+
+
+odict odict::copy() const {
+  return odict(oobj::from_new_reference(PyDict_Copy(v)));
+}
 
 
 

--- a/c/python/dict.h
+++ b/c/python/dict.h
@@ -81,6 +81,8 @@ class odict : public oobj {
     odict& operator=(const odict&) = default;
     odict& operator=(odict&&) = default;
 
+    odict copy() const;
+
     size_t size() const;
     bool empty() const;
     bool has(_obj key) const;
@@ -93,6 +95,7 @@ class odict : public oobj {
     dict_iterator end() const;
 
   private:
+    odict(oobj&&);
     odict(const robj&);
     friend class _obj;
 };

--- a/docs/changelog/v-0-10-0.rst
+++ b/docs/changelog/v-0-10-0.rst
@@ -108,6 +108,9 @@ Frame
   ``int64``. Before, it sometimes produced an ``int32`` column, and sometimes
   an ``int64`` column.
 
+- |fix| Setting a key on a copied frame no longer affects the original
+  frame (#2095).
+
 
 General
 -------

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -714,6 +714,18 @@ def test_rename_frame_copy():
         d0.colindex("ha!")
 
 
+def test_setkey_frame_copy():
+    # See issue #2095
+    DT = dt.Frame(id1=[3] * 5, id2=range(5))
+    assert DT.colindex("id1") == 0
+    assert DT.colindex("id2") == 1
+    X = DT.copy()
+    X.key = "id2"
+    assert DT.colindex("id1") == 0
+    assert DT.colindex("id2") == 1
+    frame_integrity_check(DT)
+
+
 def test_rename_bad1():
     d0 = dt.Frame([[1], [2], ["hello"]], names=("a", "b", "c"))
     with pytest.raises(TypeError):

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -716,7 +716,7 @@ def test_rename_frame_copy():
 
 def test_setkey_frame_copy():
     # See issue #2095
-    DT = dt.Frame(id1=[3] * 5, id2=range(5))
+    DT = dt.Frame([[3] * 5, range(5)], names=["id1", "id2"])
     assert DT.colindex("id1") == 0
     assert DT.colindex("id2") == 1
     X = DT.copy()


### PR DESCRIPTION
The issue was that when the frame was copied, the `py_inames` dictionary was copied using python's default copy-by-reference semantics. Subsequently, changes to that dictionary in one frame were affecting the other frame too, causing them to become inconsistent.  Now we explicitly deep-copy the `py_inames` dictionary.

Closes #2095