### PR TITLE
Add shallow copy operation to random attacker

### DIFF
--- a/tests/random_attack.py
+++ b/tests/random_attack.py
@@ -925,6 +925,7 @@ if __name__ == "__main__":
         python_output.write("#!/usr/bin/env python\n")
         python_output.write("#seed: %s\n" % args.seed)
         python_output.write("import sys; sys.path = ['.', '..'] + sys.path\n")
+        python_output.write("import copy\n")
         python_output.write("import datatable as dt\n")
         python_output.write("import numpy as np\n")
         python_output.write("import pytest\n")
@@ -938,7 +939,7 @@ if __name__ == "__main__":
     finally:
         if python_output:
             python_output.write("frame_integrity_check(DT)\n")
-            python_output.write("frame_integrity_check(DT_shallow_copy\n")
-            python_output.write("frame_integrity_check(DT_deep_copy\n")
+            python_output.write("frame_integrity_check(DT_shallow_copy)\n")
+            python_output.write("frame_integrity_check(DT_deep_copy)\n")
             python_output.write("assert_equals(DT_shallow_copy, DT_deep_copy)\n")
             python_output.close()

--- a/tests/random_attack.py
+++ b/tests/random_attack.py
@@ -326,7 +326,7 @@ class Attacker:
         print("[16] Creating a shallow copy of a frame")
         if python_output:
             python_output.write("DT_shallow_copy = DT.copy()\n")
-            python_output.write("DT_deep_copy = copy.deepcopy(DT).copy()\n")
+            python_output.write("DT_deep_copy = copy.deepcopy(DT)\n")
 
 
     #---------------------------------------------------------------------------
@@ -436,11 +436,8 @@ class Frame0:
                                 "              names=%r,\n"
                                 "              stypes=%s)\n"
                                 % (repr_data(data, 14), names, repr_types(types)))
-            python_output.write("DT_shallow_copy = DT.copy()\n")
-            python_output.write("DT_deep_copy = DT.copy()\n")
             python_output.write("assert DT.shape == (%d, %d)\n" % (nrows, ncols))
-            python_output.write("assert DT_shallow_copy.shape == (%d, %d)\n" % (nrows, ncols))
-            python_output.write("assert DT_deep_copy.shape == (%d, %d)\n" % (nrows, ncols))
+            python_output.write("DT_shallow_copy = DT_deep_copy = None\n")
 
     def random_type(self):
         return random.choice([bool, int, float, str])
@@ -570,9 +567,10 @@ class Frame0:
 
     def check(self):
         frame_integrity_check(self.df)
-        frame_integrity_check(self.df_shallow_copy)
-        frame_integrity_check(self.df_deep_copy)
-        assert_equals(self.df_shallow_copy, self.df_deep_copy)
+        if self.df_shallow_copy:
+            frame_integrity_check(self.df_shallow_copy)
+            frame_integrity_check(self.df_deep_copy)
+            assert_equals(self.df_shallow_copy, self.df_deep_copy)
         self.check_shape()
         self.check_types()
         self.check_keys()
@@ -939,7 +937,8 @@ if __name__ == "__main__":
     finally:
         if python_output:
             python_output.write("frame_integrity_check(DT)\n")
-            python_output.write("frame_integrity_check(DT_shallow_copy)\n")
-            python_output.write("frame_integrity_check(DT_deep_copy)\n")
-            python_output.write("assert_equals(DT_shallow_copy, DT_deep_copy)\n")
+            python_output.write("if DT_shallow_copy:\n")
+            python_output.write("    frame_integrity_check(DT_shallow_copy)\n")
+            python_output.write("    frame_integrity_check(DT_deep_copy)\n")
+            python_output.write("    assert_equals(DT_shallow_copy, DT_deep_copy)\n")
             python_output.close()

--- a/tests/random_attack.py
+++ b/tests/random_attack.py
@@ -428,8 +428,7 @@ class Frame0:
         self.np_data = []
         self.np_data_deepcopy = []
         self.df = dt.Frame(data, names=names, stypes=types)
-        self.df_shallow_copy = self.df.copy()
-        self.df_deep_copy = copy.deepcopy(self.df)
+        self.df_shallow_copy = self.df_deep_copy = None
         if python_output:
             python_output.write("DT = dt.Frame(%s,\n"
                                 "              names=%r,\n"

--- a/tests/random_attack.py
+++ b/tests/random_attack.py
@@ -282,7 +282,6 @@ class Attacker:
               % (plural(nkeys, "key column"), keys))
 
         res = frame.set_key_columns(keys, names)
-
         if python_output:
             if res:
                 python_output.write("DT.key = %r\n" % names)
@@ -322,11 +321,11 @@ class Attacker:
                                     "    DT = DT[:, :, join(DT)]\n\n")
 
     def shallow_copy(self, frame):
-        frame.shallow_copy()
         print("[16] Creating a shallow copy of a frame")
         if python_output:
             python_output.write("DT_shallow_copy = DT.copy()\n")
             python_output.write("DT_deep_copy = copy.deepcopy(DT)\n")
+        frame.shallow_copy()
 
 
     #---------------------------------------------------------------------------

--- a/tests/random_attack.py
+++ b/tests/random_attack.py
@@ -864,7 +864,7 @@ class Frame0:
         self.dedup_names()
         return True
 
-    # This is a noop operation for the python data
+    # This is a noop for the python data
     def shallow_copy(self):
         self.df_shallow_copy = self.df.copy()
         self.df_deep_copy = copy.deepcopy(self.df)


### PR DESCRIPTION
This is in response to #2095, that we missed due to the absence of copy operations in the random attacker. Testing it on a commit before PR #2097 was pushed, revealed the problem right away. With the latest master 10K seeds passed — no failures.