### PR TITLE
Fixed leak when converting a string numpy array into a Frame

### DIFF
--- a/c/buffer.cc
+++ b/c/buffer.cc
@@ -8,7 +8,9 @@
 #include <algorithm>           // std::min
 #include <cerrno>              // errno
 #include <mutex>               // std::mutex, std::lock_guard
+#include "python/pybuffer.h"   // py::buffer
 #include "utils/alloc.h"       // dt::malloc, dt::realloc
+#include "utils/c+++.h"        // dt::make_unique
 #include "utils/exceptions.h"  // ValueError, MemoryError
 #include "utils/macros.h"
 #include "utils/misc.h"        // malloc_size
@@ -260,38 +262,43 @@ class Memory_BufferImpl : public BufferImpl
 class External_BufferImpl : public BufferImpl
 {
   private:
-    Py_buffer* pybufinfo_;
+    std::unique_ptr<py::buffer> pybufinfo_;
 
   public:
     External_BufferImpl(const void* ptr, size_t n,
-                        std::unique_ptr<Py_buffer>&& pybuf)
+                        std::unique_ptr<py::buffer>&& pybuf)
     {
       XAssert(ptr || n == 0);
       data_ = const_cast<void*>(ptr);
       size_ = n;
-      pybufinfo_ = pybuf.release();
+      pybufinfo_ = std::move(pybuf);
       resizable_ = false;
       writable_ = false;
     }
 
-    External_BufferImpl(const void* ptr, size_t n)
-      : External_BufferImpl(ptr, n, nullptr) {}
+    External_BufferImpl(const void* ptr, size_t n) {
+      XAssert(ptr || n == 0);
+      data_ = const_cast<void*>(ptr);
+      size_ = n;
+      resizable_ = false;
+      writable_ = false;
+    }
 
     External_BufferImpl(void* ptr, size_t n)
-      : External_BufferImpl(ptr, n, nullptr) { writable_ = true; }
+      : External_BufferImpl(static_cast<const void*>(ptr), n)
+    {
+      writable_ = true;
+    }
 
     ~External_BufferImpl() override {
       // If the buffer contained pyobjects, leave them as-is and
       // do not attempt to DECREF (since the memory is not freed).
       contains_pyobjects_ = false;
-      if (pybufinfo_) {
-        PyBuffer_Release(pybufinfo_);
-      }
     }
 
     size_t memory_footprint() const noexcept override {
       // All memory is owned externally
-      return sizeof(External_BufferImpl);
+      return sizeof(External_BufferImpl) + sizeof(py::buffer);
     }
 };
 
@@ -750,10 +757,9 @@ class Overmap_BufferImpl : public Mmap_BufferImpl {
     return Buffer(new External_BufferImpl(ptr, n));
   }
 
-  Buffer Buffer::external(const void* ptr, size_t n,
-                          std::unique_ptr<Py_buffer>&& pb)
-  {
-    return Buffer(new External_BufferImpl(ptr, n, std::move(pb)));
+  Buffer Buffer::external(const void* ptr, size_t n, py::buffer&& pb) {
+    return Buffer(new External_BufferImpl(
+              ptr, n, dt::make_unique<py::buffer>(std::move(pb))));
   }
 
   Buffer Buffer::view(const Buffer& src, size_t n, size_t offset) {

--- a/c/buffer.h
+++ b/c/buffer.h
@@ -16,6 +16,7 @@
 #include "writebuf.h"
 
 class BufferImpl;
+namespace py { class buffer; }
 
 
 //==============================================================================
@@ -120,8 +121,7 @@ class Buffer
     static Buffer acquire(void* ptr, size_t n);
     static Buffer external(void* ptr, size_t n);
     static Buffer external(const void* ptr, size_t n);
-    static Buffer external(const void* ptr, size_t n,
-                           std::unique_ptr<Py_buffer>&& pybuf);
+    static Buffer external(const void* ptr, size_t n, py::buffer&& pybuf);
     static Buffer view(const Buffer& src, size_t n, size_t offset);
     static Buffer mmap(const std::string& path);
     static Buffer mmap(const std::string& path, size_t n, int fd = -1);

--- a/c/column/sentinel_fw.cc
+++ b/c/column/sentinel_fw.cc
@@ -28,6 +28,7 @@ SentinelFw_ColumnImpl<T>::SentinelFw_ColumnImpl(ColumnImpl*&& other)
   xassert(fwother != nullptr);
   mbuf_ = std::move(fwother->mbuf_);
   stats_ = std::move(fwother->stats_);
+  delete other;
 }
 
 SentinelBool_ColumnImpl::SentinelBool_ColumnImpl(ColumnImpl*&& other)

--- a/c/frame/names.cc
+++ b/c/frame/names.cc
@@ -723,6 +723,7 @@ namespace dttest {
     test_assert(check2, "Assertion 'res.to_int64_strict() == static_cast<int64_t>(i)' failed");
     dt->py_inames_.set(py::ostring("two"), py::oint(1));
     dt->verify_integrity();
+    delete dt;
   }
 
 }

--- a/c/python/pybuffer.cc
+++ b/c/python/pybuffer.cc
@@ -1,0 +1,204 @@
+//------------------------------------------------------------------------------
+// Copyright 2019 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+//
+// See: https://docs.python.org/3/c-api/buffer.html
+//
+//------------------------------------------------------------------------------
+#include "python/pybuffer.h"
+#include "utils/assert.h"
+#include "buffer.h"
+namespace py {
+
+
+
+//------------------------------------------------------------------------------
+// Constructors
+//------------------------------------------------------------------------------
+
+buffer::buffer(robj obj) {
+  info_ = new Py_buffer();
+  stride_ = 1;
+
+  // int PyObject_GetBuffer(PyObject *exporter, Py_buffer *view, int flags)
+  //
+  //   Send a request to exporter to fill in view as specified by flags. If
+  //   the exporter cannot provide a buffer of the exact type, it MUST raise
+  //   PyExc_BufferError, set view->obj to NULL and return -1.
+  //
+  //   On success, fill in view, set view->obj to a new reference to exporter
+  //   and return 0. In the case of chained buffer providers that redirect
+  //   requests to a single object, view->obj MAY refer to this object
+  //   instead of exporter (See Buffer Object Structures).
+  //
+  //   Successful calls to PyObject_GetBuffer() must be paired with calls to
+  //   PyBuffer_Release(), similar to malloc() and free(). Thus, after the
+  //   consumer is done with the buffer, PyBuffer_Release() must be called
+  //   exactly once.
+  //
+  PyObject* exporter = obj.to_borrowed_ref();
+  int ret = PyObject_GetBuffer(exporter, info_, PyBUF_FORMAT|PyBUF_STRIDES);
+  if (ret != 0) {
+    PyErr_Clear();
+    ret = PyObject_GetBuffer(exporter, info_, PyBUF_FORMAT|PyBUF_ND);
+  }
+  if (ret != 0) {
+    delete info_;
+    info_ = nullptr;
+    throw PyError();
+  }
+  _normalize_dimensions();
+}
+
+
+buffer::buffer(buffer&& other) noexcept {
+  info_ = other.info_;
+  stride_ = other.stride_;
+  other.info_ = nullptr;
+}
+
+
+buffer::~buffer() {
+  if (info_) {
+    PyBuffer_Release(info_);
+    delete info_;
+    info_ = nullptr;
+  }
+}
+
+
+void buffer::_normalize_dimensions() {
+  auto itemsize = info_->itemsize;
+  auto len = info_->len;
+  auto ndim = info_->ndim;
+  xassert(itemsize > 0);
+  xassert(len % itemsize == 0);
+  xassert(ndim >= 0);
+
+  if (len == 0) {}
+  else if (ndim == 0) {
+    xassert(len == itemsize);
+  }
+  else if (ndim == 1) {
+    if (info_->shape) xassert(info_->shape[0] * itemsize == len);
+    if (info_->strides) {
+      xassert(info_->strides[0] % itemsize == 0);
+      stride_ = static_cast<size_t>(info_->strides[0] / itemsize);
+    }
+  }
+  else {
+    xassert(info_->shape && info_->strides);
+    bool dim_found = false;
+    for (int i = 0; i < ndim; ++i) {
+      auto dim = info_->shape[i];
+      auto step = info_->strides[i];
+      xassert(dim > 0);
+      xassert(step % itemsize == 0);
+      if (dim == 1) continue;
+      if (dim_found) {
+        throw ValueError() << "Source buffer has more than one non-trivial "
+                              "dimension, which is not supported";
+      }
+      dim_found = true;
+      stride_ = static_cast<size_t>(step / itemsize);
+    }
+  }
+}
+
+
+
+
+//------------------------------------------------------------------------------
+// Properties
+//------------------------------------------------------------------------------
+
+void* buffer::data() const noexcept {
+  return info_->buf;
+}
+
+size_t buffer::itemsize() const noexcept {
+  return static_cast<size_t>(info_->itemsize);
+}
+
+size_t buffer::nelements() const noexcept {
+  return static_cast<size_t>(info_->len / info_->itemsize);
+}
+
+size_t buffer::stride() const noexcept {
+  return stride_;
+}
+
+
+
+SType buffer::stype() const {
+  const char* format = info_->format;
+  int64_t itemsize = info_->itemsize;
+
+  SType stype = SType::VOID;
+  char c = format[0];
+  if (c == '@' || c == '=') c = format[1];
+
+  if (c == 'b' || c == 'h' || c == 'i' || c == 'l' || c == 'q' || c == 'n') {
+    // These are all various integer types
+    stype = itemsize == 1 ? SType::INT8 :
+            itemsize == 2 ? SType::INT16 :
+            itemsize == 4 ? SType::INT32 :
+            itemsize == 8 ? SType::INT64 : SType::VOID;
+  }
+  else if (c == 'd' || c == 'f') {
+    stype = itemsize == 4 ? SType::FLOAT32 :
+            itemsize == 8 ? SType::FLOAT64 : SType::VOID;
+  }
+  else if (c == '?') {
+    stype = itemsize == 1 ? SType::BOOL : SType::VOID;
+  }
+  else if (c == 'O') {
+    stype = SType::OBJ;
+  }
+  else if (c >= '1' && c <= '9') {
+    if (format[strlen(format) - 1] == 'w') {
+      int numeral = atoi(format);
+      if (itemsize == numeral * 4) {
+        stype = SType::STR32;
+      }
+    }
+  }
+  if (stype == SType::VOID) {
+    throw ValueError()
+        << "Unknown format '" << format << "' with itemsize " << itemsize;
+  }
+  if (!::info(stype).is_varwidth()) {
+    xassert(::info(stype).elemsize() == static_cast<size_t>(itemsize));
+  }
+  return stype;
+}
+
+
+Buffer buffer::as_dtbuffer() && {
+  auto ptr = data();
+  auto size = nelements() * itemsize() * stride();
+  return Buffer::external(ptr, size, std::move(*this));
+}
+
+
+
+
+}  // namespace py

--- a/c/python/pybuffer.h
+++ b/c/python/pybuffer.h
@@ -1,0 +1,89 @@
+//------------------------------------------------------------------------------
+// Copyright 2019 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#ifndef dt_PYTHON_PYBUFFER_h
+#define dt_PYTHON_PYBUFFER_h
+#include "python/obj.h"
+#include "buffer.h"
+namespace py {
+
+
+
+/**
+  * This class is a wrapper around a `Py_buffer` struct. It is NOT
+  * a pyobject!
+  *
+  * The purpose of this class is to automatically release the
+  * underlying resources when this object goes out of scope.
+  */
+class buffer
+{
+  private:
+    Py_buffer* info_;  // owned
+    size_t stride_;
+
+  public:
+    // Fill-in the buffer from the object `obj`.
+    // The buffer is first queried with flags PyBUF_FORMAT|PyBUF_STRIDES,
+    // and if that fails, with flags PyBUF_FORMAT|PyBUF_ND.
+    // If both attempts fail, an exception is thrown.
+    //
+    buffer(robj obj);
+    buffer(const buffer&) = delete;
+    buffer(buffer&&) noexcept;
+    ~buffer();
+
+
+    //---- Properties -------
+
+    // Return the underlying data buffer. This buffer should be viewed
+    // as T*, where sizeof(T) == itemsize().
+    // The byte size of this buffer is `itemsize() * nelements() * stride()`.
+    void* data() const noexcept;
+
+    // Byte size of a single element in the `data()` buffer.
+    size_t itemsize() const noexcept;
+
+    // The number of elements in the buffer. The elements may not be
+    // contiguous.
+    size_t nelements() const noexcept;
+
+    // The step at which the elements should be accessed. In particular,
+    // the array `static_cast<T*>(data())` may be addressed at indices
+    //
+    //   i = 0, stride(), ..., stride() * (nelements() - 1)
+    //
+    size_t stride() const noexcept;
+
+
+    SType stype() const;
+
+    Buffer as_dtbuffer() &&;
+
+
+  private:
+    void _normalize_dimensions();
+};
+
+
+
+}  // namespace py
+#endif

--- a/docs/changelog/v-0-10-0.rst
+++ b/docs/changelog/v-0-10-0.rst
@@ -159,7 +159,11 @@ General
   The symbol ``dt`` is also exported by default, i.e. it will be available if
   you do ``from datatable import *``.
 
-- |fix| Fixed a memory leak when writing a Frame into a CSV file (#2119).
+- |fix| Fixed memory leak when writing a Frame into a CSV file (#2119).
+
+- |fix| Fixed memory leak when converting a numpy array with string values
+  into a Frame (#2123).
+
 
 
 Internal

--- a/docs/changelog/v-0-10-0.rst
+++ b/docs/changelog/v-0-10-0.rst
@@ -164,6 +164,7 @@ General
 - |fix| Fixed memory leak when converting a numpy array with string values
   into a Frame (#2123).
 
+- |fix| Fixed memory leak during reduce operations (#2125).
 
 
 Internal


### PR DESCRIPTION
- Created  a new class `py::buffer` that encapsulates a `Py_buffer` object. This will ensure that the buffer is always properly released when it is no longer needed in datatable;
- Fixed small leak in `test_coverage()`;
- Fixed a leak in `Latent_ColumnImpl::vivify()`, which is used during any reduce operation.

Closes #2123
Closes #2125