### PR TITLE
Auto-detect terminal's encoding

### DIFF
--- a/c/frame/repr/repr_options.cc
+++ b/c/frame/repr/repr_options.cc
@@ -59,7 +59,9 @@ static void _init_options()
 
   register_option(
     "display.allow_unicode",
-    []{ return py::obool(display_allow_unicode); },
+    []{
+      return py::obool(display_allow_unicode);
+    },
     [](const py::Arg& value) {
       display_allow_unicode = value.to_bool_strict();
       Terminal::standard_terminal().use_unicode(display_allow_unicode);

--- a/c/progress/progress_bar.cc
+++ b/c/progress/progress_bar.cc
@@ -17,6 +17,7 @@
 #include "progress/progress_bar.h"
 #include "python/string.h"          // py::ostring
 #include "utils/assert.h"
+#include "utils/terminal.h"
 #include "options.h"                // dt::get_option
 namespace dt {
 namespace progress {
@@ -51,8 +52,8 @@ progress_bar_enabled::progress_bar_enabled() {
   // Parameters
   bar_width = 50;
   clear_on_success = dt::progress::clear_on_success;
-  use_colors = dt::get_option("display.use_colors").to_bool_strict();
-  use_unicode = dt::get_option("display.allow_unicode").to_bool_strict();
+  use_colors = dt::Terminal::standard_terminal().colors_enabled();
+  use_unicode = dt::Terminal::standard_terminal().unicode_allowed();
 
   // Runtime support
   rtime_t freq { 1.0/updates_per_second };

--- a/c/utils/terminal.cc
+++ b/c/utils/terminal.cc
@@ -50,7 +50,7 @@ Terminal& Terminal::plain_terminal() {
 Terminal::Terminal(bool is_plain) {
   width_ = is_plain? (1 << 20) : 0;
   height_ = is_plain? 45 : 0;
-  display_allow_unicode = true;
+  allow_unicode_ = true;
   enable_colors_ = !is_plain;
   enable_ecma48_ = !is_plain;
   enable_keyboard_ = false;
@@ -65,6 +65,10 @@ Terminal::Terminal(bool is_plain) {
 Terminal::~Terminal() = default;
 
 
+/**
+  * This is called for 'standard' terminal only from "datatablemodule.cc",
+  * once during module initialization.
+  */
 void Terminal::initialize() {
   py::robj stdin = py::stdin();
   py::robj stdout = py::stdout();
@@ -75,16 +79,25 @@ void Terminal::initialize() {
     display_allow_unicode = true;
   }
   else {
-    // allow_unicode_ = false;
+    allow_unicode_ = false;
+    try {
+      std::string encoding = stdout.get_attr("encoding").to_string();
+      if (encoding == "UTF-8" || encoding == "UTF8" ||
+          encoding == "utf-8" || encoding == "utf8") {
+        allow_unicode_ = true;
+      }
+    } catch (...) {}
     enable_keyboard_ = true;
     enable_colors_ = true;
     enable_ecma48_ = true;
-    // check  encoding?
     _check_ipython();
   }
   // Set options
   display_use_colors = enable_colors_;
+  display_allow_unicode = allow_unicode_;
 }
+
+
 
 /**
   * When running inside a Jupyter notebook, IPython and ipykernel will
@@ -126,7 +139,7 @@ bool Terminal::colors_enabled() const noexcept {
 }
 
 bool Terminal::unicode_allowed() const noexcept {
-  return display_allow_unicode;
+  return allow_unicode_;
 }
 
 int Terminal::get_width() {
@@ -157,7 +170,7 @@ void Terminal::_detect_window_size() {
 }
 
 void Terminal::use_unicode(bool f) {
-  display_allow_unicode = f;
+  allow_unicode_ = f;
 }
 
 

--- a/c/utils/terminal.cc
+++ b/c/utils/terminal.cc
@@ -164,9 +164,13 @@ void Terminal::forget_window_size() {
 
 void Terminal::_detect_window_size() {
   struct winsize w;
-  ioctl(STDOUT_FILENO, TIOCGWINSZ, &w);
+  int ret = ioctl(STDOUT_FILENO, TIOCGWINSZ, &w);
   width_ = w.ws_col;
   height_ = w.ws_row;
+  if (ret == -1 || width_ == 0) {
+    width_ = 120;
+    height_ = 45;
+  }
 }
 
 void Terminal::use_unicode(bool f) {

--- a/c/utils/terminal.h
+++ b/c/utils/terminal.h
@@ -42,12 +42,13 @@ class Terminal {
   private:
     int  width_;
     int  height_;
+    bool allow_unicode_;
     bool enable_colors_;
     bool enable_ecma48_;
     bool enable_keyboard_;
     bool is_jupyter_;
     bool is_ipython_;
-    int : 24;
+    int : 16;
 
   public:
     static Terminal& standard_terminal();

--- a/tests/frame/test-repr-text.py
+++ b/tests/frame/test-repr-text.py
@@ -638,7 +638,7 @@ def test_encoding_autodetection(tempfile):
            "sys.stdout = open('%s', 'w', encoding='ascii'); " % tempfile +
            "import datatable as dt; " +
            "assert dt.options.display.allow_unicode is False; " +
-           "DT = dt.Frame(A=['✨']); " +
+           "DT = dt.Frame(A=['\\u2728']); " +
            "dt.options.display.use_colors = False; " +
            "DT.view(False)")
     out = subprocess.check_output(["python", "-c", cmd])

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -117,7 +117,6 @@ def test_progress(parallel_type, nthreads):
 
 
 # Send interrupt signal and make sure process throws KeyboardInterrupt
-@pytest.mark.skip(reason="Disabled temporarily")
 @cpp_test
 @pytest.mark.parametrize('parallel_type, nthreads',
                          itertools.product(

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -110,10 +110,10 @@ def test_internal_parallel_for_ordered2():
 def test_progress(parallel_type, nthreads):
     niterations = 1000
     ntimes = 2
-    cmd_run = "core.test_progress_%s(%s, %s);" % (
+    cmd = "core.test_progress_%s(%s, %s);" % (
               parallel_type, niterations, nthreads)
     for _ in range(ntimes) :
-        exec(cmd_run)
+        exec(cmd)
 
 
 # Send interrupt signal and make sure process throws KeyboardInterrupt
@@ -129,33 +129,43 @@ def test_progress_interrupt(parallel_type, nthreads):
     niterations = 10000
     sleep_time = 0.01
     exception = "KeyboardInterrupt\n"
-    cmd_settings = "import datatable as dt; from datatable.lib import core;"
-    cmd_settings += "dt.options.progress.enabled = True;"
-    cmd_settings += "dt.options.progress.min_duration = 0;"
-    cmd_settings += "print('%s start', flush = True); " % parallel_type;
+    message = "[cancelled]\x1b[m\x1b[K\n"
+    cmd = "import datatable as dt; from datatable.lib import core;"
+    cmd += "dt.options.progress.enabled = True;"
+    cmd += "dt.options.progress.min_duration = 0;"
+    cmd += "print('%s start', flush = True); " % parallel_type;
 
-    if parallel_type is None:
-        cmd_settings += "import time; "
-        cmd_settings += "dt.options.nthreads = %s; " % nthreads
-        cmd_run = "time.sleep(%s);" % sleep_time * 10
-    else:
+    if parallel_type:
         if parallel_type is "ordered":
             niterations //= 10
-        cmd_run = "core.test_progress_%s(%s, %s)" % (
+        cmd += "core.test_progress_%s(%s, %s)" % (
                   parallel_type, niterations, nthreads)
+    else:
+        cmd += "import time; "
+        cmd += "dt.options.nthreads = %s; " % nthreads
+        cmd += "time.sleep(%s);" % sleep_time * 10
 
-    proc = subprocess.Popen(["python", "-c", cmd_settings + cmd_run],
+    proc = subprocess.Popen(["python", "-c", cmd],
                             stdout = subprocess.PIPE,
                             stderr = subprocess.PIPE)
 
     line = proc.stdout.readline()
+    assert line.decode() == str(parallel_type) + " start\n"
     time.sleep(sleep_time);
 
     proc.send_signal(signal.Signals.SIGINT)
     (stdout, stderr) = proc.communicate()
 
-    if (parallel_type) :
-        assert stdout.decode().endswith("[cancelled]\x1b[m\x1b[K\n")
-    assert stderr.decode().endswith(exception)
+    stdout_str = stdout.decode()
+    stderr_str = stderr.decode()
 
+    is_exception = stderr_str.endswith(exception)
+    is_cancelled = stdout_str.endswith(message) if parallel_type else is_exception
+
+    if not is_exception or not is_cancelled:
+        print("\nstdout: \n%s" % stdout_str)
+        print("\nstderr: \n%s" % stderr_str)
+
+    assert is_cancelled
+    assert is_exception
 


### PR DESCRIPTION
We will now detect the encoding of `sys.stdout` at datatable startup, and set the option `display.allow_unicode` only if that encoding is UTF-8. The user still has the possibility to change the option.

In addition, the option `display.allow_unicode` will no longer affect the behavior of `str(DT)`: when stringifying we allow unicode always.