### PR TITLE
Improve stylesheet injection into a Jupyter notebook

### DIFF
--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -24,6 +24,7 @@
 #include "expr/join_node.h"
 #include "expr/sort_node.h"
 #include "frame/py_frame.h"
+#include "frame/repr/html_widget.h"
 #include "models/aggregator.h"
 #include "models/py_ftrl.h"
 #include "parallel/api.h"
@@ -343,6 +344,7 @@ void py::DatatableModule::init_methods() {
   init_methods_repeat();
   init_methods_sets();
   init_methods_str();
+  init_methods_styles();
   init_methods_zread();
 
   init_casts();

--- a/c/datatablemodule.h
+++ b/c/datatablemodule.h
@@ -43,6 +43,7 @@ class DatatableModule : public ExtModule<DatatableModule> {
     void init_methods_repeat();    // frame/repeat.cc
     void init_methods_sets();      // set_funcs.cc
     void init_methods_str();       // str/py_str.cc
+    void init_methods_styles();    // frame/repr/html_styles.cc
     void init_casts();             // frame/cast.cc
     void init_fuzzy();             // utils/fuzzy.cc
     void init_unops();             // expr/expr_unaryop.cc

--- a/c/frame/__repr__.cc
+++ b/c/frame/__repr__.cc
@@ -19,7 +19,6 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
-#include <ctime>
 #include <sstream>
 #include "frame/py_frame.h"
 #include "frame/repr/repr_options.h"
@@ -29,56 +28,6 @@
 #include "python/string.h"
 #include "options.h"
 #include "types.h"
-
-
-
-static const char* imgx =
-    "url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAA4CAYAAADuMJi0AAA"
-    "GR0lEQVR42rVZ21IbRxBtCbQrkIR2dQVjsLmDLBsET3nTQ8ouYRkQVf6e/E9+Im958qMfkgoXA"
-    "aKSSj6C9Jnd2R2NeiRSRaZqitVOT5+Z6dNnWoKGlN94JFp8Ipofkb/7SOXjGyp8wF+z35K3f0u"
-    "Up/GW4XfLQ8v2gefj3ZCCzojoNfue+43o1Q3l3xB/yA3JO7jnF2pCLnI+pNyx/qw7L+SQ7T2N9"
-    "p2f8c60QcfcK6KGXsAd+ZvA4LlZYuSSAoOhMs5vwJkEGDlbPMaJoA+FcQ0IH38QLWkbAFLkOOh"
-    "oMF5tU6/eBRhNjro0ZgKiPRAt3FLhCO/vqdgmNTm32LkmKpvBmQY4q5uAaAgbwDBG2BVv3bfI8"
-    "KKAMWj2kfw9+pkZREIbEql4ST1x7hgHIANkbJ//MF8mAH/ilTCJ2tIi4ASr1IC3VNqXHKOxjy3"
-    "4mgoImnOQtx1g81fkqTiMOBVGcTogNhiT5iBHET8R8C+iApJUmgim3SQAXhsLQz7ee2G8gOAQN"
-    "tJckBEplADiAxtX+G9NmhDl0qJKnTvyWlAMPYZnvIviGXRg6/Dh824DBXhP/tbfREXJEIvQ+aa"
-    "PGjG7pvw6r3xdx+9hqb4dgZaP2XmdHO2K/B0c1+oUph6k8kShBryl/Ft0DYgjTlOieOACHFFpV"
-    "yUl72T9V3cM1jUoYvxIC2vpCSys/ck70mDYuYvdvKjlMdKAUThneWVU1aAsyjv6PURDiwNsHGB"
-    "ZzY+JtAAgE2TFxdRHJdyIp/f+zqu09M5cDP2F08Ukkpj4YNSdX950HY2pNCCUK/Hhx5ZMBfjNS"
-    "EzdsIihVzzAMdn9dz4eDYhnyQb9SSCiAryiJcQk82LiTbJ4x2FZJaUenpKnzP95WyDf4Y+QN9E"
-    "FHHSeDLGdBjjKNQ5vKHf4XMA7KrY0y0GEObBOO/8e1ywuQExOHXktuQyJALEBpcEqhwtHqgiDu"
-    "CK5b6i0p2MQpcckIIoh+6hYgTZtO8xlMi6O4tKCF/kOGHEg/W0UUpHW0ZoGNZ1ExZWcn7EErgw"
-    "t4uj50E/sFBjXXIayWvh7WryjasxarZKssXon0zxvvkc32Q0bqbBCuZiKt9dWFysfQefeL29JY"
-    "FaeztX6tePaZdz5mYx8+6Zq3Mk0wXECQxlhdzgS2wjBHju3j1RIgKyOMdNUE8X0+RAdbSapS11"
-    "MRCv1SzUXmO6wGZe2SQYrv2MvCSWEv2VODE6DN7bz8ufypgQKW7uQskFTQHULLKyaEyrnlZbgO"
-    "GLrV5qrn9U79jjm2HJmgkaVN98AfBub91lGPLZBqdroN5LYgjSu4zYZDDHXZOIPC691HqrWI19"
-    "00I8qLzgKP4ft8DxEWigprPfrO+KcXno9gZz4jjGewWdUcpGCj0qVFuGPYbl2VturndZ2qRvlL"
-    "8acDO6lF/DY/VjsFesiUK+ypJ+r/ep+cJkSQxEK4PG4WozgA75TYrDDqStE69K8/mzGEM+JXTe"
-    "qvmedEElMmwCMm2SLd6bNNF9su02zEtoW6nAQtpMj5Gd7fKa//wqonF7UdtHFsVn+6hf1o7Afr"
-    "iPH7M6EeIUEF5zKVxXbYo7kS/OEtOqDYZKPoBsETIixn0uYrasThmzDkhdKPkz2EnaX0HdQbIg"
-    "r59vAdGYDqjHrxkjS7WOxkTD8sqEqhiwcJETgBYigrBqF08KyDaje9SZ/I1A7MzaTzMGDEulPt"
-    "ZUkuKcyIRAjxEJPVrnVlb/9wkfij31D/pQt1IN+iL8bGJcstBIO7Y5VI/cwDqURbXhMuJxBqD0"
-    "KLoK3esWFs0Jz5i5ZvJUAfFJMFb9XmGIOnzGpijpcWYCaMqXSQWp8EnCABepQ0Elyi4wfKfsw7"
-    "8ikIqif1pe1AGPlLmojl1SKxHHXp1L+Ut7AmDQHvhI5xHGi4EooO2BR7k78PEkJOdL7cAxQUZ/"
-    "Tyclu9gnfwGgOmm2lNHGNmZXsq4Pqgc1EG1ATrvKl8s4R9ywwnqulGUnaRLVhxy8v3ieUwy2hb"
-    "ooT68uscW++DCDH0WSzuoyN2D4LUJ/tLECbcSKznwMIFs0ChF4mRTCnQbIIfk4SHJo6A9BMuTn"
-    "XTs3Ku/KxsgZWqzuSe+Os8cEUfnMBY6UF5gi3SUbd5K7vDjq5WW0UENJlRsWn4sy21Er/E/AvP"
-    "QSFHy1p4fgAAAAASUVORK5CYII=');";
-static const char* imgv =
-    "url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAAkCAYAAACE7WrnAAA"
-    "AdElEQVR42mP4wyMVQQ3M8P///whqYBSDkG2A8bGJo+tBMQifIbgMQ5ZjwGUIPjY2wxiwOZWQZ"
-    "rxhhM0F6IYjq8PqNWyBh4+NN7CpGv2jBo0aNGrQqEGjBtHFIIoLf5pUR2RXkFStsqnSiKBqs4b"
-    "i6KdW0w8AxFl+XL1lK8wAAAAASUVORK5CYII=');";
-
-static bool in_jupyter() {
-  static bool jup = py::oobj::import("datatable")
-                      .get_attr("utils")
-                      .get_attr("terminal")
-                      .get_attr("term")
-                      .get_attr("jupyter")
-                      .to_bool_strict();
-  return jup;
-}
 
 
 
@@ -93,7 +42,6 @@ static bool in_jupyter() {
 class HtmlWidget : public dt::Widget {
   private:
     std::ostringstream html;
-    static bool styles_emitted;
 
   public:
     explicit HtmlWidget(DataTable* dt)
@@ -108,7 +56,6 @@ class HtmlWidget : public dt::Widget {
 
   protected:
     void _render() override {
-      _render_styles();
       html << "<div class='datatable'>\n";
       html << "  <table class='frame'>\n";
       html << "  <thead>\n";
@@ -300,69 +247,6 @@ class HtmlWidget : public dt::Widget {
       html << "<span class=na>NA</span>";
     }
 
-    void _render_styles() {
-      if (styles_emitted) return;
-      std::time_t now = std::time(nullptr);
-      std::tm* t = std::localtime(&now);
-      bool xd = (t->tm_mon == 11);
-      bool vd = (t->tm_mon == 4) && (t->tm_wday == 4) &&
-                (t->tm_mday >= 15) && (t->tm_mday <= 21);
-
-      html << "<style type='text/css'>\n";
-      html << ".datatable table.frame { margin-bottom: 0; }\n"
-              ".datatable table.frame thead { border-bottom: none; }\n"
-              ".datatable table.frame tr.coltypes td {"
-              "  color: #FFFFFF;"
-              "  line-height: 6px;"
-              "  padding: 0 0.5em;"
-              "}\n"
-              ".datatable .bool { background: #DDDD99; }\n"
-              ".datatable .obj  { background: #565656; }\n"
-              ".datatable .int  { background: #5D9E5D; }\n"
-              ".datatable .real { background: #4040CC; }\n"
-              ".datatable .str  { background: #CC4040; }\n"
-              ".datatable .row_index {"
-              "  background: var(--jp-border-color3);"
-              "  border-right: 1px solid var(--jp-border-color0);"
-              "  color: var(--jp-ui-font-color3);"
-              "  font-size: 9px;"
-              "}\n"
-              ".datatable .frame tr.coltypes .row_index {"
-              "  background: var(--jp-border-color0);"
-              "}\n"
-              ".datatable th:nth-child(2) { padding-left: 12px; }\n"
-              ".datatable .hellipsis {"
-              "  color: var(--jp-cell-editor-border-color);"
-              "}\n"
-              ".datatable .vellipsis {"
-              "  background: var(--jp-layout-color0);"
-              "  color: var(--jp-cell-editor-border-color);"
-              "}\n"
-              ".datatable .na {"
-              "  color: var(--jp-cell-editor-border-color);"
-              "  font-size: 80%;"
-              "}\n"
-              ".datatable .footer { font-size: 9px; }\n"
-              ".datatable .frame_dimensions {"
-              "  background: var(--jp-border-color3);"
-              "  border-top: 1px solid var(--jp-border-color0);"
-              "  color: var(--jp-ui-font-color3);"
-              "  display: inline-block;"
-              "  opacity: 0.6;"
-              "  padding: 1px 10px 1px 5px;"
-              "}\n";
-      if (xd || vd) {
-        html << ".datatable .frame thead tr.colnames {"
-                "  background-image: " << (xd? imgx : imgv) <<
-                "  background-repeat: repeat-x;"
-                "  background-size: 14px;"
-                "  height: 28px;"
-                "}\n";
-      }
-      html << "</style>\n";
-      styles_emitted = true;
-    }
-
     void _render_comma_separated(size_t n) {
       // It is customary not to display commas in 4-digit numbers
       if (n < 10000) {
@@ -391,8 +275,6 @@ class HtmlWidget : public dt::Widget {
       }
     }
 };
-
-bool HtmlWidget::styles_emitted = false;
 
 
 
@@ -434,7 +316,7 @@ static PKArgs args__repr_pretty_(
     0, 2, 0, false, false, {"p", "cycle"}, "_repr_pretty_", nullptr);
 
 oobj Frame::_repr_pretty_(const PKArgs&) {
-  if (in_jupyter()) {
+  if (dt::Terminal::standard_terminal().is_jupyter()) {
     return py::None();
   } else {
     return oobj(this).invoke("view", obool(false));

--- a/c/frame/repr/html_styles.cc
+++ b/c/frame/repr/html_styles.cc
@@ -157,7 +157,21 @@ namespace py {
 
 
 static PKArgs args_init_styles(
-  0, 0, 0, false, false, {}, "init_styles", "");
+  0, 0, 0, false, false, {}, "init_styles",
+  "Inject datatable's stylesheets into the Jupyter notebook. This\n"
+  "method does nothing when it runs in a normal Python environment\n"
+  "outside of Jupyter.\n"
+  "\n"
+  "When datatable runs in a Jupyter notebook, it renders its Frames\n"
+  "as HTML tables. The appearance of these tables is enhanced using\n"
+  "a custom stylesheet, which must be injected into the notebook at\n"
+  "any point on the page. This is exactly what this function does.\n"
+  "\n"
+  "Normally, this function is called automatically when datatable\n"
+  "is imported. However, in some circumstances Jupyter erases these\n"
+  "stylesheets (for example if you run ``import datatable`` cell\n"
+  "twice). In such cases, you may need to call this method manually.\n"
+);
 
 static void init_styles(const PKArgs&) {
   dt::emit_stylesheet();

--- a/c/frame/repr/html_styles.cc
+++ b/c/frame/repr/html_styles.cc
@@ -1,0 +1,173 @@
+//------------------------------------------------------------------------------
+// Copyright 2018-2019 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#include <ctime>
+#include <sstream>
+#include "frame/repr/html_widget.h"
+#include "python/string.h"
+#include "utils/terminal.h"
+#include "datatablemodule.h"
+namespace dt {
+
+
+
+static const char* imgx =
+    "url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAA4CAYAAADuMJi0AAA"
+    "GR0lEQVR42rVZ21IbRxBtCbQrkIR2dQVjsLmDLBsET3nTQ8ouYRkQVf6e/E9+Im958qMfkgoXA"
+    "aKSSj6C9Jnd2R2NeiRSRaZqitVOT5+Z6dNnWoKGlN94JFp8Ipofkb/7SOXjGyp8wF+z35K3f0u"
+    "Up/GW4XfLQ8v2gefj3ZCCzojoNfue+43o1Q3l3xB/yA3JO7jnF2pCLnI+pNyx/qw7L+SQ7T2N9"
+    "p2f8c60QcfcK6KGXsAd+ZvA4LlZYuSSAoOhMs5vwJkEGDlbPMaJoA+FcQ0IH38QLWkbAFLkOOh"
+    "oMF5tU6/eBRhNjro0ZgKiPRAt3FLhCO/vqdgmNTm32LkmKpvBmQY4q5uAaAgbwDBG2BVv3bfI8"
+    "KKAMWj2kfw9+pkZREIbEql4ST1x7hgHIANkbJ//MF8mAH/ilTCJ2tIi4ASr1IC3VNqXHKOxjy3"
+    "4mgoImnOQtx1g81fkqTiMOBVGcTogNhiT5iBHET8R8C+iApJUmgim3SQAXhsLQz7ee2G8gOAQN"
+    "tJckBEplADiAxtX+G9NmhDl0qJKnTvyWlAMPYZnvIviGXRg6/Dh824DBXhP/tbfREXJEIvQ+aa"
+    "PGjG7pvw6r3xdx+9hqb4dgZaP2XmdHO2K/B0c1+oUph6k8kShBryl/Ft0DYgjTlOieOACHFFpV"
+    "yUl72T9V3cM1jUoYvxIC2vpCSys/ck70mDYuYvdvKjlMdKAUThneWVU1aAsyjv6PURDiwNsHGB"
+    "ZzY+JtAAgE2TFxdRHJdyIp/f+zqu09M5cDP2F08Ukkpj4YNSdX950HY2pNCCUK/Hhx5ZMBfjNS"
+    "EzdsIihVzzAMdn9dz4eDYhnyQb9SSCiAryiJcQk82LiTbJ4x2FZJaUenpKnzP95WyDf4Y+QN9E"
+    "FHHSeDLGdBjjKNQ5vKHf4XMA7KrY0y0GEObBOO/8e1ywuQExOHXktuQyJALEBpcEqhwtHqgiDu"
+    "CK5b6i0p2MQpcckIIoh+6hYgTZtO8xlMi6O4tKCF/kOGHEg/W0UUpHW0ZoGNZ1ExZWcn7EErgw"
+    "t4uj50E/sFBjXXIayWvh7WryjasxarZKssXon0zxvvkc32Q0bqbBCuZiKt9dWFysfQefeL29JY"
+    "FaeztX6tePaZdz5mYx8+6Zq3Mk0wXECQxlhdzgS2wjBHju3j1RIgKyOMdNUE8X0+RAdbSapS11"
+    "MRCv1SzUXmO6wGZe2SQYrv2MvCSWEv2VODE6DN7bz8ufypgQKW7uQskFTQHULLKyaEyrnlZbgO"
+    "GLrV5qrn9U79jjm2HJmgkaVN98AfBub91lGPLZBqdroN5LYgjSu4zYZDDHXZOIPC691HqrWI19"
+    "00I8qLzgKP4ft8DxEWigprPfrO+KcXno9gZz4jjGewWdUcpGCj0qVFuGPYbl2VturndZ2qRvlL"
+    "8acDO6lF/DY/VjsFesiUK+ypJ+r/ep+cJkSQxEK4PG4WozgA75TYrDDqStE69K8/mzGEM+JXTe"
+    "qvmedEElMmwCMm2SLd6bNNF9su02zEtoW6nAQtpMj5Gd7fKa//wqonF7UdtHFsVn+6hf1o7Afr"
+    "iPH7M6EeIUEF5zKVxXbYo7kS/OEtOqDYZKPoBsETIixn0uYrasThmzDkhdKPkz2EnaX0HdQbIg"
+    "r59vAdGYDqjHrxkjS7WOxkTD8sqEqhiwcJETgBYigrBqF08KyDaje9SZ/I1A7MzaTzMGDEulPt"
+    "ZUkuKcyIRAjxEJPVrnVlb/9wkfij31D/pQt1IN+iL8bGJcstBIO7Y5VI/cwDqURbXhMuJxBqD0"
+    "KLoK3esWFs0Jz5i5ZvJUAfFJMFb9XmGIOnzGpijpcWYCaMqXSQWp8EnCABepQ0Elyi4wfKfsw7"
+    "8ikIqif1pe1AGPlLmojl1SKxHHXp1L+Ut7AmDQHvhI5xHGi4EooO2BR7k78PEkJOdL7cAxQUZ/"
+    "Tyclu9gnfwGgOmm2lNHGNmZXsq4Pqgc1EG1ATrvKl8s4R9ywwnqulGUnaRLVhxy8v3ieUwy2hb"
+    "ooT68uscW++DCDH0WSzuoyN2D4LUJ/tLECbcSKznwMIFs0ChF4mRTCnQbIIfk4SHJo6A9BMuTn"
+    "XTs3Ku/KxsgZWqzuSe+Os8cEUfnMBY6UF5gi3SUbd5K7vDjq5WW0UENJlRsWn4sy21Er/E/AvP"
+    "QSFHy1p4fgAAAAASUVORK5CYII=');";
+static const char* imgv =
+    "url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAAkCAYAAACE7WrnAAA"
+    "AdElEQVR42mP4wyMVQQ3M8P///whqYBSDkG2A8bGJo+tBMQifIbgMQ5ZjwGUIPjY2wxiwOZWQZ"
+    "rxhhM0F6IYjq8PqNWyBh4+NN7CpGv2jBo0aNGrQqEGjBtHFIIoLf5pUR2RXkFStsqnSiKBqs4b"
+    "i6KdW0w8AxFl+XL1lK8wAAAAASUVORK5CYII=');";
+
+
+
+static py::oobj generate_stylesheet() {
+  std::time_t now = std::time(nullptr);
+  std::tm* t = std::localtime(&now);
+  bool xd = (t->tm_mon == 11);
+  bool vd = (t->tm_mon == 4) && (t->tm_wday == 4) &&
+            (t->tm_mday >= 15) && (t->tm_mday <= 21);
+
+  std::ostringstream html;
+  html << "<style type='text/css'>\n";
+  html << ".datatable table.frame { margin-bottom: 0; }\n"
+          ".datatable table.frame thead { border-bottom: none; }\n"
+          ".datatable table.frame tr.coltypes td {"
+          "  color: #FFFFFF;"
+          "  line-height: 6px;"
+          "  padding: 0 0.5em;"
+          "}\n"
+          ".datatable .bool { background: #DDDD99; }\n"
+          ".datatable .obj  { background: #565656; }\n"
+          ".datatable .int  { background: #5D9E5D; }\n"
+          ".datatable .real { background: #4040CC; }\n"
+          ".datatable .str  { background: #CC4040; }\n"
+          ".datatable .row_index {"
+          "  background: var(--jp-border-color3);"
+          "  border-right: 1px solid var(--jp-border-color0);"
+          "  color: var(--jp-ui-font-color3);"
+          "  font-size: 9px;"
+          "}\n"
+          ".datatable .frame tr.coltypes .row_index {"
+          "  background: var(--jp-border-color0);"
+          "}\n"
+          ".datatable th:nth-child(2) { padding-left: 12px; }\n"
+          ".datatable .hellipsis {"
+          "  color: var(--jp-cell-editor-border-color);"
+          "}\n"
+          ".datatable .vellipsis {"
+          "  background: var(--jp-layout-color0);"
+          "  color: var(--jp-cell-editor-border-color);"
+          "}\n"
+          ".datatable .na {"
+          "  color: var(--jp-cell-editor-border-color);"
+          "  font-size: 80%;"
+          "}\n"
+          ".datatable .footer { font-size: 9px; }\n"
+          ".datatable .frame_dimensions {"
+          "  background: var(--jp-border-color3);"
+          "  border-top: 1px solid var(--jp-border-color0);"
+          "  color: var(--jp-ui-font-color3);"
+          "  display: inline-block;"
+          "  opacity: 0.6;"
+          "  padding: 1px 10px 1px 5px;"
+          "}\n";
+  if (xd || vd) {
+    html << ".datatable .frame thead tr.colnames {"
+            "  background-image: " << (xd? imgx : imgv) <<
+            "  background-repeat: repeat-x;"
+            "  background-size: 14px;"
+            "  height: 28px;"
+            "}\n";
+  }
+  html << "</style>\n";
+  return py::ostring(html.str());
+}
+
+
+void emit_stylesheet() {
+  if (!dt::Terminal::standard_terminal().is_jupyter()) {
+    return;
+  }
+  auto html = generate_stylesheet();
+
+  auto HTML = py::oobj::import("IPython.core.display", "HTML");
+  auto display = py::oobj::import("IPython.core.display", "display");
+  auto update = py::oobj::import("IPython.core.display", "update_display");
+
+  py::odict kwds;
+  kwds.set(py::ostring("display_id"), py::ostring("datatable:css"));
+  update.call(HTML.call(), kwds);
+  display.call(HTML.call(html), kwds);
+}
+
+
+
+
+}  // namespace dt
+namespace py {
+
+
+static PKArgs args_init_styles(
+  0, 0, 0, false, false, {}, "init_styles", "");
+
+static void init_styles(const PKArgs&) {
+  dt::emit_stylesheet();
+}
+
+void DatatableModule::init_methods_styles() {
+  ADD_FN(&init_styles, args_init_styles);
+}
+
+
+
+
+} // namespace py

--- a/c/frame/repr/html_widget.h
+++ b/c/frame/repr/html_widget.h
@@ -1,0 +1,33 @@
+//------------------------------------------------------------------------------
+// Copyright 2019 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#ifndef dt_FRAME_REPR_HTML_WIDGET_h
+#define dt_FRAME_REPR_HTML_WIDGET_h
+#include "frame/repr/widget.h"
+#include "python/_all.h"
+namespace dt {
+
+
+void emit_stylesheet();
+
+
+}  // namespace dt
+#endif

--- a/datatable/__init__.py
+++ b/datatable/__init__.py
@@ -27,7 +27,7 @@ from .expr import (mean, min, max, sd, isna, sum, count, first, abs, exp,
 from .fread import fread, GenericReader, FreadWarning, _DefaultLogger
 from .lib._datatable import (
     unique, union, intersect, setdiff, symdiff,
-    repeat, by, join, sort, cbind, rbind
+    repeat, by, join, sort, cbind, rbind, init_styles
 )
 from .nff import open
 from .options import options
@@ -47,11 +47,15 @@ except ImportError:
 __all__ = (
     "__git_revision__",
     "__version__",
-    "dt",
     "Frame",
+    "count",
+    "dt",
+    "first",
+    "init_styles",
+    "last",
     "mean",
     "median",
-    "sd", "count", "first", "last",
+    "sd",
     "isna", "fread", "GenericReader", "stype", "ltype", "f", "g",
     "join", "by", "exp", "log", "log10",
     "options",
@@ -59,7 +63,7 @@ __all__ = (
     "float32", "float64", "str32", "str64", "obj64",
     "cbind", "rbind", "repeat", "sort",
     "unique", "union", "intersect", "setdiff", "symdiff",
-    "split_into_nhot"
+    "split_into_nhot",
 )
 
 bool8 = stype.bool8
@@ -73,3 +77,6 @@ str32 = stype.str32
 str64 = stype.str64
 obj64 = stype.obj64
 dt = datatable
+
+# This will run only in Jupyter notebook
+init_styles()

--- a/docs/changelog/v-0-10-0.rst
+++ b/docs/changelog/v-0-10-0.rst
@@ -157,6 +157,12 @@ Frame
   obtained from joining another frame, provided that the join was only
   partially successful (#2109).
 
+- |fix| In Jupyter notebook Frame's stylesheets are now injected during
+  the datatable import. This makes it less likely that the stylesheets will
+  get accidentally removed from the page. However, if it still does occur,
+  there is now also a method to load those styles directly:
+  :meth:`init_styles` (#1871).
+
 
 General
 -------


### PR DESCRIPTION
- Added method `datatable.init_styles()` which injects datatable's stylesheets into a Jupyter notebook;
- This method is also run automatically when datatable is imported.

Note that this PR does not solve the problem of disappearing stylesheet entirely: if have a cell `import datatable as dt`, then the stylesheet will be automatically added when the cell is executed, but then will disappear if the user runs the same cell again. In a situation like this the user would have to manually call `dt.init_styles()` to restore the stylesheet. This is far from ideal, because a normal user would probably not even know about the existence of this function...

I've experimented with different approaches to this problem, but neither worked:

- Overriding Python import hooks, forcing python to re-import datatable each time (or at least, run a custom function each time). This seems like it could have worked, but unfortunately there are too many places where datatable could get imported (including within its own code), and we may end up producing copious amounts of CSS code;

- Creating an output node with custom `__del__` method, so that it would revive whenever the node gets deleted. Unfortunately, IPython is not storing these nodes anywhere after they get displayed, which means it doesn't know what nodes still exist in Jupyter and which nodes got deleted.

- Creating a Javascript snippet which sets up an event handler when the CSS node gets removed, and then automatically restores that node. This would work within a notebook webpage (provided the user hasn't disabled javascript in notebooks), but breaks as soon as the notebook is stored as an ipynb file: Jupyter will not save any DOM elements that we "sneakily" added.

In view of these difficulties, I opted to use the explicit function method, which will at least work reliably for users who care about such display issues.

Closes #1871