### PR TITLE
Added parameters append= and header= to .to_csv()

### DIFF
--- a/c/frame/to_csv.cc
+++ b/c/frame/to_csv.cc
@@ -86,8 +86,11 @@ append: bool
 
 header: bool | ...
     This option controls whether or not to write headers into the
-    output file. If this option is omitted, then the headers will be
-    written if `append` is False, and not written if `append` is True.
+    output file. If this option is not given (or equal to ...), then
+    the headers will be written unless the option `append` is True
+    and the file `path` already exists. Thus, by default the headers
+    will be written in all cases except when appending content into
+    an existing file.
 
 hex: bool
     If True, then all floating-point values will be printed in hex

--- a/c/frame/to_csv.cc
+++ b/c/frame/to_csv.cc
@@ -41,12 +41,14 @@ static void change_to_lowercase(std::string& str) {
 //------------------------------------------------------------------------------
 
 static PKArgs args_to_csv(
-    0, 1, 5, false, false,
-    {"path", "quoting", "hex", "compression", "verbose", "_strategy"},
+    0, 1, 7, false, false,
+    {"path", "quoting", "append", "header", "hex", "compression", "verbose",
+     "_strategy"},
     "to_csv",
 
-R"(to_csv(self, path=None, *, quoting="minimal", hex=False,
-       compression=None, verbose=False, _strategy="auto")
+R"(to_csv(self, path=None, *, quoting="minimal", append=False,
+       header=..., hex=False, compression=None, verbose=False,
+       _strategy="auto")
 --
 
 Write the Frame into the provided file in CSV format.
@@ -75,6 +77,17 @@ quoting: csv.QUOTE_* | "minimal" | "all" | "nonnumeric" | "none"
     csv.QUOTE_NONE (3)
         none of the fields will be quoted. This option must be used
         at user's own risk: the file produced may not be valid CSV.
+
+append: bool
+    If True, the file given in the `path` parameter will be opened
+    for appending (i.e. mode="a"), or created if it doesn't exist.
+    If False (default), the file given in the `path` will be
+    overwritten if it already exists.
+
+header: bool | ...
+    This option controls whether or not to write headers into the
+    output file. If this option is omitted, then the headers will be
+    written if `append` is False, and not written if `append` is True.
 
 hex: bool
     If True, then all floating-point values will be printed in hex
@@ -111,8 +124,17 @@ a bytes object will be returned instead.
 
 oobj Frame::to_csv(const PKArgs& args)
 {
+  const Arg& arg_path     = args[0];
+  const Arg& arg_quoting  = args[1];
+  const Arg& arg_append   = args[2];
+  const Arg& arg_header   = args[3];
+  const Arg& arg_hex      = args[4];
+  const Arg& arg_compress = args[5];
+  const Arg& arg_verbose  = args[6];
+  const Arg& arg_strategy = args[7];
+
   // path
-  oobj path = args[0].to<oobj>(ostring(""));
+  oobj path = arg_path.to<oobj>(ostring(""));
   if (!path.is_string()) {
     throw TypeError() << "Parameter `path` in Frame.to_csv() should be a "
         "string, instead got " << path.typeobj();
@@ -122,8 +144,8 @@ oobj Frame::to_csv(const PKArgs& args)
 
   // quoting
   int quoting;
-  if (args[1].is_string()) {
-    auto quoting_str = args[1].to_string();
+  if (arg_quoting.is_string()) {
+    auto quoting_str = arg_quoting.to_string();
     change_to_lowercase(quoting_str);
     if (quoting_str == "minimal") quoting = 0;
     else if (quoting_str == "all") quoting = 1;
@@ -134,18 +156,29 @@ oobj Frame::to_csv(const PKArgs& args)
           "Frame.to_csv(): '" << quoting_str << "'";
     }
   } else {
-    quoting = args[1].to<int>(0);
+    quoting = arg_quoting.to<int>(0);
     if (quoting < 0 || quoting > 3) {
       throw ValueError() << "Invalid value of the `quoting` parameter in "
           "Frame.to_csv(): " << quoting;
     }
   }
 
+  // append
+  bool append = arg_append.to<bool>(false);
+  if (append && filename.empty()) {
+    throw ValueError() << "`append` parameter is set to True, but the "
+        "output file is not specified";
+  }
+
+  // header
+  bool header = arg_header.is_ellipsis()? !append
+                                        : arg_header.to<bool>(!append);
+
   // hex
-  bool hex = args[2].to<bool>(false);
+  bool hex = arg_hex.to<bool>(false);
 
   // compress
-  auto compress_str = args[3].to<std::string>("infer");
+  auto compress_str = arg_compress.to<std::string>("infer");
   bool compress = false;  // eventually this will be an Enum
   if (compress_str == "infer") {
     size_t n = filename.size();
@@ -160,19 +193,21 @@ oobj Frame::to_csv(const PKArgs& args)
   }
 
   // verbose
-  bool verbose = args[4].to<bool>(false);
+  bool verbose = arg_verbose.to<bool>(false);
   oobj logger;
   if (verbose) {
     logger = oobj::import("datatable", "_DefaultLogger").call();
   }
 
-  auto strategy = args[5].to<std::string>("");
+  auto strategy = arg_strategy.to<std::string>("");
   auto sstrategy = (strategy == "mmap")  ? WritableBuffer::Strategy::Mmap :
                    (strategy == "write") ? WritableBuffer::Strategy::Write :
                                            WritableBuffer::Strategy::Auto;
 
   // Create the CsvWriter object
   dt::write::csv_writer writer(dt, filename);
+  writer.set_append(append);
+  writer.set_header(header);
   writer.set_strategy(sstrategy);
   writer.set_usehex(hex);
   writer.set_logger(logger);

--- a/c/frame/to_csv.cc
+++ b/c/frame/to_csv.cc
@@ -139,7 +139,7 @@ oobj Frame::to_csv(const PKArgs& args)
     throw TypeError() << "Parameter `path` in Frame.to_csv() should be a "
         "string, instead got " << path.typeobj();
   }
-  path = oobj::import("os", "path", "expanduser").call({path});
+  path = oobj::import("os", "path", "expanduser").call(path);
   std::string filename = path.to_string();
 
   // quoting
@@ -171,8 +171,14 @@ oobj Frame::to_csv(const PKArgs& args)
   }
 
   // header
-  bool header = arg_header.is_ellipsis()? !append
-                                        : arg_header.to<bool>(!append);
+  bool header;
+  if (arg_header.is_none_or_undefined() || arg_header.is_ellipsis()) {
+    header = !(append &&
+               oobj::import("os", "path", "exists").call(path)
+                  .to_bool_strict());
+  } else {
+    header = arg_header.to<bool>(true);
+  }
 
   // hex
   bool hex = arg_hex.to<bool>(false);

--- a/c/utils/file.cc
+++ b/c/utils/file.cc
@@ -19,6 +19,7 @@ const int File::READ = O_RDONLY;
 const int File::READWRITE = O_RDWR;
 const int File::CREATE = O_RDWR | O_CREAT;
 const int File::OVERWRITE = O_RDWR | O_CREAT | O_TRUNC;
+const int File::APPEND = O_WRONLY | O_CREAT | O_APPEND;
 const int File::EXTERNALFD = -1;
 
 

--- a/c/utils/file.h
+++ b/c/utils/file.h
@@ -24,6 +24,7 @@ class File
   int flags;
 
 public:
+  static const int APPEND;
   static const int READ;
   static const int READWRITE;
   static const int CREATE;

--- a/c/write/csv_writer.cc
+++ b/c/write/csv_writer.cc
@@ -81,6 +81,7 @@ void csv_writer::estimate_output_size() {
 void csv_writer::write_preamble() {
   const strvec& column_names = dt->get_names();
   if (column_names.empty()) return;
+  if (!write_header_) return;
 
   Column names_as_col = Column(new Strvec_ColumnImpl(column_names));
   auto writer = value_writer::create(names_as_col, options);

--- a/c/write/write_manager.cc
+++ b/c/write/write_manager.cc
@@ -46,6 +46,14 @@ write_manager::~write_manager() {}
 
 //---- Deferred initialization of certain parameters ----
 
+void write_manager::set_append(bool f) {
+  append_ = f;
+}
+
+void write_manager::set_header(bool f) {
+  write_header_ = f;
+}
+
 void write_manager::set_strategy(WritableBuffer::Strategy strategy_) {
   strategy = strategy_;
 }

--- a/c/write/write_manager.cc
+++ b/c/write/write_manager.cc
@@ -177,7 +177,8 @@ void write_manager::create_column_writers() {
 
 
 void write_manager::create_output_target() {
-  wb = WritableBuffer::create_target(path, estimated_output_size, strategy);
+  wb = WritableBuffer::create_target(path, estimated_output_size, strategy,
+                                     append_);
 }
 
 

--- a/c/write/write_manager.h
+++ b/c/write/write_manager.h
@@ -75,7 +75,9 @@ class write_manager {
     std::string path;
     output_options options;
     WritableBuffer::Strategy strategy;
-    size_t : 56;
+    bool append_;
+    bool write_header_;
+    size_t : 40;
 
     // Runtime parameters
     write_chronicler chronicler;
@@ -96,6 +98,8 @@ class write_manager {
     write_manager(write_manager&&) = delete;
     virtual ~write_manager();
 
+    void set_append(bool);
+    void set_header(bool);
     void set_strategy(WritableBuffer::Strategy);
     void set_logger(py::oobj logger);
     void set_usehex(bool);

--- a/c/writebuf.cc
+++ b/c/writebuf.cc
@@ -238,6 +238,11 @@ MmapWritableBuffer::MmapWritableBuffer(const std::string& path, size_t size,
   : ThreadsafeWritableBuffer(), filename(path)
 {
   File file(path, File::CREATE);
+  if (append) {
+    size_t filesize = file.size();
+    size += filesize;
+    bytes_written = filesize;
+  }
   if (size) {
     file.resize(size);
     allocsize = size;

--- a/c/writebuf.h
+++ b/c/writebuf.h
@@ -47,9 +47,14 @@ public:
    *     Which subclass of `WritableBuffer` to construct. This could be `Auto`
    *     (choose the best subclass automatically), while all  other values
    *     force the choice of a particular subclass.
+   *
+   * @param append
+   *     If true, the file will be opened in append mode ("a"); if false, the
+   *     file will be opened in overwrite mode ("w").
    */
   static std::unique_ptr<WritableBuffer> create_target(
-    const std::string& path, size_t size, Strategy strategy = Strategy::Auto
+    const std::string& path, size_t size, Strategy strategy = Strategy::Auto,
+    bool append = false
   );
 
   /**
@@ -116,7 +121,7 @@ class FileWritableBuffer : public WritableBuffer
   File* file;
 
 public:
-  FileWritableBuffer(const std::string& path);
+  FileWritableBuffer(const std::string& path, bool append = false);
   virtual ~FileWritableBuffer() override;
 
   virtual size_t prep_write(size_t n, const void* src) override;
@@ -177,7 +182,7 @@ class MmapWritableBuffer : public ThreadsafeWritableBuffer
   std::string filename;
 
 public:
-  MmapWritableBuffer(const std::string& path, size_t size);
+  MmapWritableBuffer(const std::string& path, size_t size, bool append = false);
   ~MmapWritableBuffer() override;
 
   void finalize() override;

--- a/docs/changelog/v-0-10-0.rst
+++ b/docs/changelog/v-0-10-0.rst
@@ -94,6 +94,14 @@ Frame
 - |new| A frame returned by the single-column selector is now keyed
   if and only if the original frame key consisted of the selected column only.
 
+- |new| Method :meth:`.to_csv() <datatable.Frame.to_csv>` gains two new boolean
+  parameters: ``header=`` and ``append=``. The ``header=`` parameter controls
+  whether or not to write into the output the header row with column names. The
+  ``append=`` parameter allows the CSV content to be appended to an existing
+  file instead of overwriting it::
+
+    DT.to_csv("out.log", append=True)  # infer that header=False if file exists
+
 - |api| The name deduplication algorithm now starts looking for candidate names
   starting from ``name + dt.options.frame.name_auto_index``. For example, if
   you're creating a Frame with column names `["A", "A", "A"]`, then those names

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,7 +103,8 @@ def tempfile():
     fd, fname = mod_tempfile.mkstemp()
     os.close(fd)
     yield fname
-    os.unlink(fname)
+    if os.path.exists(fname):
+        os.unlink(fname)
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_tocsv.py
+++ b/tests/test_tocsv.py
@@ -563,6 +563,7 @@ def test_header_valid():
     assert DT.to_csv(header=False) == ''
     assert DT.to_csv(header=True) == 'Q\n'
     assert DT.to_csv(header=None) == 'Q\n'
+    assert DT.to_csv(header=...) == 'Q\n'
 
 
 def test_header_invalid():
@@ -574,3 +575,96 @@ def test_header_invalid():
         DT.to_csv(header="yes")
     with pytest.raises(TypeError, match=msg):
         DT.to_csv(header=[])
+
+
+
+#-------------------------------------------------------------------------------
+# Parameter append=
+#-------------------------------------------------------------------------------
+
+def readfile(file):
+    with open(file, "r") as tmp:
+        return tmp.read()
+
+
+def test_append_to_new_file(tempfile):
+    os.unlink(tempfile)
+    DT = dt.Frame(A=[5])
+    DT.to_csv(tempfile, append=True)
+    assert readfile(tempfile) == "A\n5\n"
+    # Write again: the old content should remain in the file
+    DT[0, 0] = 3
+    DT.to_csv(tempfile, append=True)
+    assert readfile(tempfile) == "A\n5\n3\n"
+
+
+def test_append_to_existing_file(tempfile):
+    with open(tempfile, "w") as tmp:
+        tmp.write("# text/csv\n")
+    DT = dt.Frame(XYZ=range(5))
+    DT.to_csv(tempfile, append=True)
+    assert readfile(tempfile) == "# text/csv\n0\n1\n2\n3\n4\n"
+
+
+def test_append_no_file_given():
+    DT = dt.Frame(A=[5])
+    with pytest.raises(ValueError, match="`append` parameter is set to True, "
+                                         "but the output file is not specifi"):
+        DT.to_csv(append=True)
+
+
+def test_append_valid(tempfile):
+    with open(tempfile, "w") as tmp:
+        tmp.write("@")
+    DT = dt.Frame(A=[7])
+    DT.to_csv(tempfile, append=True)
+    assert readfile(tempfile) == "@7\n"  # auto-detects header=False
+    DT.to_csv(tempfile, append=False)
+    assert readfile(tempfile) == "A\n7\n"
+    DT.to_csv(tempfile, append=None)     # None is same as False
+    assert readfile(tempfile) == "A\n7\n"
+
+
+def test_append_invalid(tempfile):
+    os.unlink(tempfile)
+    msg = r"Argument `append` in Frame\.to_csv\(\) should be a boolean"
+    DT = dt.Frame()
+    with pytest.raises(TypeError, match=msg):
+        DT.to_csv('tmp', append=1)
+    with pytest.raises(TypeError, match=msg):
+        DT.to_csv('tmp', append="yes")
+    with pytest.raises(TypeError, match=msg):
+        DT.to_csv('tmp', append=[])
+    assert not os.path.exists(tempfile)
+
+
+def test_append_with_headers(tempfile):
+    DT = dt.Frame(A=[7])
+    DT.to_csv(tempfile)
+    assert readfile(tempfile) == "A\n7\n"
+    DT.to_csv(tempfile, append=True)
+    assert readfile(tempfile) == "A\n7\n7\n"
+    DT.to_csv(tempfile, append=True, header=True)
+    assert readfile(tempfile) == "A\n7\n7\nA\n7\n"
+    DT.to_csv(tempfile, append=True, header=False)
+    assert readfile(tempfile) == "A\n7\n7\nA\n7\n7\n"
+
+
+def test_append_strategy(tempfile):
+    DT = dt.Frame(D=[3])
+    DT.to_csv(tempfile)
+    DT.to_csv(tempfile, append=True, _strategy="write")
+    assert readfile(tempfile) == "D\n3\n3\n"
+    DT.to_csv(tempfile, append=True, _strategy="mmap")
+    assert readfile(tempfile) == "D\n3\n3\n3\n"
+
+
+def test_append_large(tempfile):
+    word = "supercalifragilisticexpialidocious"
+    n = 10000
+    DT = dt.Frame([word] * n, names=["..."])
+    DT.to_csv(tempfile)
+    DT.to_csv(tempfile, append=True, _strategy="write")
+    assert readfile(tempfile) == "...\n" + (word + "\n") * (2*n)
+    DT.to_csv(tempfile, append=True, _strategy="mmap")
+    assert readfile(tempfile) == "...\n" + (word + "\n") * (3*n)

--- a/tests/test_tocsv.py
+++ b/tests/test_tocsv.py
@@ -536,3 +536,41 @@ def test_compress_invalid():
         DT.to_csv(compression="rar")
     assert ("Unsupported compression method 'rar' in Frame.to_csv()"
             == str(e.value))
+
+
+
+#-------------------------------------------------------------------------------
+# Parameter header=
+#-------------------------------------------------------------------------------
+
+def test_header():
+    DT = dt.Frame(A=[5])
+    assert DT.to_csv() == "A\n5\n"
+    assert DT.to_csv(header=True) == "A\n5\n"
+    assert DT.to_csv(header=False) == "5\n"
+
+
+def test_header2():
+    DT = dt.Frame(A=range(3), B=[5]*3, ZZZ=['yes', 'no', None])
+    DT = DT[:, ["A", "B", "ZZZ"]]  # for py3.5
+    assert DT.to_csv(header=False) == ("0,5,yes\n"
+                                       "1,5,no\n"
+                                       "2,5,\n")
+
+
+def test_header_valid():
+    DT = dt.Frame(names=["Q"])
+    assert DT.to_csv(header=False) == ''
+    assert DT.to_csv(header=True) == 'Q\n'
+    assert DT.to_csv(header=None) == 'Q\n'
+
+
+def test_header_invalid():
+    msg = r"Argument `header` in Frame\.to_csv\(\) should be a boolean"
+    DT = dt.Frame()
+    with pytest.raises(TypeError, match=msg):
+        DT.to_csv(header=1)
+    with pytest.raises(TypeError, match=msg):
+        DT.to_csv(header="yes")
+    with pytest.raises(TypeError, match=msg):
+        DT.to_csv(header=[])


### PR DESCRIPTION
Method `Frame.to_csv()` gains two new boolean parameters: `header=` and `append=`. The `header=` parameter controls whether or not to write into the output the header row with column names. The `append=` parameter allows the CSV content to be appended to an existing file instead of overwriting it:
```python
DT.to_csv("out.log", append=True)
```

By default, `append=False`. The default value of `header=` parameter is inferred: it is equal to `True` in all cases except when both `append=True`, and the file given as the argument already exists.

Closes #2130