### PR TITLE
Fix binary-op applied to a columnset vs a single column

### DIFF
--- a/c/expr/head_func_binary.cc
+++ b/c/expr/head_func_binary.cc
@@ -36,20 +36,19 @@ Workframe Head_Func_Binary::evaluate_n(const vecExpr& args, EvalContext& ctx) co
   xassert(args.size() == 2);
   Workframe lhs = args[0].evaluate_n(ctx);
   Workframe rhs = args[1].evaluate_n(ctx);
-  size_t lmask = (lhs.ncols() == 1)? 0 : size_t(-1);
-  size_t rmask = (rhs.ncols() == 1)? 0 : size_t(-1);
-  if (lmask && rmask && lhs.ncols() != rhs.ncols()) {
+  if (lhs.ncols() == 1) lhs.repeat_columns(rhs.ncols());
+  if (rhs.ncols() == 1) rhs.repeat_columns(lhs.ncols());
+  if (lhs.ncols() != rhs.ncols()) {
     throw ValueError() << "Incompatible column vectors in a binary operation: "
       "LHS contains " << lhs.ncols() << " items, while RHS has " << rhs.ncols()
       << " items";
   }
-  size_t size = lmask? lhs.ncols() : rmask? rhs.ncols() : 1;
   lhs.sync_grouping_mode(rhs);
   auto gmode = lhs.get_grouping_mode();
   Workframe outputs(ctx);
-  for (size_t i = 0; i < size; ++i) {
-    Column lhscol = lhs.retrieve_column(i & lmask);
-    Column rhscol = rhs.retrieve_column(i & rmask);
+  for (size_t i = 0; i < lhs.ncols(); ++i) {
+    Column lhscol = lhs.retrieve_column(i);
+    Column rhscol = rhs.retrieve_column(i);
     outputs.add_column(binaryop(op, lhscol, rhscol),
                        std::string(),
                        gmode);

--- a/c/expr/workframe.cc
+++ b/c/expr/workframe.cc
@@ -154,6 +154,13 @@ bool Workframe::is_reference_column(
 }
 
 
+void Workframe::repeat_columns(size_t n) {
+  xassert(ncols() == 1);
+  if (n == 1) return;
+  entries.resize(n, entries[0]);
+}
+
+
 // Ensure that this workframe is suitable for updating a region
 // of the requested shape [target_nrows x target_ncols].
 //

--- a/c/expr/workframe.h
+++ b/c/expr/workframe.h
@@ -104,6 +104,7 @@ class Workframe {
     bool is_reference_column(size_t i, size_t* iframe, size_t* icol) const;
     bool is_placeholder_column(size_t i) const;
 
+    void repeat_columns(size_t n);
     void reshape_for_update(size_t target_nrows, size_t target_ncols);
     const Column& get_column(size_t i) const;
     std::string retrieve_name(size_t i);

--- a/tests/test_dt_expr.py
+++ b/tests/test_dt_expr.py
@@ -132,6 +132,11 @@ def test_equal_strings(st1, st2):
     assert df2.to_list() == [[False, True, False, False, True, True]]
 
 
+def test_equal_columnset():
+    DT = dt.Frame([[1, 2, 3], [5, 4, 1]], names=["A", "B"])
+    DT2 = DT[:, f[:] == 1]
+    assert_equals(DT2, dt.Frame(A=[True, False, False], B=[False, False, True]))
+
 
 
 #-------------------------------------------------------------------------------

--- a/tests/test_dt_expr.py
+++ b/tests/test_dt_expr.py
@@ -135,7 +135,9 @@ def test_equal_strings(st1, st2):
 def test_equal_columnset():
     DT = dt.Frame([[1, 2, 3], [5, 4, 1]], names=["A", "B"])
     DT2 = DT[:, f[:] == 1]
-    assert_equals(DT2, dt.Frame(A=[True, False, False], B=[False, False, True]))
+    DT3 = DT[:, 2 < f[:]]
+    assert_equals(DT2, dt.Frame([[True, False, False], [False, False, True]]))
+    assert_equals(DT3, dt.Frame([[False, False, True], [True, True, False]]))
 
 
 


### PR DESCRIPTION
The bug manifested for any binary operation where one side of the op contains multiple columns, while the other side only a single column. Now this case works properly.

Closes #2142