### PR TITLE
Restore a support for the negative_class FTRL parameter

### DIFF
--- a/c/models/dt_ftrl.cc
+++ b/c/models/dt_ftrl.cc
@@ -986,6 +986,7 @@ void Ftrl<T>::reset() {
   model_type = FtrlModelType::NONE;
   dt_labels = nullptr;
   colname_hashes.clear();
+  negative_class_id = NA_U8;
 }
 
 

--- a/c/models/dt_ftrl.cc
+++ b/c/models/dt_ftrl.cc
@@ -491,7 +491,7 @@ void Ftrl<T>::create_y_multinomial(const DataTable* dt,
       new_label_indices.resize(n_new_labels);
       RowIndex ri_labels(std::move(new_label_indices));
       dt_labels_in->apply_rowindex(ri_labels);
-      set_ids(dt_labels_in->get_column(1), static_cast<int32_t>(dt_labels->nrows()));
+      fill_ids(dt_labels_in->get_column(1), static_cast<int32_t>(dt_labels->nrows()));
 
       // Since we cannot rbind anything to a keyed frame, we
       // - clear the key;

--- a/c/models/dt_ftrl.cc
+++ b/c/models/dt_ftrl.cc
@@ -399,10 +399,12 @@ void Ftrl<T>::add_negative_class() {
   negative_class_id = dt_labels->nrows();
   d_ids[0] = int32_t(negative_class_id);
 
-  dtptr dt_nc = dtptr(new DataTable({
-                       std::move(c_labels).to_ocolumn(),
-                       std::move(c_ids)
-                     }, dt_labels->get_names()));
+  dtptr dt_nc = dtptr(
+                  new DataTable(
+                    {std::move(c_labels).to_ocolumn(), std::move(c_ids)},
+                    dt_labels->get_names()
+                  )
+                );
 
   dt_labels->clear_key();
   dt_labels->rbind({dt_nc.get()}, {{ 0 } , { 1 }});

--- a/c/models/dt_ftrl.cc
+++ b/c/models/dt_ftrl.cc
@@ -44,6 +44,7 @@ Ftrl<T>::Ftrl(FtrlParams params_in) :
   lambda2(static_cast<T>(params_in.lambda2)),
   nbins(params_in.nbins),
   mantissa_nbits(params_in.mantissa_nbits),
+  negative_class(params_in.negative_class),
   nepochs(params_in.nepochs),
   nfeatures(0),
   dt_X_train(nullptr),
@@ -557,8 +558,7 @@ FtrlFitOutput Ftrl<T>::fit(T(*linkfn)(T),
           U value;
           bool isvalid = target_col0_train.get_element(ii, &value);
 
-          if (isvalid && std::isfinite(value))
-          {
+          if (isvalid && std::isfinite(value)) {
             hash_row(x, hashers, ii);
             for (size_t k = 0; k < label_ids_train.size(); ++k) {
               T p = linkfn(predict_row(
@@ -1384,6 +1384,7 @@ void Ftrl<T>::set_nepochs(size_t nepochs_in) {
 template <typename T>
 void Ftrl<T>::set_negative_class(bool negative_class_in) {
   params.negative_class = negative_class_in;
+  negative_class = negative_class_in;
 }
 
 

--- a/c/models/dt_ftrl.h
+++ b/c/models/dt_ftrl.h
@@ -66,6 +66,7 @@ class Ftrl : public dt::FtrlBase {
     // Helper parameters.
     T ialpha;
     T gamma;
+    size_t negative_class_id;
 
     // Labels that are automatically extracted from the target column.
     // For binomial classification, labels are stored as
@@ -121,6 +122,7 @@ class Ftrl : public dt::FtrlBase {
     void hash_row(uint64ptr&, std::vector<hasherptr>&, size_t);
 
     // Model helper methods
+    void add_negative_class();
     void create_model();
     void adjust_model();
     void init_model();

--- a/c/models/dt_ftrl.h
+++ b/c/models/dt_ftrl.h
@@ -56,16 +56,17 @@ class Ftrl : public dt::FtrlBase {
     T beta;
     T lambda1;
     T lambda2;
-    uint64_t nbins;
-    unsigned char mantissa_nbits;
-    bool negative_class;
-    size_t: 48;
-    size_t nepochs;
+
+    // Vector of feature interactions.
     std::vector<intvec> interactions;
 
     // Helper parameters.
     T ialpha;
     T gamma;
+
+    // When problem type is multinomial regression and `params.negative_class`
+    // is `true`, this property represents a label (model) id of the
+    // negative class.
     size_t negative_class_id;
 
     // Labels that are automatically extracted from the target column.

--- a/c/models/dt_ftrl.h
+++ b/c/models/dt_ftrl.h
@@ -58,7 +58,8 @@ class Ftrl : public dt::FtrlBase {
     T lambda2;
     uint64_t nbins;
     unsigned char mantissa_nbits;
-    size_t: 56;
+    bool negative_class;
+    size_t: 48;
     size_t nepochs;
     std::vector<intvec> interactions;
 

--- a/c/models/dt_ftrl.h
+++ b/c/models/dt_ftrl.h
@@ -64,11 +64,6 @@ class Ftrl : public dt::FtrlBase {
     T ialpha;
     T gamma;
 
-    // When problem type is multinomial regression and `params.negative_class`
-    // is `true`, this property represents a label (model) id of the
-    // negative class.
-    size_t negative_class_id;
-
     // Labels that are automatically extracted from the target column.
     // For binomial classification, labels are stored as
     //   index 0: negative label

--- a/c/models/dt_ftrl_base.h
+++ b/c/models/dt_ftrl_base.h
@@ -134,8 +134,7 @@ class FtrlBase {
     // Number of mantissa bits in a double number.
     static constexpr unsigned char DOUBLE_MANTISSA_NBITS = 52;
 
-    // Separator for nhot encoding splitter.
-    // Can also be useful for multilabel regression.
+    // TODO: separator for multilabel regression.
     static constexpr char SEPARATOR = ',';
 
     // Minimum number of rows a thread will get for fitting and predicting.

--- a/c/models/label_encode.cc
+++ b/c/models/label_encode.cc
@@ -34,30 +34,80 @@ void label_encode(const Column& col, dtptr& dt_labels, dtptr& dt_encoded,
   if (is_binomial) {
     switch (stype) {
       case SType::BOOL:    label_encode_bool(col, dt_labels, dt_encoded); break;
-      case SType::INT8:    label_encode_fw<SType::INT8, SType::BOOL>(col, dt_labels, dt_encoded); break;
-      case SType::INT16:   label_encode_fw<SType::INT16, SType::BOOL>(col, dt_labels, dt_encoded); break;
-      case SType::INT32:   label_encode_fw<SType::INT32, SType::BOOL>(col, dt_labels, dt_encoded); break;
-      case SType::INT64:   label_encode_fw<SType::INT64, SType::BOOL>(col, dt_labels, dt_encoded); break;
-      case SType::FLOAT32: label_encode_fw<SType::FLOAT32, SType::BOOL>(col, dt_labels, dt_encoded); break;
-      case SType::FLOAT64: label_encode_fw<SType::FLOAT64, SType::BOOL>(col, dt_labels, dt_encoded); break;
-      case SType::STR32:   label_encode_str<uint32_t, SType::BOOL>(col, dt_labels, dt_encoded); break;
-      case SType::STR64:   label_encode_str<uint64_t, SType::BOOL>(col, dt_labels, dt_encoded); break;
+      case SType::INT8:    label_encode_fw<SType::INT8, SType::BOOL>(
+                             col, dt_labels, dt_encoded
+                           );
+                           break;
+      case SType::INT16:   label_encode_fw<SType::INT16, SType::BOOL>(
+                             col, dt_labels, dt_encoded
+                           );
+                           break;
+      case SType::INT32:   label_encode_fw<SType::INT32, SType::BOOL>(
+                             col, dt_labels, dt_encoded
+                            );
+                           break;
+      case SType::INT64:   label_encode_fw<SType::INT64, SType::BOOL>(
+                             col, dt_labels, dt_encoded
+                           );
+                           break;
+      case SType::FLOAT32: label_encode_fw<SType::FLOAT32, SType::BOOL>(
+                             col, dt_labels, dt_encoded
+                           );
+                           break;
+      case SType::FLOAT64: label_encode_fw<SType::FLOAT64, SType::BOOL>(
+                             col, dt_labels, dt_encoded
+                           );
+                           break;
+      case SType::STR32:   label_encode_str<uint32_t, SType::BOOL>(
+                             col, dt_labels, dt_encoded
+                           );
+                           break;
+      case SType::STR64:   label_encode_str<uint64_t, SType::BOOL>(
+                             col, dt_labels, dt_encoded
+                           );
+                           break;
 
-      default:             throw TypeError() << "Column type `" << stype << "` is not supported";
+      default:             throw TypeError() << "Column type `" << stype
+                                             << "` is not supported";
     }
   } else {
     switch (stype) {
       case SType::BOOL:    label_encode_bool(col, dt_labels, dt_encoded); break;
-      case SType::INT8:    label_encode_fw<SType::INT8, SType::INT32>(col, dt_labels, dt_encoded); break;
-      case SType::INT16:   label_encode_fw<SType::INT16, SType::INT32>(col, dt_labels, dt_encoded); break;
-      case SType::INT32:   label_encode_fw<SType::INT32, SType::INT32>(col, dt_labels, dt_encoded); break;
-      case SType::INT64:   label_encode_fw<SType::INT64, SType::INT32>(col, dt_labels, dt_encoded); break;
-      case SType::FLOAT32: label_encode_fw<SType::FLOAT32, SType::INT32>(col, dt_labels, dt_encoded); break;
-      case SType::FLOAT64: label_encode_fw<SType::FLOAT64, SType::INT32>(col, dt_labels, dt_encoded); break;
-      case SType::STR32:   label_encode_str<uint32_t, SType::INT32>(col, dt_labels, dt_encoded); break;
-      case SType::STR64:   label_encode_str<uint64_t, SType::INT32>(col, dt_labels, dt_encoded); break;
+      case SType::INT8:    label_encode_fw<SType::INT8, SType::INT32>(
+                             col, dt_labels, dt_encoded
+                           );
+                           break;
+      case SType::INT16:   label_encode_fw<SType::INT16, SType::INT32>(
+                             col, dt_labels, dt_encoded
+                           );
+                           break;
+      case SType::INT32:   label_encode_fw<SType::INT32, SType::INT32>(
+                             col, dt_labels, dt_encoded
+                           );
+                           break;
+      case SType::INT64:   label_encode_fw<SType::INT64, SType::INT32>(
+                             col, dt_labels, dt_encoded
+                           );
+                           break;
+      case SType::FLOAT32: label_encode_fw<SType::FLOAT32, SType::INT32>(
+                             col, dt_labels, dt_encoded
+                           );
+                           break;
+      case SType::FLOAT64: label_encode_fw<SType::FLOAT64, SType::INT32>(
+                             col, dt_labels, dt_encoded
+                           );
+                           break;
+      case SType::STR32:   label_encode_str<uint32_t, SType::INT32>(
+                             col, dt_labels, dt_encoded
+                           );
+                           break;
+      case SType::STR64:   label_encode_str<uint64_t, SType::INT32>(
+                             col, dt_labels, dt_encoded
+                           );
+                           break;
 
-      default:             throw TypeError() << "Column type `" << stype << "` is not supported";
+      default:             throw TypeError() << "Column type `" << stype
+                                             << "` is not supported";
     }
   }
 
@@ -74,7 +124,9 @@ void label_encode(const Column& col, dtptr& dt_labels, dtptr& dt_encoded,
  *  false/true. No encoding in this case is necessary, so `dt_encoded`
  *  just uses a shallow copy of `col`.
  */
-static void label_encode_bool(const Column& col, dtptr& dt_labels, dtptr& dt_encoded)
+static void label_encode_bool(const Column& col,
+                              dtptr& dt_labels,
+                              dtptr& dt_encoded)
 {
   // If we only got NA's, return
   if (col.na_count() == col.nrows()) return;

--- a/c/models/label_encode.h
+++ b/c/models/label_encode.h
@@ -88,7 +88,7 @@ dtptr create_dt_labels_str(const std::unordered_map<std::string, element_t<stype
  *  Used in the multinomial case when we encounter new labels.
  */
 template <typename T>
-void set_ids(Column& col, T i0) {
+void fill_ids(Column& col, T i0) {
   col.materialize();
   auto data = static_cast<T*>(col.get_data_editable());
   for (T i = 0; i < static_cast<T>(col.nrows()); ++i) {

--- a/c/models/label_encode.h
+++ b/c/models/label_encode.h
@@ -82,6 +82,7 @@ dtptr create_dt_labels_str(const std::unordered_map<std::string, element_t<stype
          ));
 }
 
+
 /**
  *  Fill column with the sequential ids starting from `i0`.
  *  Used in the multinomial case when we encounter new labels.
@@ -92,6 +93,20 @@ void set_ids(Column& col, T i0) {
   auto data = static_cast<T*>(col.get_data_editable());
   for (T i = 0; i < static_cast<T>(col.nrows()); ++i) {
     data[i] = i0 + i;
+  }
+}
+
+
+/**
+ *  Increase column values by `i0`.
+ *  Used in the multinomial case when we need to add a negative class.
+ */
+template <typename T>
+void increase_ids(Column& col, T i0) {
+  col.materialize();
+  auto data = static_cast<T*>(col.get_data_editable());
+  for (T i = 0; i < static_cast<T>(col.nrows()); ++i) {
+    data[i] += i0;
   }
 }
 

--- a/c/models/label_encode.h
+++ b/c/models/label_encode.h
@@ -29,9 +29,11 @@ namespace dt {
 void label_encode(const Column&, dtptr&, dtptr&, bool is_binomial = false);
 
 
-
 /**
  *  Apply a function `adjustfn()` to all the column values.
+ *  NB: this function doesn't do any NA checks and can only be applied
+ *  to FW columns. It is used by FTRL to adjust label ids for the multinomial
+ *  regression.
  */
 template <typename T, typename F>
 void adjust_values(Column& col, F adjustfn) {
@@ -47,8 +49,10 @@ void adjust_values(Column& col, F adjustfn) {
  *  Create labels datatable from unordered map for fixed width columns.
  */
 template <SType stype_from, SType stype_to>
-dtptr create_dt_labels_fw(const std::unordered_map<element_t<stype_from>,
-                                                   element_t<stype_to>>& labels_map)
+dtptr create_dt_labels_fw(const std::unordered_map<
+                            element_t<stype_from>,
+                            element_t<stype_to>
+                          >& labels_map)
 {
   using Tfrom = element_t<stype_from>;
   using Tto = element_t<stype_to>;
@@ -73,10 +77,16 @@ dtptr create_dt_labels_fw(const std::unordered_map<element_t<stype_from>,
  *  Create labels datatable from unordered map for string columns.
  */
 template <typename T, SType stype_to>
-dtptr create_dt_labels_str(const std::unordered_map<std::string, element_t<stype_to>>& labels_map) {
+dtptr create_dt_labels_str(const std::unordered_map<
+                             std::string,
+                             element_t<stype_to>
+                           >& labels_map)
+{
   size_t nlabels = labels_map.size();
   Column ids_col = Column::new_data_column(nlabels, stype_to);
-  auto ids_data = static_cast<element_t<stype_to>*>(ids_col.get_data_editable());
+  auto ids_data = static_cast<element_t<stype_to>*>(
+                    ids_col.get_data_editable()
+                  );
   dt::writable_string_col c_label_names(nlabels);
   dt::writable_string_col::buffer_impl<T> sb(c_label_names);
   sb.commit_and_start_new_chunk(0);

--- a/c/models/label_encode.h
+++ b/c/models/label_encode.h
@@ -29,6 +29,20 @@ namespace dt {
 void label_encode(const Column&, dtptr&, dtptr&, bool is_binomial = false);
 
 
+
+/**
+ *  Apply a function `adjustfn()` to all the column values.
+ */
+template <typename T, typename F>
+void adjust_values(Column& col, F adjustfn) {
+  col.materialize();
+  T* data = static_cast<T*>(col.get_data_editable());
+  for (size_t i = 0; i < col.nrows(); ++i) {
+    adjustfn(data[i], i);
+  }
+}
+
+
 /**
  *  Create labels datatable from unordered map for fixed width columns.
  */
@@ -82,33 +96,6 @@ dtptr create_dt_labels_str(const std::unordered_map<std::string, element_t<stype
          ));
 }
 
-
-/**
- *  Fill column with the sequential ids starting from `i0`.
- *  Used in the multinomial case when we encounter new labels.
- */
-template <typename T>
-void fill_ids(Column& col, T i0) {
-  col.materialize();
-  auto data = static_cast<T*>(col.get_data_editable());
-  for (T i = 0; i < static_cast<T>(col.nrows()); ++i) {
-    data[i] = i0 + i;
-  }
-}
-
-
-/**
- *  Increase column values by `i0`.
- *  Used in the multinomial case when we need to add a negative class.
- */
-template <typename T>
-void increase_ids(Column& col, T i0) {
-  col.materialize();
-  auto data = static_cast<T*>(col.get_data_editable());
-  for (T i = 0; i < static_cast<T>(col.nrows()); ++i) {
-    data[i] += i0;
-  }
-}
 
 
 /**

--- a/tests/models/test_ftrl.py
+++ b/tests/models/test_ftrl.py
@@ -929,8 +929,11 @@ def test_ftrl_fit_predict_multinomial():
     assert p.names == labels
 
 
-def test_ftrl_fit_predict_multinomial_online():
+@pytest.mark.parametrize('negative_class', [False, True])
+def test_ftrl_fit_predict_multinomial_online(negative_class):
     ft = Ftrl(alpha = 0.2, nepochs = 1000, double_precision = True)
+    ft.negative_class = negative_class
+    negative_class_label = ["_negative_class"] if negative_class else []
     labels = ["green", "red", "blue"]
 
     # Show only 1 label to the model
@@ -938,24 +941,24 @@ def test_ftrl_fit_predict_multinomial_online():
     df_target = dt.Frame(["green"])
     ft.fit(df_train, df_target)
     assert ft.model_type_trained == "multinomial"
-    assert(ft.labels[:, 0].to_list() == [["green"]])
-    assert(ft.model.shape == (ft.nbins, 2))
+    assert ft.labels[:, 0].to_list() == [negative_class_label + ["green"]]
+    assert ft.model.shape == (ft.nbins, 2 * ft.labels.nrows)
 
     # Show one more
     df_train = dt.Frame(["cucumber", None])
     df_target = dt.Frame(["green", "red"])
     ft.fit(df_train, df_target)
     assert ft.model_type_trained == "multinomial"
-    assert(ft.labels[:, 0].to_list() == [["green", "red"]])
-    assert(ft.model.shape == (ft.nbins, 4))
+    assert ft.labels[:, 0].to_list() == [negative_class_label + ["green", "red"]]
+    assert ft.model.shape == (ft.nbins, 2 * ft.labels.nrows)
 
     # And one more
     df_train = dt.Frame(["cucumber", None, "shift", "sky", "day", "orange", "ocean"])
     df_target = dt.Frame(["green", "red", "red", "blue", "green", None, "blue"])
     ft.fit(df_train, df_target)
     assert ft.model_type_trained == "multinomial"
-    assert(ft.labels[:, 0].to_list() == [["blue", "green", "red"]])
-    assert(ft.model.shape == (ft.nbins, 6))
+    assert ft.labels[:, 0].to_list() == [negative_class_label + ["blue", "green", "red"]]
+    assert ft.model.shape == (ft.nbins, 2 * ft.labels.nrows)
 
     # Do not add any new labels
     df_train = dt.Frame(["cucumber", None, "shift", "sky", "day", "orange", "ocean"])
@@ -963,8 +966,8 @@ def test_ftrl_fit_predict_multinomial_online():
 
     ft.fit(df_train, df_target)
     assert ft.model_type_trained == "multinomial"
-    assert(ft.labels[:, 0].to_list() == [["blue", "green", "red"]])
-    assert(ft.model.shape == (ft.nbins, 6))
+    assert ft.labels[:, 0].to_list() == [negative_class_label + ["blue", "green", "red"]]
+    assert ft.model.shape == (ft.nbins, 2 * ft.labels.nrows)
 
     # Test predictions
     p = ft.predict(df_train)
@@ -986,7 +989,7 @@ def test_ftrl_fit_predict_multinomial_online():
     assert max(delta_red)   < epsilon
     assert max(delta_green) < epsilon
     assert max(delta_blue)  < epsilon
-    assert list(p.names) == ["blue", "green", "red"]
+    assert list(p.names) == negative_class_label + ["blue", "green", "red"]
 
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
- restore a support for the `negative_class` FTRL parameter;
- minor cleaning;
- test adjustment.

Closes #2136 