### PR TITLE
update() function

### DIFF
--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -22,6 +22,7 @@
 #include "expr/head_func.h"
 #include "expr/head_reduce.h"
 #include "expr/join_node.h"
+#include "expr/py_update.h"          // py::oupdate
 #include "expr/sort_node.h"
 #include "frame/py_frame.h"
 #include "frame/repr/html_widget.h"
@@ -386,6 +387,7 @@ PyMODINIT_FUNC PyInit__datatable() noexcept
     py::oby::init(m);
     py::ojoin::init(m);
     py::osort::init(m);
+    py::oupdate::init(m);
     dt::Terminal::standard_terminal().initialize();
 
   } catch (const std::exception& e) {

--- a/c/expr/expr.h
+++ b/c/expr/expr.h
@@ -90,6 +90,7 @@ class Expr {
 
   public:
     explicit Expr(py::robj src);
+    Expr(ptrHead&&, vecExpr&&);
     Expr() = default;
     Expr(Expr&&) = default;
     Expr(const Expr&) = delete;

--- a/c/expr/py_update.cc
+++ b/c/expr/py_update.cc
@@ -1,0 +1,109 @@
+//------------------------------------------------------------------------------
+// Copyright 2019 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#include "expr/py_update.h"
+namespace py {
+
+
+
+//------------------------------------------------------------------------------
+// oupdate_pyobject
+//------------------------------------------------------------------------------
+
+static PKArgs args___init__(0, 0, 0, false, true, {}, "__init__", nullptr);
+
+
+void oupdate::oupdate_pyobject::impl_init_type(XTypeMaker& xt) {
+  xt.set_class_name("datatable.update");
+  xt.set_class_doc("update() clause for use in DT[i, j, ...]");
+  xt.set_subclassable(false);
+
+  xt.add(CONSTRUCTOR(&oupdate::oupdate_pyobject::m__init__, args___init__));
+  xt.add(DESTRUCTOR(&oupdate::oupdate_pyobject::m__dealloc__));
+
+  static GSArgs args__names("_names");
+  static GSArgs args__exprs("_exprs");
+  xt.add(GETTER(&oupdate::oupdate_pyobject::get_names, args__names));
+  xt.add(GETTER(&oupdate::oupdate_pyobject::get_exprs, args__exprs));
+}
+
+
+void oupdate::oupdate_pyobject::m__init__(const PKArgs& args) {
+  size_t n = args.num_varkwd_args();
+  names_ = py::olist(n);
+  exprs_ = py::olist(n);
+  size_t i = 0;
+  for (auto kw : args.varkwds()) {
+    names_.set(i, kw.first);
+    exprs_.set(i, kw.second);
+    i++;
+  }
+}
+
+
+void oupdate::oupdate_pyobject::m__dealloc__() {
+  names_ = py::olist();
+  exprs_ = py::olist();
+}
+
+
+oobj oupdate::oupdate_pyobject::get_names() const {
+  return names_;
+}
+
+oobj oupdate::oupdate_pyobject::get_exprs() const {
+  return exprs_;
+}
+
+
+
+
+//------------------------------------------------------------------------------
+// oupdate
+//------------------------------------------------------------------------------
+
+oupdate::oupdate(const robj& r) : oobj(r) {
+  xassert(check(v));
+}
+
+
+bool oupdate::check(PyObject* v) {
+  return oupdate::oupdate_pyobject::check(v);
+}
+
+
+void oupdate::init(PyObject* m) {
+  oupdate::oupdate_pyobject::init_type(m);
+}
+
+
+oobj oupdate::get_names() const {
+  return reinterpret_cast<const oupdate::oupdate_pyobject*>(v)->get_names();
+}
+
+oobj oupdate::get_exprs() const {
+  return reinterpret_cast<const oupdate::oupdate_pyobject*>(v)->get_exprs();
+}
+
+
+
+
+}  // namespace py

--- a/c/expr/py_update.h
+++ b/c/expr/py_update.h
@@ -1,0 +1,70 @@
+//------------------------------------------------------------------------------
+// Copyright 2019 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#ifndef dt_EXPR_PY_UPDATE_h
+#define dt_EXPR_PY_UPDATE_h
+#include "python/obj.h"
+#include "python/xobject.h"
+namespace py {
+
+
+class oupdate : public oobj
+{
+  class oupdate_pyobject : public XObject<oupdate_pyobject> {
+    private:
+      olist names_;
+      olist exprs_;
+
+    private:
+      void m__init__(const PKArgs&);
+      void m__dealloc__();
+
+    public:
+      static void impl_init_type(XTypeMaker& xt);
+      oobj get_names() const;
+      oobj get_exprs() const;
+  };
+
+  public:
+    oupdate() = default;
+    oupdate(const oupdate&) = default;
+    oupdate(oupdate&&) = default;
+    oupdate& operator=(const oupdate&) = default;
+    oupdate& operator=(oupdate&&) = default;
+
+    static bool check(PyObject* v);
+    static void init(PyObject* m);
+
+    oobj get_names() const;
+    oobj get_exprs() const;
+
+  private:
+    // This private constructor will reinterpret the object `r` as an
+    // `oupdate` object. This constructor does not create any new,
+    // python objects.
+    oupdate(const robj& r);
+    friend class _obj;
+};
+
+
+
+} // namespace py
+#endif

--- a/c/frame/__init__.cc
+++ b/c/frame/__init__.cc
@@ -323,9 +323,8 @@ class FrameInitializationManager {
       newnames.reserve(ncols);
       for (auto kv: all_args.varkwds()) {
         size_t i = newnames.size();
-        const py::ostring oname(kv.first);
-        SType stype = get_stype_for_column(i, &oname);
-        newnames.push_back(std::move(kv.first));
+        SType stype = get_stype_for_column(i, &kv.first);
+        newnames.push_back(kv.first.to_string());
         make_column(kv.second, stype);
       }
       make_datatable(newnames);
@@ -574,7 +573,7 @@ class FrameInitializationManager {
       if (n == 1) {
         err << "an unexpected keyword argument ";
         for (auto kv: all_args.varkwds()) {
-          err << '\'' << kv.first << '\'';
+          err << '\'' << kv.first.to_string() << '\'';
         }
       } else {
         err << n << " unexpected keyword arguments: ";
@@ -582,7 +581,7 @@ class FrameInitializationManager {
         for (auto kv: all_args.varkwds()) {
           ++i;
           if (i <= 2 || i == n) {
-            err << '\'' << kv.first << '\'';
+            err << '\'' << kv.first.to_string() << '\'';
             err << (i == n ? "" :
                     i == n - 1 ? " and " :
                     i == 1 ? ", " : ", ..., ");

--- a/c/python/args.cc
+++ b/c/python/args.cc
@@ -1,12 +1,26 @@
 //------------------------------------------------------------------------------
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright 2018-2019 H2O.ai
 //
-// © H2O.ai 2018
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
 //------------------------------------------------------------------------------
-#include "python/args.h"
 #include <cstring>             // std::strrchr
+#include "python/args.h"
 #include "utils/assert.h"
 
 namespace py {
@@ -293,7 +307,7 @@ VarArgsIterator VarArgsIterable::end() const {
 
 
 VarKwdsIterator::VarKwdsIterator(const PKArgs& args, Py_ssize_t i0)
-    : parent(args), pos(i0), curr_value(std::string(), py::robj(nullptr))
+    : parent(args), pos(i0), curr_value(py::robj(nullptr), py::robj(nullptr))
 {
   if (parent.kwds_dict) {
     advance();
@@ -324,7 +338,7 @@ void VarKwdsIterator::advance() {
   PyObject *key, *value;
   while (PyDict_Next(parent.kwds_dict, &pos, &key, &value)) {
     if (parent.kwd_map.count(key) == 0) {
-      curr_value = value_type(py::robj(key).to_string(),
+      curr_value = value_type(py::robj(key),
                               py::robj(value));
       return;
     }

--- a/c/python/args.h
+++ b/c/python/args.h
@@ -163,7 +163,7 @@ class PKArgs {
 
 class VarKwdsIterator {
   public:
-    using value_type = std::pair<std::string, py::robj>;
+    using value_type = std::pair<py::robj, py::robj>;
     using category_type = std::input_iterator_tag;
 
   private:

--- a/c/python/obj.cc
+++ b/c/python/obj.cc
@@ -24,6 +24,7 @@
 #include "expr/by_node.h"
 #include "expr/join_node.h"
 #include "expr/sort_node.h"
+#include "expr/py_update.h"
 #include "frame/py_frame.h"
 #include "python/_all.h"
 #include "python/list.h"
@@ -222,6 +223,10 @@ bool _obj::is_by_node() const noexcept {
 
 bool _obj::is_sort_node() const noexcept {
   return py::osort::check(v);
+}
+
+bool _obj::is_update_node() const noexcept {
+  return py::oupdate::check(v);
 }
 
 bool _obj::is_pandas_frame() const noexcept {
@@ -626,6 +631,11 @@ py::oby _obj::to_oby_lax() const {
 
 py::osort _obj::to_osort_lax() const {
   return is_sort_node()? osort(robj(v)) : osort();
+}
+
+
+py::oupdate _obj::to_oupdate_lax() const {
+  return is_update_node()? oupdate(robj(v)) : oupdate();
 }
 
 

--- a/c/python/obj.h
+++ b/c/python/obj.h
@@ -35,6 +35,7 @@ class orange;
 class osort;
 class otuple;
 class rtuple;
+class oupdate;
 class robj;
 class rdict;
 class oobj;
@@ -198,6 +199,7 @@ class _obj {
     bool is_tuple()         const noexcept;
     bool is_type()          const noexcept;
     bool is_undefined()     const noexcept;
+    bool is_update_node()   const noexcept;
 
     struct error_manager;  // see below
     int8_t      to_bool           (const error_manager& = _em0) const;
@@ -236,6 +238,7 @@ class _obj {
     py::ojoin   to_ojoin_lax      () const;
     py::oby     to_oby_lax        () const;
     py::osort   to_osort_lax      () const;
+    py::oupdate to_oupdate_lax    () const;
     // Defined in expr/base_expr.cc
     std::unique_ptr<dt::expr::base_expr> to_dtexpr() const;
 

--- a/datatable/__init__.py
+++ b/datatable/__init__.py
@@ -26,8 +26,19 @@ from .expr import (mean, min, max, sd, isna, sum, count, first, abs, exp,
                    last, log, log10, f, g, median)
 from .fread import fread, GenericReader, FreadWarning, _DefaultLogger
 from .lib._datatable import (
-    unique, union, intersect, setdiff, symdiff,
-    repeat, by, join, sort, cbind, rbind, init_styles
+    by,
+    cbind,
+    init_styles,
+    intersect,
+    join,
+    rbind,
+    repeat,
+    setdiff,
+    sort,
+    symdiff,
+    union,
+    unique,
+    update,
 )
 from .nff import open
 from .options import options

--- a/docs/changelog/v-0-10-0.rst
+++ b/docs/changelog/v-0-10-0.rst
@@ -39,6 +39,13 @@ also in functions that operate on lists of columns, such as ``rowsum()``,
 Frame
 -----
 
+- |new| Added function `update()`, which can be used to in a ``DT[i, j]``
+  expression. This function can be used in the ``j`` place, and it allows the
+  user to create new columns in a Frame, or update the existing ones::
+
+    DT = dt.Frame(A=range(5))
+    DT[:, update(A=f.A * 2, B=dt.str32(f.A), Z=0)]
+
 - |new| Added method :meth:`.export_names() <datatable.Frame.export_names>`
   which creates a set of global variables referencing each column in the Frame.
   This is recommended for interactive use only::
@@ -91,8 +98,8 @@ Frame
   than this value will be automatically truncated when a Frame is rendered into
   a terminal.
 
-- |new| A frame returned by the single-column selector is now keyed
-  if and only if the original frame key consisted of the selected column only.
+- |new| When selecting the key column from a keyed frame ``DT[key]``, the
+  resulting single-column frame will now retain its "keyed" property.
 
 - |new| Method :meth:`.to_csv() <datatable.Frame.to_csv>` gains two new boolean
   parameters: ``header=`` and ``append=``. The ``header=`` parameter controls

--- a/tests/ijby/test-update.py
+++ b/tests/ijby/test-update.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#-------------------------------------------------------------------------------
+# Copyright 2019 H2O.ai
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#-------------------------------------------------------------------------------
+import pytest
+from datatable import f, g, dt, by, join, update
+from datatable.internal import frame_integrity_check
+from tests import assert_equals
+
+
+
+def test_update_simple():
+    DT = dt.Frame(A=range(5))
+    DT[:, update(B=10)]
+    assert_equals(DT, dt.Frame(A=range(5), B=[10]*5))
+
+
+def test_update_existing_column():
+    DT = dt.Frame(A=range(5))
+    DT[:, update(A=f.A * 2)]
+    assert_equals(DT, dt.Frame(A=range(0, 10, 2)))
+
+
+def test_update_multiple_columns():
+    DT = dt.Frame(A=range(5))
+    DT[:, update(I8=dt.int8(f.A),
+                 I16=dt.int16(f.A),
+                 I64=dt.int64(f.A))]
+    assert_equals(DT, dt.Frame([[0, 1, 2, 3, 4]] * 4,
+                               names=["A", "I8", "I16", "I64"],
+                               stypes=[dt.int32, dt.int8, dt.int16, dt.int64]))
+
+
+def test_update_multiple_dependents():
+    DT = dt.Frame(A=range(5))
+    DT[:, update(B=f.A + 1, A=f.A + 2, D=f.A + 3)]
+    assert_equals(DT, dt.Frame(A=range(2, 7), B=range(1, 6), D=range(3, 8)))
+
+
+
+def test_update_with_delete():
+    DT = dt.Frame(A=range(5))
+    with pytest.raises(ValueError, match=r"update\(\) clause cannot be used "
+                                         r"with a delete expression"):
+        del DT[:, update(B=0)]
+
+
+def test_update_with_assign():
+    DT = dt.Frame(A=range(5))
+    with pytest.raises(ValueError, match=r"update\(\) clause cannot be used "
+                                         r"with an assignment expression"):
+        DT[:, update(B=0)] = None
+
+
+def test_update_misplaced():
+    DT = dt.Frame(A=range(5))
+    with pytest.raises(TypeError, match="Column selector must be an integer "
+                                        "or a string"):
+        DT[update(B=0)]
+    with pytest.raises(TypeError, match="Invalid item at position 2 in "
+                                        r"DT\[i, j, \.\.\.\] call"):
+        DT[:, :, update(B=0)]
+
+
+


### PR DESCRIPTION
The `update()` function can be used inside `DT[i, j]` in the j-th place. This function allows updating/creating multiple columns at once. For example:
```
DT[:, update(A = np.random.randn(100),
             B = dt.Frame(range(100)),
             C = dt.str32(f.ZipCode))]
```

In general, `update(**kwds)` takes an arbitrary keyword arguments, and then performs the assignment
```
DT[:, kwds.names()] = kwds.values()
```

Closes #1700