### PR TITLE
Allow mixing grouped and non-grouped expressions in DT[i,j]

### DIFF
--- a/c/column.cc
+++ b/c/column.cc
@@ -147,6 +147,10 @@ bool Column::is_virtual() const noexcept {
   return impl_->is_virtual();
 }
 
+bool Column::is_constant() const noexcept {
+  return bool(dynamic_cast<const dt::Const_ColumnImpl*>(impl_));
+}
+
 size_t Column::elemsize() const noexcept {
   return info(impl_->stype_).elemsize();
 }

--- a/c/column.h
+++ b/c/column.h
@@ -165,6 +165,7 @@ class Column
     size_t elemsize() const noexcept;
     bool   is_fixedwidth() const noexcept;
     bool   is_virtual() const noexcept;
+    bool   is_constant() const noexcept;
     size_t memory_footprint() const noexcept;
     operator bool() const noexcept;
 

--- a/c/column/const.cc
+++ b/c/column/const.cc
@@ -159,7 +159,7 @@ class ConstFloat_ColumnImpl : public Const_ColumnImpl {
           return SType::FLOAT64;
 
         default:
-          xassert(0 && "Invalid stype for float constant");  // LCOV_EXCL
+          xassert(0 && "Invalid stype for float constant");  // LCOV_EXCL_LINE
       }
     }
 };

--- a/c/expr/eval_context.cc
+++ b/c/expr/eval_context.cc
@@ -104,6 +104,12 @@ GroupbyMode EvalContext::get_groupby_mode() const {
   return groupby_mode;
 }
 
+const RowIndex& EvalContext::get_ungroup_rowindex() {
+  if (!ungroup_rowindex_) {
+    ungroup_rowindex_ = gb.ungroup_rowindex();
+  }
+  return ungroup_rowindex_;
+}
 
 
 

--- a/c/expr/eval_context.cc
+++ b/c/expr/eval_context.cc
@@ -75,12 +75,13 @@ void EvalContext::add_j(py::oobj oj) {
       throw ValueError() << "update() clause cannot be used with an "
                             "assignment expression";
     }
-    jexpr_ = dt::expr::Expr(arg_update.get_names());
-    repl_ = dt::expr::Expr(arg_update.get_exprs());
     mode = EvalMode::UPDATE;
+    jexpr_ = dt::expr::Expr(arg_update.get_names());
+    jexpr = j_node::make(arg_update.get_names(), *this);  // remove
+    repl_ = dt::expr::Expr(arg_update.get_exprs());
   } else {
     jexpr_ = dt::expr::Expr(oj);
-    jexpr = j_node::make(oj, *this);
+    jexpr = j_node::make(oj, *this);   // remove
   }
 }
 

--- a/c/expr/eval_context.h
+++ b/c/expr/eval_context.h
@@ -83,6 +83,7 @@ class EvalContext {
     // Runtime
     frvec         frames;
     Groupby       gb;
+    RowIndex      ungroup_rowindex_;
     EvalMode      mode;
     GroupbyMode   groupby_mode;
     size_t : 48;
@@ -116,6 +117,7 @@ class EvalContext {
     DataTable* get_datatable(size_t i) const;
     const RowIndex& get_rowindex(size_t i) const;
     const Groupby& get_groupby();
+    const RowIndex& get_ungroup_rowindex();
     const by_node& get_by_node() const;
     bool is_naturally_joined(size_t i) const;
     bool has_groupby() const;

--- a/c/expr/head_frame.cc
+++ b/c/expr/head_frame.cc
@@ -86,7 +86,7 @@ Workframe Head_Frame::evaluate_n(const vecExpr& args, EvalContext& ctx) const {
         "cannot be used in an expression where " << ctx.nrows()
         << " are expected";
   }
-  Grouping grouplevel = (nrows == 1)? Grouping::GtoONE
+  Grouping grouplevel = (nrows == 1)? Grouping::SCALAR
                                     : Grouping::GtoALL;
   Workframe res(ctx);
   for (size_t i = 0; i < dt_->ncols(); ++i) {

--- a/c/expr/workframe.cc
+++ b/c/expr/workframe.cc
@@ -179,12 +179,6 @@ void Workframe::reshape_for_update(size_t target_nrows, size_t target_ncols) {
         << target_nrows << " x " << target_ncols << "], but received ["
         << this_nrows << " x " << this_ncols << "]";
   }
-  // if (this_nrows != target_nrows) {
-  //   xassert(this_nrows == 1);
-  //   for (auto& item : entries) {
-  //     item.column.repeat(target_nrows);  // modifies the column in-place
-  //   }
-  // }
   if (this_ncols != target_ncols) {
     xassert(this_ncols == 1);
     entries.resize(target_ncols, entries[0]);
@@ -298,6 +292,7 @@ void Workframe::column_increase_grouping_mode(
     throw RuntimeError() << "Unexpected Grouping mode";  // LCOV_EXCL_LINE
   }
 }
+
 
 
 

--- a/c/expr/workframe.cc
+++ b/c/expr/workframe.cc
@@ -168,19 +168,23 @@ void Workframe::reshape_for_update(size_t target_nrows, size_t target_ncols) {
   size_t this_nrows = nrows();
   size_t this_ncols = ncols();
   if (this_ncols == 0 && target_ncols == 0 && this_nrows == 0) return;
-  bool ok = (this_nrows == target_nrows || this_nrows == 1) &&
+  if (grouping_mode != Grouping::GtoALL) {
+    increase_grouping_mode(Grouping::GtoALL);
+    this_nrows = nrows();
+  }
+  bool ok = (this_nrows == target_nrows) &&
             (this_ncols == target_ncols || this_ncols == 1);
   if (!ok) {
     throw ValueError() << "Invalid replacement Frame: expected ["
         << target_nrows << " x " << target_ncols << "], but received ["
         << this_nrows << " x " << this_ncols << "]";
   }
-  if (this_nrows != target_nrows) {
-    xassert(this_nrows == 1);
-    for (auto& item : entries) {
-      item.column.repeat(target_nrows);  // modifies the column in-place
-    }
-  }
+  // if (this_nrows != target_nrows) {
+  //   xassert(this_nrows == 1);
+  //   for (auto& item : entries) {
+  //     item.column.repeat(target_nrows);  // modifies the column in-place
+  //   }
+  // }
   if (this_ncols != target_ncols) {
     xassert(this_ncols == 1);
     entries.resize(target_ncols, entries[0]);

--- a/c/expr/workframe.cc
+++ b/c/expr/workframe.cc
@@ -262,6 +262,7 @@ void Workframe::sync_grouping_mode(Column& col, Grouping gmode) {
 
 void Workframe::increase_grouping_mode(Grouping gmode) {
   for (auto& item : entries) {
+    if (!item.column) continue;  // placeholder column
     column_increase_grouping_mode(item.column, grouping_mode, gmode);
   }
   grouping_mode = gmode;
@@ -271,10 +272,28 @@ void Workframe::increase_grouping_mode(Grouping gmode) {
 void Workframe::column_increase_grouping_mode(
     Column& col, Grouping gfrom, Grouping gto)
 {
-  // TODO
-  (void)col; (void) gfrom; (void) gto;
+  xassert(gfrom != Grouping::GtoFEW && gfrom != Grouping::GtoANY);
+  xassert(gto != Grouping::GtoFEW && gto != Grouping::GtoANY);
+  xassert(static_cast<int>(gfrom) < static_cast<int>(gto));
+  if (gfrom == Grouping::SCALAR && gto == Grouping::GtoONE) {
+    col.repeat(ctx.get_groupby().size());
+  }
+  else if (gfrom == Grouping::SCALAR && gto == Grouping::GtoALL) {
+    col.repeat(ctx.nrows());
+  }
+  else if (gfrom == Grouping::GtoONE && gto == Grouping::GtoALL) {
+    if (col.is_constant()) {
+      col.resize(1);
+      col.repeat(ctx.nrows());
+    } else {
+      col.apply_rowindex(ctx.get_ungroup_rowindex());
+    }
+    xassert(col.nrows() == ctx.nrows());
+  }
+  else {
+    throw RuntimeError() << "Unexpected Grouping mode";  // LCOV_EXCL_LINE
+  }
 }
-
 
 
 

--- a/c/groupby.h
+++ b/c/groupby.h
@@ -38,8 +38,9 @@ class Groupby {
     // Where the first 1 is located at offset `offsets[1]`, the first 2 at the
     // offset `offsets[2]`, and so on, and the total length of the RowIndex is
     // equal to `offsets[n]`.
-    // This RowIndex will be cached within the Groupby, so that it can be
-    // reused across multiple calls.
+    //
+    // This RowIndex will not be cached within the Groupby, we recommend the
+    // caller to do that.
     //
     RowIndex ungroup_rowindex();
 };

--- a/tests/ijby/test-assign-expr.py
+++ b/tests/ijby/test-assign-expr.py
@@ -111,7 +111,6 @@ def test_assign_expr_partial_with_type_change():
 # Assign complex combos
 #-------------------------------------------------------------------------------
 
-# @pytest.mark.xfail()
 def test_assign_with_groupby():
     DT = dt.Frame(A=range(5), B=[1, 1, 2, 2, 2])
     DT[:, "C", by(f.B)] = dt.mean(f.A)

--- a/tests/ijby/test-assign-expr.py
+++ b/tests/ijby/test-assign-expr.py
@@ -111,7 +111,7 @@ def test_assign_expr_partial_with_type_change():
 # Assign complex combos
 #-------------------------------------------------------------------------------
 
-@pytest.mark.xfail()
+# @pytest.mark.xfail()
 def test_assign_with_groupby():
     DT = dt.Frame(A=range(5), B=[1, 1, 2, 2, 2])
     DT[:, "C", by(f.B)] = dt.mean(f.A)
@@ -119,7 +119,6 @@ def test_assign_with_groupby():
                                C=[0.5, 0.5, 3.0, 3.0, 3.0]))
 
 
-@pytest.mark.xfail()
 def test_assign_with_groupby2():
     DT = dt.Frame(A=range(5), B=[1, 1, 2, 2, 2])
     DT[:, "C", by(f.B)] = f.A - dt.mean(f.A)

--- a/tests/ijby/test-assign-scalar.py
+++ b/tests/ijby/test-assign-scalar.py
@@ -81,12 +81,11 @@ def test_assign_boolean2():
 
 
 @pytest.mark.parametrize("stype", stypes_int + stypes_float + stypes_str)
-def test_assign_boolean_to_wrong_type(stype):
-    DT = dt.Frame(A=[5], stype=stype)
+def test_assign_boolean_to_different_type(stype):
+    DT = dt.Frame(A=[5, 7], stype=stype)
     assert DT.stype == stype
-    with pytest.raises(TypeError, match="Cannot assign boolean value to column "
-                                        "`A` of type " + stype.name):
-        DT[:, "A"] = False
+    DT[:, "A"] = False
+    assert_equals(DT, dt.Frame(A=[False, False], stype=bool))
 
 
 def test_assign_boolean_partial():
@@ -122,19 +121,17 @@ def test_assign_integer_out_of_range_to_subset():
 def test_assign_int_overflow():
     # When integer overflows, it becomes a float64 value
     DT = dt.Frame(A=range(5), B=[0.0]*5)
-    with pytest.raises(TypeError, match="Cannot assign float value"):
-        DT[:, "A"] = 10**100
+    DT[:, "A"] = 10**100
     DT[:, "B"] = 10**100
-    assert_equals(DT["B"], dt.Frame(B=[1e100] * 5))
+    assert_equals(DT, dt.Frame(A=[1.0e100]*5, B=[1.0e100]*5))
 
 
 @pytest.mark.parametrize("stype", [dt.bool8] + stypes_str)
-def test_assign_integer_to_wrong_type(stype):
+def test_assign_integer_to_different_type(stype):
     DT = dt.Frame(A=[5], stype=stype)
     assert DT.stype == stype
-    with pytest.raises(TypeError, match="Cannot assign integer value to column "
-                                        "`A` of type " + stype.name):
-        DT[:, "A"] = 777
+    DT[:, "A"] = 777
+    assert_equals(DT, dt.Frame(A=[777], stype=dt.int32))
 
 
 
@@ -163,12 +160,12 @@ def test_assign_to_float32_column():
 
 
 @pytest.mark.parametrize("stype", [dt.bool8] + stypes_int + stypes_str)
-def test_assign_float_to_wrong_type(stype):
+def test_assign_float_to_different_type(stype):
     DT = dt.Frame(A=[5], stype=stype)
     assert DT.stype == stype
-    with pytest.raises(TypeError, match="Cannot assign float value to column "
-                                        "`A` of type " + stype.name):
-        DT[:, "A"] = 3.14159265
+    DT[:, "A"] = 3.14159265
+    assert_equals(DT, dt.Frame(A=[3.14159265]))
+
 
 
 
@@ -183,12 +180,11 @@ def test_assign_string_to_str64():
 
 
 @pytest.mark.parametrize("stype", [dt.bool8] + stypes_int + stypes_float)
-def test_assign_string_to_wrong_type(stype):
+def test_assign_string_to_different_type(stype):
     DT = dt.Frame(A=[5], stype=stype)
     assert DT.stype == stype
-    with pytest.raises(TypeError, match="Cannot assign string value to column "
-                                        "`A` of type " + stype.name):
-        DT[:, "A"] = 'what?'
+    DT[:, "A"] = 'what?'
+    assert_equals(DT, dt.Frame(A=['what?']))
 
 
 def test_assign_str_to_empty_frame():

--- a/tests/ijby/test-assign.py
+++ b/tests/ijby/test-assign.py
@@ -56,8 +56,9 @@ def test_assign_to_empty_frame_3x0():
 def test_assign_to_empty_frame_0x3():
     DT = dt.Frame(A=[], B=[], C=[])
     DT[:, "A":"C"] = False
-    with pytest.raises(TypeError):
-        DT[:, "A":"C"] = 3
+    assert_equals(DT, dt.Frame(A=[], B=[], C=[], stype=bool))
+    DT[:, "A":"C"] = 3
+    assert_equals(DT, dt.Frame(A=[], B=[], C=[], stype=dt.int32))
     DT[:, "A":"C"] = True
     assert_equals(DT, dt.Frame(A=[], B=[], C=[], stype=bool))
 
@@ -156,10 +157,6 @@ def test_assign_multiple():
     assert_equals(DT, dt.Frame(A=range(10), B=[3.5]*10))
     DT[:, "C"] = "foo"
     assert_equals(DT, dt.Frame(A=range(10), B=[3.5]*10, C=["foo"]*10))
-
-    with pytest.raises(TypeError, match="Cannot assign boolean value to "
-                                        "column `B` of type float64"):
-        DT[:, ["B", "A"]] = False
 
     DT[:, ["B", "A"]] = 0
     assert_equals(DT, dt.Frame([[0]*10, [0.0]*10, ["foo"]*10],

--- a/tests/ijby/test-assign.py
+++ b/tests/ijby/test-assign.py
@@ -54,7 +54,7 @@ def test_assign_to_empty_frame_3x0():
 
 
 def test_assign_to_empty_frame_0x3():
-    DT = dt.Frame(A=[], B=[], C=[])
+    DT = dt.Frame([[], [], []], names=("A", "B", "C"))
     DT[:, "A":"C"] = False
     assert_equals(DT, dt.Frame(A=[], B=[], C=[], stype=bool))
     DT[:, "A":"C"] = 3

--- a/tests/ijby/test-update.py
+++ b/tests/ijby/test-update.py
@@ -62,6 +62,19 @@ def test_update_mixed_dimensions():
     assert_equals(DT, dt.Frame(A=range(5), B=range(0, 10, 2), C=[10]*5))
 
 
+def test_update_mixed_2():
+    DT = dt.Frame(A=range(5))
+    DT[:, update(B=3, C=f.A)]
+    assert_equals(DT, dt.Frame(A=range(5), B=[3]*5, C=range(5)))
+
+
+def test_update_with_groupby():
+    DT = dt.Frame(A=range(5), B=[1, 1, 2, 2, 2])
+    DT[:, update(C=7, D=dt.mean(f.A), E=f.A+1), by(f.B)]
+    assert_equals(DT, dt.Frame(A=range(5), B=[1, 1, 2, 2, 2], C=[7]*5,
+                               D=[0.5, 0.5, 3.0, 3.0, 3.0], E=range(1, 6)))
+
+
 def test_update_with_delete():
     DT = dt.Frame(A=range(5))
     with pytest.raises(ValueError, match=r"update\(\) clause cannot be used "

--- a/tests/ijby/test-update.py
+++ b/tests/ijby/test-update.py
@@ -56,6 +56,11 @@ def test_update_multiple_dependents():
     assert_equals(DT, dt.Frame(A=range(2, 7), B=range(1, 6), D=range(3, 8)))
 
 
+def test_update_mixed_dimensions():
+    DT = dt.Frame(A=range(5))
+    DT[:, update(B=f.A * 2, C=10)]
+    assert_equals(DT, dt.Frame(A=range(5), B=range(0, 10, 2), C=[10]*5))
+
 
 def test_update_with_delete():
     DT = dt.Frame(A=range(5))


### PR DESCRIPTION
- It is now possible to combine reduce expressions (such as `dt.sum(f.A)`) with map expressions (such as `f.A`) within `DT[i,j]` call. Thus, the following expression is now possible: `f.A / sum(f.A)`, both with and without a groupby;
- We now also allow assigning to a whole column a scalar expression that has different type than the original column;
- Several tests added, some tests that were previously xfailing now succeed;

Closes #2155 
Closes #2146