### PR TITLE
Fix creating a Frame from a numpy array with negative stride

### DIFF
--- a/c/py_buffers.cc
+++ b/c/py_buffers.cc
@@ -64,23 +64,13 @@ Column Column::from_pybuffer(const py::robj& pyobj)
   }
 
   py::buffer view(pyobj);
-  SType stype = view.stype();
-  size_t nrows = view.nelements();
 
   Column res;
-  if (stype == SType::STR32) {
+  if (view.stype() == SType::STR32) {
     res = convert_fwchararray_to_column(std::move(view));
   }
   else {
-    size_t stride_len = view.stride();
-    res = Column::new_mbuf_column(nrows * stride_len, stype,
-                                  std::move(view).as_dtbuffer());
-    if (stride_len != 1) {
-      res = Column(
-              new dt::SliceView_ColumnImpl(std::move(res),
-                                           RowIndex(0, nrows, stride_len))
-            );
-    }
+    res = std::move(view).to_column();
   }
 
   if (res.stype() == SType::OBJ) {

--- a/c/python/pybuffer.cc
+++ b/c/python/pybuffer.cc
@@ -197,7 +197,10 @@ Column buffer::to_column() &&
   SType  stype = this->stype();
   size_t nrows = this->nelements();
   void*  ptr   = this->data();
-  if (stride_ == 1) {
+  if (nrows == 0) {
+    return Column::new_data_column(0, stype);
+  }
+  else if (stride_ == 1) {
     size_t datasize = itemsize() * nrows;
     Buffer databuf = Buffer::external(ptr, datasize, std::move(*this));
     return Column::new_mbuf_column(nrows, stype, std::move(databuf));

--- a/c/python/pybuffer.h
+++ b/c/python/pybuffer.h
@@ -21,8 +21,10 @@
 //------------------------------------------------------------------------------
 #ifndef dt_PYTHON_PYBUFFER_h
 #define dt_PYTHON_PYBUFFER_h
+#include "column/view.h"
 #include "python/obj.h"
 #include "buffer.h"
+#include "column.h"
 namespace py {
 
 
@@ -76,7 +78,7 @@ class buffer
 
     SType stype() const;
 
-    Buffer as_dtbuffer() &&;
+    Column to_column() &&;
 
 
   private:

--- a/docs/changelog/v-0-10-0.rst
+++ b/docs/changelog/v-0-10-0.rst
@@ -181,6 +181,9 @@ Frame
   there is now also a method to load those styles directly:
   :meth:`init_styles` (#1871).
 
+- |fix| Fix creation of a Frame from a numpy array which was obtained from
+  another numpy array as a slice with a negative stride (#2163).
+
 
 General
 -------

--- a/tests/test_dt_create.py
+++ b/tests/test_dt_create.py
@@ -28,6 +28,7 @@
 import math
 import os
 import pytest
+import random
 import datatable as dt
 from datatable import ltype, stype, DatatableWarning
 from datatable.internal import frame_integrity_check
@@ -1109,6 +1110,20 @@ def test_create_from_numpy_floats_mixed(numpy):
 def test_create_from_numpy_reversed(numpy):
     DT = dt.Frame(numpy.array(range(10))[::-1])
     assert_equals(DT, dt.Frame(range(9, -1, -1), stype=dt.int64))
+
+
+@pytest.mark.parametrize("seed", [random.getrandbits(32) for _ in range(100)])
+def test_create_from_numpy_sliced(numpy, seed):
+    random.seed(seed)
+    start = random.randint(-20, 20)
+    end = random.randint(-20, 20)
+    step = 0
+    while step == 0:
+        step = random.randint(-5, 5)
+    arr = numpy.arange(20)[start:end:step]
+    DT = dt.Frame(arr)
+    assert_equals(DT, dt.Frame(arr.tolist(), stype=dt.int64))
+
 
 
 #-------------------------------------------------------------------------------

--- a/tests/test_dt_create.py
+++ b/tests/test_dt_create.py
@@ -1106,6 +1106,10 @@ def test_create_from_numpy_floats_mixed(numpy):
     assert DT.to_list() == [[4.0, 3.5, None, 9.33]]
 
 
+def test_create_from_numpy_reversed(numpy):
+    DT = dt.Frame(numpy.array(range(10))[::-1])
+    assert_equals(DT, dt.Frame(range(9, -1, -1), stype=dt.int64))
+
 
 #-------------------------------------------------------------------------------
 # Issues

--- a/tests/test_dt_create.py
+++ b/tests/test_dt_create.py
@@ -1112,7 +1112,7 @@ def test_create_from_numpy_reversed(numpy):
     assert_equals(DT, dt.Frame(range(9, -1, -1), stype=dt.int64))
 
 
-@pytest.mark.parametrize("seed", [random.getrandbits(32) for _ in range(100)])
+@pytest.mark.parametrize("seed", [random.getrandbits(32) for _ in range(10)])
 def test_create_from_numpy_sliced(numpy, seed):
     random.seed(seed)
     start = random.randint(-20, 20)
@@ -1122,7 +1122,7 @@ def test_create_from_numpy_sliced(numpy, seed):
         step = random.randint(-5, 5)
     arr = numpy.arange(20)[start:end:step]
     DT = dt.Frame(arr)
-    assert_equals(DT, dt.Frame(arr.tolist(), stype=dt.int64))
+    assert_equals(DT, dt.Frame(C0=arr.tolist(), stype=dt.int64))
 
 
 


### PR DESCRIPTION
When a stride is negative, the calculation of buffer size as `nrows * stride * elemsize` was producing incorrect results, and creating a buffer object from this was failing internal consistency checks. Now the case of negative stride is handled properly: we use `|stride|` to compute the buffer's size, but then change the `start` from 0 to the end of the buffer when applying a SliceView to that buffer.

The case `nrows == 0` is now also handled correctly (cannot have a non-null pointer to a memory region of size 0).

Closes #2163