### PR TITLE
Fixed "invalid data access" error when saving a masked nparray column 

### DIFF
--- a/c/column/npmasked.cc
+++ b/c/column/npmasked.cc
@@ -43,7 +43,7 @@ ColumnImpl* NpMasked_ColumnImpl::clone() const {
 
 
 template <typename T>
-void NpMasked_ColumnImpl::_apply_mask() {
+void NpMasked_ColumnImpl::_apply_mask(Column& out) {
   assert_compatible_type<T>(arg_.stype());
   auto mask_data = static_cast<const bool*>(mask_.rptr());
   auto col_data = static_cast<T*>(arg_.get_data_editable());
@@ -52,6 +52,7 @@ void NpMasked_ColumnImpl::_apply_mask() {
     [=](size_t i) {
       if (mask_data[i]) col_data[i] = GETNA<T>();
     });
+  out = std::move(arg_);
 }
 
 void NpMasked_ColumnImpl::materialize(Column& out) {
@@ -61,12 +62,12 @@ void NpMasked_ColumnImpl::materialize(Column& out) {
   {
     switch (stype_) {
       case SType::BOOL:
-      case SType::INT8:    return _apply_mask<int8_t>();
-      case SType::INT16:   return _apply_mask<int16_t>();
-      case SType::INT32:   return _apply_mask<int32_t>();
-      case SType::INT64:   return _apply_mask<int64_t>();
-      case SType::FLOAT32: return _apply_mask<float>();
-      case SType::FLOAT64: return _apply_mask<double>();
+      case SType::INT8:    return _apply_mask<int8_t>(out);
+      case SType::INT16:   return _apply_mask<int16_t>(out);
+      case SType::INT32:   return _apply_mask<int32_t>(out);
+      case SType::INT64:   return _apply_mask<int64_t>(out);
+      case SType::FLOAT32: return _apply_mask<float>(out);
+      case SType::FLOAT64: return _apply_mask<double>(out);
       default: break;
     }
   }

--- a/c/column/npmasked.h
+++ b/c/column/npmasked.h
@@ -54,7 +54,7 @@ class NpMasked_ColumnImpl : public Virtual_ColumnImpl {
     bool get_element(size_t, py::robj*) const override;
 
   private:
-    template <typename T> void _apply_mask();
+    template <typename T> void _apply_mask(Column& out);
     template <typename T> inline bool _get(size_t, T*) const;
 };
 

--- a/tests/test_dt_create.py
+++ b/tests/test_dt_create.py
@@ -1110,12 +1110,21 @@ def test_create_from_numpy_floats_mixed(numpy):
 def test_create_from_numpy_reversed(numpy):
     DT = dt.Frame(numpy.array(range(10))[::-1])
     assert_equals(DT, dt.Frame(range(9, -1, -1), stype=dt.int64))
+    assert DT.to_jay()
 
 
 def test_create_from_numpy_masked_and_sliced(numpy):
     arr = numpy.ma.array([1, 2, 3], mask=[False, True, False])
     DT = dt.Frame(arr[::2])
     assert_equals(DT, dt.Frame([1, 3], stype=dt.int64))
+    assert DT.to_jay()
+
+
+def test_create_from_0size_masked_array(numpy):
+    arr = numpy.ma.array([1, 2, 3], mask=[False, True, False])
+    DT = dt.Frame(arr[2:0])
+    assert_equals(DT, dt.Frame(C0=[], stype=dt.int64))
+    assert DT.to_jay()
 
 
 @pytest.mark.parametrize("seed", [random.getrandbits(32) for _ in range(10)])
@@ -1133,6 +1142,7 @@ def test_from_random_numpy_masked_and_sliced(numpy, seed):
     arr = arr[start:end:step]
     DT = dt.Frame(arr)
     assert_equals(DT, dt.Frame(C0=arr.tolist(), stype=dt.int64))
+    assert DT.to_jay()
 
 
 

--- a/tests/test_dt_create.py
+++ b/tests/test_dt_create.py
@@ -1127,7 +1127,7 @@ def test_create_from_0size_masked_array(numpy):
     assert DT.to_jay()
 
 
-@pytest.mark.parametrize("seed", [random.getrandbits(32) for _ in range(10)])
+@pytest.mark.parametrize("seed", [random.getrandbits(32) for _ in range(1000)])
 def test_from_random_numpy_masked_and_sliced(numpy, seed):
     random.seed(seed)
     start = random.randint(-20, 20)


### PR DESCRIPTION
The issue was that even after the materialization, the class of `NpMasked_ColumnImpl` column remained the same (i.e. "virtual"), and thus the column was not considered properly materialized.

Closes #2173