### PR TITLE
Added ability to select a specific row in each group

### DIFF
--- a/docs/changelog/v-0-10-0.rst
+++ b/docs/changelog/v-0-10-0.rst
@@ -109,6 +109,14 @@ Frame
 
     DT.to_csv("out.log", append=True)  # infer that header=False if file exists
 
+- |new| Implemented ability to select a specific row within each group, using
+  the syntax
+
+    DT[2, :, by(f.GRP)]
+
+  If the index is invalid for some of the groups, those groups will be
+  discarded.
+
 - |api| The name deduplication algorithm now starts looking for candidate names
   starting from ``name + dt.options.frame.name_auto_index``. For example, if
   you're creating a Frame with column names `["A", "A", "A"]`, then those names

--- a/tests/test-groups.py
+++ b/tests/test-groups.py
@@ -178,28 +178,6 @@ def test_groups_autoexpand():
                             [2, 7, 0, 5, 13]]
 
 
-@pytest.mark.xfail(reason="Issue #1586")
-def test_groupby_with_filter1():
-    f0 = dt.Frame(KEY=[1, 2, 1, 2, 1, 2], X=[-10, 2, 3, 0, 1, -7])
-    f1 = f0[f.X > 0, sum(f.X), f.KEY]
-    assert f1.to_list() == [[1, 2], [4, 2]]
-
-
-@pytest.mark.xfail(reason="Issue #1586")
-def test_groupby_with_filter2():
-    # Check that rowindex works even when applied to a view
-    n = 10000
-    src0 = [random.getrandbits(2) for _ in range(n)]
-    src1 = [random.gauss(1, 1) for _ in range(n)]
-    f0 = dt.Frame({"key": src0, "val": src1})
-    f1 = f0[f.val >= 0, :]
-    f2 = f1[f.val <= 2, sum(f.val), f.key]
-    answer = [sum(src1[i] for i in range(n)
-                  if src0[i] == key and 0 <= src1[i] <= 2)
-              for key in range(4)]
-    assert f2.to_list() == [[0, 1, 2, 3], answer]
-
-
 
 
 #-------------------------------------------------------------------------------
@@ -341,3 +319,42 @@ def test_groupby_with_sort():
                   count=[2] * 6, stypes={"count": dt.int64})
     assert_equals(R1, R0)
     assert_equals(R2, R0)
+
+
+
+#-------------------------------------------------------------------------------
+# i + by
+#-------------------------------------------------------------------------------
+
+@pytest.mark.xfail(reason="Issue #1586")
+def test_groupby_with_filter1():
+    f0 = dt.Frame(KEY=[1, 2, 1, 2, 1, 2], X=[-10, 2, 3, 0, 1, -7])
+    f1 = f0[f.X > 0, sum(f.X), f.KEY]
+    assert f1.to_list() == [[1, 2], [4, 2]]
+
+
+@pytest.mark.xfail(reason="Issue #1586")
+def test_groupby_with_filter2():
+    # Check that rowindex works even when applied to a view
+    n = 10000
+    src0 = [random.getrandbits(2) for _ in range(n)]
+    src1 = [random.gauss(1, 1) for _ in range(n)]
+    f0 = dt.Frame({"key": src0, "val": src1})
+    f1 = f0[f.val >= 0, :]
+    f2 = f1[f.val <= 2, sum(f.val), f.key]
+    answer = [sum(src1[i] for i in range(n)
+                  if src0[i] == key and 0 <= src1[i] <= 2)
+              for key in range(4)]
+    assert f2.to_list() == [[0, 1, 2, 3], answer]
+
+
+def test_int_row_with_by():
+    DT = dt.Frame(A=[1, 2, 3, 1, 2, 1], B=range(6))
+    assert_equals(DT[0, :, by(f.A)], dt.Frame(A=[1, 2, 3], B=[0, 1, 2]))
+    assert_equals(DT[1, :, by(f.A)], dt.Frame(A=[1, 2], B=[3, 4]))
+    assert_equals(DT[2, :, by(f.A)], dt.Frame(A=[1], B=[5], stype=dt.int32))
+    assert_equals(DT[3, :, by(f.A)], dt.Frame(A=[], B=[], stype=dt.int32))
+    assert_equals(DT[-1, :, by(f.A)], dt.Frame(A=[1, 2, 3], B=[5, 4, 2]))
+    assert_equals(DT[-2, :, by(f.A)], dt.Frame(A=[1, 2], B=[3, 1]))
+    assert_equals(DT[-3, :, by(f.A)], dt.Frame(A=[1], B=[0], stype=dt.int32))
+    assert_equals(DT[-4, :, by(f.A)], dt.Frame(A=[], B=[], stype=dt.int32))


### PR DESCRIPTION
Similar to pandas `Groupby.nth()`, we now have the ability to extract just a single row per group:
```
DT[1, :, by(f.A)]
```

Both positive and negative group index is supported.
If the index is out-of-bounds for some groups, those groups will be discarded from the output without raising an error.

Closes #1584