### PR TITLE
Expand use of range objects in DT[i,j]

### DIFF
--- a/c/expr/head_literal_range.cc
+++ b/c/expr/head_literal_range.cc
@@ -19,7 +19,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
-#include "column/const.h"
+#include "column/range.h"
 #include "expr/head_literal.h"
 #include "expr/workframe.h"
 namespace dt {
@@ -37,8 +37,13 @@ Kind Head_Literal_Range::get_expr_kind() const {
 
 
 
-Workframe Head_Literal_Range::evaluate_n(const vecExpr&, EvalContext&) const {
-  throw TypeError() << "A range expression cannot appear in this context";
+Workframe Head_Literal_Range::evaluate_n(const vecExpr&, EvalContext& ctx) const {
+  Workframe out(ctx);
+  out.add_column(Column(new Range_ColumnImpl(value.start(),
+                                             value.stop(),
+                                             value.step())),
+                 "", Grouping::GtoALL);
+  return out;
 }
 
 

--- a/docs/changelog/v-0-10-0.rst
+++ b/docs/changelog/v-0-10-0.rst
@@ -109,6 +109,11 @@ Frame
 
     DT.to_csv("out.log", append=True)  # infer that header=False if file exists
 
+- |new| Range objects can now be used directly in ``DT[i,j]`` expressions in any
+  place where a column could be expected::
+
+    DT["id"] = range(1000)
+
 - |api| The name deduplication algorithm now starts looking for candidate names
   starting from ``name + dt.options.frame.name_auto_index``. For example, if
   you're creating a Frame with column names `["A", "A", "A"]`, then those names

--- a/tests/ijby/test-assign-scalar.py
+++ b/tests/ijby/test-assign-scalar.py
@@ -192,3 +192,33 @@ def test_assign_str_to_empty_frame():
     DT = dt.Frame(W=[], stype=dt.str32)
     DT[f.W == '', f.W] = 'yay!'
     assert_equals(DT, dt.Frame(W=[], stype=dt.str32))
+
+
+
+
+#-------------------------------------------------------------------------------
+# Assign range
+#-------------------------------------------------------------------------------
+
+def test_assign_range():
+    DT = dt.Frame(A=[3, 4, 0])
+    DT["B"] = range(3)
+    assert_equals(DT, dt.Frame(A=[3, 4, 0], B=[0, 1, 2]))
+
+
+def test_assign_range2():
+    DT = dt.Frame(A=[7]*7, stype=dt.float32)
+    DT["A"] = range(3, 10)
+    assert_equals(DT, dt.Frame(A=range(3, 10)))
+
+
+def test_assign_range_subframe():
+    DT = dt.Frame(A=range(20))
+    DT[10:, "A"] = range(10)
+    assert_equals(DT, dt.Frame(A=list(range(10))*2))
+
+
+def test_assign_range_compute():
+    DT = dt.Frame(A=[5, 10, 100])
+    DT["B"] = f.A * range(3)
+    assert_equals(DT, dt.Frame(A=[5, 10, 100], B=[0, 10, 200]))


### PR DESCRIPTION
Now a `range()` object can be used instead of a single-column Frame. This includes: in an assignment expression, in computed columns, etc.
```
DT["A"] = range(100)
DT[:, {"R": f.A + range(DT.nrows)}]
```

Closes #2157