### PR TITLE
Assign type in DT[i,j]

### DIFF
--- a/c/expr/declarations.h
+++ b/c/expr/declarations.h
@@ -44,6 +44,7 @@ namespace expr {
   class EvalContext;
 
   using strvec = std::vector<std::string>;
+  using intvec = std::vector<size_t>;
   using ptrHead = std::unique_ptr<Head>;
   using vecExpr = std::vector<Expr>;
   using RiGb = std::pair<RowIndex, Groupby>;

--- a/c/expr/eval_context.cc
+++ b/c/expr/eval_context.cc
@@ -369,20 +369,16 @@ void EvalContext::evaluate_update() {
   auto ri0 = get_rowindex(0);
   auto ncols = dt0->ncols();
   auto nkeys = dt0->nkeys();
-  auto indices = evaluate_j_as_column_index();
+  intvec indices = evaluate_j_as_column_index();
 
-  std::vector<SType> stypes;
-  stypes.reserve(indices.size());
   for (size_t i : indices) {
-    stypes.push_back(i < ncols? dt0->get_column(i).stype()
-                              : SType::VOID);
     if (i < nkeys) {
       throw ValueError() << "Cannot change values in a key column "
                          << "`" << dt0->get_names()[i] << "`";
     }
   }
 
-  Workframe replacement = rexpr_.evaluate_r(*this, stypes);
+  Workframe replacement = rexpr_.evaluate_r(*this, indices);
   size_t lrows = nrows();
   size_t lcols = indices.size();
   replacement.reshape_for_update(lrows, lcols);

--- a/c/expr/expr.cc
+++ b/c/expr/expr.cc
@@ -218,10 +218,9 @@ Workframe Expr::evaluate_j(EvalContext& ctx, bool allow_new) const
   return head->evaluate_j(inputs, ctx, allow_new);
 }
 
-Workframe Expr::evaluate_r(
-    EvalContext& ctx, const std::vector<SType>& stypes) const
+Workframe Expr::evaluate_r(EvalContext& ctx, const intvec& indices) const
 {
-  return head->evaluate_r(inputs, ctx, stypes);
+  return head->evaluate_r(inputs, ctx, indices);
 }
 
 

--- a/c/expr/expr.h
+++ b/c/expr/expr.h
@@ -102,7 +102,7 @@ class Expr {
     Workframe evaluate_n(EvalContext& ctx) const;
     Workframe evaluate_f(EvalContext& ctx, size_t frame_id, bool allow_new = false) const;
     Workframe evaluate_j(EvalContext& ctx, bool allow_new = false) const;
-    Workframe evaluate_r(EvalContext& ctx, const std::vector<SType>&) const;
+    Workframe evaluate_r(EvalContext& ctx, const intvec&) const;
     RowIndex  evaluate_i(EvalContext& ctx) const;
     RiGb      evaluate_iby(EvalContext& ctx) const;
 

--- a/c/expr/head.h
+++ b/c/expr/head.h
@@ -114,7 +114,7 @@ class Head {
 
     virtual Workframe evaluate_r(const vecExpr& args,
                                  EvalContext& ctx,
-                                 const std::vector<SType>& stypes) const = 0;
+                                 const intvec& column_indices) const = 0;
 
     virtual Workframe evaluate_f(EvalContext& ctx,
                                  size_t frame_id,

--- a/c/expr/head_frame.cc
+++ b/c/expr/head_frame.cc
@@ -123,11 +123,10 @@ Workframe Head_Frame::evaluate_j(
 // take precedence in this case.
 //
 Workframe Head_Frame::evaluate_r(
-    const vecExpr& args, EvalContext& ctx,
-    const std::vector<SType>& stypes) const
+    const vecExpr& args, EvalContext& ctx, const intvec& indices) const
 {
   // Allow to assign an empty frame to an empty column set (see issue #1544)
-  if (stypes.size() == 0 && dt_->nrows() == 0 && dt_->ncols() == 0) {
+  if (indices.size() == 0 && dt_->nrows() == 0 && dt_->ncols() == 0) {
     return Workframe(ctx);
   }
   return evaluate_n(args, ctx);

--- a/c/expr/head_frame.h
+++ b/c/expr/head_frame.h
@@ -56,7 +56,7 @@ class Head_Frame : public Head {
 
     Workframe evaluate_n(const vecExpr&, EvalContext&) const override;
     Workframe evaluate_j(const vecExpr&, EvalContext&, bool) const override;
-    Workframe evaluate_r(const vecExpr&, EvalContext&, const std::vector<SType>&) const override;
+    Workframe evaluate_r(const vecExpr&, EvalContext&, const intvec&) const override;
     Workframe evaluate_f(EvalContext&, size_t, bool) const override;
     RowIndex  evaluate_i(const vecExpr&, EvalContext&) const override;
     RiGb      evaluate_iby(const vecExpr&, EvalContext&) const override;

--- a/c/expr/head_func.cc
+++ b/c/expr/head_func.cc
@@ -68,7 +68,7 @@ Workframe Head_Func::evaluate_j(
 // same as during evaluation in "normal" mode.
 //
 Workframe Head_Func::evaluate_r(
-    const vecExpr& args, EvalContext& ctx, const std::vector<SType>&) const
+    const vecExpr& args, EvalContext& ctx, const intvec&) const
 {
   return evaluate_n(args, ctx);
 }

--- a/c/expr/head_func.h
+++ b/c/expr/head_func.h
@@ -47,7 +47,7 @@ class Head_Func : public Head {
 
     Workframe evaluate_r(const vecExpr& args,
                          EvalContext& ctx,
-                         const std::vector<SType>& stypes) const override;
+                         const intvec& column_indices) const override;
 };
 
 

--- a/c/expr/head_list.cc
+++ b/c/expr/head_list.cc
@@ -47,10 +47,29 @@ Workframe Head_List::evaluate_n(const vecExpr& inputs, EvalContext& ctx) const {
 }
 
 
+// Evaluate list as a replacement target when replacing columns at
+// `indices` within the "root" Frame.
+//
 Workframe Head_List::evaluate_r(
-    const vecExpr& args, EvalContext& ctx, const intvec&) const
+    const vecExpr& inputs, EvalContext& ctx, const intvec& indices) const
 {
-  return evaluate_n(args, ctx);
+  Workframe outputs(ctx);
+  if (inputs.size() == indices.size()) {
+    for (size_t i = 0; i < inputs.size(); ++i) {
+      outputs.cbind( inputs[i].evaluate_r(ctx, {indices[i]}) );
+    }
+  }
+  else if (inputs.size() == 1) {
+    for (size_t i = 0; i < indices.size(); ++i) {
+      outputs.cbind( inputs[0].evaluate_r(ctx, {indices[i]}) );
+    }
+  }
+  else {
+    throw ValueError() << "The LHS of the replacement has " << indices.size()
+        << " columns, while the RHS has " << inputs.size()
+        << " replacement expressions";
+  }
+  return outputs;
 }
 
 

--- a/c/expr/head_list.cc
+++ b/c/expr/head_list.cc
@@ -48,7 +48,7 @@ Workframe Head_List::evaluate_n(const vecExpr& inputs, EvalContext& ctx) const {
 
 
 Workframe Head_List::evaluate_r(
-    const vecExpr& args, EvalContext& ctx, const std::vector<SType>&) const
+    const vecExpr& args, EvalContext& ctx, const intvec&) const
 {
   return evaluate_n(args, ctx);
 }
@@ -331,7 +331,7 @@ Workframe Head_NamedList::evaluate_n(const vecExpr& inputs, EvalContext& ctx) co
 
 
 Workframe Head_NamedList::evaluate_r(
-    const vecExpr& args, EvalContext& ctx, const std::vector<SType>&) const
+    const vecExpr& args, EvalContext& ctx, const intvec&) const
 {
   return evaluate_n(args, ctx);
 }

--- a/c/expr/head_list.h
+++ b/c/expr/head_list.h
@@ -33,7 +33,7 @@ class Head_List : public Head {
     Kind get_expr_kind() const override;
     Workframe evaluate_n(const vecExpr&, EvalContext&) const override;
     Workframe evaluate_j(const vecExpr&, EvalContext&, bool) const override;
-    Workframe evaluate_r(const vecExpr&, EvalContext&, const std::vector<SType>&) const override;
+    Workframe evaluate_r(const vecExpr&, EvalContext&, const intvec&) const override;
     Workframe evaluate_f(EvalContext&, size_t, bool) const override;
     RowIndex  evaluate_i(const vecExpr&, EvalContext&) const override;
     RiGb      evaluate_iby(const vecExpr&, EvalContext&) const override;
@@ -51,7 +51,7 @@ class Head_NamedList : public Head {
     Kind get_expr_kind() const override;
     Workframe evaluate_n(const vecExpr&, EvalContext&) const override;
     Workframe evaluate_j(const vecExpr&, EvalContext&, bool) const override;
-    Workframe evaluate_r(const vecExpr&, EvalContext&, const std::vector<SType>&) const override;
+    Workframe evaluate_r(const vecExpr&, EvalContext&, const intvec&) const override;
     Workframe evaluate_f(EvalContext&, size_t, bool) const override;
     RowIndex  evaluate_i(const vecExpr&, EvalContext&) const override;
     RiGb      evaluate_iby(const vecExpr&, EvalContext&) const override;

--- a/c/expr/head_literal.cc
+++ b/c/expr/head_literal.cc
@@ -38,7 +38,9 @@ Workframe Head_Literal::_wrap_column(EvalContext& ctx, Column&& col) {
 }
 
 
-Workframe Head_Literal::evaluate_r(const vecExpr& args, EvalContext& ctx, const std::vector<SType>&) const {
+Workframe Head_Literal::evaluate_r(const vecExpr& args, EvalContext& ctx,
+                                   const intvec&) const
+{
   return evaluate_n(args, ctx);
 }
 

--- a/c/expr/head_literal.h
+++ b/c/expr/head_literal.h
@@ -215,6 +215,7 @@ class Head_Literal_Type : public Head_Literal {
     Workframe evaluate_f(EvalContext&, size_t, bool) const override;
     Workframe evaluate_j(const vecExpr&, EvalContext&, bool) const override;
     RowIndex  evaluate_i(const vecExpr&, EvalContext&) const override;
+    Workframe evaluate_r(const vecExpr&, EvalContext&, const intvec&) const override;
     RiGb      evaluate_iby(const vecExpr&, EvalContext&) const override;
 };
 

--- a/c/expr/head_literal.h
+++ b/c/expr/head_literal.h
@@ -41,7 +41,7 @@ class Head_Literal : public Head {
     // Workframe evaluate(const vecExpr&, EvalContext&) const override;
     // Workframe evaluate_j(const vecExpr&, EvalContext&) const override;
     // Workframe evaluate_f(EvalContext&, size_t) const override;
-    Workframe evaluate_r(const vecExpr&, EvalContext&, const std::vector<SType>&) const override;
+    Workframe evaluate_r(const vecExpr&, EvalContext&, const intvec&) const override;
 
   protected:
     static Workframe _wrap_column(EvalContext&, Column&&);
@@ -59,7 +59,7 @@ class Head_Literal_None : public Head_Literal {
     Kind get_expr_kind() const override;
     Workframe evaluate_n(const vecExpr&, EvalContext&) const override;
     Workframe evaluate_j(const vecExpr&, EvalContext&, bool) const override;
-    Workframe evaluate_r(const vecExpr&, EvalContext&, const std::vector<SType>&) const override;
+    Workframe evaluate_r(const vecExpr&, EvalContext&, const intvec&) const override;
     Workframe evaluate_f(EvalContext&, size_t, bool) const override;
     RowIndex  evaluate_i(const vecExpr&, EvalContext&) const override;
     RiGb      evaluate_iby(const vecExpr&, EvalContext&) const override;
@@ -80,7 +80,7 @@ class Head_Literal_Bool : public Head_Literal {
     Workframe evaluate_n(const vecExpr&, EvalContext&) const override;
     Workframe evaluate_f(EvalContext&, size_t, bool) const override;
     Workframe evaluate_j(const vecExpr&, EvalContext&, bool) const override;
-    Workframe evaluate_r(const vecExpr&, EvalContext&, const std::vector<SType>&) const override;
+    Workframe evaluate_r(const vecExpr&, EvalContext&, const intvec&) const override;
     RowIndex  evaluate_i(const vecExpr&, EvalContext&) const override;
     RiGb      evaluate_iby(const vecExpr&, EvalContext&) const override;
 };
@@ -99,7 +99,7 @@ class Head_Literal_Int : public Head_Literal {
     Workframe evaluate_n(const vecExpr&, EvalContext&) const override;
     Workframe evaluate_f(EvalContext&, size_t, bool) const override;
     Workframe evaluate_j(const vecExpr&, EvalContext&, bool) const override;
-    Workframe evaluate_r(const vecExpr&, EvalContext&, const std::vector<SType>&) const override;
+    Workframe evaluate_r(const vecExpr&, EvalContext&, const intvec&) const override;
     RowIndex  evaluate_i(const vecExpr&, EvalContext&) const override;
     RiGb      evaluate_iby(const vecExpr&, EvalContext&) const override;
 };
@@ -116,7 +116,7 @@ class Head_Literal_Float : public Head_Literal {
     Workframe evaluate_n(const vecExpr&, EvalContext&) const override;
     Workframe evaluate_f(EvalContext&, size_t, bool) const override;
     Workframe evaluate_j(const vecExpr&, EvalContext&, bool) const override;
-    Workframe evaluate_r(const vecExpr&, EvalContext&, const std::vector<SType>&) const override;
+    Workframe evaluate_r(const vecExpr&, EvalContext&, const intvec&) const override;
     RowIndex  evaluate_i(const vecExpr&, EvalContext&) const override;
     RiGb      evaluate_iby(const vecExpr&, EvalContext&) const override;
 };
@@ -133,7 +133,7 @@ class Head_Literal_String : public Head_Literal {
     Workframe evaluate_n(const vecExpr&, EvalContext&) const override;
     Workframe evaluate_f(EvalContext&, size_t, bool) const override;
     Workframe evaluate_j(const vecExpr&, EvalContext&, bool) const override;
-    Workframe evaluate_r(const vecExpr&, EvalContext&, const std::vector<SType>&) const override;
+    Workframe evaluate_r(const vecExpr&, EvalContext&, const intvec&) const override;
     RowIndex  evaluate_i(const vecExpr&, EvalContext&) const override;
     RiGb      evaluate_iby(const vecExpr&, EvalContext&) const override;
 };

--- a/c/expr/head_literal_bool.cc
+++ b/c/expr/head_literal_bool.cc
@@ -50,7 +50,7 @@ Workframe Head_Literal_Bool::evaluate_n(const vecExpr&, EvalContext& ctx) const 
 //   DT[:, j] = True
 //
 Workframe Head_Literal_Bool::evaluate_r(
-    const vecExpr& args, EvalContext& ctx, const std::vector<SType>&) const
+    const vecExpr& args, EvalContext& ctx, const intvec&) const
 {
   return evaluate_n(args, ctx);
 }

--- a/c/expr/head_literal_float.cc
+++ b/c/expr/head_literal_float.cc
@@ -46,15 +46,20 @@ Workframe Head_Literal_Float::evaluate_n(const vecExpr&, EvalContext& ctx) const
 // The `j` columns must be float.
 //
 Workframe Head_Literal_Float::evaluate_r(
-    const vecExpr&, EvalContext& ctx, const std::vector<SType>& stypes) const
+    const vecExpr&, EvalContext& ctx, const intvec& indices) const
 {
+  auto dt0 = ctx.get_datatable(0);
+
   Workframe outputs(ctx);
-  for (SType stype : stypes) {
-    if (!(stype == SType::FLOAT32 || stype == SType::FLOAT64)) {
-      // Either type mismatch (the caller will throw an error then),
-      // or stype is VOID, in which case we default to FLOAT64
-      stype = SType::FLOAT64;
+  for (size_t i : indices) {
+    SType stype;
+    if (i < dt0->ncols()) {
+      const Column& col = dt0->get_column(i);
+      stype = (col.ltype() == LType::REAL)? col.stype() : SType::FLOAT64;
+    } else {
+      stype = SType::VOID;
     }
+
     outputs.add_column(
         Const_ColumnImpl::make_float_column(1, value, stype),
         "", Grouping::SCALAR);

--- a/c/expr/head_literal_none.cc
+++ b/c/expr/head_literal_none.cc
@@ -58,12 +58,14 @@ Workframe Head_Literal_None::evaluate_j(
 // their stypes.
 //
 Workframe Head_Literal_None::evaluate_r(
-    const vecExpr&, EvalContext& ctx, const std::vector<SType>& stypes) const
+    const vecExpr&, EvalContext& ctx, const intvec& indices) const
 {
+  auto dt0 = ctx.get_datatable(0);
   Workframe outputs(ctx);
-  for (SType stype : stypes) {
+  for (size_t i : indices) {
     // At some point in the future we may allow VOID columns to be created too
-    if (stype == SType::VOID) stype = SType::BOOL;
+    SType stype = (i < dt0->ncols())? dt0->get_column(i).stype()
+                                    : SType::BOOL;
     outputs.add_column(
       Column(new ConstNa_ColumnImpl(1, stype)),
       std::string(),

--- a/c/expr/head_literal_string.cc
+++ b/c/expr/head_literal_string.cc
@@ -68,13 +68,17 @@ Workframe Head_Literal_String::evaluate_f(
 // columns will try to match the stypes of the LHS.
 //
 Workframe Head_Literal_String::evaluate_r(
-    const vecExpr&, EvalContext& ctx, const std::vector<SType>& stypes) const
+    const vecExpr&, EvalContext& ctx, const intvec& indices) const
 {
+  auto dt0 = ctx.get_datatable(0);
+
   Workframe outputs(ctx);
-  for (SType stype : stypes) {
-    if (!(stype == SType::STR32 || stype == SType::STR64)) {
-      // Either type mismatch (the caller will throw an error then),
-      // or stype is VOID
+  for (size_t i : indices) {
+    SType stype;
+    if (i < dt0->ncols()) {
+      const Column& col = dt0->get_column(i);
+      stype = (col.ltype() == LType::STRING)? col.stype() : SType::STR32;
+    } else {
       stype = SType::STR32;
     }
     outputs.add_column(

--- a/c/expr/head_literal_type.cc
+++ b/c/expr/head_literal_type.cc
@@ -137,6 +137,71 @@ RiGb Head_Literal_Type::evaluate_iby(const vecExpr&, EvalContext&) const {
 }
 
 
+static void _resolve_stype(py::robj value, SType* out_stype, LType* out_ltype)
+{
+  *out_stype = SType::VOID;
+  *out_ltype = LType::MU;
+  if (value.is_type()) {
+    auto et = reinterpret_cast<PyTypeObject*>(value.to_borrowed_ref());
+    *out_ltype = (et == &PyLong_Type)?       LType::INT :
+                 (et == &PyFloat_Type)?      LType::REAL :
+                 (et == &PyUnicode_Type)?    LType::STRING :
+                 (et == &PyBool_Type)?       LType::BOOL :
+                 (et == &PyBaseObject_Type)? LType::OBJECT :
+                 LType::MU;
+  }
+  else if (value.is_ltype()) {
+    auto lt = value.get_attr("value").to_size_t();
+    *out_ltype = (lt < DT_LTYPES_COUNT)? static_cast<LType>(lt) : LType::MU;
+  }
+  else if (value.is_stype()) {
+    auto st = value.get_attr("value").to_size_t();
+    *out_stype = (st < DT_STYPES_COUNT)? static_cast<SType>(st) : SType::VOID;
+  }
+}
+
+Workframe Head_Literal_Type::evaluate_r(
+      const vecExpr&, EvalContext& ctx, const intvec& indices) const
+{
+  SType target_stype;
+  LType target_ltype;
+  _resolve_stype(value, &target_stype, &target_ltype);
+  if (target_stype == SType::VOID && target_ltype == LType::MU) {
+    throw ValueError() << "Unknown type " << value
+                       << " used in the replacement expression";
+  }
+  if (target_stype == SType::VOID) {
+    target_stype = (target_ltype == LType::BOOL)? SType::BOOL :
+                   (target_ltype == LType::INT)? SType::INT32 :
+                   (target_ltype == LType::REAL)? SType::FLOAT64 :
+                   (target_ltype == LType::STRING)? SType::STR32 :
+                   (target_ltype == LType::OBJECT)? SType::OBJ : SType::VOID;
+  }
+
+  auto dt0 = ctx.get_datatable(0);
+  Workframe res(ctx);
+  for (size_t i : indices) {
+    Column newcol;
+    if (i < dt0->ncols()) {
+      newcol = dt0->get_column(i);  // copy
+      if (target_ltype != LType::MU) {
+        if (newcol.ltype() != target_ltype) {
+          newcol.cast_inplace(target_stype);
+        }
+      } else if (target_stype != SType::VOID) {
+        newcol.cast_inplace(target_stype);
+      }
+    }
+    else {
+      newcol = Column::new_na_column(dt0->nrows(), target_stype);
+    }
+
+    res.add_column(std::move(newcol), "", Grouping::GtoALL);
+  }
+  return res;
+}
+
+
 
 
 }}  // namespace dt::expr

--- a/c/expr/head_literal_type.cc
+++ b/c/expr/head_literal_type.cc
@@ -163,6 +163,10 @@ static void _resolve_stype(py::robj value, SType* out_stype, LType* out_ltype)
 Workframe Head_Literal_Type::evaluate_r(
       const vecExpr&, EvalContext& ctx, const intvec& indices) const
 {
+  if (ctx.get_rowindex(0)) {
+    throw ValueError()
+        << "Partial reassignment of Column's type is not possible";
+  }
   SType target_stype;
   LType target_ltype;
   _resolve_stype(value, &target_stype, &target_ltype);

--- a/c/frame/__getitem__.cc
+++ b/c/frame/__getitem__.cc
@@ -182,7 +182,7 @@ oobj Frame::_main_getset(robj item, robj value) {
   }
 
   ctx.evaluate();
-  if (mode != dt::expr::EvalMode::SELECT) {
+  if (ctx.get_mode() != dt::expr::EvalMode::SELECT) {
     _clear_types();
   }
   return ctx.get_result();

--- a/docs/changelog/v-0-10-0.rst
+++ b/docs/changelog/v-0-10-0.rst
@@ -117,6 +117,11 @@ Frame
   If the index is invalid for some of the groups, those groups will be
   discarded.
 
+- |new| Now a column's type can be changed via a simple assignment::
+
+    DT["A"] = int            # Column A in frame DT will become integer
+    DT[:, int] = dt.float64  # All integer columns will be converted to float64
+
 - |api| The name deduplication algorithm now starts looking for candidate names
   starting from ``name + dt.options.frame.name_auto_index``. For example, if
   you're creating a Frame with column names `["A", "A", "A"]`, then those names

--- a/tests/ijby/test-assign-scalar.py
+++ b/tests/ijby/test-assign-scalar.py
@@ -243,6 +243,18 @@ def test_assign_ltype(lt):
     assert DT.ltypes[0] == lt
 
 
+def test_assign_type_without_stype_change():
+    # Verify that if a column already has same ltype, then that ltype will
+    # not change upon the assignment
+    DT = dt.Frame([[0], [1], [2], [3], [4], [5]],
+                  stypes=[dt.bool8, dt.int8, dt.int16, dt.int32, dt.int64,
+                          dt.float32])
+    DT[:, "C0":"C5"] = int
+    assert_equals(DT, dt.Frame([[0], [1], [2], [3], [4], [5]],
+                               stypes=[dt.int32, dt.int8, dt.int16, dt.int32,
+                                       dt.int64, dt.int32]))
+
+
 def test_assign_stype_to_new_column():
     DT = dt.Frame(S=range(5))
     DT["N"] = dt.float64

--- a/tests/ijby/test-assign-scalar.py
+++ b/tests/ijby/test-assign-scalar.py
@@ -264,3 +264,10 @@ def test_assign_different_types():
     DT[:, update(A=dt.float32, B=dt.str64)]
     assert_equals(DT, dt.Frame(A=range(5), B=list("ABCDE"),
                                stypes=dict(A=dt.float32, B=dt.str64)))
+
+
+def test_assign_types_partial():
+    DT = dt.Frame(A=range(5))
+    with pytest.raises(ValueError, match="Partial reassignment of Column's "
+                                         "type is not possible"):
+        DT[:2, "A"] = str

--- a/tests/ijby/test-assign-scalar.py
+++ b/tests/ijby/test-assign-scalar.py
@@ -192,3 +192,26 @@ def test_assign_str_to_empty_frame():
     DT = dt.Frame(W=[], stype=dt.str32)
     DT[f.W == '', f.W] = 'yay!'
     assert_equals(DT, dt.Frame(W=[], stype=dt.str32))
+
+
+
+#-------------------------------------------------------------------------------
+# Assign types
+#-------------------------------------------------------------------------------
+
+def test_assign_type_simple():
+    DT = dt.Frame(A=range(5))
+    DT["A"] = dt.float64
+    assert_equals(DT, dt.Frame(A=range(5), stype=dt.float64))
+
+
+def test_assign_type_to_many_columns():
+    DT = dt.Frame(A=[True, False], B=[3, 7], C=[2.4, 9.9])
+    DT[:, :] = dt.int64
+    assert_equals(DT, dt.Frame(A=[1, 0], B=[3, 7], C=[2, 9], stype=dt.int64))
+
+
+def test_assign_type_to_some_columns():
+    DT = dt.Frame(A=['bii', 'doo'], B=[3, 5], C=[4, 4])
+    DT[:, int] = float
+    assert_equals(DT, dt.Frame(A=['bii', 'doo'], B=[3.0, 5.0], C=[4.0, 4.0]))

--- a/tests/ijby/test-assign-scalar.py
+++ b/tests/ijby/test-assign-scalar.py
@@ -273,6 +273,7 @@ def test_assign_bad_type():
 
 def test_assign_different_types():
     DT = dt.Frame(A=range(5), B=list("ABCDE"))
+    DT = DT[:, ["A", "B"]]  # for py35
     assert DT.stypes == (dt.int32, dt.str32)
     DT[:, update(A=dt.float32, B=dt.str64)]
     assert_equals(DT, dt.Frame(A=range(5), B=list("ABCDE"),


### PR DESCRIPTION
Now a column's type can be changed via a simple assignment:
```
DT["A"] = int            # Column A in frame DT will become integer
DT[:, int] = dt.float64  # All integer columns will be converted to float64
```

Closes #2158