### PR TITLE
Implement deep-copy functionality

### DIFF
--- a/c/column.cc
+++ b/c/column.cc
@@ -89,31 +89,39 @@ Column::~Column() {
 
 dt::ColumnImpl* Column::release() && {
   xassert(impl_->refcount_ == 1);
-  dt::ColumnImpl* tmp = _get_mutable_impl();
+  auto tmp = const_cast<dt::ColumnImpl*>(impl_);
   impl_ = nullptr;
   return tmp;
 }
 
 void Column::_acquire_impl(const dt::ColumnImpl* impl) {
   impl_ = impl;
-  ++impl->refcount_;
+  impl_->refcount_ += 1;
 }
 
 void Column::_release_impl(const dt::ColumnImpl* impl) {
   if (!impl) return;
-  if ((--impl->refcount_) == 0) {
+  impl->refcount_ -= 1;
+  if (impl->refcount_ == 0) {
     delete impl;
   }
 }
 
-dt::ColumnImpl* Column::_get_mutable_impl() {
+dt::ColumnImpl* Column::_get_mutable_impl(bool keep_stats) {
   xassert(impl_);
   if (impl_->refcount_ > 1) {
-    --impl_->refcount_;
-    impl_ = impl_->clone();
+    auto newimpl = impl_->clone();
+    xassert(!newimpl->stats_);
+    if (keep_stats && impl_->stats_) {
+      newimpl->stats_ = impl_->stats_->clone();
+      newimpl->stats_->column = newimpl;
+    }
+    impl_->refcount_ -= 1;
+    impl_ = newimpl;
+  } else {
+    if (!keep_stats) reset_stats();
   }
   xassert(impl_->refcount_ == 1);
-  reset_stats();
   return const_cast<dt::ColumnImpl*>(impl_);
 }
 
@@ -289,10 +297,8 @@ Buffer Column::get_data_buffer(size_t k) const {
 //------------------------------------------------------------------------------
 
 void Column::materialize() {
-  auto stats_copy = clone_stats();
-  auto pcol = _get_mutable_impl();
+  auto pcol = _get_mutable_impl(/* keep_stats= */ true);
   pcol->materialize(*this);
-  if (stats_copy) replace_stats(std::move(stats_copy));
 }
 
 void Column::replace_values(const RowIndex& replace_at,

--- a/c/column.cc
+++ b/c/column.cc
@@ -289,8 +289,10 @@ Buffer Column::get_data_buffer(size_t k) const {
 //------------------------------------------------------------------------------
 
 void Column::materialize() {
+  auto stats_copy = clone_stats();
   auto pcol = _get_mutable_impl();
   pcol->materialize(*this);
+  if (stats_copy) replace_stats(std::move(stats_copy));
 }
 
 void Column::replace_values(const RowIndex& replace_at,

--- a/c/column.h
+++ b/c/column.h
@@ -262,6 +262,8 @@ class Column
     Stats* stats() const;
     Stats* get_stats_if_exist() const;
     void reset_stats();
+    std::unique_ptr<Stats> clone_stats() const;
+    void replace_stats(std::unique_ptr<Stats>&&);
     bool is_stat_computed(Stat) const;
 
 

--- a/c/column.h
+++ b/c/column.h
@@ -320,7 +320,7 @@ class Column
     //
     // This method should be called from any Column method that
     // intends to modify the `impl_` variable.
-    dt::ColumnImpl* _get_mutable_impl();
+    dt::ColumnImpl* _get_mutable_impl(bool keep_stats=false);
 
     friend void swap(Column& lhs, Column& rhs);
     friend class ColumnImpl;

--- a/c/column/sentinel_str.cc
+++ b/c/column/sentinel_str.cc
@@ -102,7 +102,7 @@ const void* SentinelStr_ColumnImpl<T>::get_data_readonly(size_t k) const {
 template <typename T>
 void* SentinelStr_ColumnImpl<T>::get_data_editable(size_t k) {
   xassert(k <= 1);
-  return (k == 0)? offbuf_.xptr() : strbuf_.xptr();
+  return (k == 0)? offbuf_.wptr() : strbuf_.wptr();
 }
 
 

--- a/c/datatable.cc
+++ b/c/datatable.cc
@@ -36,6 +36,23 @@ DataTable::DataTable(const DataTable& other)
 }
 
 
+DataTable::DataTable(const DataTable& other, DeepCopyTag)
+  : DataTable(other)
+{
+  for (Column& col : columns_) {
+    std::unique_ptr<Stats> stats_copy = col.clone_stats();
+    col.materialize();
+    size_t nbuf = col.get_num_data_buffers();
+    for (size_t k = 0; k < nbuf; ++k) {
+      col.get_data_editable(k);
+    }
+    if (stats_copy) {
+      col.replace_stats(std::move(stats_copy));
+    }
+  }
+}
+
+
 // Private constructor, initializes only columns but not names_
 DataTable::DataTable(colvec&& cols) : DataTable()
 {

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -65,10 +65,12 @@ class DataTable {
 
   public:
     static struct DefaultNamesTag {} default_names;
+    static struct DeepCopyTag {} deep_copy;
 
     DataTable();
     DataTable(const DataTable&);
     DataTable(DataTable&&) = default;
+    DataTable(const DataTable&, DeepCopyTag);
     DataTable(colvec&& cols, DefaultNamesTag);
     DataTable(colvec&& cols, const strvec&, bool warn_duplicates = true);
     DataTable(colvec&& cols, const py::olist&, bool warn_duplicates = true);

--- a/c/frame/integrity_check.cc
+++ b/c/frame/integrity_check.cc
@@ -150,7 +150,7 @@ void ColumnImpl::verify_integrity() const {
   XAssert(static_cast<size_t>(stype_) < DT_STYPES_COUNT);
   XAssert(refcount_ > 0 && refcount_ < uint32_t(-100));
   if (stats_) { // Stats are allowed to be null
-    stats_->verify_integrity();
+    stats_->verify_integrity(this);
   }
 }
 

--- a/c/frame/py_frame.cc
+++ b/c/frame/py_frame.cc
@@ -22,6 +22,7 @@
 #include <iostream>
 #include "frame/py_frame.h"
 #include "python/_all.h"
+#include "python/string.h"
 namespace py {
 
 PyObject* Frame_Type = nullptr;
@@ -106,6 +107,24 @@ oobj Frame::copy(const PKArgs& args) {
   newframe->ltypes = ltypes;  Py_XINCREF(ltypes);
   return res;
 }
+
+
+oobj Frame::m__copy__() {
+  args_copy.bind(nullptr, nullptr);
+  return copy(args_copy);
+}
+
+
+static PKArgs args___deepcopy__(
+  0, 1, 0, false, false, {"memo"}, "__deepcopy__", nullptr);
+
+oobj Frame::m__deepcopy__(const PKArgs&) {
+  py::odict dict_arg;
+  dict_arg.set(py::ostring("deep"), py::True());
+  args_copy.bind(nullptr, dict_arg.to_borrowed_ref());
+  return copy(args_copy);
+}
+
 
 
 
@@ -403,6 +422,8 @@ void Frame::impl_init_type(XTypeMaker& xt) {
   xt.add(METHOD(&Frame::materialize, args_materialize));
   xt.add(METHOD(&Frame::export_names, args_export_names));
   xt.add(METHOD0(&Frame::get_names, "keys"));
+  xt.add(METHOD0(&Frame::m__copy__, "__copy__"));
+  xt.add(METHOD(&Frame::m__deepcopy__, args___deepcopy__));
 }
 
 

--- a/c/frame/py_frame.cc
+++ b/c/frame/py_frame.cc
@@ -75,23 +75,32 @@ oobj Frame::tail(const PKArgs& args) {
 //------------------------------------------------------------------------------
 
 static PKArgs args_copy(
-  0, 0, 0, false, false,
-  {}, "copy",
+  0, 0, 1, false, false,
+  {"deep"}, "copy",
 
-R"(copy(self)
+R"(copy(self, deep=False)
 --
 
 Make a copy of this frame.
 
-This method creates a shallow copy of the current frame: only references
-are copied, not the data itself. However, due to copy-on-write semantics
-any changes made to one of the frames will not propagate to the other.
-Thus, for all intents and purposes the copied frame will behave as if
-it was deep-copied.)"
-);
+By default, this method creates a shallow copy of the current frame:
+only references are copied, not the data itself. However, due to
+copy-on-write semantics any changes made to one of the frames will not
+propagate to the other. Thus, for most intents and purposes the copied
+frame will behave as if it was deep-copied.
 
-oobj Frame::copy(const PKArgs&) {
-  oobj res = Frame::oframe(new DataTable(*dt));  // copy dt
+Still, it is possible to explicitly request a deep copy of the frame,
+using the parameter `deep=True`. Even though it is not needed most of
+the time, there still could be situations where you may want to use
+this parameter: for example for auditing purposes, or if you want to
+explicitly control the moment when the copying is made.
+)");
+
+oobj Frame::copy(const PKArgs& args) {
+  bool deepcopy = args[0].to<bool>(false);
+
+  oobj res = Frame::oframe(deepcopy? new DataTable(*dt, DataTable::deep_copy)
+                                   : new DataTable(*dt));
   Frame* newframe = static_cast<Frame*>(res.to_borrowed_ref());
   newframe->stypes = stypes;  Py_XINCREF(stypes);
   newframe->ltypes = ltypes;  Py_XINCREF(ltypes);

--- a/c/frame/py_frame.h
+++ b/c/frame/py_frame.h
@@ -80,6 +80,8 @@ class Frame : public XObject<Frame> {
     void m__releasebuffer__(Py_buffer* view);
     oobj m__iter__();
     oobj m__reversed__();
+    oobj m__copy__();
+    oobj m__deepcopy__(const PKArgs&);
 
     // Frame display
     oobj m__repr__() const;

--- a/c/jay/open_jay.cc
+++ b/c/jay/open_jay.cc
@@ -132,8 +132,10 @@ static void initStats(Stats* stats, const jay::Column* jcol) {
     using R = typename std::conditional<std::is_integral<T>::value,
                                         int64_t, double>::type;
     stats->set_nacount(static_cast<size_t>(jcol->nullcount()));
-    stats->set_min(static_cast<R>(jstats->min()));
-    stats->set_max(static_cast<R>(jstats->max()));
+    T min = jstats->min();
+    T max = jstats->max();
+    stats->set_min(static_cast<R>(min), (min != GETNA<T>()));
+    stats->set_max(static_cast<R>(max), (max != GETNA<T>()));
   }
 }
 

--- a/c/jay/save_jay.cc
+++ b/c/jay/save_jay.cc
@@ -201,9 +201,10 @@ static flatbuffers::Offset<void> saveStats(
   if (!(stats && stats->is_computed(Stat::Min) && stats->is_computed(Stat::Max)))
     return 0;
   R min, max;
-  stats->get_stat(Stat::Min, &min);
-  stats->get_stat(Stat::Max, &max);
-  StatBuilder ss(static_cast<T>(min), static_cast<T>(max));
+  bool min_valid = stats->get_stat(Stat::Min, &min);
+  bool max_valid = stats->get_stat(Stat::Max, &max);
+  StatBuilder ss(min_valid? static_cast<T>(min) : GETNA<T>(),
+                 max_valid? static_cast<T>(max) : GETNA<T>());
   flatbuffers::Offset<void> o = fbb.CreateStruct(ss).Union();
   return o;
 }

--- a/c/stats.cc
+++ b/c/stats.cc
@@ -1185,9 +1185,20 @@ static void check_stat(Stat stat, Stats* curr_stats, Stats* new_stats) {
   }
 }
 
-void Stats::verify_integrity() {
-  if (!column) {
-    throw AssertionError() << "Column object in Stats is missing";
+void Stats::verify_integrity(const dt::ColumnImpl* col) {
+  XAssert(column == col);
+  switch (col->stype()) {
+    case SType::BOOL:    XAssert(dynamic_cast<BooleanStats*>(this)); break;
+    case SType::INT8:    XAssert(dynamic_cast<IntegerStats<int8_t>*>(this)); break;
+    case SType::INT16:   XAssert(dynamic_cast<IntegerStats<int16_t>*>(this)); break;
+    case SType::INT32:   XAssert(dynamic_cast<IntegerStats<int32_t>*>(this)); break;
+    case SType::INT64:   XAssert(dynamic_cast<IntegerStats<int64_t>*>(this)); break;
+    case SType::FLOAT32: XAssert(dynamic_cast<RealStats<float>*>(this)); break;
+    case SType::FLOAT64: XAssert(dynamic_cast<RealStats<double>*>(this)); break;
+    case SType::STR32:
+    case SType::STR64:   XAssert(dynamic_cast<StringStats*>(this)); break;
+    case SType::OBJ:     XAssert(dynamic_cast<PyObjectStats*>(this)); break;
+    default: throw AssertionError() << "Unknown column type " << col->stype();
   }
   auto new_stats = _make_stats(column);
   check_stat<size_t>(Stat::NaCount, this, new_stats.get());

--- a/c/stats.cc
+++ b/c/stats.cc
@@ -93,10 +93,6 @@ size_t PyObjectStats::memory_footprint() const noexcept {
   return sizeof(PyObjectStats);
 }
 
-const dt::ColumnImpl* Stats::get_column() const {
-  return column;
-}
-
 
 
 
@@ -1130,22 +1126,24 @@ bool Column::is_stat_computed(Stat stat) const {
 //------------------------------------------------------------------------------
 
 template <typename S>
-std::unique_ptr<Stats> _clone(const S* inp) {
-  S* out = new S(inp->get_column());
+std::unique_ptr<Stats> Stats::_clone(const S* inp) const {
+  S* out = new S(inp->column);
   std::memcpy(static_cast<void*>(out),
               static_cast<const void*>(inp),
               sizeof(S));
+  xassert(out->_valid == inp->_valid);
+  xassert(out->_computed == inp->_computed);
   return std::unique_ptr<Stats>(out);
 }
 
 
 template <typename T>
-std::unique_ptr<Stats> RealStats<T>::clone()    const { return _clone(this); }
+std::unique_ptr<Stats> RealStats<T>::clone()    const { return this->_clone(this); }
 template <typename T>
-std::unique_ptr<Stats> IntegerStats<T>::clone() const { return _clone(this); }
-std::unique_ptr<Stats> BooleanStats::clone()    const { return _clone(this); }
-std::unique_ptr<Stats> StringStats::clone()     const { return _clone(this); }
-std::unique_ptr<Stats> PyObjectStats::clone()   const { return _clone(this); }
+std::unique_ptr<Stats> IntegerStats<T>::clone() const { return this->_clone(this); }
+std::unique_ptr<Stats> BooleanStats::clone()    const { return this->_clone(this); }
+std::unique_ptr<Stats> StringStats::clone()     const { return this->_clone(this); }
+std::unique_ptr<Stats> PyObjectStats::clone()   const { return this->_clone(this); }
 
 
 

--- a/c/stats.cc
+++ b/c/stats.cc
@@ -1112,6 +1112,7 @@ std::unique_ptr<Stats> Column::clone_stats() const {
 
 
 void Column::replace_stats(std::unique_ptr<Stats>&& new_stats) {
+  new_stats->column = impl_;
   impl_->stats_ = std::move(new_stats);
 }
 

--- a/c/stats.h
+++ b/c/stats.h
@@ -223,6 +223,7 @@ class Stats
     template <typename S> py::oobj pywrap_stat(Stat);
     template <typename S, typename R> Column colwrap_stat(Stat, SType);
     Column strcolwrap_stat(Stat);
+    friend class Column;
 };
 
 

--- a/c/stats.h
+++ b/c/stats.h
@@ -144,7 +144,6 @@ class Stats
 
     virtual size_t memory_footprint() const noexcept = 0;
     virtual std::unique_ptr<Stats> clone() const = 0;
-    const dt::ColumnImpl* get_column() const;
     void verify_integrity(const dt::ColumnImpl*);
 
   protected:
@@ -217,6 +216,7 @@ class Stats
     virtual void compute_moments34();
     virtual void compute_sorted_stats();
     void _fill_validity_flag(Stat stat, bool* isvalid);
+    template <typename S> std::unique_ptr<Stats> _clone(const S* inp) const;
 
 
   private:

--- a/c/stats.h
+++ b/c/stats.h
@@ -145,7 +145,7 @@ class Stats
     virtual size_t memory_footprint() const noexcept = 0;
     virtual std::unique_ptr<Stats> clone() const = 0;
     const dt::ColumnImpl* get_column() const;
-    void verify_integrity();
+    void verify_integrity(const dt::ColumnImpl*);
 
   protected:
     // Also sets the `computed` flag

--- a/c/stats.h
+++ b/c/stats.h
@@ -8,6 +8,7 @@
 #ifndef dt_STATS_h
 #define dt_STATS_h
 #include <bitset>
+#include <memory>
 #include <vector>
 #include "types.h"
 
@@ -142,6 +143,8 @@ class Stats
     bool is_valid(Stat s) const;
 
     virtual size_t memory_footprint() const noexcept = 0;
+    virtual std::unique_ptr<Stats> clone() const = 0;
+    const dt::ColumnImpl* get_column() const;
     void verify_integrity();
 
   protected:
@@ -307,6 +310,7 @@ template <typename T>
 class RealStats : public NumericStats<T> {
   public:
     using NumericStats<T>::NumericStats;
+    std::unique_ptr<Stats> clone() const override;
 };
 
 extern template class RealStats<float>;
@@ -325,6 +329,7 @@ template <typename T>
 class IntegerStats : public NumericStats<T> {
   public:
     using NumericStats<T>::NumericStats;
+    std::unique_ptr<Stats> clone() const override;
 };
 
 extern template class IntegerStats<int8_t>;
@@ -348,6 +353,8 @@ class BooleanStats : public NumericStats<int64_t> {
     using NumericStats<int64_t>::NumericStats;
 
   protected:
+    std::unique_ptr<Stats> clone() const override;
+
     void compute_nacount() override;
     void compute_nunique() override;
     void compute_minmax() override;
@@ -374,6 +381,7 @@ class StringStats : public Stats {
   public:
     using Stats::Stats;
     size_t memory_footprint() const noexcept override;
+    std::unique_ptr<Stats> clone() const override;
 
     CString mode_string(bool* isvalid) override;
     void set_mode(CString value, bool isvalid) override;
@@ -395,6 +403,7 @@ class PyObjectStats : public Stats {
   public:
     using Stats::Stats;
     size_t memory_footprint() const noexcept override;
+    std::unique_ptr<Stats> clone() const override;
 
   protected:
     void compute_nacount() override;

--- a/datatable/__init__.py
+++ b/datatable/__init__.py
@@ -49,6 +49,7 @@ from .utils.typechecks import TValueError as ValueError
 from .utils.typechecks import DatatableWarning
 import datatable.widget
 import datatable.math
+import datatable.internal
 try:
     from .__git__ import __git_revision__
 except ImportError:

--- a/docs/changelog/v-0-10-0.rst
+++ b/docs/changelog/v-0-10-0.rst
@@ -77,6 +77,13 @@ Frame
   ``dt.options.display.head_nrows``, ``dt.options.display.tail_nrows`` and
   ``dt.options.display.max_nrows``.
 
+- |new| Method :meth:`Frame.copy() <datatable.Frame.copy>` now has a new
+  parameter ``deep=False``. When set to ``True``, it will create a deep copy
+  of the frame instead of the usual shallow one.
+
+  In addition, standard python functions ``copy.copy()`` and ``copy.deepcopy()``
+  will now defer to the ``Frame.copy()`` method too.
+
 - |new| It is now possible to create a Frame from a list of numpy integers/
   floats. The resulting Frame will have the stype corresponding to the largest
   dtype among all elements in the list::

--- a/tests/random_attack.py
+++ b/tests/random_attack.py
@@ -959,9 +959,10 @@ if __name__ == "__main__":
     args = parser.parse_args()
     exhaustive_checks = args.exhaustive
     if args.python:
-        outfile = os.path.join(os.path.dirname(__file__), "random_attack_logs",
-                               str(args.seed) + ".py")
-        python_output = open(outfile, "wt")
+        ra_dir = os.path.join(os.path.dirname(__file__), "random_attack_logs")
+        os.makedirs(ra_dir, exist_ok=True)
+        outfile = os.path.join(ra_dir, str(args.seed) + ".py")
+        python_output = open(outfile, "wt", encoding="UTF-8")
         python_output.write("#!/usr/bin/env python\n")
         python_output.write("#seed: %s\n" % args.seed)
         python_output.write("import sys; sys.path = ['.', '..'] + sys.path\n")

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -1302,3 +1302,11 @@ def test_issue2036():
     assert DT.nrows == 14
     DT = DT.copy()
     assert DT.nrows == 14
+
+
+def test_issue2179(numpy):
+    import copy
+    DT = dt.Frame(numpy.ma.array([False], mask=[True]), names=['A'])
+    DT1 = copy.deepcopy(DT)
+    DT2 = copy.deepcopy(DT)
+    frame_integrity_check(DT2)

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -1148,6 +1148,7 @@ def test_copy_keyed_frame():
 
 def test_deep_copy():
     DT = dt.Frame(A=range(5), B=["alpha", "beta", "gamma", "delta", "epsilon"])
+    DT = DT[:, ["A", "B"]]  # for py35
     D1 = DT.copy(deep=False)
     D2 = DT.copy(deep=True)
     assert_equals(DT, D1)

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -1157,6 +1157,21 @@ def test_deep_copy():
     assert dt.internal.frame_column_data_r(D2, 1).value != dt_ptr.value
 
 
+def test_copy_copy():
+    import copy
+    DT = dt.Frame(A=range(5))
+    D1 = copy.copy(DT)
+    assert_equals(DT, D1)
+
+
+def test_copy_deepcopy():
+    import copy
+    DT = dt.Frame(A=[5.6, 4.4, 9.3, None])
+    D1 = copy.deepcopy(DT)
+    assert_equals(DT, D1)
+    assert (dt.internal.frame_column_data_r(D1, 0).value !=
+            dt.internal.frame_column_data_r(DT, 0).value)
+
 
 
 #-------------------------------------------------------------------------------

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -1146,6 +1146,12 @@ def test_copy_keyed_frame():
     assert d2.to_list() == d1.to_list() == d0.to_list()
 
 
+def test_deep_copy():
+    DT = dt.Frame(A=range(5), B=["alpha", "beta", "gamma", "delta", "epsilon"])
+    D2 = DT.copy(deep=True)
+    assert_equals(DT, D2)
+
+
 
 #-------------------------------------------------------------------------------
 # head / tail

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -1309,4 +1309,5 @@ def test_issue2179(numpy):
     DT = dt.Frame(numpy.ma.array([False], mask=[True]), names=['A'])
     DT1 = copy.deepcopy(DT)
     DT2 = copy.deepcopy(DT)
+    frame_integrity_check(DT1)
     frame_integrity_check(DT2)

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -1148,8 +1148,14 @@ def test_copy_keyed_frame():
 
 def test_deep_copy():
     DT = dt.Frame(A=range(5), B=["alpha", "beta", "gamma", "delta", "epsilon"])
+    D1 = DT.copy(deep=False)
     D2 = DT.copy(deep=True)
+    assert_equals(DT, D1)
     assert_equals(DT, D2)
+    dt_ptr = dt.internal.frame_column_data_r(DT, 1)
+    assert dt.internal.frame_column_data_r(D1, 1).value == dt_ptr.value
+    assert dt.internal.frame_column_data_r(D2, 1).value != dt_ptr.value
+
 
 
 


### PR DESCRIPTION
Now a Frame can be deep-copied using 2 different methods:
```
DT_deep_copy1 = DT.copy(deep=True)

import copy
DT_deep_copy2 = copy.deepcopy(DT)
```

In addition, frame materialization will no longer drop Stats objects, which should improve performance.

Closes #2179 
Closes #2089