### PR TITLE
export_names() now returns column exprs

### DIFF
--- a/c/frame/py_frame.h
+++ b/c/frame/py_frame.h
@@ -115,7 +115,7 @@ class Frame : public XObject<Frame> {
     void replace(const PKArgs&);
     oobj sort(const PKArgs&);
     oobj tail(const PKArgs&);
-    void export_names(const PKArgs&);
+    oobj export_names(const PKArgs&);
 
     // Conversion methods
     oobj to_csv(const PKArgs&);

--- a/docs/changelog/v-0-10-0.rst
+++ b/docs/changelog/v-0-10-0.rst
@@ -47,22 +47,16 @@ Frame
     DT[:, update(A=f.A * 2, B=dt.str32(f.A), Z=0)]
 
 - |new| Added method :meth:`.export_names() <datatable.Frame.export_names>`
-  which creates a set of global variables referencing each column in the Frame.
-  This is recommended for interactive use only::
+  which returns a tuple of variables referencing each column in the Frame::
 
-    DT.export_names()
-    # Now DT's columns 'PROC_ID' and 'SORT_NR' can be referenced as variables,
-    # without the f. syntax:
+    PROC_ID, SORT_NR, *other = DT.export_names()
     DT[(PROC_ID == "A") & (SORT_NR > 2), :]
 
   If you need to export only a subset of columns, you can select those columns
   first via the standard ``DT[i,j]`` syntax::
 
     # Only create variables for the first 5 columns
-    DT[:, :5].export_names()
-
-  The variables are created in the global scope because python's locals cannot
-  be manipulated programmatically.
+    A, B, C, D, E = DT[:, :5].export_names()
 
 - |new| Added frame property :meth:`.stype <datatable.Frame.stype>` which is
   similar to :meth:`.stypes <datatable.Frame.stypes>` except that it returns

--- a/docs/f-expressions.rst
+++ b/docs/f-expressions.rst
@@ -34,10 +34,10 @@ will refer to the frame to which it is being applied::
 
 The simple expression ``f.price`` can be saved in a variable too. In fact,
 there is a Frame helper method ``.export_names()`` which does exactly that:
-creates a local variable for each column name in the frame, allowing you to
+returns a tuple of variables for each column name in the frame, allowing you to
 omit the ``f.`` prefix::
 
-    DT.export_names()  # create variables Id, Price and Quantity
+    Id, Price, Quantity = DT.export_names()
     DT[:, [Id, Price, Quantity, Price * Quantity]]
 
 

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -1267,12 +1267,12 @@ def test_materialize_object_col():
 #-------------------------------------------------------------------------------
 
 def test_export_names(dt0):
-    assert "A" not in locals()
-    dt0.export_names()
-    all = [A, B, C, D, E, F, G]
-    assert_equals(dt0[:, all], dt0)
+    A, B, C, D, E, F, G = dt0.export_names()
+    all_names = [A, B, C, D, E, F, G]
+    assert_equals(dt0[:, all_names], dt0)
     assert_equals(dt0[A > 0, :], dt0[:2, :])
     assert str(A + B <= C + D) == str(dt.f.A + dt.f.B <= dt.f.C + dt.f.D)
+    assert "A" not in globals()
 
 
 


### PR DESCRIPTION
Before, `export_names()` injected column-exprs into the global namespace.
Now, `export_names()` returns a tuple of column-exprs to the user.

The new semantics is much safer (no messing around with global variables), more transparent to the reader (there is no question of where those variables appear from), and allow renaming the columns on the fly (i.e. if the column's name is "User Id" in the frame, then the user can assign it to a variable named simply `id`).

Also, there is now no possibility to accidentally overwrite global variables, or to create variables with invalid names.

Closes #2184