### PR TITLE
Implement functions cov() and corr()

### DIFF
--- a/c/expr/head_func.cc
+++ b/c/expr/head_func.cc
@@ -143,6 +143,12 @@ static ptrHead make_reduce1(Op op, const py::otuple& params) {
 }
 
 
+static ptrHead make_reduce2(Op op, const py::otuple& params) {
+  xassert(params.size() == 0);
+  return ptrHead(new Head_Reduce_Binary(op));
+}
+
+
 
 std::unordered_map<size_t, Head_Func::maker_t> Head_Func::factory;
 
@@ -157,6 +163,8 @@ void Head_Func::init() {
   factory[static_cast<size_t>(Op::SETPLUS)]  = make_colsetop;
   factory[static_cast<size_t>(Op::SETMINUS)] = make_colsetop;
   factory[static_cast<size_t>(Op::COUNT0)]   = make_reduce0;
+  factory[static_cast<size_t>(Op::COV)]      = make_reduce2;
+  factory[static_cast<size_t>(Op::CORR)]     = make_reduce2;
   factory[static_cast<size_t>(Op::RE_MATCH)] = &Head_Func_Re_Match::make;
   // factory[static_cast<size_t>(Op::HYPOT)]    = make_math21;
   // factory[static_cast<size_t>(Op::ARCTAN2)]  = make_math21;

--- a/c/expr/head_reduce.h
+++ b/c/expr/head_reduce.h
@@ -29,6 +29,19 @@ namespace dt {
 namespace expr {
 
 
+/**
+  * A reduction function operates on a group of data and produces a
+  * single number as a result. Thus, the columns created by the
+  * reduction function have GroupingMode == GtoONE.
+  *
+  * We further subdivide the reduction functions according to their
+  * arity (i.e. how many arguments they take):
+  *   - Head_Reduce_Nullary: no arguments, e.g. `count()`
+  *   - Head_Reduce_Unary:   single argument, e.g. `mean(X)`
+  *   - Head_Reduce_Binary:  two arguments, e.g. `corr(X, Y)`
+  *
+  * Most reducers fall into the "unary" category.
+  */
 class Head_Reduce : public Head_Func {
   protected:
     Op op;
@@ -65,7 +78,6 @@ class Head_Reduce_Binary : public Head_Reduce {
     using Head_Reduce::Head_Reduce;
     Workframe evaluate_n(const vecExpr&, EvalContext&) const override;
 };
-
 
 
 

--- a/c/expr/head_reduce_binary.cc
+++ b/c/expr/head_reduce_binary.cc
@@ -19,22 +19,183 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
+#include "column/latent.h"
 #include "expr/eval_context.h"
 #include "expr/expr.h"
 #include "expr/head_reduce.h"
 #include "expr/workframe.h"
 #include "utils/assert.h"
 #include "utils/exceptions.h"
+#include "column.h"
 namespace dt {
 namespace expr {
 
+template <typename T>
+using reducer_fn = bool(*)(const Column&, const Column&, size_t, size_t, T*);
 
-Workframe Head_Reduce_Binary::evaluate_n(const vecExpr& args, EvalContext& ctx) const
+using maker_fn = Column(*)(Column&&, Column&&, const Groupby&);
+
+static const char* _name(Op op) {
+  return (op == Op::COV)? "cov" :
+         (op == Op::CORR)? "corr" :
+         "??";
+}
+
+
+
+//------------------------------------------------------------------------------
+// BinaryReduced_ColumnImpl
+//------------------------------------------------------------------------------
+
+template <typename T>
+class BinaryReduced_ColumnImpl : public Virtual_ColumnImpl {
+  private:
+    Column arg1;
+    Column arg2;
+    Groupby groupby;
+    reducer_fn<T> reducer;
+
+  public:
+    BinaryReduced_ColumnImpl(SType stype, Column&& col1, Column&& col2,
+                             const Groupby& grpby, reducer_fn<T> fn)
+      : Virtual_ColumnImpl(grpby.size(), stype),
+        arg1(std::move(col1)),
+        arg2(std::move(col2)),
+        groupby(grpby),
+        reducer(fn)
+    {
+      assert_compatible_type<T>(stype);
+    }
+
+    ColumnImpl* clone() const override {
+      return new BinaryReduced_ColumnImpl<T>(
+                  stype_, Column(arg1), Column(arg2), groupby, reducer);
+    }
+
+    bool get_element(size_t i, T* out) const override {
+      size_t i0, i1;
+      groupby.get_group(i, &i0, &i1);
+      return reducer(arg1, arg2, i0, i1, out);
+    }
+};
+
+
+
+
+
+//------------------------------------------------------------------------------
+// cov(X, Y)
+//------------------------------------------------------------------------------
+
+template <typename T>
+static bool cov_reducer(const Column& col1, const Column& col2,
+                        size_t i0, size_t i1, T* out)
 {
-  xassert(args.size() == 0);
-  (void) args;
-  (void) ctx;
-  throw NotImplError() << "Head_Reduce_Binary::evaluate not implemented yet";
+  T mean1 = 0, mean2 = 0;
+  T cov = 0;
+  T value1, value2;
+  int64_t n = 0;
+  for (size_t i = i0; i < i1; ++i) {
+    bool isvalid1 = col1.get_element(i, &value1);
+    bool isvalid2 = col2.get_element(i, &value2);
+    if (isvalid1 && isvalid2) {
+      n++;
+      T delta1 = value1 - mean1;
+      T delta2 = value2 - mean2;
+      mean1 += delta1 / n;
+      mean2 += delta2 / n;
+      T tmp1 = value1 - mean1;  // effectively, this is delta1*(n-1)/n
+      cov += tmp1 * delta2;
+    }
+  }
+  if (n <= 1) return false;
+  *out = cov/(n - 1);
+  return true;  // *out is not NA
+}
+
+
+template <typename T>
+static Column _cov(Column&& arg1, Column&& arg2, const Groupby& gby) {
+  const SType st = stype_from<T>();
+  arg1.cast_inplace(st);
+  arg2.cast_inplace(st);
+  return Column(
+          new Latent_ColumnImpl(
+            new BinaryReduced_ColumnImpl<T>(
+                 st, std::move(arg1), std::move(arg2), gby, cov_reducer<T>
+            )));
+}
+
+
+static Column compute_cov(Column&& arg1, Column&& arg2, const Groupby& gby) {
+  xassert(arg1.nrows() == arg2.nrows());
+  return (arg1.stype() == SType::FLOAT32 && arg2.stype() == SType::FLOAT64)
+          ? _cov<float>(std::move(arg1), std::move(arg2), gby)
+          : _cov<double>(std::move(arg1), std::move(arg2), gby);
+}
+
+
+
+
+//------------------------------------------------------------------------------
+// corr(X, Y)
+//------------------------------------------------------------------------------
+
+static Column compute_corr(Column&& arg1, Column&& arg2, const Groupby& gby) {
+  xassert(arg1.nrows() == arg2.nrows());
+  (void) gby;
+  return Column();
+}
+
+
+
+
+//------------------------------------------------------------------------------
+// Head_Reduce_Binary factory function
+//------------------------------------------------------------------------------
+
+Workframe Head_Reduce_Binary::evaluate_n(const vecExpr& args,
+                                         EvalContext& ctx) const
+{
+  xassert(args.size() == 2);
+  Workframe inputs1 = args[0].evaluate_n(ctx);
+  Workframe inputs2 = args[1].evaluate_n(ctx);
+  Groupby gby = ctx.get_groupby();
+  if (!gby) gby = Groupby::single_group(ctx.nrows());
+
+  maker_fn fn = nullptr;
+  if (inputs1.get_grouping_mode() == Grouping::GtoALL &&
+      inputs2.get_grouping_mode() == Grouping::GtoALL)
+  {
+    switch (op) {
+      case Op::COV:  fn = compute_cov; break;
+      case Op::CORR: fn = compute_corr; break;
+      default: throw TypeError() << "Unknown reducer function: "
+                                 << static_cast<size_t>(op);
+    }
+  } else {
+  }
+
+  size_t n1 = inputs1.ncols();
+  size_t n2 = inputs2.ncols();
+  if (!(n1 == n2 || n1 == 1 || n2 == 1)) {
+    throw ValueError() << "Cannot apply reducer function " << _name(op)
+        << ": argument 1 has " << n1 << " columns, while argument 2 has "
+        << n2 << " columns";
+  }
+  Column col1 = (n1 == 1)? inputs1.retrieve_column(0) : Column();
+  Column col2 = (n2 == 1)? inputs2.retrieve_column(0) : Column();
+
+  size_t n = std::max(n1, n2);
+  Workframe outputs(ctx);
+  for (size_t i = 0; i < n; ++i) {
+    Column arg1 = (n1 == 1)? Column(col1) : inputs1.retrieve_column(i);
+    Column arg2 = (n2 == 1)? Column(col2) : inputs2.retrieve_column(i);
+    outputs.add_column(
+        fn(std::move(arg1), std::move(arg2), gby),
+        "", Grouping::GtoONE);
+  }
+  return outputs;
 }
 
 

--- a/c/expr/head_reduce_binary.cc
+++ b/c/expr/head_reduce_binary.cc
@@ -30,6 +30,7 @@
 namespace dt {
 namespace expr {
 
+
 template <typename T>
 using reducer_fn = bool(*)(const Column&, const Column&, size_t, size_t, T*);
 
@@ -136,7 +137,7 @@ static Column _cov(Column&& arg1, Column&& arg2, const Groupby& gby) {
 
 static Column compute_cov(Column&& arg1, Column&& arg2, const Groupby& gby) {
   xassert(arg1.nrows() == arg2.nrows());
-  return (arg1.stype() == SType::FLOAT32 && arg2.stype() == SType::FLOAT64)
+  return (arg1.stype() == SType::FLOAT32 && arg2.stype() == SType::FLOAT32)
           ? _cov<float>(std::move(arg1), std::move(arg2), gby)
           : _cov<double>(std::move(arg1), std::move(arg2), gby);
 }
@@ -198,7 +199,7 @@ static Column _corr(Column&& arg1, Column&& arg2, const Groupby& gby) {
 
 static Column compute_corr(Column&& arg1, Column&& arg2, const Groupby& gby) {
   xassert(arg1.nrows() == arg2.nrows());
-  return (arg1.stype() == SType::FLOAT32 && arg2.stype() == SType::FLOAT64)
+  return (arg1.stype() == SType::FLOAT32 && arg2.stype() == SType::FLOAT32)
           ? _corr<float>(std::move(arg1), std::move(arg2), gby)
           : _corr<double>(std::move(arg1), std::move(arg2), gby);
 }

--- a/c/expr/op.h
+++ b/c/expr/op.h
@@ -98,6 +98,8 @@ enum class Op : size_t {
   COUNT,
   COUNT0,
   MEDIAN = REDUCER_LAST,
+  COV,
+  CORR,
 
   // Math: trigonometric
   SIN = MATH_FIRST,

--- a/datatable/__init__.py
+++ b/datatable/__init__.py
@@ -23,7 +23,7 @@
 from .__version__ import version as __version__
 from .frame import Frame
 from .expr import (mean, min, max, sd, isna, sum, count, first, abs, exp,
-                   last, log, log10, f, g, median)
+                   last, log, log10, f, g, median, cov, corr)
 from .fread import fread, GenericReader, FreadWarning, _DefaultLogger
 from .lib._datatable import (
     by,
@@ -59,7 +59,9 @@ __all__ = (
     "__git_revision__",
     "__version__",
     "Frame",
+    "corr",
     "count",
+    "cov",
     "dt",
     "first",
     "init_styles",

--- a/datatable/expr/__init__.py
+++ b/datatable/expr/__init__.py
@@ -22,12 +22,15 @@
 #-------------------------------------------------------------------------------
 from .expr import f, g, Expr
 from .math import abs, log, log10, exp, isna
-from .reduce import sum, count, first, last, mean, median, min, max, sd
+from .reduce import (
+    sum, count, first, last, mean, median, min, max, sd, cov, corr)
 
 __all__ = (
     "Expr",
     "abs",
+    "corr",
     "count",
+    "cov",
     "exp",
     "f",
     "first",

--- a/datatable/expr/expr.py
+++ b/datatable/expr/expr.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #-------------------------------------------------------------------------------
-# Copyright 2018 H2O.ai
+# Copyright 2018-2019 H2O.ai
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -80,6 +80,8 @@ class OpCodes(enum.Enum):
     COUNT = 408
     COUNT0 = 409
     MEDIAN = 410
+    COV = 411
+    CORR = 412
 
     # Math: trigonometric
     SIN = 501

--- a/datatable/expr/reduce.py
+++ b/datatable/expr/reduce.py
@@ -27,7 +27,9 @@ from builtins import min as _builtin_min
 from builtins import max as _builtin_max
 
 __all__ = (
+    "corr",
     "count",
+    "cov",
     "first",
     "last",
     "max",
@@ -82,6 +84,17 @@ def sd(expr):
 
 def median(expr):
     return Expr(OpCodes.MEDIAN, (expr,))
+
+
+def cov(expr1, expr2):
+    return Expr(OpCodes.COV, (expr1, expr2))
+
+
+def corr(col1, col2):
+    """
+    Compute Pearson correlation coefficient between two columns.
+    """
+    return Expr(OpCodes.CORR, (col1, col2))
 
 
 # noinspection PyShadowingBuiltins

--- a/docs/changelog/v-0-10-0.rst
+++ b/docs/changelog/v-0-10-0.rst
@@ -224,6 +224,13 @@ General
   The symbol ``dt`` is also exported by default, i.e. it will be available if
   you do ``from datatable import *``.
 
+- |new| Added functions :func:`cov` and :func:`corr` to compute the covariance
+  and Pearson correlation coefficient between columns of a Frame. These
+  functions can be used in a group-by too::
+
+    # Compute correlation of columns A and B, group-wise by ID
+    DT[:, corr(f.A, f.B), by(f.ID)]
+
 - |fix| Fixed memory leak when writing a Frame into a CSV file (#2119).
 
 - |fix| Fixed memory leak when converting a numpy array with string values


### PR DESCRIPTION
Added 2 new reducer functions `cov()` and `corr()`.
- `cov(A, B)` computes the covariance between 2 columns,
- `corr(A, B)` computes Pearson's correlation coefficient between 2 columns.

Also fixed a bug where a reducer could not be applied if DT[i,j] expression contained `i` filter but not `by`.

Closes #1543