### PR TITLE
Function .len() now returns the number of codepoints in a string

### DIFF
--- a/docs/changelog/v-0-10-0.rst
+++ b/docs/changelog/v-0-10-0.rst
@@ -238,6 +238,10 @@ General
 
 - |fix| Fixed memory leak during reduce operations (#2125).
 
+- |fix| Column method ``.len()`` for computing string length now handles
+  unicode strings correctly and returns the number of codepoints in the
+  string instead of the number of bytes (#2160).
+
 
 Internal
 --------

--- a/tests/ijby/test-func-unary.py
+++ b/tests/ijby/test-func-unary.py
@@ -371,3 +371,9 @@ def test_len_wrong_col():
     with pytest.raises(TypeError, match=r"Cannot apply function `len\(\)` to a "
                                         r"column with stype `int32`"):
         assert DT[:, f[0].len()]
+
+
+def test_len_unicode():
+    DT = dt.Frame(["майдан", "蒙蒂巨蟒", "🤥", "𝔘𝔫𝔦𝔠𝔬𝔡𝔢"])
+    RES = DT[:, f[0].len()]
+    assert_equals(RES, dt.Frame([6, 4, 1, 7], stype=dt.int64))


### PR DESCRIPTION
Note that this does have an effect on performance. Unfortunately, there is no other way to make this function return correct result.

In the future we may keep a stat indicating whether the column is ASCII or not. And in case it is ascii, use the old simpler function for computing string length.

Closes #2160