### PR TITLE
Make use of NThreads class in parallel_region

### DIFF
--- a/c/frame/join.cc
+++ b/c/frame/join.cc
@@ -422,7 +422,7 @@ RowIndex natural_join(const DataTable& xdt, const DataTable& jdt) {
         });
     }
     else {
-      dt::parallel_region(nchunks,
+      dt::parallel_region(dt::NThreads(nchunks),
         [&] {
           // Creating the comparator may fail if xcols and jcols are incompatible
           cmpptr comparator = _make_comparator(xdt, jdt, xcols, jcols);

--- a/c/models/aggregator.cc
+++ b/c/models/aggregator.cc
@@ -782,7 +782,7 @@ bool Aggregator<T>::group_nd() {
   size_t ecounter = 0;
 
   dt::progress::work job(nrows_per_thread);
-  dt::parallel_region(nth,
+  dt::parallel_region(dt::NThreads(nth),
     [&] {
       size_t ith = dt::this_thread_index();
       size_t i0 = ith * nrows_per_thread;

--- a/c/models/dt_ftrl.cc
+++ b/c/models/dt_ftrl.cc
@@ -592,7 +592,7 @@ FtrlFitOutput Ftrl<T>::fit(T(*linkfn)(T),
   dt::progress::work job(work_total);
   job.set_message("Fitting");
 
-  dt::parallel_region(get_nthreads(iteration_nrows),
+  dt::parallel_region(NThreads(get_nthreads(iteration_nrows)),
     [&]() {
       // Each thread gets a private storage for hashes,
       // temporary weights and feature importances.
@@ -836,7 +836,7 @@ dtptr Ftrl<T>::predict(const DataTable* dt_X) {
   dt::progress::work job(work_total);
   job.set_message("Predicting");
 
-  dt::parallel_region(nthreads, [&]() {
+  dt::parallel_region(NThreads(nthreads), [&]() {
     uint64ptr x = uint64ptr(new uint64_t[nfeatures]);
     tptr<T> w = tptr<T>(new T[nfeatures]);
 

--- a/c/parallel/api.h
+++ b/c/parallel/api.h
@@ -89,7 +89,7 @@ bool is_monitor_enabled() noexcept;
 /**
  * Call function `f` exactly once in each thread.
  */
-void parallel_region(NThreads NThreads_, function<void()> f);
+void parallel_region(NThreads, function<void()> f);
 void parallel_region(function<void()> f);
 
 
@@ -108,7 +108,7 @@ void barrier();
  * Run parallel loop `for i in range(nrows): f(i)`, with dynamic scheduling.
  */
 void parallel_for_dynamic(size_t nrows, std::function<void(size_t)> fn);
-void parallel_for_dynamic(size_t nrows, NThreads NThreads_,
+void parallel_for_dynamic(size_t nrows, NThreads,
                           std::function<void(size_t)> fn);
 
 

--- a/c/parallel/api.h
+++ b/c/parallel/api.h
@@ -89,7 +89,7 @@ bool is_monitor_enabled() noexcept;
 /**
  * Call function `f` exactly once in each thread.
  */
-void parallel_region(size_t nthreads, function<void()> f);
+void parallel_region(NThreads NThreads_, function<void()> f);
 void parallel_region(function<void()> f);
 
 

--- a/c/parallel/parallel_for_static.h
+++ b/c/parallel/parallel_for_static.h
@@ -140,7 +140,7 @@ void parallel_for_static(size_t n_iterations,
   }
 
   parallel_region(
-    num_threads,
+    NThreads(num_threads),
     [=] {
       size_t i0 = chunk_size_ * this_thread_index();
       size_t di = chunk_size_ * num_threads;

--- a/c/parallel/parallel_region.cc
+++ b/c/parallel/parallel_region.cc
@@ -79,13 +79,12 @@ thread_task* once_scheduler::get_next_task(size_t i) {
 //------------------------------------------------------------------------------
 
 void parallel_region(function<void()> fn) {
-  parallel_region(0, fn);
+  parallel_region(NThreads(0), fn);
 }
 
-void parallel_region(size_t nthreads, function<void()> fn) {
+void parallel_region(NThreads NThreads_, function<void()> fn) {
   xassert(!thpool->in_parallel_region());
-  size_t nthreads0 = thpool->size();
-  if (nthreads > nthreads0 || nthreads == 0) nthreads = nthreads0;
+  size_t nthreads = NThreads_.get();
   thread_team tt(nthreads, thpool);
 
   simple_task task(fn);

--- a/c/parallel/parallel_region.cc
+++ b/c/parallel/parallel_region.cc
@@ -79,12 +79,12 @@ thread_task* once_scheduler::get_next_task(size_t i) {
 //------------------------------------------------------------------------------
 
 void parallel_region(function<void()> fn) {
-  parallel_region(NThreads(0), fn);
+  parallel_region(NThreads(), fn);
 }
 
-void parallel_region(NThreads NThreads_, function<void()> fn) {
+void parallel_region(NThreads nthreads_, function<void()> fn) {
   xassert(!thpool->in_parallel_region());
-  size_t nthreads = NThreads_.get();
+  size_t nthreads = nthreads_.get();
   thread_team tt(nthreads, thpool);
 
   simple_task task(fn);

--- a/c/progress/ztest_progress.cc
+++ b/c/progress/ztest_progress.cc
@@ -57,7 +57,7 @@ void test_progress_nested(size_t n, size_t nth) {
   size_t niterations= n * nthreads.get();
   std::vector<size_t> data(niterations, 0);
 
-  dt::parallel_region(nthreads.get(),
+  dt::parallel_region(nthreads,
     [&]() {
       if (dt::this_thread_index() == 0) {
         job.set_message("Running test_progress_nested...");

--- a/c/sort.cc
+++ b/c/sort.cc
@@ -804,7 +804,7 @@ class SortContext {
     std::atomic_flag flong = ATOMIC_FLAG_INIT;
 
     dt::parallel_region(
-      /* nthreads= */ nth,
+      dt::NThreads(nth),
       [&] {
         bool len_gt_1 = false;
         dt::nested_for_static(n, dt::ChunkSize(1024),
@@ -1015,7 +1015,7 @@ class SortContext {
     const int64_t sstart = static_cast<int64_t>(strstart) + 1;
     std::atomic_flag flong = ATOMIC_FLAG_INIT;
 
-    dt::parallel_region(nth,
+    dt::parallel_region(dt::NThreads(nth),
       [&] {
         bool tlong = false;
         dt::nested_for_static(nchunks, dt::ChunkSize(1),
@@ -1221,7 +1221,7 @@ class SortContext {
       // }
     }
 
-    dt::parallel_region(nth,
+    dt::parallel_region(dt::NThreads(nth),
       [&] {
         size_t tnum = dt::this_thread_index();
         int32_t* oo = tmp + tnum * size0;

--- a/c/str/split_into_nhot.cc
+++ b/c/str/split_into_nhot.cc
@@ -134,7 +134,7 @@ DataTable* split_into_nhot(const Column& col, char sep,
   dt::shared_mutex shmutex;
 
   dt::parallel_region(
-    /* nthreads = */ nrows,
+    NThreads(nrows),
     [&] {
       std::vector<std::string> chunks;
 


### PR DESCRIPTION
Make use of `NThreads` class in `dt::parallel_region` to be consistent with all the other `dt::parallel_*` functions.