### PR TITLE
Fix segfault when C++ tests were called with missing arguments

### DIFF
--- a/c/python/args.cc
+++ b/c/python/args.cc
@@ -253,13 +253,16 @@ size_t PKArgs::_find_kwd(PyObject* kwd) {
 
 
 /**
- * Check if any required arguments are missing.
+ * Check if any of the positional arguments are missing.
  */
-void PKArgs::check_required_args() const {
+void PKArgs::check_posonly_args() const {
   check_required_args(n_posonly_args);
 }
 
 
+/**
+ * Check if any of the `n_required_args` arguments are missing.
+ */
 void PKArgs::check_required_args(size_t n_required_args) const {
   xassert(n_required_args <= n_all_args);
   for (size_t i = 0; i < n_posonly_args; ++i) {

--- a/c/python/args.cc
+++ b/c/python/args.cc
@@ -257,6 +257,10 @@ const Arg& PKArgs::operator[](size_t i) const {
   return bound_args[i];
 }
 
+size_t PKArgs::num_posonly_args() const noexcept {
+  return n_posonly_args;
+}
+
 size_t PKArgs::num_vararg_args() const noexcept {
   return n_varargs;
 }

--- a/c/python/args.cc
+++ b/c/python/args.cc
@@ -253,7 +253,7 @@ size_t PKArgs::_find_kwd(PyObject* kwd) {
 
 
 /**
- * Check for missing positional arguments.
+ * Check if any required arguments are missing.
  */
 void PKArgs::check_required_args() const {
   check_required_args(n_posonly_args);
@@ -274,10 +274,6 @@ void PKArgs::check_required_args(size_t n_required_args) const {
 
 const Arg& PKArgs::operator[](size_t i) const {
   return bound_args[i];
-}
-
-size_t PKArgs::num_posonly_args() const noexcept {
-  return n_posonly_args;
 }
 
 size_t PKArgs::num_vararg_args() const noexcept {

--- a/c/python/args.cc
+++ b/c/python/args.cc
@@ -252,6 +252,25 @@ size_t PKArgs::_find_kwd(PyObject* kwd) {
 }
 
 
+/**
+ * Check for missing positional arguments.
+ */
+void PKArgs::check_required_args() const {
+  check_required_args(n_posonly_args);
+}
+
+
+void PKArgs::check_required_args(size_t n_required_args) const {
+  xassert(n_required_args <= n_all_args);
+  for (size_t i = 0; i < n_posonly_args; ++i) {
+    if (bound_args[i].is_undefined()) {
+      throw ValueError() << "In " << get_long_name()
+        << " the number of arguments required is " << n_required_args
+        << ", got: " << i;
+    }
+  }
+}
+
 
 const Arg& PKArgs::operator[](size_t i) const {
   return bound_args[i];

--- a/c/python/args.h
+++ b/c/python/args.h
@@ -137,6 +137,8 @@ class PKArgs {
     const char* get_arg_short_name(size_t i) const;
 
     //---- User API --------------------
+    void check_required_args() const;
+    void check_required_args(size_t n_required_args) const;
     const Arg& operator[](size_t i) const;
 
     size_t num_posonly_args() const noexcept;

--- a/c/python/args.h
+++ b/c/python/args.h
@@ -139,6 +139,7 @@ class PKArgs {
     //---- User API --------------------
     const Arg& operator[](size_t i) const;
 
+    size_t num_posonly_args() const noexcept;
     size_t num_vararg_args() const noexcept;
     size_t num_varkwd_args() const noexcept;
     VarKwdsIterable varkwds() const noexcept;

--- a/c/python/args.h
+++ b/c/python/args.h
@@ -137,7 +137,7 @@ class PKArgs {
     const char* get_arg_short_name(size_t i) const;
 
     //---- User API --------------------
-    void check_required_args() const;
+    void check_posonly_args() const;
     void check_required_args(size_t n_required_args) const;
     const Arg& operator[](size_t i) const;
 

--- a/c/python/args.h
+++ b/c/python/args.h
@@ -141,7 +141,6 @@ class PKArgs {
     void check_required_args(size_t n_required_args) const;
     const Arg& operator[](size_t i) const;
 
-    size_t num_posonly_args() const noexcept;
     size_t num_vararg_args() const noexcept;
     size_t num_varkwd_args() const noexcept;
     VarKwdsIterable varkwds() const noexcept;

--- a/c/ztest.cc
+++ b/c/ztest.cc
@@ -34,7 +34,7 @@ static PKArgs arg_test_shmutex(3, 0, 0, false, false,
   "test_shmutex");
 
 static void test_shmutex(const PKArgs& args) {
-  args.check_required_args();
+  args.check_posonly_args();
   size_t n_iters = args[0].to_size_t();
   size_t n_threads = args[1].to_size_t();
   int impl = args[2].to_int32_strict();
@@ -53,7 +53,7 @@ static PKArgs arg_test_barrier(
   1, 0, 0, false, false, {"n"}, "test_barrier");
 
 static void test_barrier(const PKArgs& args) {
-  args.check_required_args();
+  args.check_posonly_args();
   size_t n = args[0].to_size_t();
   dttest::test_barrier(n);
 }
@@ -63,7 +63,7 @@ static PKArgs arg_test_parallel_for_static(
   1, 0, 0, false, false, {"n"}, "test_parallel_for_static");
 
 static void test_parallel_for_static(const PKArgs& args) {
-  args.check_required_args();
+  args.check_posonly_args();
   size_t n = args[0].to_size_t();
   dttest::test_parallel_for_static(n);
 }
@@ -73,7 +73,7 @@ static PKArgs arg_test_parallel_for_dynamic(
   1, 0, 0, false, false, {"n"}, "test_parallel_for_dynamic");
 
 static void test_parallel_for_dynamic(const PKArgs& args) {
-  args.check_required_args();
+  args.check_posonly_args();
   size_t n = args[0].to_size_t();
   dttest::test_parallel_for_dynamic(n);
   dttest::test_parallel_for_dynamic_nested(n);
@@ -84,7 +84,7 @@ static PKArgs arg_test_parallel_for_ordered(
   1, 0, 0, false, false, {"n"}, "test_parallel_for_ordered");
 
 static void test_parallel_for_ordered(const PKArgs& args) {
-  args.check_required_args();
+  args.check_posonly_args();
   size_t n = args[0].to_size_t();
   dttest::test_parallel_for_ordered(n);
 }
@@ -96,7 +96,7 @@ static PKArgs arg_test_progress_static(2, 0, 0, false, false,
   "test_progress_static");
 
 static void test_progress_static(const PKArgs& args) {
-  args.check_required_args();
+  args.check_posonly_args();
   size_t n_iters = args[0].to_size_t();
   size_t n_threads = args[1].to_size_t();
   dttest::test_progress_static(n_iters, n_threads);
@@ -108,7 +108,7 @@ static PKArgs arg_test_progress_nested(2, 0, 0, false, false,
   "test_progress_nested");
 
 static void test_progress_nested(const PKArgs& args) {
-  args.check_required_args();
+  args.check_posonly_args();
   size_t n_iters = args[0].to_size_t();
   size_t n_threads = args[1].to_size_t();
   dttest::test_progress_nested(n_iters, n_threads);
@@ -120,7 +120,7 @@ static PKArgs arg_test_progress_dynamic(2, 0, 0, false, false,
   "test_progress_dynamic");
 
 static void test_progress_dynamic(const PKArgs& args) {
-  args.check_required_args();
+  args.check_posonly_args();
   size_t n_iters = args[0].to_size_t();
   size_t n_threads = args[1].to_size_t();
   dttest::test_progress_dynamic(n_iters, n_threads);
@@ -132,7 +132,7 @@ static PKArgs arg_test_progress_ordered(2, 0, 0, false, false,
   "test_progress_ordered");
 
 static void test_progress_ordered(const PKArgs& args) {
-  args.check_required_args();
+  args.check_posonly_args();
   size_t n_iters = args[0].to_size_t();
   size_t n_threads = args[1].to_size_t();
   dttest::test_progress_ordered(n_iters, n_threads);

--- a/c/ztest.cc
+++ b/c/ztest.cc
@@ -25,9 +25,8 @@ namespace py {
  */
 static void check_posonly_args(const PKArgs& args_spec, const PKArgs& args) {
   for (size_t i = 0; i < args_spec.num_posonly_args(); ++i) {
-    if (args[i].is_none_or_undefined()) {
-      throw ValueError() << "Positional argument " << i + 1
-                         << " can not be `None` or undefined";
+    if (args[i].is_undefined()) {
+      throw ValueError() << "Positional argument " << i + 1 << " is missing";
     }
   }
 }

--- a/c/ztest.cc
+++ b/c/ztest.cc
@@ -1,16 +1,36 @@
 //------------------------------------------------------------------------------
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright 2019 H2O.ai
 //
-// © H2O.ai 2018
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //------------------------------------------------------------------------------
 #ifdef DTTEST
 #include "datatablemodule.h"
-#include "python/args.h"
 #include "utils/exceptions.h"
 #include "ztest.h"
 namespace py {
+
+
+/**
+ * Helper function to check for missing positional arguments
+ */
+static void check_posonly_args(const PKArgs& args_spec, const PKArgs& args) {
+  for (size_t i = 0; i < args_spec.num_posonly_args(); ++i) {
+    if (args[i].is_none_or_undefined()) {
+      throw ValueError() << "Positional argument " << i + 1
+                         << " can not be `None` or undefined";
+    }
+  }
+}
 
 
 static PKArgs arg_test_coverage(0, 0, 0, false, false, {}, "test_coverage");
@@ -27,6 +47,7 @@ static PKArgs arg_test_shmutex(3, 0, 0, false, false,
   "test_shmutex");
 
 static void test_shmutex(const PKArgs& args) {
+  check_posonly_args(arg_test_shmutex, args);
   size_t n_iters = args[0].to_size_t();
   size_t n_threads = args[1].to_size_t();
   int impl = args[2].to_int32_strict();
@@ -45,6 +66,7 @@ static PKArgs arg_test_barrier(
   1, 0, 0, false, false, {"n"}, "test_barrier");
 
 static void test_barrier(const PKArgs& args) {
+  check_posonly_args(arg_test_barrier, args);
   size_t n = args[0].to_size_t();
   dttest::test_barrier(n);
 }
@@ -54,6 +76,7 @@ static PKArgs arg_test_parallel_for_static(
   1, 0, 0, false, false, {"n"}, "test_parallel_for_static");
 
 static void test_parallel_for_static(const PKArgs& args) {
+  check_posonly_args(arg_test_parallel_for_static, args);
   size_t n = args[0].to_size_t();
   dttest::test_parallel_for_static(n);
 }
@@ -63,6 +86,7 @@ static PKArgs arg_test_parallel_for_dynamic(
   1, 0, 0, false, false, {"n"}, "test_parallel_for_dynamic");
 
 static void test_parallel_for_dynamic(const PKArgs& args) {
+  check_posonly_args(arg_test_parallel_for_dynamic, args);
   size_t n = args[0].to_size_t();
   dttest::test_parallel_for_dynamic(n);
   dttest::test_parallel_for_dynamic_nested(n);
@@ -73,6 +97,7 @@ static PKArgs arg_test_parallel_for_ordered(
   1, 0, 0, false, false, {"n"}, "test_parallel_for_ordered");
 
 static void test_parallel_for_ordered(const PKArgs& args) {
+  check_posonly_args(arg_test_parallel_for_ordered, args);
   size_t n = args[0].to_size_t();
   dttest::test_parallel_for_ordered(n);
 }
@@ -84,6 +109,7 @@ static PKArgs arg_test_progress_static(2, 0, 0, false, false,
   "test_progress_static");
 
 static void test_progress_static(const PKArgs& args) {
+  check_posonly_args(arg_test_progress_static, args);
   size_t n_iters = args[0].to_size_t();
   size_t n_threads = args[1].to_size_t();
   dttest::test_progress_static(n_iters, n_threads);
@@ -95,6 +121,7 @@ static PKArgs arg_test_progress_nested(2, 0, 0, false, false,
   "test_progress_nested");
 
 static void test_progress_nested(const PKArgs& args) {
+  check_posonly_args(arg_test_progress_nested, args);
   size_t n_iters = args[0].to_size_t();
   size_t n_threads = args[1].to_size_t();
   dttest::test_progress_nested(n_iters, n_threads);
@@ -106,6 +133,7 @@ static PKArgs arg_test_progress_dynamic(2, 0, 0, false, false,
   "test_progress_dynamic");
 
 static void test_progress_dynamic(const PKArgs& args) {
+  check_posonly_args(arg_test_progress_dynamic, args);
   size_t n_iters = args[0].to_size_t();
   size_t n_threads = args[1].to_size_t();
   dttest::test_progress_dynamic(n_iters, n_threads);
@@ -117,6 +145,7 @@ static PKArgs arg_test_progress_ordered(2, 0, 0, false, false,
   "test_progress_ordered");
 
 static void test_progress_ordered(const PKArgs& args) {
+  check_posonly_args(arg_test_progress_ordered, args);
   size_t n_iters = args[0].to_size_t();
   size_t n_threads = args[1].to_size_t();
   dttest::test_progress_ordered(n_iters, n_threads);

--- a/c/ztest.cc
+++ b/c/ztest.cc
@@ -20,18 +20,6 @@
 namespace py {
 
 
-/**
- * Helper function to check for missing positional arguments
- */
-static void check_posonly_args(const PKArgs& args_spec, const PKArgs& args) {
-  for (size_t i = 0; i < args_spec.num_posonly_args(); ++i) {
-    if (args[i].is_undefined()) {
-      throw ValueError() << "Positional argument " << i + 1 << " is missing";
-    }
-  }
-}
-
-
 static PKArgs arg_test_coverage(0, 0, 0, false, false, {}, "test_coverage");
 
 static void test_coverage(const PKArgs&) {
@@ -46,7 +34,7 @@ static PKArgs arg_test_shmutex(3, 0, 0, false, false,
   "test_shmutex");
 
 static void test_shmutex(const PKArgs& args) {
-  check_posonly_args(arg_test_shmutex, args);
+  args.check_required_args();
   size_t n_iters = args[0].to_size_t();
   size_t n_threads = args[1].to_size_t();
   int impl = args[2].to_int32_strict();
@@ -65,7 +53,7 @@ static PKArgs arg_test_barrier(
   1, 0, 0, false, false, {"n"}, "test_barrier");
 
 static void test_barrier(const PKArgs& args) {
-  check_posonly_args(arg_test_barrier, args);
+  args.check_required_args();
   size_t n = args[0].to_size_t();
   dttest::test_barrier(n);
 }
@@ -75,7 +63,7 @@ static PKArgs arg_test_parallel_for_static(
   1, 0, 0, false, false, {"n"}, "test_parallel_for_static");
 
 static void test_parallel_for_static(const PKArgs& args) {
-  check_posonly_args(arg_test_parallel_for_static, args);
+  args.check_required_args();
   size_t n = args[0].to_size_t();
   dttest::test_parallel_for_static(n);
 }
@@ -85,7 +73,7 @@ static PKArgs arg_test_parallel_for_dynamic(
   1, 0, 0, false, false, {"n"}, "test_parallel_for_dynamic");
 
 static void test_parallel_for_dynamic(const PKArgs& args) {
-  check_posonly_args(arg_test_parallel_for_dynamic, args);
+  args.check_required_args();
   size_t n = args[0].to_size_t();
   dttest::test_parallel_for_dynamic(n);
   dttest::test_parallel_for_dynamic_nested(n);
@@ -96,7 +84,7 @@ static PKArgs arg_test_parallel_for_ordered(
   1, 0, 0, false, false, {"n"}, "test_parallel_for_ordered");
 
 static void test_parallel_for_ordered(const PKArgs& args) {
-  check_posonly_args(arg_test_parallel_for_ordered, args);
+  args.check_required_args();
   size_t n = args[0].to_size_t();
   dttest::test_parallel_for_ordered(n);
 }
@@ -108,7 +96,7 @@ static PKArgs arg_test_progress_static(2, 0, 0, false, false,
   "test_progress_static");
 
 static void test_progress_static(const PKArgs& args) {
-  check_posonly_args(arg_test_progress_static, args);
+  args.check_required_args();
   size_t n_iters = args[0].to_size_t();
   size_t n_threads = args[1].to_size_t();
   dttest::test_progress_static(n_iters, n_threads);
@@ -120,7 +108,7 @@ static PKArgs arg_test_progress_nested(2, 0, 0, false, false,
   "test_progress_nested");
 
 static void test_progress_nested(const PKArgs& args) {
-  check_posonly_args(arg_test_progress_nested, args);
+  args.check_required_args();
   size_t n_iters = args[0].to_size_t();
   size_t n_threads = args[1].to_size_t();
   dttest::test_progress_nested(n_iters, n_threads);
@@ -132,7 +120,7 @@ static PKArgs arg_test_progress_dynamic(2, 0, 0, false, false,
   "test_progress_dynamic");
 
 static void test_progress_dynamic(const PKArgs& args) {
-  check_posonly_args(arg_test_progress_dynamic, args);
+  args.check_required_args();
   size_t n_iters = args[0].to_size_t();
   size_t n_threads = args[1].to_size_t();
   dttest::test_progress_dynamic(n_iters, n_threads);
@@ -144,7 +132,7 @@ static PKArgs arg_test_progress_ordered(2, 0, 0, false, false,
   "test_progress_ordered");
 
 static void test_progress_ordered(const PKArgs& args) {
-  check_posonly_args(arg_test_progress_ordered, args);
+  args.check_required_args();
   size_t n_iters = args[0].to_size_t();
   size_t n_threads = args[1].to_size_t();
   dttest::test_progress_ordered(n_iters, n_threads);

--- a/c/ztest.h
+++ b/c/ztest.h
@@ -50,6 +50,5 @@ void test_progress_ordered(size_t, size_t);
 
 }  // namespace dttest
 
-
 #endif
 #endif

--- a/c/ztest.h
+++ b/c/ztest.h
@@ -1,15 +1,24 @@
 //------------------------------------------------------------------------------
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright 2019 H2O.ai
 //
-// © H2O.ai 2018
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //------------------------------------------------------------------------------
 #ifndef dt_ZTEST_h
 #define dt_ZTEST_h
 #ifdef DTTEST
 #include <functional>
 #include <string>
+#include "python/args.h"
 
 namespace dttest {
 
@@ -41,6 +50,7 @@ void test_progress_dynamic(size_t, size_t);
 void test_progress_ordered(size_t, size_t);
 
 }  // namespace dttest
+
 
 #endif
 #endif

--- a/c/ztest.h
+++ b/c/ztest.h
@@ -18,7 +18,6 @@
 #ifdef DTTEST
 #include <functional>
 #include <string>
-#include "python/args.h"
 
 namespace dttest {
 

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -40,7 +40,7 @@ cpp_test = pytest.mark.skipif(not hasattr(core, "test_coverage"),
 # Test parallel infrastructure
 #-------------------------------------------------------------------------------
 
-posargs_error_message = "Positional argument 1 can not be `None` or undefined"
+posargs_error_message = "Positional argument 1 is missing"
 
 def test_multiprocessing_threadpool():
     # Verify that threads work properly after forking (#1758)

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -40,6 +40,8 @@ cpp_test = pytest.mark.skipif(not hasattr(core, "test_coverage"),
 # Test parallel infrastructure
 #-------------------------------------------------------------------------------
 
+posargs_error_message = "Positional argument 1 can not be `None` or undefined"
+
 def test_multiprocessing_threadpool():
     # Verify that threads work properly after forking (#1758)
     import multiprocessing as mp
@@ -56,6 +58,8 @@ def test_multiprocessing_threadpool():
 
 @cpp_test
 def test_internal_shared_mutex():
+    with pytest.raises(ValueError, match = posargs_error_message):
+        core.test_shmutex()
     core.test_shmutex(500, dt.options.nthreads * 2, 1)
 
 
@@ -71,21 +75,29 @@ def test_internal_atomic():
 
 @cpp_test
 def test_internal_barrier():
+    with pytest.raises(ValueError, match = posargs_error_message):
+        core.test_barrier()
     core.test_barrier(100)
 
 
 @cpp_test
 def test_internal_parallel_for_static():
+    with pytest.raises(ValueError, match = posargs_error_message):
+        core.test_parallel_for_static()
     core.test_parallel_for_static(1000)
 
 
 @cpp_test
 def test_internal_parallel_for_dynamic():
+    with pytest.raises(ValueError, match = posargs_error_message):
+        core.test_parallel_for_dynamic()
     core.test_parallel_for_dynamic(1000)
 
 
 @cpp_test
 def test_internal_parallel_for_ordered1():
+    with pytest.raises(ValueError, match = posargs_error_message):
+        core.test_parallel_for_ordered()
     core.test_parallel_for_ordered(1723)
 
 
@@ -110,6 +122,10 @@ def test_internal_parallel_for_ordered2():
 def test_progress(parallel_type, nthreads):
     niterations = 1000
     ntimes = 2
+    with pytest.raises(ValueError, match = posargs_error_message):
+        cmd = "core.test_progress_%s()" % parallel_type
+        exec(cmd)
+
     cmd = "core.test_progress_%s(%s, %s);" % (
               parallel_type, niterations, nthreads)
     for _ in range(ntimes) :

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -40,8 +40,6 @@ cpp_test = pytest.mark.skipif(not hasattr(core, "test_coverage"),
 # Test parallel infrastructure
 #-------------------------------------------------------------------------------
 
-posargs_error_message = "Positional argument 1 is missing"
-
 def test_multiprocessing_threadpool():
     # Verify that threads work properly after forking (#1758)
     import multiprocessing as mp

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -57,9 +57,31 @@ def test_multiprocessing_threadpool():
 
 
 @cpp_test
+@pytest.mark.parametrize('test_name, nargs',
+                         [
+                            ["shmutex", 3],
+                            ["barrier", 1],
+                            ["parallel_for_static", 1],
+                            ["parallel_for_dynamic", 1],
+                            ["parallel_for_ordered", 1],
+                            ["progress_static", 2],
+                            ["progress_nested", 2],
+                            ["progress_dynamic", 2],
+                            ["progress_ordered", 2]
+                         ]
+                        )
+def test_parameters(test_name, nargs):
+    for i in range(nargs - 1):
+        args = list(range(i))
+        message = ("In %s the number of arguments required is %d, "
+                   "got: %d" % ("test_" + test_name + r"\(\)", nargs, i))
+        with pytest.raises(ValueError, match = message):
+            testfn = "test_%s" % test_name
+            getattr(core, testfn)(*args)
+
+
+@cpp_test
 def test_internal_shared_mutex():
-    with pytest.raises(ValueError, match = posargs_error_message):
-        core.test_shmutex()
     core.test_shmutex(500, dt.options.nthreads * 2, 1)
 
 
@@ -75,29 +97,21 @@ def test_internal_atomic():
 
 @cpp_test
 def test_internal_barrier():
-    with pytest.raises(ValueError, match = posargs_error_message):
-        core.test_barrier()
     core.test_barrier(100)
 
 
 @cpp_test
 def test_internal_parallel_for_static():
-    with pytest.raises(ValueError, match = posargs_error_message):
-        core.test_parallel_for_static()
     core.test_parallel_for_static(1000)
 
 
 @cpp_test
 def test_internal_parallel_for_dynamic():
-    with pytest.raises(ValueError, match = posargs_error_message):
-        core.test_parallel_for_dynamic()
     core.test_parallel_for_dynamic(1000)
 
 
 @cpp_test
 def test_internal_parallel_for_ordered1():
-    with pytest.raises(ValueError, match = posargs_error_message):
-        core.test_parallel_for_ordered()
     core.test_parallel_for_ordered(1723)
 
 
@@ -122,10 +136,6 @@ def test_internal_parallel_for_ordered2():
 def test_progress(parallel_type, nthreads):
     niterations = 1000
     ntimes = 2
-    with pytest.raises(ValueError, match = posargs_error_message):
-        cmd = "core.test_progress_%s()" % parallel_type
-        exec(cmd)
-
     cmd = "core.test_progress_%s(%s, %s);" % (
               parallel_type, niterations, nthreads)
     for _ in range(ntimes) :


### PR DESCRIPTION
Even though we do not expect users to call internal `datatable.lib.core` C++ tests, they should not segfault when called with missing arguments. In this PR we add a `PKArgs::check_required_args()` method that checks if the required arguments are missing and improve`test_parallel.py` to make sure C++ tests do not segfault.