### PR TITLE
Make module name be compatible with PyInit__datatable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ mrproper: clean
 
 build:
 	$(PYTHON) setup.py build
-	cp build/lib.*/datatable/lib/_datatable.* datatable/lib/
+	cp build/lib.*/_datatable.* datatable/lib/
 
 
 install:

--- a/c/column/sentinel_fw.cc
+++ b/c/column/sentinel_fw.cc
@@ -185,6 +185,7 @@ size_t SentinelFw_ColumnImpl<T>::get_num_data_buffers() const noexcept {
 template <typename T>
 bool SentinelFw_ColumnImpl<T>::is_data_editable(size_t k) const {
   xassert(k == 0);
+  (void) k;
   return mbuf_.is_writable();
 }
 
@@ -192,6 +193,7 @@ bool SentinelFw_ColumnImpl<T>::is_data_editable(size_t k) const {
 template <typename T>
 size_t SentinelFw_ColumnImpl<T>::get_data_size(size_t k) const {
   xassert(k == 0);
+  (void) k;
   xassert(mbuf_.size() >= nrows_ * sizeof(T));
   return nrows_ * sizeof(T);
 }
@@ -200,6 +202,7 @@ size_t SentinelFw_ColumnImpl<T>::get_data_size(size_t k) const {
 template <typename T>
 const void* SentinelFw_ColumnImpl<T>::get_data_readonly(size_t k) const {
   xassert(k == 0);
+  (void) k;
   return mbuf_.rptr();
 }
 
@@ -207,6 +210,7 @@ const void* SentinelFw_ColumnImpl<T>::get_data_readonly(size_t k) const {
 template <typename T>
 void* SentinelFw_ColumnImpl<T>::get_data_editable(size_t k) {
   xassert(k == 0);
+  (void) k;
   return mbuf_.wptr();
 }
 
@@ -214,6 +218,7 @@ void* SentinelFw_ColumnImpl<T>::get_data_editable(size_t k) {
 template <typename T>
 Buffer SentinelFw_ColumnImpl<T>::get_data_buffer(size_t k) const {
   xassert(k == 0);
+  (void) k;
   return Buffer(mbuf_);
 }
 

--- a/setup.py
+++ b/setup.py
@@ -222,7 +222,7 @@ setuptools.setup(
 
     ext_modules=[
         setuptools.Extension(
-            "datatable/lib/_datatable",
+            "_datatable",
             include_dirs=["c", "include"],
             sources=cpp_files,
             extra_compile_args=extra_compile_args,


### PR DESCRIPTION
For some reason `setuptools.Extension` in `setup.py` was using `datatable/lib/_datatable` as the module name, as a consequence, this name was not compatible with the `PyInit__datatable` function name following by the msvc linker error. In this PR we fix it and also suppress several "unused variable" warnings.
  
WIP for #1369