### PR TITLE
Add <algorithm> includes

### DIFF
--- a/c/frame/repr/text_column.cc
+++ b/c/frame/repr/text_column.cc
@@ -19,6 +19,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
+#include <algorithm>                  // std::min, std::max
 #include "frame/repr/repr_options.h"
 #include "frame/repr/text_column.h"
 #include "utils/assert.h"

--- a/c/models/dt_ftrl.cc
+++ b/c/models/dt_ftrl.cc
@@ -19,6 +19,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
+#include <algorithm>            // std::max
 #include "frame/py_frame.h"
 #include "models/dt_ftrl.h"
 #include "parallel/api.h"

--- a/c/progress/progress_bar.cc
+++ b/c/progress/progress_bar.cc
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //------------------------------------------------------------------------------
+#include <algorithm>                // std::max
 #include "progress/_options.h"
 #include "progress/progress_bar.h"
 #include "python/string.h"          // py::ostring

--- a/c/python/args.cc
+++ b/c/python/args.cc
@@ -19,7 +19,8 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
-#include <cstring>             // std::strrchr
+#include <algorithm>       // std::min
+#include <cstring>         // std::strrchr
 #include "python/args.h"
 #include "utils/assert.h"
 

--- a/c/writebuf.cc
+++ b/c/writebuf.cc
@@ -5,10 +5,11 @@
 //
 // © H2O.ai 2018
 //------------------------------------------------------------------------------
-#include <cstring>     // std::memcpy
-#include <errno.h>     // errno
-#include <sys/mman.h>  // mmap
-#include <unistd.h>    // write
+#include <algorithm>       // std::min
+#include <cstring>         // std::memcpy
+#include <errno.h>         // errno
+#include <sys/mman.h>      // mmap
+#include <unistd.h>        // write
 #include "utils/alloc.h"   // dt::realloc
 #include "utils/assert.h"
 #include "utils/misc.h"


### PR DESCRIPTION
Standard header includes are slightly different on Windows, so in some files where we use `std::min` or `std::max` we need to explicitly include `<algorithm>`, otherwise compilation fails.

WIP for #1369