### PR TITLE
Move monitor thread from idle_job to thread_pool

### DIFF
--- a/c/parallel/monitor_thread.cc
+++ b/c/parallel/monitor_thread.cc
@@ -23,7 +23,6 @@
 #include "progress/progress_manager.h"  // dt::progress::progress_manager
 #include "utils/exceptions.h"
 #include "parallel/api.h"
-#include "utils/macros.h"
 
 
 namespace dt {

--- a/c/parallel/monitor_thread.cc
+++ b/c/parallel/monitor_thread.cc
@@ -17,15 +17,13 @@
 #define _XOPEN_SOURCE
 #include <iostream>
 #include <csignal> // std::signal
+#include <unistd.h>
 #include "parallel/monitor_thread.h"
 #include "parallel/thread_worker.h"     // idle_job
 #include "progress/progress_manager.h"  // dt::progress::progress_manager
 #include "utils/exceptions.h"
 #include "parallel/api.h"
 #include "utils/macros.h"
-#if !DT_OS_WINDOWS
-  #include <unistd.h>        // nice
-#endif
 
 
 namespace dt {
@@ -52,15 +50,13 @@ monitor_thread::~monitor_thread() {
 void monitor_thread::run() noexcept {
   sigint_handler_prev = std::signal(SIGINT, sigint_handler);
   constexpr auto SLEEP_TIME = std::chrono::milliseconds(20);
-  #if !DT_OS_WINDOWS
-    // Reduce this thread's priority to a minimum.
-    // See http://man7.org/linux/man-pages/man2/nice.2.html
-    int ret = nice(+19);
-    if (ret == -1) {
-      std::cout << "[errno " << errno << "] "
-                << "when setting nice value of monitor thread\n";
-    }
-  #endif
+  // Reduce this thread's priority to a minimum.
+  // See http://man7.org/linux/man-pages/man2/nice.2.html
+  int ret = nice(+19);
+  if (ret == -1) {
+    std::cout << "[errno " << errno << "] "
+              << "when setting nice value of monitor thread\n";
+  }
   _set_thread_num(size_t(-1));
 
   std::unique_lock<std::mutex> lock(mutex);

--- a/c/parallel/monitor_thread.cc
+++ b/c/parallel/monitor_thread.cc
@@ -17,12 +17,17 @@
 #define _XOPEN_SOURCE
 #include <iostream>
 #include <csignal> // std::signal
-#include <unistd.h>
 #include "parallel/monitor_thread.h"
 #include "parallel/thread_worker.h"     // idle_job
 #include "progress/progress_manager.h"  // dt::progress::progress_manager
 #include "utils/exceptions.h"
 #include "parallel/api.h"
+#include "utils/macros.h"
+#if !DT_OS_WINDOWS
+  #include <unistd.h>        // nice
+#endif
+
+
 namespace dt {
 
 using sig_handler_t = void(*)(int);
@@ -47,13 +52,15 @@ monitor_thread::~monitor_thread() {
 void monitor_thread::run() noexcept {
   sigint_handler_prev = std::signal(SIGINT, sigint_handler);
   constexpr auto SLEEP_TIME = std::chrono::milliseconds(20);
-  // Reduce this thread's priority to a minimum.
-  // See http://man7.org/linux/man-pages/man2/nice.2.html
-  int ret = nice(+19);
-  if (ret == -1) {
-    std::cout << "[errno " << errno << "] "
-              << "when setting nice value of monitor thread\n";
-  }
+  #if !DT_OS_WINDOWS
+    // Reduce this thread's priority to a minimum.
+    // See http://man7.org/linux/man-pages/man2/nice.2.html
+    int ret = nice(+19);
+    if (ret == -1) {
+      std::cout << "[errno " << errno << "] "
+                << "when setting nice value of monitor thread\n";
+    }
+  #endif
   _set_thread_num(size_t(-1));
 
   std::unique_lock<std::mutex> lock(mutex);

--- a/c/parallel/parallel_for_static.h
+++ b/c/parallel/parallel_for_static.h
@@ -25,7 +25,6 @@ namespace dt {
 size_t this_thread_index();
 size_t num_threads_in_pool();
 size_t num_threads_in_team();
-bool is_monitor_enabled() noexcept;
 
 
 /**

--- a/c/parallel/thread_pool.cc
+++ b/c/parallel/thread_pool.cc
@@ -160,8 +160,7 @@ void thread_pool::enable_monitor(bool a) noexcept {
 
 
 bool thread_pool::is_monitor_enabled() noexcept {
-  init_monitor_thread();
-  return monitor->get_active();
+  return monitor? monitor->get_active() : false;
 }
 
 

--- a/c/parallel/thread_pool.cc
+++ b/c/parallel/thread_pool.cc
@@ -14,7 +14,6 @@
 // limitations under the License.
 //------------------------------------------------------------------------------
 #include <thread>      // std::thread::hardware_concurrency
-#include <pthread.h>   // pthread_atfork
 #include "parallel/api.h"
 #include "parallel/thread_pool.h"
 #include "parallel/thread_team.h"
@@ -23,6 +22,12 @@
 #include "python/_all.h"
 #include "utils/assert.h"
 #include "options.h"
+#include "utils/macros.h"
+#if !DT_OS_WINDOWS
+  #include <pthread.h>   // pthread_atfork
+#endif
+
+
 namespace dt {
 
 
@@ -45,16 +50,22 @@ static void _child_cleanup_after_fork() {
 //------------------------------------------------------------------------------
 // thread_pool
 //------------------------------------------------------------------------------
-static bool after_fork_handler_registered = false;
+#if !DT_OS_WINDOWS
+  // no fork on Windows
+  static bool after_fork_handler_registered = false;
+#endif
 
 thread_pool::thread_pool()
   : num_threads_requested(0),
     current_team(nullptr)
 {
+#if !DT_OS_WINDOWS
+  // no fork on Windows
   if (!after_fork_handler_registered) {
     pthread_atfork(nullptr, nullptr, _child_cleanup_after_fork);
     after_fork_handler_registered = true;
   }
+#endif
 }
 
 // In the current implementation the thread_pool instance never gets deleted
@@ -78,6 +89,7 @@ void thread_pool::resize(size_t n) {
 
 void thread_pool::instantiate_threads() {
   size_t n = num_threads_requested;
+  init_monitor_thread();
   if (workers.size() == n) return;
   if (workers.size() < n) {
     workers.reserve(n);
@@ -108,6 +120,15 @@ void thread_pool::instantiate_threads() {
 }
 
 
+void thread_pool::init_monitor_thread() noexcept {
+  if (!monitor) {
+    monitor = std::unique_ptr<monitor_thread>(
+                new monitor_thread(&controller)
+              );
+  }
+}
+
+
 void thread_pool::execute_job(thread_scheduler* job) {
   xassert(current_team);
   if (workers.empty()) instantiate_threads();
@@ -132,28 +153,33 @@ thread_team* thread_pool::get_team_unchecked() noexcept {
 }
 
 
-void thread_pool::enable_monitor(bool a) const noexcept {
-  controller.enable_monitor(a);
+void thread_pool::enable_monitor(bool a) noexcept {
+  init_monitor_thread();
+  monitor->set_active(a);
 }
 
 
-bool thread_pool::is_monitor_enabled() const noexcept {
-  return controller.is_monitor_enabled();
+bool thread_pool::is_monitor_enabled() noexcept {
+  init_monitor_thread();
+  return monitor->get_active();
+}
+
+
+//------------------------------------------------------------------------------
+// Monitor thread control.
+//------------------------------------------------------------------------------
+void enable_monitor(bool a) noexcept {
+  thpool->enable_monitor(a);
+}
+
+bool is_monitor_enabled() noexcept {
+  return thpool->is_monitor_enabled();
 }
 
 
 //------------------------------------------------------------------------------
 // Misc
 //------------------------------------------------------------------------------
-
-bool is_monitor_enabled() noexcept {
-  return thpool->is_monitor_enabled();
-}
-
-void enable_monitor(bool a) noexcept {
-  thpool->enable_monitor(a);
-}
-
 size_t num_threads_in_pool() {
   return thpool->size();
 }
@@ -184,7 +210,7 @@ size_t get_hardware_concurrency() noexcept {
 
 
 std::mutex& python_mutex() {
-  return thpool->controller.monitor->mutex;
+  return thpool->monitor->mutex;
 }
 
 

--- a/c/parallel/thread_pool.h
+++ b/c/parallel/thread_pool.h
@@ -47,6 +47,9 @@ class thread_team;
 class thread_pool {
   friend class thread_team;
   friend std::mutex& python_mutex();
+  public:
+    std::unique_ptr<monitor_thread> monitor;
+
   private:
     // Worker instances, each running on its own thread. Each thread has a
     // reference to its own worker, so these workers must be alive as long
@@ -76,6 +79,9 @@ class thread_pool {
     // TODO: merge thread_team functionality into the pool?
     thread_team* current_team;
 
+    // Create the monitor thread, if it was not created yet.
+    void init_monitor_thread() noexcept;
+
   public:
     thread_pool();
     thread_pool(const thread_pool&) = delete;
@@ -83,6 +89,7 @@ class thread_pool {
     thread_pool(thread_pool&&) = delete;
 
     static thread_team* get_team_unchecked() noexcept;
+
 
     void instantiate_threads();
     void execute_job(thread_scheduler*);
@@ -92,8 +99,10 @@ class thread_pool {
 
     bool in_parallel_region() const noexcept;
     size_t n_threads_in_team() const noexcept;
-    void enable_monitor(bool) const noexcept;
-    bool is_monitor_enabled() const noexcept;
+
+    // Monitor thread control.
+    void enable_monitor(bool) noexcept;
+    bool is_monitor_enabled() noexcept;
 
     static void init_options();
 };

--- a/c/parallel/thread_worker.h
+++ b/c/parallel/thread_worker.h
@@ -148,8 +148,6 @@ class idle_job : public thread_scheduler {
     // Thread-worker object corresponding to the master thread.
     thread_worker* master_worker;
 
-    std::unique_ptr<monitor_thread> monitor;
-
   public:
     idle_job();
 
@@ -183,8 +181,6 @@ class idle_job : public thread_scheduler {
     // This callback should be called before a thread is removed from the
     // threadpool.
     void on_before_thread_removed();
-    void enable_monitor(bool) const noexcept;
-    bool is_monitor_enabled() const noexcept;
 };
 
 


### PR DESCRIPTION
Creating monitor thread on the datatable import causes a deadlock on Windows, see this [discussion](https://stackoverflow.com/questions/32252143/stdthread-cause-deadlock-in-dllmain) for more details. In fact, we don't really need the monitor thread being available right after the `import datatable`, so its creation can be easily postponed. 

In this PR we 
- move the monitor handler from `idle_job` to `thread_pool` class, and create the monitor thread only when it is needed by datatable;
- disable fork related code on Windows, because there is no fork mechanism there.

WIP for #1369