### PR TITLE
Use portable implementation of std::isfinite in FTRL

### DIFF
--- a/c/column/func_unary.h
+++ b/c/column/func_unary.h
@@ -110,6 +110,9 @@ ColumnImpl* FuncUnary1_ColumnImpl<TI, TO>::clone() const {
 }
 
 
+/**
+ * Portable implementation of !std::isnan.
+ */
 template <typename T> inline bool _notnan(T) { return true; }
 template <> inline bool _notnan(float x) { return !std::isnan(x); }
 template <> inline bool _notnan(double x) { return !std::isnan(x); }

--- a/c/models/dt_ftrl.cc
+++ b/c/models/dt_ftrl.cc
@@ -614,7 +614,7 @@ FtrlFitOutput Ftrl<T>::fit(T(*linkfn)(T),
           U value;
           bool isvalid = target_col0_train.get_element(ii, &value);
 
-          if (isvalid && std::isfinite(value)) {
+          if (isvalid && _isfinite(value)) {
             hash_row(x, hashers, ii);
             for (size_t k = 0; k < label_ids_train.size(); ++k) {
               T p = linkfn(predict_row(
@@ -650,7 +650,7 @@ FtrlFitOutput Ftrl<T>::fit(T(*linkfn)(T),
             V value;
             bool isvalid = target_col0_val.get_element(i, &value);
 
-            if (isvalid && std::isfinite(value)) {
+            if (isvalid && _isfinite(value)) {
               hash_row(x, hashers_val, i);
               for (size_t k = 0; k < label_ids_val.size(); ++k) {
                 T p = linkfn(predict_row(

--- a/c/models/utils.h
+++ b/c/models/utils.h
@@ -96,4 +96,12 @@ inline T1 squared_loss(T1 p, T2 y) {
   return (p - y_T1) * (p - y_T1);
 }
 
+
+/**
+ *  Portable implementation of std::isfinite.
+ */
+template <typename T> inline bool _isfinite(T) { return true; }
+template <> inline bool _isfinite(float x) { return std::isfinite(x); }
+template <> inline bool _isfinite(double x) { return std::isfinite(x); }
+
 #endif

--- a/c/stats.cc
+++ b/c/stats.cc
@@ -733,8 +733,8 @@ void NumericStats<T>::compute_moments12() {
         sum += t_sum;
         mean += delta21 * n2 / n;
         M2 += t_M2 + delta21 * delta21 * n1 / n * n2;
-        has_pos_inf += t_has_pos_inf;
-        has_neg_inf += t_has_neg_inf;
+        has_pos_inf |= t_has_pos_inf;
+        has_neg_inf |= t_has_neg_inf;
       }
     });
 


### PR DESCRIPTION
- add and use portable implementation of `std::isfinite` in FTRL. ND: on Windows `std::isfinite` and `std::isnan` are only supported for `float` and `double` types;
- replace `+=` with `|=` for boolean variables in `stats.cc` that were causing warnings on WIndows.

WIP for #1369