### PR TITLE
Do not use designated struct initializers

### DIFF
--- a/c/csv/reader_fread.cc
+++ b/c/csv/reader_fread.cc
@@ -43,21 +43,22 @@ FreadReader::~FreadReader() {}
 dt::read::FreadTokenizer FreadReader::makeTokenizer(
     dt::read::field64* target, const char* anchor) const
 {
-  return {
-    .ch = nullptr,
-    .target = target,
-    .anchor = anchor,
-    .eof = eof,
-    .NAstrings = na_strings,
-    .whiteChar = whiteChar,
-    .dec = dec,
-    .sep = sep,
-    .quote = quote,
-    .quoteRule = quoteRule,
-    .strip_whitespace = strip_whitespace,
-    .blank_is_na = blank_is_na,
-    .cr_is_newline = cr_is_newline,
-  };
+  dt::read::FreadTokenizer res;
+  res.ch = nullptr;
+  res.target = target;
+  res.anchor = anchor;
+  res.eof = eof;
+  res.NAstrings = na_strings;
+  res.whiteChar = whiteChar;
+  res.dec = dec;
+  res.sep = sep;
+  res.quote = quote;
+  res.quoteRule = quoteRule;
+  res.strip_whitespace = strip_whitespace;
+  res.blank_is_na = blank_is_na;
+  res.cr_is_newline = cr_is_newline;
+
+  return res;
 }
 
 

--- a/c/python/obj.cc
+++ b/c/python/obj.cc
@@ -49,6 +49,11 @@ static void init_numpy();
 // Set from datatablemodule.cc
 PyObject* Expr_Type = nullptr;
 
+// `_Py_static_string_init` invoked by the `_Py_IDENTIFIER` uses
+// a designated initializer, that is not supported by the C++11 standard.
+// Redefine `_Py_static_string_init` here to use a regular initializer.
+#undef _Py_static_string_init
+#define _Py_static_string_init(value) { NULL, value, NULL }
 _Py_IDENTIFIER(stdin);
 _Py_IDENTIFIER(stdout);
 _Py_IDENTIFIER(write);


### PR DESCRIPTION
Designated struct initializers are not a part of the C++11 standard, so in this PR we redefine the CPython `_Py_static_string_init` macro and adjust datatable code to use other means for struct initialization.

WIP for #1369