### PR TITLE
New function: shift()

### DIFF
--- a/c/column/shift.h
+++ b/c/column/shift.h
@@ -1,0 +1,146 @@
+//------------------------------------------------------------------------------
+// Copyright 2019 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#ifndef dt_COLUMN_NAFILLED_h
+#define dt_COLUMN_NAFILLED_h
+#include <memory>
+#include "column/virtual.h"
+namespace dt {
+
+
+/**
+  * Virtual column representing the column `arg_` shifted by a
+  * certain number of observation forward (if LAG is true), or
+  * backward (if LAG is false).
+  *
+  * The observations at the beginning/end of the shifted region are
+  * filled with NAs.
+  */
+template <bool LAG>
+class Shift_ColumnImpl : public Virtual_ColumnImpl {
+  private:
+    Column arg_;
+    size_t shift_;
+
+  public:
+    Shift_ColumnImpl(Column&& col, size_t shift, size_t nrows)
+      : Virtual_ColumnImpl(nrows, col.stype()),
+        arg_(std::move(col)),
+        shift_(shift) {}
+
+    ColumnImpl* clone() const override {
+      return new Shift_ColumnImpl<LAG>(Column(arg_), shift_, nrows_);
+    }
+
+    bool allow_parallel_access() const override {
+      return arg_.allow_parallel_access();
+    }
+
+
+    bool get_element(size_t i, int8_t* out)   const override { return _elem(i, out); }
+    bool get_element(size_t i, int16_t* out)  const override { return _elem(i, out); }
+    bool get_element(size_t i, int32_t* out)  const override { return _elem(i, out); }
+    bool get_element(size_t i, int64_t* out)  const override { return _elem(i, out); }
+    bool get_element(size_t i, float* out)    const override { return _elem(i, out); }
+    bool get_element(size_t i, double* out)   const override { return _elem(i, out); }
+    bool get_element(size_t i, CString* out)  const override { return _elem(i, out); }
+    bool get_element(size_t i, py::robj* out) const override { return _elem(i, out); }
+
+  private:
+    template <typename T>
+    inline bool _elem(size_t i, T* out) {
+      if (LAG) {
+        if (i < shift_) return false;
+        return arg_.get_element(i - shift_, out);
+      } else {
+        if (i >= nrows_ - shift_) return false;
+        return arg_.get_element(i + shift_, out);
+      }
+    }
+};
+
+
+
+
+/**
+  * Similar to `Shift_ColumnImpl`, but instead of missing values at
+  * the end of the range, this column substitutes a specific "fill"
+  * value.
+  */
+template <bool LAG>
+class ShiftWithFill_ColumnImpl : public Virtual_ColumnImpl {
+  private:
+    Column arg_;
+    Column fill_;
+    size_t shift_;
+
+  public:
+    ShiftWithFill_ColumnImpl(Column&& col, Column&& fill, size_t shift,
+                             size_t nrows)
+      : Virtual_ColumnImpl(nrows, col.stype()),
+        arg_(std::move(col)),
+        fill_(std::move(fill)),
+        shift_(shift)
+    {
+      xassert(shift_ > 0);
+      xassert(arg_.stype() == fill_.stype());
+      // Note: we could easily add support for `fill_` having `shift_` rows
+      // as well.
+      xassert(fill_.nrows() == 1);
+    }
+
+    ColumnImpl* clone() const override {
+      return new ShiftWithFill_ColumnImpl<LAG>(
+                  Column(arg_), Column(fill_), shift_, nrows_);
+    }
+
+    bool allow_parallel_access() const override {
+      return arg_.allow_parallel_access();
+    }
+
+
+    bool get_element(size_t i, int8_t* out)   const override { return _elem(i, out); }
+    bool get_element(size_t i, int16_t* out)  const override { return _elem(i, out); }
+    bool get_element(size_t i, int32_t* out)  const override { return _elem(i, out); }
+    bool get_element(size_t i, int64_t* out)  const override { return _elem(i, out); }
+    bool get_element(size_t i, float* out)    const override { return _elem(i, out); }
+    bool get_element(size_t i, double* out)   const override { return _elem(i, out); }
+    bool get_element(size_t i, CString* out)  const override { return _elem(i, out); }
+    bool get_element(size_t i, py::robj* out) const override { return _elem(i, out); }
+
+  private:
+    template <typename T>
+    inline bool _elem(size_t i, T* out) {
+      if (LAG) {
+        return (i < shift_)? fill_.get_element(0, out)
+                           : arg_.get_element(i - shift_, out);
+      } else {
+        return (i >= nrows_ - shift_)? fill_.get_element(0, out)
+                                     : arg_.get_element(i + shift_, out);
+      }
+    }
+};
+
+
+
+
+}  // namespace dt
+#endif

--- a/c/column/shift.h
+++ b/c/column/shift.h
@@ -66,7 +66,7 @@ class Shift_ColumnImpl : public Virtual_ColumnImpl {
 
   private:
     template <typename T>
-    inline bool _elem(size_t i, T* out) {
+    inline bool _elem(size_t i, T* out) const {
       if (LAG) {
         if (i < shift_) return false;
         return arg_.get_element(i - shift_, out);

--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -1,9 +1,23 @@
 //------------------------------------------------------------------------------
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright 2018-2019 H2O.ai
 //
-// © H2O.ai 2018-2019
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #include <exception>       // std::exception
 #include <iostream>        // std::cerr
@@ -340,6 +354,7 @@ void py::DatatableModule::init_methods() {
   init_methods_rbind();
   init_methods_repeat();
   init_methods_sets();
+  init_methods_shift();
   init_methods_str();
   init_methods_styles();
   init_methods_zread();

--- a/c/datatablemodule.h
+++ b/c/datatablemodule.h
@@ -42,6 +42,7 @@ class DatatableModule : public ExtModule<DatatableModule> {
     void init_methods_rbind();     // frame/rbind.cc
     void init_methods_repeat();    // frame/repeat.cc
     void init_methods_sets();      // set_funcs.cc
+    void init_methods_shift();     // expr/head_func_shift.cc
     void init_methods_str();       // str/py_str.cc
     void init_methods_styles();    // frame/repr/html_styles.cc
     void init_casts();             // frame/cast.cc

--- a/c/expr/head_func.cc
+++ b/c/expr/head_func.cc
@@ -168,6 +168,7 @@ void Head_Func::init() {
   factory[static_cast<size_t>(Op::CAST)]     = make_cast;
   factory[static_cast<size_t>(Op::SETPLUS)]  = make_colsetop;
   factory[static_cast<size_t>(Op::SETMINUS)] = make_colsetop;
+  factory[static_cast<size_t>(Op::SHIFTFN)]  = &Head_Func_Shift::make;
   factory[static_cast<size_t>(Op::COUNT0)]   = make_reduce0;
   factory[static_cast<size_t>(Op::COV)]      = make_reduce2;
   factory[static_cast<size_t>(Op::CORR)]     = make_reduce2;

--- a/c/expr/head_func.h
+++ b/c/expr/head_func.h
@@ -129,6 +129,20 @@ class Head_Func_Nary : public Head_Func {
 
 
 
+class Head_Func_Shift : public Head_Func {
+  private:
+    int shift_;
+    int : 32;
+
+  public:
+    static ptrHead make(Op, const py::otuple& params);
+
+    Head_Func_Shift(int shift);
+    Workframe evaluate_n(const vecExpr&, EvalContext&) const override;
+};
+
+
+
 
 }}  // namespace dt::expr
 #endif

--- a/c/expr/head_func_shift.cc
+++ b/c/expr/head_func_shift.cc
@@ -19,15 +19,121 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
-#include "expr/op.h"
-#include "expr/declarations.h"
+#include "column/shift.h"
+#include "expr/eval_context.h"
+#include "expr/expr.h"
+#include "expr/head_func.h"
+#include "expr/workframe.h"
+#include "frame/py_frame.h"
+#include "parallel/api.h"
 #include "python/obj.h"
+#include "datatablemodule.h"
+#include "groupby.h"
+#include "rowindex.h"
 namespace dt {
 namespace expr {
 
 
+
+
+template <bool LAG>
+static RowIndex compute_lag_rowindex(const Groupby& groupby, int shift) {
+  xassert(shift > 0);
+  arr32_t arr_indices(groupby.last_offset());
+  int32_t* indices = arr_indices.data();
+
+  auto group_offsets = groupby.offsets_r();
+  dt::parallel_for_dynamic(
+    groupby.size(),
+    [&](size_t i) {
+      int32_t j0 = group_offsets[i];
+      int32_t j2 = group_offsets[i + 1];
+      int32_t j = j0;
+      if (LAG) {
+        int32_t j1 = std::min(j2, j0 + shift);
+        for (; j < j1; ++j) indices[j] = -1;
+        for (; j < j2; ++j) indices[j] = j - shift;
+      } else {
+        int32_t j1 = std::max(j0, j2 - shift);
+        for (; j < j1; ++j) indices[j] = j + shift;
+        for (; j < j2; ++j) indices[j] = -1;
+      }
+    });
+
+  return RowIndex(std::move(arr_indices), true);
+}
+
+
+
+
+//------------------------------------------------------------------------------
+// Head_Func_Shift
+//------------------------------------------------------------------------------
+
+Head_Func_Shift::Head_Func_Shift(int shift)
+  : shift_(shift) {}
+
+
+ptrHead Head_Func_Shift::make(Op, const py::otuple& params) {
+  xassert(params.size() == 1);
+  int shift = params[0].to_int32_strict();
+  return ptrHead(new Head_Func_Shift(shift));
+}
+
+
+
+Workframe Head_Func_Shift::evaluate_n(
+            const vecExpr& args, EvalContext& ctx) const
+{
+  xassert(args.size() == 1);
+  Workframe inputs = args[0].evaluate_n(ctx);
+  if (shift_ == 0) {
+    // do nothing
+  }
+  else if (ctx.has_groupby()) {
+    inputs.increase_grouping_mode(Grouping::GtoALL);
+    const Groupby& groupby = ctx.get_groupby();
+    // TODO: memoize this object within ctx
+    RowIndex ri = shift_ > 0 ? compute_lag_rowindex<true>(groupby, shift_)
+                             : compute_lag_rowindex<false>(groupby, -shift_);
+    for (size_t i = 0; i < inputs.ncols(); ++i) {
+      Column coli = inputs.retrieve_column(i);
+      coli.apply_rowindex(ri);
+      inputs.replace_column(i, std::move(coli));
+    }
+  }
+  else {
+    for (size_t i = 0; i < inputs.ncols(); ++i) {
+      Column coli = inputs.retrieve_column(i);
+      size_t nrows = coli.nrows();
+      // coli.apply_rowindex(ri);
+      if (shift_ > 0) {
+        coli = Column(new Shift_ColumnImpl<true>(
+                        std::move(coli), static_cast<size_t>(shift_), nrows));
+      } else {
+        coli = Column(new Shift_ColumnImpl<false>(
+                        std::move(coli), static_cast<size_t>(-shift_), nrows));
+      }
+      inputs.replace_column(i, std::move(coli));
+    }
+  }
+  return inputs;
+}
+
+
+
+
+}}  // dt::expr
+
+
+//------------------------------------------------------------------------------
+// Python interface
+//------------------------------------------------------------------------------
+namespace py {
+
+
 static const char* doc_shift =
-R"(shift(col, n=1, fill=None)
+R"(shift(col, n=1)
 --
 
 Produce a column obtained from `col` shifting it  `n` rows forward.
@@ -37,16 +143,33 @@ a "lag" column is created, if negative it will be a "lead" column.
 
 The shifted column will have the same number of rows as the original
 column, with `n` observations in the beginning becoming missing, and
-`n` observations at the end discarded. If parameter `fill` is given,
-then the missing observations at the beginning will be filled with
-the provided value.
+`n` observations at the end discarded.
 
 This function is group-aware, i.e. in the presence of a groupby it
 will perform the shift separately within each group.
 )";
 
-py::PKArgs args_shift(
-    1, 1, 1, false, false, {"col", "n", "fill"}, "shift", doc_shift);
+static PKArgs args_shift(
+    1, 1, 0, false, false, {"col", "n"}, "shift", doc_shift);
+
+
+
+static oobj make_pyexpr(dt::expr::Op opcode, otuple targs, otuple tparams) {
+  size_t op = static_cast<size_t>(opcode);
+  return robj(Expr_Type).call({ oint(op), targs, tparams });
+}
+
+static oobj _shift_frame(oobj arg, int n) {
+  auto slice_all = oslice(oslice::NA, oslice::NA, oslice::NA);
+  auto f_all = make_pyexpr(dt::expr::Op::COL,
+                           otuple{ slice_all },
+                           otuple{ oint(0) });
+  auto shiftexpr = make_pyexpr(dt::expr::Op::SHIFTFN,
+                               otuple{ f_all },
+                               otuple{ oint(n) });
+  auto frame = static_cast<Frame*>(arg.to_borrowed_ref());
+  return frame->m__getitem__(otuple{ slice_all, shiftexpr });
+}
 
 
 /**
@@ -55,39 +178,32 @@ py::PKArgs args_shift(
   * python scalar, or an f-expression, or a Frame (in which case the
   * function is applied to all elements of the frame).
   */
-py::oobj pyfn_shift(const py::PKArgs& args)
+static oobj pyfn_shift(const PKArgs& args)
 {
-  const py::Arg& arg_col = args[0];
-  const py::Arg& arg_n = args[1];
-  const py::Arg& arg_fill = args[2];
+  int32_t n = args[1].to<int32_t>(1);
+  if (args[0].is_none_or_undefined()) {
+    throw TypeError() << "Function `shift()` requires 1 positional argument, "
+                         "but none were given";
+  }
+  oobj arg0 = args[0].to_oobj();
+  if (arg0.is_frame()) {
+    return _shift_frame(arg0, n);
+  }
+  if (arg0.is_dtexpr()) {
+    return make_pyexpr(dt::expr::Op::SHIFTFN,
+                       otuple{ arg0 }, otuple{ oint(n) });
+  }
+  throw TypeError() << "The first argument to `shift()` must be a column "
+      "expression or a Frame, instead got " << arg0.typeobj();
+}
 
-  // n
-  int shift_amount = arg_n.to<int32_t>(1);
 
 
-  // py::robj x = args[0].to_robj();
-  // if (x.is_dtexpr()) {
-  //   return make_pyexpr(opcode, x);
-  // }
-  // if (x.is_frame()) {
-  //   return process_frame(opcode, x);
-  // }
-  // if (x.is_int())   return unaryop(opcode, x.to_int64_strict());
-  // if (x.is_float()) return unaryop(opcode, x.to_double());
-  // if (x.is_none())  return unaryop(opcode, nullptr);
-  // if (x.is_bool())  return unaryop(opcode, static_cast<bool>(x.to_bool_strict()));
-  // if (x.is_string())return unaryop(opcode, x.to_cstring());
-  // if (!x) {
-  //   throw TypeError() << "Function `" << args.get_short_name() << "()` takes "
-  //       "exactly one argument, 0 given";
-  // }
-  // throw TypeError() << "Function `" << args.get_short_name() << "()` cannot "
-  //     "be applied to an argument of type " << x.typeobj();
+void DatatableModule::init_methods_shift() {
+  ADD_FN(&pyfn_shift, args_shift);
 }
 
 
 
 
-
-
-}}  // dt::expr
+}

--- a/c/expr/head_func_shift.cc
+++ b/c/expr/head_func_shift.cc
@@ -51,12 +51,12 @@ static RowIndex compute_lag_rowindex(const Groupby& groupby, int shift) {
       int32_t j = j0;
       if (LAG) {
         int32_t j1 = std::min(j2, j0 + shift);
-        for (; j < j1; ++j) indices[j] = -1;
+        for (; j < j1; ++j) indices[j] = RowIndex::NA_ARR32;
         for (; j < j2; ++j) indices[j] = j - shift;
       } else {
         int32_t j1 = std::max(j0, j2 - shift);
         for (; j < j1; ++j) indices[j] = j + shift;
-        for (; j < j2; ++j) indices[j] = -1;
+        for (; j < j2; ++j) indices[j] = RowIndex::NA_ARR32;
       }
     });
 

--- a/c/expr/head_func_shift.cc
+++ b/c/expr/head_func_shift.cc
@@ -86,18 +86,6 @@ py::oobj pyfn_shift(const py::PKArgs& args)
 }
 
 
-template <typename T>
-class Shifted_ColumnImpl : public Virtual_ColumnImpl {
-  private:
-    Column arg_;
-    size_t shift_;
-
-  public:
-    bool get_element(size_t i, T* out) {
-      if (i < shift_) return false;
-      return arg_.get_element(i - shift_, out);
-    }
-};
 
 
 

--- a/c/expr/head_func_shift.cc
+++ b/c/expr/head_func_shift.cc
@@ -1,0 +1,105 @@
+//------------------------------------------------------------------------------
+// Copyright 2019 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#include "expr/op.h"
+#include "expr/declarations.h"
+#include "python/obj.h"
+namespace dt {
+namespace expr {
+
+
+static const char* doc_shift =
+R"(shift(col, n=1, fill=None)
+--
+
+Produce a column obtained from `col` shifting it  `n` rows forward.
+
+The shift amount, `n`, can be both positive and negative. If positive,
+a "lag" column is created, if negative it will be a "lead" column.
+
+The shifted column will have the same number of rows as the original
+column, with `n` observations in the beginning becoming missing, and
+`n` observations at the end discarded. If parameter `fill` is given,
+then the missing observations at the beginning will be filled with
+the provided value.
+
+This function is group-aware, i.e. in the presence of a groupby it
+will perform the shift separately within each group.
+)";
+
+py::PKArgs args_shift(
+    1, 1, 1, false, false, {"col", "n", "fill"}, "shift", doc_shift);
+
+
+/**
+  * Python-facing function that implements an unary operator / single-
+  * argument function. This function can take as an argument either a
+  * python scalar, or an f-expression, or a Frame (in which case the
+  * function is applied to all elements of the frame).
+  */
+py::oobj pyfn_shift(const py::PKArgs& args)
+{
+  const py::Arg& arg_col = args[0];
+  const py::Arg& arg_n = args[1];
+  const py::Arg& arg_fill = args[2];
+
+  // n
+  int shift_amount = arg_n.to<int32_t>(1);
+
+
+  // py::robj x = args[0].to_robj();
+  // if (x.is_dtexpr()) {
+  //   return make_pyexpr(opcode, x);
+  // }
+  // if (x.is_frame()) {
+  //   return process_frame(opcode, x);
+  // }
+  // if (x.is_int())   return unaryop(opcode, x.to_int64_strict());
+  // if (x.is_float()) return unaryop(opcode, x.to_double());
+  // if (x.is_none())  return unaryop(opcode, nullptr);
+  // if (x.is_bool())  return unaryop(opcode, static_cast<bool>(x.to_bool_strict()));
+  // if (x.is_string())return unaryop(opcode, x.to_cstring());
+  // if (!x) {
+  //   throw TypeError() << "Function `" << args.get_short_name() << "()` takes "
+  //       "exactly one argument, 0 given";
+  // }
+  // throw TypeError() << "Function `" << args.get_short_name() << "()` cannot "
+  //     "be applied to an argument of type " << x.typeobj();
+}
+
+
+template <typename T>
+class Shifted_ColumnImpl : public Virtual_ColumnImpl {
+  private:
+    Column arg_;
+    size_t shift_;
+
+  public:
+    bool get_element(size_t i, T* out) {
+      if (i < shift_) return false;
+      return arg_.get_element(i - shift_, out);
+    }
+};
+
+
+
+
+}}  // dt::expr

--- a/c/expr/op.h
+++ b/c/expr/op.h
@@ -52,6 +52,7 @@ enum class Op : size_t {
   CAST = 2,
   SETPLUS = 3,
   SETMINUS = 4,
+  SHIFTFN,
 
   // Unary
   UPLUS = UNOP_FIRST,       // funary/basic.cc

--- a/c/expr/workframe.cc
+++ b/c/expr/workframe.cc
@@ -278,6 +278,7 @@ void Workframe::sync_grouping_mode(Column& col, Grouping gmode) {
 
 
 void Workframe::increase_grouping_mode(Grouping gmode) {
+  if (grouping_mode_ == gmode) return;
   for (auto& item : entries_) {
     if (!item.column) continue;  // placeholder column
     column_increase_grouping_mode(item.column, grouping_mode_, gmode);

--- a/c/expr/workframe.h
+++ b/c/expr/workframe.h
@@ -126,9 +126,9 @@ class Workframe {
     void sync_grouping_mode(Workframe& other);
     void sync_grouping_mode(Column& col, Grouping gmode);
     Grouping get_grouping_mode() const;
+    void increase_grouping_mode(Grouping g);
 
   private:
-    void increase_grouping_mode(Grouping g);
     void column_increase_grouping_mode(Column&, Grouping from, Grouping to);
 
     friend class EvalContext;

--- a/datatable/__init__.py
+++ b/datatable/__init__.py
@@ -44,6 +44,7 @@ from .lib._datatable import (
     rowsd,
     rowsum,
     setdiff,
+    shift,
     sort,
     symdiff,
     union,

--- a/datatable/expr/expr.py
+++ b/datatable/expr/expr.py
@@ -32,6 +32,7 @@ class OpCodes(enum.Enum):
     CAST = 2
     SETPLUS = 3
     SETMINUS = 4
+    SHIFTFN = 5
 
     # Unary
     UPLUS = 101

--- a/datatable/math.py
+++ b/datatable/math.py
@@ -31,6 +31,7 @@ from .lib._datatable import (
     arctan,
     artanh,
     cbrt,
+    ceil,
     cos,
     cosh,
     deg2rad,
@@ -40,6 +41,7 @@ from .lib._datatable import (
     exp2,
     expm1,
     fabs,
+    floor,
     gamma,
     isna,
     isfinite,
@@ -59,6 +61,7 @@ from .lib._datatable import (
     square,
     tan,
     tanh,
+    trunc,
 )
 
 e = 2.718281828459045

--- a/docs/changelog/v-0-10-0.rst
+++ b/docs/changelog/v-0-10-0.rst
@@ -253,6 +253,19 @@ General
     # Compute correlation of columns A and B, group-wise by ID
     DT[:, corr(f.A, f.B), by(f.ID)]
 
+- |new| Added function :func:`shift` which can be used to generate lags/leads
+  of a column. For example:
+
+    DT[:, {"lag2": shift(f.A, n=2),
+           "lag1": shift(f.A),       # same as shift(f.A, n=1)
+           "lag0": f.A,              # same as shift(f.A, n=0)
+           "lead1": shift(f.A, -1),
+           "lead2": shift(f.A, -2),
+           }]
+
+  This function is group-aware: when used in an expression containing a groupby,
+  it will apply the shift separately within each group.
+
 - |fix| Fixed memory leak when writing a Frame into a CSV file (#2119).
 
 - |fix| Fixed memory leak when converting a numpy array with string values

--- a/tests/ijby/test-shift.py
+++ b/tests/ijby/test-shift.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#-------------------------------------------------------------------------------
+# Copyright 2018-2019 H2O.ai
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#-------------------------------------------------------------------------------
+import math
+import pytest
+import random
+import datatable as dt
+from datatable import f, shift, by
+from tests import assert_equals
+
+
+#-------------------------------------------------------------------------------
+# shift()
+#-------------------------------------------------------------------------------
+
+def test_shift_default():
+    DT = dt.Frame(A=range(5))
+    assert_equals(DT[:, shift(f.A)],
+                  dt.Frame(A=[None, 0, 1, 2, 3]))
+
+
+def test_shift_frame():
+    DT = dt.Frame(A=range(5))
+    RES = shift(DT, 2)
+    assert_equals(RES, dt.Frame(A=[None, None, 0, 1, 2]))
+
+
+def test_shift_amount():
+    DT = dt.Frame(range(5))
+    RES = DT[:, [shift(f.C0, n) for n in range(-5, 6)]]
+    assert_equals(RES,
+        dt.Frame([[None, None, None, None, None],
+                  [4, None, None, None, None],
+                  [3, 4, None, None, None],
+                  [2, 3, 4, None, None],
+                  [1, 2, 3, 4, None],
+                  [0, 1, 2, 3, 4],
+                  [None, 0, 1, 2, 3],
+                  [None, None, 0, 1, 2],
+                  [None, None, None, 0, 1],
+                  [None, None, None, None, 0],
+                  [None, None, None, None, None]], stype=dt.int32))
+
+
+def test_shift_stypes():
+    DT = dt.Frame([[0, 1, 2, 3, 4],
+                   [2.7, 9.4, -1.1, None, 3.4],
+                   ["one", "two", "three", "FOUR", "five"],
+                   [True, False, True, True, False]])
+    RES = shift(DT, n=1)
+    assert_equals(RES,
+        dt.Frame([[None, 0, 1, 2, 3],
+                  [None, 2.7, 9.4, -1.1, None],
+                  [None, "one", "two", "three", "FOUR"],
+                  [None, True, False, True, True]]))
+
+
+def test_shift_all_columns():
+    DT = dt.Frame([[5, 9, 1], list("ABC"), [2.3, 4.4, -2.5]],
+                  names=["A", "B", "D"])
+    RES = DT[:, shift(f[:], n=1)]
+    assert_equals(RES, dt.Frame(A=[None, 5, 9],
+                                B=[None, "A", "B"],
+                                D=[None, 2.3, 4.4]))
+
+
+def test_shift_expr():
+    DT = dt.Frame(A=[3, 4, 5, 6], B=[-1, 2, -2, 3])
+    RES = DT[:, shift(f.A + f.B, n=1)]
+    assert_equals(RES, dt.Frame([None, 2, 6, 3]))
+
+
+
+
+#-------------------------------------------------------------------------------
+# shift() with groupby
+#-------------------------------------------------------------------------------
+
+def test_shift_with_by():
+    DT = dt.Frame(A=[1, 2, 1, 1, 2, 1, 2],
+                  B=[3, 7, 9, 0, -1, 2, 1])
+    RES = DT[:, {"lag1": shift(f.B, 1),
+                 "lag2": shift(f.B, 2),
+                 "lag3": shift(f.B, 3),
+                 "nolag": shift(f.B, 0),
+                 "lead1": shift(f.B, -1),
+                 "lead2": shift(f.B, -2),
+                 "lead3": shift(f.B, -3),
+                 }, by(f.A)]
+    assert_equals(RES, dt.Frame(A=[1, 1, 1, 1, 2, 2, 2],
+                                lag1=[None, 3, 9, 0, None, 7, -1],
+                                lag2=[None, None, 3, 9, None, None, 7],
+                                lag3=[None, None, None, 3, None, None, None],
+                                nolag=[3, 9, 0, 2, 7, -1, 1],
+                                lead1=[9, 0, 2, None, -1, 1, None],
+                                lead2=[0, 2, None, None, 1, None, None],
+                                lead3=[2, None, None, None, None, None, None]))
+
+
+def test_shift_group_column():
+    DT = dt.Frame(A=[1, 2, 1, 1, 2])
+    RES = DT[:, shift(f.A), by(f.A)]
+    assert_equals(RES, dt.Frame({"A": [1, 1, 1, 2, 2],
+                                 "A.0": [None, 1, 1, None, 2]}))
+
+
+def test_shift_reduced_column():
+    DT = dt.Frame(A=[1, 2, 1, 1, 2, 1], B=range(6))
+    RES = DT[:, shift(dt.sum(f.B)), by(f.A)]
+    assert_equals(RES, dt.Frame(A=[1, 1, 1, 1, 2, 2],
+                                B=[None, 10, 10, 10, None, 5],
+                                stypes={"A": dt.int32, "B": dt.int64}))
+
+
+
+def test_shift_by_with_i():
+    DT = dt.Frame(A=[1, 2, 1, 2, 1, 2, 1, 2], B=range(8))
+    RES = DT[1:, shift(f.B), by(f.A)]
+    assert_equals(RES, dt.Frame(A=[1, 1, 1, 2, 2, 2],
+                                B=[None, 2, 4, None, 3, 5]))
+
+
+
+
+#-------------------------------------------------------------------------------
+# Test errors
+#-------------------------------------------------------------------------------
+
+def test_shift_wrong_signature1():
+    msg = r"Function `shift\(\)` requires 1 positional argument"
+    with pytest.raises(TypeError, match=msg):
+        shift()
+    with pytest.raises(TypeError, match=msg):
+        shift(None)
+    with pytest.raises(TypeError, match=msg):
+        shift(n=3)
+
+
+def test_shift_wrong_signature2():
+    msg = r"The first argument to `shift\(\)` must be a column expression " \
+          r"or a Frame"
+    for s in [3, 12.5, "hi", dt]:
+        with pytest.raises(TypeError, match=msg):
+            shift(s)
+
+
+def test_shift_wrong_signature3():
+    msg = r"Argument `n` in shift\(\) should be an integer"
+    for n in ["one", 0.0, f.B, range(3), [1, 2, 3]]:
+        with pytest.raises(TypeError, match=msg):
+            shift(f.A, n=n)


### PR DESCRIPTION
This PR implements the new function `shift(col, n=1)` to generate leads/lags of a column.
Closes #1513