### PR TITLE
New parameter `Frame.materialize(to_memory=True)` to load data into memory

### DIFF
--- a/c/column.cc
+++ b/c/column.cc
@@ -301,9 +301,9 @@ Buffer Column::get_data_buffer(size_t k) const {
 // Column : manipulation
 //------------------------------------------------------------------------------
 
-void Column::materialize() {
+void Column::materialize(bool to_memory) {
   auto pcol = _get_mutable_impl(/* keep_stats= */ true);
-  pcol->materialize(*this);
+  pcol->materialize(*this, to_memory);
 }
 
 void Column::replace_values(const RowIndex& replace_at,

--- a/c/column.h
+++ b/c/column.h
@@ -276,7 +276,7 @@ class Column
   // ColumnImpl manipulation
   //------------------------------------
   public:
-    void materialize();
+    void materialize(bool to_memory = false);
     void rbind(colvec& columns);
     void cast_inplace(SType stype);
     Column cast(SType stype) const;

--- a/c/column/column_impl.cc
+++ b/c/column/column_impl.cc
@@ -107,7 +107,8 @@ void ColumnImpl::_materialize_str(Column& out) {
 }
 
 
-void ColumnImpl::materialize(Column& out) {
+void ColumnImpl::materialize(Column& out, bool to_memory) {
+  (void) to_memory;  // default materialization is always to memory
   this->pre_materialize_hook();
   switch (stype_) {
     case SType::BOOL:

--- a/c/column/column_impl.h
+++ b/c/column/column_impl.h
@@ -68,7 +68,7 @@ class ColumnImpl
     virtual ~ColumnImpl() = default;
 
     virtual ColumnImpl* clone() const = 0;
-    virtual void materialize(Column& out);
+    virtual void materialize(Column& out, bool to_memory);
     virtual void verify_integrity() const;
     virtual bool allow_parallel_access() const;
 

--- a/c/column/const.h
+++ b/c/column/const.h
@@ -59,7 +59,7 @@ class ConstNa_ColumnImpl : public Const_ColumnImpl {
     bool get_element(size_t, py::robj*) const override;
 
     ColumnImpl* clone() const override;
-    void materialize(Column&) override;
+    void materialize(Column&, bool) override;
     void na_pad(size_t nrows, Column&) override;
 };
 

--- a/c/column/const_na.cc
+++ b/c/column/const_na.cc
@@ -89,7 +89,7 @@ static Column _str_col(size_t nrows) {
 }
 
 
-void ConstNa_ColumnImpl::materialize(Column& out) {
+void ConstNa_ColumnImpl::materialize(Column& out, bool) {
   switch (stype_) {
     case SType::VOID:
     case SType::BOOL:    out = _fw_col<int8_t,  SentinelBool_ColumnImpl>(nrows_); break;

--- a/c/column/latent.cc
+++ b/c/column/latent.cc
@@ -57,8 +57,8 @@ ColumnImpl* Latent_ColumnImpl::clone() const {
   return new Latent_ColumnImpl(column_);
 }
 
-void Latent_ColumnImpl::materialize(Column&) {
-  vivify();
+void Latent_ColumnImpl::materialize(Column&, bool to_memory) {
+  vivify(to_memory);
 }
 
 
@@ -91,7 +91,7 @@ bool Latent_ColumnImpl::get_element(size_t i, py::robj* out) const { return vivi
 // Thus, a better approach is needed: some mechanism to inform the
 // caller that this column must be "prepared" first.
 
-ColumnImpl* Latent_ColumnImpl::vivify() const {
+ColumnImpl* Latent_ColumnImpl::vivify(bool to_memory) const {
   xassert(num_threads_in_team() == 0);
   // Note: we're using placement-materialize to overwrite `this` with
   // the materialized `column` object. Effectively, the current object
@@ -99,7 +99,7 @@ ColumnImpl* Latent_ColumnImpl::vivify() const {
   // This will work, provided that `sizeof(*this)` is >= the size
   // of the class of the materialized column.
   auto ptr = const_cast<void*>(static_cast<const void*>(this));
-  column_.materialize();
+  column_.materialize(to_memory);
   ColumnImpl* new_pcol = std::move(column_).release();
   SType stype = new_pcol->stype();
 

--- a/c/column/latent.h
+++ b/c/column/latent.h
@@ -50,7 +50,7 @@ class Latent_ColumnImpl : public Virtual_ColumnImpl {
     explicit Latent_ColumnImpl(const Column&);
 
     ColumnImpl* clone() const override;
-    void materialize(Column&) override;
+    void materialize(Column&, bool) override;
     bool allow_parallel_access() const override;
 
     bool get_element(size_t, int8_t*)   const override;
@@ -63,7 +63,7 @@ class Latent_ColumnImpl : public Virtual_ColumnImpl {
     bool get_element(size_t, py::robj*) const override;
 
   private:
-    ColumnImpl* vivify() const;
+    ColumnImpl* vivify(bool to_memory = false) const;
 };
 
 

--- a/c/column/npmasked.cc
+++ b/c/column/npmasked.cc
@@ -55,7 +55,7 @@ void NpMasked_ColumnImpl::_apply_mask(Column& out) {
   out = std::move(arg_);
 }
 
-void NpMasked_ColumnImpl::materialize(Column& out) {
+void NpMasked_ColumnImpl::materialize(Column& out, bool to_memory) {
   if (arg_.get_na_storage_method() == NaStorage::SENTINEL &&
       arg_.is_fixedwidth() &&
       arg_.is_data_editable())
@@ -71,7 +71,7 @@ void NpMasked_ColumnImpl::materialize(Column& out) {
       default: break;
     }
   }
-  ColumnImpl::materialize(out);
+  ColumnImpl::materialize(out, to_memory);
 }
 
 

--- a/c/column/npmasked.h
+++ b/c/column/npmasked.h
@@ -42,7 +42,7 @@ class NpMasked_ColumnImpl : public Virtual_ColumnImpl {
     NpMasked_ColumnImpl(Column&& arg, Buffer&& mask);
 
     ColumnImpl* clone() const override;
-    void materialize(Column&) override;
+    void materialize(Column&, bool) override;
 
     bool get_element(size_t, int8_t*)  const override;
     bool get_element(size_t, int16_t*) const override;

--- a/c/column/range.cc
+++ b/c/column/range.cc
@@ -112,7 +112,7 @@ void Range_ColumnImpl::_materialize(Column& out) const {
   out = newcol;
 }
 
-void Range_ColumnImpl::materialize(Column& out) {
+void Range_ColumnImpl::materialize(Column& out, bool) {
   switch (stype_) {
     case SType::INT8:    return _materialize<int8_t>(out);
     case SType::INT16:   return _materialize<int16_t>(out);

--- a/c/column/range.h
+++ b/c/column/range.h
@@ -47,7 +47,7 @@ class Range_ColumnImpl : public Virtual_ColumnImpl {
 
     ColumnImpl* clone() const override;
     size_t memory_footprint() const noexcept override;
-    void materialize(Column&) override;
+    void materialize(Column&, bool) override;
     void verify_integrity() const override;
 
     bool get_element(size_t, int8_t*)  const override;

--- a/c/column/sentinel.h
+++ b/c/column/sentinel.h
@@ -38,7 +38,6 @@ class Sentinel_ColumnImpl : public ColumnImpl
     static Column make_str_column(size_t nrows, Buffer&&, Buffer&&);
 
     bool is_virtual() const noexcept override;
-    void materialize(Column&) override {}
     NaStorage get_na_storage_method() const noexcept override;
 
   protected:

--- a/c/column/sentinel_fw.cc
+++ b/c/column/sentinel_fw.cc
@@ -102,6 +102,16 @@ ColumnImpl* SentinelObj_ColumnImpl::clone() const {
 
 
 template <typename T>
+void SentinelFw_ColumnImpl<T>::materialize(Column&, bool to_memory) {
+  if (to_memory) {
+    mbuf_.to_memory();
+  }
+}
+
+
+
+
+template <typename T>
 size_t SentinelFw_ColumnImpl<T>::memory_footprint() const noexcept {
   return sizeof(*this) + (stats_? stats_->memory_footprint() : 0)
                        + mbuf_.memory_footprint();
@@ -184,16 +194,14 @@ size_t SentinelFw_ColumnImpl<T>::get_num_data_buffers() const noexcept {
 
 template <typename T>
 bool SentinelFw_ColumnImpl<T>::is_data_editable(size_t k) const {
-  xassert(k == 0);
-  (void) k;
+  xassert(k == 0); (void) k;
   return mbuf_.is_writable();
 }
 
 
 template <typename T>
 size_t SentinelFw_ColumnImpl<T>::get_data_size(size_t k) const {
-  xassert(k == 0);
-  (void) k;
+  xassert(k == 0); (void) k;
   xassert(mbuf_.size() >= nrows_ * sizeof(T));
   return nrows_ * sizeof(T);
 }
@@ -201,24 +209,21 @@ size_t SentinelFw_ColumnImpl<T>::get_data_size(size_t k) const {
 
 template <typename T>
 const void* SentinelFw_ColumnImpl<T>::get_data_readonly(size_t k) const {
-  xassert(k == 0);
-  (void) k;
+  xassert(k == 0); (void) k;
   return mbuf_.rptr();
 }
 
 
 template <typename T>
 void* SentinelFw_ColumnImpl<T>::get_data_editable(size_t k) {
-  xassert(k == 0);
-  (void) k;
+  xassert(k == 0); (void) k;
   return mbuf_.wptr();
 }
 
 
 template <typename T>
 Buffer SentinelFw_ColumnImpl<T>::get_data_buffer(size_t k) const {
-  xassert(k == 0);
-  (void) k;
+  xassert(k == 0); (void) k;
   return Buffer(mbuf_);
 }
 

--- a/c/column/sentinel_fw.h
+++ b/c/column/sentinel_fw.h
@@ -43,6 +43,7 @@ class SentinelFw_ColumnImpl : public Sentinel_ColumnImpl
 
     virtual ColumnImpl* clone() const override;
     void verify_integrity() const override;
+    void materialize(Column&, bool) override;
     size_t memory_footprint() const noexcept override;
 
     virtual bool get_element(size_t i, int8_t* out) const override;

--- a/c/column/sentinel_str.cc
+++ b/c/column/sentinel_str.cc
@@ -113,6 +113,15 @@ Buffer SentinelStr_ColumnImpl<T>::get_data_buffer(size_t k) const {
 }
 
 
+template <typename T>
+void SentinelStr_ColumnImpl<T>::materialize(Column&, bool to_memory) {
+  if (to_memory) {
+    offbuf_.to_memory();
+    strbuf_.to_memory();
+  }
+}
+
+
 
 
 //------------------------------------------------------------------------------

--- a/c/column/sentinel_str.h
+++ b/c/column/sentinel_str.h
@@ -39,6 +39,7 @@ class SentinelStr_ColumnImpl : public Sentinel_ColumnImpl
 
     ColumnImpl* clone() const override;
     void verify_integrity() const override;
+    void materialize(Column&, bool) override;
     size_t memory_footprint() const noexcept override;
 
     bool get_element(size_t i, CString* out) const override;

--- a/c/datatable.cc
+++ b/c/datatable.cc
@@ -244,11 +244,12 @@ void DataTable::apply_rowindex(const RowIndex& rowindex) {
 
 
 /**
- * Materialize all columns in the DataTable.
- */
-void DataTable::materialize() {
+  * Materialize all columns in the DataTable. The flag `to_memory`
+  * also forces the data to be brought from disk into the RAM.
+  */
+void DataTable::materialize(bool to_memory) {
   for (Column& col : columns_) {
-    col.materialize();
+    col.materialize(to_memory);
   }
 }
 

--- a/c/datatable.h
+++ b/c/datatable.h
@@ -85,7 +85,7 @@ class DataTable {
     void resize_rows(size_t n);
     void resize_columns(const strvec& new_names);
     void apply_rowindex(const RowIndex&);
-    void materialize();
+    void materialize(bool to_memory);
     void rbind(const std::vector<DataTable*>&, const std::vector<intvec>&);
     void cbind(const std::vector<DataTable*>&);
     DataTable extract_column(size_t i) const;

--- a/c/frame/key.cc
+++ b/c/frame/key.cc
@@ -156,7 +156,7 @@ void DataTable::set_key(std::vector<size_t>& col_indices) {
   columns_ = std::move(new_columns);
   reorder_names(col_indices);
 
-  materialize();
+  materialize(false);
 
   nkeys_ = K;
 }

--- a/c/jay/save_jay.cc
+++ b/c/jay/save_jay.cc
@@ -55,7 +55,7 @@ Buffer DataTable::save_jay() {
 
 void DataTable::save_jay_impl(WritableBuffer* wb) {
   // Cannot store a view frame, so materialize first.
-  materialize();
+  materialize(false);
 
   wb->write(8, "JAY1\0\0\0\0");
 

--- a/docs/changelog/v-0-10-0.rst
+++ b/docs/changelog/v-0-10-0.rst
@@ -164,6 +164,13 @@ Frame
     DT["A"] = int            # Column A in frame DT will become integer
     DT[:, int] = dt.float64  # All integer columns will be converted to float64
 
+- |new| Method ``Frame.materialize()`` gains a new option ``to_memory=False``.
+  If set to True, it will force the Frame's data to be lifted from disk into
+  the main memory (if the frame was opened from disk)::
+
+    DT = dt.fread("data.jay")
+    DT.materialize(to_memory=True)
+
 - |api| The name deduplication algorithm now starts looking for candidate names
   starting from ``name + dt.options.frame.name_auto_index``. For example, if
   you're creating a Frame with column names `["A", "A", "A"]`, then those names

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -23,6 +23,7 @@
 #-------------------------------------------------------------------------------
 import datatable as dt
 import math
+import os
 import pytest
 import random
 import re
@@ -1259,6 +1260,18 @@ def test_materialize_object_col():
     assert DT.stypes == (dt.obj64,)
     assert all(isinstance(x, A) and sys.getrefcount(x) > 0
                for x in DT.to_list()[0])
+
+
+def test_materialize_to_memory(tempfile_jay):
+    DT = dt.Frame(A=["red", "orange", "yellow"], B=[5, 2, 8])
+    DT.to_jay(tempfile_jay)
+    del DT
+    DT = dt.fread(tempfile_jay)
+    DT.materialize(to_memory=True)
+    os.unlink(tempfile_jay)
+    dt.Frame([5]).to_jay(tempfile_jay)
+    assert_equals(DT, dt.Frame(A=["red", "orange", "yellow"], B=[5, 2, 8]))
+
 
 
 

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -1273,6 +1273,12 @@ def test_materialize_to_memory(tempfile_jay):
     assert_equals(DT, dt.Frame(A=["red", "orange", "yellow"], B=[5, 2, 8]))
 
 
+def test_materialize_to_memory_bad_type():
+    DT = dt.Frame(range(5))
+    msg = r"Argument `to_memory` in Frame.materialize\(\) should be a boolean"
+    with pytest.raises(TypeError, match=msg):
+        DT.materialize(to_memory=0)
+
 
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
This parameter will force any memory-mapped columns to become resident in RAM. The same applies to any columns that use external memory obtained via PyBuffer interface.

Closes #1467