### PR TITLE
Fix an internal bug in umaker/bimaker

### DIFF
--- a/c/expr/fbinary/bimaker.cc
+++ b/c/expr/fbinary/bimaker.cc
@@ -90,7 +90,11 @@ Column binaryop(Op opcode, Column&& col1, Column&& col2)
   // Find the maker function
   auto id = make_id(opcode, col1.stype(), col2.stype());
   if (bimakers_library.count(id) == 0) {
-    bimakers_library[id] = resolve_op(opcode, col1.stype(), col2.stype());
+    // Note: these operations must be separate, otherwise if `resolve_op`
+    //       throws an exception, there could be an empty entry in the
+    //       bimakers_library map, which later will lead to a seg.fault
+    auto res = resolve_op(opcode, col1.stype(), col2.stype());
+    bimakers_library[id] = std::move(res);
   }
   const bimaker_ptr& maker = bimakers_library[id];
   xassert(maker);

--- a/c/expr/funary/umaker.cc
+++ b/c/expr/funary/umaker.cc
@@ -41,7 +41,11 @@ static const umaker_ptr& get_umaker(Op opcode, SType stype) {
   size_t id = ((static_cast<size_t>(opcode) - UNOP_FIRST) << 8) +
               static_cast<size_t>(stype);
   if (umakers_library.count(id) == 0) {
-    umakers_library[id] = resolve_op(opcode, stype);
+    // Note: these operations must be separate, otherwise if `resolve_op`
+    //       throws an exception, there could be an empty entry in the
+    //       umakers_library map, which later will lead to a seg.fault
+    auto res = resolve_op(opcode, stype);
+    umakers_library[id] = std::move(res);
   }
   return umakers_library[id];
 }


### PR DESCRIPTION
Assigning to a map element the result of a function invocation is unsafe if the function may throw an exception: in this case on older compilers there could be an empty element stored into the map.

This was causing a crash on PPC64le (presumably because we are using an old GCC4.8 compiler there).