### PR TITLE
Improve frame rendering in Jupyter and fix the interactive mode

### DIFF
--- a/c/frame/__repr__.cc
+++ b/c/frame/__repr__.cc
@@ -332,7 +332,7 @@ void Frame::view(const PKArgs& args) {
   bool plain = args[1].to<bool>(false);
   if (args[0].is_none()) interactive = dt::display_interactive;
   if (args[0].is_bool()) interactive = args[0].to_bool_strict();
-  if (interactive && !dt::Terminal::standard_terminal().is_jupyter()) {
+  if (dt::Terminal::standard_terminal().is_jupyter()) {
     interactive = false;
   }
   if (interactive) {

--- a/c/frame/__repr__.cc
+++ b/c/frame/__repr__.cc
@@ -332,7 +332,7 @@ void Frame::view(const PKArgs& args) {
   bool plain = args[1].to<bool>(false);
   if (args[0].is_none()) interactive = dt::display_interactive;
   if (args[0].is_bool()) interactive = args[0].to_bool_strict();
-  if (dt::Terminal::standard_terminal().is_jupyter()) {
+  if (interactive && dt::Terminal::standard_terminal().is_jupyter()) {
     interactive = false;
   }
   if (interactive) {

--- a/c/frame/__repr__.cc
+++ b/c/frame/__repr__.cc
@@ -85,25 +85,19 @@ void Frame::view(const PKArgs& args) {
   bool plain = args[1].to<bool>(false);
   if (args[0].is_none()) interactive = dt::display_interactive;
   if (args[0].is_bool()) interactive = args[0].to_bool_strict();
+
   if (is_jupyter) {
-    interactive = false;
+    auto htmlstr = _repr_html_(args__repr_html_);
+    dt::HtmlWidget::write_to_jupyter(htmlstr);
   }
-  if (interactive) {
-    oobj DFWidget = oobj::import("datatable")
-                    .get_attr("widget")
-                    .get_attr("DataFrameWidget");
+  else if (interactive) {
+    oobj DFWidget = oobj::import("datatable.widget", "DataFrameWidget");
     DFWidget.call({oobj(this), obool(interactive)}).invoke("render");
   } else {
-    if (is_jupyter) {
-      auto htmlstr = _repr_html_(args__repr_html_);
-      dt::HtmlWidget::write_to_jupyter(htmlstr);
-    }
-    else {
-      auto terminal = plain? &dt::Terminal::plain_terminal()
-                           : &dt::Terminal::standard_terminal();
-      dt::TerminalWidget widget(dt, terminal, dt::Widget::split_view_tag);
-      widget.to_stdout();
-    }
+    auto terminal = plain? &dt::Terminal::plain_terminal()
+                         : &dt::Terminal::standard_terminal();
+    dt::TerminalWidget widget(dt, terminal, dt::Widget::split_view_tag);
+    widget.to_stdout();
   }
 }
 

--- a/c/frame/__repr__.cc
+++ b/c/frame/__repr__.cc
@@ -96,7 +96,7 @@ void Frame::view(const PKArgs& args) {
   } else {
     if (is_jupyter) {
       auto htmlstr = _repr_html_(args__repr_html_);
-      dt::HtmlWidget::write_to_jupyter(htmlstr, py::odict());
+      dt::HtmlWidget::write_to_jupyter(htmlstr);
     }
     else {
       auto terminal = plain? &dt::Terminal::plain_terminal()

--- a/c/frame/__repr__.cc
+++ b/c/frame/__repr__.cc
@@ -25,258 +25,10 @@
 #include "frame/repr/terminal_widget.h"
 #include "frame/repr/text_column.h"
 #include "frame/repr/widget.h"
+#include "frame/repr/html_widget.h"
 #include "python/string.h"
 #include "options.h"
 #include "types.h"
-
-
-
-
-//------------------------------------------------------------------------------
-// HtmlWidget
-//------------------------------------------------------------------------------
-
-/**
-  * This class is responsible for rendering a Frame into HTML.
-  */
-class HtmlWidget : public dt::Widget {
-  private:
-    std::ostringstream html;
-
-  public:
-    explicit HtmlWidget(DataTable* dt)
-      : dt::Widget(dt, split_view_tag) {}
-
-    py::oobj to_python() {
-      render_all();
-      const std::string htmlstr = html.str();
-      return py::ostring(htmlstr);
-    }
-
-
-  protected:
-    void _render() override {
-      html << "<div class='datatable'>\n";
-      html << "  <table class='frame'>\n";
-      html << "  <thead>\n";
-      _render_column_names();
-      _render_column_types();
-      html << "  </thead>\n";
-      html << "  <tbody>\n";
-      _render_data_rows();
-      html << "  </tbody>\n";
-      html << "  </table>\n";
-      _render_table_footer();
-      html << "</div>\n";
-    }
-
-    void _render_column_names() {
-      const strvec& colnames = dt_->get_names();
-      html << "    <tr class='colnames'>";
-      if (render_row_indices_) {
-        html << "<td class='row_index'></td>";
-      }
-      for (size_t j : colindices_) {
-        if (j == dt::NA_index) {
-          html << "<th class='vellipsis'>&hellip;</th>";
-        } else {
-          html << (j < nkeys_? "<th class='row_index'>" : "<th>");
-          _render_escaped_string(colnames[j].data(), colnames[j].size());
-          html << "</th>";
-        }
-      }
-      html << "</tr>\n";
-    }
-
-    void _render_column_types() {
-      html << "    <tr class='coltypes'>";
-      if (render_row_indices_) {
-        html << "<td class='row_index'></td>";
-      }
-      for (size_t j : colindices_) {
-        if (j == dt::NA_index) {
-          html << "<td></td>";
-        } else {
-          auto stype_info = info(dt_->get_column(j).stype());
-          size_t elemsize = stype_info.elemsize();
-          html << "<td class='" << stype_info.ltype_name()
-               << "' title='" << stype_info.name() << "'>";
-          for (size_t k = 0; k < elemsize; ++k) html << "&#x25AA;";
-          html << "</td>";
-        }
-      }
-      html << "</tr>\n";
-    }
-
-    void _render_data_rows() {
-      for (size_t i : rowindices_) {
-        if (i == dt::NA_index) {
-          _render_ellipsis_row();
-        } else {
-          _render_data_row(i);
-        }
-      }
-    }
-
-    void _render_ellipsis_row() {
-      html << "    <tr>";
-      if (render_row_indices_) {
-        html << "<td class='row_index'>&#x22EE;</td>";
-      }
-      for (size_t j : colindices_) {
-        if (j == dt::NA_index) {
-          html << "<td class='hellipsis'>&#x22F1;</td>";
-        } else {
-          html << "<td class='hellipsis'>&#x22EE;</td>";
-        }
-      }
-      html << "</tr>\n";
-    }
-
-    void _render_data_row(size_t i) {
-      html << "    <tr>";
-      if (render_row_indices_) {
-        html << "<td class='row_index'>";
-        _render_comma_separated(i);
-        html << "</td>";
-      }
-      for (size_t j : colindices_) {
-        if (j == dt::NA_index) {
-          html << "<td class=vellipsis>&hellip;</td>";
-          continue;
-        }
-        html << (j < nkeys_? "<td class='row_index'>" : "<td>");
-        const Column& col = dt_->get_column(j);
-        switch (col.stype()) {
-          case SType::BOOL:
-          case SType::INT8:    _render_fw_value<int8_t>(col, i); break;
-          case SType::INT16:   _render_fw_value<int16_t>(col, i); break;
-          case SType::INT32:   _render_fw_value<int32_t>(col, i); break;
-          case SType::INT64:   _render_fw_value<int64_t>(col, i); break;
-          case SType::FLOAT32: _render_fw_value<float>(col, i); break;
-          case SType::FLOAT64: _render_fw_value<double>(col, i); break;
-          case SType::STR32:
-          case SType::STR64:   _render_str_value(col, i); break;
-          case SType::OBJ:     _render_obj_value(col, i); break;
-          default:
-            html << "(unknown stype)";
-        }
-        html << "</td>";
-      }
-      html << "</tr>\n";
-    }
-
-
-    void _render_table_footer() {
-      size_t nrows = dt_->nrows();
-      size_t ncols = dt_->ncols();
-      html << "  <div class='footer'>\n";
-      html << "    <div class='frame_dimensions'>";
-      _render_comma_separated(nrows);
-      html << " row" << (nrows == 1? "" : "s") << " &times; ";
-      _render_comma_separated(ncols);
-      html << " column" << (ncols == 1? "" : "s");
-      html << "</div>\n";
-      html << "  </div>\n";
-    }
-
-
-    void _render_escaped_string(const char* ch, size_t len) {
-      size_t maxi = std::min(len, size_t(50));
-      uint8_t uc;
-      for (size_t i = 0; i < maxi; ++i) {
-        char c = ch[i];
-        if (c == '&') html << "&amp;";
-        else if (c == '<') html << "&lt;";
-        else if (c == '>') html << "&gt;";
-        else {
-          html << c;
-          if (maxi < len && (uc = static_cast<uint8_t>(c)) >= 0xC0) {
-            // for Unicode characters, make sure they are calculated as a
-            // single char, and also not truncated in the middle.
-            if ((uc & 0xE0) == 0xC0)      maxi += 1;
-            else if ((uc & 0xF0) == 0xE0) maxi += 2;
-            else if ((uc & 0xF8) == 0xF0) maxi += 3;
-            if (maxi > len) maxi = len;
-          }
-        }
-      }
-      if (len > maxi) html << "&#133;";
-    }
-
-    template <typename T>
-    void _render_fw_value(const Column& col, size_t row) {
-      T val;
-      bool isvalid = col.get_element(row, &val);
-      if (isvalid) {
-        if (val < 0) {
-          html << "&minus;";
-          val = -val;
-        }
-        html << +val; // "+" ensures that `int8_t` vals are rendered as numbers
-
-      } else {
-        _render_na();
-      }
-    }
-
-    void _render_str_value(const Column& col, size_t row) {
-      CString val;
-      bool isvalid = col.get_element(row, &val);
-      if (isvalid) {
-        _render_escaped_string(val.ch, static_cast<size_t>(val.size));
-      } else {
-        _render_na();
-      }
-    }
-
-    void _render_obj_value(const Column& col, size_t row) {
-      py::robj val;
-      bool isvalid = col.get_element(row, &val);
-      if (isvalid) {
-        // Should we use repr() here instead?
-        py::ostring strval = val.to_pystring_force();
-        CString cstr = strval.to_cstring();
-        _render_escaped_string(cstr.ch, static_cast<size_t>(cstr.size));
-      } else {
-        _render_na();
-      }
-    }
-
-    void _render_na() {
-      html << "<span class=na>NA</span>";
-    }
-
-    void _render_comma_separated(size_t n) {
-      // It is customary not to display commas in 4-digit numbers
-      if (n < 10000) {
-        html << n;
-        return;
-      }
-      size_t n10 = n / 10;
-      size_t k = 1;
-      size_t m = 0;
-      while (k <= n10) {
-        k *= 10;
-        ++m;
-      }
-      m = m % 3;
-      while (k) {
-        size_t d = n / k;
-        n -= d * k;
-        k /= 10;
-        html << char('0' + d);
-        if (m == 0 && k) {
-          html << ',';
-          m = 2;
-        } else {
-          --m;
-        }
-      }
-    }
-};
-
-
 
 
 //------------------------------------------------------------------------------
@@ -307,7 +59,7 @@ static PKArgs args__repr_html_(
   0, 0, 0, false, false, {}, "_repr_html_", nullptr);
 
 oobj Frame::_repr_html_(const PKArgs&) {
-  HtmlWidget widget(dt);
+  dt::HtmlWidget widget(dt);
   return widget.to_python();
 }
 
@@ -329,10 +81,11 @@ static PKArgs args_view(
 
 void Frame::view(const PKArgs& args) {
   bool interactive = true;  // default when `interactive` is omitted entirely
+  bool is_jupyter = dt::Terminal::standard_terminal().is_jupyter();
   bool plain = args[1].to<bool>(false);
   if (args[0].is_none()) interactive = dt::display_interactive;
   if (args[0].is_bool()) interactive = args[0].to_bool_strict();
-  if (interactive && dt::Terminal::standard_terminal().is_jupyter()) {
+  if (is_jupyter) {
     interactive = false;
   }
   if (interactive) {
@@ -341,10 +94,16 @@ void Frame::view(const PKArgs& args) {
                     .get_attr("DataFrameWidget");
     DFWidget.call({oobj(this), obool(interactive)}).invoke("render");
   } else {
-    auto terminal = plain? &dt::Terminal::plain_terminal()
-                         : &dt::Terminal::standard_terminal();
-    dt::TerminalWidget widget(dt, terminal, dt::Widget::split_view_tag);
-    widget.to_stdout();
+    if (is_jupyter) {
+      auto htmlstr = _repr_html_(args__repr_html_);
+      dt::HtmlWidget::write_to_jupyter(htmlstr, py::odict());
+    }
+    else {
+      auto terminal = plain? &dt::Terminal::plain_terminal()
+                           : &dt::Terminal::standard_terminal();
+      dt::TerminalWidget widget(dt, terminal, dt::Widget::split_view_tag);
+      widget.to_stdout();
+    }
   }
 }
 

--- a/c/frame/repr/html_styles.cc
+++ b/c/frame/repr/html_styles.cc
@@ -134,19 +134,10 @@ static py::oobj generate_stylesheet() {
 
 
 void emit_stylesheet() {
-  if (!dt::Terminal::standard_terminal().is_jupyter()) {
-    return;
-  }
   auto html = generate_stylesheet();
-
-  auto HTML = py::oobj::import("IPython.core.display", "HTML");
-  auto display = py::oobj::import("IPython.core.display", "display");
-  auto update = py::oobj::import("IPython.core.display", "update_display");
-
   py::odict kwds;
   kwds.set(py::ostring("display_id"), py::ostring("datatable:css"));
-  update.call(HTML.call(), kwds);
-  display.call(HTML.call(html), kwds);
+  HtmlWidget::write_to_jupyter(html, kwds);
 }
 
 

--- a/c/frame/repr/html_styles.cc
+++ b/c/frame/repr/html_styles.cc
@@ -135,9 +135,9 @@ static py::oobj generate_stylesheet() {
 
 void emit_stylesheet() {
   auto html = generate_stylesheet();
-  py::odict kwds;
-  kwds.set(py::ostring("display_id"), py::ostring("datatable:css"));
-  HtmlWidget::write_to_jupyter(html, kwds);
+  py::odict update_kwds;
+  update_kwds.set(py::ostring("display_id"), py::ostring("datatable:css"));
+  HtmlWidget::write_to_jupyter(html, update_kwds);
 }
 
 

--- a/c/frame/repr/html_widget.h
+++ b/c/frame/repr/html_widget.h
@@ -51,6 +51,11 @@ class HtmlWidget : public dt::Widget {
       return py::ostring(htmlstr);
     }
 
+    static void write_to_jupyter(const py::oobj& htmlstr) {
+    	auto kwds = py::odict();
+    	write_to_jupyter(htmlstr, kwds);
+    }
+
     static void write_to_jupyter(const py::oobj& htmlstr, const py::odict& kwds) {
       if (!dt::Terminal::standard_terminal().is_jupyter()) {
         return;

--- a/c/frame/repr/html_widget.h
+++ b/c/frame/repr/html_widget.h
@@ -52,23 +52,25 @@ class HtmlWidget : public dt::Widget {
     }
 
     static void write_to_jupyter(const py::oobj& htmlstr) {
-    	auto kwds = py::odict();
-    	write_to_jupyter(htmlstr, kwds);
+    	auto update_kwds = py::odict();
+    	write_to_jupyter(htmlstr, update_kwds);
     }
 
-    static void write_to_jupyter(const py::oobj& htmlstr, const py::odict& kwds) {
+    static void write_to_jupyter(const py::oobj& htmlstr,
+                                 const py::odict& update_kwds)
+    {
       if (!dt::Terminal::standard_terminal().is_jupyter()) {
         return;
       }
 
       auto HTML = py::oobj::import("IPython.core.display", "HTML");
       auto display = py::oobj::import("IPython.core.display", "display");
-      if (!kwds.empty()) {
+      if (!update_kwds.empty()) {
         auto update = py::oobj::import("IPython.core.display", "update_display");
-        update.call(HTML.call(), kwds);
+        update.call(HTML.call(), update_kwds);
       }
 
-      display.call(HTML.call(htmlstr), kwds);
+      display.call(HTML.call(htmlstr), update_kwds);
     }
 
   protected:

--- a/c/frame/repr/html_widget.h
+++ b/c/frame/repr/html_widget.h
@@ -23,10 +23,270 @@
 #define dt_FRAME_REPR_HTML_WIDGET_h
 #include "frame/repr/widget.h"
 #include "python/_all.h"
+#include "python/string.h"
+#include "utils/terminal/terminal.h"
 namespace dt {
 
 
 void emit_stylesheet();
+
+//------------------------------------------------------------------------------
+// HtmlWidget
+//------------------------------------------------------------------------------
+
+/**
+  * This class is responsible for rendering a Frame into HTML.
+  */
+class HtmlWidget : public dt::Widget {
+  private:
+    std::ostringstream html;
+
+  public:
+    explicit HtmlWidget(DataTable* dt)
+      : dt::Widget(dt, split_view_tag) {}
+
+    py::oobj to_python() {
+      render_all();
+      const std::string htmlstr = html.str();
+      return py::ostring(htmlstr);
+    }
+
+    static void write_to_jupyter(const py::oobj& htmlstr, const py::odict& kwds) {
+      if (!dt::Terminal::standard_terminal().is_jupyter()) {
+        return;
+      }
+
+      auto HTML = py::oobj::import("IPython.core.display", "HTML");
+      auto display = py::oobj::import("IPython.core.display", "display");
+      if (!kwds.empty()) {
+        auto update = py::oobj::import("IPython.core.display", "update_display");
+        update.call(HTML.call(), kwds);
+      }
+
+      display.call(HTML.call(htmlstr), kwds);
+    }
+
+  protected:
+    void _render() override {
+      html << "<div class='datatable'>\n";
+      html << "  <table class='frame'>\n";
+      html << "  <thead>\n";
+      _render_column_names();
+      _render_column_types();
+      html << "  </thead>\n";
+      html << "  <tbody>\n";
+      _render_data_rows();
+      html << "  </tbody>\n";
+      html << "  </table>\n";
+      _render_table_footer();
+      html << "</div>\n";
+    }
+
+    void _render_column_names() {
+      const strvec& colnames = dt_->get_names();
+      html << "    <tr class='colnames'>";
+      if (render_row_indices_) {
+        html << "<td class='row_index'></td>";
+      }
+      for (size_t j : colindices_) {
+        if (j == NA_index) {
+          html << "<th class='vellipsis'>&hellip;</th>";
+        } else {
+          html << (j < nkeys_? "<th class='row_index'>" : "<th>");
+          _render_escaped_string(colnames[j].data(), colnames[j].size());
+          html << "</th>";
+        }
+      }
+      html << "</tr>\n";
+    }
+
+    void _render_column_types() {
+      html << "    <tr class='coltypes'>";
+      if (render_row_indices_) {
+        html << "<td class='row_index'></td>";
+      }
+      for (size_t j : colindices_) {
+        if (j == NA_index) {
+          html << "<td></td>";
+        } else {
+          auto stype_info = info(dt_->get_column(j).stype());
+          size_t elemsize = stype_info.elemsize();
+          html << "<td class='" << stype_info.ltype_name()
+               << "' title='" << stype_info.name() << "'>";
+          for (size_t k = 0; k < elemsize; ++k) html << "&#x25AA;";
+          html << "</td>";
+        }
+      }
+      html << "</tr>\n";
+    }
+
+    void _render_data_rows() {
+      for (size_t i : rowindices_) {
+        if (i == NA_index) {
+          _render_ellipsis_row();
+        } else {
+          _render_data_row(i);
+        }
+      }
+    }
+
+    void _render_ellipsis_row() {
+      html << "    <tr>";
+      if (render_row_indices_) {
+        html << "<td class='row_index'>&#x22EE;</td>";
+      }
+      for (size_t j : colindices_) {
+        if (j == NA_index) {
+          html << "<td class='hellipsis'>&#x22F1;</td>";
+        } else {
+          html << "<td class='hellipsis'>&#x22EE;</td>";
+        }
+      }
+      html << "</tr>\n";
+    }
+
+    void _render_data_row(size_t i) {
+      html << "    <tr>";
+      if (render_row_indices_) {
+        html << "<td class='row_index'>";
+        _render_comma_separated(i);
+        html << "</td>";
+      }
+      for (size_t j : colindices_) {
+        if (j == NA_index) {
+          html << "<td class=vellipsis>&hellip;</td>";
+          continue;
+        }
+        html << (j < nkeys_? "<td class='row_index'>" : "<td>");
+        const Column& col = dt_->get_column(j);
+        switch (col.stype()) {
+          case SType::BOOL:
+          case SType::INT8:    _render_fw_value<int8_t>(col, i); break;
+          case SType::INT16:   _render_fw_value<int16_t>(col, i); break;
+          case SType::INT32:   _render_fw_value<int32_t>(col, i); break;
+          case SType::INT64:   _render_fw_value<int64_t>(col, i); break;
+          case SType::FLOAT32: _render_fw_value<float>(col, i); break;
+          case SType::FLOAT64: _render_fw_value<double>(col, i); break;
+          case SType::STR32:
+          case SType::STR64:   _render_str_value(col, i); break;
+          case SType::OBJ:     _render_obj_value(col, i); break;
+          default:
+            html << "(unknown stype)";
+        }
+        html << "</td>";
+      }
+      html << "</tr>\n";
+    }
+
+
+    void _render_table_footer() {
+      size_t nrows = dt_->nrows();
+      size_t ncols = dt_->ncols();
+      html << "  <div class='footer'>\n";
+      html << "    <div class='frame_dimensions'>";
+      _render_comma_separated(nrows);
+      html << " row" << (nrows == 1? "" : "s") << " &times; ";
+      _render_comma_separated(ncols);
+      html << " column" << (ncols == 1? "" : "s");
+      html << "</div>\n";
+      html << "  </div>\n";
+    }
+
+
+    void _render_escaped_string(const char* ch, size_t len) {
+      size_t maxi = std::min(len, size_t(50));
+      uint8_t uc;
+      for (size_t i = 0; i < maxi; ++i) {
+        char c = ch[i];
+        if (c == '&') html << "&amp;";
+        else if (c == '<') html << "&lt;";
+        else if (c == '>') html << "&gt;";
+        else {
+          html << c;
+          if (maxi < len && (uc = static_cast<uint8_t>(c)) >= 0xC0) {
+            // for Unicode characters, make sure they are calculated as a
+            // single char, and also not truncated in the middle.
+            if ((uc & 0xE0) == 0xC0)      maxi += 1;
+            else if ((uc & 0xF0) == 0xE0) maxi += 2;
+            else if ((uc & 0xF8) == 0xF0) maxi += 3;
+            if (maxi > len) maxi = len;
+          }
+        }
+      }
+      if (len > maxi) html << "&#133;";
+    }
+
+    template <typename T>
+    void _render_fw_value(const Column& col, size_t row) {
+      T val;
+      bool isvalid = col.get_element(row, &val);
+      if (isvalid) {
+        if (val < 0) {
+          html << "&minus;";
+          val = -val;
+        }
+        html << +val; // "+" ensures that `int8_t` vals are rendered as numbers
+
+      } else {
+        _render_na();
+      }
+    }
+
+    void _render_str_value(const Column& col, size_t row) {
+      CString val;
+      bool isvalid = col.get_element(row, &val);
+      if (isvalid) {
+        _render_escaped_string(val.ch, static_cast<size_t>(val.size));
+      } else {
+        _render_na();
+      }
+    }
+
+    void _render_obj_value(const Column& col, size_t row) {
+      py::robj val;
+      bool isvalid = col.get_element(row, &val);
+      if (isvalid) {
+        // Should we use repr() here instead?
+        py::ostring strval = val.to_pystring_force();
+        CString cstr = strval.to_cstring();
+        _render_escaped_string(cstr.ch, static_cast<size_t>(cstr.size));
+      } else {
+        _render_na();
+      }
+    }
+
+    void _render_na() {
+      html << "<span class=na>NA</span>";
+    }
+
+    void _render_comma_separated(size_t n) {
+      // It is customary not to display commas in 4-digit numbers
+      if (n < 10000) {
+        html << n;
+        return;
+      }
+      size_t n10 = n / 10;
+      size_t k = 1;
+      size_t m = 0;
+      while (k <= n10) {
+        k *= 10;
+        ++m;
+      }
+      m = m % 3;
+      while (k) {
+        size_t d = n / k;
+        n -= d * k;
+        k /= 10;
+        html << char('0' + d);
+        if (m == 0 && k) {
+          html << ',';
+          m = 2;
+        } else {
+          --m;
+        }
+      }
+    }
+};
 
 
 }  // namespace dt


### PR DESCRIPTION
In this PR we 
- respect the `interactive` option in a terminal, and always turn the interactive mode off in Jupyter;
- move `HTMLWidget` code from `__repr__.cc` to `html_widget.h`, this seems to be a more natural place for the widget;
- add a `HTMLWidget::write_to_jupyter()` method to write HTML code to Jupyter;
- use the above method to render HTML when something like `DT.view()` is called in Jupyter. Also, make the `emit_stylesheet()` to use the new method;
- leave the behavior of `str(DT)` intact in Jupyter, because even if we return HTML here the `print(DT)` command will have no clue about it and will print the HTML source code. The only benefit of returning HTML in `str()` could be that one may later do something like `HTML(str(DT))` — but it is unlikely to happen and printing a clear output should probably be a priority. 