### PR TITLE
Fix feature importance normalization

### DIFF
--- a/c/models/py_ftrl.cc
+++ b/c/models/py_ftrl.cc
@@ -576,7 +576,7 @@ oobj Ftrl::get_fi() const {
 }
 
 oobj Ftrl::get_normalized_fi(bool normalize) const {
-  // if (!dtft->is_model_trained()) return py::None();
+  if (!dtft->is_model_trained()) return py::None();
   return dtft->get_fi(normalize);
 }
 

--- a/c/models/py_ftrl.cc
+++ b/c/models/py_ftrl.cc
@@ -576,7 +576,7 @@ oobj Ftrl::get_fi() const {
 }
 
 oobj Ftrl::get_normalized_fi(bool normalize) const {
-  if (!dtft->is_model_trained()) return py::None();
+  // if (!dtft->is_model_trained()) return py::None();
   return dtft->get_fi(normalize);
 }
 

--- a/tests/models/test_ftrl.py
+++ b/tests/models/test_ftrl.py
@@ -1266,11 +1266,11 @@ def test_ftrl_feature_importances():
     df_target = dt.Frame([False, True] * (nrows // 2))
     ft.fit(df_train, df_target)
     fi = ft.feature_importances
-    assert fi[1].max1() == 1
     assert fi[1].min1() >= 0
+    assert math.isclose(fi[1].max1(), 1, abs_tol = 1e-7)
     assert fi.stypes == (stype.str32, stype.float32)
     assert fi.names == ("feature_name", "feature_importance")
-    assert fi[:, 0].to_list() == [feature_names]
+    assert fi[0].to_list() == [feature_names]
     assert fi[0, 1] < fi[2, 1]
     assert fi[2, 1] < fi[1, 1]
 
@@ -1297,6 +1297,10 @@ def test_ftrl_fi_shallowcopy():
     df_target = dt.Frame([bool(random.getrandbits(1)) for _ in range(ft.nbins)])
     ft.fit(df_train, df_target)
     fi1 = ft.feature_importances
+    fi1 = ft.feature_importances
+    assert fi1[1].min1() >= 0
+    assert math.isclose(fi1[1].max1(), 1, abs_tol = 1e-7)
+
     fi2 = copy.deepcopy(ft.feature_importances)
     ft.reset()
     assert ft.feature_importances == None
@@ -1339,7 +1343,10 @@ def test_ftrl_interactions_formats(interactions):
     df_target = dt.Frame(target = [True, False] * 5)
 
     ft.fit(df_train, df_target)
-    assert (ft.feature_importances[:, 0].to_list() ==
+    fi = ft.feature_importances
+    assert fi[1].min1() >= 0
+    assert math.isclose(fi[1].max1(), 1, abs_tol = 1e-7)
+    assert (fi[0].to_list() ==
            [["feature1", "feature2", "feature3",
              "feature1:feature2:feature3", "feature3:feature2"]])
     assert ft.interactions == tuple(tuple(interaction) for interaction in interactions)
@@ -1357,7 +1364,10 @@ def test_ftrl_interactions_from_itertools(struct):
 
     ft = Ftrl(interactions = interactions)
     ft.fit(df_train, df_target)
-    assert (ft.feature_importances[:, 0].to_list() ==
+    fi = ft.feature_importances
+    assert fi[1].min1() >= 0
+    assert math.isclose(fi[1].max1(), 1, abs_tol = 1e-7)
+    assert (fi[0].to_list() ==
            [["feature1", "feature2", "feature3",
              "feature1:feature2", "feature1:feature3", "feature2:feature3"]])
 
@@ -1379,9 +1389,12 @@ def test_ftrl_interactions():
     df_target = dt.Frame([False, True] * (nrows // 2))
     ft.fit(df_train, df_target)
     fi = ft.feature_importances
+
+    assert fi[1].min1() >= 0
+    assert math.isclose(fi[1].max1(), 1, abs_tol = 1e-7)
     assert fi.stypes == (stype.str32, stype.float32)
     assert fi.names == ("feature_name", "feature_importance")
-    assert fi[:, 0].to_list() == [feature_names + interaction_names]
+    assert fi[0].to_list() == [feature_names + interaction_names]
     assert fi[0, 1] < fi[2, 1]
     assert fi[2, 1] < fi[1, 1]
     assert fi[3, 1] < fi[1, 1]
@@ -1400,7 +1413,9 @@ def test_ftrl_interactions():
     ft.interactions = None
     ft.fit(df_train, df_target)
     fi = ft.feature_importances
-    assert fi[:, 0].to_list() == [feature_names]
+    assert fi[1].min1() >= 0
+    assert math.isclose(fi[1].max1(), 1, abs_tol = 1e-7)
+    assert fi[0].to_list() == [feature_names]
 
 
 #-------------------------------------------------------------------------------

--- a/tests/models/test_ftrl.py
+++ b/tests/models/test_ftrl.py
@@ -1266,11 +1266,28 @@ def test_ftrl_feature_importances():
     df_target = dt.Frame([False, True] * (nrows // 2))
     ft.fit(df_train, df_target)
     fi = ft.feature_importances
+    assert fi[1].max1() == 1
+    assert fi[1].min1() >= 0
     assert fi.stypes == (stype.str32, stype.float32)
     assert fi.names == ("feature_name", "feature_importance")
     assert fi[:, 0].to_list() == [feature_names]
     assert fi[0, 1] < fi[2, 1]
     assert fi[2, 1] < fi[1, 1]
+
+
+def test_ftrl_feature_importances_none():
+    ft = Ftrl()
+    assert ft.feature_importances == None
+
+
+def test_ftrl_feature_importances_empty():
+    ft = Ftrl(nepochs = 0, double_precision = True)
+    ft.fit(dt.Frame(range(10)), dt.Frame(range(10)))
+    DT = dt.Frame(
+      [["C0"], [0.0]],
+      names = ("feature_name", "feature_importance")
+    )
+    assert_equals(ft.feature_importances, DT)
 
 
 def test_ftrl_fi_shallowcopy():


### PR DESCRIPTION
It seems that feature importance normalization got broken at the time when we converted the FTRL code to use `is_valid` parameter in the `get_element()` functions. In this PR we fix it and improve the tests.