### PR TITLE
Replace custom wheel URLs with pip install datatable in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,21 +96,9 @@ the following:
 
 ## Installation
 
-On MacOS systems installing datatable is as easy as
+On MacOS and Linux systems installing datatable is as easy as
 ```sh
 pip install datatable
-```
-
-On Linux you can install a binary distribution as
-```sh
-# If you have Python 3.5
-pip install https://s3.amazonaws.com/h2o-release/datatable/stable/datatable-0.10.0/datatable-0.10.0-cp35-cp35m-linux_x86_64.whl
-
-# If you have Python 3.6
-pip install https://s3.amazonaws.com/h2o-release/datatable/stable/datatable-0.10.0/datatable-0.10.0-cp36-cp36m-linux_x86_64.whl
-
-# If you have Python 3.7
-pip install https://s3.amazonaws.com/h2o-release/datatable/stable/datatable-0.10.0/datatable-0.10.0-cp37-cp37m-linux_x86_64.whl
 ```
 
 On all other platforms a source distribution will be needed. For more


### PR DESCRIPTION
Right now the links to install datatable on Linux, that are included in `README.md`, are broken for all the python versions. This brings a lot of confusion, because this information is also shown on the main github page for datatable. In this PR we replace installation from these links with a single `pip install datatable` command, that will install datatable v0.10 on Linux and Mac. When custom links are fixed, we can include them under the detailed installation instructions in the docs.