### PR TITLE
New Xbuild module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,18 @@ test:
 		--junitxml=build/test-reports/TEST-datatable.xml \
 		tests
 
+xasan:
+	$(PYTHON) ext.py asan
+
+xbuild:
+	$(PYTHON) ext.py build
+
+xcoverage:
+	$(PYTHON) ext.py coverage
+
+xdebug:
+	$(PYTHON) ext.py debug
+
 
 benchmark:
 	$(PYTHON) -m pytest -ra -x -v benchmarks

--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -138,7 +138,7 @@ static py::PKArgs args_in_debug_mode(
     "Return True if datatable was compiled in debug mode");
 
 static py::oobj in_debug_mode(const py::PKArgs&) {
-  #ifdef DTDEBUG
+  #if DTDEBUG
     return py::True();
   #else
     return py::False();

--- a/ci/xbuild/__init__.py
+++ b/ci/xbuild/__init__.py
@@ -23,11 +23,12 @@
 #-------------------------------------------------------------------------------
 from .compiler import Compiler
 from .extension import Extension
-from .logger import Logger0, Logger3
+from .logger import Logger0, Logger1, Logger3
 
 __all__ = (
 	"Compiler",
 	"Extension",
 	"Logger0",
+	"Logger1",
 	"Logger3",
 )

--- a/ci/xbuild/__init__.py
+++ b/ci/xbuild/__init__.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#-------------------------------------------------------------------------------
+# Copyright 2019 H2O.ai
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#-------------------------------------------------------------------------------
+from .compiler import Compiler
+from .extension import Extension
+from .logger import Logger0, Logger3
+
+__all__ = (
+	"Compiler",
+	"Extension",
+	"Logger0",
+	"Logger3",
+)

--- a/ci/xbuild/compiler.py
+++ b/ci/xbuild/compiler.py
@@ -215,10 +215,12 @@ class Compiler:
         os.makedirs(os.path.dirname(obj), exist_ok=True)
         cmd = self.get_compile_command(src, obj)
         if not silent:
-            self.log.report_compile_file(src, cmd)
+            self.log.report_compile_start(src, cmd)
 
-        return subprocess.Popen(cmd, stdout=subprocess.PIPE,
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE)
+        proc.source = src
+        return proc
 
 
 

--- a/ci/xbuild/compiler.py
+++ b/ci/xbuild/compiler.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#-------------------------------------------------------------------------------
+# Copyright 2019 H2O.ai
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#-------------------------------------------------------------------------------
+import os
+import subprocess
+import sysconfig
+from .logger import Logger0
+
+
+class Compiler:
+
+    def __init__(self):
+        self._executable = "gcc"
+        self._parent = None
+        self._compiler_flags = []
+        self._include_dirs = []
+        self._linker_flags = []
+
+
+    @property
+    def log(self):
+        if self._parent is None:
+            raise RuntimeError("Compiler object must be attached to an "
+                               "Extension")
+        return self._parent.log
+
+
+    @property
+    def include_dirs(self):
+        return self._include_dirs
+
+
+
+    #---------------------------------------------------------------------------
+    # Compiling
+    #---------------------------------------------------------------------------
+
+    def add_include_dir(self, path):
+        if not path:
+            return
+        assert isinstance(path, str)
+        if not os.path.isdir(path):
+            raise ValueError("Include directory %s not found" % path)
+        self._include_dirs.append(path)
+        self._compiler_flags += ["-I" + path]
+        self.log.report_include_dir(path)
+
+
+    def add_default_python_include_dir(self):
+        dd = sysconfig.get_config_var("CONFINCLUDEPY")
+        if not os.path.isdir(dd):
+            self._log.warn("Python include directory `%s` does not exist, "
+                           "compilation may fail" % dd)
+        elif not os.path.exists(os.path.join(dd, "Python.h")):
+            self._log.warn("Python include directory `%s` is missing the file "
+                           "Python.h, compilation may fail" % dd)
+        self.add_include_dir(dd)
+
+
+    def add_compiler_flag(self, *flags):
+        for flag in flags:
+            if flag:
+                assert isinstance(flag, str)
+                self._compiler_flags.append(flag)
+
+
+    def enable_colors(self):
+        self._compiler_flags.append("-fdiagnostics-color=always")
+
+
+    def get_compile_command(self, source, target):
+        cmd = [self._executable] + self._compiler_flags
+        cmd += ["-c", source]
+        cmd += ["-o", target]
+        return cmd
+
+
+    def compile(self, src, obj):
+        os.makedirs(os.path.dirname(obj), exist_ok=True)
+        cmd = self.get_compile_command(src, obj)
+        self.log.report_compile_file(src, cmd)
+
+        return subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE)
+
+
+
+    #---------------------------------------------------------------------------
+    # Linking
+    #---------------------------------------------------------------------------
+
+    def add_linker_flag(self, *flags):
+        for flag in flags:
+            if flag:
+                assert isinstance(flag, str)
+                self._linker_flags.append(flag)
+
+
+    def get_link_command(self, sources, target):
+        cmd = [self._executable] + self._linker_flags
+        cmd += sources
+        cmd += ["-o", target]
+        return cmd
+
+
+    def link(self, obj_files, target):
+        os.makedirs(os.path.dirname(target), exist_ok=True)
+        cmd = self.get_link_command(obj_files, target)
+        self.log.report_link_file(target, cmd)
+
+        return subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE)

--- a/ci/xbuild/compiler.py
+++ b/ci/xbuild/compiler.py
@@ -23,18 +23,27 @@
 #-------------------------------------------------------------------------------
 import os
 import subprocess
+import sys
 import sysconfig
+import tempfile
 from .logger import Logger0
 
 
 class Compiler:
 
     def __init__(self):
-        self._executable = "gcc"
-        self._parent = None
-        self._compiler_flags = []
-        self._include_dirs = []
-        self._linker_flags = []
+        # Name of the compiler executable
+        self._executable = None    # str
+
+        # The "flavor" of the executable, determines how the flags are
+        # passed.
+        self._flavor = None        # 'msvc'|'gcc'|'clang'|'unknown'
+
+        # Parent `Extension` class
+        self._parent = None        # xbuild.extension.Extension
+        self._compiler_flags = []  # List[str]
+        self._include_dirs = []    # List[str]
+        self._linker_flags = []    # List[str]
 
 
     @property
@@ -46,8 +55,104 @@ class Compiler:
 
 
     @property
+    def executable(self):
+        if self._executable is None:
+            self._detect_compiler_executable()
+        return self._executable
+
+    @executable.setter
+    def executable(self, value):
+        assert isinstance(value, str)
+        self._executable = value
+        self._flavor = "msvc" if "msvc" in value else \
+                       "clang" if "clang" in value else \
+                       "gcc" if "gcc" in value or "g++" in value else \
+                       "unknown"
+
+
+    @property
+    def flavor(self):
+        if self._flavor is None:
+            self._detect_compiler_executable()
+        return self._flavor
+
+
+    @property
     def include_dirs(self):
         return self._include_dirs
+
+
+    def is_clang(self):
+        return self.flavor == "clang"
+
+    def is_msvc(self):
+        return self.flavor == "msvc"
+
+    def is_gcc(self):
+        return self.flavor == "gcc"
+
+
+
+    #---------------------------------------------------------------------------
+    # Setup
+    #---------------------------------------------------------------------------
+
+    def _check_compiler(self, cc, source, target):
+        """
+        Check whether the given compiler is viable, i.e. whether it
+        can compile a simple example file. Returns True if the
+        compiler works, and False otherwise.
+        """
+        e = self._executable
+        f = self._flavor
+        self.executable = cc
+        proc = self.compile(source, target, silent=True)
+        ret = proc.wait()
+        self._executable = e
+        self._flavor = f
+        return (ret == 0)
+
+
+    def _detect_compiler_executable(self):
+        fd, srcname = tempfile.mkstemp(suffix=".cc")
+        outname = srcname + ".out"
+        os.close(fd)
+        assert os.path.isfile(srcname)
+        try:
+            for envvar in ["CC", "CXX"]:
+                compiler = os.environ.get(envvar)
+                if not compiler:
+                    continue
+                if os.path.isabs(compiler) and not os.path.exists(compiler):
+                    raise ValueError("The compiler `%s` from environment "
+                                     "variable `%s` does not exist"
+                                     % (compiler, envvar))
+                if not self._check_compiler(compiler, srcname, outname):
+                    raise  ValueError("The compiler `%s` from environment "
+                                     "variable `%s` failed to compile an "
+                                     "empty file" % (compiler, envvar))
+                self.executable = compiler
+                self.log.report_compiler_executable(compiler, env=envvar)
+                return
+
+            candidates = ["/usr/local/opt/llvm/bin/clang", "gcc", "clang", "cc"]
+            if sys.platform == "win32":
+                candidates = ["msvc.exe"] + [cc + ".exe" for cc in candidates]
+
+            for cc in candidates:
+                if self._check_compiler(cc, srcname, outname):
+                    self.executable = cc
+                    self.log.report_compiler_executable(cc)
+                    return
+
+            raise RuntimeError("Suitable C++ compiler cannot be determined. "
+                               "Please specify a compiler executable in the "
+                               "`CXX` environment variable.")
+        finally:
+            if srcname and os.path.isfile(srcname):
+                os.remove(srcname)
+            if outname and os.path.isfile(outname):
+                os.remove(outname)
 
 
 
@@ -55,14 +160,23 @@ class Compiler:
     # Compiling
     #---------------------------------------------------------------------------
 
-    def add_include_dir(self, path):
+    def _flags_for_include_dir(self, path, as_system):
+        if self.is_msvc():
+            return ["/I" + path]
+        elif as_system:
+            return ["-isystem", path]
+        else:
+            return ["-I" + path]
+
+
+    def add_include_dir(self, path, system=False):
         if not path:
             return
         assert isinstance(path, str)
         if not os.path.isdir(path):
             raise ValueError("Include directory %s not found" % path)
         self._include_dirs.append(path)
-        self._compiler_flags += ["-I" + path]
+        self._compiler_flags += self._flags_for_include_dir(path, system)
         self.log.report_include_dir(path)
 
 
@@ -74,7 +188,7 @@ class Compiler:
         elif not os.path.exists(os.path.join(dd, "Python.h")):
             self._log.warn("Python include directory `%s` is missing the file "
                            "Python.h, compilation may fail" % dd)
-        self.add_include_dir(dd)
+        self.add_include_dir(dd, system=True)
 
 
     def add_compiler_flag(self, *flags):
@@ -89,16 +203,19 @@ class Compiler:
 
 
     def get_compile_command(self, source, target):
-        cmd = [self._executable] + self._compiler_flags
-        cmd += ["-c", source]
-        cmd += ["-o", target]
+        cmd = [self.executable] + self._compiler_flags
+        if self.is_msvc():
+            cmd += ["/c" + source, "/Fo" + target]
+        else:
+            cmd += ["-c", source, "-o", target]
         return cmd
 
 
-    def compile(self, src, obj):
+    def compile(self, src, obj, silent=False):
         os.makedirs(os.path.dirname(obj), exist_ok=True)
         cmd = self.get_compile_command(src, obj)
-        self.log.report_compile_file(src, cmd)
+        if not silent:
+            self.log.report_compile_file(src, cmd)
 
         return subprocess.Popen(cmd, stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE)
@@ -117,9 +234,12 @@ class Compiler:
 
 
     def get_link_command(self, sources, target):
-        cmd = [self._executable] + self._linker_flags
+        cmd = [self.executable] + self._linker_flags
         cmd += sources
-        cmd += ["-o", target]
+        if self.is_msvc():
+            cmd += ["/Fe:", target]
+        else:
+            cmd += ["-o", target]
         return cmd
 
 

--- a/ci/xbuild/extension.py
+++ b/ci/xbuild/extension.py
@@ -1,0 +1,678 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#-------------------------------------------------------------------------------
+# Copyright 2019 H2O.ai
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#-------------------------------------------------------------------------------
+import glob
+import json
+import os
+import re
+import subprocess
+import sysconfig
+import time
+
+from .logger import Logger0, Logger3
+from .compiler import Compiler
+
+rx_include = re.compile(r'\s*#\s*include\s*"([^"]+)"')
+
+def normalize_path(path):
+    return os.path.relpath(os.path.expanduser(path))
+
+
+
+#-------------------------------------------------------------------------------
+# Main Extension class
+#-------------------------------------------------------------------------------
+
+class Extension:
+    """
+    Example
+    -------
+    ::
+        import xbuild
+
+        ext = xbuild.Extension()
+        ext.name = "_mypkg"
+        ext.destination_dir = "lib/"
+        ext.add_sources("c/**/*.cc")
+
+        ext.build()
+        print("File `%s` built" % ext.output_file)
+
+    """
+
+    def __init__(self):
+        # ----------------
+        # Input properties
+        # ----------------
+
+        # The directory where all temporary files will be stored, such
+        # as compiled .o files, and the .xbuild state file.
+        self._build_dir = None         # str
+
+        # The compiler object used to compile/link source files.
+        self._compiler = None          # compiler.Compiler
+
+        # The directory where the final .so file should be stored.
+        self._destination_dir = None   # str
+
+        # A logger object which gets notified about different events
+        # during the build process.
+        self._log = None               # Logger0
+
+        # Stop compiling after seeing this many lines of errors.
+        self._max_error_lines = 100    # int
+
+        # The name of the module being built.
+        self._name = None              # str
+
+        # The number of worker processes to use for compiling the
+        # source files. Defaults to the number of cores - 1.
+        self._nworkers = None          # int
+
+        # List of source files, i.e. files that need to be compiled
+        # in order to produce the final executable.
+        self._sources = []             # List[str]
+
+
+        # ------------------
+        # Runtime properties
+        # ------------------
+
+        # Dictionary of "modified" status for each source or header
+        # file. The keys are the source/header file names. The values
+        # are: True if the file was modified since the last build run
+        # and False otherwise.
+        # All source files will be placed into this dictionary. If
+        # a source file has "modified" status, it will be recompiled.
+        # All header files that are recursively reachable from any of
+        # the source files will eventually be placed into this
+        # dictionary too. If a header file is "modified" it will be
+        # rescanned to determine its list of includes.
+        self._files_modified = {}   # Dict[str, bool]
+
+        # List of source files that need to be compiled. This list is
+        # derived from `self._filed_modified` at "rescan_files" stage.
+        self._files_to_compile = [] # List[str]
+
+        # If True, then force running the link stage, even if no files
+        # were re-compiled.
+        self._force_link = False
+
+        # Name of the file that was built. This property will be
+        # filled after the `build()` command succeeds.
+        self._output_file = None    # str
+
+        # Mapping of source file names (from ._sources list) into
+        # their corresponding object file names.
+        self._src2obj = {}          # Dict[str, str]
+
+        # Mapping of source/header files into their corresponding
+        # lists of .h includes. This mapping is persisted in the
+        # .xbuild state file.
+        self._src_includes = {}     # Dict[str, List[str]]
+
+        # The time of the previous invocation of xbuilder. This is
+        # detected via the last modification time of .xbuild file.
+        # This time is used to detect which If set to 0, then
+        self._t0 = 0                # int
+
+
+
+    #---------------------------------------------------------------------------
+    # Properties
+    #---------------------------------------------------------------------------
+
+    @property
+    def build_dir(self):
+        """
+        The directory where xbuild will keep its temporary files
+        during the build process. For best results, this directory
+        should remain the same during subsequent invocations of
+        xbuild.
+        """
+        if self._build_dir is None:
+            self.build_dir = "build"
+        return self._build_dir
+
+    @build_dir.setter
+    def build_dir(self, value):
+        assert isinstance(value, str)
+        bdir = normalize_path(value)
+        self._build_dir = bdir
+        self.log.report_build_dir(bdir)
+        if not os.path.exists(bdir):
+            os.makedirs(bdir)
+            self.log.report_mkdir(bdir)
+        if not os.path.isdir(bdir):
+            raise IOError("Build directory `%s` cannot be a file" % bdir)
+
+
+    @property
+    def compiler(self):
+        """
+        The compiler object used to compile/link source files. This
+        should be an instance of a class derived from
+        :class:`xbuild.compiler.Compiler`.
+        """
+        if self._compiler is None:
+            self.compiler = Compiler()
+        return self._compiler
+
+    @compiler.setter
+    def compiler(self, cc):
+        assert isinstance(cc, Compiler)
+        cc._parent = self
+        self._compiler = cc
+        self.log.report_compiler(cc)
+
+
+    @property
+    def log(self):
+        """
+        A logger object which gets notified about different events
+        during the build process. This should be an instance of a
+        class derived from :class:`xbuild.logger.Logger0`.
+        """
+        if self._log is None:
+            self._log = Logger0()
+        return self._log
+
+    @log.setter
+    def log(self, value):
+        assert isinstance(value, Logger0)
+        self._log = value
+
+
+    @property
+    def name(self):
+        """
+        The name of the module, this should contain only alphanumeric
+        characters, so that it can work both as a file name and a
+        python identifier.
+        """
+        return self._name
+
+    @name.setter
+    def name(self, value):
+        assert isinstance(value, str)
+        assert re.fullmatch(r"\w+", value)
+        self._name = value
+        self.log.report_name(value)
+
+
+    @property
+    def destination_dir(self):
+        """
+        The directory where the final .so file should be stored.
+        """
+        if self._destination_dir is None:
+            self.destination_dir = self.build_dir
+        return self._destination_dir
+
+    @destination_dir.setter
+    def destination_dir(self, value):
+        assert isinstance(value, str)
+        ddir = normalize_path(value)
+        self._destination_dir = ddir
+        self.log.report_destdir(ddir)
+        if not os.path.exists(ddir):
+            os.makedirs(ddir)
+            self.log.report_mkdir(ddir)
+        if not os.path.isdir(ddir):
+            raise IOError("Destination directory `%s` cannot be a file" % ddir)
+
+
+    @property
+    def sources(self):
+        """
+        The list of files that the user specified as the "source"
+        files, i.e. files that have to be compiled to obtain the
+        executable. These should not include the header files.
+        """
+        return self._sources
+
+    def add_sources(self, *srcs):
+        for s in srcs:
+            assert s and isinstance(s, str)
+            ns = normalize_path(s)
+            if re.search(r"[\*\?\[]", s):  # a glob pattern
+                srcs = glob.glob(ns, recursive=True)
+                self._sources += srcs
+                self.log.report_sources(srcs, pattern=s)
+            else:
+                if not os.path.isfile(ns):
+                    raise ValueError("Cannot find source file `%s`" % s)
+                self._sources.append(ns)
+                self.log.report_sources(ns)
+
+        # deduplicate
+        if len(set(self._sources)) != len(self._sources):
+            deduplicated = []
+            seen = set()
+            for src in self._sources:
+                if src not in seen:
+                    seen.add(src)
+                    deduplicated.append(src)
+            self._sources = deduplicated
+            self.log.report_deduplicated(deduplicated)
+
+
+    @property
+    def nworkers(self):
+        """
+        The number of worker processes to use for compiling the
+        source files. Defaults to the 80% of the number of cores.
+        """
+        if self._nworkers is None:
+            self.nworkers = "auto"
+        return self._nworkers
+
+    @nworkers.setter
+    def nworkers(self, value):
+        if value == "auto":
+            ncpus = os.cpu_count()  # could return None
+            value = round(ncpus * 0.8) if ncpus else 1
+        assert isinstance(value, int)
+        assert value > 0
+        self._nworkers = value
+        self.log.report_nworkers(value)
+
+
+    @property
+    def output_file(self):
+        if self._output_file is None:
+            self.output_file = "auto"
+        return self._output_file
+
+    @output_file.setter
+    def output_file(self, value):
+        if value == "auto":
+            ext_suffix = sysconfig.get_config_var('EXT_SUFFIX')
+            assert ext_suffix[0] == "."
+            value = os.path.join(self.destination_dir,
+                                 self.name + ext_suffix)
+        assert isinstance(value, str)
+        self._output_file = value
+        self.log.report_output_file(value)
+
+
+    @property
+    def state_file(self):
+        """
+        Path to the file where we keep certain information from the
+        previous run of xbuild.
+        """
+        return os.path.join(self.build_dir, ".xbuild")
+
+
+    @property
+    def xbuild_version(self):
+        """
+        The iteration version of the xbuild module. Changing this
+        variable causes all source files to be rebuilt.
+        """
+        return "1"
+
+
+    @property
+    def pyabi(self):
+        """
+        Python `SOABI` config variable, which may look something like
+        'cpython-37m-darwin'. If this does not correspond to the value
+        stored in .xbuild, then all sources will be rebuilt.
+        """
+        return sysconfig.get_config_var("SOABI")
+
+
+    @property
+    def max_error_lines(self):
+        return self._max_error_lines
+
+    @max_error_lines.setter
+    def max_error_lines(self, value):
+        assert isinstance(value, int)
+        if value <= 0:
+            value = 10**9  # Any large number
+        self._max_error_lines = value
+
+
+
+    #---------------------------------------------------------------------------
+    # State retention
+    #---------------------------------------------------------------------------
+
+    def _save_state(self):
+        with open(self.state_file, "wt") as out:
+            json.dump({
+                "version": self.xbuild_version,
+                "abi": self.pyabi,
+                "includes": self._src_includes,
+                "compile": self.compiler.get_compile_command("X", "Y"),
+                "link": self.compiler.get_link_command(["X"], "Y"),
+            }, out, indent=2)
+
+
+    def _load_state(self):
+        state_file = self.state_file
+        self.log.step_load_state(state_file)
+        self._t0 = 0
+        if os.path.exists(state_file):
+            with open(state_file, "rt") as inp:
+                info = json.load(inp)
+                xver = self.xbuild_version
+                ccmd = self.compiler.get_compile_command("X", "Y")
+                lcmd = self.compiler.get_link_command(["X"], "Y")
+                if info["version"] != xver:
+                    self.log.report_version_mismatch(info["version"], xver)
+                elif info["abi"] != self.pyabi:
+                    self.log.report_abi_mismatch(info["abi"], self.pyabi)
+                elif info["compile"] != ccmd:
+                    self.log.report_compile_cmd_mismatch(info["compile"], ccmd)
+                else:
+                    if info["link"] != lcmd:
+                        self.log.report_link_cmd_mismatch(info["link"], lcmd)
+                        self._force_link = True
+                    self._src_includes = info["includes"]
+                    self._t0 = int(float(os.path.getmtime(state_file)))
+                    self.log.report_includes(info["includes"])
+        else:
+            self.log.report_no_state_file()
+
+        if self._t0 == 0:
+            self.log.report_full_rebuild()
+        else:
+            self.log.report_t0(self._t0)
+
+
+
+    #---------------------------------------------------------------------------
+    # Building
+    #---------------------------------------------------------------------------
+
+    def build(self):
+        """
+        Main "build" command: compiles and links a dynamic library
+        of the extension.
+        """
+        if not self.name:
+            raise ValueError("An extension doesn't have a name")
+        if not self.sources:
+            raise ValueError("No source files were specified for compiling "
+                             "this extension")
+        t_start = time.time()
+        self.output_file  # Instantiate the value of this variable
+        self.log.cmd_build()
+        self._load_state()              # [1]
+        self._build_src2obj_map()       # [2]
+        self._check_obj_uniqueness()
+        self._find_files_to_rebuild()   # [3]
+        self._scan_files()              # [4]
+        self._compile_files()           # [5]
+        self._link_files()              # [6]
+        self._save_state()              # [7]
+        t_finish = time.time()
+        self.log.step_build_done(t_finish - t_start)
+
+
+    def _build_src2obj_map(self):
+        """
+        Create dictionary `self._src2obj` which maps every source
+        file from `self._sources` into its object file name. For
+        example:
+
+            "c/column.cc": "build/column.o",
+            "c/frame/repr/html.cc": "build/frame/repr/html.o",
+            ...
+        """
+        self.log.step_src2obj()
+        commonpath = os.path.commonpath(self.sources)
+        self._src2obj = {}
+        for src in self.sources:
+            shortpath = os.path.relpath(src, start=commonpath)
+            target = os.path.splitext(shortpath)[0].lower() + ".o"
+            objfile = os.path.join(self.build_dir, target)
+            self._src2obj[src] = objfile
+
+
+    def _check_obj_uniqueness(self):
+        """
+        Verify that object file names are unique, i.e. no two source
+        files map to the same object file.
+        """
+        obj2src = {}
+        for src in self.sources:
+            objfile = self._src2obj[src]
+            if objfile in obj2src:
+                raise ValueError("Source files %s and %s both produce the "
+                                 "same object file %s"
+                                 % (obj2src[objfile], src, objfile))
+            obj2src[objfile] = src
+
+
+    def _is_modified(self, srcfile):
+        """
+        Memoized check for whether the file `srcfile` is <modified>.
+
+        A file is presumed modified if either (1) it hasn't been seen
+        during the previous run of xbuild, or (2) its modification
+        timestamp is after the `self._t0` epoch, or (3) one of its
+        includes is modified.
+
+        The function stores the <modified> status of the `srcfile` in
+        map `self._files_modified`.
+        """
+        if srcfile not in self._files_modified:
+            self._files_modified[srcfile] = (
+                srcfile not in self._src_includes or
+                os.path.getmtime(srcfile) > self._t0 or
+                any(self._is_modified(hfile)
+                    for hfile in self._src_includes[srcfile])
+            )
+        return self._files_modified[srcfile]
+
+
+    def _find_files_to_rebuild(self):
+        """
+        Check which of the source files need to be recompiled, either
+        because the corresponding obj file is missing, or if the file
+        was <modified> (see :meth:`_is_modified`).
+
+        This method populates the map `self._files_modified` with
+        boolean indicators of whether each file is considered
+        <mofified> and should be rescanned. Also it creates the list
+        `self._files_to_compile` of source files that need to be
+        compiled. And finally, this method deletes all obj files that
+        no longer correspond to any source file.
+        """
+        self.log.step_find_rebuild_targets()
+        obj_files_pattern = os.path.join(self._build_dir, "**/*.o")
+        existing_obj_files = set(glob.iglob(obj_files_pattern, recursive=True))
+
+        for src_file in self._sources:
+            obj_file = self._src2obj[src_file]
+            self._files_modified[src_file] = (
+                self._t0 == 0 or
+                obj_file not in existing_obj_files or
+                self._is_modified(src_file)
+            )
+            existing_obj_files.discard(obj_file)
+        self._files_to_compile = [src for src in self._sources
+                                  if self._files_modified[src]]
+        self.log.report_sources_modified(self._files_to_compile)
+
+        # Remaining `existing_obj_files` do not correspond to any source file,
+        # and therefore should be removed
+        self.log.report_dead_files(existing_obj_files)
+        for obj_file in existing_obj_files:
+            os.unlink(obj_file)
+            self.log.report_removed_file(obj_file)
+
+
+    def _scan_files(self):
+        """
+        Parse all <modified> files and determine their set of
+        includes. As each file is scanned, its <modified> flag is
+        cleared. At the same time, we recursively scan all includes
+        from all modified files, ensuring that full dependency tree
+        is known.
+
+        The final effect of this method is that it will populate the
+        `self._src_includes` map with up-to-date information about
+        the list of includes for each source/header file.
+        """
+        self.log.step_scan_files(sum(self._files_modified.values()))
+        while any(self._files_modified.values()):
+            # need list() here because we modify the dictionary in the loop
+            for src_file, modified in list(self._files_modified.items()):
+                if modified:
+                    self._scan_file(src_file)
+                    self._files_modified[src_file] = False
+                    # Also check the modified status of ALL include files;
+                    # the `._is_modified()` call updates the `._files_modified`
+                    # dictionary, which is why we have the outer while loop.
+                    for hfile in self._src_includes[src_file]:
+                        if hfile not in self._files_modified:
+                            mod = self._is_modified(hfile)
+                            self.log.report_new_header_found(hfile, mod)
+        self._files_modified = None
+
+
+    def _scan_file(self, src_file):
+        """
+        Scan file `src_file` and detect its list of includes.
+
+        The includes are lines of form `#include "header.h"`, where
+        the file `header.h` may be either in the same directory as
+        the source file, or relative to one of the "include"
+        directories.
+
+        This method will resolve the list of includes to their
+        normalized paths, and stores the list into the
+        `self._src_includes` map.
+        """
+        src_path = os.path.dirname(src_file)
+        includes = []
+        with open(src_file, "rt") as inp:
+            for line in inp:
+                mm = re.match(rx_include, line)
+                if mm:
+                    hfile = mm.group(1)
+                    hfile1 = os.path.join(src_path, hfile)
+                    if os.path.exists(hfile1):
+                        includes.append(hfile1)
+                    else:
+                        found = False
+                        for incl_dir in self.compiler.include_dirs:
+                            hfile2 = os.path.join(incl_dir, hfile)
+                            if os.path.exists(hfile2):
+                                includes.append(hfile2)
+                                found = True
+                                break
+                        if not found:
+                            raise ValueError("Cannot locate header file `%s` "
+                                             "included from `%s`"
+                                             % (hfile, src_file))
+        self._src_includes[src_file] = includes
+        self.log.report_src_includes(src_file, includes)
+
+
+    def _compile_files(self):
+        """
+        In this step we compile all the files in the
+        `self._files_to_compile` list.
+
+        Compilation is done in-parallel, using multiple processes
+        (up to `self.nworkers`). All errors/warnings are reported at
+        the end. A SystemExit exception is raised if any of the files
+        fail to compile. The exception, however, is deferred to a
+        point when all files were attempted to be compiled, or at
+        least until a sufficient volume of errors was produced (up to
+        `self.max_error_lines` lines).
+
+        At the end of this step, if it succeeds, all source files will
+        have their corresponding object files physically present on
+        disk.
+        """
+        self.log.step_compile(self._files_to_compile)
+
+        def compile_queue():
+            # Given a queue of workers (`subprocess.Popen` processes),
+            # wait until at least one of them finishes and return that
+            # worker, and also remove it from the `queue`.
+            def await_one(queue):
+                while queue:
+                    for i, worker in enumerate(queue):
+                        if worker.poll() is not None:
+                            del queue[i]
+                            return worker
+                    time.sleep(0.1)
+
+            queue = []
+            for src_file in self._files_to_compile:
+                if len(queue) == self.nworkers:
+                    yield await_one(queue)
+                obj_file = self._src2obj[src_file]
+                queue.append(self._compiler.compile(src_file, obj_file))
+            while queue:
+                yield await_one(queue)
+
+        errors_and_warnings = []
+        n_error_lines = 0
+        has_errors = False
+        for proc in compile_queue():
+            stdout, stderr = proc.communicate()
+            if proc.returncode:
+                has_errors = True
+            out = (stdout + stderr).decode("utf-8")
+            if out:
+                errors_and_warnings.append(out)
+                n_error_lines += len(out.split("\n"))
+                if n_error_lines >= self.max_error_lines and has_errors:
+                    self.log.report_stopped_compiling()
+                    break
+
+        self.log.report_errors_and_warnings(errors_and_warnings, has_errors)
+        if has_errors:
+            raise SystemExit("Error compiling %s" % self.name)
+
+
+    def _link_files(self):
+        """
+        Final link stage: take all object files and link them into
+        the final dynamic library.
+        """
+        need_to_link = (self._force_link or
+                        self._files_to_compile or
+                        not os.path.exists(self.output_file) or
+                        os.path.getmtime(self.output_file) > self._t0)
+        self.log.step_link(need_to_link)
+        if need_to_link:
+            obj_files = list(self._src2obj.values())
+            worker = self.compiler.link(obj_files, self.output_file)
+            stdout, stderr = worker.communicate()
+            msg = (stdout + stderr).decode("utf-8")
+            fail = (worker.returncode != 0)
+            if msg:
+                self.log.report_errors_and_warnings([msg], errors=fail)
+            if fail:
+                raise SystemExit("Error linking `%s`" % self.output_file)

--- a/ci/xbuild/extension.py
+++ b/ci/xbuild/extension.py
@@ -484,7 +484,7 @@ class Extension:
         if srcfile not in self._files_modified:
             self._files_modified[srcfile] = (
                 srcfile not in self._src_includes or
-                os.path.getmtime(srcfile) > self._t0 or
+                int(os.path.getmtime(srcfile) > self._t0) or
                 any(self._is_modified(hfile)
                     for hfile in self._src_includes[srcfile])
             )
@@ -641,6 +641,7 @@ class Extension:
         has_errors = False
         for proc in compile_queue():
             stdout, stderr = proc.communicate()
+            self.log.report_compile_finish(proc.source, (proc.returncode != 0))
             if proc.returncode:
                 has_errors = True
             out = (stdout + stderr).decode("utf-8")
@@ -664,7 +665,7 @@ class Extension:
         need_to_link = (self._force_link or
                         self._files_to_compile or
                         not os.path.exists(self.output_file) or
-                        os.path.getmtime(self.output_file) > self._t0)
+                        int(os.path.getmtime(self.output_file)) > self._t0)
         self.log.step_link(need_to_link)
         if need_to_link:
             obj_files = list(self._src2obj.values())

--- a/ci/xbuild/logger.py
+++ b/ci/xbuild/logger.py
@@ -39,6 +39,7 @@ class Logger0:
     def report_compile_cmd_mismatch(self, cmd1, cmd2): pass
     def report_compile_file(self, filename, cmd): pass
     def report_compiler(self, cc): pass
+    def report_compiler_executable(self, cc, env=None): pass
     def report_dead_files(self, files): pass
     def report_deduplicated(self, files): pass
     def report_destdir(self, dd): pass
@@ -111,6 +112,12 @@ class Logger3(Logger0):
     def report_compiler(self, cc):
         self.info("Using compiler of class %s.%s"
                   % (cc.__class__.__module__, cc.__class__.__qualname__))
+
+    def report_compiler_executable(self, cc, env=None):
+        msg = "Using compiler `%s`" % cc
+        if env:
+            msg += " from environment variable `%s`" % env
+        self.info(msg)
 
     def report_dead_files(self, files):
         if files:

--- a/ci/xbuild/logger.py
+++ b/ci/xbuild/logger.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#-------------------------------------------------------------------------------
+# Copyright 2019 H2O.ai
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#-------------------------------------------------------------------------------
+import re
+
+
+#-------------------------------------------------------------------------------
+# Logger0
+#-------------------------------------------------------------------------------
+
+class Logger0:
+    """
+    The "silent" logger: it does not report any messages.
+    """
+    def cmd_build(self): pass
+
+    def report_abi_mismatch(self, v1, v2): pass
+    def report_build_dir(self, dd): pass
+    def report_compile_cmd_mismatch(self, cmd1, cmd2): pass
+    def report_compile_file(self, filename, cmd): pass
+    def report_compiler(self, cc): pass
+    def report_dead_files(self, files): pass
+    def report_deduplicated(self, files): pass
+    def report_destdir(self, dd): pass
+    def report_full_rebuild(self): pass
+    def report_include_dir(self, dd): pass
+    def report_includes(self, inlcudes): pass
+    def report_link_cmd_mismatch(self, cmd1, cmd2): pass
+    def report_link_file(self, filename, cmd): pass
+    def report_mkdir(self, dd): pass
+    def report_name(self, name): pass
+    def report_new_header_found(self, filename, modified): pass
+    def report_no_state_file(self): pass
+    def report_nworkers(self, nworkers): pass
+    def report_output_file(self, filename): pass
+    def report_removed_file(self, filename): pass
+    def report_sources(self, sources, pattern=None): pass
+    def report_sources_modified(self, files): pass
+    def report_stopped_compiling(self): pass
+    def report_src_includes(self, filename, includes): pass
+    def report_t0(self, t0): pass
+    def report_version_mismatch(self, v1, v2): pass
+
+    def step_build_done(self, time): pass
+    def step_compile(self, files): pass
+    def step_find_rebuild_targets(self): pass
+    def step_link(self, dolink): pass
+    def step_load_state(self, filename): pass
+    def step_scan_files(self, n): pass
+    def step_src2obj(self): pass
+
+    def warn(self, msg, indent=None): pass
+    def info(self, msg, indent=None): pass
+
+    def report_errors_and_warnings(self, msgs, errors=False):
+        for msg in msgs:
+            print(msg)
+
+
+
+
+#-------------------------------------------------------------------------------
+# Logger3
+#-------------------------------------------------------------------------------
+
+class Logger3(Logger0):
+    """
+    Logger with maximum verbosity level.
+    """
+
+    def __init__(self):
+        self._indent = ""
+
+    def cmd_build(self):
+        self.info("==== BUILD ====")
+
+
+    def report_abi_mismatch(self, v1, v2):
+        self.info("Config file contains abi=`%s`, whereas current abi is `%s`"
+                  % (v1, v2))
+
+    def report_build_dir(self, dd):
+        self.info("Build directory = %r" % dd)
+
+    def report_compile_cmd_mismatch(self, cmd1, cmd2):
+        self.info("Compiler flags changed")
+
+    def report_compile_file(self, filename, cmd):
+        self.info("Compiling `%s`: %s" % (filename, " ".join(cmd)))
+
+    def report_compiler(self, cc):
+        self.info("Using compiler of class %s.%s"
+                  % (cc.__class__.__module__, cc.__class__.__qualname__))
+
+    def report_dead_files(self, files):
+        if files:
+            self.info("Found `%d dead files` which will be removed"
+                      % len(files))
+        else:
+            self.info("No dead files found")
+
+    def report_deduplicated(self, files):
+        self.info("After deduplication `%d` souce files remain" % len(files))
+
+    def report_destdir(self, dd):
+        self.info("Destination directory = %r" % dd)
+
+    def report_full_rebuild(self):
+        self.info("All source files will be recompiled")
+
+    def report_include_dir(self, dd):
+        self.info("Added include directory %r" % dd)
+
+    def report_includes(self, includes):
+        self.info("Loaded information about %d source and header files"
+                  % len(includes))
+
+    def report_link_cmd_mismatch(self, cmd1, cmd2):
+        self.info("Linker flags changed")
+
+    def report_link_file(self, filename, cmd):
+        self.info("Linking `%s`: %s" % (filename, ' '.join(cmd)))
+
+    def report_mkdir(self, dd):
+        self.info("Created directory %r" % dd)
+
+    def report_name(self, name):
+        self.info("Building extension `%s`" % name)
+
+    def report_new_header_found(self, filename, modified):
+        self.info("New header file %s, %s"
+                  % (filename, "added to queue" if modified else "unmodified"))
+
+    def report_no_state_file(self):
+        self.info("The file does not exist")
+
+    def report_nworkers(self, nworkers):
+        self.info("Use %d worker processes" % nworkers)
+
+    def report_output_file(self, filename):
+        self.info("Output file name will be %r" % filename)
+
+    def report_removed_file(self, filename):
+        self.info("File `%s` deleted" % filename)
+
+    def report_sources(self, sources, pattern=None):
+        if pattern is None:
+            self.info("Added source file %s" + sources)
+        else:
+            assert isinstance(sources, list)
+            self.info("Added %d source files from pattern `%s`: %s"
+                      % (len(sources), pattern, sources))
+
+    def report_sources_modified(self, files):
+        if files:
+            self.info("Found `%d modified source files` which will be rebuilt"
+                      % len(files))
+        else:
+            self.info("No modified source files found")
+
+    def report_src_includes(self, filename, includes):
+        self.info("Includes for %s: %r" % (filename, includes))
+
+    def report_stopped_compiling(self):
+        self.info("Stopped compiling because too many errors produced")
+
+    def report_t0(self, t0):
+        self.info("Timestamp of previous successful build: %d" % t0)
+
+    def report_version_mismatch(self, v1, v2):
+        self.info("Config files contains version=%s, whereas the current "
+                  "version is %s" % (v1, v2))
+
+
+
+    def step_build_done(self, time):
+        self._indent = ""
+        self.info("==== Build finished in %.3fs" % time)
+
+    def step_compile(self, files):
+        if files:
+            self.info("[5] Compiling `%d` source files" % len(files),
+                      indent="")
+        else:
+            self.info("[5] Compiling source files: SKIPPED", indent="")
+
+    def step_find_rebuild_targets(self):
+        self.info("[3] Determining which source files to compile",
+                  indent="")
+
+    def step_link(self, dolink):
+        self.info("[6] Linking the final dynamic library%s"
+                  % ("" if dolink else ": SKIPPED"),
+                  indent="")
+
+    def step_load_state(self, filename):
+        self.info("[1] Loading previous state from file `%s`" % filename,
+                  indent="")
+        self._indent = "    "
+
+    def step_scan_files(self, n):
+        if n:
+            self.info("[4] Scanning %d modified files to detect headers" % n,
+                      indent="")
+        else:
+            self.info("[4] Scanning modified files: SKIPPED", indent="")
+
+    def step_src2obj(self):
+        self.info("[2] Determining the names of obj files to build",
+                  indent="")
+
+
+
+    def info(self, msg, indent=None):
+        if indent is None:
+            indent = self._indent
+        msg = re.sub(r"`([^`]*)`", "\x1B[1;97m\\1\x1B[0;90m", msg)
+        print(indent + "\x1B[90m" + msg + "\x1B[m")
+
+
+    def warn(self, msg, indent=None):
+        if indent is None:
+            indent = self._indent
+        msg = re.sub(r"`([^`]*)`", "\x1B[1;97m\\1\x1B[0;91m", msg)
+        print(indent + "\x1B[91m" + msg + "\x1B[m")
+
+
+
+    def report_errors_and_warnings(self, msgs, errors=False):
+        if not msgs:
+            return
+        color = "\x1B[91m" if errors else \
+                "\x1B[93m"
+        print(color + "+==== ERRORS & WARNINGS ========\n|\x1B[m")
+        for msg in msgs:
+            for line in msg.split("\n"):
+                print(color + "|\x1B[m " + line)
+        print(color + "+===============================\x1B[m")

--- a/datatable/lib/__init__.py
+++ b/datatable/lib/__init__.py
@@ -1,9 +1,31 @@
-#!/usr/bin/env python3
-# © H2O.ai 2018; -*- encoding: utf-8 -*-
-#   This Source Code Form is subject to the terms of the Mozilla Public
-#   License, v. 2.0. If a copy of the MPL was not distributed with this
-#   file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 #-------------------------------------------------------------------------------
+# Copyright 2019 H2O.ai
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#-------------------------------------------------------------------------------
+
+try:
+	from . import _datatable_builder
+except ImportError:
+	pass
 
 # noinspection PyUnresolvedReferences
 from . import _datatable as core

--- a/datatable/lib/__init__.py
+++ b/datatable/lib/__init__.py
@@ -23,9 +23,9 @@
 #-------------------------------------------------------------------------------
 
 try:
-	from . import _datatable_builder
+    from . import _datatable_builder
 except ImportError:
-	pass
+    pass
 
 # noinspection PyUnresolvedReferences
 from . import _datatable as core

--- a/ext.py
+++ b/ext.py
@@ -139,4 +139,4 @@ if __name__ == "__main__":
     with open("datatable/lib/.xbuild-cmd", "wt") as out:
         out.write(args.cmd)
 
-    build_extension(cmd=args.cmd)
+    build_extension(cmd=args.cmd, verbosity=3)

--- a/ext.py
+++ b/ext.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#-------------------------------------------------------------------------------
+# Copyright 2019 H2O.ai
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#-------------------------------------------------------------------------------
+from ci import xbuild
+
+ext = xbuild.Extension()
+ext.log = xbuild.Logger3()
+ext.name = "_datatable"
+ext.build_dir = "build/x"
+ext.destination_dir = "datatable/lib/"
+ext.add_sources("c/**/*.cc")
+
+# Compile settings
+ext.compiler.add_include_dir("c")
+ext.compiler.add_default_python_include_dir()
+ext.compiler.add_compiler_flag("-std=c++11")
+ext.compiler.add_compiler_flag("-fPIC")
+ext.compiler.add_compiler_flag("-g3")
+ext.compiler.enable_colors()
+
+# Link settings
+ext.compiler.add_linker_flag("-bundle")
+ext.compiler.add_linker_flag("-undefined", "dynamic_lookup")
+ext.compiler.add_linker_flag("-g")
+ext.compiler.add_linker_flag("-m64")
+
+# ext.compiler.add_linker_flag("-L/usr/lib")
+# ext.compiler.add_linker_flag("-L/usr/local/opt/llvm/lib")
+# ext.compiler.add_linker_flag("-lz")
+# ext.compiler.add_linker_flag("-L/Library/Frameworks/Python.framework/Versions/3.6/lib")
+
+ext.build()

--- a/ext.py
+++ b/ext.py
@@ -21,32 +21,122 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 #-------------------------------------------------------------------------------
+import sys
 from ci import xbuild
 
-ext = xbuild.Extension()
-ext.log = xbuild.Logger3()
-ext.name = "_datatable"
-ext.build_dir = "build/x"
-ext.destination_dir = "datatable/lib/"
-ext.add_sources("c/**/*.cc")
+_valid_commands = ["asan", "build", "coverage", "debug"]
 
-# Compile settings
-ext.compiler.add_include_dir("c")
-ext.compiler.add_default_python_include_dir()
-ext.compiler.add_compiler_flag("-std=c++11")
-ext.compiler.add_compiler_flag("-fPIC")
-ext.compiler.add_compiler_flag("-g3")
-ext.compiler.enable_colors()
 
-# Link settings
-ext.compiler.add_linker_flag("-bundle")
-ext.compiler.add_linker_flag("-undefined", "dynamic_lookup")
-ext.compiler.add_linker_flag("-g")
-ext.compiler.add_linker_flag("-m64")
+def build_extension(cmd, verbosity=3):
+    assert cmd in _valid_commands
+    windows = (sys.platform == "win32")
+    macos = (sys.platform == "darwin")
+    linux = (sys.platform == "linux")
+    if not (windows or macos or linux):
+        print("\x1b[93mWarning: unknown platform %s\x1b[m" % sys.platform)
+        linux = True
 
-# ext.compiler.add_linker_flag("-L/usr/lib")
-# ext.compiler.add_linker_flag("-L/usr/local/opt/llvm/lib")
-# ext.compiler.add_linker_flag("-lz")
-# ext.compiler.add_linker_flag("-L/Library/Frameworks/Python.framework/Versions/3.6/lib")
+    ext = xbuild.Extension()
+    ext.log = xbuild.Logger0() if verbosity == 0 else \
+              xbuild.Logger1() if verbosity == 1 else \
+              xbuild.Logger2() if verbosity == 2 else \
+              xbuild.Logger3()
+    ext.name = "_datatable"
+    ext.build_dir = "build/" + cmd
+    ext.destination_dir = "datatable/lib/"
+    ext.add_sources("c/**/*.cc")
 
-ext.build()
+    # Common compile settings
+    ext.compiler.enable_colors()
+    ext.compiler.add_include_dir("c")
+    ext.compiler.add_default_python_include_dir()
+
+    if ext.compiler.is_msvc():
+        ext.compiler.add_compiler_flag("/W4")
+
+    else:
+        # Common compile flags
+        ext.compiler.add_compiler_flag("-std=c++11")
+        # "-stdlib=libc++"  (clang ???)
+        ext.compiler.add_compiler_flag("-fPIC")
+
+        # Common link flags
+        ext.compiler.add_linker_flag("-bundle")
+        ext.compiler.add_linker_flag("-undefined", "dynamic_lookup")
+        ext.compiler.add_linker_flag("-g")
+        ext.compiler.add_linker_flag("-m64")
+        # "-lc++"    (linux & clang ???)
+        # "-shared"  (linux ???)
+        # "-lstdc++" (gcc ???)
+        # "-lm"      (gcc ???)
+        # "-lz"      (???)
+
+        if cmd == "asan":
+            ext.compiler.add_compiler_flag("-fsanitize=address")
+            ext.compiler.add_compiler_flag("-fno-omit-frame-pointer")
+            ext.compiler.add_compiler_flag("-fsanitize-address-use-after-scope")
+            ext.compiler.add_compiler_flag("-shared-libasan")
+            ext.compiler.add_compiler_flag("-g3")
+            ext.compiler.add_compiler_flag("-glldb" if macos else "-ggdb")
+            ext.compiler.add_compiler_flag("-O0")
+            ext.compiler.add_compiler_flag("-DDTTEST", "-DDTDEBUG")
+            ext.compiler.add_linker_flag("-fsanitize=address", "-shared-libasan")
+
+        if cmd == "build":
+            ext.compiler.add_compiler_flag("-g2")  # include some debug info
+            ext.compiler.add_compiler_flag("-O3")  # full optimization
+
+        if cmd == "coverage":
+            ext.compiler.add_compiler_flag("-g2")
+            ext.compiler.add_compiler_flag("-O0")
+            ext.compiler.add_compiler_flag("--coverage")
+            ext.compiler.add_compiler_flag("-DDTTEST", "-DDTDEBUG")
+            ext.compiler.add_linker_flag("-O0")
+            ext.compiler.add_linker_flag("--coverage")
+
+        if cmd == "debug":
+            ext.compiler.add_compiler_flag("-g3")
+            ext.compiler.add_compiler_flag("-fdebug-macro")
+            ext.compiler.add_compiler_flag("-glldb" if macos else "-ggdb")
+            ext.compiler.add_compiler_flag("-O0")  # no optimization
+            ext.compiler.add_compiler_flag("-DDTTEST", "-DDTDEBUG")
+
+        # Compiler warnings
+        if ext.compiler.is_clang():
+            ext.compiler.add_compiler_flag(
+                "-Weverything",
+                "-Wno-c++98-compat-pedantic",
+                "-Wno-c99-extensions",
+                "-Wno-exit-time-destructors",
+                "-Wno-float-equal",
+                "-Wno-global-constructors",
+                "-Wno-reserved-id-macro",
+                "-Wno-switch-enum",
+                "-Wno-weak-template-vtables",
+                "-Wno-weak-vtables",
+            )
+        else:
+            ext.compiler.add_compiler_flag(
+                "-Wall",
+                "-Wno-unused-value",
+                "-Wno-unknown-pragmas"
+            )
+
+    # Setup is complete, ready to build
+    ext.build()
+
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description='Build _datatable module')
+    parser.add_argument("cmd", metavar="CMD", choices=_valid_commands,
+            help="Mode of the _datatable library to build. The following modes "
+                 "are supported: `asan` (built with Address Sanitizer), `build`"
+                 " (standard build mode), `coverage` (suitable for coverage "
+                 "testing), and `debug` (with full debug info).")
+
+    args = parser.parse_args()
+    with open("datatable/lib/.xbuild-cmd", "wt") as out:
+        out.write(args.cmd)
+
+    build_extension(cmd=args.cmd)


### PR DESCRIPTION
This module offers an alternative way for building the `_datatable` extension, instead of `setuptools`. It has several advantages over the traditional way:
  - There is no automatic adding of compile/link flags: the consumer of the module is in full control over how the compilation is done;
  - The build process is performed in parallel, reducing the compile time by a factor of 10 or so (similar to make);
  - Only files that need to be recompiled are recompiled (like make);
  - The implementation is pure-python (unlike make), which makes it easy to modify the code, and to reuse it from other python processes;
  - Allow the code to be automatically recompiled during python import;
  - Better log of the build process (and fully customizable);
  - Support fast recompiling in different modes (without clearing the previous build);
  - Automatic recompilation when compile flags or python version change.