### PR TITLE
Fix test_fread_omnibus

### DIFF
--- a/tests/fread/test_fread_random.py
+++ b/tests/fread/test_fread_random.py
@@ -237,7 +237,7 @@ def generate_str_column(allparams):
             for row in col:
                 try:
                     if row:
-                        i = float(row)
+                        float(row)
                 except:
                     is_numeric = False
                     break

--- a/tests/fread/test_fread_random.py
+++ b/tests/fread/test_fread_random.py
@@ -227,6 +227,18 @@ def generate_str_column(allparams):
     if rmode < 0:
         pass
     else:
-        # Generate simple alphanumeric strings
-        return [rr(random_string(int(random.expovariate(0.01))))
-                for _ in range(nrows)]
+        # Generate simple alphanumeric strings and make sure
+        # the resulting column is not fully populated with numeric values.
+        is_numeric = nrows > 0
+        col = []
+        while is_numeric:
+            col = [rr(random_string(int(random.expovariate(0.01))))
+                    for _ in range(nrows)]
+            for row in col:
+                try:
+                    if row:
+                        i = float(row)
+                except:
+                    is_numeric = False
+                    break
+        return col


### PR DESCRIPTION
`tests/fread/test_fread_random.py::test_fread_omnibus` is failing for some seeds due to the fact that `generate_str_column()` generates a column filled with only numeric values, for example for the seed of `1795109353` the column data is `['7E1', '']`. When `dt.fread()` receives such a data it converts it to a float column, while in the test the type was assumed to be `ltype.str`. 

In this PR we add a check to `generate_str_column()` function to make sure it never generates fully numeric data.