### PR TITLE
Fix min/max properties of bool8 stype

### DIFF
--- a/datatable/types.py
+++ b/datatable/types.py
@@ -247,7 +247,7 @@ _stype_2_ctype = {
 }
 
 _stype_extrema = {
-    stype.bool8: (0, 1),
+    stype.bool8: (False, True),
     stype.int8: (-127, 127),
     stype.int16: (-32767, 32767),
     stype.int32: (-2147483647, 2147483647),

--- a/docs/changelog/v-0-11-0.rst
+++ b/docs/changelog/v-0-11-0.rst
@@ -9,5 +9,20 @@ Frame
 -----
 
 - |fix| A list of frames now displays properly in a Jupyter lab (#2222).
+
+
+
+General
+-------
+
+- |api| Properties ``dt.stype.min`` and ``dt.stype.max`` are now equal to
+  ``False`` and ``True`` respectively, instead of integers 0 and 1 (#2231).
+
+
+
+FTRL model
+----------
+
 - |fix| Fix feature importance normalization to [0, 1] in FTRL (#2224).
+
 - |fix| Resetting an untrained FTRL model now doesn't result in a segfault (#2226).

--- a/docs/changelog/v-0-11-0.rst
+++ b/docs/changelog/v-0-11-0.rst
@@ -15,7 +15,7 @@ Frame
 General
 -------
 
-- |api| Properties ``dt.stype.min`` and ``dt.stype.max`` are now equal to
+- |api| Properties ``dt.bool8.min`` and ``dt.bool8.max`` are now equal to
   ``False`` and ``True`` respectively, instead of integers 0 and 1 (#2231).
 
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -243,13 +243,20 @@ def test_stype_minmax(st):
         assert st.min is None
         assert st.max is None
     else:
-        vtype = float if st.ltype == ltype.real else int
+        vtype = float if st.ltype == ltype.real else \
+                bool  if st == stype.bool8 else \
+                int
         assert isinstance(st.min, vtype)
         assert isinstance(st.max, vtype)
         F = dt.Frame([st.min, st.max], stype=st)
         assert F.stypes == (st,)
         assert F[0, 0] == st.min
         assert F[1, 0] == st.max
+        # Check that they can be assigned too:
+        F[0, 0] = st.max
+        F[1, 0] = st.min
+        assert F[0, 0] == st.max
+        assert F[1, 0] == st.min
         if vtype is int:
             # Check that cannot store any larger value
             G = dt.Frame([st.min - 1, st.max + 1], stype=st)


### PR DESCRIPTION
(We may want to include this into 0.10.1 release as well)

Closes #2231