### PR TITLE
Add a code to detect terminal size on Windows

### DIFF
--- a/c/frame/repr/terminal_widget.cc
+++ b/c/frame/repr/terminal_widget.cc
@@ -65,7 +65,8 @@ void TerminalWidget::to_stdout() {
 //------------------------------------------------------------------------------
 
 void TerminalWidget::_render() {
-  _prerender_columns(terminal_->get_width());
+  const TerminalSize ts = terminal_->get_size();
+  _prerender_columns(ts.width);
   _render_column_names();
   _render_header_separator();
   _render_data();

--- a/c/utils/terminal/terminal.cc
+++ b/c/utils/terminal/terminal.cc
@@ -187,18 +187,18 @@ void Terminal::_detect_window_size() {
   CONSOLE_SCREEN_BUFFER_INFO csbi;
   HANDLE h = GetStdHandle(STD_OUTPUT_HANDLE);
   int ret = GetConsoleScreenBufferInfo(h, &csbi);
-  bool is_size_detected = ret > 0;
+  bool is_size_not_detected = (ret == 0);
   width_ = csbi.srWindow.Right - csbi.srWindow.Left + 1;
   height_ = csbi.srWindow.Bottom - csbi.srWindow.Top + 1;
 #else
   struct winsize w;
   int ret = ioctl(STDOUT_FILENO, TIOCGWINSZ, &w);
-  bool is_size_detected = ret != -1;
+  bool is_size_not_detected = (ret == -1);
   width_ = w.ws_col;
   height_ = w.ws_row;
 #endif
 
-  if (!is_size_detected || width_ == 0) {
+  if (is_size_not_detected || width_ == 0) {
     width_ = 120;
     height_ = 45;
   }

--- a/c/utils/terminal/terminal.cc
+++ b/c/utils/terminal/terminal.cc
@@ -66,7 +66,7 @@ Terminal::Terminal(bool is_plain) {
   // Note: there is no simple way to catch the terminal re-size event
   // on Windows, because there is no `SIGWINCH` signal there.
   // For such a reason, on Windows we just re-check the terminal size
-  // everytime the `get_width()` or `get_height()` are called.
+  // everytime the `get_width()` and `get_height()` are called.
 #if !DT_OS_WINDOWS
   if (!is_plain) {
     std::signal(SIGWINCH, sigwinch_handler);

--- a/c/utils/terminal/terminal.cc
+++ b/c/utils/terminal/terminal.cc
@@ -63,8 +63,8 @@ Terminal::Terminal(bool is_plain) {
   is_ipython_ = false;
   if (!enable_ecma48_) xassert(!enable_colors_);
 
-  // Note: there is no simple way to catch the terminal re-size event on
-  // Windows, because there is no `SIGWINCH` signal there.
+  // Note: there is no simple way to catch the terminal re-size event
+  // on Windows, because there is no `SIGWINCH` signal there.
   // For such a reason, on Windows we just re-check the terminal size
   // everytime the `get_width()` or `get_height()` are called.
 #if !DT_OS_WINDOWS

--- a/c/utils/terminal/terminal.cc
+++ b/c/utils/terminal/terminal.cc
@@ -53,8 +53,8 @@ Terminal& Terminal::plain_terminal() {
 }
 
 Terminal::Terminal(bool is_plain) {
-  width_ = is_plain? (1 << 20) : 0;
-  height_ = is_plain? 45 : 0;
+  size_.width = is_plain? (1 << 20) : 0;
+  size_.height = is_plain? 45 : 0;
   allow_unicode_ = true;
   enable_colors_ = !is_plain;
   enable_ecma48_ = !is_plain;
@@ -154,22 +154,14 @@ bool Terminal::unicode_allowed() const noexcept {
   return allow_unicode_;
 }
 
-int Terminal::get_width() {
-  #if DT_OS_WINDOWS
-    _detect_window_size();
-  #else
-    if (!width_) _detect_window_size();
-  #endif
-  return width_;
-}
 
-int Terminal::get_height() {
+TerminalSize Terminal::get_size() {
   #if DT_OS_WINDOWS
     _detect_window_size();
   #else
-    if (!height_) _detect_window_size();
+    if (!size_.width || !size_.height) _detect_window_size();
   #endif
-  return height_;
+  return size_;
 }
 
 
@@ -178,8 +170,8 @@ void Terminal::use_colors(bool f) {
 }
 
 void Terminal::forget_window_size() {
-  width_ = 0;
-  height_ = 0;
+  size_.width = 0;
+  size_.height = 0;
 }
 
 void Terminal::_detect_window_size() {
@@ -187,20 +179,20 @@ void Terminal::_detect_window_size() {
     CONSOLE_SCREEN_BUFFER_INFO csbi;
     HANDLE h = GetStdHandle(STD_OUTPUT_HANDLE);
     int ret = GetConsoleScreenBufferInfo(h, &csbi);
-    bool is_size_not_detected = (ret == 0);
-    width_ = csbi.srWindow.Right - csbi.srWindow.Left + 1;
-    height_ = csbi.srWindow.Bottom - csbi.srWindow.Top + 1;
+    bool size_not_detected = (ret == 0);
+    size_.width = csbi.srWindow.Right - csbi.srWindow.Left + 1;
+    size_.height = csbi.srWindow.Bottom - csbi.srWindow.Top + 1;
   #else
     struct winsize w;
     int ret = ioctl(STDOUT_FILENO, TIOCGWINSZ, &w);
-    bool is_size_not_detected = (ret == -1);
-    width_ = w.ws_col;
-    height_ = w.ws_row;
+    bool size_not_detected = (ret == -1);
+    size_.width = w.ws_col;
+    size_.height = w.ws_row;
   #endif
 
-  if (is_size_not_detected || width_ == 0) {
-    width_ = 120;
-    height_ = 45;
+  if (size_not_detected || size_.width == 0) {
+    size_.width = 120;
+    size_.height = 45;
   }
 }
 

--- a/c/utils/terminal/terminal.cc
+++ b/c/utils/terminal/terminal.cc
@@ -63,6 +63,10 @@ Terminal::Terminal(bool is_plain) {
   is_ipython_ = false;
   if (!enable_ecma48_) xassert(!enable_colors_);
 
+  // Note: there is no simple way to catch the terminal re-size event on
+  // Windows, because there is no `SIGWINCH` signal there.
+  // For such a reason, on Windows we just re-check the terminal size
+  // everytime the `get_width()` or `get_height()` are called.
 #if !DT_OS_WINDOWS
   if (!is_plain) {
     std::signal(SIGWINCH, sigwinch_handler);
@@ -151,12 +155,20 @@ bool Terminal::unicode_allowed() const noexcept {
 }
 
 int Terminal::get_width() {
+#if DT_OS_WINDOWS
+  _detect_window_size();
+#else
   if (!width_) _detect_window_size();
+#endif
   return width_;
 }
 
 int Terminal::get_height() {
+#if DT_OS_WINDOWS
+  _detect_window_size();
+#else
   if (!height_) _detect_window_size();
+#endif
   return height_;
 }
 
@@ -195,8 +207,6 @@ void Terminal::_detect_window_size() {
 void Terminal::use_unicode(bool f) {
   allow_unicode_ = f;
 }
-
-
 
 
 

--- a/c/utils/terminal/terminal.cc
+++ b/c/utils/terminal/terminal.cc
@@ -67,11 +67,11 @@ Terminal::Terminal(bool is_plain) {
   // on Windows, because there is no `SIGWINCH` signal there.
   // For such a reason, on Windows we just re-check the terminal size
   // everytime the `get_width()` and `get_height()` are called.
-#if !DT_OS_WINDOWS
-  if (!is_plain) {
-    std::signal(SIGWINCH, sigwinch_handler);
-  }
-#endif
+  #if !DT_OS_WINDOWS
+    if (!is_plain) {
+      std::signal(SIGWINCH, sigwinch_handler);
+    }
+  #endif
 }
 
 Terminal::~Terminal() = default;
@@ -155,20 +155,20 @@ bool Terminal::unicode_allowed() const noexcept {
 }
 
 int Terminal::get_width() {
-#if DT_OS_WINDOWS
-  _detect_window_size();
-#else
-  if (!width_) _detect_window_size();
-#endif
+  #if DT_OS_WINDOWS
+    _detect_window_size();
+  #else
+    if (!width_) _detect_window_size();
+  #endif
   return width_;
 }
 
 int Terminal::get_height() {
-#if DT_OS_WINDOWS
-  _detect_window_size();
-#else
-  if (!height_) _detect_window_size();
-#endif
+  #if DT_OS_WINDOWS
+    _detect_window_size();
+  #else
+    if (!height_) _detect_window_size();
+  #endif
   return height_;
 }
 
@@ -183,20 +183,20 @@ void Terminal::forget_window_size() {
 }
 
 void Terminal::_detect_window_size() {
-#if DT_OS_WINDOWS
-  CONSOLE_SCREEN_BUFFER_INFO csbi;
-  HANDLE h = GetStdHandle(STD_OUTPUT_HANDLE);
-  int ret = GetConsoleScreenBufferInfo(h, &csbi);
-  bool is_size_not_detected = (ret == 0);
-  width_ = csbi.srWindow.Right - csbi.srWindow.Left + 1;
-  height_ = csbi.srWindow.Bottom - csbi.srWindow.Top + 1;
-#else
-  struct winsize w;
-  int ret = ioctl(STDOUT_FILENO, TIOCGWINSZ, &w);
-  bool is_size_not_detected = (ret == -1);
-  width_ = w.ws_col;
-  height_ = w.ws_row;
-#endif
+  #if DT_OS_WINDOWS
+    CONSOLE_SCREEN_BUFFER_INFO csbi;
+    HANDLE h = GetStdHandle(STD_OUTPUT_HANDLE);
+    int ret = GetConsoleScreenBufferInfo(h, &csbi);
+    bool is_size_not_detected = (ret == 0);
+    width_ = csbi.srWindow.Right - csbi.srWindow.Left + 1;
+    height_ = csbi.srWindow.Bottom - csbi.srWindow.Top + 1;
+  #else
+    struct winsize w;
+    int ret = ioctl(STDOUT_FILENO, TIOCGWINSZ, &w);
+    bool is_size_not_detected = (ret == -1);
+    width_ = w.ws_col;
+    height_ = w.ws_row;
+  #endif
 
   if (is_size_not_detected || width_ == 0) {
     width_ = 120;

--- a/c/utils/terminal/terminal.h
+++ b/c/utils/terminal/terminal.h
@@ -26,6 +26,11 @@
 namespace dt {
 using std::size_t;
 
+struct TerminalSize {
+  int width;
+  int height;
+};
+
 
 /**
   * Class that controls adorned output to a terminal. This class
@@ -40,8 +45,7 @@ using std::size_t;
 class Terminal {
   using string = std::string;
   private:
-    int  width_;
-    int  height_;
+    TerminalSize size_;
     bool allow_unicode_;
     bool enable_colors_;
     bool enable_ecma48_;
@@ -59,8 +63,7 @@ class Terminal {
     bool is_ipython() const noexcept;
     bool colors_enabled() const noexcept;
     bool unicode_allowed() const noexcept;
-    int get_width();
-    int get_height();
+    TerminalSize get_size();
 
     void use_colors(bool f);
     void use_unicode(bool f);


### PR DESCRIPTION
- add a code to detect terminal size on Windows;
- there is no simple way to catch the terminal re-size event on Windows, because there is no `SIGWINCH` signal there. For such a reason, on WIndows we just re-check the terminal size everytime the `Terminal::get_width()` and `Terminal::get_height()` are called.

WIP for #1369 