### PR TITLE
Add a workaround for a POSIX write() function on Windows

### DIFF
--- a/c/writebuf.cc
+++ b/c/writebuf.cc
@@ -18,6 +18,8 @@
 #include "writebuf.h"
 
 #if DT_OS_WINDOWS
+  // This POSIX `write()` function is deprecated on Windows,
+  // so we use the ISO C++ conformant `_write()` instead.
   #include <io.h>            // write
   #define WRITE _write
 #else

--- a/c/writebuf.cc
+++ b/c/writebuf.cc
@@ -18,7 +18,7 @@
 #include "writebuf.h"
 
 #if DT_OS_WINDOWS
-  // This POSIX `write()` function is deprecated on Windows,
+  // The POSIX `write()` function is deprecated on Windows,
   // so we use the ISO C++ conformant `_write()` instead.
   #include <io.h>            // write
   #define WRITE _write

--- a/c/writebuf.cc
+++ b/c/writebuf.cc
@@ -9,13 +9,21 @@
 #include <cstring>         // std::memcpy
 #include <errno.h>         // errno
 #include <sys/mman.h>      // mmap
-#include <unistd.h>        // write
 #include "utils/alloc.h"   // dt::realloc
 #include "utils/assert.h"
+#include "utils/macros.h"
 #include "utils/misc.h"
 #include "datatablemodule.h"
 #include "buffer.h"
 #include "writebuf.h"
+
+#if DT_OS_WINDOWS
+  #include <io.h>            // write
+  #define WRITE _write
+#else
+  #include <unistd.h>        // write
+  #define WRITE write
+#endif
 
 
 
@@ -100,7 +108,7 @@ size_t FileWritableBuffer::prep_write(size_t src_size, const void* src)
   while (written_to_file < src_size) {
     size_t bytes_to_write = std::min(src_size - written_to_file, CHUNK_SIZE);
     const void* buf = static_cast<const char*>(src) + written_to_file;
-    ssize_t r = ::write(fd, buf, bytes_to_write);
+    ssize_t r = ::WRITE(fd, buf, bytes_to_write);
     if (r < 0) {
       throw IOError() << "Cannot write to file: " << Errno
           << " (started at offset " << pos

--- a/c/writebuf.cc
+++ b/c/writebuf.cc
@@ -18,9 +18,10 @@
 #include "writebuf.h"
 
 #if DT_OS_WINDOWS
+  #include <io.h>            // _write
+
   // The POSIX `write()` function is deprecated on Windows,
   // so we use the ISO C++ conformant `_write()` instead.
-  #include <io.h>            // write
   #define WRITE _write
 #else
   #include <unistd.h>        // write


### PR DESCRIPTION
The POSIX `write()` function is [deprecated](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/posix-write?view=vs-2019) on Windows, so we use the ISO C++ conformant `_write()` instead. This also requires to use OS-specific includes.

WIP for #1369 