### PR TITLE
Add Wheel-building functionality to xbuild

### DIFF
--- a/ci/xbuild/__init__.py
+++ b/ci/xbuild/__init__.py
@@ -24,6 +24,7 @@
 from .compiler import Compiler
 from .extension import Extension
 from .logger import Logger0, Logger1, Logger3
+from .wheel import Wheel
 
 __all__ = (
 	"Compiler",
@@ -31,4 +32,5 @@ __all__ = (
 	"Logger0",
 	"Logger1",
 	"Logger3",
+	"Wheel",
 )

--- a/ci/xbuild/logger.py
+++ b/ci/xbuild/logger.py
@@ -33,8 +33,10 @@ class Logger0:
     The "silent" logger: it does not report any messages.
     """
     def cmd_build(self): pass
+    def cmd_wheel(self): pass
 
     def report_abi_mismatch(self, v1, v2): pass
+    def report_added_file_to_wheel(self, filename, size): pass
     def report_build_dir(self, dd): pass
     def report_compile_cmd_mismatch(self, cmd1, cmd2): pass
     def report_compile_start(self, filename, cmd): pass
@@ -62,8 +64,10 @@ class Logger0:
     def report_src_includes(self, filename, includes): pass
     def report_t0(self, t0): pass
     def report_version_mismatch(self, v1, v2): pass
+    def report_wheel_file(self, filename): pass
 
     def step_build_done(self, time): pass
+    def step_wheel_done(self, time, size): pass
     def step_compile(self, files): pass
     def step_find_rebuild_targets(self): pass
     def step_link(self, dolink): pass
@@ -160,10 +164,16 @@ class Logger3(Logger0):
     def cmd_build(self):
         self.info("==== BUILD ====")
 
+    def cmd_wheel(self):
+        self.info("==== WHEEL ====")
+
 
     def report_abi_mismatch(self, v1, v2):
         self.info("Config file contains abi=`%s`, whereas current abi is `%s`"
                   % (v1, v2))
+
+    def report_added_file_to_wheel(self, filename, size):
+        self.info("Added file `%s` of size %d" % (filename, size))
 
     def report_build_dir(self, dd):
         self.info("Build directory = %r" % dd)
@@ -263,11 +273,21 @@ class Logger3(Logger0):
         self.info("Config files contains version=%s, whereas the current "
                   "version is %s" % (v1, v2))
 
+    def report_wheel_file(self, filename):
+        self.info("Preparing to build wheel file `%s`" % filename)
+        self._indent = "    "
+
 
 
     def step_build_done(self, time):
         self._indent = ""
         self.info("==== Build finished in %.3fs" % time)
+
+    def step_wheel_done(self, time, size):
+        self._indent = ""
+        self.info("Final wheel size: %d bytes" % size)
+        self.info("==== Wheel built in %.3fs" % time)
+
 
     def step_compile(self, files):
         if files:

--- a/ci/xbuild/wheel.py
+++ b/ci/xbuild/wheel.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#-------------------------------------------------------------------------------
+# Copyright 2019 H2O.ai
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#-------------------------------------------------------------------------------
+# See Also
+# --------
+#   [PEP-427](https://www.python.org/dev/peps/pep-0427/)
+#       The Wheel Binary Package Format 1.0
+#       Note: PEP-491 specifies wheel format 1.9, however the status of that
+#       PEP is "deferred".
+#
+#   [PyPA](https://packaging.python.org/specifications/)
+#       List of specification maintained by Python Packaging Authority.
+#
+#-------------------------------------------------------------------------------
+import base64
+import glob
+import hashlib
+import os
+import pathlib
+import re
+import shutil
+import sysconfig
+import tempfile
+import time
+import zipfile
+
+rx_name = re.compile(r"[a-zA-Z0-9]([\w\.\-]*[a-zA-Z0-9])?")
+
+rx_version = re.compile(r"(?:\d+!)?"           # epoch
+                        r"\d+(?:\.\d+)*"       # release segment
+                        r"(?:(?:a|b|rc)\d+)?"  # pre-release segment
+                        r"(?:\.post\d+)?"      # post-release segment
+                        r"(?:\.dev\d+)?")      # development release segment
+
+
+
+class Wheel:
+    """
+    Class for building wheel files:
+
+        wb = xbuild.Wheel(**meta)
+        wb.build_wheel()
+
+    The primary payload is the dictionary of "meta" variables, which
+    is largely similar to the format of ``setuptools.setup()``. The
+    following fields are supported:
+
+    Parameters
+    ----------
+    name: str
+        The name of the module being built (required).
+
+    version: str
+        Version string of the module being built. The format of this
+        field is specified in PEP 440 (required).
+
+    summary: str
+        Short one-sentence summary describing the purpose of the
+        module. Note: this field is called `description` by
+        setuptools.
+
+    description: str
+        More detailed description of the module, can be multiple
+        paragraphs long. By default, this field should be formatted
+        using reStructuredText markup. If needed, the description can
+        also be in plain text or use Markdown. Note: this field is
+        called `long_description` in setuptools.
+
+    description_content_type: str
+        Content type of the `description` field. This should be one of
+        "text/plain", "text/x-rst" or "text/markdown". If omitted,
+        then "text/x-rst" is assumed.
+    """
+
+    def __init__(self, **meta):
+        self._check(meta)
+        self._meta = meta
+        # Wheel creation time, will be used to timestamp individual files
+        # inside the archive.
+        self._wheel_time = time.gmtime()[:6]
+        self._record_file = io.StringIO()
+
+
+    def _check(self, meta):
+        self._check_name(meta)
+        self._check_version(meta)
+        self._check_summary(meta)
+        self._check_description(meta)
+        self._check_description_content_type(meta)
+        self._check_keywords(meta)
+
+
+    def _check_name(self, meta):
+        assert "name" in meta, "`name` field is required"
+        name = meta["name"]
+        assert isinstance(name, str)
+        assert re.fullmatch(rx_name, name), \
+               "Invalid package name: ``" % name
+
+    def _check_version(self, meta):
+        assert "version" in meta, "`version` field is required"
+        version = meta["version"]
+        assert isinstance(version, str)
+        assert re.fullmatch(rx_version, version), \
+               "Version is not in canonical format: `%s`" % version
+
+    def _check_summary(self, meta):
+        if "summary" in meta:
+            summary = meta["summary"]
+            assert isinstance(summary, str)
+            meta["summary"] = summary.strip()
+
+    def _check_description(self, meta):
+        if "long_description" in meta:
+            raise KeyError("Deprecated field `long_description` specified. Did "
+                           "you mean `description`?")
+        if "description" in meta:
+            description = meta["description"]
+            assert isinstance(description, str)
+            meta["description"] = description.strip()
+
+    def _check_description_content_type(self, meta):
+        if "description_content_type" in meta:
+            dct = meta["description_content_type"]
+            assert isinstance(dct, str)
+            assert dct in ["text/plain", "text/x-rst", "text/markdown"], \
+                "Invalid description_content_type: `%s`" % dct
+
+    def _check_keywords(self, meta):
+        if "keywords" in meta:
+            keywords = meta["keywords"]
+            assert isinstance(keywords, list)
+            assert all(isinstance(kw, str) for kw in keywords)
+
+    # def _check_homepag
+
+    @property
+    def name(self):
+        return self._meta["name"]
+
+    @property
+    def version(self):
+        return self._meta["version"]
+
+    @property
+    def summary(self):
+        return self._meta.get("summary")
+
+    @property
+    def description(self):
+        return self._meta.get("description")
+
+    @property
+    def description_content_type(self):
+        return self._meta.get("description_content_type")
+
+    @property
+    def keywords(self):
+        return self._meta.get("keywords")
+
+
+
+
+    def build_wheel(self):
+        files = self._meta["sources"]
+        temp_dir = pathlib.Path(tempfile.mkdtemp())
+        # for bdir in {os.path.dirname(f) for f in files}:
+        #     tdir = os.path.join(tempdir, bdir)
+        #     os.makedirs(tdir, exist_ok=True)
+        #     print("Creating dir `%s`" % tdir)
+
+        info_dir = temp_dir / ("%s-%s.dist-info" % (self.name, self.version))
+        os.makedirs(info_dir)
+        files.append( self._create_WHEEL_file(info_dir) )
+        files.append( self._create_METADATA_file(info_dir) )
+        files.append( self._create_LICENSE_file(info_dir) )
+        # files.append( self._create_top_level_file(info_dir) )
+        files.append( self._create_RECORD_file(info_dir, files) )
+
+        wheel_name = "%s-%s-%s.whl" % (self.name, self.version, self.tag)
+        with zipfile.ZipFile(wheel_name, "w", allowZip64=True,
+                             compression=zipfile.ZIP_DEFLATED) as zipf:
+            for filename in files:
+                st = os.stat(filename)
+                zinfo = zipfile.ZipInfo(filename, self._wheel_time)
+                zinfo.external_attr = st.st_mode << 16
+                with open(filename, "rb") as inp:
+                    content = inp.read()
+                    zipf.writestr(zinfo, content)
+        print("Wheel file `%s` created" % wheel_name)
+
+
+    def add_file_to_archive(self, zipf, src):
+        if isinstance(src, str):
+            target_file = src
+        else:
+            assert isinstance(src, tuple) and len(src) == 2
+            src, target_file = src
+
+        zinfo = zipfile.ZipInfo(target_file, self._wheel_time)
+        if os.path.exists(src):
+            with open(src, "rb") as inp:
+                bcontent = inp.read()
+        elif isinstance(src, bytes):
+            bcontent = src
+        elif isinstance(src, str) and "\n" in src:
+            bcontent = src.encode("utf-8")
+        else:
+            raise FileNotFoundError("File `%s` does not exist" % src)
+
+        # Write the content to zip
+        zipf.writestr(zinfo, bcontent)
+
+        # Make
+
+
+
+    def _get_abi_tag(self):
+        soabi = sysconfig.get_config_var("SOABI")
+        parts = soabi.split("-")
+        assert parts[0] == "cpython"
+        return "cp" + parts[1]
+
+    @property
+    def tag(self):
+        abi_tag = self._get_abi_tag()
+        impl_tag = abi_tag[:4]
+        return "%s-%s-%s" % (impl_tag, abi_tag, "macosx_10_9_x86_64")
+
+
+    def _create_WHEEL_file(self, path):
+        filename = str(path / "WHEEL")
+        with open(filename, "wt", encoding="utf-8") as out:
+            out.write("Wheel-Version: 1.0\n")
+            out.write("Generator: xbuild (0.0.1)\n")
+            out.write("Root-Is-Purelib: false\n")
+            out.write("Tag: %s\n" % self.tag)
+        return filename
+
+
+    def _create_METADATA_file(self, path):
+        filename = str(path / "METADATA")
+        with open(filename, "wt", encoding="utf-8") as out:
+            out.write("Metadata-Version: 2.1\n")
+            out.write("Name: %s\n" % self.name)
+            out.write("Version: %s\n" % self.version)
+            if self.summary:
+                out.write("Summary: %s\n" % self.summary)
+            if self.description_content_type:
+                out.write("Description-Content-Type: %s\n"
+                          % self.description_content_type)
+            if self.keywords:
+                out.write("Keywords: %s\n" % ",".join(self.keywords))
+            if self.home_page:
+                out.write("Home-page: %s\n" % self.home_page)
+            out.write("Author: %s\n" % self._meta["author"])
+            out.write("Author-email: %s\n" % self._meta["author_email"])
+            out.write("License: %s\n" % self._meta["license"])
+            for classifier in self._meta["classifiers"]:
+                out.write("Classifier: %s\n" % classifier)
+            out.write("Requires-Python: %s\n" % self._meta["python_requires"])
+            for requirement in self._meta["install_requires"]:
+                out.write("Requires-Dist: %s\n" % requirement)
+            if self.description:
+                out.write("\n")
+                out.write(self.description)
+                out.write("\n")
+        return filename
+
+
+    def _create_LICENSE_file(self, path):
+        filename = str(path / "LICENSE.txt")
+        shutil.copy("LICENSE", filename)
+        return filename
+
+
+    def _create_top_level_file(self, path):
+        filename = str(path / "top_level.txt")
+        with open(filename, "wt", encoding="utf-8") as out:
+            out.write(self.name + "\n")
+        return filename
+
+
+    def _create_RECORD_file(self, path, files):
+        filename = str(path / "RECORD")
+        with open(filename, "wt", encoding="utf-8") as out:
+            for file in files:
+                with open(file, "rb") as inp:
+                    content = inp.read()
+                digest = hashlib.sha256(content).digest()
+                hashstr = base64.urlsafe_b64encode(digest).rstrip(b'=')
+                out.write("%s,sha256=%s,%d\n" % (file, hashstr, len(content)))
+            out.write("%s,,\n" % (filename,))
+        return filename

--- a/ci/xbuild/wheel.py
+++ b/ci/xbuild/wheel.py
@@ -33,14 +33,12 @@
 #
 #-------------------------------------------------------------------------------
 import base64
-import glob
 import hashlib
+import io
 import os
-import pathlib
 import re
-import shutil
 import sysconfig
-import tempfile
+import textwrap
 import time
 import zipfile
 
@@ -90,10 +88,54 @@ class Wheel:
         Content type of the `description` field. This should be one of
         "text/plain", "text/x-rst" or "text/markdown". If omitted,
         then "text/x-rst" is assumed.
+
+    keywords: List[str]
+        List of keywords to assist users in finding your package.
+
+    home_page: str
+        The URL of the module's home page. Note: this fields is called
+        `url` in setuptools.
+
+    author: str
+        The module's author name.
+
+    author_email: str
+        Contact email of the author.
+
+    maintainer: str
+        Name of the person who is maintaining the package (if different
+        from the author).
+
+    maintainer_email: str
+        Contact email of the maintainer.
+
+    license: str
+        Short string describing the license type of the package.
+
+    classifiers: List[str]
+        List of OSI-approved classifiers from the list
+        https://pypi.org/classifiers/
+
+    requirements: List[str]
+        List of prerequisites for this module. These are names of
+        other modules, optionally with standard version specifiers.
+
+    requires_python: str
+        Python version(s) that the distribution is compatible with.
+        This should be in the form of a version specifier, for example
+        ">=3", "==3.6", etc.
+
+    sources: List[str | Tuple[str|bytes, str]]
+        List of files to be put into the wheel. Each "source" is
+        either a filename, or a tuple (source_filename, dest_filename),
+        or a tuple (source_text, dest_filename), where `dest_filename`
+        is the name of the file as it should be inside the wheel
+        archive.
     """
 
     def __init__(self, **meta):
-        self._check(meta)
+        self._sources = None
+        self._check_meta(meta)
         self._meta = meta
         # Wheel creation time, will be used to timestamp individual files
         # inside the archive.
@@ -101,14 +143,42 @@ class Wheel:
         self._record_file = io.StringIO()
 
 
-    def _check(self, meta):
+    def _check_meta(self, meta):
+        self._check_sources(meta)
         self._check_name(meta)
         self._check_version(meta)
         self._check_summary(meta)
         self._check_description(meta)
         self._check_description_content_type(meta)
         self._check_keywords(meta)
+        self._check_home_page(meta)
+        self._check_author(meta)
+        self._check_author_email(meta)
+        self._check_maintainer(meta)
+        self._check_maintainer_email(meta)
+        self._check_license(meta)
+        self._check_classifiers(meta)
+        self._check_requirements(meta)
+        self._check_requires_python(meta)
+        self._check_unknown_fields(meta)
 
+
+    def _check_sources(self, meta):
+        assert "sources" in meta, "`sources` field is required"
+        sources = meta.pop("sources")
+        assert isinstance(sources, list)
+        for src in sources:
+            if isinstance(src, str):
+                if not os.path.exists(src):
+                    raise FileNotFoundError("Cannot find file `%s`" % src)
+                if os.path.isabs(src):
+                    raise ValueError("Source file `%s` cannot use absolute "
+                                     "path" % src)
+            else:
+                assert (isinstance(src, tuple) and len(src) == 2 and
+                        isinstance(src[0], (str, bytes)) and
+                        isinstance(src[1], str))
+        self._sources = sources
 
     def _check_name(self, meta):
         assert "name" in meta, "`name` field is required"
@@ -137,7 +207,7 @@ class Wheel:
         if "description" in meta:
             description = meta["description"]
             assert isinstance(description, str)
-            meta["description"] = description.strip()
+            meta["description"] = textwrap.dedent(description).strip()
 
     def _check_description_content_type(self, meta):
         if "description_content_type" in meta:
@@ -152,7 +222,64 @@ class Wheel:
             assert isinstance(keywords, list)
             assert all(isinstance(kw, str) for kw in keywords)
 
-    # def _check_homepag
+    def _check_home_page(self, meta):
+        if "home_page" in meta:
+            home_page = meta["home_page"]
+            assert isinstance(home_page, str)
+            assert re.match("^https?://", home_page)
+
+    def _check_author(self, meta):
+        if "author" in meta:
+            assert isinstance(meta["author"], str)
+
+    def _check_author_email(self, meta):
+        if "author_email" in meta:
+            assert isinstance(meta["author_email"], str)
+
+    def _check_maintainer(self, meta):
+        if "maintainer" in meta:
+            assert isinstance(meta["maintainer"], str)
+
+    def _check_maintainer_email(self, meta):
+        if "maintainer_email" in meta:
+            assert isinstance(meta["maintainer_email"], str)
+
+    def _check_license(self, meta):
+        if "license" in meta:
+            assert isinstance(meta["license"], str)
+
+    def _check_classifiers(self, meta):
+        if "classifiers" in meta:
+            classifiers = meta["classifiers"]
+            assert isinstance(classifiers, list)
+            assert all(isinstance(cls, str) for cls in classifiers)
+
+    def _check_requirements(self, meta):
+        if "requirements" in meta:
+            requirements = meta["requirements"]
+            assert isinstance(requirements, list)
+            assert all(isinstance(req, str) for req in requirements)
+
+    def _check_requires_python(self, meta):
+        if "requires_python" in meta:
+            req = meta["requires_python"]
+            assert isinstance(req, str)
+
+    def _check_unknown_fields(self, meta):
+        known_fields = {
+            "name", "version", "summary", "keywords", "description",
+            "description_content_type", "home_page", "author", "author_email",
+            "maintainer", "maintainer_email", "license", "classifiers",
+            "requirements", "requires_python"}
+        unknown_fields = set(meta.keys()) - known_fields
+        if unknown_fields:
+            raise KeyError("Unknown meta parameters %r" % unknown_fields)
+
+
+
+    #---------------------------------------------------------------------------
+    # Properties
+    #---------------------------------------------------------------------------
 
     @property
     def name(self):
@@ -178,39 +305,65 @@ class Wheel:
     def keywords(self):
         return self._meta.get("keywords")
 
+    @property
+    def home_page(self):
+        return self._meta.get("home_page")
 
+    @property
+    def author(self):
+        return self._meta.get("author")
+
+    @property
+    def author_email(self):
+        return self._meta.get("author_email")
+
+    @property
+    def maintainer(self):
+        return self._meta.get("maintainer")
+
+    @property
+    def maintainer_email(self):
+        return self._meta.get("maintainer_email")
+
+    @property
+    def license(self):
+        return self._meta.get("license")
+
+    @property
+    def classifiers(self):
+        return self._meta.get("classifiers")
+
+    @property
+    def requirements(self):
+        return self._meta.get("requirements")
+
+    @property
+    def requires_python(self):
+        return self._meta.get("requires_python")
+
+    @property
+    def sources(self):
+        return self._sources
+
+    @property
+    def info_dir(self):
+        return "%s-%s.dist-info" % (self.name, self.version)
 
 
     def build_wheel(self):
-        files = self._meta["sources"]
-        temp_dir = pathlib.Path(tempfile.mkdtemp())
-        # for bdir in {os.path.dirname(f) for f in files}:
-        #     tdir = os.path.join(tempdir, bdir)
-        #     os.makedirs(tdir, exist_ok=True)
-        #     print("Creating dir `%s`" % tdir)
-
-        info_dir = temp_dir / ("%s-%s.dist-info" % (self.name, self.version))
-        os.makedirs(info_dir)
-        files.append( self._create_WHEEL_file(info_dir) )
-        files.append( self._create_METADATA_file(info_dir) )
-        files.append( self._create_LICENSE_file(info_dir) )
-        # files.append( self._create_top_level_file(info_dir) )
-        files.append( self._create_RECORD_file(info_dir, files) )
-
-        wheel_name = "%s-%s-%s.whl" % (self.name, self.version, self.tag)
+        wheel_name = "%s-%s-%s.whl" % (self.name, self.version, self.get_tag())
         with zipfile.ZipFile(wheel_name, "w", allowZip64=True,
                              compression=zipfile.ZIP_DEFLATED) as zipf:
-            for filename in files:
-                st = os.stat(filename)
-                zinfo = zipfile.ZipInfo(filename, self._wheel_time)
-                zinfo.external_attr = st.st_mode << 16
-                with open(filename, "rb") as inp:
-                    content = inp.read()
-                    zipf.writestr(zinfo, content)
+            for filename in self.sources:
+                self._add_file_to_archive(zipf, filename)
+            self._add_LICENSE_file(zipf)
+            self._add_METADATA_file(zipf)
+            self._add_WHEEL_file(zipf)
+            self._add_RECORD_file(zipf)  # must come last
         print("Wheel file `%s` created" % wheel_name)
 
 
-    def add_file_to_archive(self, zipf, src):
+    def _add_file_to_archive(self, zipf, src):
         if isinstance(src, str):
             target_file = src
         else:
@@ -219,6 +372,8 @@ class Wheel:
 
         zinfo = zipfile.ZipInfo(target_file, self._wheel_time)
         if os.path.exists(src):
+            st = os.stat(src)
+            zinfo.external_attr = st.st_mode << 16
             with open(src, "rb") as inp:
                 bcontent = inp.read()
         elif isinstance(src, bytes):
@@ -231,8 +386,12 @@ class Wheel:
         # Write the content to zip
         zipf.writestr(zinfo, bcontent)
 
-        # Make
-
+        # Record file's sha256
+        digest = hashlib.sha256(bcontent).digest()
+        hashstr = base64.urlsafe_b64encode(digest).rstrip(b'=').decode()
+        assert isinstance(hashstr, str)
+        self._record_file.write("%s,%s,%d\n"
+                                % (target_file, hashstr, len(bcontent)))
 
 
     def _get_abi_tag(self):
@@ -241,74 +400,85 @@ class Wheel:
         assert parts[0] == "cpython"
         return "cp" + parts[1]
 
-    @property
-    def tag(self):
+    def get_tag(self):
+        from distutils.util import get_platform
         abi_tag = self._get_abi_tag()
         impl_tag = abi_tag[:4]
-        return "%s-%s-%s" % (impl_tag, abi_tag, "macosx_10_9_x86_64")
+        plat_tag = get_platform().replace('.', '_').replace('-', '_')
+        return "%s-%s-%s" % (impl_tag, abi_tag, plat_tag)
 
 
-    def _create_WHEEL_file(self, path):
-        filename = str(path / "WHEEL")
-        with open(filename, "wt", encoding="utf-8") as out:
-            out.write("Wheel-Version: 1.0\n")
-            out.write("Generator: xbuild (0.0.1)\n")
-            out.write("Root-Is-Purelib: false\n")
-            out.write("Tag: %s\n" % self.tag)
-        return filename
+
+    def _add_WHEEL_file(self, zipf):
+        out = "Wheel-Version: 1.0\n"
+        out += "Generator: xbuild (0.0.1)\n"
+        out += "Root-Is-Purelib: false\n"
+        out += "Tag: %s\n" % self.get_tag()
+        src = (out, self.info_dir + "/WHEEL")
+        self._add_file_to_archive(zipf, src)
 
 
-    def _create_METADATA_file(self, path):
-        filename = str(path / "METADATA")
-        with open(filename, "wt", encoding="utf-8") as out:
-            out.write("Metadata-Version: 2.1\n")
-            out.write("Name: %s\n" % self.name)
-            out.write("Version: %s\n" % self.version)
-            if self.summary:
-                out.write("Summary: %s\n" % self.summary)
-            if self.description_content_type:
-                out.write("Description-Content-Type: %s\n"
-                          % self.description_content_type)
-            if self.keywords:
-                out.write("Keywords: %s\n" % ",".join(self.keywords))
-            if self.home_page:
-                out.write("Home-page: %s\n" % self.home_page)
-            out.write("Author: %s\n" % self._meta["author"])
-            out.write("Author-email: %s\n" % self._meta["author_email"])
-            out.write("License: %s\n" % self._meta["license"])
-            for classifier in self._meta["classifiers"]:
-                out.write("Classifier: %s\n" % classifier)
-            out.write("Requires-Python: %s\n" % self._meta["python_requires"])
-            for requirement in self._meta["install_requires"]:
-                out.write("Requires-Dist: %s\n" % requirement)
-            if self.description:
-                out.write("\n")
-                out.write(self.description)
-                out.write("\n")
-        return filename
+    def _add_LICENSE_file(self, zipf):
+        filename = self.info_dir + "/LICENSE"
+        if os.path.exists("LICENSE"):
+            src = ("LICENSE", filename)
+        elif os.path.exists("LICENSE.txt"):
+            src = ("LICENSE.txt", filename)
+        else:
+            print("Warning: LICENSE file not found in the root directory")
+            return
+        self._add_file_to_archive(zipf, src)
 
 
-    def _create_LICENSE_file(self, path):
-        filename = str(path / "LICENSE.txt")
-        shutil.copy("LICENSE", filename)
-        return filename
+    def _add_METADATA_file(self, zipf):
+        out = "Metadata-Version: 2.1\n"
+        out += "Name: %s\n" % self.name
+        out += "Version: %s\n" % self.version
+        if self.summary:
+            out += "Summary: %s\n" % self.summary
+        if self.description_content_type:
+            out += "Description-Content-Type: %s\n" \
+                    % self.description_content_type
+        if self.keywords:
+            out += "Keywords: %s\n" % ",".join(self.keywords)
+        if self.home_page:
+            out += "Home-page: %s\n" % self.home_page
+        if self.author:
+            out += "Author: %s\n" % self.author
+        if self.author_email:
+            out += "Author-email: %s\n" % self.author_email
+        if self.maintainer:
+            out += "Maintainer: %s\n" % self.maintainer
+        if self.maintainer_email:
+            out += "Maintainer-email: %s\n" % self.maintainer_email
+        if self.license:
+            out += "License: %s\n" % self.license
+        if self.classifiers:
+            for classifier in self.classifiers:
+                out += "Classifier: %s\n" % classifier
+        if self.requirements:
+            rx_extra = re.compile(r"extra\s*==\s*['\"](\w+)['\"]")
+            extras = set()
+            for req in self.requirements:
+                mm = re.search(rx_extra, req)
+                if mm:
+                    extras.add(mm.group(1))
+                out += "Requires-Dist: %s\n" % req
+            for extra in sorted(extras):
+                out += "Provides-Extra: %s\n" % extra
+        if self.requires_python:
+            out += "Requires-Python: %s\n" % self.requires_python
+        if self.description:
+            out += "\n"
+            out += self.description
+            out += "\n"
+        src = (out, self.info_dir + "/METADATA")
+        self._add_file_to_archive(zipf, src)
 
 
-    def _create_top_level_file(self, path):
-        filename = str(path / "top_level.txt")
-        with open(filename, "wt", encoding="utf-8") as out:
-            out.write(self.name + "\n")
-        return filename
-
-
-    def _create_RECORD_file(self, path, files):
-        filename = str(path / "RECORD")
-        with open(filename, "wt", encoding="utf-8") as out:
-            for file in files:
-                with open(file, "rb") as inp:
-                    content = inp.read()
-                digest = hashlib.sha256(content).digest()
-                hashstr = base64.urlsafe_b64encode(digest).rstrip(b'=')
-                out.write("%s,sha256=%s,%d\n" % (file, hashstr, len(content)))
-            out.write("%s,,\n" % (filename,))
-        return filename
+    def _add_RECORD_file(self, zipf):
+        filename = self.info_dir + "/RECORD"
+        record = self._record_file.getvalue()
+        record += "%s,," % filename
+        src = (record, filename)
+        self._add_file_to_archive(zipf, src)

--- a/ci/xbuild/wheel.py
+++ b/ci/xbuild/wheel.py
@@ -138,9 +138,10 @@ class Wheel:
         archive.
     """
 
-    def __init__(self, **meta):
-        self._sources = None
+    def __init__(self, sources, **meta):
+        self._check_sources(sources)
         self._check_meta(meta)
+        self._sources = sources
         self._meta = meta
 
         # Wheel creation time, will be used to timestamp individual files
@@ -160,7 +161,6 @@ class Wheel:
     #---------------------------------------------------------------------------
 
     def _check_meta(self, meta):
-        self._check_sources(meta)
         self._check_name(meta)
         self._check_version(meta)
         self._check_summary(meta)
@@ -179,9 +179,7 @@ class Wheel:
         self._check_unknown_fields(meta)
 
 
-    def _check_sources(self, meta):
-        assert "sources" in meta, "`sources` field is required"
-        sources = meta.pop("sources")
+    def _check_sources(self, sources):
         assert isinstance(sources, list)
         for src in sources:
             if isinstance(src, str):
@@ -194,7 +192,6 @@ class Wheel:
                 assert (isinstance(src, tuple) and len(src) == 2 and
                         isinstance(src[0], (str, bytes)) and
                         isinstance(src[1], str))
-        self._sources = sources
 
     def _check_name(self, meta):
         assert "name" in meta, "`name` field is required"

--- a/ext.py
+++ b/ext.py
@@ -21,16 +21,22 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 #-------------------------------------------------------------------------------
+#
+# [PEP-517](https://www.python.org/dev/peps/pep-0517/)
+#     A build-system independent format for source trees
+#     Specification for a build backend system.
+#
+#-------------------------------------------------------------------------------
 import glob
+import os
 import sys
-import sysconfig
+import textwrap
 from ci import xbuild
 
-_valid_commands = ["asan", "build", "coverage", "debug", "wheel"]
 
 
 def build_extension(cmd, verbosity=3):
-    assert cmd in _valid_commands
+    assert cmd in ["asan", "build", "coverage", "debug"]
     windows = (sys.platform == "win32")
     macos = (sys.platform == "darwin")
     linux = (sys.platform == "linux")
@@ -124,15 +130,12 @@ def build_extension(cmd, verbosity=3):
 
     # Setup is complete, ready to build
     ext.build()
+    return os.path.basename(ext.output_file)
 
 
-def build_wheel(target_dir=""):
-    so_file = "_datatable" + sysconfig.get_config_var("EXT_SUFFIX")
-    files = glob.glob("datatable/**/*.py", recursive=True)
-    files += ["datatable/include/datatable.h"]
-    files += ["datatable/lib/" + so_file]
 
-    wb = xbuild.Wheel(
+def get_meta():
+    return dict(
         name="datatable",
         version="0.10.1",
 
@@ -147,12 +150,8 @@ def build_wheel(target_dir=""):
 
             See https://github.com/h2oai/datatable for more details.
         """,
-
         keywords=["datatable", "data", "dataframe", "frame", "data.table",
                   "munging", "numpy", "pandas", "data processing", "ETL"],
-
-        # The homepage
-        home_page="https://github.com/h2oai/datatable",
 
         # Author details
         author="Pasha Stetsenko",
@@ -160,8 +159,8 @@ def build_wheel(target_dir=""):
         maintainer="Oleksiy Kononenko",
         maintainer_email="oleksiy.kononenko@h2o.ai",
 
+        home_page="https://github.com/h2oai/datatable",
         license="Mozilla Public License v2.0",
-
         classifiers=[
             "Development Status :: 4 - Beta",
             "Intended Audience :: Developers",
@@ -182,34 +181,86 @@ def build_wheel(target_dir=""):
             "blessed",
             "pytest (>=3.1); extra == 'tests'",
             "docutils (>=0.14); extra == 'tests'",
+            "numpy; extra == 'optional'",
+            "pandas; extra == 'optional'",
+            "xlrd; extra == 'optional'",
         ],
-
         requires_python=">=3.5",
-
-        sources=files,
     )
-    return wb.build_wheel(target_dir)
 
 
 
-if __name__ == "__main__":
+#-------------------------------------------------------------------------------
+# Standard hooks
+#-------------------------------------------------------------------------------
+
+def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
+    """
+    Function for building wheels, satisfies requirements of PEP-517.
+    """
+    assert isinstance(wheel_directory, str)
+    assert metadata_directory is None
+
+    so_file = build_extension(cmd="build", verbosity=3)
+    files = glob.glob("datatable/**/*.py", recursive=True)
+    files += ["datatable/include/datatable.h"]
+    files += ["datatable/lib/" + so_file]
+
+    meta = get_meta()
+    wb = xbuild.Wheel(files, **meta)
+    wheel_file = wb.build_wheel(wheel_directory)
+    return wheel_file
+
+
+
+def build_sdist(wheel_directory, config_settings=None):
+    """
+    Function for building source distributions, satisfies PEP-517.
+    """
+    raise NotImplementedError()
+
+
+
+#-------------------------------------------------------------------------------
+# Allow this script to run from command line
+#-------------------------------------------------------------------------------
+
+def main():
     import argparse
-    parser = argparse.ArgumentParser(description='Build _datatable module')
-    parser.add_argument("cmd", metavar="CMD", choices=_valid_commands,
-            help="Mode of the _datatable library to build. The following modes "
-                 "are supported: `asan` (built with Address Sanitizer), `build`"
-                 " (standard build mode), `coverage` (suitable for coverage "
-                 "testing), and `debug` (with full debug info).")
+    parser = argparse.ArgumentParser(
+        description='Build _datatable module',
+        formatter_class=argparse.RawTextHelpFormatter
+    )
+    parser.add_argument("cmd", metavar="CMD",
+        choices=["asan", "build", "coverage", "debug", "sdist", "wheel"],
+        help=textwrap.dedent("""
+            Specify what this script should do:
+
+            asan     : build _datatable with Address Sanitizer enabled
+            build    : build _datatable normally, with full optimization
+            coverage : build _datatable in a mode suitable for coverage
+                       testing
+            debug    : build _datatable in debug mode, optimized for gdb
+                       on Linux and for lldb on MacOS
+            sdist    : create source distribution of datatable
+            wheel    : create wheel distribution of datatable
+            """).strip())
     parser.add_argument("-v", dest="verbosity", action="count", default=1,
-            help="Verbosity level of the output, specify the parameter up to 3 "
-                 "times for maximum verbosity; the default level is 1")
+            help="Verbosity level of the output, specify the parameter up to \n"
+                 "3 times for maximum verbosity; the default level is 1")
 
     args = parser.parse_args()
     if args.cmd == "wheel":
-        build_extension(cmd="build", verbosity=3)
-        wheel_file = build_wheel()
-        print("Wheel `%s` created" % wheel_file)
+        wheel_file = build_wheel("dist/")
+        print("Wheel file `dist/%s` created" % wheel_file)
+    elif args.cmd == "sdist":
+        sdist_file = build_sdist("dist/")
+        print("Sdist file `dist/%s` created" % sdist_file)
     else:
         with open("datatable/lib/.xbuild-cmd", "wt") as out:
             out.write(args.cmd)
         build_extension(cmd=args.cmd, verbosity=args.verbosity)
+
+
+if __name__ == "__main__":
+    main()

--- a/ext.py
+++ b/ext.py
@@ -21,7 +21,9 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 #-------------------------------------------------------------------------------
+import glob
 import sys
+import sysconfig
 from ci import xbuild
 
 _valid_commands = ["asan", "build", "coverage", "debug", "wheel"]
@@ -146,8 +148,11 @@ def build_wheel():
             See https://github.com/h2oai/datatable for more details.
         """,
 
+        keywords=["datatable", "data", "dataframe", "frame", "data.table",
+                  "munging", "numpy", "pandas", "data processing", "ETL"],
+
         # The homepage
-        url="https://github.com/h2oai/datatable",
+        home_page="https://github.com/h2oai/datatable",
 
         # Author details
         author="Pasha Stetsenko",
@@ -168,18 +173,18 @@ def build_wheel():
             "Programming Language :: Python :: 3.8",
             "Topic :: Scientific/Engineering :: Information Analysis",
         ],
-        keywords=["datatable", "data", "dataframe", "frame", "data.table",
-                  "munging", "numpy", "pandas", "data processing", "ETL"],
-
-        sources=files,
 
         # Runtime dependencies
-        install_requires=[
+        requirements=[
             "typesentry (>=0.2.6)",
             "blessed",
+            "pytest; extra == 'tests'",
+            "docutils; extra == 'tests'",
         ],
 
-        python_requires=">=3.5",
+        requires_python=">=3.5",
+
+        sources=files,
     )
     wb.build_wheel()
 

--- a/ext.py
+++ b/ext.py
@@ -126,7 +126,7 @@ def build_extension(cmd, verbosity=3):
     ext.build()
 
 
-def build_wheel():
+def build_wheel(target_dir=""):
     so_file = "_datatable" + sysconfig.get_config_var("EXT_SUFFIX")
     files = glob.glob("datatable/**/*.py", recursive=True)
     files += ["datatable/include/datatable.h"]
@@ -157,6 +157,8 @@ def build_wheel():
         # Author details
         author="Pasha Stetsenko",
         author_email="pasha.stetsenko@h2o.ai",
+        maintainer="Oleksiy Kononenko",
+        maintainer_email="oleksiy.kononenko@h2o.ai",
 
         license="Mozilla Public License v2.0",
 
@@ -178,15 +180,15 @@ def build_wheel():
         requirements=[
             "typesentry (>=0.2.6)",
             "blessed",
-            "pytest; extra == 'tests'",
-            "docutils; extra == 'tests'",
+            "pytest (>=3.1); extra == 'tests'",
+            "docutils (>=0.14); extra == 'tests'",
         ],
 
         requires_python=">=3.5",
 
         sources=files,
     )
-    wb.build_wheel()
+    return wb.build_wheel(target_dir)
 
 
 
@@ -205,7 +207,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
     if args.cmd == "wheel":
         build_extension(cmd="build", verbosity=3)
-        build_wheel()
+        wheel_file = build_wheel()
+        print("Wheel `%s` created" % wheel_file)
     else:
         with open("datatable/lib/.xbuild-cmd", "wt") as out:
             out.write(args.cmd)

--- a/ext.py
+++ b/ext.py
@@ -24,7 +24,7 @@
 import sys
 from ci import xbuild
 
-_valid_commands = ["asan", "build", "coverage", "debug"]
+_valid_commands = ["asan", "build", "coverage", "debug", "wheel"]
 
 
 def build_extension(cmd, verbosity=3):
@@ -124,6 +124,67 @@ def build_extension(cmd, verbosity=3):
     ext.build()
 
 
+def build_wheel():
+    so_file = "_datatable" + sysconfig.get_config_var("EXT_SUFFIX")
+    files = glob.glob("datatable/**/*.py", recursive=True)
+    files += ["datatable/include/datatable.h"]
+    files += ["datatable/lib/" + so_file]
+
+    wb = xbuild.Wheel(
+        name="datatable",
+        version="0.10.1",
+
+        summary="Python library for fast multi-threaded data manipulation and "
+                "munging.",
+        description="""
+            This is a Python package for manipulating 2-dimensional tabular data
+            structures (aka data frames). It is close in spirit to pandas or SFrame;
+            however we put specific emphasis on speed and big data support. As the
+            name suggests, the package is closely related to R's data.table and
+            attempts to mimic its core algorithms and API.
+
+            See https://github.com/h2oai/datatable for more details.
+        """,
+
+        # The homepage
+        url="https://github.com/h2oai/datatable",
+
+        # Author details
+        author="Pasha Stetsenko",
+        author_email="pasha.stetsenko@h2o.ai",
+
+        license="Mozilla Public License v2.0",
+
+        classifiers=[
+            "Development Status :: 4 - Beta",
+            "Intended Audience :: Developers",
+            "Intended Audience :: Science/Research",
+            "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
+            "Operating System :: MacOS",
+            "Operating System :: Unix",
+            "Programming Language :: Python :: 3.5",
+            "Programming Language :: Python :: 3.6",
+            "Programming Language :: Python :: 3.7",
+            "Programming Language :: Python :: 3.8",
+            "Topic :: Scientific/Engineering :: Information Analysis",
+        ],
+        keywords=["datatable", "data", "dataframe", "frame", "data.table",
+                  "munging", "numpy", "pandas", "data processing", "ETL"],
+
+        sources=files,
+
+        # Runtime dependencies
+        install_requires=[
+            "typesentry (>=0.2.6)",
+            "blessed",
+        ],
+
+        python_requires=">=3.5",
+    )
+    wb.build_wheel()
+
+
+
 if __name__ == "__main__":
     import argparse
     parser = argparse.ArgumentParser(description='Build _datatable module')
@@ -137,7 +198,10 @@ if __name__ == "__main__":
                  "times for maximum verbosity; the default level is 1")
 
     args = parser.parse_args()
-    with open("datatable/lib/.xbuild-cmd", "wt") as out:
-        out.write(args.cmd)
-
-    build_extension(cmd=args.cmd, verbosity=args.verbosity)
+    if args.cmd == "wheel":
+        build_extension(cmd="build", verbosity=3)
+        build_wheel()
+    else:
+        with open("datatable/lib/.xbuild-cmd", "wt") as out:
+            out.write(args.cmd)
+        build_extension(cmd=args.cmd, verbosity=args.verbosity)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools", "wheel"]
-build-backend = "setuptools.build_meta:__legacy__ "
+requires = ["setuptools >= 42.0", "wheel"]
+build-backend = "setuptools.build_meta:__legacy__"
 # requires = ["pip >= 19.0"]
 # build-backend = "ext"
 # backend-path = ["."]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[build-system]
+requires = ["pip >= 19.0"]
+build-backend = "ext"
+backend-path = ["."]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,6 @@
 [build-system]
-requires = ["pip >= 19.0"]
-build-backend = "ext"
-backend-path = ["."]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta:__legacy__ "
+# requires = ["pip >= 19.0"]
+# build-backend = "ext"
+# backend-path = ["."]


### PR DESCRIPTION
In this PR we add the ability for `ext.py` to build wheel files, conforming to PEP-517 specification for build-backends.

The `pyproject.toml` file still refers to the legacy setup.py/setuptools; the new functionality has to be invoked manually.