### PR TITLE
Add Windows implementation of mmap functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,15 @@ coverage:
 		--cov=datatable --cov-report=xml:build/coverage.xml \
 		tests
 	chmod +x ci/llvm-gcov.sh
-	lcov --gcov-tool ci/llvm-gcov.sh --capture --directory . --no-external --output-file build/coverage.info
+	# Note: running `lcov` we should pass an absolute path to
+	# `ci/llvm-gcov.sh`. The reason is that `lcov` invokes
+	# `geninfo` that is trying to detect the base directory in the
+	# `find_base_from_graph()` routine. This routine fails
+	# for source files that have no function definitions, because
+	# these files are excluded from the file graph,
+	# where `find_base_from_graph()` does the search. Passing
+	# `${CURDIR}/ci/llvm-gcov.sh` to `lcov` fixes the problem.
+	lcov --gcov-tool ${CURDIR}/ci/llvm-gcov.sh --capture --directory . --no-external --output-file build/coverage.info
 	genhtml --legend --output-directory build/coverage-c --demangle-cpp build/coverage.info
 	mv .coverage build/
 

--- a/c/buffer.cc
+++ b/c/buffer.cc
@@ -18,7 +18,9 @@
 #include "buffer.h"
 #include "mmm.h"               // MemoryMapWorker, MemoryMapManager
 
-#if !DT_OS_WINDOWS
+#if DT_OS_WINDOWS
+  #include "lib/mman/mman.h"   // mmap, munmap
+#else
   #include <sys/mman.h>        // mmap, munmap
 #endif
 
@@ -490,119 +492,114 @@ class Mmap_BufferImpl : public BufferImpl, MemoryMapWorker {
   protected:
     virtual void memmap() {
       if (mapped_) return;
-      #if DT_OS_WINDOWS
-        throw NotImplError() << "Memory-mapping not supported on Windows yet";
 
-      #else
-        // Place a mutex lock to prevent multiple threads from trying
-        // to perform memory-mapping of different files (or same file)
-        // in parallel. If multiple threads called this method at the
-        // same time, then only one will proceed, while all others
-        // will wait until the lock is released, and then exit because
-        // flag `mapped_` will now be true.
-        static std::mutex mmp_mutex;
-        std::lock_guard<std::mutex> _(mmp_mutex);
-        if (mapped_) return;
+      // Place a mutex lock to prevent multiple threads from trying
+      // to perform memory-mapping of different files (or same file)
+      // in parallel. If multiple threads called this method at the
+      // same time, then only one will proceed, while all others
+      // will wait until the lock is released, and then exit because
+      // flag `mapped_` will now be true.
+      static std::mutex mmp_mutex;
+      std::lock_guard<std::mutex> _(mmp_mutex);
+      if (mapped_) return;
 
-        bool create = temporary_file_;
-        size_t n = size_;
+      bool create = temporary_file_;
+      size_t n = size_;
 
-        File file(filename_, create? File::CREATE : File::READ, fd_);
-        file.assert_is_not_dir();
-        if (create) {
-          file.resize(n);
-        }
-        size_t filesize = file.size();
-        if (filesize == 0) {
-          // Cannot memory-map 0-bytes file. However we shouldn't
-          // really need to: if memory size is 0 then mmp can be NULL
-          // as nobody is going to read from it anyways.
-          size_ = 0;
-          data_ = nullptr;
-          mapped_ = true;
-          return;
-        }
-        size_ = filesize + (create? 0 : n);
-
-        // Memory-map the file.
-        // In "open" mode if `n` is non-zero, then we will be opening
-        // a buffer with larger size than the actual file size. Also,
-        // the file is opened in "private, read-write" mode -- meaning
-        // that the user can write to that buffer if needed. From the
-        // man pages of `mmap`:
-        //
-        // | MAP_SHARED
-        // |   Share this mapping. Updates to the mapping are visible
-        // |   to other processes that map this file, and are carried
-        // |   through to the underlying file. The file may not
-        // |   actually be updated until msync(2) or munmap() is
-        // |   called.
-        // | MAP_PRIVATE
-        // |   Create a private copy-on-write mapping.  Updates to the
-        // |   mapping are not carried through to the underlying file.
-        // | MAP_NORESERVE
-        // |   Do not reserve swap space for this mapping.  When swap
-        // |   space is reserved, one has the guarantee that it is
-        // |   possible to modify the mapping.  When swap space is not
-        // |   reserved one might get SIGSEGV upon a write if no
-        // |   physical memory is available.
-        //
-        int attempts = 3;
-        while (attempts--) {
-          int flags = create? MAP_SHARED : MAP_PRIVATE|MAP_NORESERVE;
-          data_ = mmap(/* address = */ nullptr,
-                         /* length = */ size_,
-                         /* protection = */ PROT_WRITE|PROT_READ,
-                         /* flags = */ flags,
-                         /* fd = */ file.descriptor(),
-                         /* offset = */ 0);
-          if (data_ == MAP_FAILED) {
-            data_ = nullptr;
-            if (errno == 12) {  // release some memory and try again
-              MemoryMapManager::get()->freeup_memory();
-              if (attempts) {
-                errno = 0;
-                continue;
-              }
-            }
-            // Exception is thrown from the constructor -> the base class'
-            // destructor will be called, which checks that `data_` is null.
-            throw IOError() << "Memory-map failed for file " << file.cname()
-                            << " of size " << filesize
-                            << " +" << size_ - filesize << Errno;
-          } else {
-            MemoryMapManager::get()->add_entry(this, size_);
-            break;
-          }
-        }
+      File file(filename_, create? File::CREATE : File::READ, fd_);
+      file.assert_is_not_dir();
+      if (create) {
+        file.resize(n);
+      }
+      size_t filesize = file.size();
+      if (filesize == 0) {
+        // Cannot memory-map 0-bytes file. However we shouldn't
+        // really need to: if memory size is 0 then mmp can be NULL
+        // as nobody is going to read from it anyways.
+        size_ = 0;
+        data_ = nullptr;
         mapped_ = true;
-        xassert(mmm_index_);
-      #endif
+        return;
+      }
+      size_ = filesize + (create? 0 : n);
+
+      // Memory-map the file.
+      // In "open" mode if `n` is non-zero, then we will be opening
+      // a buffer with larger size than the actual file size. Also,
+      // the file is opened in "private, read-write" mode -- meaning
+      // that the user can write to that buffer if needed. From the
+      // man pages of `mmap`:
+      //
+      // | MAP_SHARED
+      // |   Share this mapping. Updates to the mapping are visible
+      // |   to other processes that map this file, and are carried
+      // |   through to the underlying file. The file may not
+      // |   actually be updated until msync(2) or munmap() is
+      // |   called.
+      // | MAP_PRIVATE
+      // |   Create a private copy-on-write mapping.  Updates to the
+      // |   mapping are not carried through to the underlying file.
+      // | MAP_NORESERVE
+      // |   Do not reserve swap space for this mapping.  When swap
+      // |   space is reserved, one has the guarantee that it is
+      // |   possible to modify the mapping.  When swap space is not
+      // |   reserved one might get SIGSEGV upon a write if no
+      // |   physical memory is available.
+      //
+      int attempts = 3;
+      while (attempts--) {
+        int flags = create? MAP_SHARED : MAP_PRIVATE|MAP_NORESERVE;
+        data_ = mmap(/* address = */ nullptr,
+                       /* length = */ size_,
+                       /* protection = */ PROT_WRITE|PROT_READ,
+                       /* flags = */ flags,
+                       /* fd = */ file.descriptor(),
+                       /* offset = */ 0);
+        if (data_ == MAP_FAILED) {
+          data_ = nullptr;
+          if (errno == 12) {  // release some memory and try again
+            MemoryMapManager::get()->freeup_memory();
+            if (attempts) {
+              errno = 0;
+              continue;
+            }
+          }
+          // Exception is thrown from the constructor -> the base class'
+          // destructor will be called, which checks that `data_` is null.
+          throw IOError() << "Memory-map failed for file " << file.cname()
+                          << " of size " << filesize
+                          << " +" << size_ - filesize << Errno;
+        } else {
+          MemoryMapManager::get()->add_entry(this, size_);
+          break;
+        }
+      }
+      mapped_ = true;
+      xassert(mmm_index_);
     }
 
     void memunmap() noexcept {
       if (!mapped_) return;
-      #if !DT_OS_WINDOWS
-        if (data_) {
-          int ret = munmap(data_, size_);
-          if (ret) {
-            // Cannot throw exceptions from a destructor, so just
-            // print a message
-            printf("Error unmapping the view of file: [errno %d] %s. "
-                   "Resources may have not been freed properly.",
-                   errno, std::strerror(errno));
-          }
-          data_ = nullptr;
+
+      if (data_) {
+        int ret = munmap(data_, size_);
+        if (ret) {
+          // Cannot throw exceptions from a destructor, so just
+          // print a message
+          printf("Error unmapping the view of file: [errno %d] %s. "
+                 "Resources may have not been freed properly.",
+                 errno, std::strerror(errno));
         }
-        mapped_ = false;
-        size_ = 0;
-        if (mmm_index_) {
-          try {
-            MemoryMapManager::get()->del_entry(mmm_index_);
-          } catch (...) {}
-          mmm_index_ = 0;
-        }
-      #endif
+        data_ = nullptr;
+      }
+      mapped_ = false;
+      size_ = 0;
+      if (mmm_index_) {
+        try {
+          MemoryMapManager::get()->del_entry(mmm_index_);
+        } catch (...) {}
+        mmm_index_ = 0;
+      }
     }
 };
 
@@ -629,13 +626,11 @@ class Overmap_BufferImpl : public Mmap_BufferImpl {
 
     ~Overmap_BufferImpl() override {
       if (!xbuf_) return;
-      #if !DT_OS_WINDOWS
-        int ret = munmap(xbuf_, xsize_);
-        if (ret) {
-          printf("Cannot unmap extra memory %p: [errno %d] %s",
-                 xbuf_, errno, std::strerror(errno));
-        }
-      #endif
+      int ret = munmap(xbuf_, xsize_);
+      if (ret) {
+        printf("Cannot unmap extra memory %p: [errno %d] %s",
+               xbuf_, errno, std::strerror(errno));
+      }
     }
 
     virtual size_t memory_footprint() const noexcept override {
@@ -648,74 +643,70 @@ class Overmap_BufferImpl : public Mmap_BufferImpl {
       Mmap_BufferImpl::memmap();
       if (xsize_ == 0) return;
       if (!data_) return;
-      #if DT_OS_WINDOWS
-        throw NotImplError() << "Memory-mapping not supported on Windows yet";
 
-      #else
-        // The parent's constructor has opened a memory-mapped region
-        // of size `filesize + xn`. This, however, is not always
-        // enough:
-        // | A file is mapped in multiples of the page size. For a
-        // | file that is not a multiple of the page size, the
-        // | remaining memory is 0ed when mapped, and writes to that
-        // | region are not written out to the file.
-        //
-        // Thus, when `filesize` is *not* a multiple of pagesize,
-        // then the memory mapping will have some writable "scratch"
-        // space at the end, filled with '\0' bytes. We check -- if
-        // this space is large enough to hold `xn` bytes, then don't
-        // do anything extra. If not (for example when `filesize` is
-        // an exact multiple of `pagesize`), then attempt to read/
-        // write past physical end of file wil fail with a BUS error,
-        // despite the fact that the map was overallocated for the
-        // extra `xn` bytes:
-        // | Use of a mapped region can result in these signals:
-        // | SIGBUS:
-        // |   Attempted access to a portion of the buffer that does
-        // |   not correspond to the file (for example, beyond the
-        // |   end of the file)
-        //
-        // In order to circumvent this, we allocate a new memory-
-        // mapped region of size `xn` and placed at address `buf +
-        // filesize`. In theory, this should always succeed because
-        // we over-allocated `buf` by `xn` bytes; and even though
-        // those extra bytes are not readable/writable, at least
-        // there is a guarantee that it is not occupied by anyone
-        // else. Now, `mmap()` documentation explicitly allows to
-        // declare mappings that overlap each other:
-        // | MAP_ANONYMOUS:
-        // |   The mapping is not backed by any file; its contents are
-        // |   initialized to zero. The fd argument is ignored.
-        // | MAP_FIXED
-        // |   Don't interpret addr as a hint: place the mapping at
-        // |   exactly that address.  `addr` must be a multiple of
-        // |   the page size. If the memory region specified by addr
-        // |   and len overlaps pages of any existing mapping(s), then
-        // |   the overlapped part of the existing mapping(s) will be
-        // |   discarded.
-        //
-        size_t xn = xsize_;
-        size_t pagesize = static_cast<size_t>(sysconf(_SC_PAGE_SIZE));
-        size_t filesize = size() - xn;
-        // How much to add to filesize to align it to a page boundary
-        size_t gapsize = (pagesize - filesize%pagesize) % pagesize;
-        if (xn > gapsize) {
-          void* target = static_cast<void*>(
-                            static_cast<char*>(data_) + filesize + gapsize);
-          xsize_ = xn - gapsize;
-          xbuf_ = mmap(/* address = */ target,
-                      /* size = */ xsize_,
-                      /* protection = */ PROT_WRITE|PROT_READ,
-                      /* flags = */ MAP_ANONYMOUS|MAP_PRIVATE|MAP_FIXED,
-                      /* file descriptor, ignored */ -1,
-                      /* offset, ignored */ 0);
-          if (xbuf_ == MAP_FAILED) {
-            throw RuntimeError() << "Cannot allocate additional " << xsize_
-                                 << " bytes at address " << target << ": "
-                                 << Errno;
-          }
+      // The parent's constructor has opened a memory-mapped region
+      // of size `filesize + xn`. This, however, is not always
+      // enough:
+      // | A file is mapped in multiples of the page size. For a
+      // | file that is not a multiple of the page size, the
+      // | remaining memory is 0ed when mapped, and writes to that
+      // | region are not written out to the file.
+      //
+      // Thus, when `filesize` is *not* a multiple of pagesize,
+      // then the memory mapping will have some writable "scratch"
+      // space at the end, filled with '\0' bytes. We check -- if
+      // this space is large enough to hold `xn` bytes, then don't
+      // do anything extra. If not (for example when `filesize` is
+      // an exact multiple of `pagesize`), then attempt to read/
+      // write past physical end of file wil fail with a BUS error,
+      // despite the fact that the map was overallocated for the
+      // extra `xn` bytes:
+      // | Use of a mapped region can result in these signals:
+      // | SIGBUS:
+      // |   Attempted access to a portion of the buffer that does
+      // |   not correspond to the file (for example, beyond the
+      // |   end of the file)
+      //
+      // In order to circumvent this, we allocate a new memory-
+      // mapped region of size `xn` and placed at address `buf +
+      // filesize`. In theory, this should always succeed because
+      // we over-allocated `buf` by `xn` bytes; and even though
+      // those extra bytes are not readable/writable, at least
+      // there is a guarantee that it is not occupied by anyone
+      // else. Now, `mmap()` documentation explicitly allows to
+      // declare mappings that overlap each other:
+      // | MAP_ANONYMOUS:
+      // |   The mapping is not backed by any file; its contents are
+      // |   initialized to zero. The fd argument is ignored.
+      // | MAP_FIXED
+      // |   Don't interpret addr as a hint: place the mapping at
+      // |   exactly that address.  `addr` must be a multiple of
+      // |   the page size. If the memory region specified by addr
+      // |   and len overlaps pages of any existing mapping(s), then
+      // |   the overlapped part of the existing mapping(s) will be
+      // |   discarded.
+      //
+      size_t xn = xsize_;
+      size_t pagesize = static_cast<size_t>(sysconf(_SC_PAGE_SIZE));
+      size_t filesize = size() - xn;
+      // How much to add to filesize to align it to a page boundary
+      size_t gapsize = (pagesize - filesize%pagesize) % pagesize;
+      if (xn > gapsize) {
+        void* target = static_cast<void*>(
+                          static_cast<char*>(data_) + filesize + gapsize);
+        xsize_ = xn - gapsize;
+        xbuf_ = mmap(/* address = */ target,
+                    /* size = */ xsize_,
+                    /* protection = */ PROT_WRITE|PROT_READ,
+                    /* flags = */ MAP_ANONYMOUS|MAP_PRIVATE|MAP_FIXED,
+                    /* file descriptor, ignored */ -1,
+                    /* offset, ignored */ 0);
+        if (xbuf_ == MAP_FAILED) {
+          throw RuntimeError() << "Cannot allocate additional " << xsize_
+                               << " bytes at address " << target << ": "
+                               << Errno;
         }
-      #endif
+      }
     }
 };
 

--- a/c/buffer.cc
+++ b/c/buffer.cc
@@ -19,7 +19,9 @@
 #include "mmm.h"               // MemoryMapWorker, MemoryMapManager
 
 #if DT_OS_WINDOWS
+  #include <windows.h>
   #include "lib/mman/mman.h"   // mmap, munmap
+  #undef min
 #else
   #include <sys/mman.h>        // mmap, munmap
 #endif
@@ -687,7 +689,15 @@ class Overmap_BufferImpl : public Mmap_BufferImpl {
       // |   discarded.
       //
       size_t xn = xsize_;
-      size_t pagesize = static_cast<size_t>(sysconf(_SC_PAGE_SIZE));
+
+      #if DT_OS_WINDOWS
+        SYSTEM_INFO sysInfo;
+        GetSystemInfo(&sysInfo);
+        size_t pagesize = sysInfo.dwPageSize;
+      #else
+        size_t pagesize = static_cast<size_t>(sysconf(_SC_PAGE_SIZE));
+      #endif
+
       size_t filesize = size() - xn;
       // How much to add to filesize to align it to a page boundary
       size_t gapsize = (pagesize - filesize%pagesize) % pagesize;

--- a/c/buffer.cc
+++ b/c/buffer.cc
@@ -19,7 +19,7 @@
 #include "mmm.h"               // MemoryMapWorker, MemoryMapManager
 
 #if DT_OS_WINDOWS
-  #include <windows.h>
+  #include <windows.h>         // SYSTEM_INFO, GetSystemInfo
   #include "lib/mman/mman.h"   // mmap, munmap
   #undef min
 #else

--- a/c/lib/mman/mman.cc
+++ b/c/lib/mman/mman.cc
@@ -1,0 +1,206 @@
+//------------------------------------------------------------------------------
+// Copyright kutuzov.viktor.84@gmail.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#include "utils/macros.h"
+
+#if DT_OS_WINDOWS
+
+  #include <windows.h>
+  #include <errno.h>
+  #include <io.h>
+
+  #include "lib/mman/mman.h"
+
+  #ifndef FILE_MAP_EXECUTE
+  #define FILE_MAP_EXECUTE    0x0020
+  #endif /* FILE_MAP_EXECUTE */
+
+  static int __map_mman_error(const DWORD err, const int deferr)
+  {
+      if (err == 0)
+          return 0;
+      //TODO: implement
+      return err;
+  }
+
+  static DWORD __map_mmap_prot_page(const int prot)
+  {
+      DWORD protect = 0;
+
+      if (prot == PROT_NONE)
+          return protect;
+
+      if ((prot & PROT_EXEC) != 0)
+      {
+          protect = ((prot & PROT_WRITE) != 0) ?
+                      PAGE_EXECUTE_READWRITE : PAGE_EXECUTE_READ;
+      }
+      else
+      {
+          protect = ((prot & PROT_WRITE) != 0) ?
+                      PAGE_READWRITE : PAGE_READONLY;
+      }
+
+      return protect;
+  }
+
+  static DWORD __map_mmap_prot_file(const int prot)
+  {
+      DWORD desiredAccess = 0;
+
+      if (prot == PROT_NONE)
+          return desiredAccess;
+
+      if ((prot & PROT_READ) != 0)
+          desiredAccess |= FILE_MAP_READ;
+      if ((prot & PROT_WRITE) != 0)
+          desiredAccess |= FILE_MAP_WRITE;
+      if ((prot & PROT_EXEC) != 0)
+          desiredAccess |= FILE_MAP_EXECUTE;
+
+      return desiredAccess;
+  }
+
+  void* mmap(void *addr, size_t len, int prot, int flags, int fildes, off_t off)
+  {
+      HANDLE fm, h;
+
+      void * map = MAP_FAILED;
+
+  #ifdef _MSC_VER
+  #pragma warning(push)
+  #pragma warning(disable: 4293)
+  #endif
+
+      const DWORD dwFileOffsetLow = (sizeof(off_t) <= sizeof(DWORD)) ?
+                      (DWORD)off : (DWORD)(off & 0xFFFFFFFFL);
+      const DWORD dwFileOffsetHigh = (sizeof(off_t) <= sizeof(DWORD)) ?
+                      (DWORD)0 : (DWORD)((off >> 32) & 0xFFFFFFFFL);
+      const DWORD protect = __map_mmap_prot_page(prot);
+      const DWORD desiredAccess = __map_mmap_prot_file(prot);
+
+      const off_t maxSize = off + (off_t)len;
+
+      const DWORD dwMaxSizeLow = (sizeof(off_t) <= sizeof(DWORD)) ?
+                      (DWORD)maxSize : (DWORD)(maxSize & 0xFFFFFFFFL);
+      const DWORD dwMaxSizeHigh = (sizeof(off_t) <= sizeof(DWORD)) ?
+                      (DWORD)0 : (DWORD)((maxSize >> 32) & 0xFFFFFFFFL);
+
+  #ifdef _MSC_VER
+  #pragma warning(pop)
+  #endif
+
+      errno = 0;
+
+      if (len == 0
+          /* Unsupported flag combinations */
+          || (flags & MAP_FIXED) != 0
+          /* Usupported protection combinations */
+          || prot == PROT_EXEC)
+      {
+          errno = EINVAL;
+          return MAP_FAILED;
+      }
+
+      h = ((flags & MAP_ANONYMOUS) == 0) ?
+                      (HANDLE)_get_osfhandle(fildes) : INVALID_HANDLE_VALUE;
+
+      if ((flags & MAP_ANONYMOUS) == 0 && h == INVALID_HANDLE_VALUE)
+      {
+          errno = EBADF;
+          return MAP_FAILED;
+      }
+
+      fm = CreateFileMapping(h, NULL, protect, dwMaxSizeHigh, dwMaxSizeLow, NULL);
+
+      if (fm == NULL)
+      {
+          errno = __map_mman_error(GetLastError(), EPERM);
+          return MAP_FAILED;
+      }
+
+      map = MapViewOfFile(fm, desiredAccess, dwFileOffsetHigh, dwFileOffsetLow, len);
+
+      CloseHandle(fm);
+
+      if (map == NULL)
+      {
+          errno = __map_mman_error(GetLastError(), EPERM);
+          return MAP_FAILED;
+      }
+
+      return map;
+  }
+
+  int munmap(void *addr, size_t len)
+  {
+      if (UnmapViewOfFile(addr))
+          return 0;
+
+      errno =  __map_mman_error(GetLastError(), EPERM);
+
+      return -1;
+  }
+
+  int mprotect(void *addr, size_t len, int prot)
+  {
+      DWORD newProtect = __map_mmap_prot_page(prot);
+      DWORD oldProtect = 0;
+
+      if (VirtualProtect(addr, len, newProtect, &oldProtect))
+          return 0;
+
+      errno =  __map_mman_error(GetLastError(), EPERM);
+
+      return -1;
+  }
+
+  int msync(void *addr, size_t len, int flags)
+  {
+      if (FlushViewOfFile(addr, len))
+          return 0;
+
+      errno =  __map_mman_error(GetLastError(), EPERM);
+
+      return -1;
+  }
+
+  int mlock(const void *addr, size_t len)
+  {
+      if (VirtualLock((LPVOID)addr, len))
+          return 0;
+
+      errno =  __map_mman_error(GetLastError(), EPERM);
+
+      return -1;
+  }
+
+  int munlock(const void *addr, size_t len)
+  {
+      if (VirtualUnlock((LPVOID)addr, len))
+          return 0;
+
+      errno =  __map_mman_error(GetLastError(), EPERM);
+
+      return -1;
+  }
+
+#endif

--- a/c/lib/mman/mman.cc
+++ b/c/lib/mman/mman.cc
@@ -19,15 +19,13 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
-#include "utils/macros.h"
+#include "lib/mman/mman.h"
 
 #if DT_OS_WINDOWS
 
   #include <windows.h>
   #include <errno.h>
   #include <io.h>
-
-  #include "lib/mman/mman.h"
 
   #ifndef FILE_MAP_EXECUTE
   #define FILE_MAP_EXECUTE    0x0020

--- a/c/lib/mman/mman.cc
+++ b/c/lib/mman/mman.cc
@@ -206,10 +206,3 @@
   }
 
 #endif
-
-
-namespace mman {
-
-  void foo() {}
-
-}

--- a/c/lib/mman/mman.cc
+++ b/c/lib/mman/mman.cc
@@ -206,3 +206,10 @@
   }
 
 #endif
+
+
+namespace mman {
+
+  void foo() {}
+
+}

--- a/c/lib/mman/mman.cc
+++ b/c/lib/mman/mman.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright kutuzov.viktor.84@gmail.com
+// Copyright 2010-2012, Viktor Kutuzov - kutuzov.viktor.84@gmail.com
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -18,6 +18,12 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+//
+// The code in this file is a slightly modified version of mman-win32, see
+// https://code.google.com/archive/p/mman-win32/
+//
 //------------------------------------------------------------------------------
 #include "lib/mman/mman.h"
 

--- a/c/lib/mman/mman.cc
+++ b/c/lib/mman/mman.cc
@@ -1,12 +1,16 @@
 //------------------------------------------------------------------------------
-// Copyright 2010-2012, Viktor Kutuzov - kutuzov.viktor.84@gmail.com
+// The code in this file is a slightly modified version of mman Windows library:
+//   https://code.google.com/p/mman-win32/
+// (MIT licensed)
 //
-// Permission is hereby granted, free of charge, to any person obtaining a
-// copy of this software and associated documentation files (the "Software"),
-// to deal in the Software without restriction, including without limitation
-// the rights to use, copy, modify, merge, publish, distribute, sublicense,
-// and/or sell copies of the Software, and to permit persons to whom the
-// Software is furnished to do so, subject to the following conditions:
+// Copyright kutuzov.viktor.84@gmail.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
 //
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
@@ -15,15 +19,9 @@
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
-// IN THE SOFTWARE.
-//
-//------------------------------------------------------------------------------
-//
-// The code in this file is a slightly modified version of mman-win32, see
-// https://code.google.com/archive/p/mman-win32/
-//
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 //------------------------------------------------------------------------------
 #include "lib/mman/mman.h"
 

--- a/c/lib/mman/mman.h
+++ b/c/lib/mman/mman.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright kutuzov.viktor.84@gmail.com
+// Copyright 2010-2012, Viktor Kutuzov - kutuzov.viktor.84@gmail.com
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -18,6 +18,12 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+//
+// The code in this file is a slightly modified version of mman-win32, see
+// https://code.google.com/archive/p/mman-win32/
+//
 //------------------------------------------------------------------------------
 #include "utils/macros.h"
 
@@ -26,7 +32,7 @@
 	#ifndef _SYS_MMAN_H_
 	#define _SYS_MMAN_H_
 
-	#ifndef _WIN32_WINNT		// Allow use of features specific to Windows XP or later.
+	#ifndef _WIN32_WINNT		    // Allow use of features specific to Windows XP or later.
 	#define _WIN32_WINNT 0x0501	// Change this to the appropriate value to target other versions of Windows.
 	#endif
 

--- a/c/lib/mman/mman.h
+++ b/c/lib/mman/mman.h
@@ -29,10 +29,12 @@
 // version of the original:
 // - added an operating system check, so that this code only builds on Windows;
 // - added MAP_NORESERVE;
+// - a fix to make it compatible with `make coverage`;
 // - minor changes to code format.
 //
 //------------------------------------------------------------------------------
 #include "utils/macros.h"
+
 
 #if DT_OS_WINDOWS
 
@@ -89,3 +91,12 @@
 	#endif /*  _SYS_MMAN_H_ */
 
 #endif
+
+
+// FIXME: this is a temporary fix, so that `make coverage` do not fail.
+// See a reason for this in `read/constants.h`
+namespace mman {
+
+	void foo();
+
+}

--- a/c/lib/mman/mman.h
+++ b/c/lib/mman/mman.h
@@ -29,7 +29,6 @@
 // version of the original:
 // - added an operating system check, so that this code only builds on Windows;
 // - added MAP_NORESERVE;
-// - a fix to make it compatible with `make coverage`;
 // - minor changes to code format.
 //
 //------------------------------------------------------------------------------
@@ -91,12 +90,3 @@
 	#endif /*  _SYS_MMAN_H_ */
 
 #endif
-
-
-// FIXME: this is a temporary fix, so that `make coverage` do not fail.
-// See a reason for this in `read/constants.h`
-namespace mman {
-
-	void foo();
-
-}

--- a/c/lib/mman/mman.h
+++ b/c/lib/mman/mman.h
@@ -52,6 +52,7 @@
 	#define MAP_TYPE        0xf
 	#define MAP_FIXED       0x10
 	#define MAP_ANONYMOUS   0x20
+	#define MAP_NORESERVE   0x00
 	#define MAP_ANON        MAP_ANONYMOUS
 
 	#define MAP_FAILED      ((void *)-1)

--- a/c/lib/mman/mman.h
+++ b/c/lib/mman/mman.h
@@ -1,12 +1,16 @@
 //------------------------------------------------------------------------------
-// Copyright 2010-2012, Viktor Kutuzov - kutuzov.viktor.84@gmail.com
+// The code in this file is a slightly modified version of mman Windows library:
+//   https://code.google.com/p/mman-win32/
+// (MIT licensed)
 //
-// Permission is hereby granted, free of charge, to any person obtaining a
-// copy of this software and associated documentation files (the "Software"),
-// to deal in the Software without restriction, including without limitation
-// the rights to use, copy, modify, merge, publish, distribute, sublicense,
-// and/or sell copies of the Software, and to permit persons to whom the
-// Software is furnished to do so, subject to the following conditions:
+// Copyright kutuzov.viktor.84@gmail.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
 //
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
@@ -15,14 +19,17 @@
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
-// IN THE SOFTWARE.
-//
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 //------------------------------------------------------------------------------
 //
-// The code in this file is a slightly modified version of mman-win32, see
-// https://code.google.com/archive/p/mman-win32/
+// This library implements a wrapper for mmap functions around
+// the memory mapping Windows API. The code below is a modified
+// version of the original:
+// - added an operating system check, so that this code only builds on Windows;
+// - added MAP_NORESERVE;
+// - minor changes to code format.
 //
 //------------------------------------------------------------------------------
 #include "utils/macros.h"

--- a/c/lib/mman/mman.h
+++ b/c/lib/mman/mman.h
@@ -1,0 +1,77 @@
+//------------------------------------------------------------------------------
+// Copyright kutuzov.viktor.84@gmail.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#include "utils/macros.h"
+
+#if DT_OS_WINDOWS
+
+	#ifndef _SYS_MMAN_H_
+	#define _SYS_MMAN_H_
+
+	#ifndef _WIN32_WINNT		// Allow use of features specific to Windows XP or later.
+	#define _WIN32_WINNT 0x0501	// Change this to the appropriate value to target other versions of Windows.
+	#endif
+
+	/* All the headers include this file. */
+	#ifndef _MSC_VER
+	#include <_mingw.h>
+	#endif
+
+	#include <sys/types.h>
+
+	#ifdef __cplusplus
+	extern "C" {
+	#endif
+
+	#define PROT_NONE       0
+	#define PROT_READ       1
+	#define PROT_WRITE      2
+	#define PROT_EXEC       4
+
+	#define MAP_FILE        0
+	#define MAP_SHARED      1
+	#define MAP_PRIVATE     2
+	#define MAP_TYPE        0xf
+	#define MAP_FIXED       0x10
+	#define MAP_ANONYMOUS   0x20
+	#define MAP_ANON        MAP_ANONYMOUS
+
+	#define MAP_FAILED      ((void *)-1)
+
+	/* Flags for msync. */
+	#define MS_ASYNC        1
+	#define MS_SYNC         2
+	#define MS_INVALIDATE   4
+
+	void*   mmap(void *addr, size_t len, int prot, int flags, int fildes, off_t off);
+	int     munmap(void *addr, size_t len);
+	int     mprotect(void *addr, size_t len, int prot);
+	int     msync(void *addr, size_t len, int flags);
+	int     mlock(const void *addr, size_t len);
+	int     munlock(const void *addr, size_t len);
+
+	#ifdef __cplusplus
+	};
+	#endif
+
+	#endif /*  _SYS_MMAN_H_ */
+
+#endif

--- a/c/read/constants.cc
+++ b/c/read/constants.cc
@@ -147,8 +147,4 @@ const long double pow10lookup[701] = {
 };
 
 
-
-void foo() {}
-
-
 }}  // namespace dt::read::

--- a/c/read/constants.h
+++ b/c/read/constants.h
@@ -16,7 +16,15 @@ extern const uint8_t allowedseps[128];
 extern const long double pow10lookup[701];
 
 
-// Don't know why, but without this `make coverage` fails.
+// FIXME: this is a temporary fix, so that `make coverage` do not fail.
+// The problem is that if there are no function definitions in the `.cc` file,
+// then `ci/llvm-gcov.sh` is invoked from the wrong directory.
+// This is because we are using `lcov` that in its turn invokes `geninfo`,
+// and when `geninfo` is trying to detect the base directory in the
+// `find_base_from_graph()` routine — it fails.
+// The reason seems to be that if a particular `.cc` file contains
+// no function definitions, it is excluded from the file graph
+// where this routine does the search.
 void foo();
 
 }} // namespace dt::read::

--- a/c/read/constants.h
+++ b/c/read/constants.h
@@ -15,17 +15,5 @@ extern const uint8_t hexdigits[256];
 extern const uint8_t allowedseps[128];
 extern const long double pow10lookup[701];
 
-
-// FIXME: this is a temporary fix, so that `make coverage` do not fail.
-// The problem is that if there are no function definitions in the `.cc` file,
-// then `ci/llvm-gcov.sh` is invoked from the wrong directory.
-// This is because we are using `lcov` that in its turn invokes `geninfo`,
-// and when `geninfo` is trying to detect the base directory in the
-// `find_base_from_graph()` routine — it fails.
-// The reason seems to be that if a particular `.cc` file contains
-// no function definitions, it is excluded from the file graph
-// where this routine does the search.
-void foo();
-
 }} // namespace dt::read::
 #endif

--- a/c/writebuf.cc
+++ b/c/writebuf.cc
@@ -19,11 +19,13 @@
 
 #if DT_OS_WINDOWS
   #include <io.h>            // _write
+  #include "lib/mman/mman.h" // mmap, munmap
 
   // The POSIX `write()` function is deprecated on Windows,
   // so we use the ISO C++ conformant `_write()` instead.
   #define WRITE _write
 #else
+  #include <sys/mman.h>      // mmap
   #include <unistd.h>        // write
   #define WRITE write
 #endif

--- a/c/writebuf.cc
+++ b/c/writebuf.cc
@@ -8,7 +8,6 @@
 #include <algorithm>       // std::min
 #include <cstring>         // std::memcpy
 #include <errno.h>         // errno
-#include <sys/mman.h>      // mmap
 #include "utils/alloc.h"   // dt::realloc
 #include "utils/assert.h"
 #include "utils/macros.h"


### PR DESCRIPTION
- add Windows implementation of `mmap` functions. The code can be compiled and linked on Windows, though it is not functional yet;
- fix a problem when `make coverage` failed on files that had no function definitions.

WIP for #1369 