### PR TITLE
Frame from list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,16 +92,16 @@ test:
 		tests
 
 xasan:
-	$(PYTHON) ext.py asan
+	@$(PYTHON) ext.py asan
 
 xbuild:
-	$(PYTHON) ext.py build
+	@$(PYTHON) ext.py build
 
 xcoverage:
-	$(PYTHON) ext.py coverage
+	@$(PYTHON) ext.py coverage
 
 xdebug:
-	$(PYTHON) ext.py debug
+	@$(PYTHON) ext.py debug
 
 
 benchmark:

--- a/c/column/pysources.cc
+++ b/c/column/pysources.cc
@@ -1,0 +1,102 @@
+//------------------------------------------------------------------------------
+// Copyright 2019 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#include "column/pysources.h"
+#include "python/dict.h"
+#include "python/tuple.h"
+#include "utils/assert.h"
+namespace dt {
+
+
+
+//------------------------------------------------------------------------------
+// PyList_ColumnImpl
+//------------------------------------------------------------------------------
+
+PyList_ColumnImpl::PyList_ColumnImpl(const py::olist& list)
+  : Virtual_ColumnImpl(list.size(), SType::OBJ),
+    list_(list) {}
+
+
+ColumnImpl* PyList_ColumnImpl::clone() const {
+  return new PyList_ColumnImpl(list_);
+}
+
+
+bool PyList_ColumnImpl::get_element(size_t i, py::robj* out) const {
+  xassert(i < nrows_);
+  *out = list_[i];
+  return true;
+}
+
+
+
+
+//------------------------------------------------------------------------------
+// PyTupleList_ColumnImpl
+//------------------------------------------------------------------------------
+
+PyTupleList_ColumnImpl::PyTupleList_ColumnImpl(const py::olist& list, size_t j)
+  : Virtual_ColumnImpl(list.size(), SType::OBJ),
+    tuple_list_(list),
+    index_(j) {}
+
+
+ColumnImpl* PyTupleList_ColumnImpl::clone() const {
+  return new PyTupleList_ColumnImpl(tuple_list_, index_);
+}
+
+
+bool PyTupleList_ColumnImpl::get_element(size_t i, py::robj* out) const {
+  xassert(i < nrows_);
+  *out = py::rtuple::unchecked(tuple_list_[i])[index_];
+  return true;
+}
+
+
+
+
+//------------------------------------------------------------------------------
+// PyDictList_ColumnImpl
+//------------------------------------------------------------------------------
+
+PyDictList_ColumnImpl::PyDictList_ColumnImpl(const py::olist& list, py::oobj k)
+  : Virtual_ColumnImpl(list.size(), SType::OBJ),
+    dict_list_(list),
+    key_(k) {}
+
+
+ColumnImpl* PyDictList_ColumnImpl::clone() const {
+  return new PyDictList_ColumnImpl(dict_list_, key_);
+}
+
+
+bool PyDictList_ColumnImpl::get_element(size_t i, py::robj* out) const {
+  xassert(i < nrows_);
+  *out = py::rdict::unchecked(dict_list_[i]).get_or_none(key_);
+  return true;
+}
+
+
+
+
+
+}  // namespace dt

--- a/c/column/pysources.h
+++ b/c/column/pysources.h
@@ -1,0 +1,85 @@
+//------------------------------------------------------------------------------
+// Copyright 2019 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#ifndef dt_COLUMN_PYSOURCES_h
+#define dt_COLUMN_PYSOURCES_h
+#include "column/virtual.h"
+#include "python/list.h"
+namespace dt {
+
+
+
+/**
+  * Virtual column that wraps a simple python list.
+  */
+class PyList_ColumnImpl : public Virtual_ColumnImpl {
+  private:
+    py::olist list_;
+
+  public:
+    explicit PyList_ColumnImpl(const py::olist&);
+
+    ColumnImpl* clone() const override;
+    bool get_element(size_t, py::robj*) const override;
+};
+
+
+
+/**
+  * Virtual column whose source is a list of python tuples, and it
+  * outputs elements of those tuples at some specific index.
+  */
+class PyTupleList_ColumnImpl : public Virtual_ColumnImpl {
+  private:
+    py::olist tuple_list_;
+    size_t index_;
+
+  public:
+    explicit PyTupleList_ColumnImpl(const py::olist&, size_t index);
+
+    ColumnImpl* clone() const override;
+    bool get_element(size_t, py::robj*) const override;
+};
+
+
+
+/**
+  * Virtual column whose source is a list of python dictionaries, and
+  * the column outputs elements of those dictionaries corresponding
+  * to some fixed key.
+  */
+class PyDictList_ColumnImpl : public Virtual_ColumnImpl {
+  private:
+    py::olist dict_list_;
+    py::oobj key_;
+
+  public:
+    explicit PyDictList_ColumnImpl(const py::olist&, py::oobj key);
+
+    ColumnImpl* clone() const override;
+    bool get_element(size_t, py::robj*) const override;
+};
+
+
+
+
+}  // namespace dt
+#endif

--- a/c/column_from_pylist.cc
+++ b/c/column_from_pylist.cc
@@ -67,8 +67,8 @@ static size_t parse_as_bool(const Column& inputcol, Buffer& mbuf, size_t i0)
 {
   return parse_as_X<int8_t>(inputcol, mbuf, i0,
             [](py::robj item, int8_t* out) {
-              return item.parse_none(out) ||
-                     item.parse_bool(out);
+              return item.parse_bool(out) ||
+                     item.parse_none(out);
             });
 }
 
@@ -80,8 +80,8 @@ static size_t parse_as_int01(const Column& inputcol, Buffer& mbuf, size_t i0)
 {
   return parse_as_X<int8_t>(inputcol, mbuf, i0,
             [](py::robj item, int8_t* out) {
-              return item.parse_none(out) ||
-                     item.parse_bool(out) ||
+              return item.parse_bool(out) ||
+                     item.parse_none(out) ||
                      item.parse_01(out);
             });
 }
@@ -133,16 +133,10 @@ static size_t parse_as_int(const Column& inputcol, Buffer& mbuf, size_t i0)
 {
   return parse_as_X<T>(inputcol, mbuf, i0,
             [](py::robj item, T* out) {
-              bool ok = item.parse_none(out) ||
-                        (sizeof(T) >= 4 && item.parse_int_no_overflow(out)) ||
-                        item.parse_bool(out);
-              if (ok) return true;
-              int r = item.is_numpy_int();
-              if (r && r <= int(sizeof(T))) {
-                *out = static_cast<T>(item.to_int64());
-                return true;
-              }
-              return false;
+              return (sizeof(T) >= 4 && item.parse_int_no_overflow(out)) ||
+                     item.parse_none(out) ||
+                     item.parse_numpy_int(out) ||
+                     item.parse_bool(out);
             });
 }
 

--- a/c/column_from_python.cc
+++ b/c/column_from_python.cc
@@ -47,7 +47,6 @@
   *   be converted. If all entries convert successfully, this will be
   *   equal to `inputcol.nrows()`.
   */
-
 template <typename T>
 static size_t parse_as_X(const Column& inputcol, Buffer& mbuf, size_t i0,
                          bool(*f)(py::robj, T*))
@@ -85,20 +84,6 @@ static size_t parse_as_bool(const Column& inputcol, Buffer& mbuf, size_t i0)
                      item.parse_none(out);
             });
 }
-
-
-// Parse list of "weak" booleans, i.e. `True`, `False`, `1`, `0`
-// and `None`. These will be converted to SType::INT8 column.
-//
-// static size_t parse_as_int01(const Column& inputcol, Buffer& mbuf, size_t i0)
-// {
-//   return parse_as_X<int8_t>(inputcol, mbuf, i0,
-//             [](py::robj item, int8_t* out) {
-//               return item.parse_bool(out) ||
-//                      item.parse_none(out) ||
-//                      item.parse_01(out);
-//             });
-// }
 
 
 /**
@@ -162,6 +147,17 @@ static size_t parse_as_int8(const Column& inputcol, Buffer& mbuf, size_t i0)
               return item.parse_01(out) ||
                      item.parse_none(out) ||
                      item.parse_numpy_int(out) ||
+                     item.parse_bool(out);
+            });
+}
+
+static size_t parse_as_int16(const Column& inputcol, Buffer& mbuf, size_t i0)
+{
+  return parse_as_X<int16_t>(inputcol, mbuf, i0,
+            [](py::robj item, int16_t* out) {
+              return item.parse_numpy_int(out) ||
+                     item.parse_none(out) ||
+                     item.parse_01(out) ||
                      item.parse_bool(out);
             });
 }
@@ -470,7 +466,7 @@ static Column resolve_column(const Column& inputcol, int stype0)
       switch (stype) {
         case SType::BOOL:    i = parse_as_bool(inputcol, membuf, i); break;
         case SType::INT8:    i = parse_as_int8(inputcol, membuf, i); break;
-        case SType::INT16:   i = parse_as_int<int16_t>(inputcol, membuf, i); break;
+        case SType::INT16:   i = parse_as_int16(inputcol, membuf, i); break;
         case SType::INT32:   i = parse_as_int<int32_t>(inputcol, membuf, i); break;
         case SType::INT64:   i = parse_as_int<int64_t>(inputcol, membuf, i); break;
         case SType::FLOAT32: i = parse_as_float32(inputcol, membuf, i); break;

--- a/c/models/dt_ftrl.cc
+++ b/c/models/dt_ftrl.cc
@@ -773,7 +773,8 @@ dtptr Ftrl<T>::dispatch_predict(const DataTable* dt_X) {
   SType label_id_stype = dt_labels->get_column(1).stype();
   dtptr dt_p;
   switch (label_id_stype) {
-    case SType::BOOL:  dt_p = predict<int8_t>(dt_X); break;
+    case SType::BOOL:
+    case SType::INT8:  dt_p = predict<int8_t>(dt_X); break;
     case SType::INT32: dt_p = predict<int32_t>(dt_X); break;
     default: throw TypeError() << "Label id type  `"
                                << label_id_stype << "` is not supported";

--- a/c/models/dt_ftrl.cc
+++ b/c/models/dt_ftrl.cc
@@ -300,7 +300,7 @@ FtrlFitOutput Ftrl<T>::fit_regression() {
   if (!is_model_trained()) {
     const strvec& colnames = dt_y_train->get_names();
     std::unordered_map<std::string, int8_t> colnames_map = {{colnames[0], 0}};
-    dt_labels = create_dt_labels_str<uint32_t, SType::BOOL>(colnames_map);
+    dt_labels = create_dt_labels_str<uint32_t, SType::INT8>(colnames_map);
 
     create_model();
     model_type = FtrlModelType::REGRESSION;
@@ -773,7 +773,6 @@ dtptr Ftrl<T>::dispatch_predict(const DataTable* dt_X) {
   SType label_id_stype = dt_labels->get_column(1).stype();
   dtptr dt_p;
   switch (label_id_stype) {
-    case SType::BOOL:
     case SType::INT8:  dt_p = predict<int8_t>(dt_X); break;
     case SType::INT32: dt_p = predict<int32_t>(dt_X); break;
     default: throw TypeError() << "Label id type  `"

--- a/c/models/label_encode.cc
+++ b/c/models/label_encode.cc
@@ -34,35 +34,35 @@ void label_encode(const Column& col, dtptr& dt_labels, dtptr& dt_encoded,
   if (is_binomial) {
     switch (stype) {
       case SType::BOOL:    label_encode_bool(col, dt_labels, dt_encoded); break;
-      case SType::INT8:    label_encode_fw<SType::INT8, SType::BOOL>(
+      case SType::INT8:    label_encode_fw<SType::INT8, SType::INT8>(
                              col, dt_labels, dt_encoded
                            );
                            break;
-      case SType::INT16:   label_encode_fw<SType::INT16, SType::BOOL>(
+      case SType::INT16:   label_encode_fw<SType::INT16, SType::INT8>(
                              col, dt_labels, dt_encoded
                            );
                            break;
-      case SType::INT32:   label_encode_fw<SType::INT32, SType::BOOL>(
+      case SType::INT32:   label_encode_fw<SType::INT32, SType::INT8>(
                              col, dt_labels, dt_encoded
                             );
                            break;
-      case SType::INT64:   label_encode_fw<SType::INT64, SType::BOOL>(
+      case SType::INT64:   label_encode_fw<SType::INT64, SType::INT8>(
                              col, dt_labels, dt_encoded
                            );
                            break;
-      case SType::FLOAT32: label_encode_fw<SType::FLOAT32, SType::BOOL>(
+      case SType::FLOAT32: label_encode_fw<SType::FLOAT32, SType::INT8>(
                              col, dt_labels, dt_encoded
                            );
                            break;
-      case SType::FLOAT64: label_encode_fw<SType::FLOAT64, SType::BOOL>(
+      case SType::FLOAT64: label_encode_fw<SType::FLOAT64, SType::INT8>(
                              col, dt_labels, dt_encoded
                            );
                            break;
-      case SType::STR32:   label_encode_str<uint32_t, SType::BOOL>(
+      case SType::STR32:   label_encode_str<uint32_t, SType::INT8>(
                              col, dt_labels, dt_encoded
                            );
                            break;
-      case SType::STR64:   label_encode_str<uint64_t, SType::BOOL>(
+      case SType::STR64:   label_encode_str<uint64_t, SType::INT8>(
                              col, dt_labels, dt_encoded
                            );
                            break;
@@ -132,7 +132,7 @@ static void label_encode_bool(const Column& col,
   if (col.na_count() == col.nrows()) return;
 
   // Set up boolean labels and their corresponding ids.
-  Column ids_col = Column::new_data_column(2, SType::BOOL);
+  Column ids_col = Column::new_data_column(2, SType::INT8);
   Column labels_col = Column::new_data_column(2, SType::BOOL);
   auto ids_data = static_cast<int8_t*>(ids_col.get_data_editable());
   auto labels_data = static_cast<int8_t*>(labels_col.get_data_editable());

--- a/c/python/dict.cc
+++ b/c/python/dict.cc
@@ -41,6 +41,9 @@ odict::odict(oobj&& src) : oobj(std::move(src)) {}
 odict::odict(const robj& src) : oobj(src) {}
 rdict::rdict(const robj& src) : robj(src) {}
 
+rdict rdict::unchecked(const robj& src) {
+  return rdict(src);
+}
 
 odict odict::copy() const {
   return odict(oobj::from_new_reference(PyDict_Copy(v)));

--- a/c/python/dict.h
+++ b/c/python/dict.h
@@ -109,6 +109,8 @@ class rdict : public robj {
   public:
     using robj::robj;
 
+    static rdict unchecked(const robj&);
+
     size_t size() const;
     bool empty() const;
     bool has(_obj key) const;

--- a/c/python/obj.cc
+++ b/c/python/obj.cc
@@ -368,6 +368,28 @@ bool _obj::parse_int_no_overflow(int32_t* out) const { return _parse_int(v, out)
 bool _obj::parse_int_no_overflow(int64_t* out) const { return _parse_int(v, out); }
 
 
+template <typename T>
+static bool _parse_npint(PyObject* v, T* out) {
+  if (!numpy_int64) init_numpy();
+  if (numpy_int64 && v) {
+    if ((sizeof(T) >= 8 && PyObject_IsInstance(v, numpy_int64)) ||
+        (sizeof(T) >= 4 && PyObject_IsInstance(v, numpy_int32)) ||
+        (sizeof(T) >= 2 && PyObject_IsInstance(v, numpy_int16)) ||
+        (sizeof(T) >= 1 && PyObject_IsInstance(v, numpy_int8)))
+    {
+      *out = static_cast<T>(PyNumber_AsSsize_t(v, nullptr));
+      return true;
+    }
+  }
+  return false;
+}
+
+bool _obj::parse_numpy_int(int8_t* out)  const { return _parse_npint(v, out); }
+bool _obj::parse_numpy_int(int16_t* out) const { return _parse_npint(v, out); }
+bool _obj::parse_numpy_int(int32_t* out) const { return _parse_npint(v, out); }
+bool _obj::parse_numpy_int(int64_t* out) const { return _parse_npint(v, out); }
+
+
 
 
 //------------------------------------------------------------------------------

--- a/c/python/obj.cc
+++ b/c/python/obj.cc
@@ -318,18 +318,23 @@ bool _obj::parse_bool(double* out)  const { return _parse_bool(v, out); }
 
 
 
-bool _obj::parse_01(int8_t* out) const {
+template <typename T>
+static inline bool _parse_01(PyObject* v, T* out) {
   if (PyLong_CheckExact(v)) {
     int overflow;
     long x = PyLong_AsLongAndOverflow(v, &overflow);
     if (x == 0 || x == 1) {
-      *out = static_cast<int8_t>(x);
+      *out = static_cast<T>(x);
       return true;
     }
     // Fall-through for all other values of `x`, including overflow (x == -1)
   }
   return false;
 }
+
+bool _obj::parse_01(int8_t* out)  const { return _parse_01(v, out); }
+bool _obj::parse_01(int16_t* out) const { return _parse_01(v, out); }
+
 
 
 

--- a/c/python/obj.cc
+++ b/c/python/obj.cc
@@ -285,6 +285,92 @@ bool _obj::is_dtexpr() const noexcept {
 
 
 //------------------------------------------------------------------------------
+// Value parsers
+//------------------------------------------------------------------------------
+
+template <typename T>
+static inline bool _parse_none(PyObject* v, T* out) {
+  if (v == Py_None) { *out = GETNA<T>(); return true; }
+  return false;
+}
+
+bool _obj::parse_none(int8_t* out) const  { return _parse_none(v, out); }
+bool _obj::parse_none(int16_t* out) const { return _parse_none(v, out); }
+bool _obj::parse_none(int32_t* out) const { return _parse_none(v, out); }
+bool _obj::parse_none(int64_t* out) const { return _parse_none(v, out); }
+
+
+
+template <typename T>
+static inline bool _parse_bool(PyObject* v, T* out) {
+  if (v == Py_True)  { *out = 1; return true; }
+  if (v == Py_False) { *out = 0; return true; }
+  return false;
+}
+
+bool _obj::parse_bool(int8_t* out) const  { return _parse_bool(v, out); }
+bool _obj::parse_bool(int16_t* out) const { return _parse_bool(v, out); }
+bool _obj::parse_bool(int32_t* out) const { return _parse_bool(v, out); }
+bool _obj::parse_bool(int64_t* out) const { return _parse_bool(v, out); }
+
+
+
+bool _obj::parse_01(int8_t* out) const {
+  if (PyLong_CheckExact(v)) {
+    int overflow;
+    long x = PyLong_AsLongAndOverflow(v, &overflow);
+    if (x == 0 || x == 1) {
+      *out = static_cast<int8_t>(x);
+      return true;
+    }
+    // Fall-through for all other values of `x`, including overflow (x == -1)
+  }
+  return false;
+}
+
+
+
+template <typename T>
+bool _parse_int(PyObject* v, T* out) {
+  static_assert(sizeof(T) <= sizeof(long), "Wrong size of T");
+  if (PyLong_Check(v)) {
+    int overflow;
+    long value = PyLong_AsLongAndOverflow(v, &overflow);
+    auto res = static_cast<T>(value);
+    if (!overflow && value == res) {
+      *out = res;
+      return true;
+    }
+  }
+  return false;
+}
+
+#if LONG_MAX != 9223372036854775807
+  template <>
+  bool _parse_int(PyObject* v, int64_t* out) {
+    static_assert(sizeof(int64_t) <= sizeof(long long), "Wrong size of long long");
+    if (PyLong_Check(v)) {
+      int overflow;
+      long long value = PyLong_AsLongLongAndOverflow(v, &overflow);
+      auto res = static_cast<int64_t>(value);
+      if (!overflow && value == res) {
+        *out = res;
+        return true;
+      }
+    }
+    return false;
+  }
+#endif
+
+bool _obj::parse_int_no_overflow(int8_t* out) const  { return _parse_int(v, out); }
+bool _obj::parse_int_no_overflow(int16_t* out) const { return _parse_int(v, out); }
+bool _obj::parse_int_no_overflow(int32_t* out) const { return _parse_int(v, out); }
+bool _obj::parse_int_no_overflow(int64_t* out) const { return _parse_int(v, out); }
+
+
+
+
+//------------------------------------------------------------------------------
 // Bool conversions
 //------------------------------------------------------------------------------
 
@@ -309,12 +395,12 @@ int8_t _obj::to_bool_strict(const error_manager& em) const {
 
 int8_t _obj::to_bool_force(const error_manager&) const noexcept {
   if (v == Py_None) return GETNA<int8_t>();
+  if (v == Py_True) return 1;
+  if (v == Py_False) return 0;
   int r = PyObject_IsTrue(v);
-  if (r == -1) {
-    PyErr_Clear();
-    return GETNA<int8_t>();
-  }
-  return static_cast<int8_t>(r);
+  if (r >= 0) return static_cast<int8_t>(r);
+  PyErr_Clear();
+  return GETNA<int8_t>();
 }
 
 

--- a/c/python/obj.h
+++ b/c/python/obj.h
@@ -203,19 +203,26 @@ class _obj {
     bool parse_none(int16_t*) const;
     bool parse_none(int32_t*) const;
     bool parse_none(int64_t*) const;
+    bool parse_none(float*) const;
+    bool parse_none(double*) const;
     bool parse_bool(int8_t*) const;
     bool parse_bool(int16_t*) const;
     bool parse_bool(int32_t*) const;
     bool parse_bool(int64_t*) const;
+    bool parse_bool(double*) const;
     bool parse_01(int8_t*) const;
-    bool parse_int_no_overflow(int8_t*) const;
-    bool parse_int_no_overflow(int16_t*) const;
-    bool parse_int_no_overflow(int32_t*) const;
-    bool parse_int_no_overflow(int64_t*) const;
+    bool parse_int(int8_t*) const;
+    bool parse_int(int16_t*) const;
+    bool parse_int(int32_t*) const;
+    bool parse_int(int64_t*) const;
+    bool parse_int(double*) const;
     bool parse_numpy_int(int8_t*) const;
     bool parse_numpy_int(int16_t*) const;
     bool parse_numpy_int(int32_t*) const;
     bool parse_numpy_int(int64_t*) const;
+    bool parse_numpy_float(float*) const;
+    bool parse_numpy_float(double*) const;
+    bool parse_double(double*) const;
 
     struct error_manager;  // see below
     int8_t      to_bool           (const error_manager& = _em0) const;

--- a/c/python/obj.h
+++ b/c/python/obj.h
@@ -212,6 +212,10 @@ class _obj {
     bool parse_int_no_overflow(int16_t*) const;
     bool parse_int_no_overflow(int32_t*) const;
     bool parse_int_no_overflow(int64_t*) const;
+    bool parse_numpy_int(int8_t*) const;
+    bool parse_numpy_int(int16_t*) const;
+    bool parse_numpy_int(int32_t*) const;
+    bool parse_numpy_int(int64_t*) const;
 
     struct error_manager;  // see below
     int8_t      to_bool           (const error_manager& = _em0) const;

--- a/c/python/obj.h
+++ b/c/python/obj.h
@@ -211,6 +211,7 @@ class _obj {
     bool parse_bool(int64_t*) const;
     bool parse_bool(double*) const;
     bool parse_01(int8_t*) const;
+    bool parse_01(int16_t*) const;
     bool parse_int(int8_t*) const;
     bool parse_int(int16_t*) const;
     bool parse_int(int32_t*) const;

--- a/c/python/obj.h
+++ b/c/python/obj.h
@@ -199,6 +199,20 @@ class _obj {
     bool is_undefined()     const noexcept;
     bool is_update_node()   const noexcept;
 
+    bool parse_none(int8_t*) const;
+    bool parse_none(int16_t*) const;
+    bool parse_none(int32_t*) const;
+    bool parse_none(int64_t*) const;
+    bool parse_bool(int8_t*) const;
+    bool parse_bool(int16_t*) const;
+    bool parse_bool(int32_t*) const;
+    bool parse_bool(int64_t*) const;
+    bool parse_01(int8_t*) const;
+    bool parse_int_no_overflow(int8_t*) const;
+    bool parse_int_no_overflow(int16_t*) const;
+    bool parse_int_no_overflow(int32_t*) const;
+    bool parse_int_no_overflow(int64_t*) const;
+
     struct error_manager;  // see below
     int8_t      to_bool           (const error_manager& = _em0) const;
     int8_t      to_bool_strict    (const error_manager& = _em0) const;

--- a/docs/changelog/v-0-11-0.rst
+++ b/docs/changelog/v-0-11-0.rst
@@ -8,10 +8,24 @@ Version 0.11.0
 Frame
 -----
 
+- |api| A Python list of integers containing only 0s and 1s will now
+  produce an ``int8`` column instead of ``bool8``. In order to create a
+  boolean column supply a list of Trues and Falses, or force the
+  boolean stype with the constructor parameter ``stype=bool``::
+
+      assert dt.Frame([False, True]) == dt.bool8
+      assert dt.Frame([0, 1]).stype == dt.int8
+      assert dt.Frame([0, 1], stype=bool).stype == dt.bool8
+      assert dt.Frame([0, 1, 2]).stype == dt.int32
+
 - |fix| A list of frames now displays properly in a Jupyter lab (#2222).
 
 - |fix| Mixing reduce and map operations should no longer produce error
   "Unable to create a nested thread team" (#2242).
+
+- |fix| Fix rare deadlock when creating a Frame from a python list. The
+  deadlock occurred only on ppc64le and datatable compiled with gcc version
+  4.8 or earlier (#2250).
 
 
 
@@ -32,3 +46,6 @@ FTRL model
 - |fix| Fix feature importance normalization to [0, 1] in FTRL (#2224).
 
 - |fix| Resetting an untrained FTRL model now doesn't result in a segfault (#2226).
+
+- |enh| The ``id`` column in FTRL model ``.labels`` frame now has stype ``int8``
+  instead of ``bool`` for binomial models.

--- a/tests/models/test_aggregate.py
+++ b/tests/models/test_aggregate.py
@@ -94,7 +94,7 @@ def test_aggregate_1d_continuous_integer_tiny():
 
 def test_aggregate_1d_continuous_integer_equal():
     n_bins = 2
-    d_in = dt.Frame([0, 0, None, 0, None, 0, 0, 0, 0, 0])
+    d_in = dt.Frame([0, 0, None, 0, None, 0, 0, 0, 0, 0], stype=bool)
     d_in_copy = dt.Frame(d_in)
     [d_exemplars, d_members] = aggregate(d_in, min_rows=0, n_bins=n_bins)
     frame_integrity_check(d_members)

--- a/tests/models/test_ftrl.py
+++ b/tests/models/test_ftrl.py
@@ -776,12 +776,14 @@ def test_ftrl_fit_predict_binomial_online_1_1():
     df_train_odd = dt.Frame([[1, 3, 7, 5, 9]])
     df_target_odd = dt.Frame([["odd", "odd", "odd", "odd", "odd"]])
     ft.fit(df_train_odd, df_target_odd)
-    assert_equals(ft.labels, dt.Frame([["odd"], [0]], names = ["label", "id"]))
+    assert_equals(ft.labels,
+                  dt.Frame(label=["odd"], id=[0], stypes={"id": dt.int8}))
 
     df_train_even = dt.Frame([[2, 4, 8, 6]])
     df_target_even = dt.Frame([["even", "even", "even", "even"]])
     ft.fit(df_train_even, df_target_even)
-    assert_equals(ft.labels, dt.Frame([["even", "odd"], [1, 0]], names = ["label", "id"]))
+    assert_equals(ft.labels,
+                  dt.Frame(label=["even", "odd"], id=[1, 0], stypes={"id": dt.int8}))
 
     df_train_wrong = dt.Frame([[2, 4, None, 6]])
     df_target_wrong = dt.Frame([["even", "even", "none", "even"]])
@@ -813,7 +815,8 @@ def test_ftrl_fit_predict_binomial_online_1_2():
     df_train_odd = dt.Frame([[1, 3, 7, 5, 9]])
     df_target_odd = dt.Frame([["odd", "odd", "odd", "odd", "odd"]])
     ft.fit(df_train_odd, df_target_odd)
-    assert_equals(ft.labels, dt.Frame([["odd"], [0]], names = ["label", "id"]))
+    assert_equals(ft.labels,
+                  dt.Frame(label=["odd"], id=[0], stypes={"id": dt.int8}))
 
     df_train_wrong = dt.Frame([[2, 4, None, 6]])
     df_target_wrong = dt.Frame([["even", "even", "none", "even"]])
@@ -826,7 +829,8 @@ def test_ftrl_fit_predict_binomial_online_1_2():
     df_train_even_odd = dt.Frame([[2, 1, 8, 3]])
     df_target_even_odd = dt.Frame([["even", "odd", "even", "odd"]])
     ft.fit(df_train_even_odd, df_target_even_odd)
-    assert_equals(ft.labels, dt.Frame([["even", "odd"], [1, 0]], names = ["label", "id"]))
+    assert_equals(ft.labels,
+                  dt.Frame(label=["even", "odd"], id=[1, 0], stypes={"id": dt.int8}))
 
     p = ft.predict(df_train_odd)
     p_dict = p.to_dict()
@@ -850,12 +854,14 @@ def test_ftrl_fit_predict_binomial_online_2_1():
     df_train_even_odd = dt.Frame([[2, 1, 8, 3]])
     df_target_even_odd = dt.Frame([["even", "odd", "even", "odd"]])
     ft.fit(df_train_even_odd, df_target_even_odd)
-    assert_equals(ft.labels, dt.Frame([["even", "odd"], [0, 1]], names = ["label", "id"]))
+    assert_equals(ft.labels,
+                  dt.Frame(label=["even", "odd"], id=[0, 1], stypes={"id": dt.int8}))
 
     df_train_odd = dt.Frame([[1, 3, 7, 5, 9]])
     df_target_odd = dt.Frame([["odd", "odd", "odd", "odd", "odd"]])
     ft.fit(df_train_odd, df_target_odd)
-    assert_equals(ft.labels, dt.Frame([["even", "odd"], [0, 1]], names = ["label", "id"]))
+    assert_equals(ft.labels,
+                  dt.Frame(label=["even", "odd"], id=[0, 1], stypes={"id": dt.int8}))
 
     df_train_wrong = dt.Frame([[math.inf, math.inf, None, math.inf]])
     df_target_wrong = dt.Frame([["inf", "inf", "none", "inf"]])
@@ -888,12 +894,14 @@ def test_ftrl_fit_predict_binomial_online_2_2():
     df_train_even_odd = dt.Frame([[2, 1, 8, 3]])
     df_target_even_odd = dt.Frame([["even", "odd", "even", "odd"]])
     ft.fit(df_train_even_odd, df_target_even_odd)
-    assert_equals(ft.labels, dt.Frame([["even", "odd"], [0, 1]], names = ["label", "id"]))
+    assert_equals(ft.labels,
+                  dt.Frame(label=["even", "odd"], id=[0, 1], stypes={"id": dt.int8}))
 
     df_train_odd_even = dt.Frame([[1, 2, 3, 8]])
     df_target_odd_even = dt.Frame([["odd", "even", "odd", "even"]])
     ft.fit(df_train_odd_even, df_target_odd_even)
-    assert_equals(ft.labels, dt.Frame([["even", "odd"], [0, 1]], names = ["label", "id"]))
+    assert_equals(ft.labels,
+                  dt.Frame(label=["even", "odd"], id=[0, 1], stypes={"id": dt.int8}))
 
     df_train_wrong = dt.Frame([[math.inf, math.inf, None, math.inf]])
     df_target_wrong = dt.Frame([["inf", "inf", "none", "inf"]])

--- a/tests/models/test_ftrl.py
+++ b/tests/models/test_ftrl.py
@@ -1072,6 +1072,8 @@ def test_ftrl_regression_fit_none():
     df_train = dt.Frame(range(ft.nbins))
     df_target = dt.Frame([None] * ft.nbins)
     res = ft.fit(df_train, df_target)
+    assert_equals(ft.labels,
+                  dt.Frame(label=["C0"], id=[0], stypes={"id": dt.int8}))
     assert ft.model_type == "regression"
     assert ft.model_type_trained == "regression"
     assert res.epoch == 1.0
@@ -1085,6 +1087,8 @@ def test_ftrl_regression_fit():
     df_target = dt.Frame(r + [math.inf])
     ft.fit(df_train, df_target)
     p = ft.predict(df_train)
+    assert_equals(ft.labels,
+                  dt.Frame(label=["C0"], id=[0], stypes={"id": dt.int8}))
     delta = [abs(i - j) for i, j in zip(p.to_list()[0], r + [0])]
     assert ft.labels[:, 0].to_list() == [["C0"]]
     assert ft.model_type_trained == "regression"

--- a/tests/munging/test_cbind.py
+++ b/tests/munging/test_cbind.py
@@ -210,11 +210,12 @@ def test_cbind_multiple():
     d4 = dt.Frame({"E": [1]})[:0, :]
     dt_compute_stats(d0, d1, d2, d3, d4)
     d0.cbind(d1, d2, d3, d4, force=True)
-    dr = dt.Frame({"A": [1, 2, 3, None],
-                   "B": ["doo", "doo", "doo", "doo"],
-                   "C": [True, False, None, None],
-                   "D": [10, 9, 8, 7],
-                   "E": [None] * 4})
+    dr = dt.Frame(A=[1, 2, 3, None],
+                  B=["doo", "doo", "doo", "doo"],
+                  C=[True, False, None, None],
+                  D=[10, 9, 8, 7],
+                  E=[None] * 4,
+                  stypes={"E": dt.int32})
     assert_equals(d0, dr)
 
 

--- a/tests/munging/test_cbind.py
+++ b/tests/munging/test_cbind.py
@@ -215,7 +215,7 @@ def test_cbind_multiple():
                   C=[True, False, None, None],
                   D=[10, 9, 8, 7],
                   E=[None] * 4,
-                  stypes={"E": dt.int32})
+                  stypes={"E": dt.int8})
     assert_equals(d0, dr)
 
 

--- a/tests/munging/test_delete.py
+++ b/tests/munging/test_delete.py
@@ -31,7 +31,7 @@ from tests import assert_equals
 # Not a fixture: create a new datatable each time this function is called
 def smalldt():
     res = dt.Frame([[i] for i in range(16)], names=list("ABCDEFGHIJKLMNOP"))
-    assert res.ltypes == (ltype.bool, ltype.bool) + (ltype.int,) * 14
+    assert res.ltypes == (ltype.int,) * 16
     return res
 
 

--- a/tests/munging/test_dt_cols.py
+++ b/tests/munging/test_dt_cols.py
@@ -34,11 +34,12 @@ from datatable.internal import frame_integrity_check
 
 @pytest.fixture()
 def tbl0():
+    T, F = True, False
     return [
         [1,   7,   9,    0,   -4,   3],  # int
         [2,   3,   2,    1,   10,   0],  # int
         [0.5, 0.1, 0.7, -0.3,  0.1, 1],  # real
-        [1,   0,   1,    1,    0,   1],  # bool
+        [T,   F,   T,    T,    F,   T],  # bool
     ]
 
 @pytest.fixture()

--- a/tests/munging/test_dt_rows.py
+++ b/tests/munging/test_dt_rows.py
@@ -36,8 +36,9 @@ from tests import same_iterables, noop, assert_equals, isview
 @pytest.fixture(name="dt0")
 def _dt0():
     from math import nan
+    T, F = True, False
     return dt.Frame([
-        [0,   1,   1,  None,    0,  0,    1, None,   1,    1],  # bool
+        [F,   T,   T,  None,    F,  F,    T, None,   T,    T],  # bool
         [7, -11,   9, 10000, None,  0,    0,   -1,   1, None],  # int
         [5,   1, 1.3,   0.1,  1e5,  0, -2.6,  -14, nan,    2],  # real
     ], names=["colA", "colB", "colC"])
@@ -404,7 +405,7 @@ def test_rows_multislice_invalid5(dt0):
 #-------------------------------------------------------------------------------
 
 def test_rows_bool_column(dt0):
-    col = dt.Frame([1, 0, 1, 1, None, 0, None, 1, 1, 0])
+    col = dt.Frame([1, 0, 1, 1, None, 0, None, 1, 1, 0], stype=bool)
     dt1 = dt0[col, :]
     frame_integrity_check(dt1)
     assert dt1.shape == (5, 3)
@@ -416,7 +417,7 @@ def test_rows_bool_column(dt0):
 
 def test_rows_bool_column_error(dt0):
     assert_valueerror(
-        dt0, dt.Frame(list(i % 2 for i in range(20))),
+        dt0, dt.Frame(list(bool(i % 2) for i in range(20))),
         "`i` selector has 20 rows, but applied to a Frame with 10 rows")
 
 

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -179,8 +179,8 @@ def test_dt_properties(dt0):
     assert dt0.names == ("A", "B", "C", "D", "E", "F", "G")
     assert dt0.ltypes == (ltype.int, ltype.bool, ltype.int, ltype.real,
                           ltype.bool, ltype.int, ltype.str)
-    assert dt0.stypes == (stype.int32, stype.bool8, stype.int32, stype.float64,
-                          stype.bool8, stype.int32, stype.str32)
+    assert dt0.stypes == (stype.int32, stype.bool8, stype.int8, stype.float64,
+                          stype.bool8, stype.int8, stype.str32)
     assert sys.getsizeof(dt0) > 500
 
 

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -177,10 +177,10 @@ def test_dt_properties(dt0):
     assert dt0.shape == (4, 7)
     assert dt0.ndims == 2
     assert dt0.names == ("A", "B", "C", "D", "E", "F", "G")
-    assert dt0.ltypes == (ltype.int, ltype.bool, ltype.bool, ltype.real,
-                          ltype.bool, ltype.bool, ltype.str)
-    assert dt0.stypes == (stype.int32, stype.bool8, stype.bool8, stype.float64,
-                          stype.bool8, stype.bool8, stype.str32)
+    assert dt0.ltypes == (ltype.int, ltype.bool, ltype.int, ltype.real,
+                          ltype.bool, ltype.int, ltype.str)
+    assert dt0.stypes == (stype.int32, stype.bool8, stype.int32, stype.float64,
+                          stype.bool8, stype.int32, stype.str32)
     assert sys.getsizeof(dt0) > 500
 
 
@@ -321,7 +321,7 @@ def test_random_attack():
 def test_dt_stype(dt0):
     assert dt0[0].stype == stype.int32
     assert dt0[1].stype == stype.bool8
-    assert dt0[:, [1, 2, 4, 5]].stype == stype.bool8
+    assert dt0[:, [1, 4]].stype == stype.bool8
     assert dt0[-1].stype == stype.str32
 
 

--- a/tests/test_dt_create.py
+++ b/tests/test_dt_create.py
@@ -600,28 +600,88 @@ def test_auto_bool8():
     assert d0.stypes == (stype.bool8,)
 
 
-def test_auto_int8():
-    src = [0, 3, 12, None, -5]
+
+def test_auto_int8_1():
+    src = [0, 1, 0, None, 0]
+    DT = dt.Frame(src)
+    frame_integrity_check(DT)
+    assert DT.stype == dt.int8
+    assert DT.to_list() == [src]
+
+
+def test_auto_int8_2():
+    src = [1, 0, False, True, None, 1, True]
+    DT = dt.Frame(src)
+    frame_integrity_check(DT)
+    assert DT.stype == dt.int8
+    assert DT.to_list() == [[1, 0, 0, 1, None, 1, 1]]
+
+
+def test_auto_int8_3(numpy):
+    i8 = numpy.int8
+    src = [i8(3), i8(5), None, 1, True, False, i8(-1)]
+    DT = dt.Frame(src)
+    frame_integrity_check(DT)
+    assert DT.stype == dt.int8
+    assert DT.to_list() == [[3, 5, None, 1, 1, 0, -1]]
+
+
+
+def test_auto_int16_1(numpy):
+    i16 = numpy.int16
+    src = [i16(50), i16(2303), None, i16(-45)]
+    d0 = dt.Frame(src)
+    frame_integrity_check(d0)
+    assert d0.stype == dt.int16
+    assert d0.to_list() == [[50, 2303, None, -45]]
+
+
+def test_auto_int16_2(numpy):
+    i16 = numpy.int16
+    src = [i16(1), i16(0)]
+    d0 = dt.Frame(src)
+    frame_integrity_check(d0)
+    assert d0.stype == dt.int16
+    assert d0.to_list() == [[1, 0]]
+
+
+def test_auto_int16_3(numpy):
+    i8 = numpy.int8
+    i16 = numpy.int16
+    src = [i16(1), i16(0), 1, 0, i8(1), i8(0), True, False, None]
+    d0 = dt.Frame(src)
+    frame_integrity_check(d0)
+    assert d0.stype == dt.int16
+    assert d0.to_list() == [[1, 0, 1, 0, 1, 0, 1, 0, None]]
+
+
+
+def test_auto_int32_1():
+    src = [0, 1, 2]
     d0 = dt.Frame(src)
     frame_integrity_check(d0)
     assert d0.stype == dt.int32
-    assert d0.to_list()[0] == src
+    assert d0.to_list() == [[0, 1, 2]]
 
 
-def test_auto_int16():
-    src = [50, 2303, None, -45]
-    d0 = dt.Frame(src)
-    frame_integrity_check(d0)
-    assert d0.stype == dt.int32
-    assert d0.to_list()[0] == src
-
-
-def test_auto_int32():
+def test_auto_int32_2():
     src = [None, 0, 1, 44, 9548, 428570247, -12]
     d0 = dt.Frame(src)
     frame_integrity_check(d0)
     assert d0.stype == dt.int32
     assert d0.to_list()[0] == src
+
+
+def test_auto_int32_3(numpy):
+    i8 = numpy.int8
+    i16 = numpy.int16
+    i32 = numpy.int32
+    src = [None, False, 0, i8(0), i16(0), i32(0)]
+    d0 = dt.Frame(src)
+    frame_integrity_check(d0)
+    assert d0.stype == dt.int32
+    assert d0.to_list() == [[None, 0, 0, 0, 0, 0]]
+
 
 
 def test_auto_int64():


### PR DESCRIPTION
- Reorganize code in "column_from-python.cc" so that it no longer relies on exceptions for type-bumping.

- Lists containing integers 0 and 1 will now produce columns of type `int8` (instead of `bool8`)

- Make code more robust in what types are accepted: all stypes should be able to accept values for lower stypes. For example, `bool` is considered lower than `int8`, and therefore an `int8` list will now accept `bool`s mixed with `int8` values.

Closes #2250 
Closes #2251