### PR TITLE
Improve handling of .labels in FTRL

### DIFF
--- a/c/models/dt_ftrl.cc
+++ b/c/models/dt_ftrl.cc
@@ -759,36 +759,10 @@ void Ftrl<T>::update(const uint64ptr& x,
 
 
 /**
- *  This method calls `predict` with the proper label id type:
- *  - for binomial and numeric regression label ids are `int8`;
- *  - for multinomial regression label ids are `int32`.
- */
-template <typename T>
-dtptr Ftrl<T>::dispatch_predict(const DataTable* dt_X) {
-  if (!is_model_trained()) {
-    throw ValueError() << "To make predictions, the model should be trained "
-                          "first";
-  }
-
-  SType label_id_stype = dt_labels->get_column(1).stype();
-  dtptr dt_p;
-  switch (label_id_stype) {
-    case SType::INT8:  dt_p = predict<int8_t>(dt_X); break;
-    case SType::INT32: dt_p = predict<int32_t>(dt_X); break;
-    default: throw TypeError() << "Label id type  `"
-                               << label_id_stype << "` is not supported";
-  }
-
-  return dt_p;
-}
-
-
-/**
  *  Predict on a datatable and return a new datatable with
  *  the predicted probabilities.
  */
 template <typename T>
-template <typename U /* label id type */>
 dtptr Ftrl<T>::predict(const DataTable* dt_X) {
   if (!is_model_trained()) {
     throw ValueError() << "To make predictions, the model should be trained "
@@ -807,7 +781,7 @@ dtptr Ftrl<T>::predict(const DataTable* dt_X) {
   // Create datatable for predictions and obtain column data pointers.
   size_t nlabels = dt_labels->nrows();
 
-  auto data_label_ids = static_cast<const U*>(
+  auto data_label_ids = static_cast<const int32_t*>(
                           dt_labels->get_column(1).get_data_readonly()
                         );
 

--- a/c/models/dt_ftrl.cc
+++ b/c/models/dt_ftrl.cc
@@ -204,9 +204,9 @@ void Ftrl<T>::create_y_binomial(const DataTable* dt,
     RowIndex ri_join = natural_join(*dt_labels_in.get(), *dt_labels.get());
     size_t nlabels = dt_labels->nrows();
     xassert(nlabels != 0 && nlabels < 3);
-    auto data_label_ids_in = static_cast<int8_t*>(
+    auto data_label_ids_in = static_cast<int32_t*>(
                               dt_labels_in->get_column(1).get_data_editable());
-    auto data_label_ids = static_cast<const int8_t*>(
+    auto data_label_ids = static_cast<const int32_t*>(
                               dt_labels->get_column(1).get_data_readonly());
 
     size_t ri0_index = 0, ri1_index;
@@ -299,8 +299,8 @@ FtrlFitOutput Ftrl<T>::fit_regression() {
 
   if (!is_model_trained()) {
     const strvec& colnames = dt_y_train->get_names();
-    std::unordered_map<std::string, int8_t> colnames_map = {{colnames[0], 0}};
-    dt_labels = create_dt_labels_str<uint32_t, SType::INT8>(colnames_map);
+    std::unordered_map<std::string, int32_t> colnames_map = {{colnames[0], 0}};
+    dt_labels = create_dt_labels_str<uint32_t>(colnames_map);
 
     create_model();
     model_type = FtrlModelType::REGRESSION;

--- a/c/models/dt_ftrl.h
+++ b/c/models/dt_ftrl.h
@@ -106,9 +106,6 @@ class Ftrl : public dt::FtrlBase {
     template <typename U>
     void update(const uint64ptr&, const tptr<T>&, T, U, size_t);
 
-    // Predicting methods
-    template <typename>
-    dtptr predict(const DataTable*);
     template <typename F> T predict_row(const uint64ptr&, tptr<T>&, size_t, F);
     dtptr create_p(size_t);
 
@@ -148,7 +145,7 @@ class Ftrl : public dt::FtrlBase {
                                double, double, size_t) override;
 
     // Main predicting method
-    dtptr dispatch_predict(const DataTable*) override;
+    dtptr predict(const DataTable*) override;
 
     // Model methods
     void reset() override;

--- a/c/models/dt_ftrl_base.h
+++ b/c/models/dt_ftrl_base.h
@@ -88,7 +88,7 @@ class FtrlBase {
     virtual FtrlFitOutput dispatch_fit(const DataTable*, const DataTable*,
                                        const DataTable*, const DataTable*,
                                        double, double, size_t) = 0;
-    virtual dtptr dispatch_predict(const DataTable*) = 0;
+    virtual dtptr predict(const DataTable*) = 0;
     virtual void reset() = 0;
     virtual bool is_model_trained() = 0;
 

--- a/c/models/label_encode.cc
+++ b/c/models/label_encode.cc
@@ -68,7 +68,7 @@ void label_encode(const Column& col, dtptr& dt_labels, dtptr& dt_encoded,
                          break;
 
     default:             throw TypeError() << "Target column type `" << stype
-                                           << "` is not supported by FTRL";
+                                           << "` is not supported";
   }
 
   // Set key to the labels column for later joining with the new labels.

--- a/c/models/label_encode.cc
+++ b/c/models/label_encode.cc
@@ -31,84 +31,44 @@ void label_encode(const Column& col, dtptr& dt_labels, dtptr& dt_encoded,
   xassert(dt_encoded == nullptr);
 
   SType stype = col.stype();
-  if (is_binomial) {
-    switch (stype) {
-      case SType::BOOL:    label_encode_bool(col, dt_labels, dt_encoded); break;
-      case SType::INT8:    label_encode_fw<SType::INT8, SType::INT8>(
-                             col, dt_labels, dt_encoded
-                           );
-                           break;
-      case SType::INT16:   label_encode_fw<SType::INT16, SType::INT8>(
-                             col, dt_labels, dt_encoded
-                           );
-                           break;
-      case SType::INT32:   label_encode_fw<SType::INT32, SType::INT8>(
-                             col, dt_labels, dt_encoded
-                            );
-                           break;
-      case SType::INT64:   label_encode_fw<SType::INT64, SType::INT8>(
-                             col, dt_labels, dt_encoded
-                           );
-                           break;
-      case SType::FLOAT32: label_encode_fw<SType::FLOAT32, SType::INT8>(
-                             col, dt_labels, dt_encoded
-                           );
-                           break;
-      case SType::FLOAT64: label_encode_fw<SType::FLOAT64, SType::INT8>(
-                             col, dt_labels, dt_encoded
-                           );
-                           break;
-      case SType::STR32:   label_encode_str<uint32_t, SType::INT8>(
-                             col, dt_labels, dt_encoded
-                           );
-                           break;
-      case SType::STR64:   label_encode_str<uint64_t, SType::INT8>(
-                             col, dt_labels, dt_encoded
-                           );
-                           break;
+  switch (stype) {
+    case SType::BOOL:    label_encode_bool(col, dt_labels, dt_encoded);
+                         break;
+    case SType::INT8:    label_encode_fw<SType::INT8>(
+                           col, dt_labels, dt_encoded, is_binomial
+                         );
+                         break;
+    case SType::INT16:   label_encode_fw<SType::INT16>(
+                           col, dt_labels, dt_encoded, is_binomial
+                         );
+                         break;
+    case SType::INT32:   label_encode_fw<SType::INT32>(
+                           col, dt_labels, dt_encoded, is_binomial
+                          );
+                         break;
+    case SType::INT64:   label_encode_fw<SType::INT64>(
+                           col, dt_labels, dt_encoded, is_binomial
+                         );
+                         break;
+    case SType::FLOAT32: label_encode_fw<SType::FLOAT32>(
+                           col, dt_labels, dt_encoded, is_binomial
+                         );
+                         break;
+    case SType::FLOAT64: label_encode_fw<SType::FLOAT64>(
+                           col, dt_labels, dt_encoded, is_binomial
+                         );
+                         break;
+    case SType::STR32:   label_encode_str<uint32_t>(
+                           col, dt_labels, dt_encoded, is_binomial
+                         );
+                         break;
+    case SType::STR64:   label_encode_str<uint64_t>(
+                           col, dt_labels, dt_encoded, is_binomial
+                         );
+                         break;
 
-      default:             throw TypeError() << "Column type `" << stype
-                                             << "` is not supported";
-    }
-  } else {
-    switch (stype) {
-      case SType::BOOL:    label_encode_bool(col, dt_labels, dt_encoded); break;
-      case SType::INT8:    label_encode_fw<SType::INT8, SType::INT32>(
-                             col, dt_labels, dt_encoded
-                           );
-                           break;
-      case SType::INT16:   label_encode_fw<SType::INT16, SType::INT32>(
-                             col, dt_labels, dt_encoded
-                           );
-                           break;
-      case SType::INT32:   label_encode_fw<SType::INT32, SType::INT32>(
-                             col, dt_labels, dt_encoded
-                           );
-                           break;
-      case SType::INT64:   label_encode_fw<SType::INT64, SType::INT32>(
-                             col, dt_labels, dt_encoded
-                           );
-                           break;
-      case SType::FLOAT32: label_encode_fw<SType::FLOAT32, SType::INT32>(
-                             col, dt_labels, dt_encoded
-                           );
-                           break;
-      case SType::FLOAT64: label_encode_fw<SType::FLOAT64, SType::INT32>(
-                             col, dt_labels, dt_encoded
-                           );
-                           break;
-      case SType::STR32:   label_encode_str<uint32_t, SType::INT32>(
-                             col, dt_labels, dt_encoded
-                           );
-                           break;
-      case SType::STR64:   label_encode_str<uint64_t, SType::INT32>(
-                             col, dt_labels, dt_encoded
-                           );
-                           break;
-
-      default:             throw TypeError() << "Column type `" << stype
-                                             << "` is not supported";
-    }
+    default:             throw TypeError() << "Target column type `" << stype
+                                           << "` is not supported by FTRL";
   }
 
   // Set key to the labels column for later joining with the new labels.

--- a/c/models/label_encode.cc
+++ b/c/models/label_encode.cc
@@ -92,14 +92,15 @@ static void label_encode_bool(const Column& col,
   if (col.na_count() == col.nrows()) return;
 
   // Set up boolean labels and their corresponding ids.
-  Column ids_col = Column::new_data_column(2, SType::INT8);
   Column labels_col = Column::new_data_column(2, SType::BOOL);
-  auto ids_data = static_cast<int8_t*>(ids_col.get_data_editable());
   auto labels_data = static_cast<int8_t*>(labels_col.get_data_editable());
-  ids_data[0] = 0;
-  ids_data[1] = 1;
   labels_data[0] = 0;
   labels_data[1] = 1;
+
+  Column ids_col = Column::new_data_column(2, SType::INT32);
+  auto ids_data = static_cast<int32_t*>(ids_col.get_data_editable());
+  ids_data[0] = 0;
+  ids_data[1] = 1;
 
   dt_labels = dtptr(new DataTable({std::move(labels_col), std::move(ids_col)},
                                   {"label", "id"}));

--- a/c/models/label_encode.h
+++ b/c/models/label_encode.h
@@ -143,7 +143,7 @@ void label_encode_fw(const Column& ocol,
         if (labels_map.count(v) == 0) {
           if (is_binomial && labels_map.size() == 2) {
             throw ValueError() << "Target column for binomial problem cannot "
-                                  "contain more than two labels";
+                                  "contain more than two unique labels";
           }
           size_t nlabels = labels_map.size();
           labels_map[v] = static_cast<int32_t>(nlabels);
@@ -201,7 +201,7 @@ void label_encode_str(const Column& ocol,
         if (labels_map.count(v) == 0) {
           if (is_binomial && labels_map.size() == 2) {
             throw ValueError() << "Target column for binomial problem cannot "
-                                  "contain more than two labels";
+                                  "contain more than two unique labels";
           }
           size_t nlabels = labels_map.size();
           labels_map[v] = static_cast<int32_t>(nlabels);

--- a/c/models/py_ftrl.cc
+++ b/c/models/py_ftrl.cc
@@ -460,7 +460,7 @@ oobj Ftrl::predict(const PKArgs& args) {
   }
 
 
-  DataTable* dt_p = dtft->dispatch_predict(dt_X).release();
+  DataTable* dt_p = dtft->predict(dt_X).release();
   py::oobj df_p = py::Frame::oframe(dt_p);
 
   return df_p;

--- a/docs/changelog/v-0-11-0.rst
+++ b/docs/changelog/v-0-11-0.rst
@@ -49,5 +49,5 @@ FTRL model
 
 - |fix| Resetting an untrained FTRL model now doesn't result in a segfault (#2226).
 
-- |enh| The ``id`` column in FTRL model ``.labels`` frame now has stype ``int8``
-  instead of ``bool`` for binomial models.
+- |enh| The ``id`` column in FTRL model ``.labels`` frame now has stype ``int32``
+  instead of ``bool`` for binomial and regression models.

--- a/tests/models/test_ftrl.py
+++ b/tests/models/test_ftrl.py
@@ -803,8 +803,11 @@ def test_ftrl_fit_predict_binomial_online_1_1():
     df_train_odd = dt.Frame([[1, 3, 7, 5, 9]])
     df_target_odd = dt.Frame([["odd", "odd", "odd", "odd", "odd"]])
     ft.fit(df_train_odd, df_target_odd)
-    assert_equals(ft.labels,
-                  dt.Frame(label=["odd"], id=[0], stypes={"id": dt.int32}))
+    assert_equals(
+        ft.labels,
+        dt.Frame(label=["odd"], id=[0], stypes={"id": dt.int32}
+    )
+                  )
 
     df_train_even = dt.Frame([[2, 4, 8, 6]])
     df_target_even = dt.Frame([["even", "even", "even", "even"]])
@@ -844,8 +847,10 @@ def test_ftrl_fit_predict_binomial_online_1_2():
     df_train_odd = dt.Frame([[1, 3, 7, 5, 9]])
     df_target_odd = dt.Frame([["odd", "odd", "odd", "odd", "odd"]])
     ft.fit(df_train_odd, df_target_odd)
-    assert_equals(ft.labels,
-                  dt.Frame(label=["odd"], id=[0], stypes={"id": dt.int32}))
+    assert_equals(
+        ft.labels,
+        dt.Frame(label=["odd"], id=[0], stypes={"id": dt.int32})
+    )
 
     df_train_wrong = dt.Frame([[2, 4, None, 6]])
     df_target_wrong = dt.Frame([["even", "even", "none", "even"]])
@@ -885,8 +890,10 @@ def test_ftrl_fit_predict_binomial_online_2_1():
     df_train_even_odd = dt.Frame([[2, 1, 8, 3]])
     df_target_even_odd = dt.Frame([["even", "odd", "even", "odd"]])
     ft.fit(df_train_even_odd, df_target_even_odd)
-    assert_equals(ft.labels,
-                  dt.Frame(label=["even", "odd"], id=[0, 1], stypes={"id": dt.int32}))
+    assert_equals(
+        ft.labels,
+        dt.Frame(label=["even", "odd"], id=[0, 1], stypes={"id": dt.int32})
+    )
 
     df_train_odd = dt.Frame([[1, 3, 7, 5, 9]])
     df_target_odd = dt.Frame([["odd", "odd", "odd", "odd", "odd"]])
@@ -935,8 +942,10 @@ def test_ftrl_fit_predict_binomial_online_2_2():
     df_train_odd_even = dt.Frame([[1, 2, 3, 8]])
     df_target_odd_even = dt.Frame([["odd", "even", "odd", "even"]])
     ft.fit(df_train_odd_even, df_target_odd_even)
-    assert_equals(ft.labels,
-                  dt.Frame(label=["even", "odd"], id=[0, 1], stypes={"id": dt.int32}))
+    assert_equals(
+        ft.labels,
+        dt.Frame(label=["even", "odd"], id=[0, 1], stypes={"id": dt.int32})
+    )
 
     df_train_wrong = dt.Frame([[math.inf, math.inf, None, math.inf]])
     df_target_wrong = dt.Frame([["inf", "inf", "none", "inf"]])

--- a/tests/models/test_ftrl.py
+++ b/tests/models/test_ftrl.py
@@ -777,13 +777,13 @@ def test_ftrl_fit_predict_binomial_online_1_1():
     df_target_odd = dt.Frame([["odd", "odd", "odd", "odd", "odd"]])
     ft.fit(df_train_odd, df_target_odd)
     assert_equals(ft.labels,
-                  dt.Frame(label=["odd"], id=[0], stypes={"id": dt.int8}))
+                  dt.Frame(label=["odd"], id=[0], stypes={"id": dt.int32}))
 
     df_train_even = dt.Frame([[2, 4, 8, 6]])
     df_target_even = dt.Frame([["even", "even", "even", "even"]])
     ft.fit(df_train_even, df_target_even)
     assert_equals(ft.labels,
-                  dt.Frame(label=["even", "odd"], id=[1, 0], stypes={"id": dt.int8}))
+                  dt.Frame(label=["even", "odd"], id=[1, 0], stypes={"id": dt.int32}))
 
     df_train_wrong = dt.Frame([[2, 4, None, 6]])
     df_target_wrong = dt.Frame([["even", "even", "none", "even"]])
@@ -816,7 +816,7 @@ def test_ftrl_fit_predict_binomial_online_1_2():
     df_target_odd = dt.Frame([["odd", "odd", "odd", "odd", "odd"]])
     ft.fit(df_train_odd, df_target_odd)
     assert_equals(ft.labels,
-                  dt.Frame(label=["odd"], id=[0], stypes={"id": dt.int8}))
+                  dt.Frame(label=["odd"], id=[0], stypes={"id": dt.int32}))
 
     df_train_wrong = dt.Frame([[2, 4, None, 6]])
     df_target_wrong = dt.Frame([["even", "even", "none", "even"]])
@@ -830,7 +830,7 @@ def test_ftrl_fit_predict_binomial_online_1_2():
     df_target_even_odd = dt.Frame([["even", "odd", "even", "odd"]])
     ft.fit(df_train_even_odd, df_target_even_odd)
     assert_equals(ft.labels,
-                  dt.Frame(label=["even", "odd"], id=[1, 0], stypes={"id": dt.int8}))
+                  dt.Frame(label=["even", "odd"], id=[1, 0], stypes={"id": dt.int32}))
 
     p = ft.predict(df_train_odd)
     p_dict = p.to_dict()
@@ -855,13 +855,13 @@ def test_ftrl_fit_predict_binomial_online_2_1():
     df_target_even_odd = dt.Frame([["even", "odd", "even", "odd"]])
     ft.fit(df_train_even_odd, df_target_even_odd)
     assert_equals(ft.labels,
-                  dt.Frame(label=["even", "odd"], id=[0, 1], stypes={"id": dt.int8}))
+                  dt.Frame(label=["even", "odd"], id=[0, 1], stypes={"id": dt.int32}))
 
     df_train_odd = dt.Frame([[1, 3, 7, 5, 9]])
     df_target_odd = dt.Frame([["odd", "odd", "odd", "odd", "odd"]])
     ft.fit(df_train_odd, df_target_odd)
     assert_equals(ft.labels,
-                  dt.Frame(label=["even", "odd"], id=[0, 1], stypes={"id": dt.int8}))
+                  dt.Frame(label=["even", "odd"], id=[0, 1], stypes={"id": dt.int32}))
 
     df_train_wrong = dt.Frame([[math.inf, math.inf, None, math.inf]])
     df_target_wrong = dt.Frame([["inf", "inf", "none", "inf"]])
@@ -895,13 +895,13 @@ def test_ftrl_fit_predict_binomial_online_2_2():
     df_target_even_odd = dt.Frame([["even", "odd", "even", "odd"]])
     ft.fit(df_train_even_odd, df_target_even_odd)
     assert_equals(ft.labels,
-                  dt.Frame(label=["even", "odd"], id=[0, 1], stypes={"id": dt.int8}))
+                  dt.Frame(label=["even", "odd"], id=[0, 1], stypes={"id": dt.int32}))
 
     df_train_odd_even = dt.Frame([[1, 2, 3, 8]])
     df_target_odd_even = dt.Frame([["odd", "even", "odd", "even"]])
     ft.fit(df_train_odd_even, df_target_odd_even)
     assert_equals(ft.labels,
-                  dt.Frame(label=["even", "odd"], id=[0, 1], stypes={"id": dt.int8}))
+                  dt.Frame(label=["even", "odd"], id=[0, 1], stypes={"id": dt.int32}))
 
     df_train_wrong = dt.Frame([[math.inf, math.inf, None, math.inf]])
     df_target_wrong = dt.Frame([["inf", "inf", "none", "inf"]])
@@ -1073,7 +1073,7 @@ def test_ftrl_regression_fit_none():
     df_target = dt.Frame([None] * ft.nbins)
     res = ft.fit(df_train, df_target)
     assert_equals(ft.labels,
-                  dt.Frame(label=["C0"], id=[0], stypes={"id": dt.int8}))
+                  dt.Frame(label=["C0"], id=[0], stypes={"id": dt.int32}))
     assert ft.model_type == "regression"
     assert ft.model_type_trained == "regression"
     assert res.epoch == 1.0
@@ -1088,7 +1088,7 @@ def test_ftrl_regression_fit():
     ft.fit(df_train, df_target)
     p = ft.predict(df_train)
     assert_equals(ft.labels,
-                  dt.Frame(label=["C0"], id=[0], stypes={"id": dt.int8}))
+                  dt.Frame(label=["C0"], id=[0], stypes={"id": dt.int32}))
     delta = [abs(i - j) for i, j in zip(p.to_list()[0], r + [0])]
     assert ft.labels[:, 0].to_list() == [["C0"]]
     assert ft.model_type_trained == "regression"

--- a/tests/models/test_ftrl.py
+++ b/tests/models/test_ftrl.py
@@ -623,6 +623,7 @@ def test_ftrl_fit_none():
     df_train = dt.Frame(range(ft.nbins))
     df_target = dt.Frame([None] * ft.nbins)
     res = ft.fit(df_train, df_target)
+    assert not ft.labels
     assert ft.model_type == "binomial"
     assert ft.model_type_trained == "none"
     assert res.epoch == 0.0
@@ -635,6 +636,10 @@ def test_ftrl_fit_unique():
     df_target = dt.Frame([True] * ft.nbins)
     ft.fit(df_train, df_target)
     model = [[0.5] * ft.nbins, [0.25] * ft.nbins]
+    assert_equals(
+        ft.labels,
+        dt.Frame(label=[False, True], id=[0, 1], stypes={"id" : stype.int32})
+    )
     assert ft.model_type_trained == "binomial"
     assert ft.model.to_list() == model
 
@@ -645,6 +650,10 @@ def test_ftrl_fit_unique_ignore_none():
     df_target = dt.Frame([True] * ft.nbins + [None] * ft.nbins)
     ft.fit(df_train, df_target)
     model = [[0.5] * ft.nbins, [0.25] * ft.nbins]
+    assert_equals(
+        ft.labels,
+        dt.Frame(label=[False, True], id=[0, 1], stypes={"id" : stype.int32})
+    )
     assert ft.model_type_trained == "binomial"
     assert ft.model.to_list() == model
 
@@ -655,6 +664,10 @@ def test_ftrl_fit_predict_bool():
     df_target = dt.Frame([[True, False]])
     ft.fit(df_train, df_target)
     df_target = ft.predict(df_train[:,0])
+    assert_equals(
+        ft.labels,
+        dt.Frame(label=[False, True], id=[0, 1], stypes={"id" : stype.int32})
+    )
     assert ft.model_type_trained == "binomial"
     assert df_target[0, 1] <= 1
     assert df_target[0, 1] >= 1 - epsilon
@@ -712,6 +725,16 @@ def test_ftrl_fit_predict_bool_binomial(target):
     df_target = dt.Frame(target)
     ft.fit(df_train, df_target)
     df_res = ft.predict(df_train)
+    target.sort()
+    ids = [1, 0]
+    # When a target column has a boolean type, negatives
+    # will always be assigned a `0` label id.
+    if ft.labels.stypes[0] == dt.stype.bool8:
+        ids.sort()
+    assert_equals(
+        ft.labels,
+        dt.Frame(label=target, id=ids, stypes={"id" : stype.int32})
+    )
     assert ft.labels[:, 0].to_list() == [sorted(target)]
     assert ft.model_type_trained == "binomial"
     assert df_res[0, 1] <= 1
@@ -745,6 +768,10 @@ def test_ftrl_fit_predict_view():
     ft.fit(df_train_range, df_target_range)
     predictions_range = ft.predict(df_train_range)
 
+    assert_equals(
+        ft.labels,
+        dt.Frame(label=[False, True], id=[0, 1], stypes={"id" : stype.int32})
+    )
     assert ft.model_type_trained == "binomial"
     assert_equals(model, ft.model)
     assert_equals(predictions, predictions_range)
@@ -782,8 +809,10 @@ def test_ftrl_fit_predict_binomial_online_1_1():
     df_train_even = dt.Frame([[2, 4, 8, 6]])
     df_target_even = dt.Frame([["even", "even", "even", "even"]])
     ft.fit(df_train_even, df_target_even)
-    assert_equals(ft.labels,
-                  dt.Frame(label=["even", "odd"], id=[1, 0], stypes={"id": dt.int32}))
+    assert_equals(
+        ft.labels,
+        dt.Frame(label=["even", "odd"], id=[1, 0], stypes={"id": dt.int32})
+    )
 
     df_train_wrong = dt.Frame([[2, 4, None, 6]])
     df_target_wrong = dt.Frame([["even", "even", "none", "even"]])
@@ -829,8 +858,10 @@ def test_ftrl_fit_predict_binomial_online_1_2():
     df_train_even_odd = dt.Frame([[2, 1, 8, 3]])
     df_target_even_odd = dt.Frame([["even", "odd", "even", "odd"]])
     ft.fit(df_train_even_odd, df_target_even_odd)
-    assert_equals(ft.labels,
-                  dt.Frame(label=["even", "odd"], id=[1, 0], stypes={"id": dt.int32}))
+    assert_equals(
+        ft.labels,
+        dt.Frame(label=["even", "odd"], id=[1, 0], stypes={"id": dt.int32})
+    )
 
     p = ft.predict(df_train_odd)
     p_dict = p.to_dict()
@@ -860,8 +891,10 @@ def test_ftrl_fit_predict_binomial_online_2_1():
     df_train_odd = dt.Frame([[1, 3, 7, 5, 9]])
     df_target_odd = dt.Frame([["odd", "odd", "odd", "odd", "odd"]])
     ft.fit(df_train_odd, df_target_odd)
-    assert_equals(ft.labels,
-                  dt.Frame(label=["even", "odd"], id=[0, 1], stypes={"id": dt.int32}))
+    assert_equals(
+        ft.labels,
+        dt.Frame(label=["even", "odd"], id=[0, 1], stypes={"id": dt.int32})
+    )
 
     df_train_wrong = dt.Frame([[math.inf, math.inf, None, math.inf]])
     df_target_wrong = dt.Frame([["inf", "inf", "none", "inf"]])
@@ -894,8 +927,10 @@ def test_ftrl_fit_predict_binomial_online_2_2():
     df_train_even_odd = dt.Frame([[2, 1, 8, 3]])
     df_target_even_odd = dt.Frame([["even", "odd", "even", "odd"]])
     ft.fit(df_train_even_odd, df_target_even_odd)
-    assert_equals(ft.labels,
-                  dt.Frame(label=["even", "odd"], id=[0, 1], stypes={"id": dt.int32}))
+    assert_equals(
+        ft.labels,
+        dt.Frame(label=["even", "odd"], id=[0, 1], stypes={"id": dt.int32})
+    )
 
     df_train_odd_even = dt.Frame([[1, 2, 3, 8]])
     df_target_odd_even = dt.Frame([["odd", "even", "odd", "even"]])
@@ -929,6 +964,7 @@ def test_ftrl_fit_multinomial_none():
     df_train = dt.Frame(range(ft.nbins))
     df_target = dt.Frame([None] * ft.nbins)
     res = ft.fit(df_train, df_target)
+    assert not ft.labels
     assert ft.model_type == "multinomial"
     assert ft.model_type_trained == "none"
     assert res.epoch == 0.0
@@ -955,6 +991,14 @@ def test_ftrl_fit_predict_multinomial_vs_binomial():
                           "C0" : f[target_index * 2],
                           "C1" : f[target_index * 2 + 1]
                         }]
+    assert_equals(
+        ft_binomial.labels,
+        dt.Frame(label=[False, True], id=[0, 1], stypes={"id": dt.int32})
+    )
+    assert_equals(
+        ft_multinomial.labels,
+        dt.Frame(label=["cat", "dog"], id=[0, 1], stypes={"id": dt.int32})
+    )
     assert ft_binomial.model_type_trained == "binomial"
     assert ft_multinomial.model_type_trained == "multinomial"
     assert_equals(ft_binomial.model, multinomial_model)
@@ -967,7 +1011,7 @@ def test_ftrl_fit_predict_multinomial(negative_class):
     nepochs = 1000
     ft = Ftrl(alpha = 0.2, nepochs = nepochs, double_precision = True)
     ft.negative_class = negative_class
-    labels = ["blue", "green", "red"]
+    labels = negative_class_label + ["blue", "green", "red"]
 
     df_train = dt.Frame(["cucumber", None, "shift", "sky", "day", "orange", "ocean"])
     df_target = dt.Frame(["green", "red", "red", "blue", "green", None, "blue"])
@@ -987,12 +1031,18 @@ def test_ftrl_fit_predict_multinomial(negative_class):
                    zip(p_dict["green"], [1, 0, 0, 0, 1, p_none, 0])]
     delta_blue =  [abs(i - j) for i, j in
                    zip(p_dict["blue"], [0, 0, 0, 1, 0, p_none, 1])]
+
+    ids = [0, 3, 1, 2] if negative_class else [2, 0, 1]
+    assert_equals(
+        ft.labels,
+        dt.Frame(label=labels, id=ids, stypes={"id": dt.int32})
+    )
     assert ft.model_type_trained == "multinomial"
     assert max(delta_sum)   < 1e-12
     assert max(delta_red)   < epsilon
     assert max(delta_green) < epsilon
     assert max(delta_blue)  < epsilon
-    assert list(p.names) == negative_class_label + labels
+    assert list(p.names) == labels
 
 
 @pytest.mark.parametrize('negative_class', [False, True])
@@ -1000,14 +1050,19 @@ def test_ftrl_fit_predict_multinomial_online(negative_class):
     ft = Ftrl(alpha = 0.2, nepochs = 1000, double_precision = True)
     ft.negative_class = negative_class
     negative_class_label = ["_negative_class"] if negative_class else []
-    labels = ["green", "red", "blue"]
 
     # Show only 1 label to the model
     df_train = dt.Frame(["cucumber"])
     df_target = dt.Frame(["green"])
     ft.fit(df_train, df_target)
+
+    labels = negative_class_label + ["green"]
+    ids = list(range(len(labels)))
+    assert_equals(
+        ft.labels,
+        dt.Frame(label=labels, id=ids, stypes={"id": dt.int32})
+    )
     assert ft.model_type_trained == "multinomial"
-    assert ft.labels[:, 0].to_list() == [negative_class_label + ["green"]]
     assert ft.model.shape == (ft.nbins, 2 * ft.labels.nrows)
 
     # Also do pickling unpickling in the middle.
@@ -1018,16 +1073,28 @@ def test_ftrl_fit_predict_multinomial_online(negative_class):
     df_train = dt.Frame(["cucumber", None])
     df_target = dt.Frame(["green", "red"])
     ft.fit(df_train, df_target)
+
+    labels += ["red"]
+    ids += [len(ids)]
+    assert_equals(
+        ft.labels,
+        dt.Frame(label=labels, id=ids, stypes={"id": dt.int32})
+    )
     assert ft.model_type_trained == "multinomial"
-    assert ft.labels[:, 0].to_list() == [negative_class_label + ["green", "red"]]
     assert ft.model.shape == (ft.nbins, 2 * ft.labels.nrows)
 
     # And one more
     df_train = dt.Frame(["cucumber", None, "shift", "sky", "day", "orange", "ocean"])
     df_target = dt.Frame(["green", "red", "red", "blue", "green", None, "blue"])
     ft.fit(df_train, df_target)
+
+    labels.insert(negative_class, "blue")
+    ids.insert(negative_class, len(ids))
+    assert_equals(
+        ft.labels,
+        dt.Frame(label=labels, id=ids, stypes={"id": dt.int32})
+    )
     assert ft.model_type_trained == "multinomial"
-    assert ft.labels[:, 0].to_list() == [negative_class_label + ["blue", "green", "red"]]
     assert ft.model.shape == (ft.nbins, 2 * ft.labels.nrows)
 
     # Do not add any new labels
@@ -1035,8 +1102,11 @@ def test_ftrl_fit_predict_multinomial_online(negative_class):
     df_target = dt.Frame(["green", "red", "red", "blue", "green", None, "blue"])
 
     ft.fit(df_train, df_target)
+    assert_equals(
+        ft.labels,
+        dt.Frame(label=labels, id=ids, stypes={"id": dt.int32})
+    )
     assert ft.model_type_trained == "multinomial"
-    assert ft.labels[:, 0].to_list() == [negative_class_label + ["blue", "green", "red"]]
     assert ft.model.shape == (ft.nbins, 2 * ft.labels.nrows)
 
     # Test predictions
@@ -1054,6 +1124,10 @@ def test_ftrl_fit_predict_multinomial_online(negative_class):
     delta_blue =  [abs(i - j) for i, j in
                    zip(p_dict["blue"], [0, 0, 0, 1, 0, p_none, 1])]
 
+    assert_equals(
+        ft.labels,
+        dt.Frame(label=labels, id=ids, stypes={"id": dt.int32})
+    )
     assert ft.model_type_trained == "multinomial"
     assert max(delta_sum)   < 1e-12
     assert max(delta_red)   < epsilon
@@ -1072,8 +1146,10 @@ def test_ftrl_regression_fit_none():
     df_train = dt.Frame(range(ft.nbins))
     df_target = dt.Frame([None] * ft.nbins)
     res = ft.fit(df_train, df_target)
-    assert_equals(ft.labels,
-                  dt.Frame(label=["C0"], id=[0], stypes={"id": dt.int32}))
+    assert_equals(
+        ft.labels,
+        dt.Frame(label=["C0"], id=[0], stypes={"id": dt.int32})
+    )
     assert ft.model_type == "regression"
     assert ft.model_type_trained == "regression"
     assert res.epoch == 1.0
@@ -1087,8 +1163,10 @@ def test_ftrl_regression_fit():
     df_target = dt.Frame(r + [math.inf])
     ft.fit(df_train, df_target)
     p = ft.predict(df_train)
-    assert_equals(ft.labels,
-                  dt.Frame(label=["C0"], id=[0], stypes={"id": dt.int32}))
+    assert_equals(
+        ft.labels,
+        dt.Frame(label=["C0"], id=[0], stypes={"id": dt.int32})
+    )
     delta = [abs(i - j) for i, j in zip(p.to_list()[0], r + [0])]
     assert ft.labels[:, 0].to_list() == [["C0"]]
     assert ft.model_type_trained == "regression"


### PR DESCRIPTION
- use `SType::INT32` for `id` column in `.labels` for all the model types as this makes the code more consistent and much cleaner. Since for numeric and binomial regressions we only have one or two labels this change has a negligible effect on the memory usage;
- improve tests.