### PR TITLE
Improve py::oiter::size()

### DIFF
--- a/docs/changelog/v-0-11-0.rst
+++ b/docs/changelog/v-0-11-0.rst
@@ -43,6 +43,10 @@ General
 - |fix| :func:`frame_column_data_r` now works properly with virtual columns
   (#2269).
 
+- |fix| Avoid rare deadlock when creating a frame from pandas DataFrame in
+  a forked process, in the datatable compiled with gcc version before 7.0
+  (#2272).
+
 
 FTRL model
 ----------


### PR DESCRIPTION
- Try `.__len__()` before going for `.__length_hint__()`;
- Test for existence of `.__len__` and `.__length_hint__` before attempting to call them -- this avoids throwing an exception unless in exceptional circumstances.

Closes #2272