### PR TITLE
Improve the interrupt signal handler 

### DIFF
--- a/c/parallel/api.h
+++ b/c/parallel/api.h
@@ -76,11 +76,6 @@ size_t get_hardware_concurrency() noexcept;
 
 
 
-/**
- * Check if the monitor thread is running.
- */
-bool is_monitor_enabled() noexcept;
-
 
 //------------------------------------------------------------------------------
 // Parallel constructs

--- a/c/parallel/monitor_thread.cc
+++ b/c/parallel/monitor_thread.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019 H2O.ai
+// Copyright 2019-2020 H2O.ai
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
   #include <unistd.h>                   // nice
 #endif
 #include <iostream>
-#include <csignal>                      // std::signal
+#include <csignal>                      // std::signal, sig_atomic_t
 #include "parallel/api.h"
 #include "parallel/monitor_thread.h"
 #include "progress/progress_manager.h"  // dt::progress::progress_manager

--- a/c/parallel/monitor_thread.h
+++ b/c/parallel/monitor_thread.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019 H2O.ai
+// Copyright 2019-2020 H2O.ai
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/c/parallel/monitor_thread.h
+++ b/c/parallel/monitor_thread.h
@@ -49,12 +49,11 @@ class monitor_thread {
      * set_active(false) puts the thread back to sleep.
      */
     void set_active(bool a) noexcept;
-    bool get_active();
+    bool get_active() const noexcept;
     void stop_running();
 
   private:
     void run() noexcept;
-    static void sigint_handler(int);
 };
 
 

--- a/c/parallel/monitor_thread.h
+++ b/c/parallel/monitor_thread.h
@@ -26,6 +26,15 @@ class idle_job;
 void enable_monitor(bool) noexcept;
 
 
+/**
+  * This class represents a monitor thread, i.e. a low-priority
+  * background thread that periodically checks task progress and
+  * interrupt status, and sends status updates to python.
+  *
+  * There can only be one monitor_thread instance at a time, since
+  * at least part of the monitor_thread's state is kept in static
+  * variables that are also accessed from a signal handler.
+  */
 class monitor_thread {
   friend std::mutex& python_mutex();
   private:
@@ -34,8 +43,7 @@ class monitor_thread {
     std::mutex mutex;
     std::condition_variable sleep_state_cv;
     bool running;
-    bool is_active;
-    size_t : 48;
+    size_t : 56;
 
   public:
     monitor_thread(idle_job*);
@@ -49,11 +57,10 @@ class monitor_thread {
      * set_active(false) puts the thread back to sleep.
      */
     void set_active(bool a) noexcept;
-    bool get_active() const noexcept;
-    void stop_running();
 
   private:
     void run() noexcept;
+    void stop_running();
 };
 
 

--- a/c/parallel/thread_pool.cc
+++ b/c/parallel/thread_pool.cc
@@ -159,9 +159,6 @@ void thread_pool::enable_monitor(bool a) noexcept {
 }
 
 
-bool thread_pool::is_monitor_enabled() noexcept {
-  return monitor? monitor->get_active() : false;
-}
 
 
 //------------------------------------------------------------------------------
@@ -171,9 +168,6 @@ void enable_monitor(bool a) noexcept {
   thpool->enable_monitor(a);
 }
 
-bool is_monitor_enabled() noexcept {
-  return thpool->is_monitor_enabled();
-}
 
 
 //------------------------------------------------------------------------------

--- a/c/parallel/thread_pool.h
+++ b/c/parallel/thread_pool.h
@@ -102,7 +102,6 @@ class thread_pool {
 
     // Monitor thread control.
     void enable_monitor(bool) noexcept;
-    bool is_monitor_enabled() noexcept;
 
     static void init_options();
 };

--- a/c/progress/progress_manager.cc
+++ b/c/progress/progress_manager.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019 H2O.ai
+// Copyright 2019-2020 H2O.ai
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/c/progress/progress_manager.cc
+++ b/c/progress/progress_manager.cc
@@ -32,7 +32,7 @@ progress_manager* manager = new progress_manager;
 progress_manager::progress_manager()
   : pbar(nullptr)
 {
-  interrupt_status.store(InterruptStatus::RUN);
+  interrupt_status = InterruptStatus::RUN;
 }
 
 
@@ -67,7 +67,7 @@ void progress_manager::finish_work(work* task, bool successfully) {
     delete pbar;
     pbar = nullptr;
   }
-  interrupt_status.store(InterruptStatus::RUN);
+  interrupt_status = InterruptStatus::RUN;
 }
 
 
@@ -95,24 +95,24 @@ void progress_manager::set_error_status(bool cancelled) noexcept {
 }
 
 
-void progress_manager::set_interrupt() const {
-  interrupt_status.store(InterruptStatus::HANDLE_INTERRUPT);
+void progress_manager::set_interrupt() const noexcept {
+  interrupt_status = InterruptStatus::HANDLE_INTERRUPT;
 }
 
 
-bool progress_manager::is_interrupt_occurred() const {
+bool progress_manager::is_interrupt_occurred() const noexcept {
   return interrupt_status != InterruptStatus::RUN;
 }
 
 
-void progress_manager::reset_interrupt_status() const {
-  interrupt_status.store(InterruptStatus::RUN);
+void progress_manager::reset_interrupt_status() const noexcept {
+  interrupt_status = InterruptStatus::RUN;
 }
 
 
 void progress_manager::handle_interrupt() const {
   if (interrupt_status == InterruptStatus::HANDLE_INTERRUPT) {
-    interrupt_status.store(InterruptStatus::ABORT_EXECUTION);
+    interrupt_status = InterruptStatus::ABORT_EXECUTION;
     PyErr_SetNone(PyExc_KeyboardInterrupt);
     throw PyError();
   }

--- a/c/progress/progress_manager.h
+++ b/c/progress/progress_manager.h
@@ -28,7 +28,7 @@ class progress_bar_enabled;
 class work;
 
 
-enum class InterruptStatus : unsigned char {
+enum InterruptStatus : unsigned char {
   RUN = 0,
   ABORT_EXECUTION = 1,
   HANDLE_INTERRUPT = 2
@@ -70,8 +70,8 @@ class progress_manager {
     // is set to InterruptStatus::ABORT_EXECUTION, meaning that
     // job execution should be aborted. When execution is aborted,
     // this flag is set back to InterruptStatus::RUN.
-    mutable std::atomic<InterruptStatus> interrupt_status;
-    size_t : 56;
+    mutable volatile sig_atomic_t interrupt_status;
+    int : 32;
 
   public:
     void update_view() const;
@@ -83,9 +83,9 @@ class progress_manager {
     void start_work(work* task);
     // called by `work.done()` / `~work()`
     void finish_work(work* task, bool successfully);
-    void set_interrupt() const;
-    bool is_interrupt_occurred() const;
-    void reset_interrupt_status() const;
+    void set_interrupt() const noexcept;
+    bool is_interrupt_occurred() const noexcept;
+    void reset_interrupt_status() const noexcept;
     void handle_interrupt() const;
 };
 

--- a/c/progress/progress_manager.h
+++ b/c/progress/progress_manager.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019 H2O.ai
+// Copyright 2019-2020 H2O.ai
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 //------------------------------------------------------------------------------
 #ifndef dt_PROGRESS_MANAGER_h
 #define dt_PROGRESS_MANAGER_h
-#include <atomic>
+#include <csignal>    // sig_atomic_t
 #include <stack>      // std::stack
 #include <mutex>      // std::mutex, std::lock_guard
 namespace dt {

--- a/docs/changelog/v0.11.0.rst
+++ b/docs/changelog/v0.11.0.rst
@@ -18,7 +18,9 @@
 
   -[fix] Avoid rare deadlock when creating a frame from pandas DataFrame in
     a forked process, in the datatable compiled with gcc version before 7.0.
-    (#2272)
+    [#2272]
+
+  -[fix] Fix rare crash in the interrupt signal handler. [#2282]
 
 
   FTRL model


### PR DESCRIPTION
- The signal handler is now declared as an `extern "C"` function, as recommended by the spec;
- The handler only accesses `volatile sig_atomic_t` variables, as required by pre-C++11 standard;
- Check whether `sigint_handler_prev` is NULL before trying to call it (can it possibly be null?).

Closes #2282