### PR TITLE
Another PPC build fix

### DIFF
--- a/ext.py
+++ b/ext.py
@@ -29,6 +29,7 @@
 #-------------------------------------------------------------------------------
 import glob
 import os
+import platform
 import sys
 import textwrap
 from ci import xbuild
@@ -44,7 +45,7 @@ def create_logger(verbosity):
 
 def build_extension(cmd, verbosity=3):
     assert cmd in ["asan", "build", "coverage", "debug"]
-    arch = getattr(sys.implementation, "_multiarch", "unknown")
+    arch = platform.machine()  # 'x86_64' or 'ppc64le'
     windows = (sys.platform == "win32")
     macos = (sys.platform == "darwin")
     linux = (sys.platform == "linux")


### PR DESCRIPTION
The approach with `sys.implementation._multiarch` doesn't work on Python3.5, so we can use `platform.machine()` instead ([platform](https://docs.python.org/3/library/platform.html) is a standard library).