### PR TITLE
Added Sphinx directive ..ref-context

### DIFF
--- a/datatable/sphinxext/ref_context.py
+++ b/datatable/sphinxext/ref_context.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+#-------------------------------------------------------------------------------
+# Copyright 2020 H2O.ai
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#-------------------------------------------------------------------------------
+#
+# Simple Sphinx directive that can be used like this:
+#
+#     .. ref-context:: datatable.Frame
+#
+#     Method :meth:`.to_csv()` allows to create CSV files ...
+#
+# What this directive does is that it treats all references
+# encountered after this directive as belonging to the specified
+# module/class, and resolves those references accordingly.
+#
+#-------------------------------------------------------------------------------
+from docutils import nodes
+from sphinx import addnodes
+from sphinx.util.docutils import SphinxDirective
+
+
+
+#-------------------------------------------------------------------------------
+# ref-context directive + node
+#-------------------------------------------------------------------------------
+
+class RefContextDirective(SphinxDirective):
+    has_content = False
+    required_arguments = 1
+    optional_arguments = 0
+
+    def run(self):
+        context = self.arguments[0]
+        return [ref_context_node(context)]
+
+
+class ref_context_node(nodes.Node):
+    def __init__(self, context):
+        super().__init__()
+        self.children = ()  # needed for traversal by docutils
+        self.context = context
+
+def noop(self, node):   # visit/depart node
+    pass
+
+
+
+#-------------------------------------------------------------------------------
+# Resolve references
+#-------------------------------------------------------------------------------
+
+# See https://www.sphinx-doc.org/en/master/extdev/appapi.html#event-doctree-read
+def on_doctree_read(app, doctree):
+    for ctx_node in doctree.traverse(ref_context_node):
+        context = ctx_node.context
+        for ref_node in ctx_node.traverse(addnodes.pending_xref, siblings=True):
+            if ref_node['refexplicit']:
+                continue
+            target = ref_node['reftarget']
+            if "(" in target:
+                target = target[:target.find("(")]
+            if target[:1] == '.':
+                target = target[1:]
+            if "." in target:
+                prefix = target[:target.rfind('.')]
+                if context.endswith(prefix):
+                    target = target[len(prefix) + 1:]
+                else:
+                    continue
+            target = context + "." + target
+            ref_node['reftarget'] = target
+
+
+
+
+#-------------------------------------------------------------------------------
+# setup
+#-------------------------------------------------------------------------------
+
+def setup(app):
+    app.add_node(ref_context_node, html=(noop, noop))
+    app.connect("doctree-read", on_doctree_read)
+    app.add_directive("ref-context", RefContextDirective)
+    return {"parallel_read_safe": True, "parallel_write_safe": True}

--- a/docs/changelog/v0.10.1.rst
+++ b/docs/changelog/v0.10.1.rst
@@ -6,6 +6,8 @@
   Frame
   -----
 
+  .. ref-context:: datatable.Frame
+
   -[api] A Python list of integers containing only 0s and 1s will now produce
     an ``int8`` column instead of ``bool8``. In order to create a boolean
     column supply a list of Trues and Falses, or force the boolean stype with
@@ -26,11 +28,13 @@
     version 4.8 or earlier. (#2250)
 
   -[fix] Fixed an error when a frame with a computed boolean column was
-    saved into csv. [#2253]
+    saved into a CSV file. [#2253]
 
 
   General
   -------
+
+  .. ref-context:: datatable
 
   -[api] Properties ``dt.bool8.min`` and ``dt.bool8.max`` are now equal to
     ``False`` and ``True`` respectively, instead of integers 0 and 1. (#2231)
@@ -43,13 +47,15 @@
   FTRL model
   ----------
 
+  .. ref-context:: datatable.models.Ftrl
+
   -[fix] Fix feature importance normalization to [0, 1] in FTRL. (#2224)
 
   -[fix] Resetting an untrained FTRL model now doesn't result in a segfault.
     (#2226)
 
-  -[enh] The ``id`` column in FTRL model ``.labels`` frame now has stype
-    ``int32`` instead of ``bool`` for binomial and regression models.
+  -[enh] The "id" column in FTRL model's frame :attr:`.labels` now has stype
+    ``int32`` instead of ``bool8`` for binomial and regression models.
 
 
 
@@ -62,6 +68,6 @@
 
   People who contributed patches and pull requests (PRs):
 
-  - :user:`Pasha Stetsenko <st-pasha>`
-  - :user:`Oleksiy Kononenko <oleksiyskononenko>`
-  - :user:`Bijan Pourhamzeh <bpourhamzeh>`
+  -[gh.old] :user:`Pasha Stetsenko <st-pasha>`
+  -[gh.old] :user:`Oleksiy Kononenko <oleksiyskononenko>`
+  -[gh.new] :user:`Bijan Pourhamzeh <bpourhamzeh>`

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,6 +57,7 @@ needs_sphinx = '1.8'
 extensions = [
     'sphinxext.dtframe_directive',
     'sphinxext.dt_changelog',
+    'sphinxext.ref_context',
     'nbsphinx',
     'sphinx.ext.autodoc',
     'sphinx.ext.mathjax',


### PR DESCRIPTION
This new directive makes it easy to link to functions / methods from datatable doc pages. In particular, the following functionality is enabled:
```
.. ref-context:: datatable.Frame

* :meth:`.to_dict()`
* :meth:`Frame.to_tuples`
* :meth:`.to_csv(filename, **kwargs)`
```
these will all be linked to their proper targets: `datatable.Frame.to_dict`, `datatable.Frame.to_tuples` and `datatable.Frame.to_csv` respectively. At the same time, the links will retain their text as written, allowing us to tailor the text to the context where it appears. 

For example:
```
*  Added function :func:`repeat(frame, n)` that creates a new
   Frame by row-binding ``n`` copies of the ``frame``.
```
Here it makes sense to write the function with its list of parameters, so that we could also describe those parameters in the same sentence.