### PR TITLE
Fix a leak in aggregate_exemplars()

### DIFF
--- a/c/models/aggregator.cc
+++ b/c/models/aggregator.cc
@@ -449,7 +449,7 @@ void Aggregator<T>::aggregate_exemplars(bool was_sampled) {
   // Applying exemplars row index and binding exemplars with the counts.
   RowIndex ri_exemplars = RowIndex(std::move(exemplar_indices));
   dt_exemplars->apply_rowindex(ri_exemplars);
-  std::vector<DataTable*> dts = { dt_counts.release() };
+  std::vector<DataTable*> dts = { dt_counts.get() };
   dt_exemplars->cbind(dts);
   job.done();
 }


### PR DESCRIPTION
`DataTable` object stored in `dt_counts` unique_ptr was never deleted.