### PR TITLE
Improve documentation of cbind()

### DIFF
--- a/c/frame/cbind.cc
+++ b/c/frame/cbind.cc
@@ -40,17 +40,17 @@ method is roughly equivalent to `pandas.concat(axis=1)`.
 
 The frames being cbound must all either have the same number of rows,
 or some of them may have only a single row. Such single-row frames
-will be automatically expanded, replicating thei value as needed.
-This makes it easy to create constant columns, or to append reduction
+will be automatically expanded, replicating the value as needed.
+This makes it easy to create constant columns or to append reduction
 results (such as min/max/mean/etc) to the current Frame.
 
-If some of the `frames` have incompatible number of rows, then the
+If some of the `frames` have an incompatible number of rows, then the
 operation will fail with an :exc:`InvalidOperationError`. However, if
 you set the flag `force` to True, then the error will no longer be
 raised - instead all frames that are shorter than the others will be
 padded with NAs.
 
-If the frames being appended have same column names as the current
+If the frames being appended have the same column names as the current
 frame, then those names will be :ref:`mangled <name-mangling>`
 to ensure that the column names in the current frame remain unique.
 A warning will also be issued in this case.

--- a/c/frame/cbind.cc
+++ b/c/frame/cbind.cc
@@ -117,10 +117,9 @@ Examples
 See also
 --------
 - :func:`dt.cbind() <datatable.cbind>` -- function for cbinding frames
-  "out-of-place".
+  "out-of-place" instead of in-place;
 
-- :meth:`.rbind()` -- method for row-binding frames, i.e. append them
-  along the rows-dimension, instead of column-axis.
+- :meth:`.rbind()` -- method for row-binding frames.
 )";
 
 static PKArgs args_cbind(0, 0, 1, true, false, {"force"}, "cbind", doc_cbind);

--- a/c/frame/cbind.cc
+++ b/c/frame/cbind.cc
@@ -51,7 +51,7 @@ raised - instead all frames that are shorter than the others will be
 padded with NAs.
 
 If the frames being appended have same column names as the current
-frame, then those names will be :ref:`mangled <names_deduplication>`
+frame, then those names will be :ref:`mangled <name-mangling>`
 to ensure that the column names in the current frame remain unique.
 A warning will also be issued in this case.
 

--- a/c/frame/cbind.cc
+++ b/c/frame/cbind.cc
@@ -31,29 +31,37 @@ static const char* doc_cbind =
 R"(cbind(self, *frames, force=False)
 --
 
-Append columns of Frames `frames` to the current Frame.
+Append columns of one or more `frames` to the current Frame.
 
-This is equivalent to `pandas.concat(axis=1)`: the Frames are combined
-by columns, i.e. cbinding a Frame of shape [n x m] to a Frame of
-shape [n x k] produces a Frame of shape [n x (m + k)].
+For example, if the current frame has `n` columns, and you are
+appending another frame with `k` columns, then after this method
+succeeds, the current frame will have `n + k` columns. Thus, this
+method is roughly equivalent to `pandas.concat(axis=1)`.
 
-As a special case, if you cbind a single-row Frame, then that row will
-be replicated as many times as there are rows in the current Frame. This
-makes it easy to create constant columns, or to append reduction results
-(such as min/max/mean/etc) to the current Frame.
+The frames being cbound must all either have the same number of rows,
+or some of them may have only a single row. Such single-row frames
+will be automatically expanded, replicating thei value as needed.
+This makes it easy to create constant columns, or to append reduction
+results (such as min/max/mean/etc) to the current Frame.
 
-If Frame(s) being appended have different number of rows (with the
-exception of Frames having 1 row), then the operation will fail by
-default. You can force cbinding these Frames anyways by providing option
-`force` `=True`: this will fill all "short" Frames with NAs. Thus there is
-a difference in how Frames with 1 row are treated compared to Frames
-with any other number of rows.
+If some of the `frames` have incompatible number of rows, then the
+operation will fail with an :exc:`InvalidOperationError`. However, if
+you set the flag `force` to True, then the error will no longer be
+raised - instead all frames that are shorter than the others will be
+padded with NAs.
+
+If the frames being appended have same column names as the current
+frame, then those names will be :ref:`mangled <names_deduplication>`
+to ensure that the column names in the current frame remain unique.
+A warning will also be issued in this case.
+
 
 Parameters
 ----------
-frames: Frame | List[Frame]
-    One or more Frame to append. They should have the same number of
-    rows (unless option `force` is also used).
+frames: Frame | List[Frame] | None
+    The list/tuple/sequence/generator expression of Frames to append
+    to the current frame. The list may also contain `None` values,
+    which will be simply skipped.
 
 force: bool
     If True, allows Frames to be appended even if they have unequal
@@ -62,6 +70,57 @@ force: bool
     than the largest number of rows, will be padded with NAs (with the
     exception of Frames having just 1 row, which will be replicated
     instead of filling with NAs).
+
+(return): None
+    This method alters the current frame in-place, and doesn't return
+    anything.
+
+(except): InvalidOperationError
+    If trying to cbind frames with the number of rows different from
+    the current frame's, and the option `force` is not set.
+
+
+Notes
+-----
+
+Cbinding frames is a very cheap operation: the columns are copied by
+reference, which means the complexity of the operation depends only
+on the number of columns, not on the number of rows. Still, if you
+are planning to cbind a large number of frames, it will be beneficial
+to collect them in a list first and then call a single `cbind()`
+instead of cbinding them one-by-one.
+
+It is possible to cbind frames using the standard `DT[i,j]` syntax::
+
+    df[:, update(**frame1, **frame2, ...)]
+
+Or, if you need to append just a single column::
+
+    df["newcol"] = frame1
+
+
+Examples
+--------
+>>> DT = dt.Frame(A=[1, 2, 3], B=[4, 7, 0])
+>>> frame1 = dt.Frame(N=[-1, -2, -5])
+>>> DT.cbind(frame1)
+>>> DT
+   |  A   B   N
+-- + --  --  --
+ 0 |  1   4  -1
+ 1 |  2   7  -2
+ 2 |  3   0  -5
+--
+[3 rows x 3 columns]
+
+
+See also
+--------
+- :func:`dt.cbind() <datatable.cbind>` -- function for cbinding frames
+  "out-of-place".
+
+- :meth:`.rbind()` -- method for row-binding frames, i.e. append them
+  along the rows-dimension, instead of column-axis.
 )";
 
 static PKArgs args_cbind(0, 0, 1, true, false, {"force"}, "cbind", doc_cbind);

--- a/docs/_static/code.css
+++ b/docs/_static/code.css
@@ -210,6 +210,7 @@ div[role=navigation] hr {
 h1 {
   border-bottom: 1px solid #ccc;
   font-family: inherit;
+  margin-top: -22pt;
 }
 
 h2 {
@@ -220,4 +221,21 @@ h2 {
 p {
   font-size: 100%;
   line-height: 22px;
+}
+
+p + ul.simple, p + ol.simple {
+  margin-top: -12pt;
+  margin-left: 12pt;
+}
+
+/* inter-paragraph distance is reduced in a ul|ol */
+.rst-content .section ol p + ul.simple,
+.rst-content .section ul p + ul.simple,
+.rst-content .section ol p + ol.simple,
+.rst-content .section ul p + ul.simple {
+  margin-top: -6pt;
+}
+
+ul.simple li, ol.simple li {
+  margin-bottom: 6pt;
 }

--- a/docs/_static/code.css
+++ b/docs/_static/code.css
@@ -99,15 +99,14 @@ div.document div.notranslate.highlight-default {
 }
 
 div.document div.notranslate.highlight-default + div.output-cell {
-  margin-top: -16px;
+  margin-top: -18px;
 }
 
 div.document div.notranslate.highlight-default:before {
-  color: #A6D2BB;
+  color: #CCC;
   content: "[" counter(cc) "]:";
   flex: 0 0 48px;
   font-family: "Source Code Pro", monospace;
-  font-weight: bold;
   font-size: 80%;
   line-height: 24px;
   padding: 0.2em 0.4em;
@@ -117,8 +116,8 @@ div.document div.notranslate.highlight-default:before {
 div.document div.notranslate.highlight-default div.highlight {
   background: #F5F5F5;
   border: 1px solid #E0E0E0;
-  border-radius: 3px;
   flex: 1 1 auto;
+  margin-bottom: 0;
 }
 
 div.document div.notranslate.highlight-default div.highlight pre {
@@ -136,11 +135,10 @@ div.document div.output-cell {
 }
 
 div.document div.output-cell:before {
-  color: #D9B1B2;
+  color: #CCC;
   content: "[" counter(cc) "]:";
   flex: 0 0 48px;
   font-family: "Source Code Pro", monospace;
-  font-weight: bold;
   font-size: 80%;
   padding: .385em;
   text-align: right;

--- a/docs/_static/xfunction.css
+++ b/docs/_static/xfunction.css
@@ -1,6 +1,6 @@
 
 .x-function {
-    margin-bottom: 18pt;
+    margin-bottom: 32pt;
     margin-top: -22pt;
 }
 
@@ -165,6 +165,11 @@
 
 .xparam-head .param.return {
     background-color: #469e36;
+    color: #FFF;
+}
+
+.xparam-head .param.except {
+    background-color: #C50000;
     color: #FFF;
 }
 

--- a/docs/_static/xfunction.css
+++ b/docs/_static/xfunction.css
@@ -1,7 +1,6 @@
 
 .x-function {
     margin-bottom: 32pt;
-    margin-top: -22pt;
 }
 
 

--- a/docs/api/frame.rst
+++ b/docs/api/frame.rst
@@ -10,7 +10,9 @@ Frame
 
 
 .. toctree::
-	:glob:
 	:hidden:
 
-	frame/*
+	.cbind()     <frame/cbind>
+	.colindex()  <frame/colindex>
+	.replace()   <frame/replace>
+	.to_csv()    <frame/to_csv>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,10 +60,9 @@ extensions = [
     'sphinxext.xfunction',
     'sphinxext.dt_changelog',
     'sphinxext.ref_context',
-    'nbsphinx',
+    # 'nbsphinx',
     'sphinx.ext.autodoc',
     'sphinx.ext.mathjax',
-    # 'sphinx.ext.viewcode',
     'sphinx.ext.napoleon'
 ]
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -89,6 +89,7 @@ messages, and powerful API similar to R ``data.table``'s.
     :hidden:
 
     f-expressions
+    manual/name_mangling
     install
     contrib
     changelog

--- a/docs/manual/name_mangling.rst
+++ b/docs/manual/name_mangling.rst
@@ -14,13 +14,13 @@ Column names in a :class:`Frame` satisfy several invariants:
 - within a single Frame column names must be unique;
 
 - no column name may contain characters from the `C0 control block`_. Among
-  others, this set of forbidden characters includes: the NUL character ``\0``,
+  others, this set of forbidden characters includes: the NULL character ``\0``,
   TAB character ``\t``, and the newline ``\n``.
 
 
 If the user makes an attempt to create a Frame that would violate some of
 these assumptions, then instead of failing we will attempt to **mangle** the
-provided names forcing them to satisfy the above requirements.
+provided names, forcing them to satisfy the above requirements.
 
 Given a list of column names requested by the user, the following algorithm
 is used:
@@ -42,7 +42,7 @@ is used:
      plus 1;
 
    - If the name does not end with a number, then append a dot (``.``) to the
-     name and consider this the ``stem``, for the ``count`` variable take the
+     name and consider this the ``stem``. For the ``count`` variable, take the
      value of option ``dt.options.frame.name_auto_index``.
 
    - Concatenate ``stem`` and ``count``, and check whether this name has been

--- a/docs/manual/name_mangling.rst
+++ b/docs/manual/name_mangling.rst
@@ -1,0 +1,99 @@
+
+.. ref-context:: datatable
+
+.. _name-mangling:
+
+=============
+Name mangling
+=============
+
+Column names in a :class:`Frame` satisfy several invariants:
+
+- they are all non-empty strings;
+
+- within a single Frame column names must be unique;
+
+- no column name may contain characters from the `C0 control block`_. Among
+  others, this set of forbidden characters includes: the NUL character ``\0``,
+  TAB character ``\t``, and the newline ``\n``.
+
+
+If the user makes an attempt to create a Frame that would violate some of
+these assumptions, then instead of failing we will attempt to **mangle** the
+provided names forcing them to satisfy the above requirements.
+
+Given a list of column names requested by the user, the following algorithm
+is used:
+
+1. First, we check all the non-empty names in the list, from left to right.
+   If a name contains characters in the range ``\x00-\x1F``, then every run
+   of 1 or more such characters is replaced with a single dot.
+
+2. Once the special characters are removed from the name, we check it against
+   the set of names that were already encountered. If the current name hasn't
+   been seen before, then we add it to the final list of names and proceed to
+   consider the next name in the list. However, if the name was seen before,
+   then it goes into the *deduplication* stage.
+
+3. When a name needs to be deduplicated, we do the following:
+
+   - If the name ends with a number, then split it into two parts: the ``stem``
+     and the numeric suffix. Let ``count`` be the value of the numeric suffix
+     plus 1;
+
+   - If the name does not end with a number, then append a dot (``.``) to the
+     name and consider this the ``stem``, for the ``count`` variable take the
+     value of option ``dt.options.frame.name_auto_index``.
+
+   - Concatenate ``stem`` and ``count``, and check whether this name has been
+     seen before. If it was, then increment ``count`` by 1, and repeat this
+     step.
+
+   - Use ``stem + count`` as this column's final name. Continue processing
+     other columns.
+
+4. Finally, re-scan the list of column names once again, this time replacing
+   all the empty names. For each empty name we proceed exactly as in (3),
+   using ``dt.options.frame.name_auto_prefix`` as the ``stem``, and
+   ``dt.options.frame.name_auto_index`` as the initial ``count``.
+
+
+Examples
+--------
+
+The default value of ``dt.options.frame.name_auto_prefix`` is ``"C"``, and the
+default value of ``dt.options.frame.name_auto_index`` is ``0``. This means that
+if no column names are given, they will be named as ``C0, C1, C2, ...``::
+
+    >>> dt.Frame([[]] * 5).names
+    ('C0', 'C1', 'C2', 'C3', 'C4')
+
+If the column names contain duplicates, then they will gain a numeric suffix
+(or reuse the existing suffix, if any)::
+
+    >>> dt.Frame(names=["A", "A", "A"]).names
+    ('A', 'A.0', 'A.1')
+    >>> dt.Frame(names=["R3"] * 4).names
+    ('R3', 'R4', 'R5', 'R6')
+
+If some of the column names are given, while others are missing, then the
+missing names will be filled as ``C0, C1, ...``::
+
+    >>> dt.Frame(names=["A", None, "B", None]).names
+    ('A', 'C0', 'B', 'C1')
+
+When replacing the missing names, explicitly given names will have a higher
+precedence and tend to retain their names::
+
+    >>> dt.Frame(names=["A", None, "C0", "C1"]).names
+    ('A', 'C2', 'C0', 'C1')
+
+However, deduplication of the existing names happen from left to right, which
+may affect the subsequent columns::
+
+    >>> dt.Frame(names=["A1", "A1", "A2", "A3"]).names
+    ('A1', 'A2', 'A3', 'A4')
+
+
+
+.. _`C0 control block`: https://en.wikipedia.org/wiki/C0_and_C1_control_codes

--- a/docs/using-datatable.rst
+++ b/docs/using-datatable.rst
@@ -1,19 +1,22 @@
-Using ``datatable``
-===================
+
+.. ref-context datatable
+
+===============
+Using datatable
+===============
 
 This section describes common functionality and commands that you can run in ``datatable``.
 
 Create Frame
 ------------
 
-You can create a Frame from a variety of sources, including ``numpy`` arrays, ``pandas`` DataFrames, raw Python objects, etc:
+You can create a Frame from a variety of sources, including ``numpy`` arrays,
+``pandas`` DataFrames, raw Python objects, etc::
 
-::
-
-  import datatable as dt
-  import numpy as np
-  np.random.seed(1)
-  dt.Frame(np.random.randn(1000000))
+    import datatable as dt
+    import numpy as np
+    np.random.seed(1)
+    dt.Frame(np.random.randn(1000000))
 
 .. dtframe::
     :names: C0
@@ -85,9 +88,8 @@ You can create a Frame from a variety of sources, including ``numpy`` arrays, ``
 Convert a Frame
 ---------------
 
-Convert an existing Frame into a ``numpy`` array, a ``pandas`` DataFrame, or a pure Python object:
-
-::
+Convert an existing Frame into a ``numpy`` array, a ``pandas`` DataFrame,
+or a pure Python object::
 
    nparr = df1.to_numpy()
    pddfr = df1.to_pandas()
@@ -96,9 +98,7 @@ Convert an existing Frame into a ``numpy`` array, a ``pandas`` DataFrame, or a p
 Parse Text (csv) Files
 ----------------------
 
-``datatable`` provides fast and convenient parsing of text (csv) files:
-
-::
+``datatable`` provides fast and convenient parsing of text (csv) files::
 
    df = dt.fread("train.csv")
 
@@ -115,18 +115,15 @@ The ``datatable`` parser
 Write the Frame
 ---------------
 
-Write the Frame's content into a ``csv`` file (also multi-threaded):
-
-::
+Write the Frame's content into a ``csv`` file (also multi-threaded)::
 
    df.to_csv("out.csv")
 
 Save a Frame
 ------------
 
-Save a Frame into a binary format on disk, then open it later instantly, regardless of the data size:
-
-::
+Save a Frame into a binary format on disk, then open it later instantly,
+regardless of the data size::
 
    df.to_jay("out.jay")
    df2 = dt.open("out.jay")
@@ -134,9 +131,7 @@ Save a Frame into a binary format on disk, then open it later instantly, regardl
 Basic Frame Properties
 ----------------------
 
-Basic Frame properties include:
-
-::
+Basic Frame properties include::
 
     print(df.shape)   # (nrows, ncols)
     print(df.names)   # column names
@@ -145,9 +140,7 @@ Basic Frame properties include:
 Compute Per-Column Summary Stats
 --------------------------------
 
-Compute per-column summary stats using:
-
-::
+Compute per-column summary stats using::
 
    df.sum()
    df.max()
@@ -161,9 +154,7 @@ Compute per-column summary stats using:
 Select Subsets of Rows/Columns
 ------------------------------
 
-Select subsets of rows and/or columns using:
-
-::
+Select subsets of rows and/or columns using::
 
    df[:, "A"]         # select 1 column
    df[:10, :]         # first 10 rows
@@ -173,9 +164,7 @@ Select subsets of rows and/or columns using:
 Delete Rows/Columns
 -------------------
 
-Delete rows and or columns using:
-
-::
+Delete rows and or columns using::
 
    del df[:, "D"]     # delete column D
    del df[f.A < 0, :] # delete rows where column A has negative values
@@ -183,27 +172,22 @@ Delete rows and or columns using:
 Filter Rows
 -----------
 
-Filter rows via an expression using the following. In this example, ``mean``, ``sd``, ``f`` are all symbols imported from ``datatable``.
-
-::
+Filter rows via an expression using the following. In this example, ``mean``,
+``sd``, ``f`` are all symbols imported from ``datatable``::
 
    df[(f.x > mean(f.y) + 2.5 * sd(f.y)) | (f.x < -mean(f.y) - sd(f.y)), :]
 
 Compute Columnar Expressions
 ----------------------------
 
-Compute columnar expressions using:
-
-::
+Compute columnar expressions using::
 
    df[:, {"x": f.x, "y": f.y, "x+y": f.x + f.y, "x-y": f.x - f.y}]
 
 Sort Columns
 ------------
 
-Sort columns using:
-
-::
+Sort columns using::
 
     df.sort("A")
     df[:, :, sort(f.A)]
@@ -212,9 +196,7 @@ Sort columns using:
 Perform Groupby Calculations
 ----------------------------
 
-Perform groupby calculations using:
-
-::
+Perform groupby calculations using::
 
     df[:, mean(f.x), by("y")]
 
@@ -222,9 +204,7 @@ Perform groupby calculations using:
 Append Rows/Columns
 -------------------
 
-Append rows / columns to a Frame using:
+Append rows / columns to a Frame using :meth:`Frame.cbind() <datatable.Frame.cbind>`::
 
-::
-
-   df1.cbind(df2, df3)
-   df1.rbind(df4, force=True)
+    df1.cbind(df2, df3)
+    df1.rbind(df4, force=True)

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,5 +1,5 @@
-docutils>=0.14
-sphinx>=1.8
+docutils>=0.15
+sphinx>=2.3
 sphinx_rtd_theme
-nbsphinx>=0.3.5
+nbsphinx>=0.5
 datatable


### PR DESCRIPTION
- The documentation of `cbind()` greatly expanded;
- Added new documentation page "Name mangling" which describes the handling of column names;
- Make sure the HTML title of the page corresponding to each function contains the short function name only, instead of the full name;
- Added new special parameter "except" to the Parameter list, this tag will be highlighted in red;
- Minor style tweaks;