### PR TITLE
Add exception class InvalidOperationError

### DIFF
--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -191,6 +191,7 @@ static void _register_function(const py::PKArgs& args) {
     case 5: replace_valueError(fnref); break;
     case 6: replace_dtWarning(fnref); break;
     case 7: py::Frame_Type = fnref; break;
+    case 8: replace_invalidOpError(fnref); break;
     case 9: py::Expr_Type = fnref; break;
     default: throw ValueError() << "Unknown index: " << n;
   }

--- a/c/frame/cbind.cc
+++ b/c/frame/cbind.cc
@@ -103,9 +103,9 @@ void Frame::cbind(const PKArgs& args)
       size_t inrows = idt->nrows();
       if (nrows == 1) nrows = inrows;
       if (nrows == inrows || inrows == 1) continue;
-      throw ValueError() << "Cannot cbind frame with " << inrows << " rows to "
-          "a frame with " << nrows << " rows. Use `force=True` to disregard "
-          "this check and merge the frames anyways.";
+      throw InvalidOperationError() <<
+          "Cannot cbind frame with " << inrows << " rows to a frame with " <<
+          nrows << " rows";
     }
   }
 

--- a/c/utils/exceptions.cc
+++ b/c/utils/exceptions.cc
@@ -23,6 +23,7 @@ CErrno Errno;
 static PyObject* type_error_class;
 static PyObject* value_error_class;
 static PyObject* datatable_warning_class;
+static PyObject* invalid_operation_error_class;
 
 
 //==============================================================================
@@ -247,10 +248,12 @@ Error OverflowError()  { return Error(PyExc_OverflowError); }
 Error RuntimeError()   { return Error(PyExc_RuntimeError); }
 Error TypeError()      { return Error(type_error_class); }
 Error ValueError()     { return Error(value_error_class); }
+Error InvalidOperationError() { return Error(invalid_operation_error_class); }
 
 void replace_typeError(PyObject* obj) { type_error_class = obj; }
 void replace_valueError(PyObject* obj) { value_error_class = obj; }
 void replace_dtWarning(PyObject* obj) { datatable_warning_class = obj; }
+void replace_invalidOpError(PyObject* obj) { invalid_operation_error_class = obj; }
 
 void init_exceptions() {
   type_error_class = PyExc_TypeError;

--- a/c/utils/exceptions.h
+++ b/c/utils/exceptions.h
@@ -108,10 +108,12 @@ Error NotImplError();
 Error IOError();
 Error AssertionError();
 Error ImportError();
+Error InvalidOperationError();
 
 void replace_typeError(PyObject* obj);
 void replace_valueError(PyObject* obj);
 void replace_dtWarning(PyObject* obj);
+void replace_invalidOpError(PyObject* obj);
 void init_exceptions();
 
 

--- a/datatable/__init__.py
+++ b/datatable/__init__.py
@@ -56,7 +56,7 @@ from .str import split_into_nhot
 from .types import stype, ltype
 from .utils.typechecks import TTypeError as TypeError
 from .utils.typechecks import TValueError as ValueError
-from .utils.typechecks import DatatableWarning
+from .utils.typechecks import DatatableWarning, InvalidOperationError
 import datatable.widget
 import datatable.math
 import datatable.internal
@@ -70,6 +70,7 @@ __all__ = (
     "__git_revision__",
     "__version__",
     "Frame",
+    "InvalidOperationError",
     "corr",
     "count",
     "cov",

--- a/datatable/utils/typechecks.py
+++ b/datatable/utils/typechecks.py
@@ -26,6 +26,10 @@ class TImportError(ImportError):
     _handle_ = TTypeError._handle_
 
 
+class InvalidOperationError(Exception):
+    _handle_ = TTypeError._handle_
+
+
 TTypeError.__module__ = "datatable"
 TValueError.__module__ = "datatable"
 TImportError.__module__ = "datatable"
@@ -69,6 +73,7 @@ warnings.showwarning = _showwarning
 core._register_function(4, TTypeError)
 core._register_function(5, TValueError)
 core._register_function(6, DatatableWarning)
+core._register_function(8, InvalidOperationError)
 
 
 __all__ = ("typed", "is_type", "U", "TTypeError", "TValueError", "TImportError",

--- a/docs/changelog/v0.11.0.rst
+++ b/docs/changelog/v0.11.0.rst
@@ -1,17 +1,27 @@
 
+
 .. changelog::
 
 
   Frame
   -----
+  .. ref-context:: datatable.Frame
 
   -[enh] String columns now support comparison operators ``<``, ``>``, ``<=``
     and ``>=``. [#2274]
 
+  -[api] Method :meth:`.cbind()` now throws an :exc:`InvalidOperationError`
+    instead of a ``ValueError`` if the argument frames have incompatible
+    shapes.
 
 
   General
   -------
+  .. ref-context:: datatable
+
+  -[new] Added exception :exc:`InvalidOperationError`, which can be used to
+    signal when an operation is requested that would be illegal for the given
+    combination of parameters.
 
   -[fix] Internal function :func:`frame_column_data_r` now works properly with
     virtual columns. [#2269]
@@ -25,9 +35,10 @@
 
   FTRL model
   ----------
+  .. ref-context:: datatable.models.Ftrl
 
-  -[enh] ``.nepochs``, the number of epochs to train the model, can now be a
-    float rather than an integer.
+  -[enh] :attr:`.nepochs`, the number of epochs to train the model, can now
+    be a float rather than an integer.
 
 
   Contributors

--- a/tests/munging/test_cbind.py
+++ b/tests/munging/test_cbind.py
@@ -1,14 +1,31 @@
 #!/usr/bin/env python
-# © H2O.ai 2018; -*- encoding: utf-8 -*-
-#   This Source Code Form is subject to the terms of the Mozilla Public
-#   License, v. 2.0. If a copy of the MPL was not distributed with this
-#   file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -*- coding: utf-8 -*-
+#-------------------------------------------------------------------------------
+# Copyright 2018-2020 H2O.ai
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
 #-------------------------------------------------------------------------------
 import pytest
 import types
 import datatable as dt
 from tests import assert_equals
-from datatable import stype, DatatableWarning
+from datatable import stype, DatatableWarning, InvalidOperationError
 from datatable.internal import frame_integrity_check, frame_columns_virtual
 
 
@@ -105,10 +122,9 @@ def test_cbind_notinplace():
 def test_cbind_notforced():
     d0 = dt.Frame([1, 2, 3])
     d1 = dt.Frame([4, 5])
-    with pytest.raises(ValueError) as e:
+    msg = "Cannot cbind frame with 2 rows to a frame with 3 rows"
+    with pytest.raises(InvalidOperationError, match=msg):
         d0.cbind(d1)
-    assert ("Cannot cbind frame with 2 rows to a frame with 3 rows"
-            in str(e.value))
 
 
 def test_cbind_forced1():
@@ -302,28 +318,25 @@ def test_cbind_0rows_3():
 
 def test_cbind_error_1():
     DT = dt.Frame(A=[1, 5])
-    with pytest.raises(ValueError) as e:
+    msg = "Cannot cbind frame with 0 rows to a frame with 2 rows"
+    with pytest.raises(InvalidOperationError, match=msg):
         DT.cbind(dt.Frame(B=[]))
-    assert ("Cannot cbind frame with 0 rows to a frame with 2 rows"
-            in str(e.value))
 
 
 def test_cbind_error_2():
     DT = dt.Frame(A=[])
-    with pytest.raises(ValueError) as e:
+    msg = "Cannot cbind frame with 2 rows to a frame with 0 rows"
+    with pytest.raises(InvalidOperationError, match=msg):
         DT.cbind(dt.Frame(B=[1, 5]))
-    assert ("Cannot cbind frame with 2 rows to a frame with 0 rows"
-            in str(e.value))
 
 
 def test_cbind_error_3():
     DT = dt.Frame()
     DT.nrows = 5
     assert DT.shape == (5, 0)
-    with pytest.raises(ValueError) as e:
+    msg = "Cannot cbind frame with 0 rows to a frame with 5 rows"
+    with pytest.raises(InvalidOperationError, match=msg):
         DT.cbind(dt.Frame(B=[]))
-    assert ("Cannot cbind frame with 0 rows to a frame with 5 rows"
-            in str(e.value))
 
 
 def test_issue1905():


### PR DESCRIPTION
In this PR the new class is used in `cbind()` method only. Over time we can convert more methods to use this new exception class as seem appropriate.