### PR TITLE
Improve documentation for copy()

### DIFF
--- a/c/frame/py_frame.cc
+++ b/c/frame/py_frame.cc
@@ -86,9 +86,9 @@ including column names, types, and keys.
 
 By default, copying is shallow with copy-on-write semantics. This
 means that only the minimal information about the frame is copied,
-while all internal data buffers are shared between the copies.
+while all the internal data buffers are shared between the copies.
 Nevertheless, due to the copy-on-write semantics, any changes made to
-one of the frames will not propagate to the other: instead, the data
+one of the frames will not propagate to the other; instead, the data
 will be copied whenever the user attempts to modify it.
 
 It is also possible to explicitly request a deep copy of the frame
@@ -104,7 +104,7 @@ deep: bool
     "deep" copy of the original frame.
 
 (return): Frame
-    A new Frame, which is the copy of the current.
+    A new Frame, which is the copy of the current frame.
 
 
 Examples
@@ -127,7 +127,7 @@ Notes
 
 - Deep copying is more expensive, since the data has to be physically
   written to new memory, and if the source columns are virtual, then
-  it needs to be computed too.
+  they need to be computed too.
 
 - Another way to create a copy of the frame is using a `DT[i,j]`
   expression (however, this will not copy the key property)::

--- a/c/frame/py_frame.cc
+++ b/c/frame/py_frame.cc
@@ -92,9 +92,9 @@ one of the frames will not propagate to the other; instead, the data
 will be copied whenever the user attempts to modify it.
 
 It is also possible to explicitly request a deep copy of the frame
-by setting the parameter `deep` to True. With this flag, the returned
-copy will be truly independent from the original. The returned frame
-will also be fully materialized in this case.
+by setting the parameter `deep` to `True`. With this flag, the
+returned copy will be truly independent from the original. The
+returned frame will also be fully materialized in this case.
 
 
 Parameters
@@ -129,7 +129,7 @@ Notes
   written to new memory, and if the source columns are virtual, then
   they need to be computed too.
 
-- Another way to create a copy of the frame is using a `DT[i,j]`
+- Another way to create a copy of the frame is using a `DT[i, j]`
   expression (however, this will not copy the key property)::
 
     DT[:, :]

--- a/c/frame/py_frame.cc
+++ b/c/frame/py_frame.cc
@@ -75,27 +75,56 @@ oobj Frame::tail(const PKArgs& args) {
 // copy()
 //------------------------------------------------------------------------------
 
-static PKArgs args_copy(
-  0, 0, 1, false, false,
-  {"deep"}, "copy",
-
+static const char* doc_copy =
 R"(copy(self, deep=False)
 --
 
-Make a copy of this frame.
+Make a copy of the frame.
 
-By default, this method creates a shallow copy of the current frame:
-only references are copied, not the data itself. However, due to
-copy-on-write semantics any changes made to one of the frames will not
-propagate to the other. Thus, for most intents and purposes the copied
-frame will behave as if it was deep-copied.
+The returned frame will be an identical copy of the original,
+including column names, types, and keys.
 
-Still, it is possible to explicitly request a deep copy of the frame,
-using the parameter `deep=True`. Even though it is not needed most of
-the time, there still could be situations where you may want to use
-this parameter: for example for auditing purposes, or if you want to
-explicitly control the moment when the copying is made.
-)");
+By default, copying is shallow with copy-on-write semantics. This
+means that only the minimal information about the frame is copied,
+while all internal data buffers are shared between the copies.
+Nevertheless, due to the copy-on-write semantics, any changes made to
+one of the frames will not propagate to the other: instead, the data
+will be copied whenever the user attempts to modify it.
+
+It is also possible to explicitly request a deep copy of the frame
+by setting the parameter `deep` to True. With this flag, the returned
+copy will be truly independent from the original. The returned frame
+will also be fully materialized in this case.
+
+
+Parameters
+----------
+deep: bool
+    Flag indicating whether to return a "shallow" (default), or a
+    "deep" copy of the original frame.
+
+(return): Frame
+    A new Frame, which is the copy of the current.
+
+Notes
+-----
+(low cost)
+(deepcopt - high cost)
+(DT[:,:])
+(copy.copy / copy.deepcopy)
+
+
+Examples
+--------
+
+>>> DT1 = dt.Frame(range(5))
+>>> DT2 = DT1.copy()
+>>>
+)";
+
+static PKArgs args_copy(0, 0, 1, false, false, {"deep"}, "copy", doc_copy);
+
+
 
 oobj Frame::copy(const PKArgs& args) {
   bool deepcopy = args[0].to<bool>(false);

--- a/c/frame/py_frame.cc
+++ b/c/frame/py_frame.cc
@@ -135,7 +135,7 @@ Notes
     DT[:, :]
 
 - `Frame` class also supports copying via the standard Python library
-  `copy()`::
+  ``copy``::
 
     import copy
     DT_shallow_copy = copy.copy(DT)

--- a/c/frame/py_frame.cc
+++ b/c/frame/py_frame.cc
@@ -106,24 +106,44 @@ deep: bool
 (return): Frame
     A new Frame, which is the copy of the current.
 
-Notes
------
-(low cost)
-(deepcopt - high cost)
-(DT[:,:])
-(copy.copy / copy.deepcopy)
-
 
 Examples
 --------
 
 >>> DT1 = dt.Frame(range(5))
 >>> DT2 = DT1.copy()
->>>
+>>> DT2[0, 0] = -1
+>>> DT2.to_list()
+[[-1, 1, 2, 3, 4]]
+>>> DT1.to_list()
+[[0, 1, 2, 3, 4]]
+
+
+Notes
+-----
+- Non-deep frame copy is a very low-cost operation: its speed depends
+  on the number of columns only, not on the number of rows. On a
+  regular laptop copying a 100-column frame takes about 30-50µs.
+
+- Deep copying is more expensive, since the data has to be physically
+  written to new memory, and if the source columns are virtual, then
+  it needs to be computed too.
+
+- Another way to create a copy of the frame is using a `DT[i,j]`
+  expression (however, this will not copy the key property)::
+
+    DT[:, :]
+
+- `Frame` class also supports copying via the standard Python library
+  `copy()`::
+
+    import copy
+    DT_shallow_copy = copy.copy(DT)
+    DT_deep_copy = copy.deepcopy(DT)
+
 )";
 
 static PKArgs args_copy(0, 0, 1, false, false, {"deep"}, "copy", doc_copy);
-
 
 
 oobj Frame::copy(const PKArgs& args) {

--- a/docs/api/frame.rst
+++ b/docs/api/frame.rst
@@ -6,7 +6,7 @@ Frame
     :members:
     :inherited-members:
     :undoc-members:
-    :exclude-members: cbind, colindex, replace, to_csv
+    :exclude-members: cbind, colindex, copy, replace, to_csv
 
 
 .. toctree::
@@ -14,5 +14,6 @@ Frame
 
 	.cbind()     <frame/cbind>
 	.colindex()  <frame/colindex>
+	.copy()      <frame/copy>
 	.replace()   <frame/replace>
 	.to_csv()    <frame/to_csv>

--- a/docs/api/frame/copy.rst
+++ b/docs/api/frame/copy.rst
@@ -1,3 +1,4 @@
 
 .. xmethod:: datatable.Frame.copy
     :src: c/frame/py_frame.cc Frame::copy
+    :tests: tests/frame/test-copy.py

--- a/docs/api/frame/copy.rst
+++ b/docs/api/frame/copy.rst
@@ -1,0 +1,3 @@
+
+.. xmethod:: datatable.Frame.copy
+    :src: c/frame/py_frame.cc Frame::copy

--- a/tests/frame/test-copy.py
+++ b/tests/frame/test-copy.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#-------------------------------------------------------------------------------
+# Copyright 2018-2020 H2O.ai
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#-------------------------------------------------------------------------------
+import copy
+import datatable as dt
+import pytest
+from datatable import f
+from datatable.internal import frame_integrity_check
+from tests import assert_equals
+
+
+
+def test_copy_frame():
+    d0 = dt.Frame(A=range(5),
+                  B=["dew", None, "strab", "g", None],
+                  C=[1.0 - i * 0.2 for i in range(5)],
+                  D=[True, False, None, False, True])
+    assert sorted(d0.names) == list("ABCD")
+    d1 = d0.copy()
+    frame_integrity_check(d0)
+    frame_integrity_check(d1)
+    assert d0.names == d1.names
+    assert d0.stypes == d1.stypes
+    assert d0.to_list() == d1.to_list()
+    d0[1, "A"] = 100
+    assert d0.to_list() != d1.to_list()
+    d0.names = ("w", "x", "y", "z")
+    assert d1.names != d0.names
+
+
+def test_copy_keyed_frame():
+    d0 = dt.Frame(A=range(5), B=["alpha", "beta", "gamma", "delta", "epsilon"])
+    d0.key = "A"
+    d1 = d0.copy()
+    d2 = dt.Frame(d0)
+    frame_integrity_check(d1)
+    frame_integrity_check(d2)
+    assert d2.names == d1.names == d0.names
+    assert d2.stypes == d1.stypes == d0.stypes
+    assert d2.key == d1.key == d0.key
+    assert d2.to_list() == d1.to_list() == d0.to_list()
+
+
+def test_deep_copy():
+    DT = dt.Frame(A=range(5), B=["alpha", "beta", "gamma", "delta", "epsilon"])
+    DT = DT[:, ["A", "B"]]  # for py35
+    D1 = DT.copy(deep=False)
+    D2 = DT.copy(deep=True)
+    assert_equals(DT, D1)
+    assert_equals(DT, D2)
+    dt_ptr = dt.internal.frame_column_data_r(DT, 1)
+    assert dt.internal.frame_column_data_r(D1, 1).value == dt_ptr.value
+    assert dt.internal.frame_column_data_r(D2, 1).value != dt_ptr.value
+
+
+def test_copy_copy():
+    DT = dt.Frame(A=range(5))
+    D1 = copy.copy(DT)
+    assert_equals(DT, D1)
+
+
+def test_copy_deepcopy():
+    DT = dt.Frame(A=[5.6, 4.4, 9.3, None])
+    D1 = copy.deepcopy(DT)
+    assert_equals(DT, D1)
+    assert (dt.internal.frame_column_data_r(D1, 0).value !=
+            dt.internal.frame_column_data_r(DT, 0).value)
+
+
+def test_rename_after_copy():
+    # Check that when copying a frame, the changes to memoized .py_names and
+    # .py_inames do not get propagated to the original Frame.
+    d0 = dt.Frame([[1], [2], [3]])
+    assert d0.names == ("C0", "C1", "C2")
+    d1 = d0.copy()
+    assert d1.names == ("C0", "C1", "C2")
+    d1.names = {"C1": "ha!"}
+    assert d1.names == ("C0", "ha!", "C2")
+    assert d0.names == ("C0", "C1", "C2")
+    assert d1.colindex("ha!") == 1
+    with pytest.raises(KeyError):
+        d0.colindex("ha!")
+
+
+def test_setkey_after_copy():
+    # See issue #2095
+    DT = dt.Frame([[3] * 5, range(5)], names=["id1", "id2"])
+    assert DT.colindex("id1") == 0
+    assert DT.colindex("id2") == 1
+    X = DT.copy()
+    X.key = "id2"
+    assert DT.colindex("id1") == 0
+    assert DT.colindex("id2") == 1
+    frame_integrity_check(DT)
+
+
+def test_issue2179(numpy):
+    DT = dt.Frame(numpy.ma.array([False], mask=[True]), names=['A'])
+    DT1 = copy.deepcopy(DT)
+    DT2 = copy.deepcopy(DT)
+    frame_integrity_check(DT1)
+    frame_integrity_check(DT2)

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -576,33 +576,6 @@ def test_rename_dict():
     assert d0.colindex("z") == 2
 
 
-def test_rename_frame_copy():
-    # Check that when copying a frame, the changes to memoized .py_names and
-    # .py_inames do not get propagated to the original Frame.
-    d0 = dt.Frame([[1], [2], [3]])
-    assert d0.names == ("C0", "C1", "C2")
-    d1 = d0.copy()
-    assert d1.names == ("C0", "C1", "C2")
-    d1.names = {"C1": "ha!"}
-    assert d1.names == ("C0", "ha!", "C2")
-    assert d0.names == ("C0", "C1", "C2")
-    assert d1.colindex("ha!") == 1
-    with pytest.raises(KeyError):
-        d0.colindex("ha!")
-
-
-def test_setkey_frame_copy():
-    # See issue #2095
-    DT = dt.Frame([[3] * 5, range(5)], names=["id1", "id2"])
-    assert DT.colindex("id1") == 0
-    assert DT.colindex("id2") == 1
-    X = DT.copy()
-    X.key = "id2"
-    assert DT.colindex("id1") == 0
-    assert DT.colindex("id2") == 1
-    frame_integrity_check(DT)
-
-
 def test_rename_bad1():
     d0 = dt.Frame([[1], [2], ["hello"]], names=("a", "b", "c"))
     with pytest.raises(TypeError):
@@ -1033,71 +1006,6 @@ def test_single_element_select_invalid_column(dt0):
 
 
 
-
-#-------------------------------------------------------------------------------
-# Frame copy
-#-------------------------------------------------------------------------------
-
-def test_copy_frame():
-    d0 = dt.Frame(A=range(5),
-                  B=["dew", None, "strab", "g", None],
-                  C=[1.0 - i * 0.2 for i in range(5)],
-                  D=[True, False, None, False, True])
-    assert sorted(d0.names) == list("ABCD")
-    d1 = d0.copy()
-    frame_integrity_check(d0)
-    frame_integrity_check(d1)
-    assert d0.names == d1.names
-    assert d0.stypes == d1.stypes
-    assert d0.to_list() == d1.to_list()
-    d0[1, "A"] = 100
-    assert d0.to_list() != d1.to_list()
-    d0.names = ("w", "x", "y", "z")
-    assert d1.names != d0.names
-
-
-def test_copy_keyed_frame():
-    d0 = dt.Frame(A=range(5), B=["alpha", "beta", "gamma", "delta", "epsilon"])
-    d0.key = "A"
-    d1 = d0.copy()
-    d2 = dt.Frame(d0)
-    frame_integrity_check(d1)
-    frame_integrity_check(d2)
-    assert d2.names == d1.names == d0.names
-    assert d2.stypes == d1.stypes == d0.stypes
-    assert d2.key == d1.key == d0.key
-    assert d2.to_list() == d1.to_list() == d0.to_list()
-
-
-def test_deep_copy():
-    DT = dt.Frame(A=range(5), B=["alpha", "beta", "gamma", "delta", "epsilon"])
-    DT = DT[:, ["A", "B"]]  # for py35
-    D1 = DT.copy(deep=False)
-    D2 = DT.copy(deep=True)
-    assert_equals(DT, D1)
-    assert_equals(DT, D2)
-    dt_ptr = dt.internal.frame_column_data_r(DT, 1)
-    assert dt.internal.frame_column_data_r(D1, 1).value == dt_ptr.value
-    assert dt.internal.frame_column_data_r(D2, 1).value != dt_ptr.value
-
-
-def test_copy_copy():
-    import copy
-    DT = dt.Frame(A=range(5))
-    D1 = copy.copy(DT)
-    assert_equals(DT, D1)
-
-
-def test_copy_deepcopy():
-    import copy
-    DT = dt.Frame(A=[5.6, 4.4, 9.3, None])
-    D1 = copy.deepcopy(DT)
-    assert_equals(DT, D1)
-    assert (dt.internal.frame_column_data_r(D1, 0).value !=
-            dt.internal.frame_column_data_r(DT, 0).value)
-
-
-
 #-------------------------------------------------------------------------------
 # head / tail
 #-------------------------------------------------------------------------------
@@ -1265,15 +1173,6 @@ def test_issue2036():
     assert DT.nrows == 14
     DT = DT.copy()
     assert DT.nrows == 14
-
-
-def test_issue2179(numpy):
-    import copy
-    DT = dt.Frame(numpy.ma.array([False], mask=[True]), names=['A'])
-    DT1 = copy.deepcopy(DT)
-    DT2 = copy.deepcopy(DT)
-    frame_integrity_check(DT1)
-    frame_integrity_check(DT2)
 
 
 def test_issue2269():


### PR DESCRIPTION
- expanded documentation of `Frame.copy()` and converted into new xfunction format;
- tests for this function moved into a separate file.