### PR TITLE
Add dt.options.progress.allow_interruption option

### DIFF
--- a/c/parallel/monitor_thread.cc
+++ b/c/parallel/monitor_thread.cc
@@ -27,7 +27,6 @@
 #include "progress/progress_manager.h"  // dt::progress::progress_manager
 #include "parallel/thread_worker.h"     // idle_job
 #include "utils/exceptions.h"
-#include <iostream>
 
 // volatile std::sig_atomic_t gSignalStatus;
 using sig_handler_t = void(*)(int);

--- a/c/parallel/monitor_thread.cc
+++ b/c/parallel/monitor_thread.cc
@@ -23,9 +23,11 @@
 #include <csignal>                      // std::signal, sig_atomic_t
 #include "parallel/api.h"
 #include "parallel/monitor_thread.h"
+#include "progress/_options.h"
 #include "progress/progress_manager.h"  // dt::progress::progress_manager
 #include "parallel/thread_worker.h"     // idle_job
 #include "utils/exceptions.h"
+#include <iostream>
 
 // volatile std::sig_atomic_t gSignalStatus;
 using sig_handler_t = void(*)(int);
@@ -65,7 +67,6 @@ monitor_thread::~monitor_thread() {
 
 
 void monitor_thread::run() noexcept {
-  sigint_handler_prev = std::signal(SIGINT, sigint_handler);
   constexpr auto SLEEP_TIME = std::chrono::milliseconds(20);
 
   // Reduce this thread's priority to a minimum.
@@ -92,6 +93,18 @@ void monitor_thread::run() noexcept {
     // Sleep state
     while (!monitor_thread_active && running) {
       sleep_state_cv.wait(lock);
+    }
+
+    // Set the dt interrupt handler if allowed and if it was not already set.
+    if (dt::progress::allow_interruption && !sigint_handler_prev) {
+      sigint_handler_prev = std::signal(SIGINT, sigint_handler);
+    }
+
+    // Restore the original interrupt handler if we are not allowed
+    // to use the dt handler and if the original handler exists.
+    if (!dt::progress::allow_interruption && sigint_handler_prev) {
+      std::signal(SIGINT, sigint_handler_prev);
+      sigint_handler_prev = nullptr;
     }
 
     // Wake state

--- a/c/progress/_options.cc
+++ b/c/progress/_options.cc
@@ -39,6 +39,23 @@ static void init_option_clear_on_success() {
 
 
 //------------------------------------------------------------------------------
+// dt.options.progress.allow_interruption
+//------------------------------------------------------------------------------
+
+bool allow_interruption = true;
+
+static void init_option_allow_interruption() {
+  dt::register_option(
+    "progress.allow_interruption",
+    []{ return py::obool(allow_interruption); },
+    [](const py::Arg& value){ allow_interruption = value.to_bool_strict(); },
+    "If `True`, allow datatable to handle the `SIGINT` signal to interrupt\n"
+    "long-running tasks."
+  );
+}
+
+
+//------------------------------------------------------------------------------
 // dt.options.progress.enabled
 //------------------------------------------------------------------------------
 
@@ -180,6 +197,7 @@ void init_options() {
   init_option_min_duration();
   init_option_callback();
   init_option_clear_on_success();
+  init_option_allow_interruption();
 }
 
 

--- a/c/progress/_options.h
+++ b/c/progress/_options.h
@@ -34,6 +34,7 @@ extern double min_duration;
 extern PyObject* progress_fn;
 extern bool enabled;
 extern bool clear_on_success;
+extern bool allow_interruption;
 
 
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -54,6 +54,7 @@ def test_options_all():
         "enabled",
         "min_duration",
         "updates_per_second",
+        "allow_interruption",
     }
 
 


### PR DESCRIPTION
Add the `dt.options.progress.allow_interruption` option that will control if datatable is allowed to set a `SIGINT` handler or not. This option is `True` by default. If this option is set to `False`, then it won't be possible to interrupt any long-running datatable tasks with `Control+C`.

WIP for https://github.com/h2oai/h2oai/issues/13469