### PR TITLE
Xfunction Examples section

### DIFF
--- a/datatable/sphinxext/dtframe_directive.py
+++ b/datatable/sphinxext/dtframe_directive.py
@@ -351,7 +351,6 @@ class DtframeDirective(Directive):
         "shape": parse_shape,
         "types": parse_types,
         "names": parse_names,
-        "output": directives.flag,  # temporary
     }
 
     def run(self):
@@ -361,12 +360,9 @@ class DtframeDirective(Directive):
         root_node = div_node(classes=["datatable"])
         root_node += self._make_table(names, types, frame_data)
         root_node += self._make_footer(shape)
-        if "output" in self.options:
-            div = div_node(classes=["output-cell"])
-            div += root_node
-            return [div]
-        else:
-            return [root_node]
+        div = div_node(classes=["highlight-pycon", "notranslate"])
+        div += root_node
+        return [div]
 
 
     def _parse_options(self):

--- a/datatable/sphinxext/xfunction.py
+++ b/datatable/sphinxext/xfunction.py
@@ -570,6 +570,8 @@ class XobjectDirective(SphinxDirective):
         out.append("")
         while i < len(lines):
             line = lines[i]
+            if line == "":
+                break
             if not line.startswith(indent):
                 raise self.error("Unexpected indent in docstring `%s` in "
                                  "file %s" % (self.doc_var, self.doc_file))

--- a/datatable/utils/typechecks.py
+++ b/datatable/utils/typechecks.py
@@ -30,7 +30,7 @@ class InvalidOperationError(Exception):
     _handle_ = TTypeError._handle_
 
 
-class KeyError(KeyError):
+class TKeyError(KeyError):
     """
     This class is similar to `KeyError`, except that it doesn't quote
     its argument in the error message (which is arguably a bug in
@@ -49,7 +49,8 @@ TTypeError.__qualname__ = "TypeError"
 TValueError.__qualname__ = "ValueError"
 TImportError.__qualname__ = "ImportError"
 TImportError.__name__ = "ImportError"
-KeyError.__module__ = "builtins"
+TKeyError.__name__ = "KeyError"
+TKeyError.__module__ = "builtins"
 
 
 
@@ -87,7 +88,7 @@ core._register_function(4, TTypeError)
 core._register_function(5, TValueError)
 core._register_function(6, DatatableWarning)
 core._register_function(8, InvalidOperationError)
-core._register_function(10, KeyError)
+core._register_function(10, TKeyError)
 
 
 __all__ = ("typed", "is_type", "U", "TTypeError", "TValueError", "TImportError",

--- a/datatable/utils/typechecks.py
+++ b/datatable/utils/typechecks.py
@@ -30,7 +30,7 @@ class InvalidOperationError(Exception):
     _handle_ = TTypeError._handle_
 
 
-class TKeyError(KeyError):
+class KeyError(KeyError):
     """
     This class is similar to `KeyError`, except that it doesn't quote
     its argument in the error message (which is arguably a bug in
@@ -49,8 +49,7 @@ TTypeError.__qualname__ = "TypeError"
 TValueError.__qualname__ = "ValueError"
 TImportError.__qualname__ = "ImportError"
 TImportError.__name__ = "ImportError"
-TKeyError.__module__ = "builtins"
-TKeyError.__name__ = "KeyError"
+KeyError.__module__ = "builtins"
 
 
 
@@ -88,7 +87,7 @@ core._register_function(4, TTypeError)
 core._register_function(5, TValueError)
 core._register_function(6, DatatableWarning)
 core._register_function(8, InvalidOperationError)
-core._register_function(10, TKeyError)
+core._register_function(10, KeyError)
 
 
 __all__ = ("typed", "is_type", "U", "TTypeError", "TValueError", "TImportError",

--- a/docs/_static/code.css
+++ b/docs/_static/code.css
@@ -89,6 +89,7 @@ div.document div.notranslate.highlight-bash .highlight {
 
 /* ------- Python code highlighting ----------------------------------------- */
 
+div.document div.notranslate.highlight-python,
 div.document div.notranslate.highlight-default {
   border: none;
   counter-increment: cc;
@@ -98,10 +99,14 @@ div.document div.notranslate.highlight-default {
   margin: 0 0 24px 0;
 }
 
-div.document div.notranslate.highlight-default + div.output-cell {
-  margin-top: -18px;
+div.document div.notranslate.highlight-python + div.output-cell,
+div.document div.notranslate.highlight-python + div.highlight-pycon,
+div.document div.notranslate.highlight-default + div.output-cell,
+div.document div.notranslate.highlight-default + div.highlight-pycon {
+  margin-top: -20px;
 }
 
+div.document div.notranslate.highlight-python:before,
 div.document div.notranslate.highlight-default:before {
   color: #CCC;
   content: "[" counter(cc) "]:";
@@ -113,6 +118,7 @@ div.document div.notranslate.highlight-default:before {
   text-align: right;
 }
 
+div.document div.notranslate.highlight-python div.highlight,
 div.document div.notranslate.highlight-default div.highlight {
   background: #F5F5F5;
   border: 1px solid #E0E0E0;
@@ -120,6 +126,7 @@ div.document div.notranslate.highlight-default div.highlight {
   margin-bottom: 0;
 }
 
+div.document div.notranslate.highlight-python div.highlight pre,
 div.document div.notranslate.highlight-default div.highlight pre {
   padding: .5em 1em;
 }
@@ -127,6 +134,7 @@ div.document div.notranslate.highlight-default div.highlight pre {
 
 /* ------- Output highlighting ---------------------------------------------- */
 
+div.document div.notranslate.highlight-pycon,
 div.document div.output-cell {
   border: none;
   display: flex;
@@ -134,6 +142,12 @@ div.document div.output-cell {
   margin: 0 0 24px 0;
 }
 
+div.document div.notranslate.highlight-pycon + div.highlight-default,
+div.document div.notranslate.highlight-pycon + div.highlight-python {
+  margin-top: -12px;
+}
+
+div.document div.notranslate.highlight-pycon:before,
 div.document div.output-cell:before {
   color: #CCC;
   content: "[" counter(cc) "]:";
@@ -144,11 +158,13 @@ div.document div.output-cell:before {
   text-align: right;
 }
 
+div.document div.notranslate.highlight-pycon .highlight,
 div.document div.output-cell .highlight {
   background: none;
   border: none;
 }
 
+div.document div.notranslate.highlight-pycon .highlight pre,
 div.document div.output-cell .highlight pre {
   padding: 4pt 10pt;
 }

--- a/docs/_static/code.css
+++ b/docs/_static/code.css
@@ -99,9 +99,7 @@ div.document div.notranslate.highlight-default {
   margin: 0 0 24px 0;
 }
 
-div.document div.notranslate.highlight-python + div.output-cell,
 div.document div.notranslate.highlight-python + div.highlight-pycon,
-div.document div.notranslate.highlight-default + div.output-cell,
 div.document div.notranslate.highlight-default + div.highlight-pycon {
   margin-top: -20px;
 }
@@ -134,8 +132,7 @@ div.document div.notranslate.highlight-default div.highlight pre {
 
 /* ------- Output highlighting ---------------------------------------------- */
 
-div.document div.notranslate.highlight-pycon,
-div.document div.output-cell {
+div.document div.notranslate.highlight-pycon {
   border: none;
   display: flex;
   flex-direction: row;
@@ -147,8 +144,7 @@ div.document div.notranslate.highlight-pycon + div.highlight-python {
   margin-top: -12px;
 }
 
-div.document div.notranslate.highlight-pycon:before,
-div.document div.output-cell:before {
+div.document div.notranslate.highlight-pycon:before {
   color: #CCC;
   content: "[" counter(cc) "]:";
   flex: 0 0 48px;
@@ -158,14 +154,12 @@ div.document div.output-cell:before {
   text-align: right;
 }
 
-div.document div.notranslate.highlight-pycon .highlight,
-div.document div.output-cell .highlight {
+div.document div.notranslate.highlight-pycon .highlight {
   background: none;
   border: none;
 }
 
-div.document div.notranslate.highlight-pycon .highlight pre,
-div.document div.output-cell .highlight pre {
+div.document div.notranslate.highlight-pycon .highlight pre {
   padding: 4pt 10pt;
 }
 

--- a/docs/api/math.rst
+++ b/docs/api/math.rst
@@ -381,7 +381,6 @@ Floating-point functions
         :names: C0
         :types: int8
         :shape: 5, 1
-        :output:
 
         0,   3
         1,   2

--- a/docs/using-datatable.rst
+++ b/docs/using-datatable.rst
@@ -22,7 +22,6 @@ You can create a Frame from a variety of sources, including ``numpy`` arrays,
     :names: C0
     :types: float64
     :shape: 1000000, 1
-    :output:
 
     0,1.62435
     1,-0.611756
@@ -51,7 +50,6 @@ You can create a Frame from a variety of sources, including ``numpy`` arrays,
     :names: A
     :types: int64
     :shape: 1000, 1
-    :output:
 
     0,0
     1,1
@@ -78,7 +76,6 @@ You can create a Frame from a variety of sources, including ``numpy`` arrays,
     :names: n, s
     :types: int8, str32
     :shape: 2, 2
-    :output:
 
     0,1,"foo"
     1,3,"bar"


### PR DESCRIPTION
Improve rendering of Examples section in the documentation of functions.
Now the code is properly converted into input/output blocks.
In addition, the textual output of a frame is converted to `..dtframe` directive (although types are not handled properly yet).