### PR TITLE
Ensure KeyError is properly picklable

### DIFF
--- a/c/datatablemodule.cc
+++ b/c/datatablemodule.cc
@@ -193,7 +193,6 @@ static void _register_function(const py::PKArgs& args) {
     case 7: py::Frame_Type = fnref; break;
     case 8: replace_invalidOpError(fnref); break;
     case 9: py::Expr_Type = fnref; break;
-    case 10: replace_keyError(fnref); break;
     default: throw ValueError() << "Unknown index: " << n;
   }
 }

--- a/c/utils/exceptions.cc
+++ b/c/utils/exceptions.cc
@@ -13,6 +13,7 @@
 #include "progress/progress_manager.h"
 #include "python/obj.h"
 #include "python/string.h"
+#include "python/tuple.h"
 #include "utils/exceptions.h"
 #include "utils/assert.h"
 
@@ -24,7 +25,6 @@ static PyObject* type_error_class;
 static PyObject* value_error_class;
 static PyObject* datatable_warning_class;
 static PyObject* invalid_operation_error_class;
-static PyObject* key_error_class;
 
 
 //==============================================================================
@@ -183,7 +183,13 @@ void Error::to_python() const noexcept {
   // See https://stackoverflow.com/questions/1374468
   try {
     const std::string errstr = error.str();
-    PyErr_SetString(pycls, errstr.c_str());
+    if (pycls == PyExc_KeyError) {
+      auto _str = py::oobj::import("datatable.exceptions", "unrepr_str");
+      auto newstr = _str.call({ py::ostring(errstr) });
+      PyErr_SetObject(pycls, newstr.to_borrowed_ref());
+    } else {
+      PyErr_SetString(pycls, errstr.c_str());
+    }
   } catch (const std::exception& e) {
     PyErr_SetString(PyExc_RuntimeError, e.what());
   }
@@ -244,7 +250,7 @@ Error AssertionError() { return Error(PyExc_AssertionError); }
 Error ImportError()    { return Error(PyExc_ImportError); }
 Error IndexError()     { return Error(PyExc_IndexError); }
 Error IOError()        { return Error(PyExc_IOError); }
-Error KeyError()       { return Error(key_error_class); }
+Error KeyError()       { return Error(PyExc_KeyError); }
 Error MemoryError()    { return Error(PyExc_MemoryError); }
 Error NotImplError()   { return Error(PyExc_NotImplementedError); }
 Error OverflowError()  { return Error(PyExc_OverflowError); }
@@ -257,14 +263,12 @@ void replace_typeError(PyObject* obj) { type_error_class = obj; }
 void replace_valueError(PyObject* obj) { value_error_class = obj; }
 void replace_dtWarning(PyObject* obj) { datatable_warning_class = obj; }
 void replace_invalidOpError(PyObject* obj) { invalid_operation_error_class = obj; }
-void replace_keyError(PyObject* obj) { key_error_class = obj; }
 
 void init_exceptions() {
   type_error_class = PyExc_TypeError;
   value_error_class = PyExc_ValueError;
   datatable_warning_class = PyExc_Warning;
   invalid_operation_error_class = PyExc_RuntimeError;
-  key_error_class = PyExc_KeyError;
 }
 
 

--- a/c/utils/exceptions.h
+++ b/c/utils/exceptions.h
@@ -116,7 +116,6 @@ void replace_typeError(PyObject* obj);
 void replace_valueError(PyObject* obj);
 void replace_dtWarning(PyObject* obj);
 void replace_invalidOpError(PyObject* obj);
-void replace_keyError(PyObject* obj);
 void init_exceptions();
 
 

--- a/datatable/exceptions.py
+++ b/datatable/exceptions.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+#-------------------------------------------------------------------------------
+# Copyright 2020 H2O.ai
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#-------------------------------------------------------------------------------
+
+
+
+class unrepr_str(str):
+    """
+    This is a helper class for KeyError, to be used like this:
+
+        >>> raise KeyError(_str("column A not found"))
+        Traceback (most recent call last):
+          File "<stdin>", line 1, in <module>
+        KeyError: column A not found
+
+    The reason this helper class is needed at all is because by
+    default Python will try to repr the message of the exception:
+
+        >>> raise KeyError("column A not found")
+        Traceback (most recent call last):
+          File "<stdin>", line 1, in <module>
+        KeyError: 'column A not found'
+
+    This was a deliberate (although arguably bad) choice in the early
+    days of Python. With this class we attempt to mitigate this design
+    choice by providing a "fake" repr function that returns the
+    wrapped string.
+    """
+    def __init__(self, msg):
+        self.msg = msg
+
+    def __repr__(self):
+        return self.msg

--- a/datatable/utils/typechecks.py
+++ b/datatable/utils/typechecks.py
@@ -30,18 +30,6 @@ class InvalidOperationError(Exception):
     _handle_ = TTypeError._handle_
 
 
-class TKeyError(KeyError):
-    """
-    This class is similar to `KeyError`, except that it doesn't quote
-    its argument in the error message (which is arguably a bug in
-    KeyError's spec).
-    """
-    _handle_ = TTypeError._handle_
-
-    def __str__(self):
-        return self.args[0]
-
-
 TTypeError.__module__ = "datatable"
 TValueError.__module__ = "datatable"
 TImportError.__module__ = "datatable"
@@ -49,8 +37,6 @@ TTypeError.__qualname__ = "TypeError"
 TValueError.__qualname__ = "ValueError"
 TImportError.__qualname__ = "ImportError"
 TImportError.__name__ = "ImportError"
-TKeyError.__name__ = "KeyError"
-TKeyError.__module__ = "builtins"
 
 
 
@@ -88,7 +74,6 @@ core._register_function(4, TTypeError)
 core._register_function(5, TValueError)
 core._register_function(6, DatatableWarning)
 core._register_function(8, InvalidOperationError)
-core._register_function(10, TKeyError)
 
 
 __all__ = ("typed", "is_type", "U", "TTypeError", "TValueError", "TImportError",

--- a/tests/frame/test-colindex.py
+++ b/tests/frame/test-colindex.py
@@ -139,3 +139,19 @@ def test_colindex_after_column_deleted():
     msg = "Column `D` does not exist in the Frame"
     with pytest.raises(KeyError, match=msg):
         DT.colindex("D")
+
+
+def test_keyerror():
+    import pickle
+    import traceback
+    try:
+        dt.Frame()["A"]
+        assert False
+    except KeyError as e:
+        obj = pickle.dumps(e)
+    ee = pickle.loads(obj)
+    assert isinstance(ee, KeyError)
+    assert str(ee) == "Column `A` does not exist in the Frame"
+    # Check that there are no extra quotes
+    assert traceback.format_exception_only(type(ee), ee) == \
+           ["KeyError: Column `A` does not exist in the Frame\n"]


### PR DESCRIPTION
- Added new `exceptions.py` script where we can store all datatable exceptions (currently they live in `dt.utils.typechecks`, which is not a proper place for them);
- Do not subclass builtin `KeyError` exception -- instead give it a "fake" string object, which reprs into a regular string, circumventing python's bug with KeyError;
- Added a test. 