### PR TITLE
AppVeyor integration

### DIFF
--- a/ci/xbuild/compiler.py
+++ b/ci/xbuild/compiler.py
@@ -143,7 +143,7 @@ class Compiler:
 
             if sys.platform == "win32":
                 self._detect_winsdk()
-                msvc_default_path = "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools\\VC\\Tools\\MSVC\\"
+                msvc_default_path = "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Tools\\MSVC\\"
                 msvc_path = os.environ.get("DT_MSVC_PATH", msvc_default_path)
                 if not os.path.isdir(msvc_path):
                     raise ValueError("Microsoft Visual Studio directory %s not found. "

--- a/ci/xbuild/compiler.py
+++ b/ci/xbuild/compiler.py
@@ -147,17 +147,17 @@ class Compiler:
                 msvc_path = os.environ.get("DT_MSVC_PATH", msvc_default_path)
                 if not os.path.isdir(msvc_path):
                     raise ValueError("Microsoft Visual Studio directory %s not found. "
-                                     "Please specify its location in `DT_MSVC_PATH` environment variable." 
+                                     "Please specify its location in `DT_MSVC_PATH` environment variable."
                                      % msvc_path)
 
                 candidates = []
-                compiler_versions = next(os.walk(msvc_default_path))[1]
+                compiler_versions = next(os.walk(msvc_path))[1]
                 for compiler_version in compiler_versions:
                     path =  msvc_default_path + compiler_version
                     bin_path = path + "\\bin\\Hostx64\\x64\\"
                     candidates += [{
-                                    "compiler": bin_path + "cl.exe", 
-                                    "linker": bin_path + "link.exe", 
+                                    "compiler": bin_path + "cl.exe",
+                                    "linker": bin_path + "link.exe",
                                     "path" : path
                                   }]
 
@@ -197,11 +197,11 @@ class Compiler:
         winsdk_path = os.environ.get("DT_WINSDK_PATH", winsdk_default_path)
         if not os.path.isdir(winsdk_path):
             raise ValueError("Windows SDK directory %s not found. "
-                             "Please specify its location in `DT_WINSDK_PATH` environment variable." 
+                             "Please specify its location in `DT_WINSDK_PATH` environment variable."
                              % msvc_path)
 
         # Detect the latest available SDK version
-        winsdk_version_dir = next(os.walk(winsdk_default_path + "\\include"))[1][-1] 
+        winsdk_version_dir = next(os.walk(winsdk_default_path + "\\include"))[1][-1]
         winsdk_include_path = winsdk_default_path + "\\Include\\" + winsdk_version_dir
         winsdk_lib_path = winsdk_default_path + "\\Lib\\" + winsdk_version_dir
         if not os.path.isdir(winsdk_include_path):


### PR DESCRIPTION
- fix a bug when the environment variable `DT_MSVC_PATH` was ignored;
- adjust MSVC default path to correspond to AppVeyor path for build tools.