### PR TITLE
Converted changelogs 0.6.0, 0.5.0, 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,44 +35,6 @@ website.
 
 
 
-## [0.6.0][] — 2018-06-05
-
-### Added
-
-- fread will detect feather file and issue an appropriate error message.
-
-- when fread extracts data from archives into memory, it will now display
-  the size of the extracted data in verbose mode.
-
-- syntax `DT[i, j, by]` is now supported.
-
-- multiple reduction operators can now be performed at once.
-
-- in groupby, reduction columns can now be combined with regular or computed
-  columns.
-
-- during grouping, group keys are now added automatically to the select list.
-
-- implement `sum()` reducer.
-
-- `==` operator now works for string columns too.
-
-- Improved performance of groupby operations.
-
-
-### Fixed
-
-- fread will no longer emit an error if there is an NA string in the header.
-
-- if the input contains excessively long lines, fread will no longer waste time
-  printing a sample of first 5 lines in verbose mode.
-
-- fixed wrong calculation of mean / standard deviation of line length in fread
-  if the sample contained broken lines.
-
-- frame view will no longer get stuck in a Jupyter notebook.
-
-
 ## [0.5.0][] — 2018-05-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,17 +35,6 @@ website.
 
 
 
-## [0.4.0][] — 2018-05-07
-
-### Added
-
-- Fread now parses integers with thousands separator (e.g. "1,000").
-
-- Added option `fread.anonymize` which forces fread to anonymize all user input
-  in the verbose logs / error messages.
-
-- Allow type-casts from booleans / integers / floats into strings.
-
 
 
 ## [0.3.2][] — 2018-04-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,35 +35,6 @@ website.
 
 
 
-## [0.5.0][] — 2018-05-25
-
-### Added
-
-- rbind()-ing now works on columns of all types (including between any types).
-
-- `dt.rbind()` function to perform out-of-place row binding.
-
-- ability to change the number of rows in a Frame.
-
-- ability to modify a Frame in-place by assigning new values to particular
-  cells.
-
-- `dt.__git_version__` variable containing the commit hash from which the
-  package was built.
-
-- ability to read .bz2 compressed files with fread.
-
-
-### Fixed
-
-- Ensure that fread only emits messages to Python from the master thread.
-- Fread can now properly recognize quoted NA strings.
-- Fixed error when unbounded f-expressions were printed to console.
-- Fixed problems when operating with too many memory-mapped Frames at once.
-- Fixed incorrect groupby calculation in some rare cases.
-
-
-
 ## [0.4.0][] — 2018-05-07
 
 ### Added

--- a/docs/release-history.rst
+++ b/docs/release-history.rst
@@ -10,6 +10,7 @@ Release History
 - :doc:`releases/v0.7.0`
 - :doc:`releases/v0.6.0`
 - :doc:`releases/v0.5.0`
+- :doc:`releases/v0.4.0`
 
 
 
@@ -25,3 +26,4 @@ Release History
     releases/v0.7.0
     releases/v0.6.0
     releases/v0.5.0
+    releases/v0.4.0

--- a/docs/release-history.rst
+++ b/docs/release-history.rst
@@ -8,6 +8,7 @@ Release History
 - :doc:`releases/v0.9.0`
 - :doc:`releases/v0.8.0`
 - :doc:`releases/v0.7.0`
+- :doc:`releases/v0.6.0`
 
 
 
@@ -21,3 +22,4 @@ Release History
     releases/v0.9.0
     releases/v0.8.0
     releases/v0.7.0
+    releases/v0.6.0

--- a/docs/release-history.rst
+++ b/docs/release-history.rst
@@ -9,6 +9,7 @@ Release History
 - :doc:`releases/v0.8.0`
 - :doc:`releases/v0.7.0`
 - :doc:`releases/v0.6.0`
+- :doc:`releases/v0.5.0`
 
 
 
@@ -23,3 +24,4 @@ Release History
     releases/v0.8.0
     releases/v0.7.0
     releases/v0.6.0
+    releases/v0.5.0

--- a/docs/releases/v0.4.0.rst
+++ b/docs/releases/v0.4.0.rst
@@ -1,0 +1,18 @@
+
+.. currentmodule:: datatable
+
+.. changelog::
+  :version: 0.4.0
+  :released: 2018-05-07
+
+  .. ref-context:: datatable
+
+
+  -[enh] :func:`fread` now parses integers with thousands separator (for example
+    ``1,000``).
+
+  -[enh] Added option ``fread.anonymize`` which forces fread to anonymize all
+    user input in the verbose logs / error messages.
+
+  -[enh] Allow type-casts from booleans / integers / floats into strings.
+

--- a/docs/releases/v0.5.0.rst
+++ b/docs/releases/v0.5.0.rst
@@ -1,0 +1,36 @@
+
+.. currentmodule:: datatable
+
+.. changelog::
+  :version: 0.5.0
+  :released: 2018-05-25
+
+  .. ref-context:: datatable
+
+  -[new] New function :func:`rbind()` to perform out-of-place row binding.
+
+  -[enh] :func:`rbind`-ing now works on columns of all types (including between
+    any types).
+
+  -[enh] Added ability to change the number of rows in a Frame.
+
+  -[new] It's now possible to modify a Frame in-place by assigning new values
+    to particular cells.
+
+  -[new] Created ``dt.__git_version__`` variable containing the commit hash from
+    which the package was built.
+
+  -[new] Added ability to read ``.bz2`` compressed files with :func:`fread`.
+
+  -[enh] Fread can now properly recognize quoted NA strings.
+
+  -[fix] Ensure that :func:`fread` only emits messages to Python from the master
+    thread.
+
+  -[fix] Fixed an error when unbounded f-expressions were printed to console.
+
+  -[fix] Fixed problems when operating with too many memory-mapped Frames
+    simultaneously.
+
+  -[fix] Fixed incorrect groupby calculation in some rare cases.
+

--- a/docs/releases/v0.6.0.rst
+++ b/docs/releases/v0.6.0.rst
@@ -1,0 +1,41 @@
+
+.. currentmodule:: datatable
+
+.. changelog::
+  :version: 0.6.0
+  :released: 2018-06-05
+
+  .. ref-context:: datatable
+
+  -[new] Syntax ``DT[i, j, by]`` is now supported.
+
+  -[enh] :func:`fread()` will detect a feather file and issue an appropriate
+    error message.
+
+  -[enh] When :func:`fread()` extracts data from archives into memory, it will
+    now display the size of the extracted data in verbose mode.
+
+  -[enh] Multiple reduction operators can now be performed at once.
+
+  -[enh] In groupby, reduction columns can now be combined with regular or
+    computed columns.
+
+  -[enh] During grouping, group keys are now added automatically to the select
+    list.
+
+  -[new] Implemented :func:`sum()` reducer.
+
+  -[enh] The equality operator ``==`` now works for string columns too.
+
+  -[enh] Improved performance of groupby operations.
+
+  -[fix] :func:`fread()` will no longer emit an error if there is an NA string
+    in the header.
+
+  -[fix] If the input contains excessively long lines, :func:`fread()` will no
+    longer waste time printing a sample of first 5 lines in verbose mode.
+
+  -[fix] Fixed wrong calculation of mean / standard deviation of line length in
+    :func:`fread` if the sample contained broken lines.
+
+  -[fix] Frame view will no longer get stuck in a Jupyter notebook.


### PR DESCRIPTION
Convert changelogs from the `.md` format to the `.rst`; minimal cleanup.

WIP for #2304