### PR TITLE
Wheel links in the changelog

### DIFF
--- a/docs/_static/changelog.css
+++ b/docs/_static/changelog.css
@@ -111,11 +111,21 @@
     background: #b9ccf7;
 }
 
-.changelog table.infobox tr.title th {
+.changelog table.infobox tr.subheader {
+    background: #F7D495;
+}
+
+.changelog table.infobox tr.title th,
+.changelog table.infobox tr.subheader th {
     padding: 2px;
     text-align: center;
 }
 
+.changelog table.infobox tr.subheader th {
+    border-top: 6px solid #fafafa;  /* fake margin */
+}
+
 .changelog table.infobox th {
     text-align: left;
+    vertical-align: top;
 }

--- a/docs/releases/v0.10.0.rst
+++ b/docs/releases/v0.10.0.rst
@@ -3,6 +3,12 @@
 .. changelog::
   :version: 0.10.0
   :released: 2019-12-02
+  :wheels: https://files.pythonhosted.org/packages/ed/3a/09d8767fd6b517a4b56e678d2dca4cb954332f374e8de2615a14753c7e70/datatable-0.10.0-cp35-cp35m-macosx_10_7_x86_64.whl
+           https://files.pythonhosted.org/packages/7c/aa/5702847b8523c75746380dabbc0fbab29af1b76ef7aace733e398a178287/datatable-0.10.0-cp35-cp35m-manylinux2010_x86_64.whl
+           https://files.pythonhosted.org/packages/76/ac/0daab502195928df8b99e990f097ba6f5023184bad67e27551fe49918381/datatable-0.10.0-cp36-cp36m-macosx_10_7_x86_64.whl
+           https://files.pythonhosted.org/packages/c4/e8/b96bc264e9e5a7a2589d4d6428ea0b93a46d1e551aba63cd44b595f951f4/datatable-0.10.0-cp36-cp36m-manylinux2010_x86_64.whl
+           https://files.pythonhosted.org/packages/a1/b4/bcb0d0b1c1785d089a43895d5c4e39261792777db2d18e1e1f08c0ee88a6/datatable-0.10.0-cp37-cp37m-macosx_10_7_x86_64.whl
+           https://files.pythonhosted.org/packages/65/eb/005bec115fcd86b3428646361ea2ec20f4647320eda79c1002482c24f386/datatable-0.10.0-cp37-cp37m-manylinux2010_x86_64.whl
 
   Columnsets
   ----------

--- a/docs/releases/v0.10.1.rst
+++ b/docs/releases/v0.10.1.rst
@@ -2,6 +2,14 @@
 .. changelog::
   :version: 0.10.1
   :released: 2019-12-23
+  :wheels: https://files.pythonhosted.org/packages/4c/17/42b347e5f8d4d392a04b463e3c25a34830c9f93af0107055b76407cc0fb6/datatable-0.10.1-cp35-cp35m-macosx_10_7_x86_64.whl
+           https://files.pythonhosted.org/packages/57/17/e7d3c74a629d44263a3b22397b7e43cd2d7d14d5a170bdcbe81f99f77926/datatable-0.10.1-cp35-cp35m-manylinux2010_x86_64.whl
+           https://files.pythonhosted.org/packages/ea/6f/a643d80b70b0b5828580332e4d6d3956abaa257668597857cd296c5083c5/datatable-0.10.1-cp36-cp36m-macosx_10_7_x86_64.whl
+           https://files.pythonhosted.org/packages/3a/e6/55c464201cdfe62e5cb39744d1d04f9d6cf369053edf28f3e7971ec80e63/datatable-0.10.1-cp36-cp36m-manylinux2010_x86_64.whl
+           https://files.pythonhosted.org/packages/72/73/7f7fa7b744b2afea31ef4aef968c744e3b22a7800a313ab6009600d4710a/datatable-0.10.1-cp37-cp37m-macosx_10_7_x86_64.whl
+           https://files.pythonhosted.org/packages/37/79/8f0efc6151f47c8f28238de05d53011a73a12e11201435f09fc651baf4c4/datatable-0.10.1-cp37-cp37m-manylinux2010_x86_64.whl
+           https://files.pythonhosted.org/packages/69/60/1be2bac0477f3d1edae113be010d8fb988df9fb121ea41bb5947e2e9aa76/datatable-0.10.1-cp38-cp38-manylinux2010_x86_64.whl
+           https://files.pythonhosted.org/packages/46/d3/66325bc3a1645f53d530a36d97061b84e2ab380b2b5434fb1f5889846ebe/datatable-0.10.1.tar.gz
 
   Frame
   -----

--- a/docs/releases/v0.3.0.rst
+++ b/docs/releases/v0.3.0.rst
@@ -2,6 +2,7 @@
 .. changelog::
   :version: 0.3.0
   :released: 2018-03-19
+  :wheels: https://files.pythonhosted.org/packages/a0/c4/fb925a263ab65f4706e0f06e6e31a8c3a57f2cc07ec7f16eef53bb1b57f3/datatable-0.3.0-cp35-cp35m-macosx_10_6_x86_64.whl
 
   .. ref-context:: datatable
 

--- a/docs/releases/v0.3.1.rst
+++ b/docs/releases/v0.3.1.rst
@@ -2,6 +2,9 @@
 .. changelog::
   :version: 0.3.1
   :released: 2018-04-20
+  :wheels: https://files.pythonhosted.org/packages/f5/df/08d765bff48d8f2630314eb5b6e703798f765a9952c0a94495a05ea13ffd/datatable-0.3.1-cp35-cp35m-macosx_10_6_x86_64.whl
+           https://files.pythonhosted.org/packages/95/f6/4798ab9418eecea6adb6f060f27e254c6a185352e8a4539ee6c64d5efe8c/datatable-0.3.1-cp36-cp36m-macosx_10_6_intel.whl
+           https://files.pythonhosted.org/packages/fd/98/a881ebd763f8785c4df59518f67f3703c7194f496040c9a472982fb8544d/datatable-0.3.1.tar.gz
 
   .. ref-context:: datatable
 

--- a/docs/releases/v0.3.2.rst
+++ b/docs/releases/v0.3.2.rst
@@ -2,6 +2,9 @@
 .. changelog::
   :version: 0.3.2
   :released: 2018-04-25
+  :wheels: https://files.pythonhosted.org/packages/7b/35/0f6ec6f8cdf97a1334a4d612382444cd8406df967afee1b8d359239561d2/datatable-0.3.2-cp35-cp35m-macosx_10_6_x86_64.whl
+           https://files.pythonhosted.org/packages/b0/d0/2727e2355c748435fa5407a25b12c69c1ed72e644bad6a532f03131237fc/datatable-0.3.2-cp36-cp36m-macosx_10_6_intel.whl
+           https://files.pythonhosted.org/packages/82/ca/5690f19c149874de9a23ae9fc25f787269c4023d39fdb48ab1f815e863d5/datatable-0.3.2.tar.gz
 
   .. ref-context:: datatable
 

--- a/docs/releases/v0.4.0.rst
+++ b/docs/releases/v0.4.0.rst
@@ -4,6 +4,7 @@
 .. changelog::
   :version: 0.4.0
   :released: 2018-05-07
+  :wheels: https://files.pythonhosted.org/packages/af/10/5f458bb24545845da3f290179a139f93c9c6966a3817fab9049f930cd5b8/datatable-0.4.0.tar.gz
 
   .. ref-context:: datatable
 

--- a/docs/releases/v0.5.0.rst
+++ b/docs/releases/v0.5.0.rst
@@ -4,6 +4,9 @@
 .. changelog::
   :version: 0.5.0
   :released: 2018-05-25
+  :wheels: https://files.pythonhosted.org/packages/5a/a6/2785bd9ac05ebffb71c067e8e1e0d0e65667482e15c3d1e221e9ebc80c3b/datatable-0.5.0-cp35-cp35m-macosx_10_7_x86_64.whl
+           https://files.pythonhosted.org/packages/0e/cd/d994e4d67867f1ffbfbb355b98e43db5e689507fb785ed11057ea907980a/datatable-0.5.0-cp36-cp36m-macosx_10_7_x86_64.whl
+           https://files.pythonhosted.org/packages/09/ac/fd225408382529a4995143ff97c5226c72c8df8057496831256376e0ff9f/datatable-0.5.0.tar.gz
 
   .. ref-context:: datatable
 

--- a/docs/releases/v0.6.0.rst
+++ b/docs/releases/v0.6.0.rst
@@ -4,6 +4,9 @@
 .. changelog::
   :version: 0.6.0
   :released: 2018-06-05
+  :wheels: https://files.pythonhosted.org/packages/bd/67/09d6fb031456aec7e03a0a7ee9d904b6528b438b9a48019ed16a60d439dc/datatable-0.6.0-cp35-cp35m-macosx_10_7_x86_64.whl
+           https://files.pythonhosted.org/packages/14/06/212109e29351a4351a2684e5c8c80bf14744fc2edac008d555b5bcc2de21/datatable-0.6.0-cp36-cp36m-macosx_10_7_x86_64.whl
+           https://files.pythonhosted.org/packages/41/f1/cbe0dcb4dc513f754cf4ff4e0ab72e16e3aeafc2f44205ba30d28abc8184/datatable-0.6.0.tar.gz
 
   .. ref-context:: datatable
 

--- a/docs/releases/v0.7.0.rst
+++ b/docs/releases/v0.7.0.rst
@@ -4,6 +4,10 @@
 .. changelog::
   :version: 0.7.0
   :released: 2018-11-16
+  :wheels: https://files.pythonhosted.org/packages/4f/ce/edc756fbb3ebf25844faf5cf40e141ad13de8d01a1c44fb5d6451272d91c/datatable-0.7.0-cp35-cp35m-macosx_10_7_x86_64.whl
+           https://files.pythonhosted.org/packages/d0/8e/20151d986c342138d390e968b25428697c539c69cd0d6fa0095c18455636/datatable-0.7.0-cp36-cp36m-macosx_10_7_x86_64.whl
+           https://files.pythonhosted.org/packages/a1/e4/77e2feba6d0f7475576fd14c92a449e2b3941508aa150f125824a809e284/datatable-0.7.0-cp37-cp37m-macosx_10_7_x86_64.whl
+           https://files.pythonhosted.org/packages/0b/b6/323297afd7258e7960f474cc256dd988a2bb923109adf87445435edbe575/datatable-0.7.0.tar.gz
 
   Frame
   -----

--- a/docs/releases/v0.8.0.rst
+++ b/docs/releases/v0.8.0.rst
@@ -4,6 +4,10 @@
 .. changelog::
   :version: 0.8.0
   :released: 2019-02-05
+  :wheels: https://files.pythonhosted.org/packages/4e/8a/fcbd50c3084398dcdcb38ad7c0f517861517bbf4e80af329c3110df8ad6e/datatable-0.8.0-cp35-cp35m-macosx_10_7_x86_64.whl
+           https://files.pythonhosted.org/packages/de/61/3a20a529980d18f1ed2805fd1ccc0c4609ad5ae1dd489c1f80ea58928ef9/datatable-0.8.0-cp36-cp36m-macosx_10_7_x86_64.whl
+           https://files.pythonhosted.org/packages/f3/63/f13b22b3a4e220b91e453ebe76e715fd68bb3b0f084fa1b4d1a14b38576e/datatable-0.8.0-cp37-cp37m-macosx_10_7_x86_64.whl
+           https://files.pythonhosted.org/packages/33/6b/02045aa871501bec23a17563c9fb70782fa5b152b2f03faaf1b147c667e0/datatable-0.8.0.tar.gz
 
   Frame
   -----

--- a/docs/releases/v0.9.0.rst
+++ b/docs/releases/v0.9.0.rst
@@ -2,6 +2,13 @@
 .. changelog::
   :version: 0.9.0
   :released: 2019-07-25
+  :wheels: https://files.pythonhosted.org/packages/ef/d9/447d7361b74c843d865e47c9509f294ea158cfa03b9900ff365130fcdaf5/datatable-0.9.0-cp35-cp35m-macosx_10_7_x86_64.whl
+           https://files.pythonhosted.org/packages/75/a9/acd8d0725460c8370b68a1d0ceb58fe893d57fe3666b1bc0b22ea1b09637/datatable-0.9.0-cp35-cp35m-manylinux2010_x86_64.whl
+           https://files.pythonhosted.org/packages/48/1f/789653311f87794df631abcfb32677292b79cf97de5a4ad1ea19859568e4/datatable-0.9.0-cp36-cp36m-macosx_10_7_x86_64.whl
+           https://files.pythonhosted.org/packages/17/27/796081e2f75b482dc18155ef51d559f185d7c0c4e4273047babb58f9e92b/datatable-0.9.0-cp36-cp36m-manylinux2010_x86_64.whl
+           https://files.pythonhosted.org/packages/35/96/2430b8562206f1021f2be71f18f25fa3e2ed449c92a71ae2b5ddb7f3dc72/datatable-0.9.0-cp37-cp37m-macosx_10_7_x86_64.whl
+           https://files.pythonhosted.org/packages/6f/4d/d11077f5d167826ac224ee06c427fd18104fcc22b4896caa95bd535864ea/datatable-0.9.0-cp37-cp37m-manylinux2010_x86_64.whl
+           https://files.pythonhosted.org/packages/4e/83/ef04b3d1340a4b2346c3afe442f94cec66d0e9dad11d8996c75161c8dd20/datatable-0.9.0.tar.gz
 
   Frame
   -----

--- a/src/datatable/sphinxext/dt_changelog.py
+++ b/src/datatable/sphinxext/dt_changelog.py
@@ -38,7 +38,7 @@ def parse_wheels_option(txt):
         return []
     urls = txt.strip().split()
     for url in urls:
-        if not re.fullmatch(r"https://(.*)\.whl", url):
+        if not re.fullmatch(r"https://(.*)\.(whl|tar\.gz)", url):
             raise ValueError("Invalid URL `%s` in the :wheels: option" % url)
     return urls
 
@@ -158,6 +158,9 @@ class ChangelogInfoboxDirective(SphinxDirective):
         entries = {}
         for url in self.options["wheels"]:
             _, filename = url.rsplit("/", 1)
+            if filename.endswith(".tar.gz"):
+                entries["SDist"] = {"sources": url}
+                continue
             assert filename.endswith(".whl")
             parts = filename[:-4].split('-')
             assert len(parts) == 5

--- a/src/datatable/sphinxext/dtframe_directive.py
+++ b/src/datatable/sphinxext/dtframe_directive.py
@@ -280,20 +280,6 @@ def parse_names(s):
 
 
 
-#-------------------------------------------------------------------------------
-# Nodes
-#-------------------------------------------------------------------------------
-
-class div_node(nodes.General, nodes.Element): pass
-
-def visit_div(self, node):
-    self.body.append(self.starttag(node, "div"))
-
-def depart_div(self, node):
-    self.body.append("</div>")
-
-
-
 
 #-------------------------------------------------------------------------------
 # DtframeDirective
@@ -313,10 +299,10 @@ class DtframeDirective(Directive):
         shape, types, names = self._parse_options()
         frame_data = self._parse_table(types, names)
 
-        root_node = div_node(classes=["datatable"])
+        root_node = xnodes.div(classes=["datatable"])
         root_node += self._make_table(names, types, frame_data)
         root_node += self._make_footer(shape)
-        div = div_node(classes=["highlight-pycon", "notranslate"])
+        div = xnodes.div(classes=["highlight-pycon", "notranslate"])
         div += root_node
         return [div]
 
@@ -447,15 +433,14 @@ class DtframeDirective(Directive):
 
 
     def _make_footer(self, shape):
-        footer_node = div_node(classes=["footer"])
-        dim_node = div_node(classes=["frame_dimensions"])
         shape_text = ("%s row%s × %s column%s"
                       % (comma_separated(shape[0]),
                          "" if shape[0] == 1 else "s",
                          comma_separated(shape[1]),
                          "" if shape[1] == 1 else "s"))
-        dim_node += nodes.Text(shape_text)
-        footer_node += dim_node
+        footer_node = xnodes.div(classes=["footer"], children=[
+            xnodes.div(shape_text, classes=["frame_dimensions"])
+        ])
         return footer_node
 
 
@@ -551,7 +536,7 @@ def html_page_context(app, pagename, templatename, context, doctree):
 
 
 def setup(app):
+    app.setup_extension("sphinxext.xnodes")
     app.add_directive("dtframe", DtframeDirective)
-    app.add_node(div_node, html=(visit_div, depart_div))
     app.connect('html-page-context', html_page_context)
     return {"parallel_read_safe": True, "parallel_write_safe": True}

--- a/src/datatable/sphinxext/xfunction.py
+++ b/src/datatable/sphinxext/xfunction.py
@@ -53,6 +53,7 @@ from sphinx import addnodes
 from sphinx.util import logging
 from sphinx.util.docutils import SphinxDirective
 from sphinx.util.nodes import make_refnode
+from . import xnodes
 
 logger = logging.getLogger(__name__)
 
@@ -642,11 +643,11 @@ class XobjectDirective(SphinxDirective):
 
 
     def _generate_signature(self, targetname):
-        sig_node = mydiv_node(classes=["sig-container"], ids=[targetname])
-        sig_nodeL = mydiv_node(classes=["sig-body"])
+        sig_node = xnodes.div(classes=["sig-container"], ids=[targetname])
+        sig_nodeL = xnodes.div(classes=["sig-body"])
         self._generate_sigbody(sig_nodeL)
         sig_node += sig_nodeL
-        sig_nodeR = mydiv_node(classes=["code-links"])
+        sig_nodeR = xnodes.div(classes=["code-links"])
         self._generate_siglinks(sig_nodeR)
         sig_node += sig_nodeR
 
@@ -658,7 +659,7 @@ class XobjectDirective(SphinxDirective):
 
 
     def _generate_sigbody(self, node):
-        row1 = mydiv_node(classes=["sig-qualifier"])
+        row1 = xnodes.div(classes=["sig-qualifier"])
         ref = addnodes.pending_xref("", nodes.Text(self.qualifier),
                                     reftarget=self.qualifier[:-1],
                                     reftype="class", refdomain="py")
@@ -667,7 +668,7 @@ class XobjectDirective(SphinxDirective):
         row1 += nodes.generated("", "", ref)
         node += row1
 
-        row2 = mydiv_node(classes=["sig-main"])
+        row2 = xnodes.div(classes=["sig-main"])
         self._generate_sigmain(row2)
         node += row2
 
@@ -681,13 +682,13 @@ class XobjectDirective(SphinxDirective):
 
 
     def _generate_sigmain(self, node):
-        div1 = mydiv_node(classes=["sig-name"])
+        div1 = xnodes.div(classes=["sig-name"])
         div1 += nodes.Text(self.obj_name)
         node += div1
         if self.name != "xdata":
             node += nodes.inline("", nodes.Text("("),
                                  classes=["sig-open-paren"])
-            params = mydiv_node(classes=["sig-parameters"])
+            params = xnodes.div(classes=["sig-parameters"])
             last_i = len(self.parsed_params) - 1
             for i, param in enumerate(self.parsed_params):
                 classes = ["param"]
@@ -699,7 +700,7 @@ class XobjectDirective(SphinxDirective):
                         ref = nodes.Text(param)
                     else:
                         ref = a_node(text=param, href="#" + param)
-                    params += mydiv_node("", ref, classes=classes)
+                    params += xnodes.div(ref, classes=classes)
                 else:
                     assert isinstance(param, tuple)
                     param_node = a_node(text=param[0], href="#" + param[0])
@@ -708,8 +709,11 @@ class XobjectDirective(SphinxDirective):
                     # "improve" quotation marks and ...s
                     default_value_node = nodes.literal("", nodes.Text(param[1]),
                                                       classes=["default"])
-                    params += mydiv_node("", param_node, equal_sign_node,
-                                         default_value_node, classes=classes)
+                    params += xnodes.div(classes=classes, children=[
+                                            param_node,
+                                            equal_sign_node,
+                                            default_value_node
+                                         ])
                 if i < len(self.parsed_params) - 1:
                     params += nodes.inline("", nodes.Text(", "), classes=["punct"])
             params += nodes.inline("", nodes.Text(")"),
@@ -718,7 +722,7 @@ class XobjectDirective(SphinxDirective):
 
 
     def _generate_body(self):
-        out = mydiv_node(classes=["x-function-body"])
+        out = xnodes.div(classes=["x-function-body"])
         for head, lines in self.parsed_body:
             if head:
                 lines = [head, "="*len(head), ""] + lines
@@ -743,16 +747,16 @@ class XparamDirective(SphinxDirective):
     def run(self):
         self._parse_arguments()
         id0 = self.param.strip("*/()[]")
-        root = mydiv_node(classes=["xparam-box"], ids=[id0])
-        head = mydiv_node(classes=["xparam-head"])
+        root = xnodes.div(classes=["xparam-box"], ids=[id0])
+        head = xnodes.div(classes=["xparam-head"])
         if id0 in ["return", "except"]:
-            param_node = mydiv_node(classes=["param", id0])
+            param_node = xnodes.div(classes=["param", id0])
             param_node += nodes.Text(id0)
         else:
-            param_node = mydiv_node(classes=["param"])
+            param_node = xnodes.div(classes=["param"])
             param_node += nodes.Text(self.param)
         head += param_node
-        types_node = mydiv_node(classes=["types"])
+        types_node = xnodes.div(classes=["types"])
         types_str = " | ".join("``%s``" % p for p in self.types)
         self.state.nested_parse(StringList([types_str]), self.content_offset,
                                 types_node)
@@ -760,7 +764,7 @@ class XparamDirective(SphinxDirective):
         types_node.children = types_node[0].children
         head += types_node
         root += head
-        desc_node = mydiv_node(classes=["xparam-body"])
+        desc_node = xnodes.div(classes=["xparam-body"])
         self.state.nested_parse(self.content, self.content_offset, desc_node)
         root += desc_node
         return [root]
@@ -787,18 +791,6 @@ def xparamref(name, rawtext, text, lineno, inliner, options={}, content=[]):
 #-------------------------------------------------------------------------------
 # Nodes
 #-------------------------------------------------------------------------------
-
-class mydiv_node(nodes.General, nodes.Element): pass
-
-def visit_div(self, node):
-    # Note: Sphinx's `.starttag()` adds a newline after the tag, which causes
-    # problem if the content of the div is a text node
-    self.body.append(self.starttag(node, "div").strip())
-
-def depart_div(self, node):
-    self.body.append("</div>")
-
-
 
 class a_node(nodes.Element, nodes.Inline):
     def __init__(self, href, text="", new=False, **attrs):
@@ -828,6 +820,7 @@ def fix_html_titles(app, pagename, templatename, context, doctree):
 
 
 def setup(app):
+    app.setup_extension("sphinxext.xnodes")
     app.add_config_value("xf_module_name", None, "env")
     app.add_config_value("xf_project_root", "..", "env")
     app.add_config_value("xf_permalink_url0", "", "env")
@@ -838,7 +831,6 @@ def setup(app):
     app.add_directive("xfunction", XobjectDirective)
     app.add_directive("xmethod", XobjectDirective)
     app.add_directive("xparam", XparamDirective)
-    app.add_node(mydiv_node, html=(visit_div, depart_div))
     app.add_node(a_node, html=(visit_a, depart_a))
     app.add_role("xparam-ref", xparamref)
     app.connect("html-page-context", fix_html_titles)

--- a/src/datatable/sphinxext/xnodes.py
+++ b/src/datatable/sphinxext/xnodes.py
@@ -57,6 +57,7 @@ class xElement(nodes.Element):
 		super().__init__(rawtext, *children, **attributes)
 
 
+
 # xnodes.table()
 #   Similar to nodes.table, this node is used to build an HTML table.
 #   However, unlike the docutils' `table`, this node is suitable for
@@ -70,6 +71,7 @@ def visit_table(self, node):
 
 def depart_table(self, node):
     self.body.append("</table>")
+
 
 
 # xnodes.tr()
@@ -109,17 +111,36 @@ def depart_tdth(self, node):
 
 
 
+# xnodes.div()
+#   Simple structural element node, corresponds to <div> in HTML.
+#
+class div(xElement, nodes.General): pass
+
+def visit_div(self, node):
+    # Note: Sphinx's `.starttag()` adds a newline after the tag, which causes
+    # problem if the content of the div is a text node
+    self.body.append(self.starttag(node, "div").strip())
+
+def depart_div(self, node):
+    self.body.append("</div>")
+
+
+
 
 #-------------------------------------------------------------------------------
 # Extension setup
 #-------------------------------------------------------------------------------
 
 def setup(app):
+	# Set custom names for the node classes, otherwise Sphinx
+	# complains that the node with same name already registered.
 	table.__name__ = "xtable"
 	tr.__name__ = "xtr"
 	th.__name__ = "xth"
 	td.__name__ = "xtd"
+	div.__name__ = "xdiv"
 	app.add_node(table, html=(visit_table, depart_table))
 	app.add_node(tr, html=(visit_tr, depart_tr))
 	app.add_node(td, html=(visit_tdth, depart_tdth))
 	app.add_node(th, html=(visit_tdth, depart_tdth))
+	app.add_node(div, html=(visit_div, depart_div))

--- a/src/datatable/sphinxext/xnodes.py
+++ b/src/datatable/sphinxext/xnodes.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python
+#-------------------------------------------------------------------------------
+# Copyright 2019-2020 H2O.ai
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#-------------------------------------------------------------------------------
+"""
+This is a helper module that provides several nodes that are useful
+for building HTML content, yet they are not provided by the standard
+docutils / Sphinx.
+"""
+from docutils import nodes
+
+__all__ = (
+	"table",
+	"td",
+	"th",
+	"tr",
+)
+
+
+
+# Parent class for all x-nodes. It provides a simpler constructor
+# API compared to `nodes.Element`: the children of a node can be
+# specified both as a parameter, and as a vararg-sequence. For
+# example:
+#
+#     tr(classes=["example-row"], children=[
+#            td("Cell 1"), td("Cell 2")
+#        ])
+#
+class xElement(nodes.Element):
+	def __init__(self, *args, rawtext="", children=[], **attributes):
+		assert isinstance(children, list)
+		if args:
+			assert not children
+			children = list(args)
+		for i, child in enumerate(children):
+			if isinstance(child, str):
+				children[i] = nodes.Text(child)
+		super().__init__(rawtext, *children, **attributes)
+
+
+# xnodes.table()
+#   Similar to nodes.table, this node is used to build an HTML table.
+#   However, unlike the docutils' `table`, this node is suitable for
+#   structural tables (i.e. table used as a scaffolding for the
+#   content).
+#
+class table(xElement, nodes.General): pass
+
+def visit_table(self, node):
+    self.body.append(self.starttag(node, "table"))
+
+def depart_table(self, node):
+    self.body.append("</table>")
+
+
+# xnodes.tr()
+#   Similar to nodes.row, this is a node that will be rendered as a
+#   <tr> HTML element. Unlike the docutils' row, this node will not
+#   be embellished with odd/even row classes.
+#
+class tr(xElement, nodes.Part): pass
+
+def visit_tr(self, node):
+    self.body.append(self.starttag(node, "tr"))
+
+def depart_tr(self, node):
+    self.body.append("</tr>")
+
+
+
+# xnodes.td()
+# xnodes.th()
+#   Node that renders into a <td> / <th> HTML element, supports
+#   attributes `colspan` and `rowspan`.
+#
+class th(xElement, nodes.Part): pass
+class td(xElement, nodes.Part): pass
+
+def visit_tdth(self, node):
+    attrs = {}
+    for key in ["rowspan", "colspan"]:
+        if key in node.attributes:
+            attrs[key] = node.attributes[key]
+    tag = node.__class__.__name__[1:]
+    self.body.append(self.starttag(node, tag, suffix="", **attrs))
+
+def depart_tdth(self, node):
+    tag = node.__class__.__name__[1:]
+    self.body.append("</%s>" % tag)
+
+
+
+
+#-------------------------------------------------------------------------------
+# Extension setup
+#-------------------------------------------------------------------------------
+
+def setup(app):
+	table.__name__ = "xtable"
+	tr.__name__ = "xtr"
+	th.__name__ = "xth"
+	td.__name__ = "xtd"
+	app.add_node(table, html=(visit_table, depart_table))
+	app.add_node(tr, html=(visit_tr, depart_tr))
+	app.add_node(td, html=(visit_tdth, depart_tdth))
+	app.add_node(th, html=(visit_tdth, depart_tdth))


### PR DESCRIPTION
- Added ability to list wheel file links in infoboxes on the changelog pages;
- Added wheel links for all past versions;
- Refactored the use of custom sphinx nodes: now they are declared in a separate shared extension.

WIP for #2304