### PR TITLE
Add Logger2 to xbuild

### DIFF
--- a/ci/xbuild/__init__.py
+++ b/ci/xbuild/__init__.py
@@ -28,13 +28,13 @@ from .logger import Logger0, Logger1, Logger2, Logger3
 from .wheel import Wheel
 
 __all__ = (
-	"Compiler",
-	"Extension",
-	"Logger0",
-	"Logger1",
+    "Compiler",
+    "Extension",
+    "Logger0",
+    "Logger1",
     "Logger2",
-	"Logger3",
-	"Wheel",
+    "Logger3",
+    "Wheel",
 )
 
 

--- a/ci/xbuild/__init__.py
+++ b/ci/xbuild/__init__.py
@@ -24,7 +24,7 @@
 import sys
 from .compiler import Compiler
 from .extension import Extension
-from .logger import Logger0, Logger1, Logger3
+from .logger import Logger0, Logger1, Logger2, Logger3
 from .wheel import Wheel
 
 __all__ = (
@@ -32,6 +32,7 @@ __all__ = (
 	"Extension",
 	"Logger0",
 	"Logger1",
+  "Logger2",
 	"Logger3",
 	"Wheel",
 )

--- a/ci/xbuild/__init__.py
+++ b/ci/xbuild/__init__.py
@@ -32,7 +32,7 @@ __all__ = (
 	"Extension",
 	"Logger0",
 	"Logger1",
-  "Logger2",
+    "Logger2",
 	"Logger3",
 	"Wheel",
 )
@@ -40,16 +40,16 @@ __all__ = (
 
 # Enable console virtual terminal sequences on Windows
 if sys.platform == "win32":
-  import ctypes
-  from ctypes import wintypes
-  windll = ctypes.LibraryLoader(ctypes.WinDLL)
-  set_console_mode = windll.kernel32.SetConsoleMode
-  set_console_mode.argtypes = [wintypes.HANDLE, wintypes.DWORD]
-  set_console_mode.restype = wintypes.BOOL
+    import ctypes
+    from ctypes import wintypes
+    windll = ctypes.LibraryLoader(ctypes.WinDLL)
+    set_console_mode = windll.kernel32.SetConsoleMode
+    set_console_mode.argtypes = [wintypes.HANDLE, wintypes.DWORD]
+    set_console_mode.restype = wintypes.BOOL
 
-  get_std_handle = windll.kernel32.GetStdHandle
-  get_std_handle.argtypes = [wintypes.DWORD]
-  get_std_handle.restype = wintypes.HANDLE
+    get_std_handle = windll.kernel32.GetStdHandle
+    get_std_handle.argtypes = [wintypes.DWORD]
+    get_std_handle.restype = wintypes.HANDLE
 
-  STDOUT = get_std_handle(-11)
-  set_console_mode(STDOUT, 5)
+    STDOUT = get_std_handle(-11)
+    set_console_mode(STDOUT, 5)

--- a/ci/xbuild/logger.py
+++ b/ci/xbuild/logger.py
@@ -155,6 +155,65 @@ class Logger1(Logger0):
         print(line, end="", flush=True)
 
 
+#-------------------------------------------------------------------------------
+# Logger2
+#-------------------------------------------------------------------------------
+
+class Logger2(Logger0):
+    """
+    Sublime friendly conservative logger.
+    """
+
+    def __init__(self):
+        self._indent = ""
+
+    def report_compile_start(self, filename, cmd):
+        self.info("Compiling `%s`" % filename)
+
+    def report_compiler_executable(self, cc, env=None):
+        msg = "Using compiler `%s`" % cc
+        if env:
+            msg += " from environment variable `%s`" % env
+        self.info(msg)
+
+    def report_link_file(self, filename, cmd):
+        self.info("Linking `%s`" % filename)
+
+    def report_output_file(self, filename):
+        self.info("Output file name will be `%r`" % filename)
+
+
+    def step_compile(self, files):
+        if files:
+            self.info("Compiling `%d` source files" % len(files),
+                      indent="")
+        else:
+            self.info("Compiling source files: SKIPPED", indent="")
+
+    def info(self, msg, indent=None):
+        if indent is None:
+            indent = self._indent
+        msg = re.sub(r"`([^`]*)`", "\x1B[1;97m\\1\x1B[0;90m", msg)
+        print(indent + "\x1B[90m" + msg + "\x1B[m")
+
+
+    def warn(self, msg, indent=None):
+        if indent is None:
+            indent = self._indent
+        msg = re.sub(r"`([^`]*)`", "\x1B[1;97m\\1\x1B[0;91m", msg)
+        print(indent + "\x1B[91m" + msg + "\x1B[m")
+
+
+    def report_errors_and_warnings(self, msgs, errors=False):
+        if not msgs:
+            return
+        color = "\x1B[91m" if errors else \
+                "\x1B[93m"
+        print(color + "+==== ERRORS & WARNINGS ========\n\x1B[m")
+        for msg in msgs:
+            for line in msg.split("\n"):
+                print(color + "\x1B[m" + line)
+
 
 
 #-------------------------------------------------------------------------------
@@ -263,7 +322,7 @@ class Logger3(Logger0):
         self.info("Use %d worker processes" % nworkers)
 
     def report_output_file(self, filename):
-        self.info("Output file name will be %r" % filename)
+        self.info("Output file name will be `%r`" % filename)
 
     def report_removed_file(self, filename):
         self.info("File `%s` deleted" % filename)

--- a/ci/xbuild/logger.py
+++ b/ci/xbuild/logger.py
@@ -182,7 +182,6 @@ class Logger2(Logger0):
     def report_output_file(self, filename):
         self.info("Output file name will be `%r`" % filename)
 
-
     def step_compile(self, files):
         if files:
             self.info("Compiling `%d` source files" % len(files),
@@ -190,19 +189,19 @@ class Logger2(Logger0):
         else:
             self.info("Compiling source files: SKIPPED", indent="")
 
+
+
     def info(self, msg, indent=None):
         if indent is None:
             indent = self._indent
         msg = re.sub(r"`([^`]*)`", "\x1B[1;97m\\1\x1B[0;90m", msg)
         print(indent + "\x1B[90m" + msg + "\x1B[m")
 
-
     def warn(self, msg, indent=None):
         if indent is None:
             indent = self._indent
         msg = re.sub(r"`([^`]*)`", "\x1B[1;97m\\1\x1B[0;91m", msg)
         print(indent + "\x1B[91m" + msg + "\x1B[m")
-
 
     def report_errors_and_warnings(self, msgs, errors=False):
         if not msgs:

--- a/src/core/column/const.cc
+++ b/src/core/column/const.cc
@@ -159,9 +159,8 @@ class ConstFloat_ColumnImpl : public Const_ColumnImpl {
           return SType::FLOAT64;
 
         default:
-          xassert(0 && "Invalid stype for float constant");  // LCOV_EXCL_LINE
           throw RuntimeError() << "Wrong `stype0` in `normalize_stype()`: "
-                  << stype0;
+                  << stype0;  // LCOV_EXCL_LINE
       }
     }
 };

--- a/src/core/column/const.cc
+++ b/src/core/column/const.cc
@@ -160,6 +160,8 @@ class ConstFloat_ColumnImpl : public Const_ColumnImpl {
 
         default:
           xassert(0 && "Invalid stype for float constant");  // LCOV_EXCL_LINE
+          throw RuntimeError() << "Wrong `stype0` in `normalize_stype()`: "
+                  << stype0;
       }
     }
 };

--- a/src/core/column/sentinel_str.cc
+++ b/src/core/column/sentinel_str.cc
@@ -73,6 +73,7 @@ size_t SentinelStr_ColumnImpl<T>::get_num_data_buffers() const noexcept {
 template <typename T>
 bool SentinelStr_ColumnImpl<T>::is_data_editable(size_t k) const {
   xassert(k <= 1);
+  (void) k;
   return false;
 }
 

--- a/src/core/expr/fnary/rowmean.cc
+++ b/src/core/expr/fnary/rowmean.cc
@@ -88,6 +88,9 @@ Column naryop_rowmean(colvec&& columns) {
     case SType::FLOAT32: return _rowmean<float>(std::move(columns));
     case SType::FLOAT64: return _rowmean<double>(std::move(columns));
     default: xassert(0);
+             throw RuntimeError()
+               << "Wrong `res_stype` in `naryop_rowmean()`: "
+               << res_stype;
   }
 }
 

--- a/src/core/expr/fnary/rowmean.cc
+++ b/src/core/expr/fnary/rowmean.cc
@@ -87,10 +87,9 @@ Column naryop_rowmean(colvec&& columns) {
   switch (res_stype) {
     case SType::FLOAT32: return _rowmean<float>(std::move(columns));
     case SType::FLOAT64: return _rowmean<double>(std::move(columns));
-    default: xassert(0);
-             throw RuntimeError()
+    default: throw RuntimeError()
                << "Wrong `res_stype` in `naryop_rowmean()`: "
-               << res_stype;
+               << res_stype;  // LCOV_EXCL_LINE
   }
 }
 

--- a/src/core/expr/fnary/rowminmax.cc
+++ b/src/core/expr/fnary/rowminmax.cc
@@ -105,7 +105,7 @@ Column naryop_rowminmax(colvec&& columns, bool MIN) {
     case SType::FLOAT64: return _rowminmax<double>(std::move(columns), MIN);
     default: throw RuntimeError()
                << "Wrong `res_stype` in `naryop_rowminmax()`: "
-               << res_stype;
+               << res_stype;  // LCOV_EXCL_LINE
   }
 }
 

--- a/src/core/expr/fnary/rowminmax.cc
+++ b/src/core/expr/fnary/rowminmax.cc
@@ -103,8 +103,7 @@ Column naryop_rowminmax(colvec&& columns, bool MIN) {
     case SType::INT64:   return _rowminmax<int64_t>(std::move(columns), MIN);
     case SType::FLOAT32: return _rowminmax<float>(std::move(columns), MIN);
     case SType::FLOAT64: return _rowminmax<double>(std::move(columns), MIN);
-    default: xassert(0);
-             throw RuntimeError()
+    default: throw RuntimeError()
                << "Wrong `res_stype` in `naryop_rowminmax()`: "
                << res_stype;
   }

--- a/src/core/expr/fnary/rowminmax.cc
+++ b/src/core/expr/fnary/rowminmax.cc
@@ -104,6 +104,9 @@ Column naryop_rowminmax(colvec&& columns, bool MIN) {
     case SType::FLOAT32: return _rowminmax<float>(std::move(columns), MIN);
     case SType::FLOAT64: return _rowminmax<double>(std::move(columns), MIN);
     default: xassert(0);
+             throw RuntimeError()
+               << "Wrong `res_stype` in `naryop_rowminmax()`: "
+               << res_stype;
   }
 }
 

--- a/src/core/expr/fnary/rowsd.cc
+++ b/src/core/expr/fnary/rowsd.cc
@@ -92,6 +92,9 @@ Column naryop_rowsd(colvec&& columns) {
     case SType::FLOAT32: return _rowsd<float>(std::move(columns));
     case SType::FLOAT64: return _rowsd<double>(std::move(columns));
     default: xassert(0);
+             throw RuntimeError()
+               << "Wrong `res_stype` in `naryop_rowsd()`: "
+               << res_stype;
   }
 }
 

--- a/src/core/expr/fnary/rowsd.cc
+++ b/src/core/expr/fnary/rowsd.cc
@@ -91,10 +91,9 @@ Column naryop_rowsd(colvec&& columns) {
   switch (res_stype) {
     case SType::FLOAT32: return _rowsd<float>(std::move(columns));
     case SType::FLOAT64: return _rowsd<double>(std::move(columns));
-    default: xassert(0);
-             throw RuntimeError()
+    default: throw RuntimeError()
                << "Wrong `res_stype` in `naryop_rowsd()`: "
-               << res_stype;
+               << res_stype;  // LCOV_EXCL_LINE
   }
 }
 

--- a/src/core/expr/fnary/rowsum.cc
+++ b/src/core/expr/fnary/rowsum.cc
@@ -81,6 +81,9 @@ Column naryop_rowsum(colvec&& columns) {
     case SType::FLOAT32: return _rowsum<float>(std::move(columns));
     case SType::FLOAT64: return _rowsum<double>(std::move(columns));
     default: xassert(0);
+             throw RuntimeError()
+               << "Wrong `res_stype` in `naryop_rowsum()`: "
+               << res_stype;
   }
 }
 

--- a/src/core/expr/fnary/rowsum.cc
+++ b/src/core/expr/fnary/rowsum.cc
@@ -80,10 +80,9 @@ Column naryop_rowsum(colvec&& columns) {
     case SType::INT64:   return _rowsum<int64_t>(std::move(columns));
     case SType::FLOAT32: return _rowsum<float>(std::move(columns));
     case SType::FLOAT64: return _rowsum<double>(std::move(columns));
-    default: xassert(0);
-             throw RuntimeError()
+    default: throw RuntimeError()
                << "Wrong `res_stype` in `naryop_rowsum()`: "
-               << res_stype;
+               << res_stype;  // LCOV_EXCL_LINE
   }
 }
 

--- a/src/core/expr/head_func.cc
+++ b/src/core/expr/head_func.cc
@@ -116,41 +116,48 @@ static ptrHead make_cast(Op, const py::otuple& params) {
 
 static ptrHead make_colsetop(Op op, const py::otuple& params) {
   xassert(params.size() == 0);
+  (void) params;
   return ptrHead(new Head_Func_Colset(op));
 }
 
 static ptrHead make_unop(Op op, const py::otuple& params) {
   xassert(params.size() == 0);
+  (void) params;
   return ptrHead(new Head_Func_Unary(op));
 }
 
 
 static ptrHead make_binop(Op op, const py::otuple& params) {
   xassert(params.size() == 0);
+  (void) params;
   return ptrHead(new Head_Func_Binary(op));
 }
 
 
 static ptrHead make_reduce0(Op op, const py::otuple& params) {
   xassert(params.size() == 0);
+  (void) params;
   return ptrHead(new Head_Reduce_Nullary(op));
 }
 
 
 static ptrHead make_reduce1(Op op, const py::otuple& params) {
   xassert(params.size() == 0);
+  (void) params;
   return ptrHead(new Head_Reduce_Unary(op));
 }
 
 
 static ptrHead make_reduce2(Op op, const py::otuple& params) {
   xassert(params.size() == 0);
+  (void) params;
   return ptrHead(new Head_Reduce_Binary(op));
 }
 
 
 static ptrHead make_rowfn(Op op, const py::otuple& params) {
   xassert(params.size() == 0);
+  (void) params;
   return ptrHead(new Head_Func_Nary(op));
 }
 

--- a/src/core/models/aggregator.cc
+++ b/src/core/models/aggregator.cc
@@ -596,6 +596,7 @@ bool Aggregator<T>::group_1d_categorical() {
     size_t row;
     bool row_valid = ri.get_element(0, &row);
     xassert(row_valid);
+    (void) row_valid;
     na_group = !col.get_element(row, &val);
   }
 
@@ -701,6 +702,7 @@ bool Aggregator<T>::group_2d_mixed()
     size_t row;
     bool row_valid = ri.get_element(0, &row);
     xassert(row_valid);
+    (void) row_valid;
     na_cat_group = !col0.get_element(row, &val);
   }
 


### PR DESCRIPTION
- add a conservative Sublime friendly `Logger2` to xbuild; 
- fix all the compilation warnings produced by `clang` on Mac.