### PR TITLE
Sphinx extension Xcontributors

### DIFF
--- a/ci/gh.py
+++ b/ci/gh.py
@@ -124,7 +124,12 @@ def issue_and_pr_authors(repo, args):
     for i, issue in enumerate(prs):
         progress_bar(i + 1, count)
         milestone = issue.milestone.title if issue.milestone else ""
-        kind = "PRs" if issue.pull_request else "issues"
+        if issue.pull_request:
+            if not issue.as_pull_request().merged:
+                continue  # skip PRs that were closed without merging
+            kind = "PRs"
+        else:
+            kind = "issues"
         mm = re.search(rx_attribution, issue.body) if issue.body else None
         if mm:
             author = mm.group(1)

--- a/ci/gh.py
+++ b/ci/gh.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#-------------------------------------------------------------------------------
+# Copyright 2020 H2O.ai
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#-------------------------------------------------------------------------------
+import argparse
+import getpass
+import github
+import re
+from github.GithubException import (
+    BadCredentialsException,
+    RateLimitExceededException,
+    UnknownObjectException
+)
+
+rx_attribution = re.compile(r"^Attribute[\s\-][tT]o:\s*@([\w\-]+)\s*$",
+                            re.MULTILINE)
+
+
+def progress_bar(current, total, progress_bar_size=50):
+    if current is None:
+        print("\r" + " "*(progress_bar_size + 10) + "\r", end="")
+        return
+    if not(0 <= current <= total):
+        import pdb
+        pdb.set_trace()
+    assert 0 <= current <= total
+    n_chars_done = round(progress_bar_size * current / total)
+    n_chars_todo = progress_bar_size - n_chars_done
+    pbar = "\r["
+    pbar += "#" * n_chars_done
+    pbar += "-" * n_chars_todo
+    pbar += "] %.1f%%   " % (100 * current / total)
+    print(pbar, end="")
+
+
+def get_repo(repository_name, auth=None):
+    """
+    Return a Github.Repository object given the repository name.
+
+    Parameters
+    ----------
+    repository_name: str
+        The name of the repository, including the organization. For
+        example: "h2oai/datatable".
+
+    auth: bool | None
+        Do we need to authenticate to access the repository? If True,
+        then a login/password will be prompted. If False, the
+        repository must be public or otherwise an exception will be
+        raised. If None, then the method will first attempt to access
+        the repository publicly, and if that fails fall back to
+        authentication.
+    """
+    assert isinstance(repository_name, str)
+    assert auth is None or isinstance(auth, bool)
+
+    if auth is False:
+        g = github.Github()
+        return g.get_repo(repository_name)
+
+    if auth is None:
+        g = github.Github()
+        try:
+            return g.get_repo(repository_name)
+        except UnknownObjectException:
+            pass  # we will retry with authentication
+
+    username = input("Enter your GitHub username: ")
+    while True:
+        password = getpass.getpass("Enter your GitHub password: ")
+        try:
+            g = github.Github(username, password)
+            return g.get_repo(repository_name)
+        except UnknownObjectException:
+            raise KeyError("Repository %s not found"
+                           % repository_name) from None
+        except BadCredentialsException:
+            print("Incorrect password.")
+    print()
+
+
+def issue_and_pr_authors(repo, args):
+    """
+    Return the dict of authors for all closed PRs/issues in the
+    repository, grouped by the milestone.
+
+    Returns a dictionary of the form
+
+        {<milestone>: {"PRs": {<author>: <count>},
+                       "issues": {<author>: <count>}}}
+
+    """
+    assert isinstance(repo, github.Repository.Repository)
+    attrs = {"state": "closed"}
+    if args.milestone:
+        for milestone in repo.get_milestones(state="all"):
+            if milestone.title == args.milestone:
+                attrs["milestone"] = milestone
+                break
+        if not attrs["milestone"]:
+            raise KeyError("Milestone `%s` not found" % args.milestone)
+    prs = repo.get_issues(**attrs)
+    count = prs.totalCount
+    out = {}
+    for i, issue in enumerate(prs):
+        progress_bar(i + 1, count)
+        milestone = issue.milestone.title if issue.milestone else ""
+        kind = "PRs" if issue.pull_request else "issues"
+        mm = re.search(rx_attribution, issue.body) if issue.body else None
+        if mm:
+            author = mm.group(1)
+        else:
+            author = issue.user.login
+
+        if milestone not in out:
+            out[milestone] = {"PRs": {}, "issues": {}}
+        if author not in out[milestone][kind]:
+            out[milestone][kind][author] = 0
+        out[milestone][kind][author] += 1
+
+    # Clear the progress bar
+    progress_bar(None, None)
+    return out
+
+
+
+def cmd_milestones(repo):
+    assert isinstance(repo, github.Repository.Repository)
+    print("==== Milestones in %s ====" % repo.full_name)
+    for milestone in repo.get_milestones(state="all"):
+        print("    " + milestone.title)
+
+
+def cmd_authors(repo, args):
+    assert isinstance(repo, github.Repository.Repository)
+    print("==== Authors in %s ====" % repo.full_name)
+    out = issue_and_pr_authors(gdt, args)
+    for milestone in sorted(out.keys()):
+        print("~~~~ Milestone: `%s` ~~~~" % milestone)
+        for kind in ["PRs", "issues"]:
+            print("    -- %s --" % kind)
+            authors = out[milestone][kind]
+            sorted_authors = sorted(authors.keys(),
+                                    key=lambda k: -authors[k])
+            for author in sorted_authors:
+                count = authors[author]
+                print("    %d %s" % (count, author))
+        print()
+
+
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description='Gather GitHub properties of a repository'
+    )
+    parser.add_argument("cmd", metavar="CMD",
+        choices=["milestones", "authors"],
+        help="What information to return: `milestones` produces the list "
+             "of milestones in the repository, `authors` reports the count "
+             "of closed issues/PRs per each author, grouped by milestone"
+        )
+    parser.add_argument("--auth", action="store_true",
+        help="Use authentication when connecting to the repository")
+    parser.add_argument("--repository", default="h2oai/datatable",
+        help="Full name of the GitHub repository, including the organization")
+    parser.add_argument("--milestone", default=None,
+        help="Only consider issues belonging to the specified milestone.")
+    args = parser.parse_args()
+
+    try:
+        gdt = get_repo(args.repository, auth=args.auth)
+        if args.cmd == "milestones":
+            cmd_milestones(gdt)
+        if args.cmd == "authors":
+            cmd_authors(gdt, args=args)
+    except RateLimitExceededException as e:
+        msg = "RuntimeError: Rate limit exceeded, consider using argument --auth."
+        if hasattr(e, "data") and "documentation_url" in e.data:
+            msg += "\nSee %s" % e.data['documentation_url']
+        raise SystemExit("\x1b[3;91m" + msg + "\x1b[m")

--- a/docs/_static/changelog.css
+++ b/docs/_static/changelog.css
@@ -79,7 +79,6 @@
     font-family: FontAwesome;
     left: 10px;
     position: absolute;
-    top: 3px;
 }
 
 .changelog ul.changelog-list li.changelog-list-item.gh.old:before {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,6 +52,7 @@ needs_sphinx = '1.8'
 # ones.
 extensions = [
     'sphinxext.dtframe_directive',
+    'sphinxext.xcontributors',
     'sphinxext.xfunction',
     'sphinxext.dt_changelog',
     'sphinxext.ref_context',

--- a/docs/releases/v0.10.0.rst
+++ b/docs/releases/v0.10.0.rst
@@ -355,8 +355,19 @@
 
   .. contributors::
 
-    st-pasha
-    oleksiyskononenko
-    viktor-demin <Viktor Demin>
-    abal5 <Anmol Bal>
-    siddhesh <Siddhesh Poyarekar>
+    121 st-pasha
+    22  oleksiyskononenko
+    3   siddhesh          <Siddhesh Poyarekar>
+    1   Viktor-Demin      <Viktor Demin>
+    1   achraf-mer        <Achraf Merzouki>
+    --
+    65 st-pasha
+    9  oleksiyskononenko
+    6  jangorecki         <Jan Gorecki>
+    3  junghoocho
+    1  ben519             <Ben 519>
+    1  ultraNick          <Nick Kim>
+    1  zawrahman          <Zmnako Awrahman>
+    1  Viktor-Demin       <Viktor Demin>
+    1  mmalohlava         <Michal Malohlava>
+    1  atroiano           <Andy Troiano>

--- a/docs/releases/v0.10.0.rst
+++ b/docs/releases/v0.10.0.rst
@@ -353,17 +353,10 @@
 
 
 
-  Contributors
-  ------------
+  .. contributors::
 
-  This release was made possible via the effort of a number of people, some who
-  contributed code, but also those who helped making the product better by
-  submitting bug reports and new feature requests.
-
-  People who contributed patches and pull requests (PRs):
-
-  - :user:`Pasha Stetsenko <st-pasha>`
-  - :user:`Oleksiy Kononenko <oleksiyskononenko>`
-  - :user:`Viktor Demin <Viktor-Demin>`
-  - :user:`Anmol Bal <abal5>`
-  - :user:`Siddhesh Poyarekar <siddhesh>`
+    st-pasha
+    oleksiyskononenko
+    viktor-demin <Viktor Demin>
+    abal5 <Anmol Bal>
+    siddhesh <Siddhesh Poyarekar>

--- a/docs/releases/v0.10.1.rst
+++ b/docs/releases/v0.10.1.rst
@@ -68,6 +68,10 @@
 
   .. contributors::
 
-    st-pasha <Pasha Stetsenko>
-    oleksiyskononenko <Oleksiy Kononenko>
-    bpourhamzeh <Bijan Pourhamzeh>
+    6 st-pasha           <Pasha Stetsenko>
+    2 oleksiyskononenko  <Oleksiy Kononenko>
+    1 bpourhamzeh        <Bijan Pourhamzeh>
+    --
+    4 st-pasha
+    1 toddrme2178        <Todd>
+    1 igor-susic         <Igor Šušić>

--- a/docs/releases/v0.10.1.rst
+++ b/docs/releases/v0.10.1.rst
@@ -66,16 +66,8 @@
     ``int32`` instead of ``bool8`` for binomial and regression models.
 
 
+  .. contributors::
 
-  Contributors
-  ------------
-
-  This release was made possible via the effort of a number of people, some who
-  contributed code, but also those who helped making the product better by
-  submitting bug reports and new feature requests.
-
-  People who contributed patches and pull requests (PRs):
-
-  -[gh.old] :user:`Pasha Stetsenko <st-pasha>`
-  -[gh.old] :user:`Oleksiy Kononenko <oleksiyskononenko>`
-  -[gh.new] :user:`Bijan Pourhamzeh <bpourhamzeh>`
+    st-pasha <Pasha Stetsenko>
+    oleksiyskononenko <Oleksiy Kononenko>
+    bpourhamzeh <Bijan Pourhamzeh>

--- a/docs/releases/v0.11.0.rst
+++ b/docs/releases/v0.11.0.rst
@@ -49,20 +49,11 @@
     be a float rather than an integer.
 
 
-  Contributors
-  ------------
+  .. contributors::
 
-  This release was made possible via the effort of a number of people, some who
-  contributed code, but also those who helped making the product better by
-  submitting bug reports and new feature requests.
-
-  People who contributed patches and pull requests (PRs):
-
-  -[gh.old] :user:`Pasha Stetsenko <st-pasha>`
-  -[gh.old] :user:`Oleksiy Kononenko <oleksiyskononenko>`
-  -[gh.new] :user:`Bryce Boe <bboe>`
-
-
-  People who contributed with bug reports and feature requests:
-
-  -[gh] :user:`Arno Candel <arnocandel>`
+    38  st-pasha
+    20  oleksiyskononenko
+    1   bboe                <Bryce Boe>
+    --
+    8   st-pasha
+    3   oleksiyskononenko

--- a/src/datatable/sphinxext/xcontributors.py
+++ b/src/datatable/sphinxext/xcontributors.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python
+#-------------------------------------------------------------------------------
+# Copyright 2020 H2O.ai
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#-------------------------------------------------------------------------------
+import re
+from docutils import nodes
+from docutils.parsers.rst import directives
+from sphinx.util.docutils import SphinxDirective
+from . import xnodes
+
+
+
+#-------------------------------------------------------------------------------
+# .. contributors
+#-------------------------------------------------------------------------------
+
+class XContributorsDirective(SphinxDirective):
+    has_content = True
+    required_arguments = 0
+    optional_arguments = 0
+    option_spec = {}
+
+    def run(self):
+        self._parse(self.content.data)
+        self._store_env()
+        return [contributors_placeholder_node()]
+
+
+    def _parse(self, lines):
+        rx_separator = re.compile(r"\-+")
+        rx_contributor = re.compile(r"(?:(\d+)\s+)?"
+                                    r"([\w\-]+)"
+                                    r"(?:\s+<([^<>]*)>)?")
+        self.people = {"PRs": {}, "issues": {}}
+        mode = "PRs"
+        for line in lines:
+            if not line:
+                continue
+            if re.fullmatch(rx_separator, line):
+                mode = "issues"
+                continue
+            mm = re.fullmatch(rx_contributor, line)
+            if not mm:
+                raise self.error("Invalid contributor %r" % line)
+            amount = int(mm.group(1)) if mm.group(1) else 1
+            username = mm.group(2)
+            fullname = mm.group(3)
+            if username in self.people[mode]:
+                raise self.error("Duplicate user %s in ..contributors "
+                                 "directive" % username)
+            self.people[mode][username] = (amount, fullname)
+        if not self.people["PRs"]:
+            raise self.error("Missing code contributors")
+
+
+    def _store_env(self):
+        env = self.env
+        docname = env.docname
+        if not hasattr(env, "xchangelog"):
+            env.xchangelog = []
+        version = None
+        for entry in env.xchangelog:
+            if entry["doc"] == docname:
+                version = entry["version"]
+                assert isinstance(version, tuple)
+        if not version:
+            raise self.error("..contributors directive must be used in "
+                             "conjunction with a ..changelog directive")
+        if not hasattr(env, "xcontributors"):
+            env.xcontributors = dict()
+        if docname in env.xcontributors:
+            raise self.error("Only single ..contributors directive is "
+                             "allowed on a page")
+        env.xcontributors[docname] = self.people
+
+
+
+# This node will get replaced with actual content
+class contributors_placeholder_node(nodes.Element, nodes.General):
+    """
+    Temporary node that will be replaced with actual content before
+    the page is rendered.
+    """
+
+    def resolve(self, record):
+        sect = nodes.section(ids=["contributors"], classes=["contributors"])
+        sect += nodes.title("", "Contributors")
+        sect += nodes.paragraph("", self._prepare_text(record))
+        if record["PRs"]:
+            sect += nodes.paragraph("", "",
+                        nodes.strong("", "Code & documentation contributors:"))
+            sect += self._render_contributors(record["PRs"])
+        if record["issues"]:
+            sect += nodes.paragraph("", "",
+                        nodes.strong("", "Issues contributors:"))
+            sect += self._render_contributors(record["issues"])
+
+        j = self.parent.parent.children.index(self.parent)
+        self.parent.parent.children.insert(j + 1, sect)
+        self.replace_self([])
+
+    def _prepare_text(self, record):
+        n_contributors_prs = len(record["PRs"])
+        n_contributors_issues = len(record["issues"])
+        assert n_contributors_prs
+
+        if n_contributors_prs == 1:
+            people_prs = "1 person"
+        else:
+            people_prs = "%d people" % n_contributors_prs
+        if n_contributors_issues == 1:
+            people_issues = "1 more person"
+        else:
+            people_issues = "%d more people" % n_contributors_issues
+
+        text = ("This release was created with the help of %s who contributed "
+                "code and documentation" % people_prs)
+        if n_contributors_issues:
+            text += (", and %s who submitted bug reports and feature requests"
+                     % people_issues)
+        text += "."
+        return text
+
+    def _render_contributors(self, people):
+        ul = nodes.bullet_list(classes=["changelog-list", "simple"])
+        for username, record in people.items():
+            fullname = record[1]
+            if not fullname:
+                fullname = username
+            url = "https://github.com/" + username
+            link = nodes.reference("", fullname, refuri=url, internal=False)
+            li = nodes.list_item(classes=["changelog-list-item", "gh"])
+            li += nodes.inline("", "", link)
+            ul += li
+        return ul
+
+
+
+
+
+#-------------------------------------------------------------------------------
+# Event handlers
+#-------------------------------------------------------------------------------
+
+# This event is emitted when a source file is removed from the
+# environment (including just before it is freshly read), and
+# extensions are expected to purge their info about that file.
+#
+def on_env_purge_doc(app, env, docname):
+    if hasattr(env, "xcontributors"):
+        env.xcontributors.pop(docname, None)
+
+
+# This event is only emitted when parallel reading of documents is
+# enabled. It is emitted once for every subprocess that has read some
+# documents.
+#
+# You must handle this event in an extension that stores data in the
+# environment in a custom location. Otherwise the environment in the
+# main process will not be aware of the information stored in the
+# subprocess.
+#
+def on_env_merge_info(app, env, docnames, other):
+    if not hasattr(other, "xcontributors"):
+        return
+    if hasattr(env, "xcontributors"):
+        env.xcontributors.update(other.xcontributors)
+    else:
+        env.xcontributors = other.xcontributors
+
+
+
+# Emitted when a doctree has been “resolved” by the environment, that
+# is, all references have been resolved and TOCs have been inserted.
+# The doctree can be modified in place.
+#
+def on_doctree_resolved(app, doctree, docname):
+    env = app.builder.env
+    if not hasattr(env, "xcontributors"):
+        return
+    if docname in env.xcontributors:
+        for node in doctree.traverse(contributors_placeholder_node):
+            node.resolve(env.xcontributors[docname])
+
+
+
+
+#-------------------------------------------------------------------------------
+# Extension setup
+#-------------------------------------------------------------------------------
+
+def setup(app):
+    app.setup_extension("sphinxext.xnodes")
+    app.add_directive("contributors", XContributorsDirective)
+    app.connect("env-purge-doc", on_env_purge_doc)
+    app.connect("env-merge-info", on_env_merge_info)
+    app.connect("doctree-resolved", on_doctree_resolved)
+    return {"parallel_read_safe": True,
+            "parallel_write_safe": True,
+            "env_version": 1}


### PR DESCRIPTION
- Created Sphinx extension that provides the `.. contributors` directive. This directive is used on "changelog" pages to list the users who contributed to a particular release.
- Added helper script `ci/gh.py` for retrieving contributor lists from GitHub;
- Recorded contributors for versions 0.10.x and 0.11.0. These may still change, especially for 0.11.0 as we create new PRs/issues; but also for 0.10.x if we ever find mis-categorized old issues/PRs.

WIP for #2304