### PR TITLE
Switch to C++17 language standard

### DIFF
--- a/ci/ext.py
+++ b/ci/ext.py
@@ -248,7 +248,7 @@ def build_extension(cmd, verbosity=3):
             ext.compiler.add_linker_flag("/DEBUG:FULL")
     else:
         # Common compile flags
-        ext.compiler.add_compiler_flag("-std=c++11")
+        ext.compiler.add_compiler_flag("-std=c++17")
         # "-stdlib=libc++"  (clang ???)
         ext.compiler.add_compiler_flag("-fPIC")
 

--- a/src/core/python/obj.cc
+++ b/src/core/python/obj.cc
@@ -703,7 +703,7 @@ char** _obj::to_cstringlist(const error_manager&) const {
     Py_ssize_t count = Py_SIZE(v);
     char** res = nullptr;
     try {
-      res = new char*[count + 1]();
+      res = new char*[static_cast<size_t>(count + 1)]();
       for (Py_ssize_t i = 0; i <= count; ++i) res[i] = nullptr;
       for (Py_ssize_t i = 0; i < count; ++i) {
         PyObject* item = islist? PyList_GET_ITEM(v, i)


### PR DESCRIPTION
Today we compile `datatable` only with C++17 -compliant compilers, so there is no reason to keep using the old C++11 language standard.

This switch doesn't require any changes to the existing code, and we do not expect any externally-visible effects.

