### PR TITLE
Fix to_int64() functions to take into account size of long

### DIFF
--- a/ci/ext.py
+++ b/ci/ext.py
@@ -243,7 +243,7 @@ def build_extension(cmd, verbosity=3):
             raise RuntimeError("`make coverage` is not supported on Windows systems")
 
         if cmd == "debug":
-            xt.compiler.add_compiler_flag("/Od")    # no optimization
+            ext.compiler.add_compiler_flag("/Od")    # no optimization
             ext.compiler.add_compiler_flag("/Z7")
             ext.compiler.add_linker_flag("/DEBUG:FULL")
     else:

--- a/src/core/python/int.cc
+++ b/src/core/python/int.cc
@@ -38,12 +38,10 @@ oint::oint(int32_t n) {
 }
 
 oint::oint(int64_t n) {
-  #if LONG_MAX==9223372036854775807
+  #if DT_TYPE_LONG64
     v = PyLong_FromLong(n);
-  #elif LLONG_MAX==9223372036854775807
-    v = PyLong_FromLongLong(n);
   #else
-    #error "Cannot determine size of `long`"
+    v = PyLong_FromLongLong(n);
   #endif
 }
 
@@ -109,7 +107,7 @@ int32_t oint::ovalue(int* overflow) const {
 template<>
 int64_t oint::ovalue(int* overflow) const {
   if (!v) return GETNA<int64_t>();
-  #if LONG_MAX==9223372036854775807
+  #if DT_TYPE_LONG64
     long res = PyLong_AsLongAndOverflow(v, overflow);
   #else
     long long res = PyLong_AsLongLongAndOverflow(v, overflow);
@@ -266,7 +264,7 @@ int32_t oint::mvalue() const {
 
 template<>
 int64_t oint::mvalue() const {
-  #if LONG_MAX==9223372036854775807
+  #if DT_TYPE_LONG64
     return masked_value_long<int64_t>(v);
   #else
     if (!v) return GETNA<int64_t>();

--- a/src/core/python/int.cc
+++ b/src/core/python/int.cc
@@ -22,9 +22,9 @@
 // See https://docs.python.org/3/c-api/long.html
 // for the details of Python API
 //------------------------------------------------------------------------------
-#include <limits>
 #include "python/int.h"
 #include "utils/exceptions.h"
+#include "utils/macros.h"
 
 namespace py {
 

--- a/src/core/python/list.cc
+++ b/src/core/python/list.cc
@@ -8,6 +8,7 @@
 #include "python/list.h"
 #include "utils/assert.h"
 #include "utils/exceptions.h"
+#include "utils/macros.h"
 
 namespace py {
 

--- a/src/core/python/obj.cc
+++ b/src/core/python/obj.cc
@@ -523,7 +523,11 @@ int64_t _obj::to_int64(const error_manager& em) const {
   if (is_none()) return GETNA<int64_t>();
   if (PyLong_Check(v)) {
     int overflow;
-    long value = PyLong_AsLongAndOverflow(v, &overflow);
+    #if LONG_MAX==9223372036854775807
+      long value = PyLong_AsLongAndOverflow(v, &overflow);
+    #else
+      long long value = PyLong_AsLongLongAndOverflow(v, &overflow);
+    #endif
     int64_t res = static_cast<int64_t>(value);
     if (overflow ) {
       res = overflow == 1 ? MAX : -MAX;
@@ -542,7 +546,11 @@ int64_t _obj::to_int64_strict(const error_manager& em) const {
     throw em.error_not_integer(v);
   }
   int overflow;
-  long value = PyLong_AsLongAndOverflow(v, &overflow);
+  #if LONG_MAX==9223372036854775807
+    long value = PyLong_AsLongAndOverflow(v, &overflow);
+  #else
+    long long value = PyLong_AsLongLongAndOverflow(v, &overflow);
+  #endif
   if (overflow) {
     throw em.error_int64_overflow(v);
   }

--- a/src/core/python/obj.cc
+++ b/src/core/python/obj.cc
@@ -30,6 +30,7 @@
 #include "python/list.h"
 #include "python/obj.h"
 #include "python/string.h"
+#include "utils/macros.h"
 
 namespace py {
 static PyObject* pandas_DataFrame_type = nullptr;
@@ -523,7 +524,7 @@ int64_t _obj::to_int64(const error_manager& em) const {
   if (is_none()) return GETNA<int64_t>();
   if (PyLong_Check(v)) {
     int overflow;
-    #if LONG_MAX==9223372036854775807
+    #if DT_TYPE_LONG64
       long value = PyLong_AsLongAndOverflow(v, &overflow);
     #else
       long long value = PyLong_AsLongLongAndOverflow(v, &overflow);
@@ -546,7 +547,7 @@ int64_t _obj::to_int64_strict(const error_manager& em) const {
     throw em.error_not_integer(v);
   }
   int overflow;
-  #if LONG_MAX==9223372036854775807
+  #if DT_TYPE_LONG64
     long value = PyLong_AsLongAndOverflow(v, &overflow);
   #else
     long long value = PyLong_AsLongLongAndOverflow(v, &overflow);

--- a/src/core/python/obj.cc
+++ b/src/core/python/obj.cc
@@ -354,7 +354,7 @@ bool _parse_int(PyObject* v, T* out) {
   return false;
 }
 
-#if LONG_MAX != 9223372036854775807
+#if !DT_TYPE_LONG64
   template <>
   bool _parse_int(PyObject* v, int64_t* out) {
     static_assert(sizeof(int64_t) <= sizeof(long long), "Wrong size of long long");

--- a/src/core/utils/macros.h
+++ b/src/core/utils/macros.h
@@ -146,5 +146,17 @@ struct alignas(CACHELINE_SIZE) cache_aligned {
 };
 
 
+//------------------------------------------------------------------------------
+// Types
+//------------------------------------------------------------------------------
+
+#if LONG_MAX==9223372036854775807
+  #define DT_TYPE_LONG64 1
+#elif LLONG_MAX==9223372036854775807
+  #define DT_TYPE_LONG64 0
+#else
+  #error "Cannot determine size of `long`"
+#endif
+
 
 #endif

--- a/src/core/utils/macros.h
+++ b/src/core/utils/macros.h
@@ -21,6 +21,7 @@
 //------------------------------------------------------------------------------
 #ifndef dt_UTILS_MACROS_h
 #define dt_UTILS_MACROS_h
+#include <climits>
 #include <utility>  // std::move
 
 


### PR DESCRIPTION
- add `DT_TYPE_LONG64` variable to facilitate handling of 32 and 64 bit longs;
- fix `to_int64()` and `to_int64_strict()` to take into account size of long on a system;
- make use of `DT_TYPE_LONG64` in some other places.

WIP for #2301 