### PR TITLE
Fix frame to string conversion on Windows

### DIFF
--- a/src/core/frame/repr/repr_options.cc
+++ b/src/core/frame/repr/repr_options.cc
@@ -144,17 +144,18 @@ static void _init_options()
               : py::oint(display_max_column_width);
     },
     [](const py::Arg& value) {
+      const int max_column_width_limit = 2;
       if (value.is_none()) {
         display_max_column_width = MAX_int;
       } else {
         int n = value.to_int32_strict();
 
-        if (n < 2) {
+        if (n < max_column_width_limit) {
           throw ValueError() << "The smalled allowed value for `max_column_width`"
-            << " is 2, got: " << n;
+            << " is " << max_column_width_limit << ", got: " << n;
         }
 
-        display_max_column_width = (n < 0)? MAX_int : std::max(n, 2);
+        display_max_column_width = n;
       }
     },
     "A column's name or values that exceed `max_column_width` in size\n"

--- a/src/core/frame/repr/repr_options.cc
+++ b/src/core/frame/repr/repr_options.cc
@@ -151,7 +151,7 @@ static void _init_options()
         int n = value.to_int32_strict();
 
         if (n < max_column_width_limit) {
-          throw ValueError() << "The smalled allowed value for `max_column_width`"
+          throw ValueError() << "The smallest allowed value for `max_column_width`"
             << " is " << max_column_width_limit << ", got: " << n;
         }
 

--- a/src/core/frame/repr/repr_options.cc
+++ b/src/core/frame/repr/repr_options.cc
@@ -148,6 +148,12 @@ static void _init_options()
         display_max_column_width = MAX_int;
       } else {
         int n = value.to_int32_strict();
+
+        if (n < 2) {
+          throw ValueError() << "The smalled allowed value for `max_column_width`"
+            << " is 2, got: " << n;
+        }
+
         display_max_column_width = (n < 0)? MAX_int : std::max(n, 2);
       }
     },
@@ -155,7 +161,7 @@ static void _init_options()
     "will be truncated. This option applies both to rendering a frame\n"
     "in a terminal, and to rendering in a Jupyter notebook. The\n"
     "smallest allowed `max_column_width` is 2.\n"
-    "Setting the value to `None` (or negative) indicates that the\n"
+    "Setting the value to `None` indicates that the\n"
     "column's content should never be truncated.\n"
   );
 }

--- a/src/core/utils/terminal/terminal.cc
+++ b/src/core/utils/terminal/terminal.cc
@@ -52,22 +52,22 @@ Terminal& Terminal::plain_terminal() {
   return term;
 }
 
-Terminal::Terminal(bool is_plain) {
+Terminal::Terminal(bool is_plain) : is_plain_(is_plain){
   // Note: there is no simple way to catch the terminal re-size event
   // on Windows, because there is no `SIGWINCH` signal there.
   // For such a reason, on Windows we just re-check the terminal size
   // everytime the `get_width()` and `get_height()` are called.
   #if !DT_OS_WINDOWS
-    if (!is_plain) {
+    if (!is_plain_) {
       std::signal(SIGWINCH, sigwinch_handler);
     }
   #endif
 
-  size_.width = is_plain? (1 << 20) : 0;
-  size_.height = is_plain? 45 : 0;
+  size_.width = is_plain_? (1 << 20) : 0;
+  size_.height = is_plain_? 45 : 0;
   allow_unicode_ = true;
-  enable_colors_ = !is_plain;
-  enable_ecma48_ = !is_plain;
+  enable_colors_ = !is_plain_;
+  enable_ecma48_ = !is_plain_;
   enable_keyboard_ = false;
   is_jupyter_ = false;
   is_ipython_ = false;
@@ -157,7 +157,7 @@ bool Terminal::unicode_allowed() const noexcept {
 
 TerminalSize Terminal::get_size() {
   #if DT_OS_WINDOWS
-    _detect_window_size();
+    if (!is_plain_) _detect_window_size();
   #else
     if (!size_.width || !size_.height) _detect_window_size();
   #endif

--- a/src/core/utils/terminal/terminal.cc
+++ b/src/core/utils/terminal/terminal.cc
@@ -156,11 +156,9 @@ bool Terminal::unicode_allowed() const noexcept {
 
 
 TerminalSize Terminal::get_size() {
-  #if DT_OS_WINDOWS
-    if (!is_plain_) _detect_window_size();
-  #else
-    if (!size_.width || !size_.height) _detect_window_size();
-  #endif
+  if (!is_plain_ && (DT_OS_WINDOWS || size_.width == 0)) {
+    _detect_window_size();
+  }
   return size_;
 }
 

--- a/src/core/utils/terminal/terminal.h
+++ b/src/core/utils/terminal/terminal.h
@@ -53,7 +53,7 @@ class Terminal {
     bool is_jupyter_;
     bool is_ipython_;
     bool is_plain_;
-    int : 16;
+    int : 8;
 
   public:
     static Terminal& standard_terminal();

--- a/src/core/utils/terminal/terminal.h
+++ b/src/core/utils/terminal/terminal.h
@@ -52,6 +52,7 @@ class Terminal {
     bool enable_keyboard_;
     bool is_jupyter_;
     bool is_ipython_;
+    bool is_plain_;
     int : 16;
 
   public:

--- a/tests/frame/test-repr-text.py
+++ b/tests/frame/test-repr-text.py
@@ -596,9 +596,12 @@ def test_max_width_colored(capsys, uni):
 
 def test_max_width1():
     DT = dt.Frame(A=['foo', None, 'z'])
-    with dt.options.display.context(max_column_width=1):
+    with dt.options.display.context(max_column_width=2):
         assert dt.options.display.max_column_width == 2
-        dt.options.display.max_column_width = 0
+        with pytest.raises(ValueError, match = "The smalled allowed value for "
+                                       "`max_column_width` is 2, got: 0"):
+            dt.options.display.max_column_width = 0
+
         assert dt.options.display.max_column_width == 2
         assert str(DT) == (
             "   | A \n"

--- a/tests/frame/test-repr-text.py
+++ b/tests/frame/test-repr-text.py
@@ -654,8 +654,6 @@ def test_max_width_invalid():
 def test_max_width_none():
     with dt.options.display.context(max_column_width=None):
         assert dt.options.display.max_column_width is None
-        dt.options.display.max_column_width = -1
-        assert dt.options.display.max_column_width is None
         DT = dt.Frame(Long=["a" * 12321])
         assert str(DT) == (
             "   | Long" + " "*12317 + "\n" +

--- a/tests/frame/test-repr-text.py
+++ b/tests/frame/test-repr-text.py
@@ -708,7 +708,7 @@ def test_encoding_autodetection(tempfile):
     # datatable can detect it and set display.allow_unicode option
     # to False automatically.
     cmd = ("import sys; " +
-           "sys.stdout = open('%s', 'w', encoding='ascii'); " % tempfile +
+           "sys.stdout = open(r'%s', 'w', encoding='ascii'); " % tempfile +
            "import datatable as dt; " +
            "assert dt.options.display.allow_unicode is False; " +
            "DT = dt.Frame(A=['\\u2728']); " +

--- a/tests/frame/test-repr-text.py
+++ b/tests/frame/test-repr-text.py
@@ -598,7 +598,7 @@ def test_max_width1():
     DT = dt.Frame(A=['foo', None, 'z'])
     with dt.options.display.context(max_column_width=2):
         assert dt.options.display.max_column_width == 2
-        with pytest.raises(ValueError, match = "The smalled allowed value for "
+        with pytest.raises(ValueError, match = "The smallest allowed value for "
                                        "`max_column_width` is 2, got: 0"):
             dt.options.display.max_column_width = 0
 


### PR DESCRIPTION
- fix the way terminal size is detected on Windows;
- since internally `dt.options.display.max_column_width` couldn't be less than `2`, to be consistent, also adjust the setter for this option.

WIP for #2301 