### PR TITLE
Do not use Popen.wait() in fread

### DIFF
--- a/src/datatable/fread.py
+++ b/src/datatable/fread.py
@@ -280,12 +280,10 @@ class GenericReader(object):
         proc = subprocess.Popen(cmd, shell=True,
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE)
-        ret = proc.wait()
         msgout, msgerr = proc.communicate()
-        if ret:
+        if msgerr:
             msgerr = msgerr.decode("utf-8", errors="replace").strip()
-            raise TValueError("Shell command returned error code %r: `%s`"
-                              % (ret, msgerr))
+            raise TValueError("Shell command returned an error: `%s`" % msgerr)
         else:
             self._text = msgout
             self._src = cmd

--- a/src/datatable/fread.py
+++ b/src/datatable/fread.py
@@ -281,9 +281,11 @@ class GenericReader(object):
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE)
         msgout, msgerr = proc.communicate()
-        if msgerr:
+        ret = proc.returncode
+        if ret:
             msgerr = msgerr.decode("utf-8", errors="replace").strip()
-            raise TValueError("Shell command returned an error: `%s`" % msgerr)
+            raise TValueError("Shell command returned error code %r: `%s`"
+                  % (ret, msgerr))
         else:
             self._text = msgout
             self._src = cmd

--- a/src/datatable/fread.py
+++ b/src/datatable/fread.py
@@ -285,7 +285,7 @@ class GenericReader(object):
         if ret:
             msgerr = msgerr.decode("utf-8", errors="replace").strip()
             raise TValueError("Shell command returned error code %r: `%s`"
-                  % (ret, msgerr))
+                              % (ret, msgerr))
         else:
             self._text = msgout
             self._src = cmd

--- a/src/datatable/utils/terminal.py
+++ b/src/datatable/utils/terminal.py
@@ -66,7 +66,12 @@ class Terminal:
             enc = self._encoding.upper()
             if enc == "UTF8" or enc == "UTF-8":
                 self._allow_unicode = True
-            self.is_a_tty = sys.__stdin__.isatty() and sys.__stdout__.isatty()
+
+            if sys.__stdin__.closed or sys.__stdout__.closed:
+                self.is_a_tty = False
+            else:
+                self.is_a_tty = sys.__stdin__.isatty() and sys.__stdout__.isatty()
+
             self._width = 0
             self._height = 0
             self._check_ipython()

--- a/tests/fread/test_fread_issues.py
+++ b/tests/fread/test_fread_issues.py
@@ -27,7 +27,8 @@ def test_issue1935():
         dt.fread(cmd="leeroy jenkins")
     assert ("Shell command returned error code" in str(e.value))
     # This may need adjustments for different OSes
-    assert re.search(r"leeroy:(?: command)? not found\s*", str(e.value))
+    assert re.search(r"leeroy(:|\')(?: command)? (.*) not (found|recognized)\s*",
+                     str(e.value))
 
 
 

--- a/tests/fread/test_fread_issues.py
+++ b/tests/fread/test_fread_issues.py
@@ -20,7 +20,7 @@ def test_issue1935():
     # an error instead of returning an empty Frame silently.
     with pytest.raises(ValueError) as e:
         dt.fread(cmd="leeroy jenkins")
-    assert ("Shell command returned error code" in str(e.value))
+    assert ("Shell command returned an error" in str(e.value))
     # This may need adjustments for different OSes
     assert re.search(r"leeroy:(?: command)? not found\s*", str(e.value))
 

--- a/tests/fread/test_fread_issues.py
+++ b/tests/fread/test_fread_issues.py
@@ -27,7 +27,7 @@ def test_issue1935():
         dt.fread(cmd="leeroy jenkins")
     assert ("Shell command returned error code" in str(e.value))
     # This may need adjustments for different OSes
-    assert re.search(r"leeroy(:|\')(?: command)? (.*) not (found|recognized)\s*",
+    assert re.search(r"leeroy(:|\')(command)? (.*) not (found|recognized)\s*",
                      str(e.value))
 
 

--- a/tests/fread/test_fread_issues.py
+++ b/tests/fread/test_fread_issues.py
@@ -27,7 +27,7 @@ def test_issue1935():
         dt.fread(cmd="leeroy jenkins")
     assert ("Shell command returned error code" in str(e.value))
     # This may need adjustments for different OSes
-    assert re.search(r"leeroy(:|\')(command)? (.*) not (found|recognized)\s*",
+    assert re.search(r"leeroy(:|')(.*) not (found|recognized)\s*",
                      str(e.value))
 
 

--- a/tests/fread/test_fread_issues.py
+++ b/tests/fread/test_fread_issues.py
@@ -16,11 +16,16 @@ from tests import find_file, same_iterables
 
 
 def test_issue1935():
+    # Check that we properly handle situations when a command terminates
+    # with an error but don't write anything to stderr.
+    with pytest.raises(ValueError, match="Shell command returned error code 1:"):
+        dt.fread(cmd="exit 1")
+
     # Check that giving wrong command to `cmd=` parameter raises
     # an error instead of returning an empty Frame silently.
     with pytest.raises(ValueError) as e:
         dt.fread(cmd="leeroy jenkins")
-    assert ("Shell command returned an error" in str(e.value))
+    assert ("Shell command returned error code" in str(e.value))
     # This may need adjustments for different OSes
     assert re.search(r"leeroy:(?: command)? not found\s*", str(e.value))
 


### PR DESCRIPTION
- `Popen.wait()` is [known](https://docs.python.org/2/library/subprocess.html#subprocess.Popen.wait) to cause deadlocks when used in conjunction with pipes. Due to this fact some tests, like `test_fread_from_cmd2`, were constantly hanging on Windows. In this PR we adjust `fread()` not to call `Popen.wait()`.

- minor fix in the `terminal.py` to prevent it from hanging when used in the multiprocessing pool. Python terminal class is going to be fully replaced by the corresponding C++ code anyways.

WIP for #2301 