### PR TITLE
Read Excel date values

### DIFF
--- a/docs/releases/v0.11.0.rst
+++ b/docs/releases/v0.11.0.rst
@@ -28,6 +28,14 @@
     consistent with fread's behavior when reading CSV files.
 
 
+  Fread
+  -----
+
+  -[fix] When reading Excel files, the cells with datetime or boolean types
+    are now handled correctly, in particular a datetime value is converted
+    into its string representation. [#1701]
+
+
   General
   -------
   .. ref-context:: datatable

--- a/docs/releases/v0.11.0.rst
+++ b/docs/releases/v0.11.0.rst
@@ -22,6 +22,11 @@
     given a numeric column index outside of the allowed range. Previously it
     was throwing a ``ValueError`` in both cases.
 
+  -[api] When creating a Frame from a list containing mixed integers / floats
+    and strings, the resulting Frame will now have stype ``str32``. Previously
+    an ``obj64`` column was created instead. The new behavior is more
+    consistent with fread's behavior when reading CSV files.
+
 
   General
   -------

--- a/tests/models/test_ftrl.py
+++ b/tests/models/test_ftrl.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #-------------------------------------------------------------------------------
-# Copyright 2018-2019 H2O.ai
+# Copyright 2018-2020 H2O.ai
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -511,7 +511,7 @@ def test_ftrl_fit_wrong_empty_target():
 def test_ftrl_fit_wrong_target_obj64():
     ft = Ftrl()
     df_train = dt.Frame(list(range(8)))
-    df_target = dt.Frame([3, "point", None, None, 14, 15, 92, "6"])
+    df_target = dt.Frame([3, "point", None, None, 14, 15, {92}, "6"])
     with pytest.raises(TypeError) as e:
         ft.fit(df_train, df_target)
     assert ("Target column type `obj64` is not supported" ==

--- a/tests/test_dt_create.py
+++ b/tests/test_dt_create.py
@@ -700,10 +700,24 @@ def test_auto_float64():
     assert d0.to_list()[0] == src
 
 
-def test_auto_str32():
+def test_auto_str32_1():
     d0 = dt.Frame(["start", None, "end"])
     frame_integrity_check(d0)
     assert d0.stypes == (stype.str32,)
+
+
+def test_auto_str32_2():
+    DT = dt.Frame([None, 1, 12, "fini"])
+    frame_integrity_check(DT)
+    assert DT.stype == stype.str32
+    assert DT.to_list() == [[None, "1", "12", "fini"]]
+
+
+def test_auto_str32_3():
+    DT = dt.Frame([True, 5.75, 9, "hi", 4, False])
+    frame_integrity_check(DT)
+    assert DT.stype == stype.str32
+    assert DT.to_list() == [["True", "5.75", "9", "hi", "4", "False"]]
 
 
 def test_auto_str64():

--- a/tests/test_dt_create.py
+++ b/tests/test_dt_create.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #-------------------------------------------------------------------------------
-# Copyright 2018-2019 H2O.ai
+# Copyright 2018-2020 H2O.ai
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -1237,7 +1237,7 @@ def test_issue_42():
     frame_integrity_check(d)
     assert d.shape == (1, 1)
     assert d.ltypes == (ltype.int, )
-    d = dt.Frame([-1, 2, 5, "hooray"])
+    d = dt.Frame([-1, 2, {5}, "hooray"])
     frame_integrity_check(d)
     assert d.shape == (4, 1)
     assert d.ltypes == (ltype.obj, )

--- a/tests/test_dt_stats.py
+++ b/tests/test_dt_stats.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #-------------------------------------------------------------------------------
-# Copyright 2018 H2O.ai
+# Copyright 2018-2020 H2O.ai
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -397,7 +397,7 @@ def test_empty_frame(st):
 
 
 def test_object_column():
-    df = dt.Frame([None, nan, 3, "srsh"])
+    df = dt.Frame([None, nan, 3, [], "srsh"])
     frame_integrity_check(df)
     assert df.countna1() == 2
     assert df.min1() is None
@@ -411,7 +411,7 @@ def test_object_column():
 
 
 def test_object_column2():
-    df = dt.Frame([None, nan, 3, "srsh"])
+    df = dt.Frame([None, nan, 3, [], "srsh"])
 
     f0 = df.countna()
     frame_integrity_check(f0)


### PR DESCRIPTION
- When creating a frame from list of mixed types containing bools/ints/floats and also strings, the resulting column will now have string type instead of object type. This is consistent with how fread reads CSV files, and also with the semantics of rowbinding.
- When reading an Excel file we now parse datetime and boolean values correctly.

Closes #1701