### PR TITLE
Use `with` when working with the multiprocessing pool

### DIFF
--- a/ci/xbuild/compiler.py
+++ b/ci/xbuild/compiler.py
@@ -213,7 +213,7 @@ class Compiler:
                 winsdk_version_dir = version
                 break
 
-        if winsdk_version_dir is "":
+        if winsdk_version_dir == "":
             raise ValueError("A valid Windows SDK version directory %s not found.")
 
         winsdk_include_path = winsdk_default_path + "\\Include\\" + winsdk_version_dir

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -42,19 +42,18 @@ cpp_test = pytest.mark.skipif(not hasattr(core, "test_coverage"),
 #-------------------------------------------------------------------------------
 
 def test_multiprocessing_threadpool():
-    import atexit
     # Verify that threads work properly after forking (#1758)
     import multiprocessing as mp
     from datatable.internal import get_thread_ids
     parent_threads = get_thread_ids()
     n = 4
-    pool = mp.Pool(processes=n)
-    atexit.register(pool.close)
-    child_threads = pool.starmap(get_thread_ids, [()] * n, chunksize=1)
-    assert len(child_threads) == n
-    for chthreads in child_threads:
-        assert len(parent_threads) == len(chthreads)
-        assert chthreads != parent_threads
+    with mp.Pool(processes=n) as pool:
+        # atexit.register(pool.close)
+        child_threads = pool.starmap(get_thread_ids, [()] * n, chunksize=1)
+        assert len(child_threads) == n
+        for chthreads in child_threads:
+            assert len(parent_threads) == len(chthreads)
+            assert chthreads != parent_threads
 
 
 @cpp_test

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -42,12 +42,14 @@ cpp_test = pytest.mark.skipif(not hasattr(core, "test_coverage"),
 #-------------------------------------------------------------------------------
 
 def test_multiprocessing_threadpool():
+    import atexit
     # Verify that threads work properly after forking (#1758)
     import multiprocessing as mp
     from datatable.internal import get_thread_ids
     parent_threads = get_thread_ids()
     n = 4
     pool = mp.Pool(processes=n)
+    atexit.register(pool.close)
     child_threads = pool.starmap(get_thread_ids, [()] * n, chunksize=1)
     assert len(child_threads) == n
     for chthreads in child_threads:

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -48,7 +48,6 @@ def test_multiprocessing_threadpool():
     parent_threads = get_thread_ids()
     n = 4
     with mp.Pool(processes=n) as pool:
-        # atexit.register(pool.close)
         child_threads = pool.starmap(get_thread_ids, [()] * n, chunksize=1)
         assert len(child_threads) == n
         for chthreads in child_threads:


### PR DESCRIPTION
Using `with` statement, when working with the multiprocessing pool in `test_parallel.py::test_multiprocessing_threadpool`, seems to fix hangs in Python 3.8, as it properly closes the pool at exit.