### PR TITLE
Fix sort-related issues

### DIFF
--- a/src/core/column.cc
+++ b/src/core/column.cc
@@ -125,6 +125,10 @@ dt::ColumnImpl* Column::_get_mutable_impl(bool keep_stats) {
   return const_cast<dt::ColumnImpl*>(impl_);
 }
 
+bool Column::operator==(const Column& other) const noexcept {
+  return impl_ == other.impl_;
+}
+
 
 
 //------------------------------------------------------------------------------

--- a/src/core/column.cc
+++ b/src/core/column.cc
@@ -302,8 +302,18 @@ Buffer Column::get_data_buffer(size_t k) const {
 //------------------------------------------------------------------------------
 
 void Column::materialize(bool to_memory) {
-  auto pcol = _get_mutable_impl(/* keep_stats= */ true);
-  pcol->materialize(*this, to_memory);
+  if (impl_->is_virtual()) {
+    auto pcol = _get_mutable_impl(/* keep_stats= */ true);
+    pcol->materialize(*this, to_memory);
+  }
+  else if (to_memory) {
+    // A non-virtual column doesn't need to be materialized, unless
+    // it's to bring the memory-mapped data into RAM. However, in
+    // that case we're not really changing the column, so no need to
+    // acquire the "mutable impl", which may incur unnecessary data
+    // copy.
+    const_cast<dt::ColumnImpl*>(impl_)->materialize(*this, to_memory);
+  }
 }
 
 void Column::replace_values(const RowIndex& replace_at,

--- a/src/core/column.h
+++ b/src/core/column.h
@@ -158,6 +158,9 @@ class Column
     // the class overtakes ownership of that pointer.
     explicit Column(dt::ColumnImpl*&& col) noexcept;
 
+    // Columns are considered equal if they have the same `impl_`.
+    bool operator==(const Column& other) const noexcept;
+
   //------------------------------------
   // Properties
   //------------------------------------

--- a/src/core/datatablemodule.cc
+++ b/src/core/datatablemodule.cc
@@ -266,7 +266,7 @@ static void initialize_options(const py::PKArgs& args) {
 //------------------------------------------------------------------------------
 // Support memory leak detection
 //------------------------------------------------------------------------------
-#ifdef DTDEBUG
+#if DTDEBUG
 
 struct PtrInfo {
   size_t alloc_size;
@@ -371,7 +371,7 @@ void py::DatatableModule::init_methods() {
   #ifdef DTTEST
     init_tests();
   #endif
-  #ifdef DTDEBUG
+  #if DTDEBUG
     ADD_FN(&get_tracked_objects, args_get_tracked_objects);
   #endif
 }

--- a/src/core/datatablemodule.h
+++ b/src/core/datatablemodule.h
@@ -61,7 +61,7 @@ class DatatableModule : public ExtModule<DatatableModule> {
 }  // namespace py
 
 
-#ifdef DTDEBUG
+#if DTDEBUG
   void TRACK(void* ptr, size_t size, const char* name);
   void UNTRACK(void* ptr);
   bool IS_TRACKED(void* ptr);

--- a/src/core/expr/eval_context.cc
+++ b/src/core/expr/eval_context.cc
@@ -250,15 +250,10 @@ void EvalContext::compute_groupby_and_sort() {
     if (ncols) {
       for (size_t i = 0; i < ncols; ++i) {
         const Column& col = wf.get_column(i);
-        // Remove duplicate columns from the sorting list
-        for (const Column& existing_col : cols) {
-          if (col == existing_col) goto skip_col;
-        }
         cols.push_back(col);  // copy
         if (i >= n_group_cols) {
           flags[i] = flags[i] | SortFlag::SORT_ONLY;
         }
-        skip_col:;
       }
       wf.truncate_columns(n_group_cols);
       set_groupby_columns(std::move(wf));

--- a/src/core/expr/eval_context.cc
+++ b/src/core/expr/eval_context.cc
@@ -250,7 +250,6 @@ void EvalContext::compute_groupby_and_sort() {
     if (ncols) {
       for (size_t i = 0; i < ncols; ++i) {
         const Column& col = wf.get_column(i);
-        const_cast<Column&>(col).materialize();
         cols.push_back(col);  // copy
         if (i >= n_group_cols) {
           flags[i] = flags[i] | SortFlag::SORT_ONLY;

--- a/src/core/expr/eval_context.cc
+++ b/src/core/expr/eval_context.cc
@@ -250,10 +250,15 @@ void EvalContext::compute_groupby_and_sort() {
     if (ncols) {
       for (size_t i = 0; i < ncols; ++i) {
         const Column& col = wf.get_column(i);
+        // Remove duplicate columns from the sorting list
+        for (const Column& existing_col : cols) {
+          if (col == existing_col) goto skip_col;
+        }
         cols.push_back(col);  // copy
         if (i >= n_group_cols) {
           flags[i] = flags[i] | SortFlag::SORT_ONLY;
         }
+        skip_col:;
       }
       wf.truncate_columns(n_group_cols);
       set_groupby_columns(std::move(wf));

--- a/src/core/sort.cc
+++ b/src/core/sort.cc
@@ -553,7 +553,10 @@ class SortContext {
     _fill_rrmap_from_groups(rrmap_ptr);
 
     if (make_groups) {
-      gg.init(static_cast<int32_t*>(groups.xptr()) + 1, 0);
+      // Note: `groups` variable may have been stored in another
+      // variable, if doing groupby+sort (by more than 1 column).
+      // Thus, use `.wptr()` instead of `.xptr()` here.
+      gg.init(static_cast<int32_t*>(groups.wptr()) + 1, 0);
       _radix_recurse<true>(rrmap_ptr);
     } else {
       _radix_recurse<false>(rrmap_ptr);

--- a/src/core/sort.cc
+++ b/src/core/sort.cc
@@ -122,6 +122,8 @@
 //
 //
 //------------------------------------------------------------------------------
+#include <iostream>
+
 #include <algorithm>  // std::min
 #include <atomic>     // std::atomic_flag
 #include <cstdlib>    // std::abs
@@ -166,7 +168,7 @@ class rmem {
   private:
   public:
     void* ptr;
-    #ifdef DTDEBUG
+    #if DTDEBUG
       size_t size;
     #endif
   public:
@@ -204,21 +206,21 @@ void* omem::release() {
 
 rmem::rmem() {
   ptr = nullptr;
-  #ifdef DTDEBUG
+  #if DTDEBUG
     size = 0;
   #endif
 }
 
 rmem::rmem(const omem& o) {
   ptr = o.ptr;
-  #ifdef DTDEBUG
+  #if DTDEBUG
     size = o.size;
   #endif
 }
 
 rmem::rmem(const rmem& o) {
   ptr = o.ptr;
-  #ifdef DTDEBUG
+  #if DTDEBUG
     size = o.size;
   #endif
 }
@@ -226,7 +228,7 @@ rmem::rmem(const rmem& o) {
 rmem::rmem(const rmem& o, size_t offset, size_t n) {
   ptr = static_cast<char*>(o.ptr) + offset;
   (void)n;
-  #ifdef DTDEBUG
+  #if DTDEBUG
     size = n;
     xassert(offset + n <= o.size);
   #endif
@@ -242,7 +244,7 @@ template <typename T> T* rmem::data() const noexcept {
 
 void swap(rmem& left, rmem& right) noexcept {
   std::swap(left.ptr, right.ptr);
-  #ifdef DTDEBUG
+  #if DTDEBUG
     std::swap(left.size, right.size);
   #endif
 }
@@ -535,6 +537,9 @@ class SortContext {
     descending = desc;
     xassert(nradixes > 0);
     xassert(o == container_o.ptr);
+    std::cout << "continue_sort: o = [";
+    for (int i = 0; i < n; ++i) std::cout << o[i] << ", ";
+    std::cout << "]\n";
     if (desc) {
       _prepare_data_for_column<false>();
     } else {

--- a/src/core/sort.cc
+++ b/src/core/sort.cc
@@ -122,8 +122,6 @@
 //
 //
 //------------------------------------------------------------------------------
-#include <iostream>
-
 #include <algorithm>  // std::min
 #include <atomic>     // std::atomic_flag
 #include <cstdlib>    // std::abs
@@ -537,9 +535,6 @@ class SortContext {
     descending = desc;
     xassert(nradixes > 0);
     xassert(o == container_o.ptr);
-    std::cout << "continue_sort: o = [";
-    for (int i = 0; i < n; ++i) std::cout << o[i] << ", ";
-    std::cout << "]\n";
     if (desc) {
       _prepare_data_for_column<false>();
     } else {
@@ -561,6 +556,7 @@ class SortContext {
       // Note: `groups` variable may have been stored in another
       // variable, if doing groupby+sort (by more than 1 column).
       // Thus, use `.wptr()` instead of `.xptr()` here.
+      groups.ensuresize(sizeof(int32_t*) * (n + 1));
       gg.init(static_cast<int32_t*>(groups.wptr()) + 1, 0);
       _radix_recurse<true>(rrmap_ptr);
     } else {

--- a/src/core/sort.h
+++ b/src/core/sort.h
@@ -117,7 +117,7 @@ class GroupGatherer {
     void push(size_t grp);
 
     template <typename T, typename V>
-    void from_data(const T*, V*, size_t);
+    void from_data(const T*, const V*, size_t);
 
     template <typename V>
     void from_data(const Column&, const V*, size_t);
@@ -166,10 +166,10 @@ extern template void insert_sort_values_str(const Column&, size_t, int32_t*, int
 extern template int compare_strings<1>(const CString&, bool, const CString&, bool, size_t);
 extern template int compare_strings<-1>(const CString&, bool, const CString&, bool, size_t);
 
-extern template void GroupGatherer::from_data(const uint8_t*,  int32_t*, size_t);
-extern template void GroupGatherer::from_data(const uint16_t*, int32_t*, size_t);
-extern template void GroupGatherer::from_data(const uint32_t*, int32_t*, size_t);
-extern template void GroupGatherer::from_data(const uint64_t*, int32_t*, size_t);
+extern template void GroupGatherer::from_data(const uint8_t*,  const int32_t*, size_t);
+extern template void GroupGatherer::from_data(const uint16_t*, const int32_t*, size_t);
+extern template void GroupGatherer::from_data(const uint32_t*, const int32_t*, size_t);
+extern template void GroupGatherer::from_data(const uint64_t*, const int32_t*, size_t);
 extern template void GroupGatherer::from_data(const Column&, const int32_t*, size_t);
 extern template void GroupGatherer::from_data(const Column&, const int64_t*, size_t);
 

--- a/src/core/sort_groups.cc
+++ b/src/core/sort_groups.cc
@@ -1,9 +1,23 @@
 //------------------------------------------------------------------------------
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright 2018-2020 H2O.ai
 //
-// © H2O.ai 2018
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #include <utility>  // std::move
 #include "utils/assert.h"
@@ -30,7 +44,7 @@ void GroupGatherer::push(size_t grp) {
 
 
 template <typename T, typename V>
-void GroupGatherer::from_data(const T* data, V* o, size_t n) {
+void GroupGatherer::from_data(const T* data, const V* o, size_t n) {
   if (n == 0) return;
   T curr_value = data[o[0]];
   size_t lasti = 0;
@@ -102,9 +116,9 @@ void GroupGatherer::from_histogram(
 }
 
 
-template void GroupGatherer::from_data(const uint8_t*,  int32_t*, size_t);
-template void GroupGatherer::from_data(const uint16_t*, int32_t*, size_t);
-template void GroupGatherer::from_data(const uint32_t*, int32_t*, size_t);
-template void GroupGatherer::from_data(const uint64_t*, int32_t*, size_t);
+template void GroupGatherer::from_data(const uint8_t*,  const int32_t*, size_t);
+template void GroupGatherer::from_data(const uint16_t*, const int32_t*, size_t);
+template void GroupGatherer::from_data(const uint32_t*, const int32_t*, size_t);
+template void GroupGatherer::from_data(const uint64_t*, const int32_t*, size_t);
 template void GroupGatherer::from_data(const Column&, const int32_t*, size_t);
 template void GroupGatherer::from_data(const Column&, const int64_t*, size_t);

--- a/tests/test_dt_sort.py
+++ b/tests/test_dt_sort.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #-------------------------------------------------------------------------------
-# Copyright 2018-2019 H2O.ai
+# Copyright 2018-2020 H2O.ai
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -931,3 +931,16 @@ def test_h2oai7014(tempfile_jay):
     counts = counts[:, :, sort("count")]
     counts.materialize()
     assert counts.to_list() == [['t'], [1047]]
+
+
+def test_issue2348():
+    DT = dt.Frame(A=[1, 2, 3, 1, 2, 3], B=list('akdfnv'),
+                  C=[0.1, 0.2, 0.3, 0.4, 0.5, 0.6],
+                  D=[11]*6, E=[2]*6)
+    # Check that these expressions do not crash
+    DT[:, :, by(f.A), sort(f.A, f.E)]
+    # DT[:, :, by(f.A, f.B), sort(f.A, f.B)]
+    # assert_equals(DT[:, dt.count(), by(f.D), sort(f.E, f.A)],
+    #               dt.Frame([[11], [6]],
+    #                        names=["D", "count"],
+    #                        stypes=[dt.int32, dt.int64]))

--- a/tests/test_dt_sort.py
+++ b/tests/test_dt_sort.py
@@ -939,8 +939,8 @@ def test_issue2348():
                   D=[11]*6, E=[2]*6)
     # Check that these expressions do not crash
     DT[:, :, by(f.A), sort(f.A, f.E)]
-    # DT[:, :, by(f.A, f.B), sort(f.A, f.B)]
-    # assert_equals(DT[:, dt.count(), by(f.D), sort(f.E, f.A)],
-    #               dt.Frame([[11], [6]],
-    #                        names=["D", "count"],
-    #                        stypes=[dt.int32, dt.int64]))
+    DT[:, :, by(f.A, f.B), sort(f.A, f.B)]
+    assert_equals(DT[:, dt.count(), by(f.D), sort(f.E, f.A)],
+                  dt.Frame([[11], [6]],
+                           names=["D", "count"],
+                           stypes=[dt.int32, dt.int64]))


### PR DESCRIPTION
- Column materialization is adjusted so that a non-virtual column which has refcount>1 wouldn't get copied needlessly. This should improve the performance of sorting: currently we materialize all columns before using them for sorting/grouping, and during this process we currently accidentally create a copy of the data.

- Fixed the use of `DTDEBUG` macro: this macro is always defined, and equal either 0 or 1. However, using it as `#ifdef DTDEBUG` is incorrect, it should be `#if DTDEBUG` instead. Because of this misunderstanding, we were including some code that was meant for debug builds only into production, specifically code for tracking/untracking all memory allocation. After this fix we expect the performance to improve, especially the sort function which allocates many memory ranges internally.

- There was an issue with combining a `by()` operator with a `sort()` when the sort function involves more than one column. The issue was manifesting as an assertion error after we switched from an array to buffer implementation in one of the recent PRs (however it seems the problem existed before too, only it was masked). With certain configuration of the data it was even possible to cause a segfault. This has now been fixed. 

Closes #2348 