### PR TITLE
Improve performance of groupby operation

### DIFF
--- a/src/core/column/column_impl.h
+++ b/src/core/column/column_impl.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2019 H2O.ai
+// Copyright 2018-2020 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -94,6 +94,7 @@ class ColumnImpl
     size_t nrows() const noexcept { return nrows_; }
     SType  stype() const noexcept { return stype_; }
     virtual bool is_virtual() const noexcept = 0;
+    virtual bool computationally_expensive() const { return false; }
     virtual size_t memory_footprint() const noexcept = 0;
 
 

--- a/src/core/expr/head_reduce_binary.cc
+++ b/src/core/expr/head_reduce_binary.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019 H2O.ai
+// Copyright 2019-2020 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -84,6 +84,10 @@ class BinaryReduced_ColumnImpl : public Virtual_ColumnImpl {
       size_t i0, i1;
       groupby.get_group(i, &i0, &i1);
       return reducer(arg1, arg2, i0, i1, out);
+    }
+
+    bool computationally_expensive() const override {
+      return true;
     }
 };
 

--- a/src/core/expr/head_reduce_unary.cc
+++ b/src/core/expr/head_reduce_unary.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019 H2O.ai
+// Copyright 2019-2020 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -82,6 +82,10 @@ class Reduced_ColumnImpl : public Virtual_ColumnImpl {
       groupby.get_group(i, &i0, &i1);
       return reducer(arg, i0, i1, out);
     }
+
+    bool computationally_expensive() const override {
+      return true;
+    }
 };
 
 
@@ -115,6 +119,11 @@ class FirstLast_ColumnImpl : public Virtual_ColumnImpl {
     bool get_element(size_t i, double*   out) const override { return _get(i, out); }
     bool get_element(size_t i, CString*  out) const override { return _get(i, out); }
     bool get_element(size_t i, py::robj* out) const override { return _get(i, out); }
+
+
+    bool computationally_expensive() const override {
+      return true;
+    }
 
   private:
     template <typename T>


### PR DESCRIPTION
Groupby operator is relatively expensive; when materializing such column we should assign each thread per row (row=group) and use dynamic scheduling.
Instead we were using standard "static batched" schedule, which essentially was causing single-threaded evaluation if the number of group wasn't very big.
This PR fixes the problem.

Closes #2325