### PR TITLE
Docs2

### DIFF
--- a/docs/api/frame.rst
+++ b/docs/api/frame.rst
@@ -6,7 +6,8 @@ Frame
     :members:
     :inherited-members:
     :undoc-members:
-    :exclude-members: cbind, colindex, copy, countna, countna1, export_names, names, replace, to_csv
+    :exclude-members: cbind, colindex, copy, countna, countna1, export_names,
+    				  head, names, replace, tail, to_csv
 
 
 .. toctree::
@@ -18,6 +19,8 @@ Frame
 	.countna()       <frame/countna>
 	.countna1()      <frame/countna1>
 	.export_names()  <frame/export_names>
+	.head()          <frame/head>
 	.names           <frame/names>
 	.replace()       <frame/replace>
+	.tail()          <frame/tail>
 	.to_csv()        <frame/to_csv>

--- a/docs/api/frame.rst
+++ b/docs/api/frame.rst
@@ -7,20 +7,21 @@ Frame
     :inherited-members:
     :undoc-members:
     :exclude-members: cbind, colindex, copy, countna, countna1, export_names,
-    				  head, names, replace, tail, to_csv
+                      head, key, names, replace, tail, to_csv
 
 
 .. toctree::
-	:hidden:
+    :hidden:
 
-	.cbind()         <frame/cbind>
-	.colindex()      <frame/colindex>
-	.copy()          <frame/copy>
-	.countna()       <frame/countna>
-	.countna1()      <frame/countna1>
-	.export_names()  <frame/export_names>
-	.head()          <frame/head>
-	.names           <frame/names>
-	.replace()       <frame/replace>
-	.tail()          <frame/tail>
-	.to_csv()        <frame/to_csv>
+    .cbind()         <frame/cbind>
+    .colindex()      <frame/colindex>
+    .copy()          <frame/copy>
+    .countna()       <frame/countna>
+    .countna1()      <frame/countna1>
+    .export_names()  <frame/export_names>
+    .head()          <frame/head>
+    .key             <frame/key>
+    .names           <frame/names>
+    .replace()       <frame/replace>
+    .tail()          <frame/tail>
+    .to_csv()        <frame/to_csv>

--- a/docs/api/frame/head.rst
+++ b/docs/api/frame/head.rst
@@ -1,0 +1,3 @@
+
+.. xmethod:: datatable.Frame.head
+    :src: src/core/frame/py_frame.cc Frame::head

--- a/docs/api/frame/key.rst
+++ b/docs/api/frame/key.rst
@@ -1,5 +1,7 @@
 
 .. xdata:: datatable.Frame.key
-    :src: src/core/frame/key.cc Frame::get_key
+    :src: src/core/frame/key.cc Frame::get_key Frame::set_key
     :doc: src/core/frame/key.cc doc_key
+    :tests: tests/test_keys.py
     :settable: newkey
+    :deletable:

--- a/docs/api/frame/key.rst
+++ b/docs/api/frame/key.rst
@@ -1,0 +1,5 @@
+
+.. xdata:: datatable.Frame.key
+    :src: src/core/frame/key.cc Frame::get_key
+    :doc: src/core/frame/key.cc doc_key
+    :settable: newkey

--- a/docs/api/frame/names.rst
+++ b/docs/api/frame/names.rst
@@ -1,6 +1,6 @@
 
 .. xdata:: datatable.Frame.names
-    :src: src/core/frame/names.cc Frame::get_names
+    :src: src/core/frame/names.cc Frame::get_names Frame::set_names
     :doc: src/core/frame/names.cc doc_names
     :settable: newnames
     :deletable:

--- a/docs/api/frame/tail.rst
+++ b/docs/api/frame/tail.rst
@@ -1,0 +1,3 @@
+
+.. xmethod:: datatable.Frame.tail
+    :src: src/core/frame/py_frame.cc Frame::tail

--- a/docs/releases/v0.11.0.rst
+++ b/docs/releases/v0.11.0.rst
@@ -27,6 +27,9 @@
     an ``obj64`` column was created instead. The new behavior is more
     consistent with fread's behavior when reading CSV files.
 
+  -[bug] Deleting a key from the Frame (``del DT.key``) no longer causes a
+    seg.fault. [#2357]
+
 
   Fread
   -----

--- a/src/core/frame/key.cc
+++ b/src/core/frame/key.cc
@@ -35,12 +35,12 @@ static const char* doc_key =
 R"(
 The tuple of column names that are the primary key for this frame.
 
+If the frame has no primary key, this property returns an empty tuple.
+
 The primary key columns are always located at the beginning of the
-frame, and therefore the following identity always holds::
+frame, and therefore the following holds::
 
     DT.key == DT.names[:len(DT.key)]
-
-If the frame is not keyed, this property returns an empty tuple.
 
 Assigning to this property will make the Frame keyed by the specified
 column(s). The key columns will be moved to the front, and the Frame
@@ -53,7 +53,38 @@ Parameters
     key columns.
 
 newkey: str | List[str] | Tuple[str, ...] | None
-    slm
+    Specify a column or a list of columns that will become the new
+    primary key of the Frame. Object columns cannot be used for a key.
+    The values in the key column must be unique; if multiple columns
+    are assigned as the key, then their combined (tuple-like) values
+    must be unique.
+
+    If `newkey` is `None`, then this is equivalent to deleting the
+    key. When the key is deleted, the key columns remain in the frame,
+    they merely stop being marked as "key".
+
+(except): ValueError
+    Raised when the values in the key column(s) are not unique.
+
+(except): KeyError
+    Raised when `newkey` contains a column name that doesn't exist
+    in the Frame.
+
+Examples
+--------
+>>> DT = dt.Frame(A=range(5), B=['one', 'two', 'three', 'four', 'five'])
+>>> DT.key = 'B'
+>>> DT
+B     |     A
+str32 | int32
+----- + -----
+five  |     4
+four  |     3
+one   |     0
+three |     2
+two   |     1
+--
+[5 rows x 2 columns]
 )";
 
 static GSArgs args_key("key", doc_key);

--- a/src/core/frame/key.cc
+++ b/src/core/frame/key.cc
@@ -70,7 +70,7 @@ oobj Frame::get_key() const {
 
 
 void Frame::set_key(const Arg& val) {
-  if (val.is_none()) {
+  if (val.is_none_or_undefined()) {
     return dt->clear_key();
   }
   std::vector<size_t> col_indices;

--- a/src/core/frame/key.cc
+++ b/src/core/frame/key.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018 H2O.ai
+// Copyright 2018-2020 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -31,16 +31,32 @@
 //------------------------------------------------------------------------------
 namespace py {
 
-static GSArgs args_key(
-  "key",
-R"(Tuple of column names that serve as a primary key for this Frame.
+static const char* doc_key =
+R"(
+The tuple of column names that are the primary key for this frame.
 
-If the Frame is not keyed, this will return an empty tuple.
+The primary key columns are always located at the beginning of the
+frame, and therefore the following identity always holds::
+
+    DT.key == DT.names[:len(DT.key)]
+
+If the frame is not keyed, this property returns an empty tuple.
 
 Assigning to this property will make the Frame keyed by the specified
 column(s). The key columns will be moved to the front, and the Frame
 will be sorted. The values in the key columns must be unique.
-)");
+
+Parameters
+----------
+(return): Tuple[str, ...]
+    When used as a getter, returns the tuple of names of the primary
+    key columns.
+
+newkey: str | List[str] | Tuple[str, ...] | None
+    slm
+)";
+
+static GSArgs args_key("key", doc_key);
 
 
 oobj Frame::get_key() const {

--- a/src/core/frame/names.cc
+++ b/src/core/frame/names.cc
@@ -109,7 +109,7 @@ class strvecNP : public NameProvider {
 
 
 //------------------------------------------------------------------------------
-// Frame names API
+// colindex()
 //------------------------------------------------------------------------------
 namespace py {
 
@@ -207,6 +207,15 @@ oobj Frame::colindex(const PKArgs& args) {
 }
 
 
+} // namespace py
+
+
+
+//------------------------------------------------------------------------------
+// .names
+//------------------------------------------------------------------------------
+namespace py {
+
 static const char* doc_names =
 R"(
 The tuple of names of all columns in the frame.
@@ -241,16 +250,16 @@ newnames: List[str?] | Tuple[str?, ...] | Dict[str, str?] | None
 
     If ``newnames`` is a dictionary, then it provides a mapping from
     old to new column names. The dictionary may contain less entries
-    than the number of columns in the frame: the remaining columns
-    will retain their names.
+    than the number of columns in the frame: the columns not mentioned
+    in the dictionary will retain their names.
 
     Setting the ``.names`` to ``None`` is equivalent to using the
     ``del`` keyword: the names will be set to their default values,
     which are usually ``C0, C1, ...``.
 
 (except): ValueError
-    If the length of the list `newnames` does not match the number
-    of columns in the frame.
+    If the length of the list/tuple `newnames` does not match the
+    number of columns in the frame.
 
 (except): KeyError
     If `newnames` is a dictionary containing entries that do not
@@ -275,7 +284,7 @@ static GSArgs args_names("names", doc_names);
 
 oobj Frame::get_names() const {
   return dt->get_pynames();
-}  // LCOV_EXCL_LINE
+}
 
 
 void Frame::set_names(const Arg& arg)

--- a/src/core/frame/py_frame.cc
+++ b/src/core/frame/py_frame.cc
@@ -30,17 +30,56 @@ PyObject* Frame_Type = nullptr;
 
 
 //------------------------------------------------------------------------------
-// head() & tail()
+// head()
 //------------------------------------------------------------------------------
 
-static PKArgs args_head(
-    1, 0, 0, false, false,
-    {"n"}, "head",
+static const char* doc_head =
 R"(head(self, n=10)
 --
 
-Return the first `n` rows of the frame, same as ``self[:n, :]``.
-)");
+Return the first `n` rows of the frame.
+
+If the number of rows in the frame is less than `n`, then all rows
+are returned.
+
+This is a convenience function and it is equivalent to `DT[:n, :]`.
+
+Parameters
+----------
+n : int
+    The maximum number of rows to return, 10 by default. This number
+    cannot be negative.
+
+return: Frame
+    A frame containing the first up to `n` rows from the original
+    frame, and same columns.
+
+
+Examples
+--------
+
+>>> DT = dt.Frame(A=["apples", "bananas", "cherries", "dates",
+...                  "eggplants", "figs", "grapes", "kiwi"])
+>>> DT.head(4)
+   | A
+   | <str32>
+-- + --------
+ 0 | apples
+ 1 | bananas
+ 2 | cherries
+ 3 | dates
+--
+[4 rows x 1 column]
+
+
+See also
+--------
+- :meth:`.tail` -- return the last `n` rows of the Frame.
+)";
+
+static PKArgs args_head(
+    1, 0, 0, false, false, {"n"}, "head", doc_head);
+
 
 oobj Frame::head(const PKArgs& args) {
   size_t n = std::min(args.get<size_t>(0, 10),
@@ -51,14 +90,58 @@ oobj Frame::head(const PKArgs& args) {
 
 
 
-static PKArgs args_tail(
-    1, 0, 0, false, false,
-    {"n"}, "tail",
+
+//------------------------------------------------------------------------------
+// tail()
+//------------------------------------------------------------------------------
+
+static const char* doc_tail =
 R"(tail(self, n=10)
 --
 
-Return the last `n` rows of the frame, same as ``self[-n:, :]``.
-)");
+Return the last `n` rows of the frame.
+
+If the number of rows in the frame is less than `n`, then all rows
+are returned.
+
+This is a convenience function and it is equivalent to `DT[-n:, :]`
+(except when `n` is 0).
+
+Parameters
+----------
+n : int
+    The maximum number of rows to return, 10 by default. This number
+    cannot be negative.
+
+return: Frame
+    A frame containing the last up to `n` rows from the original
+    frame, and same columns.
+
+
+Examples
+--------
+
+>>> DT = dt.Frame(A=["apples", "bananas", "cherries", "dates",
+...                  "eggplants", "figs", "grapes", "kiwi"])
+>>> DT.tail(3)
+   | A
+   | <str32>
+-- + -------
+ 0 | figs
+ 1 | grapes
+ 2 | kiwi
+--
+[3 rows x 1 column]
+
+
+See also
+--------
+- :meth:`.head` -- return the first `n` rows of the Frame.
+)";
+
+static PKArgs args_tail(
+    1, 0, 0, false, false, {"n"}, "tail", doc_tail);
+
 
 oobj Frame::tail(const PKArgs& args) {
   size_t n = std::min(args.get<size_t>(0, 10),
@@ -68,6 +151,7 @@ oobj Frame::tail(const PKArgs& args) {
   return m__getitem__(otuple(oslice(start, oslice::NA, 1),
                              None()));
 }
+
 
 
 

--- a/src/core/frame/stats.cc
+++ b/src/core/frame/stats.cc
@@ -70,9 +70,10 @@ Examples
 --------
 >>> DT = dt.Frame(A=[1, 5, None], B=[math.nan]*3, C=[None, None, 'bah!'])
 >>> DT.countna()
-   |  A   B   C
--- + --  --  --
- 0 |  1   3   2
+   |     A      B      C
+   | int64  int64  int64
+-- + -----  -----  -----
+ 0 |     1      3      2
 --
 [1 row x 3 columns]
 

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -165,6 +165,16 @@ def test_key_after_group():
     assert sum(tmp.to_list()[1]) == n
 
 
+def test_del_key():
+    # See issue #2357
+    DT = dt.Frame(A=range(5))
+    DT.key = "A"
+    del DT.key
+    assert DT.key == ()
+    frame_integrity_check(DT)
+
+
+
 #-------------------------------------------------------------------------------
 # Test if a key was dropped or kept after certain operations
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
- Fixed crash from `del DT.key`;
- Added docs for `.head()`, `.tail()` and `.key`;
- Implemented keyed frames for `..dtframe` Sphinx directive;
- Added ability to supply source-link for property setters;
- Added ability to detect types line when parsing a frame from docs;

Closes #2357