### PR TITLE
Added .git_date and .git_diff to dt.build_version

### DIFF
--- a/docs/releases/v0.11.0.rst
+++ b/docs/releases/v0.11.0.rst
@@ -50,6 +50,11 @@
   -[enh] Datatable no longer lists module ``blessed`` as a dependency.
     [#1677]
 
+  -[enh] Added 2 new fields into the ``dt.build_info`` struct: ``.git_date``
+    is the UTC timestamp of the git revision from which that version of
+    datatable was built, and ``.git_diff`` which will be non-empty for builds
+    from code that was modified compared to the git revision they are based on.
+
   -[fix] Internal function :func:`frame_column_data_r` now works properly with
     virtual columns. [#2269]
 

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -147,11 +147,14 @@ def test_dt_version():
     assert isinstance(dt.build_info.build_date, str)
     assert isinstance(dt.build_info.git_revision, str)
     assert isinstance(dt.build_info.git_branch, str)
+    assert isinstance(dt.build_info.git_date, str)
+    assert isinstance(dt.build_info.git_diff, str)
     assert isinstance(dt.build_info.version, str)
     if "DTCOVERAGE" not in os.environ:
         assert dt.build_info.build_date
         assert dt.build_info.git_revision
         assert dt.build_info.git_branch
+        assert dt.build_info.git_date
         assert dt.build_info.version
         assert len(dt.build_info.git_revision) == 40
         assert dt.build_info.version == dt.__version__


### PR DESCRIPTION
Added 2 new fields into the `dt.build_info` struct: 

- `.git_date` is the UTC timestamp of the git revision from which that version of datatable was built. This field is useful to be able to quickly understand how old a particular version of datatable is. The `.build_date` is insufficient because it is possible to have a recent build of an old commit. 

- `.git_diff` contains short diff of the working directory compared to its HEAD revision. Normally this field will be empty. This field is useful to identify whether the the datatable was built on top of the `.git_revision` commit, or whether it was based on a modified source (and if so, which files were modified). 