### PR TITLE
Fix memory mapping on WIndows

### DIFF
--- a/src/core/datatablemodule.cc
+++ b/src/core/datatablemodule.cc
@@ -428,7 +428,6 @@ extern "C" {
 
       // Initialize submodules
       if (!init_py_encodings(m)) return nullptr;
-      dt::Terminal::standard_terminal().initialize();
 
       init_types();
       dt::expr::Head_Func::init();

--- a/src/core/lib/mman/mman.cc
+++ b/src/core/lib/mman/mman.cc
@@ -62,7 +62,7 @@
       else
       {
           DWORD page_write = is_private? PAGE_WRITECOPY :
-                                       PAGE_READWRITE;
+                                         PAGE_READWRITE;
 
           protect = ((prot & PROT_WRITE) != 0) ? page_write :
                                                  PAGE_READONLY;

--- a/src/core/lib/mman/mman.h
+++ b/src/core/lib/mman/mman.h
@@ -29,6 +29,7 @@
 // version of the original:
 // - added an operating system check, so that this code only builds on Windows;
 // - added MAP_NORESERVE;
+// - added MAP_PRIVATE handling to page and file protection routines;
 // - minor changes to code format.
 //
 //------------------------------------------------------------------------------

--- a/src/core/utils/terminal/terminal.cc
+++ b/src/core/utils/terminal/terminal.cc
@@ -72,6 +72,7 @@ Terminal::Terminal(bool is_plain) : is_plain_(is_plain){
   is_jupyter_ = false;
   is_ipython_ = false;
   if (!enable_ecma48_) xassert(!enable_colors_);
+  if (!is_plain_) _initialize();
 }
 
 Terminal::~Terminal() = default;
@@ -81,7 +82,7 @@ Terminal::~Terminal() = default;
   * This is called for 'standard' terminal only from "datatablemodule.cc",
   * once during module initialization.
   */
-void Terminal::initialize() {
+void Terminal::_initialize() {
   py::robj rstdin = py::rstdin();
   py::robj rstdout = py::rstdout();
   py::robj rstderr = py::rstderr();
@@ -113,6 +114,16 @@ void Terminal::initialize() {
         enable_ecma48_ = true;
         enable_keyboard_ = true;
       }
+
+      // To render colors on Windows, we switch terminal to the ANSI mode
+      #if DT_OS_WINDOWS
+        DWORD dw_mode = ENABLE_PROCESSED_INPUT |
+                        ENABLE_ECHO_INPUT |
+                        ENABLE_LINE_INPUT;
+        HANDLE h_console_handle = GetStdHandle(STD_OUTPUT_HANDLE);
+        SetConsoleMode(h_console_handle, dw_mode);
+      #endif
+
     } catch (...) {}
     _check_ipython();
   }

--- a/src/core/utils/terminal/terminal.h
+++ b/src/core/utils/terminal/terminal.h
@@ -58,7 +58,6 @@ class Terminal {
   public:
     static Terminal& standard_terminal();
     static Terminal& plain_terminal();
-    void initialize();
 
     bool is_jupyter() const noexcept;
     bool is_ipython() const noexcept;
@@ -77,6 +76,7 @@ class Terminal {
     Terminal(Terminal&&) = delete;
     ~Terminal();
 
+    void _initialize();
     void _check_ipython();
     void _detect_window_size();
 };


### PR DESCRIPTION
Take into account the `MAP_PRIVATE` flag in the page and file protection routines of mman. This fixes memory mapping functionality when working with the `.jay` files on Windows.

Also fix color rendering in Windows terminal that was broken since #2361.

WIP for #2301 