### PR TITLE
Allow `len(DT)` syntax to work

### DIFF
--- a/docs/releases/v0.11.0.rst
+++ b/docs/releases/v0.11.0.rst
@@ -7,6 +7,10 @@
   -----
   .. ref-context:: datatable.Frame
 
+  -[new] The expression ``len(DT)`` now works, and returns the number of
+    columns in the Frame. This allows the Frame to be used in contexts where
+    an iterable might be expected.
+
   -[enh] String columns now support comparison operators ``<``, ``>``, ``<=``
     and ``>=``. [#2274]
 

--- a/src/core/frame/py_frame.cc
+++ b/src/core/frame/py_frame.cc
@@ -273,29 +273,6 @@ size_t Frame::m__len__() const {
 
 
 //------------------------------------------------------------------------------
-// __contains__()
-//------------------------------------------------------------------------------
-
-static PKArgs args___contains__(
-  1, 0, 0, false, false, {"item"}, "__contains__", nullptr);
-
-oobj Frame::m__contains__(const PKArgs& args) {
-  auto arg0 = args[0];
-  if (arg0.is_undefined()) {
-    throw TypeError() << "Missing required positional argument";
-  }
-  bool ret = false;
-  if (arg0.is_string()) {
-    int64_t pos = dt->colindex(arg0.to_robj());
-    ret = (pos >= 0);
-  }
-  return obool(ret);
-}
-
-
-
-
-//------------------------------------------------------------------------------
 // export_names()
 //------------------------------------------------------------------------------
 
@@ -647,7 +624,6 @@ void Frame::impl_init_type(XTypeMaker& xt) {
   xt.add(METHOD0(&Frame::get_names, "keys"));
   xt.add(METHOD0(&Frame::m__copy__, "__copy__"));
   xt.add(METHOD(&Frame::m__deepcopy__, args___deepcopy__));
-  xt.add(METHOD(&Frame::m__contains__, args___contains__));
 }
 
 

--- a/src/core/frame/py_frame.cc
+++ b/src/core/frame/py_frame.cc
@@ -262,6 +262,17 @@ oobj Frame::m__deepcopy__(const PKArgs&) {
 
 
 //------------------------------------------------------------------------------
+// __len__()
+//------------------------------------------------------------------------------
+
+size_t Frame::m__len__() const {
+  return dt->ncols();
+}
+
+
+
+
+//------------------------------------------------------------------------------
 // export_names()
 //------------------------------------------------------------------------------
 
@@ -575,6 +586,7 @@ void Frame::impl_init_type(XTypeMaker& xt) {
   xt.set_subclassable(true);
   xt.add(CONSTRUCTOR(&Frame::m__init__, args___init__));
   xt.add(DESTRUCTOR(&Frame::m__dealloc__));
+  xt.add(METHOD__LEN__(&Frame::m__len__));
   xt.add(METHOD__GETITEM__(&Frame::m__getitem__));
   xt.add(METHOD__SETITEM__(&Frame::m__setitem__));
   xt.add(BUFFERS(&Frame::m__getbuffer__, &Frame::m__releasebuffer__));

--- a/src/core/frame/py_frame.cc
+++ b/src/core/frame/py_frame.cc
@@ -273,6 +273,29 @@ size_t Frame::m__len__() const {
 
 
 //------------------------------------------------------------------------------
+// __contains__()
+//------------------------------------------------------------------------------
+
+static PKArgs args___contains__(
+  1, 0, 0, false, false, {"item"}, "__contains__", nullptr);
+
+oobj Frame::m__contains__(const PKArgs& args) {
+  auto arg0 = args[0];
+  if (arg0.is_undefined()) {
+    throw TypeError() << "Missing required positional argument";
+  }
+  bool ret = false;
+  if (arg0.is_string()) {
+    int64_t pos = dt->colindex(arg0.to_robj());
+    ret = (pos >= 0);
+  }
+  return obool(ret);
+}
+
+
+
+
+//------------------------------------------------------------------------------
 // export_names()
 //------------------------------------------------------------------------------
 
@@ -624,6 +647,7 @@ void Frame::impl_init_type(XTypeMaker& xt) {
   xt.add(METHOD0(&Frame::get_names, "keys"));
   xt.add(METHOD0(&Frame::m__copy__, "__copy__"));
   xt.add(METHOD(&Frame::m__deepcopy__, args___deepcopy__));
+  xt.add(METHOD(&Frame::m__contains__, args___contains__));
 }
 
 

--- a/src/core/frame/py_frame.h
+++ b/src/core/frame/py_frame.h
@@ -82,6 +82,7 @@ class Frame : public XObject<Frame> {
     oobj m__reversed__();
     oobj m__copy__();
     oobj m__deepcopy__(const PKArgs&);
+    size_t m__len__() const;
 
     // Frame display
     oobj m__repr__() const;

--- a/src/core/frame/py_frame.h
+++ b/src/core/frame/py_frame.h
@@ -83,6 +83,7 @@ class Frame : public XObject<Frame> {
     oobj m__copy__();
     oobj m__deepcopy__(const PKArgs&);
     size_t m__len__() const;
+    oobj m__contains__(const PKArgs&);
 
     // Frame display
     oobj m__repr__() const;

--- a/src/core/frame/py_frame.h
+++ b/src/core/frame/py_frame.h
@@ -83,7 +83,6 @@ class Frame : public XObject<Frame> {
     oobj m__copy__();
     oobj m__deepcopy__(const PKArgs&);
     size_t m__len__() const;
-    oobj m__contains__(const PKArgs&);
 
     // Frame display
     oobj m__repr__() const;

--- a/src/core/python/xobject.cc
+++ b/src/core/python/xobject.cc
@@ -24,6 +24,7 @@ XTypeMaker::MethodTag XTypeMaker::method_tag;
 XTypeMaker::Method0Tag XTypeMaker::method0_tag;
 XTypeMaker::ReprTag XTypeMaker::repr_tag;
 XTypeMaker::StrTag XTypeMaker::str_tag;
+XTypeMaker::LengthTag XTypeMaker::length_tag;
 XTypeMaker::GetitemTag XTypeMaker::getitem_tag;
 XTypeMaker::SetitemTag XTypeMaker::setitem_tag;
 XTypeMaker::BuffersTag XTypeMaker::buffers_tag;
@@ -147,6 +148,13 @@ void XTypeMaker::add(reprfunc _repr, ReprTag) {
 // reprfunc = PyObject*(*)(PyObject*)
 void XTypeMaker::add(reprfunc _str, StrTag) {
   type->tp_str = _str;
+}
+
+
+// lenfunc = Py_ssize_t(*)(PyObject*)
+void XTypeMaker::add(lenfunc _length, LengthTag) {
+  init_tp_as_mapping();
+  type->tp_as_mapping->mp_length = _length;
 }
 
 

--- a/src/datatable/fread.py
+++ b/src/datatable/fread.py
@@ -399,7 +399,7 @@ class GenericReader(object):
             if self._verbose:
                 self._logger.debug("[1] Prepare for reading")
             self._resolve_source(*self._src)
-            if self._result:
+            if self._result is not None:
                 return self._result
             if self._files:
                 res = {}

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -333,12 +333,18 @@ def test__len__():
 
 
 def test_collections():
-    import collections
     DT = dt.Frame()
-    assert isinstance(DT, collections.Sized)
-    assert isinstance(DT, collections.Iterable)
-    if hasattr(collections, "Reversible"):  # doesn't exist in py3.5
-        assert isinstance(DT, collections.Reversible)
+    if sys.version_info >= (3, 7):
+        import collections.abc
+        assert isinstance(DT, collections.abc.Sized)
+        assert isinstance(DT, collections.abc.Iterable)
+        assert isinstance(DT, collections.abc.Reversible)
+    else:
+        import collections
+        assert isinstance(DT, collections.Sized)
+        assert isinstance(DT, collections.Iterable)
+        if hasattr(collections, "Reversible"):  # doesn't exist in py3.5
+            assert isinstance(DT, collections.Reversible)
 
 
 

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -262,7 +262,7 @@ def test_frame_as_mapping(dt0):
     i = 0
     for name, col in dict(dt0).items():
         assert name == dt0.names[i]
-        assert_equals(col, dt0[:, i])
+        assert_equals(col, dt0[i])
         i += 1
 
 

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -306,6 +306,17 @@ def test_names_deduplication():
         assert DT.names == ("A", "A01", "A2")
 
 
+
+def test__len__():
+    DT = dt.Frame(A=[1, 2], B=[3, 7], D=["a", 'n'], V=[1.1, None])
+    assert len(DT) == 4
+    assert DT.__len__() == 4
+    with pytest.raises(TypeError):
+        assert DT.__len__(3)
+
+
+
+
 #-------------------------------------------------------------------------------
 # Run several random attacks on a datatable as a whole
 #-------------------------------------------------------------------------------

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -266,6 +266,23 @@ def test_frame_as_mapping(dt0):
         i += 1
 
 
+def test_frame_singlestar_expansion(dt0):
+    def foo1(*args):
+        for item in args:
+            assert isinstance(item, dt.Frame)
+            assert item.shape == (dt0.nrows, 1)
+            frame_integrity_check(item)
+
+    foo1(*dt0)
+
+
+def test_frame_singlestar_expansion2(dt0):
+    dt0list = [*dt0]
+    assert len(dt0list) == dt0.ncols
+    for i, col in enumerate(dt0list):
+        assert_equals(col, dt0[:, i])
+
+
 def test_frame_doublestar_expansion(dt0):
     def foo(**kwds):
         for name, col in kwds.items():
@@ -313,6 +330,14 @@ def test__len__():
     assert DT.__len__() == 4
     with pytest.raises(TypeError):
         assert DT.__len__(3)
+
+
+def test_collections():
+    import collections
+    DT = dt.Frame()
+    assert isinstance(DT, collections.Sized)
+    assert isinstance(DT, collections.Iterable)
+    assert isinstance(DT, collections.Reversible)
 
 
 

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -337,7 +337,8 @@ def test_collections():
     DT = dt.Frame()
     assert isinstance(DT, collections.Sized)
     assert isinstance(DT, collections.Iterable)
-    assert isinstance(DT, collections.Reversible)
+    if hasattr(collections, "Reversible"):  # doesn't exist in py3.5
+        assert isinstance(DT, collections.Reversible)
 
 
 


### PR DESCRIPTION
The "length" of a Frame is its number of columns, consistent with how the frame expands under `[*DT]` or `{**DT}`. The implementation of `__len__()` will allow the Frame to interoperate easier with python libraries.