### PR TITLE
Rbind many str32 columns may create a str64 column

### DIFF
--- a/docs/releases/v0.11.0.rst
+++ b/docs/releases/v0.11.0.rst
@@ -37,6 +37,10 @@
   -[bug] Casting a 0-row ``str32`` column into ``str64`` stype no longer goes
     into an infinite loop. [#2369]
 
+  -[bug] Rbinding several ``str32`` columns such that their combined string
+    buffers have size over 2GB now properly creates a ``str64`` column as a
+    result. [#2367]
+
 
   Fread
   -----

--- a/src/core/column/column_impl.cc
+++ b/src/core/column/column_impl.cc
@@ -188,7 +188,7 @@ void ColumnImpl::replace_values(const RowIndex&, const Column&, Column&) {
   throw NotImplError() << "Method ColumnImpl::replace_values() not implemented";
 }
 
-void ColumnImpl::rbind_impl(colvec&, size_t, bool) {
+void ColumnImpl::rbind_impl(colvec&, size_t, bool, SType&) {
   throw NotImplError() << "Method ColumnImpl::rbind_impl() not implemented";
 }
 

--- a/src/core/column/column_impl.h
+++ b/src/core/column/column_impl.h
@@ -132,7 +132,8 @@ class ColumnImpl
   //------------------------------------
   private:
     // TODO: this should really be materializer for RBound column impl
-    virtual void rbind_impl(colvec& columns, size_t nrows, bool isempty);
+    virtual void rbind_impl(colvec& columns, size_t nrows, bool isempty,
+                            SType& cast_stype);
 
     template <typename T> void _materialize_fw(Column&);
     void _materialize_str(Column&);

--- a/src/core/column/sentinel_fw.h
+++ b/src/core/column/sentinel_fw.h
@@ -65,7 +65,7 @@ class SentinelFw_ColumnImpl : public Sentinel_ColumnImpl
     void replace_values(const RowIndex& at, T with);
 
   protected:
-    void rbind_impl(colvec& columns, size_t nrows, bool isempty) override;
+    void rbind_impl(colvec& columns, size_t nrows, bool isempty, SType&) override;
 };
 
 
@@ -128,7 +128,7 @@ public:
   bool get_element(size_t i, py::robj* out) const override;
 
 protected:
-  void rbind_impl(colvec& columns, size_t nrows, bool isempty) override;
+  void rbind_impl(colvec& columns, size_t nrows, bool, SType&) override;
   void verify_integrity() const override;
 };
 

--- a/src/core/column/sentinel_str.h
+++ b/src/core/column/sentinel_str.h
@@ -55,7 +55,7 @@ class SentinelStr_ColumnImpl : public Sentinel_ColumnImpl
                         Column& out) override;
 
   protected:
-    void rbind_impl(colvec& columns, size_t nrows, bool isempty) override;
+    void rbind_impl(colvec& columns, size_t nrows, bool isempty, SType&) override;
 };
 
 

--- a/src/core/parallel/string_utils.cc
+++ b/src/core/parallel/string_utils.cc
@@ -1,17 +1,23 @@
 //------------------------------------------------------------------------------
-// Copyright 2018 H2O.ai
+// Copyright 2018-2020 H2O.ai
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
 //
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #include "column/sentinel_str.h"
 #include "parallel/api.h"

--- a/tests/munging/test_rbind.py
+++ b/tests/munging/test_rbind.py
@@ -250,6 +250,14 @@ def test_rbind_strings5():
     assert f1.to_list() == [["foo", "bra", "1", "2", "3"]]
 
 
+def test_rbind_strings_large():
+    s = "ABCDEFGHIJ" * 110 + "xyz"
+    n = 1000000
+    assert len(s) * n * 2 > (1 << 31)
+    DT0 = dt.Frame(A=[s] * n)
+    DT1 = dt.rbind(DT0, DT0)
+    assert DT1[-1, 0] == s
+
 
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
When multiple str32 columns are rbinded, the combined character data buffers may exceed 2GB in size. In this case the resulting str32 column must be converted into str64.

Closes #2367