### PR TITLE
Update to new-sort

### DIFF
--- a/src/core/sort.cc
+++ b/src/core/sort.cc
@@ -133,6 +133,7 @@
 #include "frame/py_frame.h"
 #include "parallel/api.h"
 #include "python/args.h"
+#include "sort/sorter.h"
 #include "utils/alloc.h"
 #include "utils/assert.h"
 #include "utils/misc.h"
@@ -1364,6 +1365,13 @@ RiGb group(const std::vector<Column>& columns,
     result.first = RowIndex(std::move(buf), RowIndex::ARR32|RowIndex::SORTED);
     result.second = Groupby::single_group(nrows);
     return result;
+  }
+  if (n == 1 && col0.stype() == SType::BOOL &&
+      (flags[0] & SortFlag::SORT_ONLY) &&
+      !(flags[0] & SortFlag::DESCENDING))
+  {
+    auto sorter = dt::sort::make_sorter(col0);
+    return sorter->sort();
   }
 
   // TODO: avoid materialization

--- a/src/core/sort.cc
+++ b/src/core/sort.cc
@@ -1367,11 +1367,11 @@ RiGb group(const std::vector<Column>& columns,
     return result;
   }
   if (n == 1 && col0.stype() == SType::BOOL &&
-      (flags[0] & SortFlag::SORT_ONLY) &&
       !(flags[0] & SortFlag::DESCENDING))
   {
+    bool sort_only = (flags[0] & SortFlag::SORT_ONLY);
     auto sorter = dt::sort::make_sorter(col0);
-    return sorter->sort();
+    return sorter->sort(!sort_only);
   }
 
   // TODO: avoid materialization

--- a/src/core/sort.cc
+++ b/src/core/sort.cc
@@ -1346,7 +1346,6 @@ RiGb group(const std::vector<Column>& columns,
   xassert(n == flags.size());
 
   const Column& col0 = columns[0];
-  col0.stats();  // instantiate Stats object; TODO: remove this
 
   size_t nrows = col0.nrows();
   #if DTDEBUG
@@ -1374,6 +1373,7 @@ RiGb group(const std::vector<Column>& columns,
 
   bool do_groups = n > 1 || !(flags[0] & SortFlag::SORT_ONLY);
   SortContext sc(nrows, RowIndex(), do_groups);
+  col0.stats();  // instantiate Stats object; TODO: remove this
   sc.start_sort(col0, bool(flags[0] & SortFlag::DESCENDING));
   for (size_t j = 1; j < n; ++j) {
     bool j_sort_only = (flags[j] & SortFlag::SORT_ONLY);

--- a/src/core/sort.cc
+++ b/src/core/sort.cc
@@ -1366,11 +1366,11 @@ RiGb group(const std::vector<Column>& columns,
     result.second = Groupby::single_group(nrows);
     return result;
   }
-  if (n == 1 && col0.stype() == SType::BOOL &&
-      !(flags[0] & SortFlag::DESCENDING))
-  {
+  if (n == 1 && col0.stype() == SType::BOOL) {
     bool sort_only = (flags[0] & SortFlag::SORT_ONLY);
-    auto sorter = dt::sort::make_sorter(col0);
+    auto direction = (flags[0] & SortFlag::DESCENDING)? dt::sort::Direction::DESCENDING
+                                                      : dt::sort::Direction::ASCENDING;
+    auto sorter = dt::sort::make_sorter(col0, direction);
     return sorter->sort(!sort_only);
   }
 

--- a/src/core/sort/common.h
+++ b/src/core/sort/common.h
@@ -33,6 +33,13 @@ static constexpr size_t MAX_NROWS_INT32 = 0x7FFFFFFF;
 static constexpr size_t INSERTSORT_NROWS = 16;
 
 
+enum class Mode {
+  SINGLE_THREADED,
+  PARALLEL
+};
+
+
+
 /**
   * Simple struct-like class which represents a raw pointer viewed
   * as an array of elements of type `T`. The pointer is not owned.

--- a/src/core/sort/common.h
+++ b/src/core/sort/common.h
@@ -38,6 +38,10 @@ enum class Mode {
   PARALLEL
 };
 
+enum class Direction {
+  ASCENDING,
+  DESCENDING
+};
 
 
 /**

--- a/src/core/sort/common.h
+++ b/src/core/sort/common.h
@@ -38,28 +38,68 @@ static constexpr size_t INSERTSORT_NROWS = 16;
   * as an array of elements of type `T`. The pointer is not owned.
   *
   * The main difference between `array<T>` and a simple pointer `T*`
-  * is that the former also knows its size.
+  * is that the array also knows its size.
   */
 template <typename T>
-class array {
-  public:
-    T* ptr;
-    size_t size;
+class array
+{
+  private:
+    T* ptr_;
+    size_t size_;
 
   public:
-    array() : ptr(nullptr), size(0) {}
-    array(T* p, size_t n) : ptr(p), size(n) {}
+    array() : ptr_(nullptr), size_(0) {}
     array(const array&) = default;
     array& operator=(const array&) = default;
 
+    array(T* p, size_t n)
+      : ptr_(p), size_(n)
+    {
+      xassert((ptr_ == nullptr) == (size_ == 0));
+    }
+
     array(const Buffer& buf)
-      : ptr(static_cast<T*>(buf.xptr())),
-        size(buf.size() / sizeof(T))
-    { xassert(buf.size() % sizeof(T) == 0); }
+      : ptr_(static_cast<T*>(buf.xptr())),
+        size_(buf.size() / sizeof(T))
+    {
+      xassert(buf.size() % sizeof(T) == 0);
+    }
 
     array<T> subset(size_t start, size_t length) {
-      xassert(start + length <= size);
-      return array<T>(ptr + start, length);
+      xassert(start + length <= size_);
+      return array<T>(ptr_ + start, length);
+    }
+
+
+  //------------------------------------
+  // Properties
+  //------------------------------------
+  public:
+    size_t size() const noexcept {
+      return size_;
+    }
+
+    T* ptr() const noexcept {
+      return ptr_;
+    }
+
+    operator bool() const noexcept {
+      return (ptr_ == nullptr);
+    }
+
+    T& operator[](size_t i) const {
+      xassert(i < size_);
+      return ptr_[i];
+    }
+
+    T& operator[](int32_t i) const {
+      xassert(static_cast<size_t>(i) < size_);
+      return ptr_[i];
+    }
+
+    T& operator[](int64_t i) const {
+      xassert(static_cast<size_t>(i) < size_);
+      return ptr_[i];
     }
 };
 

--- a/src/core/sort/common.h
+++ b/src/core/sort/common.h
@@ -65,11 +65,12 @@ class array
       xassert((ptr_ == nullptr) == (size_ == 0));
     }
 
-    array(const Buffer& buf)
-      : ptr_(static_cast<T*>(buf.xptr())),
-        size_(buf.size() / sizeof(T))
+    array(const Buffer& buf, size_t offset = 0)
+      : ptr_(static_cast<T*>(buf.xptr()) + offset),
+        size_(buf.size() / sizeof(T) - offset)
     {
       xassert(buf.size() % sizeof(T) == 0);
+      xassert(buf.size() >= offset * sizeof(T));
     }
 
     array<T> subset(size_t start, size_t length) {

--- a/src/core/sort/common.h
+++ b/src/core/sort/common.h
@@ -84,7 +84,7 @@ class array
     }
 
     operator bool() const noexcept {
-      return (ptr_ == nullptr);
+      return (ptr_ != nullptr);
     }
 
     T& operator[](size_t i) const {

--- a/src/core/sort/grouper.h
+++ b/src/core/sort/grouper.h
@@ -78,10 +78,13 @@ class Grouper
     void fill_from_data(vec ordering, compare_fn cmp) {
       const size_t nrows = ordering.size();
       size_t last_i = 0;
+      size_t last_oi = static_cast<size_t>(ordering[0]);
       for (size_t i = 1; i < nrows; ++i) {
-        if (cmp(last_i, i)) {
+        size_t oi = static_cast<size_t>(ordering[i]);
+        if (cmp(last_oi, oi)) {
           push(i - last_i);
           last_i = i;
+          last_oi = oi;
         }
       }
       push(nrows - last_i);

--- a/src/core/sort/grouper.h
+++ b/src/core/sort/grouper.h
@@ -27,6 +27,7 @@ namespace dt {
 namespace sort {
 
 
+
 /**
  * Helper class to collect grouping information while sorting.
  *
@@ -41,10 +42,10 @@ namespace sort {
  * -------------------
  * data_
  *     The array of cumulative group sizes. The array must be pre-allocated
- *     and passed to this class via `init()`.
+ *     and passed to this class in the constructor.
  *
  * n_
- *     The number of groups that were stored in the `data_` array.
+ *     The number of groups that were stored in the `data_` array so far.
  *
  * offset_
  *     The total size of all groups added so far. This is always equals to

--- a/src/core/sort/grouper.h
+++ b/src/core/sort/grouper.h
@@ -1,0 +1,102 @@
+//------------------------------------------------------------------------------
+// Copyright 2020 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#ifndef dt_SORT_GROUPER_h
+#define dt_SORT_GROUPER_h
+#include "sort/common.h"        // array<T>
+#include "utils/function.h"     // dt::function
+namespace dt {
+namespace sort {
+
+
+/**
+ * Helper class to collect grouping information while sorting.
+ *
+ * The end product of this class is the array of cumulative group sizes. This
+ * array will have 1 + ngroups elements, with the first element being 0, and
+ * the last the total number of elements in the data being sorted/grouped.
+ *
+ * In order to accommodate parallel sorting, the array of group sizes is
+ * provided externally, and is not managed by this class (only written to).
+ *
+ * Internal parameters
+ * -------------------
+ * data_
+ *     The array of cumulative group sizes. The array must be pre-allocated
+ *     and passed to this class via `init()`.
+ *
+ * n_
+ *     The number of groups that were stored in the `data_` array.
+ *
+ * offset_
+ *     The total size of all groups added so far. This is always equals to
+ *     `data_[n_ - 1]`.
+ *
+ */
+template <typename T>
+class Grouper
+{
+  using vec = array<T>;
+  using compare_fn = dt::function<bool(size_t, size_t)>;
+
+  private:
+    vec data_;
+    size_t offset_;
+    size_t n_;
+
+  public:
+    Grouper(vec data, size_t initial_offset)
+      : data_(data),
+        offset_(initial_offset),
+        n_(0) {}
+
+
+    size_t size() const noexcept {
+      return n_;
+    }
+
+
+    void fill_from_data(vec ordering, compare_fn cmp) {
+      const size_t nrows = ordering.size();
+      size_t last_i = 0;
+      for (size_t i = 1; i < nrows; ++i) {
+        if (cmp(last_i, i)) {
+          push(i - last_i);
+          last_i = i;
+        }
+      }
+      push(nrows - last_i);
+    }
+
+
+  private:
+    void push(size_t group_size) {
+      xassert(n_ < data_.size());
+      offset_ += group_size;
+      data_[n_++] = offset_;
+    }
+
+};
+
+
+
+}}  // namespace dt::sort
+#endif

--- a/src/core/sort/grouper.h
+++ b/src/core/sort/grouper.h
@@ -92,7 +92,7 @@ class Grouper
     void push(size_t group_size) {
       xassert(n_ < data_.size());
       offset_ += group_size;
-      data_[n_++] = offset_;
+      data_[n_++] = static_cast<T>(offset_);
     }
 
 };

--- a/src/core/sort/insert-sort.h
+++ b/src/core/sort/insert-sort.h
@@ -22,6 +22,10 @@
 //
 // See http://quick-bench.com/gl2wXMVIU4i4eswQL2dBg2oKCZs for variations
 //
+// See http://quick-bench.com/0O1TXlyBu-d-nwpjHcAibMEjj_o for comparison of
+// template-based implementation, and implementations based on a dt::function
+// or std::function pointers.
+//
 //------------------------------------------------------------------------------
 #ifndef dt_SORT_INSERT_SORT_h
 #define dt_SORT_INSERT_SORT_h
@@ -33,6 +37,7 @@
 namespace dt {
 namespace sort {
 
+using Compare = dt::function<bool(size_t, size_t)>;
 
 
 /**
@@ -51,18 +56,13 @@ namespace sort {
   * are in the range `[0; n)` (where `n` is the size of
   * `ordering_out`). Notably, these indices do not take `ordering_in`
   * into account.
-  *
   */
-template <typename T, typename Compare>
+template <typename T>
 void insert_sort(array<T> ordering_in,
                  array<T> ordering_out,
                  Grouper<T>* grouper,
                  Compare compare)
 {
-  static_assert(
-    std::is_convertible<Compare, dt::function<bool(size_t, size_t)>>::value,
-    "Invalid signature of comparator function");
-
   size_t n = ordering_out.size();
   xassert(n > 0);
   if (ordering_in.size()) {
@@ -98,7 +98,7 @@ void insert_sort(array<T> ordering_in,
   * Same as `insert_sort()`, but uses stable_sort algorithm from the
   * standard library (typically this is a quick-sort implementation).
   */
-template <typename T, typename Compare>
+template <typename T>
 void std_sort(array<T> ordering_in,
               array<T> ordering_out,
               Grouper<T>* grouper,
@@ -132,7 +132,7 @@ void std_sort(array<T> ordering_in,
   * function is single-threaded and thus should only be used for
   * relatively small `n`s.
   */
-template <typename T, typename Compare>
+template <typename T>
 void small_sort(array<T> ordering_in,
                 array<T> ordering_out,
                 Grouper<T>* grouper,

--- a/src/core/sort/insert-sort.h
+++ b/src/core/sort/insert-sort.h
@@ -25,10 +25,10 @@
 //------------------------------------------------------------------------------
 #ifndef dt_SORT_INSERT_SORT_h
 #define dt_SORT_INSERT_SORT_h
-#include <algorithm>       // std::stable_sort
-#include <functional>      // std::function
-#include <type_traits>     // std::is_convertible
-#include "sort/common.h"   // array
+#include <algorithm>         // std::stable_sort
+#include <type_traits>       // std::is_convertible
+#include "sort/common.h"     // array
+#include "utils/function.h"  // dt::function
 namespace dt {
 namespace sort {
 
@@ -52,13 +52,13 @@ namespace sort {
   * into account.
   *
   */
-template <typename TO, typename Compare>
-void insert_sort(array<TO> ordering_in,
-                 array<TO> ordering_out,
+template <typename T, typename Compare>
+void insert_sort(array<T> ordering_in,
+                 array<T> ordering_out,
                  Compare compare)
 {
   static_assert(
-    std::is_convertible<Compare, std::function<bool(size_t, size_t)>>::value,
+    std::is_convertible<Compare, dt::function<bool(size_t, size_t)>>::value,
     "Invalid signature of comparator function");
 
   size_t n = ordering_out.size();
@@ -67,7 +67,7 @@ void insert_sort(array<TO> ordering_in,
     xassert(ordering_in.size() == n);
   }
 
-  TO* const oo = ordering_out.ptr();
+  T* const oo = ordering_out.ptr();
   oo[0] = 0;
   for (size_t i = 1; i < n; ++i) {
     size_t j = i;
@@ -75,7 +75,7 @@ void insert_sort(array<TO> ordering_in,
       oo[j] = oo[j - 1];
       j--;
     }
-    oo[j] = static_cast<TO>(i);
+    oo[j] = static_cast<T>(i);
   }
 
   if (ordering_in) {
@@ -93,18 +93,18 @@ void insert_sort(array<TO> ordering_in,
   * Same as `insert_sort()`, but uses stable_sort algorithm from the
   * standard library (typically this is a quick-sort implementation).
   */
-template <typename TO, typename Compare>
-void std_sort(array<TO> ordering_in,
-              array<TO> ordering_out,
+template <typename T, typename Compare>
+void std_sort(array<T> ordering_in,
+              array<T> ordering_out,
               Compare compare)
 {
   size_t n = ordering_out.size();
   xassert(n > 0);
   xassert(!ordering_in || ordering_in.size() == n);
 
-  TO* const oo = ordering_out.ptr();
+  T* const oo = ordering_out.ptr();
   for (size_t i = 0; i < n; ++i) {
-    oo[i] = static_cast<TO>(i);
+    oo[i] = static_cast<T>(i);
   }
   std::stable_sort(oo, oo + n, compare);
 
@@ -123,9 +123,9 @@ void std_sort(array<TO> ordering_in,
   * function is single-threaded and thus should only be used for
   * relatively small `n`s.
   */
-template <typename TO, typename Compare>
-void small_sort(array<TO> ordering_in,
-                array<TO> ordering_out,
+template <typename T, typename Compare>
+void small_sort(array<T> ordering_in,
+                array<T> ordering_out,
                 Compare compare)
 {
   if (ordering_out.size() < INSERTSORT_NROWS) {

--- a/src/core/sort/insert-sort.h
+++ b/src/core/sort/insert-sort.h
@@ -100,9 +100,7 @@ void std_sort(array<TO> ordering_in,
 {
   size_t n = ordering_out.size();
   xassert(n > 0);
-  if (ordering_in.size()) {
-    xassert(ordering_in.size() == n);
-  }
+  xassert(!ordering_in || ordering_in.size() == n);
 
   TO* const oo = ordering_out.ptr();
   for (size_t i = 0; i < n; ++i) {

--- a/src/core/sort/insert-sort.h
+++ b/src/core/sort/insert-sort.h
@@ -28,6 +28,7 @@
 #include <algorithm>         // std::stable_sort
 #include <type_traits>       // std::is_convertible
 #include "sort/common.h"     // array
+#include "sort/grouper.h"    // Grouper
 #include "utils/function.h"  // dt::function
 namespace dt {
 namespace sort {
@@ -55,6 +56,7 @@ namespace sort {
 template <typename T, typename Compare>
 void insert_sort(array<T> ordering_in,
                  array<T> ordering_out,
+                 Grouper<T>* grouper,
                  Compare compare)
 {
   static_assert(
@@ -78,6 +80,9 @@ void insert_sort(array<T> ordering_in,
     oo[j] = static_cast<T>(i);
   }
 
+  if (grouper) {
+    grouper->fill_from_data(ordering_out, compare);
+  }
   if (ordering_in) {
     for (size_t i = 0; i < n; ++i) {
       oo[i] = ordering_in[oo[i]];
@@ -96,6 +101,7 @@ void insert_sort(array<T> ordering_in,
 template <typename T, typename Compare>
 void std_sort(array<T> ordering_in,
               array<T> ordering_out,
+              Grouper<T>* grouper,
               Compare compare)
 {
   size_t n = ordering_out.size();
@@ -108,6 +114,9 @@ void std_sort(array<T> ordering_in,
   }
   std::stable_sort(oo, oo + n, compare);
 
+  if (grouper) {
+    grouper->fill_from_data(ordering_out, compare);
+  }
   if (ordering_in) {
     for (size_t i = 0; i < n; ++i) {
       oo[i] = ordering_in[oo[i]];
@@ -126,13 +135,14 @@ void std_sort(array<T> ordering_in,
 template <typename T, typename Compare>
 void small_sort(array<T> ordering_in,
                 array<T> ordering_out,
+                Grouper<T>* grouper,
                 Compare compare)
 {
   if (ordering_out.size() < INSERTSORT_NROWS) {
-    insert_sort(ordering_in, ordering_out, compare);
+    insert_sort(ordering_in, ordering_out, grouper, compare);
   }
   else {
-    std_sort(ordering_in, ordering_out, compare);
+    std_sort(ordering_in, ordering_out, grouper, compare);
   }
 }
 

--- a/src/core/sort/insert-sort.h
+++ b/src/core/sort/insert-sort.h
@@ -61,14 +61,13 @@ void insert_sort(array<TO> ordering_in,
     std::is_convertible<Compare, std::function<bool(size_t, size_t)>>::value,
     "Invalid signature of comparator function");
 
-  size_t n = ordering_out.size;
+  size_t n = ordering_out.size();
   xassert(n > 0);
-  if (ordering_in.size) {
-    xassert(ordering_in.size == n);
-    xassert(ordering_in.ptr);
+  if (ordering_in.size()) {
+    xassert(ordering_in.size() == n);
   }
 
-  TO* const oo = ordering_out.ptr;
+  TO* const oo = ordering_out.ptr();
   oo[0] = 0;
   for (size_t i = 1; i < n; ++i) {
     size_t j = i;
@@ -79,9 +78,9 @@ void insert_sort(array<TO> ordering_in,
     oo[j] = static_cast<TO>(i);
   }
 
-  if (ordering_in.size) {
+  if (ordering_in) {
     for (size_t i = 0; i < n; ++i) {
-      oo[i] = ordering_in.ptr[oo[i]];
+      oo[i] = ordering_in[oo[i]];
     }
   }
 }
@@ -99,22 +98,21 @@ void std_sort(array<TO> ordering_in,
               array<TO> ordering_out,
               Compare compare)
 {
-  size_t n = ordering_out.size;
+  size_t n = ordering_out.size();
   xassert(n > 0);
-  if (ordering_in.size) {
-    xassert(ordering_in.size == n);
-    xassert(ordering_in.ptr);
+  if (ordering_in.size()) {
+    xassert(ordering_in.size() == n);
   }
 
-  TO* const oo = ordering_out.ptr;
+  TO* const oo = ordering_out.ptr();
   for (size_t i = 0; i < n; ++i) {
     oo[i] = static_cast<TO>(i);
   }
   std::stable_sort(oo, oo + n, compare);
 
-  if (ordering_in.size) {
+  if (ordering_in) {
     for (size_t i = 0; i < n; ++i) {
-      oo[i] = ordering_in.ptr[oo[i]];
+      oo[i] = ordering_in[oo[i]];
     }
   }
 }
@@ -132,7 +130,7 @@ void small_sort(array<TO> ordering_in,
                 array<TO> ordering_out,
                 Compare compare)
 {
-  if (ordering_out.size < INSERTSORT_NROWS) {
+  if (ordering_out.size() < INSERTSORT_NROWS) {
     insert_sort(ordering_in, ordering_out, compare);
   }
   else {

--- a/src/core/sort/newsort.cc
+++ b/src/core/sort/newsort.cc
@@ -93,8 +93,8 @@ oobj Frame::newsort(const PKArgs&) {
 
   auto sorter = (dt->ncols() == 1)? dt::sort::make_sorter(dt->get_column(0))
                                   : dt::sort::make_sorter(dt->get_columns());
-  RowIndex rowindex = sorter->sort();
-  Column ricol = rowindex.as_column(sorter->nrows());
+  dt::sort::RiGb rigb = sorter->sort();
+  Column ricol = rigb.first.as_column(dt->nrows());
   return py::Frame::oframe(new DataTable({std::move(ricol)}, {"order"}));
 }
 

--- a/src/core/sort/radix-sort.h
+++ b/src/core/sort/radix-sort.h
@@ -111,18 +111,17 @@ class RadixSort {
                             MoveData move_data)
     {
       static_assert(
-        std::is_convertible<GetRadix, std::function<size_t(size_t)>>::value,
+        std::is_convertible<GetRadix, dt::function<size_t(size_t)>>::value,
         "Incorrect signature of get_radix function");
       static_assert(
-        std::is_convertible<MoveData,
-                            std::function<void(size_t,size_t)>>::value,
+        std::is_convertible<MoveData, dt::function<void(size_t,size_t)>>::value,
         "Incorrect signature of move_data function");
       xassert(ordering_in.size() == n_rows_ || ordering_in.size() == 0);
       xassert(ordering_out.size() == n_rows_);
 
       array<TO> histogram = allocate_histogram<TO>();
       build_histogram(histogram, get_radix);
-      if (ordering_in.size()) {
+      if (ordering_in) {
         reorder_data(histogram, get_radix,
                      [&](size_t i, size_t j) {
                        ordering_out[j] = ordering_in[i];

--- a/src/core/sort/radix-sort.h
+++ b/src/core/sort/radix-sort.h
@@ -252,6 +252,8 @@ class RadixSort {
         dt::ChunkSize(1),  // each iteration processed individually
         [&](size_t i) {
           TH* tcounts = histogram.ptr() + (n_radixes_ * i);
+          std::fill(tcounts, tcounts + n_radixes_, 0);
+
           size_t j0, j1; std::tie(j0, j1) = get_chunk(i);
           for (size_t j = j0; j < j1; ++j) {
             size_t radix = get_radix(j);

--- a/src/core/sort/radix-sort.h
+++ b/src/core/sort/radix-sort.h
@@ -117,25 +117,25 @@ class RadixSort {
         std::is_convertible<MoveData,
                             std::function<void(size_t,size_t)>>::value,
         "Incorrect signature of move_data function");
-      xassert(ordering_in.size == n_rows_ || ordering_in.size == 0);
-      xassert(ordering_out.size == n_rows_);
+      xassert(ordering_in.size() == n_rows_ || ordering_in.size() == 0);
+      xassert(ordering_out.size() == n_rows_);
 
       array<TO> histogram = allocate_histogram<TO>();
       build_histogram(histogram, get_radix);
-      if (ordering_in.size) {
+      if (ordering_in.size()) {
         reorder_data(histogram, get_radix,
                      [&](size_t i, size_t j) {
-                       ordering_out.ptr[j] = ordering_in.ptr[i];
+                       ordering_out[j] = ordering_in[i];
                        move_data(i, j);
                      });
       } else {
         reorder_data(histogram, get_radix,
                      [&](size_t i, size_t j) {
-                       ordering_out.ptr[j] = static_cast<TO>(i);
+                       ordering_out[j] = static_cast<TO>(i);
                        move_data(i, j);
                      });
       }
-      return array<TO>(histogram.ptr + (n_chunks_ - 1) * n_radixes_,
+      return array<TO>(histogram.ptr() + (n_chunks_ - 1) * n_radixes_,
                        n_radixes_);
     }
 
@@ -167,14 +167,14 @@ class RadixSort {
         std::is_convertible<Subsort,
                             std::function<void(size_t,size_t,array<TO>,array<TO>,bool)>>::value,
         "Invalid signature of subsort function");
-      xassert(groups.size > 0);
-      xassert(ordering_in.size == n_rows_ && ordering_out.size == n_rows_);
+      xassert(groups.size() > 0);
+      xassert(ordering_in.size() == n_rows_ && ordering_out.size() == n_rows_);
 
       if (n_chunks_ == 1 || true) {
-        const size_t ngroups = groups.size;
+        const size_t ngroups = groups.size();
         size_t group_start = 0;
         for (size_t i = 0; i < ngroups; ++i) {
-          size_t group_end = static_cast<size_t>(groups.ptr[i]);
+          size_t group_end = static_cast<size_t>(groups[i]);
           size_t group_size = group_end - group_start;
           if (group_size > 1) {
             subsort(group_start, group_size,
@@ -251,7 +251,7 @@ class RadixSort {
         n_chunks_,          // n iterations
         dt::ChunkSize(1),  // each iteration processed individually
         [&](size_t i) {
-          TH* tcounts = histogram.ptr + (n_radixes_ * i);
+          TH* tcounts = histogram.ptr() + (n_radixes_ * i);
           size_t j0, j1; std::tie(j0, j1) = get_chunk(i);
           for (size_t j = j0; j < j1; ++j) {
             size_t radix = get_radix(j);
@@ -268,8 +268,8 @@ class RadixSort {
       size_t histogram_size = n_chunks_ * n_radixes_;
       for (size_t j = 0; j < n_radixes_; ++j) {
         for (size_t r = j; r < histogram_size; r += n_radixes_) {
-          TH t = histogram.ptr[r];
-          histogram.ptr[r] = static_cast<TH>(cumsum);
+          TH t = histogram[r];
+          histogram[r] = static_cast<TH>(cumsum);
           cumsum += static_cast<size_t>(t);
         }
       }
@@ -286,7 +286,7 @@ class RadixSort {
         n_chunks_,
         dt::ChunkSize(1),
         [&](size_t i) {
-          TH* tcounts = histogram.ptr + (n_radixes_ * i);
+          TH* tcounts = histogram.ptr() + (n_radixes_ * i);
           size_t j0, j1; std::tie(j0, j1) = get_chunk(i);
           for (size_t j = j0; j < j1; ++j) {
             size_t radix = get_radix(j);
@@ -295,7 +295,7 @@ class RadixSort {
             move_data(j, static_cast<size_t>(k));
           }
         });
-      xassert(static_cast<size_t>(histogram.ptr[histogram.size - 1]) == n_rows_);
+      xassert(static_cast<size_t>(histogram[histogram.size() - 1]) == n_rows_);
     }
 
 

--- a/src/core/sort/sorter.cc
+++ b/src/core/sort/sorter.cc
@@ -95,7 +95,7 @@ oobj Frame::newsort(const PKArgs&) {
 
   auto sorter = (dt->ncols() == 1)? dt::sort::make_sorter(dt->get_column(0))
                                   : dt::sort::make_sorter(dt->get_columns());
-  dt::sort::RiGb rigb = sorter->sort();
+  dt::sort::RiGb rigb = sorter->sort(false);
   Column ricol = rigb.first.as_column(dt->nrows());
   return py::Frame::oframe(new DataTable({std::move(ricol)}, {"order"}));
 }

--- a/src/core/sort/sorter.cc
+++ b/src/core/sort/sorter.cc
@@ -42,7 +42,7 @@ static std::unique_ptr<SSorter<T>> _make_sorter(const Column& col)
 {
   using so = std::unique_ptr<SSorter<T>>;
   switch (col.stype()) {
-    case SType::BOOL:  return so(new Sorter_Bool<T, ASC>(col));
+    case SType::BOOL:  return make_sorter_bool<T, ASC>(col);
     case SType::INT8:  return so(new Sorter_Int<T, int8_t>(col));
     case SType::INT16: return so(new Sorter_Int<T, int16_t>(col));
     case SType::INT32: return so(new Sorter_Int<T, int32_t>(col));

--- a/src/core/sort/sorter.cc
+++ b/src/core/sort/sorter.cc
@@ -24,6 +24,7 @@
 #include "python/args.h"       // py::PKArgs
 #include "sort/insert-sort.h"  // insert_sort
 #include "sort/radix-sort.h"   // RadixSort
+#include "sort/sorter.h"       // Sorter_Bool
 #include "sort/sorter_bool.h"  // Sorter_Bool
 #include "sort/sorter_int.h"   // Sorter_Int
 #include "sort/sorter_multi.h" // Sorter_Multi
@@ -34,7 +35,6 @@ namespace dt {
 namespace sort {
 
 
-using ptrSorter = std::unique_ptr<Sorter>;
 
 
 template <typename TO>
@@ -62,17 +62,19 @@ static std::unique_ptr<SSorter<TO>> _make_sorter(const colvec& cols) {
 }
 
 
-static ptrSorter make_sorter(const Column& col) {
+using psorter = std::unique_ptr<Sorter>;
+
+psorter make_sorter(const Column& col) {
   return (col.nrows() <= dt::sort::MAX_NROWS_INT32)
-      ? ptrSorter(_make_sorter<int32_t>(col))
-      : ptrSorter(_make_sorter<int64_t>(col));
+      ? psorter(_make_sorter<int32_t>(col))
+      : psorter(_make_sorter<int64_t>(col));
 }
 
-static ptrSorter make_sorter(const std::vector<Column>& cols) {
+psorter make_sorter(const std::vector<Column>& cols) {
   xassert(cols.size() > 1);
   return (cols[0].nrows() <= dt::sort::MAX_NROWS_INT32)
-      ? ptrSorter(_make_sorter<int32_t>(cols))
-      : ptrSorter(_make_sorter<int64_t>(cols));
+      ? psorter(_make_sorter<int32_t>(cols))
+      : psorter(_make_sorter<int64_t>(cols));
 }
 
 

--- a/src/core/sort/sorter.h
+++ b/src/core/sort/sorter.h
@@ -25,7 +25,7 @@
 namespace dt {
 namespace sort {
 
-template <typename TO> class Sorter_MultiImpl;
+template <typename TO> class Sorter_Multi;
 
 
 /**
@@ -56,7 +56,7 @@ class Sorter {
 template <typename TO>
 class SSorter : public Sorter
 {
-  friend class Sorter_MultiImpl<TO>;
+  friend class Sorter_Multi<TO>;
   using ovec = array<TO>;
   public:
     SSorter(size_t n) : Sorter(n) {
@@ -104,7 +104,7 @@ class SSorter : public Sorter
     /**
       */
     using ssoptr = std::unique_ptr<SSorter<TO>>;
-    using next_wrapper = std::function<ssoptr(const ssoptr&)>;
+    using next_wrapper = std::function<ssoptr(ssoptr&&)>;
     virtual void radix_sort(ovec ordering_in, ovec ordering_out,
                             size_t offset, bool parallel,
                             next_wrapper wrap = nullptr) const = 0;

--- a/src/core/sort/sorter.h
+++ b/src/core/sort/sorter.h
@@ -156,7 +156,7 @@ class SSorter : public Sorter
 
 
 // Factory functions
-std::unique_ptr<Sorter> make_sorter(const Column&);
+std::unique_ptr<Sorter> make_sorter(const Column&, Direction dir);
 std::unique_ptr<Sorter> make_sorter(const std::vector<Column>&);
 
 

--- a/src/core/sort/sorter.h
+++ b/src/core/sort/sorter.h
@@ -77,7 +77,7 @@ class SSorter : public Sorter
       if (nrows_ <= INSERTSORT_NROWS) {
         small_sort(ordering_out);
       } else {
-        radix_sort(ovec(), ordering_out, 0, true);
+        radix_sort(ovec(), ordering_out, 0, Mode::PARALLEL);
       }
       auto rowindex_type = sizeof(TO) == 4? RowIndex::ARR32 : RowIndex::ARR64;
       RowIndex result_rowindex(std::move(rowindex_buf), rowindex_type);
@@ -114,7 +114,7 @@ class SSorter : public Sorter
       */
     using next_wrapper = std::function<uqsorter(uqsorter&&)>;
     virtual void radix_sort(ovec ordering_in, ovec ordering_out,
-                            size_t offset, bool parallel,
+                            size_t offset, Mode sort_mode,
                             next_wrapper wrap = nullptr) const = 0;
 
     /**

--- a/src/core/sort/sorter.h
+++ b/src/core/sort/sorter.h
@@ -135,5 +135,11 @@ class SSorter : public Sorter
 
 
 
+// Factory functions
+std::unique_ptr<Sorter> make_sorter(const Column&);
+std::unique_ptr<Sorter> make_sorter(const std::vector<Column>&);
+
+
+
 }}  // namespace dt::sort
 #endif

--- a/src/core/sort/sorter.h
+++ b/src/core/sort/sorter.h
@@ -89,8 +89,8 @@ class SSorter : public Sorter
       if (nrows_ <= INSERTSORT_NROWS) {
         small_sort(ordering_out, grouper.get());
       } else {
-        xassert(!grouper);
-        radix_sort(Vec(), ordering_out, 0, Mode::PARALLEL);
+        radix_sort(Vec(), ordering_out, 0, grouper.get(),
+                   Mode::PARALLEL, nullptr);
       }
       auto rowindex_type = sizeof(T) == 4? RowIndex::ARR32 : RowIndex::ARR64;
       RowIndex result_rowindex(std::move(rowindex_buf), rowindex_type);
@@ -134,8 +134,8 @@ class SSorter : public Sorter
     /**
       */
     virtual void radix_sort(Vec ordering_in, Vec ordering_out,
-                            size_t offset, Mode sort_mode,
-                            NextWrapper wrap = nullptr) const = 0;
+                            size_t offset, TGrouper* grouper,
+                            Mode sort_mode, NextWrapper wrap) const = 0;
 
     /**
       * Comparator function that compares the values of the underlying

--- a/src/core/sort/sorter_bool.h
+++ b/src/core/sort/sorter_bool.h
@@ -56,8 +56,8 @@ class Sorter_Bool : public SSorter<TO> {
 
     void small_sort(ovec ordering_in, ovec ordering_out, size_t) const override
     {
-      xassert(ordering_in.size == ordering_out.size);
-      const TO* oin = ordering_in.ptr;
+      xassert(ordering_in.size() == ordering_out.size());
+      const TO* oin = ordering_in.ptr();
       dt::sort::small_sort(ordering_in, ordering_out,
         [&](size_t i, size_t j) {  // compare_lt
           int8_t ivalue, jvalue;

--- a/src/core/sort/sorter_bool.h
+++ b/src/core/sort/sorter_bool.h
@@ -31,7 +31,7 @@ namespace sort {
 /**
  * SSorter for (virtual) boolean columns.
  */
-template <typename T>
+template <typename T, bool ASC>
 class Sorter_Bool : public SSorter<T>
 {
   using Vec = array<T>;
@@ -56,7 +56,8 @@ class Sorter_Bool : public SSorter<T>
       int8_t ivalue, jvalue;
       bool ivalid = column_.get_element(i, &ivalue);
       bool jvalid = column_.get_element(j, &jvalue);
-      return (ivalid - jvalid) + (ivalid & jvalid) * (ivalue - jvalue);
+      return (ivalid - jvalid) +
+             (ivalid & jvalid) * (ASC? ivalue - jvalue : jvalue - ivalue);
     }
 
 
@@ -72,7 +73,7 @@ class Sorter_Bool : public SSorter<T>
           auto jj = static_cast<size_t>(oin[j]);
           bool ivalid = column_.get_element(ii, &ivalue);
           bool jvalid = column_.get_element(jj, &jvalue);
-          return jvalid & (!ivalid | (ivalue < jvalue));
+          return jvalid & (!ivalid | (ASC? ivalue < jvalue : ivalue > jvalue));
         });
     }
 
@@ -83,7 +84,7 @@ class Sorter_Bool : public SSorter<T>
           int8_t ivalue, jvalue;
           bool ivalid = column_.get_element(i, &ivalue);
           bool jvalid = column_.get_element(j, &jvalue);
-          return jvalid & (!ivalid | (ivalue < jvalue));
+          return jvalid & (!ivalid | (ASC? ivalue < jvalue : ivalue > jvalue));
         });
     }
 
@@ -99,7 +100,7 @@ class Sorter_Bool : public SSorter<T>
           [&](size_t i) {  // get_radix
             int8_t ivalue;
             bool ivalid = column_.get_element(i, &ivalue);
-            return static_cast<size_t>(ivalid * (ivalue + 1));
+            return static_cast<size_t>(ivalid * (ASC? ivalue + 1 : 2 - ivalue));
           });
       if (grouper) {
         grouper->fill_from_offsets(groups);

--- a/src/core/sort/sorter_bool.h
+++ b/src/core/sort/sorter_bool.h
@@ -90,15 +90,17 @@ class Sorter_Bool : public SSorter<T>
                     NextWrapper wrap) const override
     {
       (void) offset;
-      (void) grouper;
       (void) wrap;
       RadixSort rdx(nrows_, 1, sort_mode);
-      rdx.sort_by_radix(ordering_in, ordering_out,
-        [&](size_t i) {  // get_radix
-          int8_t ivalue;
-          bool ivalid = column_.get_element(i, &ivalue);
-          return static_cast<size_t>(ivalid * (ivalue + 1));
-        });
+      auto groups = rdx.sort_by_radix(ordering_in, ordering_out,
+          [&](size_t i) {  // get_radix
+            int8_t ivalue;
+            bool ivalid = column_.get_element(i, &ivalue);
+            return static_cast<size_t>(ivalid * (ivalue + 1));
+          });
+      if (grouper) {
+        grouper->fill_from_offsets(groups);
+      }
     }
 
 };

--- a/src/core/sort/sorter_bool.h
+++ b/src/core/sort/sorter_bool.h
@@ -86,10 +86,12 @@ class Sorter_Bool : public SSorter<T>
 
 
     void radix_sort(Vec ordering_in, Vec ordering_out,
-                    size_t offset, Mode sort_mode,
-                    NextWrapper wrap = nullptr) const override
+                    size_t offset, TGrouper* grouper, Mode sort_mode,
+                    NextWrapper wrap) const override
     {
       (void) offset;
+      (void) grouper;
+      (void) wrap;
       RadixSort rdx(nrows_, 1, sort_mode);
       rdx.sort_by_radix(ordering_in, ordering_out,
         [&](size_t i) {  // get_radix

--- a/src/core/sort/sorter_bool.h
+++ b/src/core/sort/sorter_bool.h
@@ -80,11 +80,11 @@ class Sorter_Bool : public SSorter<TO> {
 
 
     void radix_sort(ovec ordering_in, ovec ordering_out,
-                    size_t offset, bool parallel,
+                    size_t offset, Mode sort_mode,
                     next_wrapper wrap = nullptr) const override
     {
       (void) offset;
-      RadixSort rdx(nrows_, 1, parallel);
+      RadixSort rdx(nrows_, 1, sort_mode);
       rdx.sort_by_radix(ordering_in, ordering_out,
         [&](size_t i) {  // get_radix
           int8_t ivalue;

--- a/src/core/sort/sorter_bool.h
+++ b/src/core/sort/sorter_bool.h
@@ -45,7 +45,10 @@ class Sorter_Bool : public SSorter<T>
   public:
     Sorter_Bool(const Column& col)
       : SSorter<T>(col.nrows()),
-        column_(col) { xassert(col.stype() == SType::BOOL); }
+        column_(col)
+    {
+      xassert(col.stype() == SType::BOOL);
+    }
 
 
   protected:

--- a/src/core/sort/sorter_bool.h
+++ b/src/core/sort/sorter_bool.h
@@ -31,18 +31,20 @@ namespace sort {
 /**
  * SSorter for (virtual) boolean columns.
  */
-template <typename TO>
-class Sorter_Bool : public SSorter<TO> {
+template <typename T>
+class Sorter_Bool : public SSorter<T>
+{
+  using Vec = array<T>;
+  using TGrouper = Grouper<T>;
+  using UnqSorter = std::unique_ptr<SSorter<T>>;
+  using NextWrapper = dt::function<UnqSorter(UnqSorter&&)>;
   private:
-    using Vec = array<TO>;
-    using TGrouper = Grouper<TO>;
-    using typename SSorter<TO>::next_wrapper;
-    using SSorter<TO>::nrows_;
+    using SSorter<T>::nrows_;
     Column column_;
 
   public:
     Sorter_Bool(const Column& col)
-      : SSorter<TO>(col.nrows()),
+      : SSorter<T>(col.nrows()),
         column_(col) { xassert(col.stype() == SType::BOOL); }
 
 
@@ -59,7 +61,7 @@ class Sorter_Bool : public SSorter<TO> {
                     TGrouper* grouper) const override
     {
       xassert(ordering_in.size() == ordering_out.size());
-      const TO* oin = ordering_in.ptr();
+      const T* oin = ordering_in.ptr();
       dt::sort::small_sort(ordering_in, ordering_out, grouper,
         [&](size_t i, size_t j) {  // compare_lt
           int8_t ivalue, jvalue;
@@ -85,7 +87,7 @@ class Sorter_Bool : public SSorter<TO> {
 
     void radix_sort(Vec ordering_in, Vec ordering_out,
                     size_t offset, Mode sort_mode,
-                    next_wrapper wrap = nullptr) const override
+                    NextWrapper wrap = nullptr) const override
     {
       (void) offset;
       RadixSort rdx(nrows_, 1, sort_mode);

--- a/src/core/sort/sorter_bool.h
+++ b/src/core/sort/sorter_bool.h
@@ -56,11 +56,11 @@ class Sorter_Bool : public SSorter<TO> {
 
 
     void small_sort(Vec ordering_in, Vec ordering_out, size_t,
-                    TGrouper*) const override
+                    TGrouper* grouper) const override
     {
       xassert(ordering_in.size() == ordering_out.size());
       const TO* oin = ordering_in.ptr();
-      dt::sort::small_sort(ordering_in, ordering_out,
+      dt::sort::small_sort(ordering_in, ordering_out, grouper,
         [&](size_t i, size_t j) {  // compare_lt
           int8_t ivalue, jvalue;
           auto ii = static_cast<size_t>(oin[i]);
@@ -72,8 +72,8 @@ class Sorter_Bool : public SSorter<TO> {
     }
 
 
-    void small_sort(Vec ordering_out, TGrouper*) const override {
-      dt::sort::small_sort(Vec(), ordering_out,
+    void small_sort(Vec ordering_out, TGrouper* grouper) const override {
+      dt::sort::small_sort(Vec(), ordering_out, grouper,
         [&](size_t i, size_t j) {  // compare_lt
           int8_t ivalue, jvalue;
           bool ivalid = column_.get_element(i, &ivalue);

--- a/src/core/sort/sorter_int.h
+++ b/src/core/sort/sorter_int.h
@@ -88,8 +88,11 @@ class Sorter_Int : public SSorter<T> {
     }
 
     void radix_sort(Vec ordering_in, Vec ordering_out, size_t offset,
-                    Mode sort_mode, NextWrapper wrap = nullptr) const override
+                    TGrouper* grouper, Mode sort_mode, NextWrapper wrap
+                    ) const override
     {
+      (void) grouper;
+      (void) wrap;
       xassert(ordering_in.size() == 0);
       xassert(offset == 0);
       bool minmax_valid;
@@ -128,7 +131,7 @@ class Sorter_Int : public SSorter<T> {
       Sorter_Raw<T, TU> nextcol(std::move(out_buffer), nrows_, shift);
       rdx.sort_subgroups(groups, ordering_tmp, ordering_out,
         [&](size_t offs, size_t len, Vec ord_in, Vec ord_out, Mode m) {
-          nextcol.sort_subgroup(offs, len, ord_in, ord_out, m);
+          nextcol.sort_subgroup(offs, len, ord_in, ord_out, nullptr, m);
         });
     }
 

--- a/src/core/sort/sorter_int.h
+++ b/src/core/sort/sorter_int.h
@@ -34,19 +34,20 @@ namespace sort {
 /**
  * SSorter for (virtual) integer columns.
  */
-template <typename TO, typename TI>
-class Sorter_Int : public SSorter<TO> {
+template <typename T, typename TI>
+class Sorter_Int : public SSorter<T> {
   using TU = typename std::make_unsigned<TI>::type;
+  using Vec = array<T>;
+  using TGrouper = Grouper<T>;
+  using UnqSorter = std::unique_ptr<SSorter<T>>;
+  using NextWrapper = dt::function<UnqSorter(UnqSorter&&)>;
   private:
-    using ovec = array<TO>;
-    using TGrouper = Grouper<TO>;
-    using typename SSorter<TO>::next_wrapper;
-    using SSorter<TO>::nrows_;
+    using SSorter<T>::nrows_;
     Column column_;
 
   public:
     Sorter_Int(const Column& col)
-      : SSorter<TO>(col.nrows()),
+      : SSorter<T>(col.nrows()),
         column_(col) { assert_compatible_type<TI>(col.stype()); }
 
 
@@ -59,12 +60,12 @@ class Sorter_Int : public SSorter<TO> {
                              : (ivalid - jvalid);
     }
 
-    void small_sort(ovec ordering_in, ovec ordering_out,
+    void small_sort(Vec ordering_in, Vec ordering_out,
                     size_t offset, TGrouper* grouper) const override
     {
       (void) offset;
       xassert(ordering_in.size() == ordering_out.size());
-      const TO* oin = ordering_in.ptr();
+      const T* oin = ordering_in.ptr();
       dt::sort::small_sort(ordering_in, ordering_out, grouper,
         [&](size_t i, size_t j) -> bool {  // compare_lt
           TI ivalue, jvalue;
@@ -76,8 +77,8 @@ class Sorter_Int : public SSorter<TO> {
         });
     }
 
-    void small_sort(ovec ordering_out, TGrouper* grouper) const override {
-      dt::sort::small_sort(ovec(), ordering_out, grouper,
+    void small_sort(Vec ordering_out, TGrouper* grouper) const override {
+      dt::sort::small_sort(Vec(), ordering_out, grouper,
         [&](size_t i, size_t j) -> bool {  // compare_lt
           TI ivalue, jvalue;
           bool ivalid = column_.get_element(i, &ivalue);
@@ -86,8 +87,8 @@ class Sorter_Int : public SSorter<TO> {
         });
     }
 
-    void radix_sort(ovec ordering_in, ovec ordering_out, size_t offset,
-                    Mode sort_mode, next_wrapper wrap = nullptr) const override
+    void radix_sort(Vec ordering_in, Vec ordering_out, size_t offset,
+                    Mode sort_mode, NextWrapper wrap = nullptr) const override
     {
       xassert(ordering_in.size() == 0);
       xassert(offset == 0);
@@ -105,14 +106,14 @@ class Sorter_Int : public SSorter<TO> {
       int shift = nsigbits - nradixbits;
       TU mask = static_cast<TU>((size_t(1) << shift) - 1);
 
-      Buffer tmp = Buffer::mem(sizeof(TO) * nrows_);
-      ovec ordering_tmp(tmp);
+      Buffer tmp = Buffer::mem(sizeof(T) * nrows_);
+      Vec ordering_tmp(tmp);
 
       Buffer out_buffer = Buffer::mem(sizeof(TU) * nrows_);
       array<TU> out_array(out_buffer);
 
       RadixSort rdx(nrows_, 1, sort_mode);
-      auto groups = rdx.sort_by_radix(ovec(), ordering_tmp,
+      auto groups = rdx.sort_by_radix(Vec(), ordering_tmp,
         [&](size_t i) -> size_t {  // get_radix
           TI value;
           bool isvalid = column_.get_element(i, &value);
@@ -124,19 +125,19 @@ class Sorter_Int : public SSorter<TO> {
           out_array[j] = static_cast<TU>(value - min) & mask;
         });
 
-      Sorter_Raw<TO, TU> nextcol(std::move(out_buffer), nrows_, shift);
+      Sorter_Raw<T, TU> nextcol(std::move(out_buffer), nrows_, shift);
       rdx.sort_subgroups(groups, ordering_tmp, ordering_out,
-        [&](size_t offs, size_t len, ovec ord_in, ovec ord_out, Mode m) {
+        [&](size_t offs, size_t len, Vec ord_in, Vec ord_out, Mode m) {
           nextcol.sort_subgroup(offs, len, ord_in, ord_out, m);
         });
     }
 
 
   private:
-    void write_range(ovec ordering_out) const {
+    void write_range(Vec ordering_out) const {
       size_t n = ordering_out.size();
       for (size_t i = 0; i < n; ++i) {
-        ordering_out[i] = static_cast<TO>(i);
+        ordering_out[i] = static_cast<T>(i);
       }
     }
 

--- a/src/core/sort/sorter_int.h
+++ b/src/core/sort/sorter_int.h
@@ -93,6 +93,8 @@ class Sorter_Int : public SSorter<T> {
     {
       (void) grouper;
       (void) wrap;
+      (void) offset;
+      (void) ordering_in;
       xassert(ordering_in.size() == 0);
       xassert(offset == 0);
       bool minmax_valid;

--- a/src/core/sort/sorter_int.h
+++ b/src/core/sort/sorter_int.h
@@ -62,8 +62,8 @@ class Sorter_Int : public SSorter<TO> {
                     size_t offset) const override
     {
       (void) offset;
-      xassert(ordering_in.size == ordering_out.size);
-      const TO* oin = ordering_in.ptr;
+      xassert(ordering_in.size() == ordering_out.size());
+      const TO* oin = ordering_in.ptr();
       dt::sort::small_sort(ordering_in, ordering_out,
         [&](size_t i, size_t j) -> bool {  // compare_lt
           TI ivalue, jvalue;
@@ -86,7 +86,7 @@ class Sorter_Int : public SSorter<TO> {
     void radix_sort(ovec ordering_in, ovec ordering_out, size_t offset,
                     bool parallel, next_wrapper wrap = nullptr) const override
     {
-      xassert(ordering_in.size == 0);
+      xassert(ordering_in.size() == 0);
       xassert(offset == 0);
       bool minmax_valid;
       TI min = static_cast<TI>(column_.stats()->min_int(&minmax_valid));
@@ -118,7 +118,7 @@ class Sorter_Int : public SSorter<TO> {
         [&](size_t i, size_t j) {  // move_data
           TI value;
           column_.get_element(i, &value);
-          out_array.ptr[j] = static_cast<TU>(value - min) & mask;
+          out_array[j] = static_cast<TU>(value - min) & mask;
         });
 
       Sorter_Raw<TO, TU> nextcol(std::move(out_buffer), nrows_, shift);
@@ -131,9 +131,9 @@ class Sorter_Int : public SSorter<TO> {
 
   private:
     void write_range(ovec ordering_out) const {
-      size_t n = ordering_out.size;
+      size_t n = ordering_out.size();
       for (size_t i = 0; i < n; ++i) {
-        ordering_out.ptr[i] = static_cast<TO>(i);
+        ordering_out[i] = static_cast<TO>(i);
       }
     }
 

--- a/src/core/sort/sorter_int.h
+++ b/src/core/sort/sorter_int.h
@@ -39,6 +39,7 @@ class Sorter_Int : public SSorter<TO> {
   using TU = typename std::make_unsigned<TI>::type;
   private:
     using ovec = array<TO>;
+    using TGrouper = Grouper<TO>;
     using typename SSorter<TO>::next_wrapper;
     using SSorter<TO>::nrows_;
     Column column_;
@@ -59,7 +60,7 @@ class Sorter_Int : public SSorter<TO> {
     }
 
     void small_sort(ovec ordering_in, ovec ordering_out,
-                    size_t offset) const override
+                    size_t offset, TGrouper*) const override
     {
       (void) offset;
       xassert(ordering_in.size() == ordering_out.size());
@@ -67,13 +68,15 @@ class Sorter_Int : public SSorter<TO> {
       dt::sort::small_sort(ordering_in, ordering_out,
         [&](size_t i, size_t j) -> bool {  // compare_lt
           TI ivalue, jvalue;
-          bool ivalid = column_.get_element(static_cast<size_t>(oin[i]), &ivalue);
-          bool jvalid = column_.get_element(static_cast<size_t>(oin[j]), &jvalue);
+          auto ii = static_cast<size_t>(oin[i]);
+          auto jj = static_cast<size_t>(oin[j]);
+          bool ivalid = column_.get_element(ii, &ivalue);
+          bool jvalid = column_.get_element(jj, &jvalue);
           return jvalid && (!ivalid || ivalue < jvalue);
         });
     }
 
-    void small_sort(ovec ordering_out) const override {
+    void small_sort(ovec ordering_out, TGrouper*) const override {
       dt::sort::small_sort(ovec(), ordering_out,
         [&](size_t i, size_t j) -> bool {  // compare_lt
           TI ivalue, jvalue;

--- a/src/core/sort/sorter_int.h
+++ b/src/core/sort/sorter_int.h
@@ -60,12 +60,12 @@ class Sorter_Int : public SSorter<TO> {
     }
 
     void small_sort(ovec ordering_in, ovec ordering_out,
-                    size_t offset, TGrouper*) const override
+                    size_t offset, TGrouper* grouper) const override
     {
       (void) offset;
       xassert(ordering_in.size() == ordering_out.size());
       const TO* oin = ordering_in.ptr();
-      dt::sort::small_sort(ordering_in, ordering_out,
+      dt::sort::small_sort(ordering_in, ordering_out, grouper,
         [&](size_t i, size_t j) -> bool {  // compare_lt
           TI ivalue, jvalue;
           auto ii = static_cast<size_t>(oin[i]);
@@ -76,8 +76,8 @@ class Sorter_Int : public SSorter<TO> {
         });
     }
 
-    void small_sort(ovec ordering_out, TGrouper*) const override {
-      dt::sort::small_sort(ovec(), ordering_out,
+    void small_sort(ovec ordering_out, TGrouper* grouper) const override {
+      dt::sort::small_sort(ovec(), ordering_out, grouper,
         [&](size_t i, size_t j) -> bool {  // compare_lt
           TI ivalue, jvalue;
           bool ivalid = column_.get_element(i, &ivalue);

--- a/src/core/sort/sorter_int.h
+++ b/src/core/sort/sorter_int.h
@@ -84,7 +84,7 @@ class Sorter_Int : public SSorter<TO> {
     }
 
     void radix_sort(ovec ordering_in, ovec ordering_out, size_t offset,
-                    bool parallel, next_wrapper wrap = nullptr) const override
+                    Mode sort_mode, next_wrapper wrap = nullptr) const override
     {
       xassert(ordering_in.size() == 0);
       xassert(offset == 0);
@@ -108,7 +108,7 @@ class Sorter_Int : public SSorter<TO> {
       Buffer out_buffer = Buffer::mem(sizeof(TU) * nrows_);
       array<TU> out_array(out_buffer);
 
-      RadixSort rdx(nrows_, 1, parallel);
+      RadixSort rdx(nrows_, 1, sort_mode);
       auto groups = rdx.sort_by_radix(ovec(), ordering_tmp,
         [&](size_t i) -> size_t {  // get_radix
           TI value;
@@ -123,8 +123,8 @@ class Sorter_Int : public SSorter<TO> {
 
       Sorter_Raw<TO, TU> nextcol(std::move(out_buffer), nrows_, shift);
       rdx.sort_subgroups(groups, ordering_tmp, ordering_out,
-        [&](size_t offs, size_t len, ovec ord_in, ovec ord_out, bool para) {
-          nextcol.sort_subgroup(offs, len, ord_in, ord_out, para);
+        [&](size_t offs, size_t len, ovec ord_in, ovec ord_out, Mode m) {
+          nextcol.sort_subgroup(offs, len, ord_in, ord_out, m);
         });
     }
 

--- a/src/core/sort/sorter_multi.h
+++ b/src/core/sort/sorter_multi.h
@@ -111,15 +111,16 @@ class Sorter_Multi : public SSorter<T>
       }
     }
 
-    virtual void radix_sort(Vec ordering_in, Vec ordering_out,
-                            size_t offset, Mode sort_mode,
-                            NextWrapper wrap = nullptr) const override
+    void radix_sort(Vec ordering_in, Vec ordering_out, size_t offset,
+                    TGrouper* grouper, Mode sort_mode, NextWrapper wrap
+                    ) const override
     {
-      column0_->radix_sort(ordering_in, ordering_out, offset, sort_mode,
+      (void) wrap;
+      column0_->radix_sort(ordering_in, ordering_out, offset, grouper, sort_mode,
           [&](UnqSorter&& next_sorter) {
             if (next_sorter) {
               return UnqSorter(new Sorter_Multi<T>(std::move(next_sorter),
-                                                    other_columns_));
+                                                   other_columns_));
             } else {
               return UnqSorter();  // FIXME
               // return ssoptr(new Sorter_MultiImpl<T>());

--- a/src/core/sort/sorter_multi.h
+++ b/src/core/sort/sorter_multi.h
@@ -38,6 +38,7 @@ class Sorter_Multi : public SSorter<TO>
   using uqSsorter = std::unique_ptr<SSorter<TO>>;
   using shSsorter = std::shared_ptr<SSorter<TO>>;
   using ovec = array<TO>;
+  using TGrouper = Grouper<TO>;
   private:
     shSsorter column0_;
     std::vector<shSsorter> other_columns_;
@@ -60,7 +61,7 @@ class Sorter_Multi : public SSorter<TO>
     {}
 
   protected:
-    void small_sort(ovec ordering_out) const override {
+    void small_sort(ovec ordering_out, TGrouper*) const override {
       dt::sort::small_sort(ovec(), ordering_out,
         [&](size_t i, size_t j) {  // compare_lt
           int cmp = column0_->compare_lge(i, j);
@@ -74,7 +75,7 @@ class Sorter_Multi : public SSorter<TO>
         });
     }
 
-    void small_sort(ovec ordering_in, ovec ordering_out, size_t offset)
+    void small_sort(ovec ordering_in, ovec ordering_out, size_t offset, TGrouper*)
         const override
     {
       xassert(ordering_in.size() == ordering_out.size());

--- a/src/core/sort/sorter_multi.h
+++ b/src/core/sort/sorter_multi.h
@@ -103,8 +103,8 @@ class Sorter_MultiImpl : public SSorter<TO>
         [&](size_t i, size_t j) {  // compare_lt
           int cmp = column0_->compare_lge(i, j);
           if (cmp == 0) {
-            for (size_t k = 0; k < other_columns_.size; ++k) {
-              cmp = other_columns_.ptr[k]->compare_lge(i, j);
+            for (size_t k = 0; k < other_columns_.size(); ++k) {
+              cmp = other_columns_[k]->compare_lge(i, j);
               if (cmp) break;
             }
           }
@@ -115,16 +115,16 @@ class Sorter_MultiImpl : public SSorter<TO>
     void small_sort(ovec ordering_in, ovec ordering_out, size_t offset)
         const override
     {
-      xassert(ordering_in.size == ordering_out.size);
+      xassert(ordering_in.size() == ordering_out.size());
       if (column0_->contains_reordered_data()) {
         dt::sort::small_sort(ordering_in, ordering_out,
           [&](size_t i, size_t j) {
             int cmp = column0_->compare_lge(i + offset, j + offset);
             if (cmp == 0) {
-              size_t ii = static_cast<size_t>(ordering_in.ptr[i]);
-              size_t jj = static_cast<size_t>(ordering_in.ptr[j]);
-              for (size_t k = 0; k < other_columns_.size; ++k) {
-                cmp = other_columns_.ptr[k]->compare_lge(ii, jj);
+              size_t ii = static_cast<size_t>(ordering_in[i]);
+              size_t jj = static_cast<size_t>(ordering_in[j]);
+              for (size_t k = 0; k < other_columns_.size(); ++k) {
+                cmp = other_columns_[k]->compare_lge(ii, jj);
                 if (cmp) break;
               }
             }
@@ -134,12 +134,12 @@ class Sorter_MultiImpl : public SSorter<TO>
       else {
         dt::sort::small_sort(ordering_in, ordering_out,
           [&](size_t i, size_t j) {
-            size_t ii = static_cast<size_t>(ordering_in.ptr[i]);
-            size_t jj = static_cast<size_t>(ordering_in.ptr[j]);
+            size_t ii = static_cast<size_t>(ordering_in[i]);
+            size_t jj = static_cast<size_t>(ordering_in[j]);
             int cmp = column0_->compare_lge(ii, jj);
             if (cmp == 0) {
-              for (size_t k = 0; k < other_columns_.size; ++k) {
-                cmp = other_columns_.ptr[k]->compare_lge(ii, jj);
+              for (size_t k = 0; k < other_columns_.size(); ++k) {
+                cmp = other_columns_[k]->compare_lge(ii, jj);
                 if (cmp) break;
               }
             }

--- a/src/core/sort/sorter_multi.h
+++ b/src/core/sort/sorter_multi.h
@@ -21,6 +21,7 @@
 //------------------------------------------------------------------------------
 #ifndef dt_SORT_SORTER_MULTI_h
 #define dt_SORT_SORTER_MULTI_h
+#include <memory>                // std::shared_ptr
 #include <vector>                // std::vector
 #include "sort/common.h"         // array
 #include "sort/insert-sort.h"    // small_sort
@@ -28,74 +29,35 @@
 namespace dt {
 namespace sort {
 
-// forward-declare
-template <typename TO> class Sorter_MultiImpl;
 
 
 template <typename TO>
 class Sorter_Multi : public SSorter<TO>
 {
   using typename SSorter<TO>::next_wrapper;
-  using ptrSsorter = std::unique_ptr<SSorter<TO>>;
+  using uqSsorter = std::unique_ptr<SSorter<TO>>;
+  using shSsorter = std::shared_ptr<SSorter<TO>>;
   using ovec = array<TO>;
   private:
-    std::vector<ptrSsorter> sorters_;
-    Sorter_MultiImpl<TO> impl_;
+    shSsorter column0_;
+    std::vector<shSsorter> other_columns_;
 
   public:
-    Sorter_Multi(std::vector<ptrSsorter>&& cols)
+    Sorter_Multi(std::vector<uqSsorter>&& cols)
       : SSorter<TO>(cols[0]->nrows()),
-        sorters_(std::move(cols)),
-        impl_(reinterpret_cast<SSorter<TO>**>(sorters_.data()),
-              sorters_.size()) {}
-
-  protected:
-    void small_sort(ovec ordering_out) const override {
-      impl_.small_sort(ordering_out);
-    }
-
-    void small_sort(ovec ordering_in, ovec ordering_out,
-                    size_t offset) const override
+        column0_(std::move(cols[0]))
     {
-      impl_.small_sort(ordering_in, ordering_out, offset);
+      other_columns_.reserve(cols.size() - 1);
+      for (size_t i = 1; i < cols.size(); ++i) {
+        other_columns_.push_back(shSsorter(std::move(cols[i])));
+      }
     }
 
-    void radix_sort(ovec ordering_in, ovec ordering_out,
-                    size_t offset, bool parallel,
-                    next_wrapper wrap = nullptr) const override
-    {
-      impl_.radix_sort(ordering_in, ordering_out, offset, parallel, wrap);
-    }
-
-    int compare_lge(size_t i, size_t j) const override {
-      return impl_.compare_lge(i, j);
-    }
-};
-
-
-
-template <typename TO>
-class Sorter_MultiImpl : public SSorter<TO>
-{
-  friend class Sorter_Multi<TO>;
-  using typename SSorter<TO>::ovec;
-  using typename SSorter<TO>::ssoptr;
-  using typename SSorter<TO>::next_wrapper;
-  using Sorter::nrows_;
-  private:
-    SSorter<TO>* column0_;
-    array<SSorter<TO>*> other_columns_;
-
-  public:
-    Sorter_MultiImpl(SSorter<TO>* col0, array<SSorter<TO>*> cols)
+    Sorter_Multi(uqSsorter&& col0, const std::vector<shSsorter>& cols1)
       : SSorter<TO>(col0->nrows()),
-        column0_(col0),
-        other_columns_(cols) {}
-
-    Sorter_MultiImpl(SSorter<TO>** cols, size_t n)
-      : SSorter<TO>(cols[0]->nrows()),
-        column0_(cols[0]),
-        other_columns_(cols + 1, n - 1) {}
+        column0_(std::move(col0)),
+        other_columns_(cols1)
+    {}
 
   protected:
     void small_sort(ovec ordering_out) const override {
@@ -153,12 +115,12 @@ class Sorter_MultiImpl : public SSorter<TO>
                             next_wrapper wrap = nullptr) const override
     {
       column0_->radix_sort(ordering_in, ordering_out, offset, parallel,
-          [&](const ssoptr& next_sorter) {
+          [&](uqSsorter&& next_sorter) {
             if (next_sorter) {
-              return ssoptr(new Sorter_MultiImpl<TO>(next_sorter.get(),
-                                                     other_columns_));
+              return uqSsorter(new Sorter_Multi<TO>(std::move(next_sorter),
+                                                    other_columns_));
             } else {
-              return ssoptr();  // FIXME
+              return uqSsorter();  // FIXME
               // return ssoptr(new Sorter_MultiImpl<TO>());
             }
           });

--- a/src/core/sort/sorter_multi.h
+++ b/src/core/sort/sorter_multi.h
@@ -61,8 +61,8 @@ class Sorter_Multi : public SSorter<TO>
     {}
 
   protected:
-    void small_sort(ovec ordering_out, TGrouper*) const override {
-      dt::sort::small_sort(ovec(), ordering_out,
+    void small_sort(ovec ordering_out, TGrouper* grouper) const override {
+      dt::sort::small_sort(ovec(), ordering_out, grouper,
         [&](size_t i, size_t j) {  // compare_lt
           int cmp = column0_->compare_lge(i, j);
           if (cmp == 0) {
@@ -75,12 +75,12 @@ class Sorter_Multi : public SSorter<TO>
         });
     }
 
-    void small_sort(ovec ordering_in, ovec ordering_out, size_t offset, TGrouper*)
-        const override
+    void small_sort(ovec ordering_in, ovec ordering_out, size_t offset,
+                    TGrouper* grouper) const override
     {
       xassert(ordering_in.size() == ordering_out.size());
       if (column0_->contains_reordered_data()) {
-        dt::sort::small_sort(ordering_in, ordering_out,
+        dt::sort::small_sort(ordering_in, ordering_out, grouper,
           [&](size_t i, size_t j) {
             int cmp = column0_->compare_lge(i + offset, j + offset);
             if (cmp == 0) {
@@ -95,7 +95,7 @@ class Sorter_Multi : public SSorter<TO>
           });
       }
       else {
-        dt::sort::small_sort(ordering_in, ordering_out,
+        dt::sort::small_sort(ordering_in, ordering_out, grouper,
           [&](size_t i, size_t j) {
             size_t ii = static_cast<size_t>(ordering_in[i]);
             size_t jj = static_cast<size_t>(ordering_in[j]);

--- a/src/core/sort/sorter_multi.h
+++ b/src/core/sort/sorter_multi.h
@@ -111,10 +111,10 @@ class Sorter_Multi : public SSorter<TO>
     }
 
     virtual void radix_sort(ovec ordering_in, ovec ordering_out,
-                            size_t offset, bool parallel,
+                            size_t offset, Mode sort_mode,
                             next_wrapper wrap = nullptr) const override
     {
-      column0_->radix_sort(ordering_in, ordering_out, offset, parallel,
+      column0_->radix_sort(ordering_in, ordering_out, offset, sort_mode,
           [&](uqSsorter&& next_sorter) {
             if (next_sorter) {
               return uqSsorter(new Sorter_Multi<TO>(std::move(next_sorter),

--- a/src/core/sort/sorter_raw.h
+++ b/src/core/sort/sorter_raw.h
@@ -57,12 +57,12 @@ class Sorter_Raw : public SSorter<T>
 
     void sort_subgroup(size_t offset, size_t length,
                        Vec ordering_in, Vec ordering_out,
-                       Mode sort_mode)
+                       TGrouper* grouper, Mode sort_mode)
     {
       if (length <= INSERTSORT_NROWS) {
-        small_sort(ordering_in, ordering_out, offset, nullptr);
+        small_sort(ordering_in, ordering_out, offset, grouper);
       } else {
-        radix_sort(ordering_in, ordering_out, offset, sort_mode);
+        radix_sort(ordering_in, ordering_out, offset, grouper, sort_mode, nullptr);
       }
     }
 
@@ -94,8 +94,11 @@ class Sorter_Raw : public SSorter<T>
 
 
     void radix_sort(Vec ordering_in, Vec ordering_out, size_t offset,
-                    Mode mode, NextWrapper wrap = nullptr) const override
+                    TGrouper* grouper, Mode mode, NextWrapper wrap
+                    ) const override
     {
+      (void) grouper;
+      (void) wrap;
       int n_radix_bits = (n_significant_bits_ < 16)? n_significant_bits_ : 8;
       int n_remaining_bits = n_significant_bits_ - n_radix_bits;
       if (n_remaining_bits == 0)       radix_sort0(ordering_in, ordering_out, offset, mode);
@@ -137,7 +140,7 @@ class Sorter_Raw : public SSorter<T>
 
       rdx.sort_subgroups(groups, ordering_out, ordering_in,
         [&](size_t offs, size_t length, Vec oin, Vec oout, Mode m) {
-          nextcol.sort_subgroup(offs, length, oin, oout, m);
+          nextcol.sort_subgroup(offs, length, oin, oout, nullptr, m);
         });
     }
 };

--- a/src/core/sort/sorter_raw.h
+++ b/src/core/sort/sorter_raw.h
@@ -34,6 +34,7 @@ class Sorter_Raw : public SSorter<TO>
 {
   using typename SSorter<TO>::next_wrapper;
   using ovec = array<TO>;
+  using TGrouper = Grouper<TO>;
   using SSorter<TO>::nrows_;
   private:
     TU* data_;        // array with nrows_ elements
@@ -57,7 +58,7 @@ class Sorter_Raw : public SSorter<TO>
                        Mode sort_mode)
     {
       if (length <= INSERTSORT_NROWS) {
-        small_sort(ordering_in, ordering_out, offset);
+        small_sort(ordering_in, ordering_out, offset, nullptr);
       } else {
         radix_sort(ordering_in, ordering_out, offset, sort_mode);
       }
@@ -77,7 +78,7 @@ class Sorter_Raw : public SSorter<TO>
     }
 
     void small_sort(ovec ordering_in, ovec ordering_out,
-                     size_t offset) const override
+                    size_t offset, TGrouper*) const override
     {
       TU* x = data_ + offset;
       dt::sort::small_sort(ordering_in, ordering_out,
@@ -85,8 +86,8 @@ class Sorter_Raw : public SSorter<TO>
     }
 
 
-    void small_sort(ovec ordering_out) const override {
-      small_sort(ovec(), ordering_out, 0);
+    void small_sort(ovec ordering_out, TGrouper* grouper) const override {
+      small_sort(ovec(), ordering_out, 0, grouper);
     }
 
 

--- a/src/core/sort/sorter_raw.h
+++ b/src/core/sort/sorter_raw.h
@@ -78,10 +78,10 @@ class Sorter_Raw : public SSorter<TO>
     }
 
     void small_sort(ovec ordering_in, ovec ordering_out,
-                    size_t offset, TGrouper*) const override
+                    size_t offset, TGrouper* grouper) const override
     {
       TU* x = data_ + offset;
-      dt::sort::small_sort(ordering_in, ordering_out,
+      dt::sort::small_sort(ordering_in, ordering_out, grouper,
         [&](size_t i, size_t j){ return x[i] < x[j]; });
     }
 

--- a/src/core/sort/sorter_raw.h
+++ b/src/core/sort/sorter_raw.h
@@ -107,7 +107,7 @@ class Sorter_Raw : public SSorter<TO>
     void radix_sort0(ovec ordering_in, ovec ordering_out, size_t offset,
                      bool parallel) const
     {
-      size_t n = ordering_out.size;
+      size_t n = ordering_out.size();
       RadixSort rdx(n, n_significant_bits_, parallel);
       TU* x = data_ + offset;
       rdx.sort_by_radix(ordering_in, ordering_out,
@@ -120,7 +120,7 @@ class Sorter_Raw : public SSorter<TO>
                      int n_radix_bits, bool parallel) const
     {
       static_assert(std::is_unsigned<TNext>::value, "Wrong TNext type");
-      size_t n = ordering_out.size;
+      size_t n = ordering_out.size();
       int shift = n_significant_bits_ - n_radix_bits;
       TU mask = static_cast<TU>(TU(1) << shift) - 1;
       Sorter_Raw<TO, TNext> nextcol(Buffer::mem(n*sizeof(TNext)), n, shift);

--- a/src/core/utils/function.h
+++ b/src/core/utils/function.h
@@ -19,23 +19,24 @@ namespace dt {
 
 
 /**
- * An efficient, type-erasing, non-owning reference to a callable. This is
- * intended for use as the type of a function parameter that is not used
- * after the function in question returns.
- *
- * This class does not own the callable, so it is not in general safe to store
- * a dt::function.
- *
- * In particular, beware of the following use pattern:
- *
- *     function<void()> f = [&]{ ... };
- *
- * Here the RHS is a lambda, which is created as a temporary variable. It is
- * then assigned to `f`, at which point the temporary gets destroyed and its
- * storage reclaimed. However, since `f` is a non-owning wrapper, any
- * subsequent call to `f` will be invoking a dangling pointer, which may
- * cause memory corruption and crashes.
- */
+  * An efficient, type-erasing, non-owning reference to a callable.
+  * This is intended for use as the type of a function parameter that
+  * is not used after the function returns.
+  *
+  * This class does not own the callable, so it is not in general
+  * safe to store a dt::function.
+  *
+  * In particular, avoid the following use pattern:
+  *
+  *     dt::function<void()> fn = [&]{ ... };
+  *
+  * Here the RHS is a lambda, which is created as a temporary
+  * variable. It is then assigned to `fn`, at which point the
+  * temporary gets destroyed and its storage reclaimed. However,
+  * since `fn` is a non-owning wrapper, any subsequent call to `fn`
+  * will be invoking a dangling pointer, which will cause memory
+  * corruption and crashes.
+  */
 template<typename Fn> class function;
 
 
@@ -72,8 +73,11 @@ class function<TReturn(TArgs...)>
       return _callback(_callable, std::forward<TArgs>(params)...);
     }
 
-    operator bool() const { return bool(_callback); }
+    operator bool() const {
+      return bool(_callback);
+    }
 };
+
 
 
 }  // namespace dt

--- a/tests/ijby/test-sort.py
+++ b/tests/ijby/test-sort.py
@@ -266,6 +266,8 @@ def test_int8_large_stable(n):
 
 
 #-------------------------------------------------------------------------------
+# Bool8
+#-------------------------------------------------------------------------------
 
 def test_bool8_small():
     d0 = dt.Frame([True, False, False, None, True, True, None])
@@ -681,7 +683,7 @@ def test_strXX_large5(st):
 
 @pytest.mark.parametrize("st", [dt.str32, dt.str64])
 def test_strXX_large6(st):
-    rootdir = os.path.join(os.path.dirname(__file__), "..", "src", "core")
+    rootdir = os.path.join(os.path.dirname(__file__), "..", "..", "src", "core")
     assert os.path.isdir(rootdir)
     words = []
     for dirname, _, files in os.walk(rootdir):

--- a/tests/ijby/test-sort.py
+++ b/tests/ijby/test-sort.py
@@ -270,53 +270,54 @@ def test_int8_large_stable(n):
 #-------------------------------------------------------------------------------
 
 def test_bool8_small():
-    d0 = dt.Frame([True, False, False, None, True, True, None])
-    assert d0.stypes == (stype.bool8, )
-    d1 = d0[:, :, sort("C0")]
-    assert d1.stypes == d0.stypes
-    assert isview(d1)
-    frame_integrity_check(d1)
-    assert d1.to_list() == [[None, None, False, False, True, True, True]]
+    DT0 = dt.Frame([True, False, False, None, True, True, None])
+    DT1 = dt.Frame([None, None, False, False, True, True, True])
+    DTS = DT0[:, :, sort("C0")]
+    assert DT0.stype == dt.bool8
+    assert isview(DTS)
+    assert_equals(DTS, DT1)
 
 
 def test_bool8_small_stable():
-    d0 = dt.Frame([[True, False, False, None, True, True, None],
-                   [1, 2, 3, 4, 5, 6, 7]],
-                  names=["A", "B"], stypes={"B": "int8"})
-    assert d0.stypes == (stype.bool8, stype.int8)
-    d1 = d0[:, :, sort("A")]
-    assert d1.stypes == d0.stypes
-    assert d1.names == d0.names
-    assert isview(d1)
-    frame_integrity_check(d1)
-    assert d1.to_list() == [[None, None, False, False, True, True, True],
-                            [4, 7, 2, 3, 1, 5, 6]]
+    DT0 = dt.Frame(A=[True, False, False, None, True, True, None],
+                   B=[1, 2, 3, 4, 5, 6, 7])
+    DT1 = dt.Frame(A=[None, None, False, False, True, True, True],
+                   B=[4, 7, 2, 3, 1, 5, 6])
+    DTS = DT0[:, :, sort(f.A)]
+    assert DT0['A'].stype == dt.bool8
+    assert isview(DTS)
+    assert_equals(DTS, DT1)
 
 
-@pytest.mark.parametrize("n", [100, 512, 1000, 5000, 100000])
+def test_bool8_small_view():
+    DT0 = dt.Frame([True, False, False, True, None, True, True, None])
+    DT1 = dt.Frame([None, None, False, False, True, True, True, True])
+    DTS = dt.rbind(DT0[::2, :], DT0[1::2, :]).sort(0)
+    assert_equals(DTS, DT1)
+
+
+@pytest.mark.parametrize("n", [100, 512, 1000, 5000, 123457])
 def test_bool8_large(n):
-    d0 = dt.Frame([True, False, True, None, None, False] * n)
-    assert d0.stypes == (stype.bool8, )
-    d1 = d0.sort(0)
-    assert d1.stypes == d0.stypes
-    assert d1.names == d0.names
-    assert isview(d1)
-    frame_integrity_check(d0)
-    frame_integrity_check(d1)
     nn = 2 * n
-    assert d1.to_list() == [[None] * nn + [False] * nn + [True] * nn]
+    DT0 = dt.Frame([True, False, True, None, None, False] * n)
+    DT1 = dt.Frame([[None] * nn + [False] * nn + [True] * nn])
+    assert DT0.stype == dt.bool8
+    DTS = DT0.sort(0)
+    DTT = DT0[::-1, :].sort(0)
+    assert isview(DTS)
+    assert_equals(DTS, DT1)
+    assert_equals(DTT, DT1)
 
 
-@pytest.mark.parametrize("n", [254, 255, 256, 257, 258, 1000, 10000])
+@pytest.mark.parametrize("n", [254, 255, 256, 257, 258, 1000, 11111])
 def test_bool8_large_stable(n):
-    d0 = dt.Frame([[True, False, None] * n, range(3 * n)], names=["A", "B"])
-    assert d0.stypes[0] == stype.bool8
-    d1 = d0[:, f.B, sort(f.A)]
-    assert isview(d1)
-    frame_integrity_check(d1)
-    assert d1.to_list() == [list(range(2, 3 * n, 3)) +
-                            list(range(1, 3 * n, 3)) +
-                            list(range(0, 3 * n, 3))]
+    DT0 = dt.Frame(A=[True, False, None] * n, B=range(3 * n))
+    DT1 = dt.Frame(B=list(range(2, 3 * n, 3)) +
+                     list(range(1, 3 * n, 3)) +
+                     list(range(0, 3 * n, 3)))
+    DTS = DT0[:, f.B, sort(f.A)]
+    assert_equals(DTS, DT1)
+
 
 
 

--- a/tests/ijby/test-sort.py
+++ b/tests/ijby/test-sort.py
@@ -319,8 +319,27 @@ def test_bool8_large_stable(n):
     assert_equals(DTS, DT1)
 
 
+def test_bool8_small_descending():
+    DT0 = dt.Frame([True, False, False, None, True, True, None])
+    DT1 = dt.Frame([None, None, True, True, True, False, False])
+    DTS = DT0[:, :, sort(-f.C0)]
+    assert DT0.stype == dt.bool8
+    assert isview(DTS)
+    assert_equals(DTS, DT1)
 
 
+@pytest.mark.parametrize("n", [int(random.expovariate(0.00001)) + 100])
+def test_bool8_large_descending(n):
+    DT0 = dt.Frame([True, False, True, None, None, False, True] * n)
+    DT1 = dt.Frame([None] * (2*n) + [True] * (3*n) + [False] * (2*n))
+    DTS = DT0[:, :, sort(-f[0])]
+    assert_equals(DTS, DT1)
+
+
+
+
+#-------------------------------------------------------------------------------
+# Int16
 #-------------------------------------------------------------------------------
 
 def test_int16_small():
@@ -366,6 +385,8 @@ def test_int16_large_stable(n):
 
 
 
+#-------------------------------------------------------------------------------
+# Int64
 #-------------------------------------------------------------------------------
 
 def test_int64_small():
@@ -414,6 +435,8 @@ def test_int64_large_random(seed):
 
 
 #-------------------------------------------------------------------------------
+# Float32
+#-------------------------------------------------------------------------------
 
 def test_float32_small():
     d0 = dt.Frame([0, .4, .9, .2, .1, nan, -inf, -5, 3, 11, inf, 5.2],
@@ -452,6 +475,8 @@ def test_float32_random(numpy, n):
 
 
 
+#-------------------------------------------------------------------------------
+# Float64
 #-------------------------------------------------------------------------------
 
 def test_float64_small():

--- a/tests/ijby/test-sort.py
+++ b/tests/ijby/test-sort.py
@@ -31,6 +31,21 @@ from math import inf, nan
 from tests import list_equals, random_string, assert_equals, isview
 
 
+def check_newsort(fn):
+    @pytest.mark.parametrize("newsort", [True, False])
+    def foo(newsort):
+        with dt.options.sort.context(new=newsort):
+            fn()
+    return foo
+
+
+def check_newsort_n(fn):
+    @pytest.mark.parametrize("newsort", [True, False])
+    def foo(newsort, n):
+        with dt.options.sort.context(new=newsort):
+            fn(n)
+    return foo
+
 
 #-------------------------------------------------------------------------------
 # Simple sort
@@ -269,6 +284,7 @@ def test_int8_large_stable(n):
 # Bool8
 #-------------------------------------------------------------------------------
 
+@check_newsort
 def test_bool8_small():
     DT0 = dt.Frame([True, False, False, None, True, True, None])
     DT1 = dt.Frame([None, None, False, False, True, True, True])
@@ -278,6 +294,7 @@ def test_bool8_small():
     assert_equals(DTS, DT1)
 
 
+@check_newsort
 def test_bool8_small_stable():
     DT0 = dt.Frame(A=[True, False, False, None, True, True, None],
                    B=[1, 2, 3, 4, 5, 6, 7])
@@ -289,6 +306,7 @@ def test_bool8_small_stable():
     assert_equals(DTS, DT1)
 
 
+@check_newsort
 def test_bool8_small_view():
     DT0 = dt.Frame([True, False, False, True, None, True, True, None])
     DT1 = dt.Frame([None, None, False, False, True, True, True, True])
@@ -297,6 +315,7 @@ def test_bool8_small_view():
 
 
 @pytest.mark.parametrize("n", [100, 512, 1000, 5000, 123457])
+@check_newsort_n
 def test_bool8_large(n):
     nn = 2 * n
     DT0 = dt.Frame([True, False, True, None, None, False] * n)
@@ -310,6 +329,7 @@ def test_bool8_large(n):
 
 
 @pytest.mark.parametrize("n", [254, 255, 256, 257, 258, 1000, 11111])
+@check_newsort_n
 def test_bool8_large_stable(n):
     DT0 = dt.Frame(A=[True, False, None] * n, B=range(3 * n))
     DT1 = dt.Frame(B=list(range(2, 3 * n, 3)) +
@@ -319,6 +339,7 @@ def test_bool8_large_stable(n):
     assert_equals(DTS, DT1)
 
 
+@check_newsort
 def test_bool8_small_descending():
     DT0 = dt.Frame([True, False, False, None, True, True, None])
     DT1 = dt.Frame([None, None, True, True, True, False, False])
@@ -329,6 +350,7 @@ def test_bool8_small_descending():
 
 
 @pytest.mark.parametrize("n", [int(random.expovariate(0.00001)) + 100])
+@check_newsort_n
 def test_bool8_large_descending(n):
     DT0 = dt.Frame([True, False, True, None, None, False, True] * n)
     DT1 = dt.Frame([None] * (2*n) + [True] * (3*n) + [False] * (2*n))

--- a/tests/test-groups.py
+++ b/tests/test-groups.py
@@ -193,8 +193,25 @@ def test_group_boolean():
 def test_group_boolean2():
     DT = dt.Frame(A=[True, False, False] * 500 + [None, True])
     DTR = DT[:, count(), by(f.A)]
-    assert_equals(DTR, dt.Frame(A=[None, False, True], count=[1, 501, 1000],
+    assert_equals(DTR, dt.Frame(A=[None, False, True], count=[1, 1000, 501],
                                 stypes={"count": dt.int64}))
+
+
+def test_group_boolean3():
+    DT = dt.Frame(A=[True] * 1234)
+    DTR = DT[:, count(), by(f.A)]
+    assert_equals(DTR, dt.Frame(A=[True], count=[1234],
+                                stypes={"count": dt.int64}))
+
+
+def test_group_boolean4():
+    n = 43701
+    DT = dt.Frame(A=range(2*n), B=[False, True]*n)
+    DTR = DT[:, dt.sum(f.A), by(f.B)]
+    assert_equals(DTR, dt.Frame(B=[False, True],
+                                A=[sum(range(0, 2*n, 2)),
+                                   sum(range(1, 2*n, 2))],
+                                stypes={"A": dt.int64}))
 
 
 

--- a/tests/test-groups.py
+++ b/tests/test-groups.py
@@ -181,6 +181,24 @@ def test_groups_autoexpand():
 
 
 #-------------------------------------------------------------------------------
+# Test grouping for boolean columns
+#-------------------------------------------------------------------------------
+
+def test_group_boolean():
+    DT = dt.Frame(A=[True, None, False, False, True, True, False, True])
+    DTR = DT[:, count(), by(f.A)]
+    assert_equals(DTR, dt.Frame(A=[None, False, True], count=[1, 3, 4],
+                                stypes={"count": dt.int64}))
+
+def test_group_boolean2():
+    DT = dt.Frame(A=[True, False, False] * 500 + [None, True])
+    DTR = DT[:, count(), by(f.A)]
+    assert_equals(DTR, dt.Frame(A=[None, False, True], count=[1, 501, 1000],
+                                stypes={"count": dt.int64}))
+
+
+
+#-------------------------------------------------------------------------------
 # Test different reducers
 #-------------------------------------------------------------------------------
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -26,6 +26,7 @@ def test_options_all():
         "insert_method_threshold",
         "max_chunk_length",
         "max_radix_bits",
+        "new",
         "nthreads",
         "over_radix_bits",
         "thread_multiplier",


### PR DESCRIPTION
This is an update to new sorting functionality.
Currently works for boolean columns only; however supports both virtual and material boolean columns directly.

Added an option `dt.options.sort.new = False`, which controls whether the new algo is used or not (default). 

Preliminary tests show that for a 100M-rows boolean column the sorting time goes down from ≈0.4s to ≈0.3s, owing to the fact that the initial "data preparation" step is skipped.