### PR TITLE
Allow dividing a python list by an stype

### DIFF
--- a/docs/releases/v0.11.0.rst
+++ b/docs/releases/v0.11.0.rst
@@ -17,6 +17,13 @@
   -[enh] Method :meth:`Frame.colindex()` now accepts a column selector
     f-expression as an argument.
 
+  -[enh] When creating a Frame from a python list, it is now possible to
+    explicitly specify the stype of the resulting column by "dividing" the
+    list by the type you need::
+
+        dt.Frame(A=[1, 5, 10] / dt.int64,
+                 B=[0, 0, 0] / dt.float64)
+
   -[api] Method :meth:`.cbind()` now throws an :exc:`InvalidOperationError`
     instead of a ``ValueError`` if the argument frames have incompatible
     shapes.

--- a/src/core/frame/__init__.cc
+++ b/src/core/frame/__init__.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2019 H2O.ai
+// Copyright 2018-2020 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -607,6 +607,10 @@ class FrameInitializationManager {
         col = Column::from_pybuffer(colsrc);
       }
       else if (colsrc.is_list_or_tuple()) {
+        if (s == SType::VOID && colsrc.has_attr("type")) {
+          auto srctype = colsrc.get_attr("type");
+          s = srctype.to_stype();
+        }
         col = Column::from_pylist(colsrc.to_pylist(), int(s));
       }
       else if (colsrc.is_range()) {

--- a/src/datatable/types.py
+++ b/src/datatable/types.py
@@ -1,8 +1,25 @@
-#!/usr/bin/env python3
-# © H2O.ai 2018; -*- encoding: utf-8 -*-
-#   This Source Code Form is subject to the terms of the Mozilla Public
-#   License, v. 2.0. If a copy of the MPL was not distributed with this
-#   file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#-------------------------------------------------------------------------------
+# Copyright 2018-2020 H2O.ai
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
 #-------------------------------------------------------------------------------
 import ctypes
 import enum
@@ -12,6 +29,9 @@ from datatable.lib import core
 
 __all__ = ("stype", "ltype")
 
+
+class typed_list(list):
+    __slots__ = ["type"]
 
 
 @enum.unique
@@ -133,6 +153,14 @@ class stype(enum.Enum):
         The largest finite value that this stype can represent.
         """
         return _stype_extrema.get(self, (None, None))[1]
+
+
+    def __rtruediv__(self, lhs):
+        if isinstance(lhs, list):
+            res = typed_list(lhs)
+            res.type = self
+            return res
+        return NotImplemented
 
 
 

--- a/tests/frame/test-create.py
+++ b/tests/frame/test-create.py
@@ -334,6 +334,39 @@ def test_create_from_kwargs_error():
 
 
 #-------------------------------------------------------------------------------
+# Create from a typed list
+#-------------------------------------------------------------------------------
+
+def test_create_from_typed_list():
+    DT = dt.Frame([1, 2, 3] / dt.int16)
+    assert DT.stype == dt.int16
+    assert DT.to_list() == [[1, 2, 3]]
+    frame_integrity_check(DT)
+
+
+def test_create_from_typed_list2():
+    DT = dt.Frame([[1, 2, 3] / dt.int64,
+                   [1, 2, 3] / dt.float64])
+    assert DT.stypes == (dt.int64, dt.float64)
+    assert DT.to_list() == [[1, 2, 3]] * 2
+    frame_integrity_check(DT)
+
+
+def test_create_from_typed_list3():
+    DT = dt.Frame(A=[1, 2, 3] / dt.str32,
+                  B=[1, 2, 3] / dt.bool8,
+                  C=[1, 2, 3] / dt.float64)
+    assert_equals(DT, dt.Frame(A=["1", "2", "3"], B=[True, True, True],
+                               C=[1.0, 2.0, 3.0]))
+
+
+def test_create_from_typed_list4():
+    DT = dt.Frame({"A": [1, 2, 3] / dt.int8})
+    assert_equals(DT, dt.Frame([1, 2, 3], names=["A"], stypes=[dt.int8]))
+
+
+
+#-------------------------------------------------------------------------------
 # Create from a Frame (copy)
 #-------------------------------------------------------------------------------
 


### PR DESCRIPTION
When creating a Frame from a python list, it is now possible to explicitly specify the stype of the resulting column by "dividing" the list by the type you need:
```
        dt.Frame(A=[1, 5, 10] / dt.int64,
                 B=[0, 0, 0] / dt.float64)
```