### PR TITLE
Implement the BOM mark for .to_csv()

### DIFF
--- a/docs/releases/v0.11.0.rst
+++ b/docs/releases/v0.11.0.rst
@@ -24,6 +24,10 @@
         dt.Frame(A=[1, 5, 10] / dt.int64,
                  B=[0, 0, 0] / dt.float64)
 
+  -[enh] Added new argument ``bom=False`` to the :meth:`Frame.to_csv()` method.
+    If set to ``True``, it will add the Byte-Order Mark (BOM) to the output
+    CSV file. [#2379]
+
   -[api] Method :meth:`.cbind()` now throws an :exc:`InvalidOperationError`
     instead of a ``ValueError`` if the argument frames have incompatible
     shapes.

--- a/src/core/python/args.cc
+++ b/src/core/python/args.cc
@@ -48,7 +48,7 @@ PKArgs::PKArgs(
     arg_names(_names),
     n_varkwds(0)
 {
-  xassert(n_all_args == arg_names.size());
+  wassert(n_all_args == arg_names.size());
   if (has_varargs) xassert(n_pos_kwd_args == 0);
   bound_args.resize(n_all_args);
   for (size_t i = 0; i < n_all_args; ++i) {

--- a/src/core/utils/file.cc
+++ b/src/core/utils/file.cc
@@ -15,6 +15,7 @@
 #include "utils/misc.h"
 
 #if DT_OS_WINDOWS
+  #include <Windows.h>
   #include <io.h>               // close, write, _chsize
   #define FTRUNCATE _chsize
 #else

--- a/src/core/utils/file.cc
+++ b/src/core/utils/file.cc
@@ -18,7 +18,7 @@
   #include <io.h>               // close, write, _chsize
   #define FTRUNCATE _chsize
 #else
-  #include <unistd.h>           // close, write, ftruncate
+  #include <unistd.h>           // access, close, write, ftruncate
   #define FTRUNCATE ftruncate
 #endif
 
@@ -155,6 +155,7 @@ void File::load_stats() const {
   }
 }
 
+
 void File::remove(const std::string& name, bool except) {
   int ret = ::remove(name.c_str());
   if (ret == -1) {
@@ -165,4 +166,21 @@ void File::remove(const std::string& name, bool except) {
              name.c_str(), errno, strerror(errno));
     }
   }
+}
+
+
+bool File::exists(const std::string& name) noexcept {
+  int ret = ::access(name.c_str(), F_OK);
+  return (ret == 0);
+}
+
+
+/**
+  * Return true if the file exists and is non-empty, and false
+  * otherwise.
+  */
+bool File::nonempty(const std::string& name) noexcept {
+  struct stat statbuf;
+  int ret = stat(name.c_str(), &statbuf);
+  return (ret == 0) && S_ISREG(statbuf.st_mode) && (statbuf.st_size > 0);
 }

--- a/src/core/utils/file.cc
+++ b/src/core/utils/file.cc
@@ -199,9 +199,9 @@ bool File::nonempty(const std::string& name) noexcept {
         nullptr                 // hTemplateFile
     );
     if (hFile == INVALID_HANDLE_VALUE) return false;
-    size_t size;
+    LARGE_INTEGER size;
     bool ret = GetFileSizeEx(hFile, &size);
-    return ret && (size != 0);
+    return ret && (size.QuadPart != 0);
 
   #else
     struct stat statbuf;

--- a/src/core/utils/file.cc
+++ b/src/core/utils/file.cc
@@ -172,7 +172,7 @@ void File::remove(const std::string& name, bool except) {
 
 bool File::exists(const std::string& name) noexcept {
   #if DT_OS_WINDOWS
-    DWORD attrs = GetFileAttributesW(name.c_str());
+    DWORD attrs = GetFileAttributes(name.c_str());
     return (attrs != INVALID_FILE_ATTRIBUTES) &&
             !(attrs & FILE_ATTRIBUTE_DIRECTORY);
 

--- a/src/core/utils/file.h
+++ b/src/core/utils/file.h
@@ -44,6 +44,9 @@ public:
 
   static void remove(const std::string& name, bool except = false);
 
+  static bool exists(const std::string& name) noexcept;
+  static bool nonempty(const std::string& name) noexcept;
+
 private:
   void load_stats() const;
 };

--- a/src/core/write/csv_writer.cc
+++ b/src/core/write/csv_writer.cc
@@ -85,7 +85,13 @@ void csv_writer::write_preamble() {
 
   Column names_as_col = Column(new Strvec_ColumnImpl(column_names));
   auto writer = value_writer::create(names_as_col, options);
-  writing_context ctx { 3*dt->ncols(), 1, options.compress_zlib };
+  writing_context ctx { 3*dt->ncols() + 3, 1, options.compress_zlib };
+
+  if (options.bom) {
+    *ctx.ch++ = '\xEF';
+    *ctx.ch++ = '\xBB';
+    *ctx.ch++ = '\xBF';
+  }
 
   if (options.quoting_mode == Quoting::ALL) {
     for (size_t i = 0; i < dt->ncols(); ++i) {

--- a/src/core/write/output_options.h
+++ b/src/core/write/output_options.h
@@ -60,8 +60,6 @@ struct output_options {
 };
 
 
-static_assert(sizeof(output_options) == 16,
-              "Unexpected size of output_options");
 
 
 }}  // namespace dt::write

--- a/src/core/write/output_options.h
+++ b/src/core/write/output_options.h
@@ -43,7 +43,9 @@ struct output_options {
   bool strings_never_quote;
   bool strings_always_quote;
   bool strings_escape_quotes;
+  bool bom;
   Quoting quoting_mode;
+  size_t : 56;
 
   output_options()
     : compress_zlib(false),
@@ -53,11 +55,12 @@ struct output_options {
       strings_never_quote(false),
       strings_always_quote(false),
       strings_escape_quotes(false),
+      bom(false),
       quoting_mode(Quoting::MINIMAL) {}
 };
 
 
-static_assert(sizeof(output_options) == 8,
+static_assert(sizeof(output_options) == 16,
               "Unexpected size of output_options");
 
 

--- a/src/core/write/write_manager.cc
+++ b/src/core/write/write_manager.cc
@@ -67,6 +67,10 @@ void write_manager::set_usehex(bool f) {
   options.integers_as_hex = f;
 }
 
+void write_manager::set_bom(bool b) {
+  options.bom = b;
+}
+
 void write_manager::set_quoting(int q) {
   options.quoting_mode = static_cast<Quoting>(q);
 }

--- a/src/core/write/write_manager.h
+++ b/src/core/write/write_manager.h
@@ -103,6 +103,7 @@ class write_manager {
     void set_strategy(WritableBuffer::Strategy);
     void set_logger(py::oobj logger);
     void set_usehex(bool);
+    void set_bom(bool);
     void set_quoting(int);
     void set_compression(bool);
 

--- a/tests/test_tocsv.py
+++ b/tests/test_tocsv.py
@@ -675,3 +675,52 @@ def test_append_large(tempfile):
     assert readfile(tempfile) == "...\n" + (word + "\n") * (2*n)
     DT.to_csv(tempfile, append=True, _strategy="mmap")
     assert readfile(tempfile) == "...\n" + (word + "\n") * (3*n)
+
+
+
+#-------------------------------------------------------------------------------
+# Parameter bom=
+#-------------------------------------------------------------------------------
+
+def test_bom1():
+    DT = dt.Frame(A=[1,2,3])
+    assert DT.to_csv(bom=False) == "A\n1\n2\n3\n"
+    assert DT.to_csv(bom=True) == "\uFEFF" + "A\n1\n2\n3\n"
+
+
+def test_bom2(tempfile):
+    DT = dt.Frame(A=[1,2,3])
+    DT.to_csv(tempfile, bom=True)
+    with open(tempfile, 'rb') as inp:
+        assert inp.read() == b"\xEF\xBB\xBFA\n1\n2\n3\n"
+
+
+def test_bom3(tempfile):
+    # Appending to a file that doesn't exist: write BOM if requested
+    os.remove(tempfile)
+    assert not os.path.exists(tempfile)
+    DT = dt.Frame(A=[1,2,3])
+    DT.to_csv(tempfile, append=True, bom=True)
+    with open(tempfile, 'rb') as inp:
+        assert inp.read() == b"\xEF\xBB\xBFA\n1\n2\n3\n"
+
+
+
+def test_bom4(tempfile):
+    # When appending to an empty file, add the BOM mark if requested
+    assert os.path.exists(tempfile)
+    DT = dt.Frame(B=[5,6,7])
+    DT.to_csv(tempfile, append=True, bom=True)
+    with open(tempfile, 'rb') as inp:
+        assert inp.read() == b"\xEF\xBB\xBFB\n5\n6\n7\n"
+
+
+def test_bom5(tempfile):
+    # When appending to a non-empty file, the BOM mark is not written
+    assert os.path.exists(tempfile)
+    with open(tempfile, "w") as out:
+        out.write("# test file\n")
+    DT = dt.Frame(B=[5,6,7])
+    DT.to_csv(tempfile, append=True, bom=True)
+    with open(tempfile, 'rb') as inp:
+        assert inp.read() == b"# test file\n5\n6\n7\n"


### PR DESCRIPTION
Added argument `bom=False` to the `Frame.to_csv()` method. This argument controls whether or not to write BOM (Byte-Order Mark) into the output csv file.

Closes #2379