### PR TITLE
Fix crash in .to_csv(quoting=all)

### DIFF
--- a/docs/releases/v0.11.0.rst
+++ b/docs/releases/v0.11.0.rst
@@ -55,6 +55,9 @@
     buffers have size over 2GB now properly creates a ``str64`` column as a
     result. [#2367]
 
+  -[bug] Fixed crash when writing to CSV a frame with many boolean columns
+    when the option ``quoting="all"`` is used. [#2382]
+
 
   Fread
   -----

--- a/src/core/write/csv_writer.cc
+++ b/src/core/write/csv_writer.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2019 H2O.ai
+// Copyright 2018-2020 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -67,6 +67,10 @@ void csv_writer::estimate_output_size() {
     total_columns_size += column_names[i].size() + 1;
   }
   rowsize_fixed += 1 * ncols;  // separators
+  if (options.quoting_mode == Quoting::ALL) {
+    rowsize_fixed += 2 * ncols;
+    total_columns_size += 2 * ncols;
+  }
 
   fixed_size_per_row = rowsize_fixed;
   estimated_output_size = (rowsize_fixed + rowsize_dynamic) * nrows

--- a/tests/test_tocsv.py
+++ b/tests/test_tocsv.py
@@ -415,6 +415,13 @@ def test_issue2253():
     assert X.to_csv() == "A,B\n" + "10,0\n" + "20,1\n"
 
 
+def test_issue2382():
+    DT = dt.Frame([[True] * 20] * 200)
+    out = DT.to_csv(quoting='all')
+    assert out == (','.join('"C%d"' % i for i in range(200)) + "\n" +
+                   '\n'.join(','.join(['"1"'] * 200) for j in range(20)) + "\n")
+
+
 
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
The error was due to not properly accounting for space needed to write the quote  marks.

Closes #2382 