### PR TITLE
Fix rbind crashing on Python strings

### DIFF
--- a/src/core/frame/rbind.cc
+++ b/src/core/frame/rbind.cc
@@ -116,13 +116,13 @@ void Frame::rbind(const PKArgs& args) {
   // Any frames with 0 rows will be disregarded.
   {
     size_t j = 0;
-    std::function<void(py::robj)> process_arg = [&](py::robj arg) {
+    std::function<void(const py::robj)> process_arg = [&](const py::robj arg) {
       if (arg.is_frame()) {
         DataTable* df = arg.to_datatable();
         if (df->nrows()) dts.push_back(df);
         ++j;
       }
-      else if (arg.is_iterable()) {
+      else if (arg.is_iterable() && !arg.is_string()) {
         for (auto item : arg.to_oiter()) {
           process_arg(item);
         }

--- a/tests/munging/test_rbind.py
+++ b/tests/munging/test_rbind.py
@@ -101,7 +101,7 @@ def test_rbind_columns_mismatch():
 def test_rbind_error1():
     dt0 = dt.Frame(range(5))
     msg = r"Frame.rbind\(\) expects a list or sequence of Frames as an " \
-          "argument; instead item 0 was a <class 'int'>"
+           "argument; instead item 0 was a <class 'int'>"
     with pytest.raises(TypeError, match = msg):
         dt0.rbind(123)
 
@@ -109,7 +109,7 @@ def test_rbind_error1():
 def test_rbind_error2():
     dt0 = dt.Frame(range(5))
     msg = r"Frame.rbind\(\) expects a list or sequence of Frames as an " \
-          "argument; instead item 2 was a <class 'int'>"
+           "argument; instead item 2 was a <class 'int'>"
     with pytest.raises(TypeError, match = msg):
         dt0.rbind(dt.Frame(range(1)), [dt.Frame(range(4)), 123])
 
@@ -117,7 +117,7 @@ def test_rbind_error2():
 def test_rbind_error3():
     dt0 = dt.Frame(range(5))
     msg = r"Frame.rbind\(\) expects a list or sequence of Frames as an " \
-          "argument; instead item 0 was a <class 'int'>"
+           "argument; instead item 0 was a <class 'int'>"
     with pytest.raises(TypeError, match = msg):
         dt0.rbind([123])
 
@@ -125,7 +125,7 @@ def test_rbind_error3():
 def test_rbind_error4():
     dt0 = dt.Frame(range(5))
     msg = r"Frame.rbind\(\) expects a list or sequence of Frames as an " \
-          "argument; instead item 0 was a <class 'str'>"
+           "argument; instead item 0 was a <class 'str'>"
     with pytest.raises(TypeError, match = msg):
         dt0.rbind("iddqd")
 
@@ -133,7 +133,7 @@ def test_rbind_error4():
 def test_rbind_error5():
     dt0 = dt.Frame(range(5))
     msg = r"Frame.rbind\(\) expects a list or sequence of Frames as an " \
-          "argument; instead item 0 was a <class 'str'>"
+           "argument; instead item 0 was a <class 'str'>"
     with pytest.raises(TypeError, match = msg):
         dt0.rbind(["iddqd", "idkfa", "idclip"])
 

--- a/tests/munging/test_rbind.py
+++ b/tests/munging/test_rbind.py
@@ -100,19 +100,42 @@ def test_rbind_columns_mismatch():
 
 def test_rbind_error1():
     dt0 = dt.Frame(range(5))
-    with pytest.raises(TypeError) as e:
+    msg = r"Frame.rbind\(\) expects a list or sequence of Frames as an " \
+          "argument; instead item 0 was a <class 'int'>"
+    with pytest.raises(TypeError, match = msg):
         dt0.rbind(123)
-    assert ("Frame.rbind() expects a list or sequence of Frames as an "
-            "argument; instead item 0 was a <class 'int'>" == str(e.value))
 
 
 def test_rbind_error2():
     dt0 = dt.Frame(range(5))
-    with pytest.raises(TypeError) as e:
+    msg = r"Frame.rbind\(\) expects a list or sequence of Frames as an " \
+          "argument; instead item 2 was a <class 'int'>"
+    with pytest.raises(TypeError, match = msg):
         dt0.rbind(dt.Frame(range(1)), [dt.Frame(range(4)), 123])
-    assert ("Frame.rbind() expects a list or sequence of Frames as an "
-            "argument; instead item 2 was a <class 'int'>" == str(e.value))
 
+
+def test_rbind_error3():
+    dt0 = dt.Frame(range(5))
+    msg = r"Frame.rbind\(\) expects a list or sequence of Frames as an " \
+          "argument; instead item 0 was a <class 'int'>"
+    with pytest.raises(TypeError, match = msg):
+        dt0.rbind([123])
+
+
+def test_rbind_error4():
+    dt0 = dt.Frame(range(5))
+    msg = r"Frame.rbind\(\) expects a list or sequence of Frames as an " \
+          "argument; instead item 0 was a <class 'str'>"
+    with pytest.raises(TypeError, match = msg):
+        dt0.rbind("iddqd")
+
+
+def test_rbind_error5():
+    dt0 = dt.Frame(range(5))
+    msg = r"Frame.rbind\(\) expects a list or sequence of Frames as an " \
+          "argument; instead item 0 was a <class 'str'>"
+    with pytest.raises(TypeError, match = msg):
+        dt0.rbind(["iddqd", "idkfa", "idclip"])
 
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
Strings in Python are iterable and each string character is a string again, hence, iterable. This caused an infinite recursion when processing arguments in `rbind()`. In this PR we fix this issue and add some relevant tests. 

Closes #2384 