### PR TITLE
Fix possible infinite recursion in dt.rbind()/dt.union()

### DIFF
--- a/docs/releases/v0.11.0.rst
+++ b/docs/releases/v0.11.0.rst
@@ -92,6 +92,10 @@
 
   -[fix] Fix rare crash in the interrupt signal handler. [#2282]
 
+  -[fix] Fixed possible crash in :func:`rbind()` and :func:`union()` when
+    they were called with a string argument, or with an object that caused
+    infinite recursion. [#2386]
+
   -[api] All exceptions thrown by datatable are now declared in the
     ``datatable.exceptions`` module. These exceptions are now organized to
     derive from the common base class ``DtException``.

--- a/src/core/python/iter.cc
+++ b/src/core/python/iter.cc
@@ -31,12 +31,12 @@ oiter::oiter(PyObject* src) : oobj(PyObject_GetIter(src)) {}
 
 
 
-iter_iterator oiter::begin() const noexcept {
+iter_iterator oiter::begin() const {
   return iter_iterator(v);
 }
 
 
-iter_iterator oiter::end() const noexcept {
+iter_iterator oiter::end() const {
   return iter_iterator(nullptr);
 }
 
@@ -104,6 +104,7 @@ void iter_iterator::advance() {
   if (res) {
     next_value = py::oobj::from_new_reference(res);
   } else {
+    if (PyErr_Occurred()) throw PyError();
     iter = py::oobj(nullptr);
     next_value = py::oobj(nullptr);
   }

--- a/src/core/python/iter.h
+++ b/src/core/python/iter.h
@@ -41,8 +41,8 @@ class oiter : public oobj {
     // Returns size of the iterator, or -1 if unknown
     size_t size() const noexcept;
 
-    iter_iterator begin() const noexcept;
-    iter_iterator end() const noexcept;
+    iter_iterator begin() const;
+    iter_iterator end() const;
 
   private:
     // Wrap an existing PyObject* into an `oiter`.

--- a/tests/munging/test_rbind.py
+++ b/tests/munging/test_rbind.py
@@ -138,6 +138,30 @@ def test_rbind_error5():
         dt0.rbind(["iddqd", "idkfa", "idclip"])
 
 
+def test_rbind_infinite():
+    def foo():
+        yield dt.Frame()
+        yield from foo()
+
+    with pytest.raises(RecursionError):
+        dt.rbind(foo())
+
+
+def test_rbind_infinite2():
+    class A:
+        def __next__(self):
+            return self
+
+        def __iter__(self):
+            return self
+
+    msg = r"Frame.rbind\(\) expects a list or sequence of Frames as an " \
+          r"argument; instead item 0 was a <class '.*\.A'>"
+    with pytest.raises(TypeError, match=msg):
+        dt.rbind(A())
+
+
+
 #-------------------------------------------------------------------------------
 # Simple test cases
 #-------------------------------------------------------------------------------

--- a/tests/test_sets.py
+++ b/tests/test_sets.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #-------------------------------------------------------------------------------
-# Copyright 2018 H2O.ai
+# Copyright 2018-2020 H2O.ai
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -98,6 +98,27 @@ def test_setfns_between_empty_frames2(fn):
     DT = dt.Frame(A=[])
     res = fn(DT, DT)
     assert_equals(res, DT)
+
+
+def test_union_badargs():
+    msg = (r"union\(\) expects a list or sequence of Frames, but got an "
+           r"argument of type <class 'str'>")
+    with pytest.raises(TypeError, match=msg):
+        dt.union('a')
+
+
+def test_union_infinite():
+    class A:
+        def __next__(self):
+            return self
+
+        def __iter__(self):
+            return self
+
+    msg = r"union\(\) expects a list or sequence of Frames, but " \
+          r"got an argument of type <class '.*\.A'>"
+    with pytest.raises(TypeError, match=msg):
+        dt.union(A())
 
 
 


### PR DESCRIPTION
The issue of `dt.rbind("string")` was fixed in #2385; but there are other kinds of arguments that could still cause infinite recursion. This PR addresses that.

Closes #2386