### PR TITLE
Reduce too many levels of indirection in fread

### DIFF
--- a/src/core/csv/py_csv.cc
+++ b/src/core/csv/py_csv.cc
@@ -21,9 +21,9 @@ namespace py {
 //------------------------------------------------------------------------------
 
 static PKArgs args_read_csv(
-  1, 0, 0, false, false, {"reader"}, "gread",
+  2, 0, 0, false, false, {"reader", "sources"}, "gread",
 
-R"(gread(reader)
+R"(gread(reader, sources)
 --
 
 Generic read function, similar to `fread` but supports other
@@ -33,7 +33,8 @@ file types, not just csv.
 
 static oobj read_csv(const PKArgs& args) {
   robj pyreader = args[0];
-  GenericReader rdr(pyreader);
+  robj sources  = args[1];
+  GenericReader rdr(pyreader, sources);
   return rdr.read_all();
 }
 

--- a/src/core/csv/py_csv.cc
+++ b/src/core/csv/py_csv.cc
@@ -17,31 +17,60 @@ namespace py {
 
 
 //------------------------------------------------------------------------------
-// read_csv()
+// gread()
 //------------------------------------------------------------------------------
 
-static PKArgs args_read_csv(
-  2, 0, 0, false, false, {"reader", "sources"}, "gread",
+static PKArgs args_gread(
+  1, 0, 0, false, false, {"reader"}, "gread",
 
-R"(gread(reader, sources)
+R"(gread(reader)
 --
 
 Generic read function, similar to `fread` but supports other
 file types, not just csv.
 )");
 
-
-static oobj read_csv(const PKArgs& args) {
+static oobj gread(const PKArgs& args) {
   robj pyreader = args[0];
-  robj sources  = args[1];
-  GenericReader rdr(pyreader, sources);
-  return rdr.read_all();
+  oobj source = pyreader.get_attr("_src");
+  oobj logger = pyreader.get_attr("_logger");
+  oobj tempfiles = pyreader.get_attr("_tempfiles");
+
+  if (!logger.is_none()) {
+    logger.invoke("debug", ostring("[1] Prepare for reading"));
+  }
+  auto resolve_source = oobj::import("datatable.fread", "_resolve_source");
+  auto res_tuple = resolve_source.call({source, tempfiles, logger}).to_otuple();
+  auto sources = res_tuple[0];
+  auto result = res_tuple[1];
+  if (result.is_none()) {
+    GenericReader rdr(pyreader, sources);
+    return rdr.read_all();
+  }
+  if (result.is_list_or_tuple()) {
+    py::olist result_list = result.to_pylist();
+    py::odict result_dict;
+    for (size_t i = 0; i < result_list.size(); ++i) {
+      auto entry = result_list[i].to_otuple();
+      auto isources = entry[0];
+      auto iresult = entry[1];
+      auto isrc = isources.to_otuple()[0];
+      if (iresult.is_none()) {
+        GenericReader rdr(pyreader, isources);
+        result_dict.set(isrc, rdr.read_all());
+      } else {
+        result_dict.set(isrc, iresult);
+      }
+    }
+    return oobj(std::move(result_dict));
+  }
+  return result;
 }
 
 
 
 void DatatableModule::init_methods_csv() {
-  ADD_FN(&read_csv, args_read_csv);
+  ADD_FN(&gread, args_gread);
 }
 
 } // namespace py

--- a/src/core/csv/py_csv.cc
+++ b/src/core/csv/py_csv.cc
@@ -21,12 +21,12 @@ namespace py {
 //------------------------------------------------------------------------------
 
 static PKArgs args_gread(
-  1, 0, 21, false, false,
+  1, 0, 22, false, false,
   {"anysource", "file", "text", "cmd", "url",
    "columns", "sep", "dec", "max_nrows", "header", "na_strings",
    "verbose", "fill", "encoding", "skip_to_string", "skip_to_line",
    "skip_blank_lines", "strip_whitespace", "quotechar", "save_to",
-   "nthreads", "logger"
+   "tempdir", "nthreads", "logger"
    },
   "gread",
 
@@ -38,29 +38,31 @@ file types, not just csv.
 )");
 
 static oobj gread(const PKArgs& args) {
-  const Arg& arg_anysource  = args[0];
-  const Arg& arg_file       = args[1];
-  const Arg& arg_text       = args[2];
-  const Arg& arg_cmd        = args[3];
-  const Arg& arg_url        = args[4];
+  size_t k = 0;
+  const Arg& arg_anysource  = args[k++];
+  const Arg& arg_file       = args[k++];
+  const Arg& arg_text       = args[k++];
+  const Arg& arg_cmd        = args[k++];
+  const Arg& arg_url        = args[k++];
 
-  const Arg& arg_columns    = args[5];
-  const Arg& arg_sep        = args[6];
-  const Arg& arg_dec        = args[7];
-  const Arg& arg_maxnrows   = args[8];
-  const Arg& arg_header     = args[9];
-  const Arg& arg_nastrings  = args[10];
-  const Arg& arg_verbose    = args[11];
-  const Arg& arg_fill       = args[12];
-  const Arg& arg_encoding   = args[13];
-  const Arg& arg_skiptostr  = args[14];
-  const Arg& arg_skiptoline = args[15];
-  const Arg& arg_skipblanks = args[16];
-  const Arg& arg_stripwhite = args[17];
-  const Arg& arg_quotechar  = args[18];
-  const Arg& arg_saveto     = args[19];
-  const Arg& arg_nthreads   = args[20];
-  const Arg& arg_logger     = args[21];
+  const Arg& arg_columns    = args[k++];
+  const Arg& arg_sep        = args[k++];
+  const Arg& arg_dec        = args[k++];
+  const Arg& arg_maxnrows   = args[k++];
+  const Arg& arg_header     = args[k++];
+  const Arg& arg_nastrings  = args[k++];
+  const Arg& arg_verbose    = args[k++];
+  const Arg& arg_fill       = args[k++];
+  const Arg& arg_encoding   = args[k++];
+  const Arg& arg_skiptostr  = args[k++];
+  const Arg& arg_skiptoline = args[k++];
+  const Arg& arg_skipblanks = args[k++];
+  const Arg& arg_stripwhite = args[k++];
+  const Arg& arg_quotechar  = args[k++];
+  const Arg& arg_saveto     = args[k++];
+  const Arg& arg_tempdir    = args[k++];
+  const Arg& arg_nthreads   = args[k++];
+  const Arg& arg_logger     = args[k++];
 
   GenericReader rdr;
   rdr.init_logger(     arg_logger, arg_verbose);
@@ -77,6 +79,8 @@ static oobj gread(const PKArgs& args) {
   rdr.init_stripwhite( arg_stripwhite);
   rdr.init_skipblanks( arg_skipblanks);
   rdr.init_columns(    arg_columns);
+  (void) arg_saveto;
+  (void) arg_encoding;
 
   oobj source = otuple({arg_anysource.to_oobj(),
                         arg_file.to_oobj(),
@@ -85,8 +89,9 @@ static oobj gread(const PKArgs& args) {
                         arg_url.to_oobj()});
   oobj logger = rdr.get_logger();
   oobj clsTempFiles = oobj::import("datatable.fread", "TempFiles");
-  oobj tempfiles = logger? clsTempFiles.call({py::None(), logger})
-                         : clsTempFiles.call();
+  oobj tempdir = arg_tempdir.to_oobj();
+  oobj tempfiles = logger? clsTempFiles.call({tempdir, logger})
+                         : clsTempFiles.call(tempdir);
 
   if (logger) {
     logger.invoke("debug", ostring("[1] Prepare for reading"));

--- a/src/core/csv/py_csv.cc
+++ b/src/core/csv/py_csv.cc
@@ -21,8 +21,8 @@ namespace py {
 //------------------------------------------------------------------------------
 
 static PKArgs args_gread(
-  2, 0, 21, false, false,
-  {"reader", "anysource", "file", "text", "cmd", "url",
+  1, 0, 21, false, false,
+  {"anysource", "file", "text", "cmd", "url",
    "columns", "sep", "dec", "max_nrows", "header", "na_strings",
    "verbose", "fill", "encoding", "skip_to_string", "skip_to_line",
    "skip_blank_lines", "strip_whitespace", "quotechar", "save_to",
@@ -38,36 +38,32 @@ file types, not just csv.
 )");
 
 static oobj gread(const PKArgs& args) {
-  robj pyreader = args[0];
+  const Arg& arg_anysource  = args[0];
+  const Arg& arg_file       = args[1];
+  const Arg& arg_text       = args[2];
+  const Arg& arg_cmd        = args[3];
+  const Arg& arg_url        = args[4];
 
-  const Arg& arg_anysource  = args[1];
-  const Arg& arg_file       = args[2];
-  const Arg& arg_text       = args[3];
-  const Arg& arg_cmd        = args[4];
-  const Arg& arg_url        = args[5];
-
-  const Arg& arg_columns    = args[6];
-  const Arg& arg_sep        = args[7];
-  const Arg& arg_dec        = args[8];
-  const Arg& arg_maxnrows   = args[9];
-  const Arg& arg_header     = args[10];
-  const Arg& arg_nastrings  = args[11];
-  const Arg& arg_verbose    = args[12];
-  const Arg& arg_fill       = args[13];
-  const Arg& arg_encoding   = args[14];
-  const Arg& arg_skiptostr  = args[15];
-  const Arg& arg_skiptoline = args[16];
-
-  const Arg& arg_skipblanks = args[17];
-  const Arg& arg_stripwhite = args[18];
-  const Arg& arg_quotechar  = args[19];
-  const Arg& arg_saveto     = args[20];
-  const Arg& arg_nthreads   = args[21];
-  const Arg& arg_logger     = args[22];
+  const Arg& arg_columns    = args[5];
+  const Arg& arg_sep        = args[6];
+  const Arg& arg_dec        = args[7];
+  const Arg& arg_maxnrows   = args[8];
+  const Arg& arg_header     = args[9];
+  const Arg& arg_nastrings  = args[10];
+  const Arg& arg_verbose    = args[11];
+  const Arg& arg_fill       = args[12];
+  const Arg& arg_encoding   = args[13];
+  const Arg& arg_skiptostr  = args[14];
+  const Arg& arg_skiptoline = args[15];
+  const Arg& arg_skipblanks = args[16];
+  const Arg& arg_stripwhite = args[17];
+  const Arg& arg_quotechar  = args[18];
+  const Arg& arg_saveto     = args[19];
+  const Arg& arg_nthreads   = args[20];
+  const Arg& arg_logger     = args[21];
 
   GenericReader rdr;
-  rdr.init_verbose(    arg_verbose);
-  rdr.init_logger(     arg_logger);
+  rdr.init_logger(     arg_logger, arg_verbose);
   rdr.init_nthreads(   arg_nthreads);
   rdr.init_fill(       arg_fill);
   rdr.init_maxnrows(   arg_maxnrows);
@@ -87,14 +83,16 @@ static oobj gread(const PKArgs& args) {
                         arg_text.to_oobj(),
                         arg_cmd.to_oobj(),
                         arg_url.to_oobj()});
-  oobj logger = pyreader.get_attr("_logger");
-  oobj tempfiles = pyreader.get_attr("_tempfiles");
+  oobj logger = rdr.get_logger();
+  oobj clsTempFiles = oobj::import("datatable.fread", "TempFiles");
+  oobj tempfiles = logger? clsTempFiles.call({py::None(), logger})
+                         : clsTempFiles.call();
 
-  if (!logger.is_none()) {
+  if (logger) {
     logger.invoke("debug", ostring("[1] Prepare for reading"));
   }
   auto resolve_source = oobj::import("datatable.fread", "_resolve_source");
-  auto res_tuple = resolve_source.call({source, tempfiles, logger}).to_otuple();
+  auto res_tuple = resolve_source.call({source, tempfiles}).to_otuple();
   auto sources = res_tuple[0];
   auto result = res_tuple[1];
   if (result.is_none()) {

--- a/src/core/csv/reader.cc
+++ b/src/core/csv/reader.cc
@@ -88,7 +88,7 @@ GenericReader::GenericReader(const py::robj& pyrdr)
   text_arg = pyrdr.get_attr("_text");
   fileno   = pyrdr.get_attr("_fileno").to_int32();
 
-  init_verbose(   py::Arg(pyrdr.get_attr("_verbose"), "Parameter `verbose`"));
+  init_verbose(   py::Arg(pyrdr.get_attr("verbose"), "Parameter `verbose`"));
   init_logger(    py::Arg(pyrdr.get_attr("_logger"), "Parameter `logger`"));
   init_nthreads(  py::Arg(pyrdr.get_attr("_nthreads"), "Parameter `nthreads`"));
   init_fill(      py::Arg(pyrdr.get_attr("_fill"), "Parameter `fill`"));

--- a/src/core/csv/reader.cc
+++ b/src/core/csv/reader.cc
@@ -83,8 +83,8 @@ GenericReader::GenericReader(py::robj pyrdr)
   line = 0;
   cr_is_newline = 0;
 
-  init_verbose(   py::Arg(pyrdr.get_attr("_verbose"), "Parameter `verbose`"));
-  init_logger(    py::Arg(pyrdr.get_attr("_logger"), "Parameter `logger`"));
+  init_logger(    py::Arg(pyrdr.get_attr("_logger"), "Parameter `logger`"),
+                  py::Arg(pyrdr.get_attr("_verbose"), "Parameter `verbose`"));
   init_nthreads(  py::Arg(pyrdr.get_attr("_nthreads"), "Parameter `nthreads`"));
   init_fill(      py::Arg(pyrdr.get_attr("_fill"), "Parameter `fill`"));
   init_maxnrows(  py::Arg(pyrdr.get_attr("_maxnrows"), "Parameter `max_nrows`"));
@@ -131,10 +131,6 @@ GenericReader::GenericReader(const GenericReader& g)
 
 GenericReader::~GenericReader() {}
 
-
-void GenericReader::init_verbose(const py::Arg& arg) {
-  verbose = arg.to<bool>(false);
-}
 
 void GenericReader::init_nthreads(const py::Arg& arg) {
   int32_t DEFAULT = -(1 << 30);
@@ -331,13 +327,16 @@ void GenericReader::init_columns(const py::Arg& arg) {
   }
 }
 
-void GenericReader::init_logger(const py::Arg& arg) {
-  if (arg.is_none_or_undefined()) {
+void GenericReader::init_logger(
+        const py::Arg& arg_logger, const py::Arg& arg_verbose)
+{
+  verbose = arg_verbose.to<bool>(false);
+  if (arg_logger.is_none_or_undefined()) {
     if (verbose) {
       logger = py::oobj::import("datatable.fread", "_DefaultLogger").call();
     }
   } else {
-    logger = arg.to_oobj();
+    logger = arg_logger.to_oobj();
     verbose = true;
   }
 }
@@ -385,6 +384,11 @@ py::oobj GenericReader::read_all(py::robj pysources)
 
 
 //------------------------------------------------------------------------------
+
+py::oobj GenericReader::get_logger() const {
+  return logger;
+}
+
 
 size_t GenericReader::datasize() const {
   return static_cast<size_t>(eof - sof);

--- a/src/core/csv/reader.cc
+++ b/src/core/csv/reader.cc
@@ -76,19 +76,21 @@ GenericReader::GenericReader()
 }
 
 
-GenericReader::GenericReader(const py::robj& pyrdr)
+GenericReader::GenericReader(py::robj pyrdr, py::robj pysources)
 {
   job = std::make_shared<dt::progress::work>(WORK_PREPARE + WORK_READ);
   sof = nullptr;
   eof = nullptr;
   line = 0;
   cr_is_newline = 0;
-  src_arg  = pyrdr.get_attr("_src");
-  file_arg = pyrdr.get_attr("_file");
-  text_arg = pyrdr.get_attr("_text");
-  fileno   = pyrdr.get_attr("_fileno").to_int32();
 
-  init_verbose(   py::Arg(pyrdr.get_attr("verbose"), "Parameter `verbose`"));
+  auto pysrcs = pysources.to_otuple();
+  src_arg  = pysrcs[0];
+  file_arg = pysrcs[1];
+  fileno   = pysrcs[2].to_int32();
+  text_arg = pysrcs[3];
+
+  init_verbose(   py::Arg(pyrdr.get_attr("_verbose"), "Parameter `verbose`"));
   init_logger(    py::Arg(pyrdr.get_attr("_logger"), "Parameter `logger`"));
   init_nthreads(  py::Arg(pyrdr.get_attr("_nthreads"), "Parameter `nthreads`"));
   init_fill(      py::Arg(pyrdr.get_attr("_fill"), "Parameter `fill`"));

--- a/src/core/csv/reader.cc
+++ b/src/core/csv/reader.cc
@@ -1,9 +1,23 @@
 //------------------------------------------------------------------------------
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright 2018-2020 H2O.ai
 //
-// © H2O.ai 2018-2019
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #include <stdlib.h>             // strtod
 #include <cerrno>               // errno
@@ -317,7 +331,7 @@ void GenericReader::init_stripwhite(const py::Arg& arg) {
 }
 
 void GenericReader::init_skipblanks(const py::Arg& arg) {
-  skip_blank_lines = arg.to<bool>(true);
+  skip_blank_lines = arg.to<bool>(false);
   trace("skip_blank_lines = %s", skip_blank_lines? "True" : "False");
 }
 
@@ -333,7 +347,7 @@ void GenericReader::init_logger(
   verbose = arg_verbose.to<bool>(false);
   if (arg_logger.is_none_or_undefined()) {
     if (verbose) {
-      logger = py::oobj::import("datatable.fread", "_DefaultLogger").call();
+      logger = py::oobj::import("datatable.utils.fread", "_DefaultLogger").call();
     }
   } else {
     logger = arg_logger.to_oobj();
@@ -881,7 +895,7 @@ void GenericReader::report_columns_to_python() {
     }
 
     py::otuple newColumns =
-      py::oobj::import("datatable.fread", "_override_columns")
+      py::oobj::import("datatable.utils.fread", "_override_columns")
         .call({columns_arg, colDescriptorList}).to_otuple();
 
     column_names = newColumns[0].to_pylist();

--- a/src/core/csv/reader.cc
+++ b/src/core/csv/reader.cc
@@ -76,19 +76,12 @@ GenericReader::GenericReader()
 }
 
 
-GenericReader::GenericReader(py::robj pyrdr, py::robj pysources)
+GenericReader::GenericReader(py::robj pyrdr)
 {
-  job = std::make_shared<dt::progress::work>(WORK_PREPARE + WORK_READ);
   sof = nullptr;
   eof = nullptr;
   line = 0;
   cr_is_newline = 0;
-
-  auto pysrcs = pysources.to_otuple();
-  src_arg  = pysrcs[0];
-  file_arg = pysrcs[1];
-  fileno   = pysrcs[2].to_int32();
-  text_arg = pysrcs[3];
 
   init_verbose(   py::Arg(pyrdr.get_attr("_verbose"), "Parameter `verbose`"));
   init_logger(    py::Arg(pyrdr.get_attr("_logger"), "Parameter `logger`"));
@@ -356,8 +349,15 @@ void GenericReader::init_logger(const py::Arg& arg) {
 // Main read_all() function
 //------------------------------------------------------------------------------
 
-py::oobj GenericReader::read_all()
+py::oobj GenericReader::read_all(py::robj pysources)
 {
+  auto pysrcs = pysources.to_otuple();
+  src_arg  = pysrcs[0];
+  file_arg = pysrcs[1];
+  fileno   = pysrcs[2].to_int32();
+  text_arg = pysrcs[3];
+
+  job = std::make_shared<dt::progress::work>(WORK_PREPARE + WORK_READ);
   open_input();
   bool done = read_jay();
 

--- a/src/core/csv/reader.h
+++ b/src/core/csv/reader.h
@@ -116,7 +116,7 @@ class GenericReader
   //---- Public API ----
   public:
     GenericReader();
-    GenericReader(const py::robj& pyreader);
+    GenericReader(py::robj pyreader, py::robj pysources);
     GenericReader& operator=(const GenericReader&) = delete;
     virtual ~GenericReader();
 

--- a/src/core/csv/reader.h
+++ b/src/core/csv/reader.h
@@ -121,6 +121,7 @@ class GenericReader
     GenericReader& operator=(const GenericReader&) = delete;
     virtual ~GenericReader();
 
+    py::oobj get_logger() const;
     py::oobj read_all(py::robj pysources);
 
     bool has_next() const;
@@ -162,7 +163,6 @@ class GenericReader
 
   // Helper functions
   public:
-    void init_verbose   (const py::Arg&);
     void init_nthreads  (const py::Arg&);
     void init_fill      (const py::Arg&);
     void init_maxnrows  (const py::Arg&);
@@ -176,7 +176,7 @@ class GenericReader
     void init_stripwhite(const py::Arg&);
     void init_skipblanks(const py::Arg&);
     void init_columns   (const py::Arg&);
-    void init_logger    (const py::Arg&);
+    void init_logger    (const py::Arg& arg_logger, const py::Arg& arg_verbose);
 
   protected:
     void open_input();

--- a/src/core/csv/reader.h
+++ b/src/core/csv/reader.h
@@ -116,11 +116,12 @@ class GenericReader
   //---- Public API ----
   public:
     GenericReader();
-    GenericReader(py::robj pyreader, py::robj pysources);
+    GenericReader(const GenericReader&);
+    GenericReader(py::robj pyreader);
     GenericReader& operator=(const GenericReader&) = delete;
     virtual ~GenericReader();
 
-    py::oobj read_all();
+    py::oobj read_all(py::robj pysources);
 
     bool has_next() const;
     py::oobj read_next();
@@ -196,7 +197,6 @@ class GenericReader
 
   //---- Inherited API ----
   protected:
-    GenericReader(const GenericReader&);
     dtptr makeDatatable();
 };
 

--- a/src/core/frame/to_csv.cc
+++ b/src/core/frame/to_csv.cc
@@ -221,7 +221,7 @@ oobj Frame::to_csv(const PKArgs& args)
   bool verbose = arg_verbose.to<bool>(false);
   oobj logger;
   if (verbose) {
-    logger = oobj::import("datatable", "_DefaultLogger").call();
+    logger = oobj::import("datatable.utils.fread", "_DefaultLogger").call();
   }
 
   auto strategy = arg_strategy.to<std::string>("");

--- a/src/core/python/arg.h
+++ b/src/core/python/arg.h
@@ -74,6 +74,7 @@ class Arg : public _obj::error_manager {
     SType       to_stype              () const;
     SType       to_stype              (const error_manager&) const;
     py::oobj    to_oobj               () const { return oobj(pyobj); }
+    py::oobj    to_oobj_or_none       () const { return pyobj? oobj(pyobj) : py::None(); }
     py::robj    to_robj               () const { return pyobj; }
     py::oiter   to_oiter              () const;
     DataTable*  to_datatable          () const;

--- a/src/core/python/tuple.cc
+++ b/src/core/python/tuple.cc
@@ -95,10 +95,12 @@ robj rtuple::operator[](size_t i) const {
 
 void otuple::set(size_t i, const _obj& value) {
   // PyTuple_SET_ITEM "steals" a reference to the last argument
+  xassert(!value.is_undefined());
   PyTuple_SET_ITEM(v, static_cast<Py_ssize_t>(i), value.to_pyobject_newref());
 }
 
 void otuple::set(size_t i, oobj&& value) {
+  xassert(!value.is_undefined());
   PyTuple_SET_ITEM(v, static_cast<Py_ssize_t>(i), std::move(value).release());
 }
 
@@ -109,6 +111,7 @@ void otuple::replace(size_t i, const _obj& value) {
   make_editable();
 
   // PyTuple_SetItem "steals" a reference to the last argument
+  xassert(!value.is_undefined());
   PyTuple_SetItem(v, static_cast<Py_ssize_t>(i), value.to_pyobject_newref());
 }
 
@@ -118,6 +121,7 @@ void otuple::replace(size_t i, oobj&& value) {
   // will result in a `SystemError`.
   make_editable();
 
+  xassert(!value.is_undefined());
   PyTuple_SetItem(v, static_cast<Py_ssize_t>(i), std::move(value).release());
 }
 

--- a/src/core/read/py_read.cc
+++ b/src/core/read/py_read.cc
@@ -93,8 +93,7 @@ static py::oobj zread(const py::PKArgs& args)
   const py::Arg& arg_logger           = args[21];
 
   GenericReader gr;
-  gr.init_verbose(arg_verbose);
-  gr.init_logger(arg_logger);
+  gr.init_logger(arg_logger, arg_verbose);
   gr.init_nthreads(arg_nthreads);
   gr.init_fill(arg_fill);
   gr.init_maxnrows(arg_max_nrows);

--- a/src/datatable/__init__.py
+++ b/src/datatable/__init__.py
@@ -23,7 +23,7 @@
 from .frame import Frame
 from .expr import (mean, min, max, sd, isna, sum, count, first, abs, exp,
                    last, log, log10, f, g, median, cov, corr)
-from .fread import fread, GenericReader, FreadWarning, _DefaultLogger
+from .fread import fread, FreadWarning
 from .lib._datatable import (
     by,
     cbind,

--- a/src/datatable/__init__.py
+++ b/src/datatable/__init__.py
@@ -23,10 +23,10 @@
 from .frame import Frame
 from .expr import (mean, min, max, sd, isna, sum, count, first, abs, exp,
                    last, log, log10, f, g, median, cov, corr)
-from .fread import fread, FreadWarning
 from .lib._datatable import (
     by,
     cbind,
+    fread,
     init_styles,
     intersect,
     join,
@@ -77,7 +77,7 @@ __all__ = (
     "mean",
     "median",
     "sd",
-    "GenericReader", "stype", "ltype", "f", "g",
+    "stype", "ltype", "f", "g",
     "join", "by", "exp", "log", "log10",
     "options",
     "bool8", "int8", "int16", "int32", "int64",

--- a/src/datatable/fread.py
+++ b/src/datatable/fread.py
@@ -72,7 +72,7 @@ def fread(
     params = {**locals(), **extra}
     del params["extra"]
     freader = GenericReader(**params)
-    return freader.read()
+    return core.gread(freader)
 
 
 
@@ -147,91 +147,11 @@ class GenericReader(object):
         self._skip_to_string = skip_to_string
         self._strip_whitespace = strip_whitespace
         self._columns = columns
-        # self._save_to = save_to
+        self._save_to = save_to
         self._nthreads = nthreads
         if args:
             raise TypeError("Unknown argument(s) %r in FReader(...)"
                             % list(args.keys()))
-
-
-    def read(self):
-        if self._logger:
-            self._logger.debug("[1] Prepare for reading")
-        sources, result = _resolve_source(self._src, self._tempfiles, self._logger)
-        if isinstance(result, list):
-            res = {}
-            for isources, iresult in result:
-                src = isources[0]
-                if iresult:
-                    res[src] = iresult
-                else:
-                    try:
-                        res[src] = core.gread(self, isources)
-                    except Exception as e:
-                        res[src] = e
-            return res
-        elif result is not None:
-            return result
-        else:
-            return core.gread(self, sources)
-
-
-    #---------------------------------------------------------------------------
-
-    # def _get_destination(self, estimated_size):
-    #     """
-    #     Invoked from the C level, this function will return either the name of
-    #     the folder where the datatable is to be saved; or None, indicating that
-    #     the datatable should be read into RAM. This function may also raise an
-    #     exception if it determines that it cannot find a good strategy to
-    #     handle a dataset of the requested size.
-    #     """
-    #     global _psutil_load_attempted
-    #     if not _psutil_load_attempted:
-    #         _psutil_load_attempted = True
-    #         try:
-    #             import psutil
-    #         except ImportError:
-    #             psutil = None
-    #
-    #     if self._logger and estimated_size > 1:
-    #         self._logger.debug("The Frame is estimated to require %s bytes"
-    #                           % humanize_bytes(estimated_size))
-    #     if estimated_size < 1024 or psutil is None:
-    #         return None
-    #     vm = psutil.virtual_memory()
-    #     if self._logger:
-    #         self._logger.debug("Memory available = %s (out of %s)"
-    #                           % (humanize_bytes(vm.available),
-    #                              humanize_bytes(vm.total)))
-    #     if (estimated_size < vm.available and self._save_to is None or
-    #             self._save_to == "memory"):
-    #         if self._logger:
-    #             self._logger.debug("Frame will be loaded into memory")
-    #         return None
-    #     else:
-    #         if self._save_to:
-    #             tmpdir = self._save_to
-    #             os.makedirs(tmpdir)
-    #         else:
-    #             tmpdir = tempfile.mkdtemp()
-    #         du = psutil.disk_usage(tmpdir)
-    #         if self._logger:
-    #             self._logger.debug("Free disk space on drive %s = %s"
-    #                               % (os.path.splitdrive(tmpdir)[0] or "/",
-    #                                  humanize_bytes(du.free)))
-    #         if du.free > estimated_size or self._save_to:
-    #             if self._logger:
-    #                 self._logger.debug("Frame will be stored in %s"
-    #                                   % tmpdir)
-    #             return tmpdir
-    #     raise RuntimeError("The Frame is estimated to require at lest %s "
-    #                        "of memory, and you don't have that much available "
-    #                        "either in RAM or on a hard drive."
-    #                        % humanize_bytes(estimated_size))
-
-
-
 
 
 

--- a/src/datatable/fread.py
+++ b/src/datatable/fread.py
@@ -40,7 +40,6 @@ from datatable.xls import read_xls_workbook
 
 _url_regex = re.compile(r"(?:https?|ftp|file)://")
 _glob_regex = re.compile(r"[\*\?\[\]]")
-# _psutil_load_attempted = False
 
 
 def fread(
@@ -68,10 +67,13 @@ def fread(
         save_to=None,
         nthreads=None,
         logger=None):
-    freader = GenericReader(verbose=verbose, logger=logger)
-    return core.gread(freader, anysource, file=file, text=text, cmd=cmd, url=url,
-                      columns=columns, sep=sep, dec=dec, max_nrows=max_nrows,
-                      header=header, na_strings=na_strings, verbose=verbose,
+    return core.gread(anysource, file=file, text=text, cmd=cmd, url=url,
+                      columns=columns,
+                      sep=sep,
+                      dec=dec,
+                      max_nrows=max_nrows,
+                      header=header,
+                      na_strings=na_strings,
                       fill=fill,
                       encoding=encoding,
                       skip_to_string=skip_to_string,
@@ -81,13 +83,14 @@ def fread(
                       quotechar=quotechar,
                       save_to=save_to,
                       nthreads=nthreads,
+                      verbose=verbose,
                       logger=logger
                       )
 
 
 
 class TempFiles:
-    def __init__(self, tempdir, logger=None):
+    def __init__(self, tempdir=None, logger=None):
         self._logger = logger
         self._tempfiles = []
         self._tempdir = tempdir
@@ -125,26 +128,14 @@ class TempFiles:
 
 
 
-class GenericReader(object):
-    """
-    Parser object for reading CSV files.
-    """
-
-    def __init__(self, verbose, logger):
-        if verbose and not logger:
-            logger = _DefaultLogger()
-        self._logger = logger
-        self._verbose = (logger is not None)
-        self._tempfiles = TempFiles(tempdir=None, logger=logger)
-
-
 
 #-------------------------------------------------------------------------------
 # Resolvers
 #-------------------------------------------------------------------------------
 
-def _resolve_source(src, tempfiles, logger):
+def _resolve_source(src, tempfiles):
     anysource, file, text, cmd, url = src
+    logger = tempfiles._logger
     args = (["any"] * (anysource is not None) +
             ["file"] * (file is not None) +
             ["text"] * (text is not None) +

--- a/src/datatable/fread.py
+++ b/src/datatable/fread.py
@@ -65,6 +65,7 @@ def fread(
         strip_whitespace=True,
         quotechar='"',
         save_to=None,
+        tempdir=None,
         nthreads=None,
         logger=None):
     return core.gread(anysource, file=file, text=text, cmd=cmd, url=url,
@@ -83,6 +84,7 @@ def fread(
                       quotechar=quotechar,
                       save_to=save_to,
                       nthreads=nthreads,
+                      tempdir=tempdir,
                       verbose=verbose,
                       logger=logger
                       )

--- a/src/datatable/fread.py
+++ b/src/datatable/fread.py
@@ -67,12 +67,22 @@ def fread(
         quotechar='"',
         save_to=None,
         nthreads=None,
-        logger=None,
-        **extra):
-    params = {**locals(), **extra}
-    del params["extra"]
-    freader = GenericReader(**params)
-    return core.gread(freader)
+        logger=None):
+    freader = GenericReader(verbose=verbose, logger=logger)
+    return core.gread(freader, anysource, file=file, text=text, cmd=cmd, url=url,
+                      columns=columns, sep=sep, dec=dec, max_nrows=max_nrows,
+                      header=header, na_strings=na_strings, verbose=verbose,
+                      fill=fill,
+                      encoding=encoding,
+                      skip_to_string=skip_to_string,
+                      skip_to_line=skip_to_line,
+                      skip_blank_lines=skip_blank_lines,
+                      strip_whitespace=strip_whitespace,
+                      quotechar=quotechar,
+                      save_to=save_to,
+                      nthreads=nthreads,
+                      logger=logger
+                      )
 
 
 
@@ -98,7 +108,8 @@ class TempFiles:
                     self._logger.debug("Removing temporary file %s" % f)
                 os.remove(f)
             except OSError as e:
-                self._logger.warning("Failed to remove a temporary file: %r" % e)
+                if self._logger:
+                    self._logger.warning("Failed to remove a temporary file: %r" % e)
         if self._tempdir_own:
             shutil.rmtree(self._tempdir, ignore_errors=True)
         self._tempfiles = []
@@ -119,39 +130,12 @@ class GenericReader(object):
     Parser object for reading CSV files.
     """
 
-    def __init__(self, anysource=None, *, file=None, text=None, url=None,
-                 cmd=None, columns=None, sep=None,
-                 max_nrows=None, header=None, na_strings=None, verbose=False,
-                 fill=False, encoding=None, dec=".",
-                 skip_to_string=None, skip_to_line=None, save_to=None,
-                 nthreads=None, logger=None, skip_blank_lines=True,
-                 strip_whitespace=True, quotechar='"', **args):
-        self._src = (anysource, file, text, cmd, url)
-
-        self._logger = logger
+    def __init__(self, verbose, logger):
         if verbose and not logger:
-            self._logger = _DefaultLogger()
-        self._verbose = (self._logger is not None)
-        self._tempfiles = TempFiles(tempdir=args.pop("_tempdir", None),
-                                    logger=self._logger)
-        self._sep = args.pop("separator", sep)
-        self._dec = dec
-        self._maxnrows = max_nrows
-        self._header = header
-        self._nastrings = na_strings
-        self._fill = fill
-        self._encoding = encoding
-        self._quotechar = quotechar
-        self._skip_to_line = skip_to_line
-        self._skip_blank_lines = skip_blank_lines
-        self._skip_to_string = skip_to_string
-        self._strip_whitespace = strip_whitespace
-        self._columns = columns
-        self._save_to = save_to
-        self._nthreads = nthreads
-        if args:
-            raise TypeError("Unknown argument(s) %r in FReader(...)"
-                            % list(args.keys()))
+            logger = _DefaultLogger()
+        self._logger = logger
+        self._verbose = (logger is not None)
+        self._tempfiles = TempFiles(tempdir=None, logger=logger)
 
 
 

--- a/src/datatable/utils/fread.py
+++ b/src/datatable/utils/fread.py
@@ -42,53 +42,6 @@ _url_regex = re.compile(r"(?:https?|ftp|file)://")
 _glob_regex = re.compile(r"[\*\?\[\]]")
 
 
-def fread(
-        # Input source
-        anysource=None, *,
-        file=None,
-        text=None,
-        cmd=None,
-        url=None,
-
-        columns=None,
-        sep=None,
-        dec=".",
-        max_nrows=None,
-        header=None,
-        na_strings=None,
-        verbose=False,
-        fill=False,
-        encoding=None,
-        skip_to_string=None,
-        skip_to_line=None,
-        skip_blank_lines=False,
-        strip_whitespace=True,
-        quotechar='"',
-        save_to=None,
-        tempdir=None,
-        nthreads=None,
-        logger=None):
-    return core.gread(anysource, file=file, text=text, cmd=cmd, url=url,
-                      columns=columns,
-                      sep=sep,
-                      dec=dec,
-                      max_nrows=max_nrows,
-                      header=header,
-                      na_strings=na_strings,
-                      fill=fill,
-                      encoding=encoding,
-                      skip_to_string=skip_to_string,
-                      skip_to_line=skip_to_line,
-                      skip_blank_lines=skip_blank_lines,
-                      strip_whitespace=strip_whitespace,
-                      quotechar=quotechar,
-                      save_to=save_to,
-                      nthreads=nthreads,
-                      tempdir=tempdir,
-                      verbose=verbose,
-                      logger=logger
-                      )
-
 
 
 class TempFiles:

--- a/tests/fread/test_fread_api.py
+++ b/tests/fread/test_fread_api.py
@@ -661,10 +661,10 @@ def test_sep_selection(sep):
 
 
 def test_sep_invalid1():
-    with pytest.raises(TypeError) as e:
+    msg = r"Argument sep in gread\(\) should be a string, instead got " \
+          r"<class 'int'>"
+    with pytest.raises(TypeError, match=msg) as e:
         dt.fread("A,,B\n", sep=12)
-    assert ("Parameter sep should be a string, instead got <class 'int'>"
-            in str(e.value))
 
 
 def test_sep_invalid2():

--- a/tests/fread/test_fread_api.py
+++ b/tests/fread/test_fread_api.py
@@ -661,7 +661,7 @@ def test_sep_selection(sep):
 
 
 def test_sep_invalid1():
-    msg = r"Argument sep in gread\(\) should be a string, instead got " \
+    msg = r"Argument sep in fread\(\) should be a string, instead got " \
           r"<class 'int'>"
     with pytest.raises(TypeError, match=msg) as e:
         dt.fread("A,,B\n", sep=12)

--- a/tests/test_utils_misc.py
+++ b/tests/test_utils_misc.py
@@ -1,15 +1,29 @@
 #!/usr/bin/env python
-# © H2O.ai 2018; -*- encoding: utf-8 -*-
-#   This Source Code Form is subject to the terms of the Mozilla Public
-#   License, v. 2.0. If a copy of the MPL was not distributed with this
-#   file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -*- coding: utf-8 -*-
+#-------------------------------------------------------------------------------
+# Copyright 2018-2020 H2O.ai
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
 #-------------------------------------------------------------------------------
 import random
 import datatable
-
-# `datatable` doesn't export its `utils`, hence the warning
-# noinspection PyUnresolvedReferences
-utils_misc = datatable.utils.misc
+import datatable.utils.misc as utils_misc
 
 
 def test_plural_form():


### PR DESCRIPTION
Previously we had `fread()` function in fread.py creating an object of class `GenericReader`, which in turn called C++ `core.gread()` function which did the actual reading.

Now the first 2 steps are removed, and `core.gread()` became the new `fread` function. The file "fread.py" moved to "utils/fread.py" after heavy editing -- it is no longer useful for any external purpose, and eventually will be removed once we replace the remaining code with C++ equivalents.

WIP for #1832