### PR TITLE
Frame.source

### DIFF
--- a/docs/api/frame.rst
+++ b/docs/api/frame.rst
@@ -7,7 +7,7 @@ Frame
     :inherited-members:
     :undoc-members:
     :exclude-members: cbind, colindex, copy, countna, countna1, export_names,
-                      head, key, names, replace, tail, to_csv
+                      head, key, names, replace, source, tail, to_csv
 
 
 .. toctree::
@@ -23,5 +23,6 @@ Frame
     .key             <frame/key>
     .names           <frame/names>
     .replace()       <frame/replace>
+    .source          <frame/source>
     .tail()          <frame/tail>
     .to_csv()        <frame/to_csv>

--- a/docs/api/frame/source.rst
+++ b/docs/api/frame/source.rst
@@ -1,0 +1,3 @@
+
+.. xdata:: datatable.Frame.source
+    :src: src/core/frame/py_frame.cc Frame::get_source

--- a/docs/releases/v0.11.0.rst
+++ b/docs/releases/v0.11.0.rst
@@ -7,6 +7,11 @@
   -----
   .. ref-context:: datatable.Frame
 
+  -[new] Property :attr:`Frame.source` will contain the name of the file
+    where the frame was loaded from. If the frame was modified after loading,
+    or if it was created dynamically to begin with, this property will
+    return ``None``.
+
   -[new] The expression ``len(DT)`` now works, and returns the number of
     columns in the Frame. This allows the Frame to be used in contexts where
     an iterable might be expected.

--- a/src/core/csv/reader.cc
+++ b/src/core/csv/reader.cc
@@ -375,12 +375,12 @@ py::oobj GenericReader::read_all(py::robj pysources)
     read_csv();
   }
 
-  if (outputs.empty()) {
+  if (!output_) {
     throw RuntimeError() << "Unable to read input " << src_arg.to_string();
   }
 
   job->done();
-  return outputs[0];
+  return output_;
 }
 
 
@@ -406,12 +406,12 @@ py::oobj GenericReader::read_buffer(const Buffer& buf, size_t extra_byte)
     read_csv();
   }
 
-  if (outputs.empty()) {
+  if (!output_) {
     throw RuntimeError() << "Unable to read input " << src_arg.to_string();
   }
 
   job->done();
-  return outputs[0];
+  return output_;
 }
 
 
@@ -830,7 +830,7 @@ bool GenericReader::read_empty_input() {
   if (size == 0 || (size == 1 && *sof == '\0')) {
     trace("Input is empty, returning a (0 x 0) DataTable");
     job->add_done_amount(WORK_READ);
-    outputs.push_back(py::Frame::oframe(new DataTable()));
+    output_ = py::Frame::oframe(new DataTable());
     return true;
   }
   return false;
@@ -870,7 +870,7 @@ bool GenericReader::read_jay() {
     input_mbuf.resize(datasize());
     DataTable* dt = open_jay_from_mbuf(input_mbuf);
     job->add_done_amount(WORK_READ);
-    outputs.push_back(py::Frame::oframe(dt));
+    output_ = py::Frame::oframe(dt);
     return true;
   }
   return false;
@@ -880,7 +880,7 @@ bool GenericReader::read_jay() {
 bool GenericReader::read_csv() {
   auto dt = FreadReader(*this).read_all();
   if (dt) {
-    outputs.push_back(py::Frame::oframe(dt.release()));
+    output_ = py::Frame::oframe(dt.release());
     return true;
   }
   return false;

--- a/src/core/csv/reader.h
+++ b/src/core/csv/reader.h
@@ -1,14 +1,28 @@
 //------------------------------------------------------------------------------
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright 2018-2020 H2O.ai
 //
-// © H2O.ai 2018
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #ifndef dt_CSV_READER_h
 #define dt_CSV_READER_h
 #include <memory>           // std::unique_ptr, std::shared_ptr
-#include "buffer.h"       // Buffer
+#include "buffer.h"         // Buffer
 #include "progress/work.h"  // dt::progress::work
 #include "python/obj.h"     // py::robj, py::oobj
 #include "python/list.h"    // py::olist
@@ -98,7 +112,7 @@ class GenericReader
     dt::read::Columns columns;
     double t_open_input{ 0 };
 
-    std::vector<py::oobj> outputs;
+    py::oobj output_;
 
   private:
     py::oobj logger;

--- a/src/core/frame/__getitem__.cc
+++ b/src/core/frame/__getitem__.cc
@@ -184,6 +184,7 @@ oobj Frame::_main_getset(robj item, robj value) {
   auto res = ctx.evaluate();
   if (ctx.get_mode() != dt::expr::EvalMode::SELECT) {
     _clear_types();
+    source_ = nullptr;
   }
   return res;
 }

--- a/src/core/frame/__init__.cc
+++ b/src/core/frame/__init__.cc
@@ -686,6 +686,7 @@ Error FrameInitializationManager::em::error_not_stype(PyObject*) const {
 void Frame::m__init__(const PKArgs& args) {
   if (dt) m__dealloc__();
   dt = nullptr;
+  source_ = nullptr;
   stypes = nullptr;
   ltypes = nullptr;
   if (Frame::internal_construction) return;
@@ -729,6 +730,7 @@ void Frame::m__setstate__(const PKArgs& args) {
   const char* data = PyBytes_AS_STRING(_state);
   size_t length = static_cast<size_t>(PyBytes_GET_SIZE(_state));
   dt = open_jay_from_bytes(data, length);
+  source_ = py::ostring("<pickle>");
 }
 
 

--- a/src/core/frame/__init__.cc
+++ b/src/core/frame/__init__.cc
@@ -367,6 +367,7 @@ class FrameInitializationManager {
         std::swap(frame->dt,      resframe->dt);
         std::swap(frame->stypes,  resframe->stypes);
         std::swap(frame->ltypes,  resframe->ltypes);
+        std::swap(frame->source_, resframe->source_);
       } else {
         xassert(res.is_dict());
         auto err = ValueError();

--- a/src/core/frame/py_frame.cc
+++ b/src/core/frame/py_frame.cc
@@ -522,7 +522,21 @@ oobj Frame::get_ndims() const {
 
 static const char* doc_source =
 R"(
-The location of the file where this frame was loaded from.
+The name of the file where this frame was loaded from.
+
+This is a read-only property that describes the origin of the frame.
+When a frame is loaded from a Jay or CSV file, this property will
+contain the name of that file. Similarly, if the frame was opened
+from a URL or a from a shell command, the source will report the
+original URL / the command.
+
+Certain sources may be converted into a Frame only partially,
+in such case the ``source`` property will attempt to reflect this
+fact. For example, when opening a multi-file zip archive, the
+source will contain the name of the file within the archive.
+Similarly, when opening an XLS file with several worksheets, the
+source property will contain the name of the XLS file, the name of
+the worksheet, and possibly even the range of cells that were read.
 
 Parameters
 ----------

--- a/src/core/frame/py_frame.cc
+++ b/src/core/frame/py_frame.cc
@@ -238,6 +238,7 @@ oobj Frame::copy(const PKArgs& args) {
   Frame* newframe = static_cast<Frame*>(res.to_borrowed_ref());
   newframe->stypes = stypes;  Py_XINCREF(stypes);
   newframe->ltypes = ltypes;  Py_XINCREF(ltypes);
+  newframe->source_ = source_;
   return res;
 }
 

--- a/src/core/frame/py_frame.h
+++ b/src/core/frame/py_frame.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018 H2O.ai
+// Copyright 2018-2020 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -37,6 +37,7 @@ class Frame : public XObject<Frame> {
   private:
     DataTable* dt;  // owned (cannot use unique_ptr because this class's
                     // destructor is never called by Python)
+    py::oobj source_;
     mutable PyObject* stypes;  // memoized tuple of stypes
     mutable PyObject* ltypes;  // memoized tuple of ltypes
 
@@ -93,19 +94,21 @@ class Frame : public XObject<Frame> {
     void view(const PKArgs&);
     oobj newview(const PKArgs&);
 
-    oobj get_ncols() const;
-    oobj get_nrows() const;
-    oobj get_ndims() const;
-    oobj get_shape() const;
-    oobj get_stypes() const;
-    oobj get_stype() const;
+    // Getters/setters
+    oobj get_key() const;
     oobj get_ltypes() const;
     oobj get_names() const;
-    oobj get_key() const;
-    void set_nrows(const Arg&);
-    void set_names(const Arg&);
+    oobj get_ncols() const;
+    oobj get_ndims() const;
+    oobj get_nrows() const;
+    oobj get_shape() const;
+    oobj get_source() const;
+    oobj get_stype() const;
+    oobj get_stypes() const;
     void set_key(const Arg&);
-    void set_internal(robj);
+    void set_names(const Arg&);
+    void set_nrows(const Arg&);
+    void set_source(const std::string&);  // internal use only
 
     void cbind(const PKArgs&);
     oobj colindex(const PKArgs&);
@@ -145,7 +148,7 @@ class Frame : public XObject<Frame> {
     class NameProvider;
 
     ~Frame() {}
-    void _clear_types() const;
+    void _clear_types();
     void _init_names() const;
     void _init_inames() const;
     void _fill_default_names();

--- a/src/core/frame/replace.cc
+++ b/src/core/frame/replace.cc
@@ -182,6 +182,7 @@ void Frame::replace(const PKArgs& args) {
     }
   }
   if (ra.types_changed()) _clear_types();
+  source_ = nullptr;
 }
 
 

--- a/src/core/jay/open_jay.cc
+++ b/src/core/jay/open_jay.cc
@@ -1,9 +1,23 @@
 //------------------------------------------------------------------------------
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright 2018-2020 H2O.ai
 //
-// © H2O.ai 2018
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #include <string>
 #include <cstring>              // std::memcmp
@@ -201,23 +215,26 @@ static PKArgs args_open_jay(
   "Open a Frame from the provided .jay file.\n");
 
 
-static oobj open_jay(const PKArgs& args) {
-  DataTable* dt = nullptr;
+static oobj open_jay(const PKArgs& args)
+{
   if (args[0].is_bytes()) {
     // TODO: create & use class obytes
     PyObject* arg1 = args[0].to_borrowed_ref();
     const char* data = PyBytes_AS_STRING(arg1);
     size_t length = static_cast<size_t>(PyBytes_GET_SIZE(arg1));
-    dt = open_jay_from_bytes(data, length);
+    auto dt = open_jay_from_bytes(data, length);
+    return Frame::oframe(dt);
   }
   else if (args[0].is_string()) {
     std::string filename = args[0].to_string();
-    dt = open_jay_from_file(filename);
+    auto dt = open_jay_from_file(filename);
+    auto res = Frame::oframe(dt);
+    res.to_pyframe()->set_source(filename);
+    return res;
   }
   else {
     throw TypeError() << "Invalid type of the argument to open_jay()";
   }
-  return Frame::oframe(dt);
 }
 
 

--- a/src/core/python/obj.cc
+++ b/src/core/python/obj.cc
@@ -782,6 +782,14 @@ DataTable* _obj::to_datatable(const error_manager& em) const {
   throw em.error_not_frame(v);
 }
 
+py::Frame* _obj::to_pyframe(const error_manager& em) const {
+  if (v == Py_None) return nullptr;
+  if (is_frame()) {
+    return static_cast<py::Frame*>(v);
+  }
+  throw em.error_not_frame(v);
+}
+
 
 
 SType _obj::to_stype(const error_manager& em) const {

--- a/src/core/python/obj.h
+++ b/src/core/python/obj.h
@@ -1,9 +1,23 @@
 //------------------------------------------------------------------------------
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright 2018-2020 H2O.ai
 //
-// © H2O.ai 2018-2019
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #ifndef dt_PYTHON_OBJ_h
 #define dt_PYTHON_OBJ_h
@@ -20,6 +34,7 @@ namespace py {
 
 // Forward declarations
 class Arg;
+class Frame;
 class oby;
 class odict;
 class ofloat;
@@ -259,6 +274,7 @@ class _obj {
     py::rtuple  to_rtuple_lax     () const;
 
     DataTable*  to_datatable      (const error_manager& = _em0) const;
+    py::Frame*  to_pyframe        (const error_manager& = _em0) const;
     SType       to_stype          (const error_manager& = _em0) const;
     py::ojoin   to_ojoin_lax      () const;
     py::oby     to_oby_lax        () const;

--- a/src/core/read/multisource.cc
+++ b/src/core/read/multisource.cc
@@ -181,17 +181,19 @@ static MultiSource _from_url(py::robj src, const GenericReader& rdr) {
 py::oobj MultiSource::read_all_fread_style(GenericReader& reader) {
   xassert(!sources_.empty());
   if (sources_.size() == 1) {
+    const std::string& name = sources_[0]->name();
     py::oobj res = sources_[0]->read(reader);
-    res.to_pyframe()->set_source(sources_[0]->name());
+    if (!name.empty()) res.to_pyframe()->set_source(name);
     return res;
   }
   else {
     py::odict result_dict;
     for (auto& src : sources_) {
+      const std::string& iname = src->name();
       GenericReader ireader(reader);
       py::oobj res = src->read(ireader);
-      res.to_pyframe()->set_source(src->name());
-      result_dict.set(py::ostring(src->name()), res);
+      if (!iname.empty()) res.to_pyframe()->set_source(iname);
+      result_dict.set(py::ostring(iname), res);
     }
     return std::move(result_dict);
   }

--- a/src/core/read/multisource.cc
+++ b/src/core/read/multisource.cc
@@ -103,10 +103,10 @@ static MultiSource _from_python(py::robj pysource) {
   auto res_tuple = pysource.to_otuple();
   auto sources = res_tuple[0];
   auto result = res_tuple[1];
+  auto name = sources.to_otuple()[0].to_string();
 
   SourceVec out;
   if (result.is_none()) {
-    auto name = sources.to_otuple()[0].to_string();
     out.emplace_back(new Source_Python(name, sources));
   }
   else if (result.is_list_or_tuple()) {
@@ -130,7 +130,7 @@ static MultiSource _from_python(py::robj pysource) {
     }
   }
   else {
-    out.emplace_back(new Source_Result("", result));
+    out.emplace_back(new Source_Result(name, result));
   }
   return MultiSource(std::move(out));
 }

--- a/src/core/read/source.h
+++ b/src/core/read/source.h
@@ -21,9 +21,9 @@
 //------------------------------------------------------------------------------
 #ifndef dt_READ_SOURCE_h
 #define dt_READ_SOURCE_h
-#include <memory>         // std::unique_ptr
-#include <string>         // std::string
-#include "python/_all.h"  // py::oobj
+#include <memory>            // std::unique_ptr
+#include <string>            // std::string
+#include "python/_all.h"     // py::oobj
 namespace dt {
 namespace read {
 

--- a/src/datatable/utils/fread.py
+++ b/src/datatable/utils/fread.py
@@ -235,6 +235,7 @@ def _resolve_archive(filename, subpath, tempfiles):
                if not(name.startswith("__MACOSX/") or name.endswith("/"))]
         if subpath:
             if subpath in zff:
+                filename += "/" + subpath
                 zff = [subpath]
             else:
                 raise ValueError("File `%s` does not exist in archive `%s`"
@@ -243,6 +244,7 @@ def _resolve_archive(filename, subpath, tempfiles):
             warnings.warn("Zip file %s contains multiple compressed "
                           "files: %r. Only the first of them will be used."
                           % (filename, zff), category=FreadWarning)
+            filename += "/" + zff[0]
         if len(zff) == 0:
             raise ValueError("Zip file %s is empty" % filename)
         if logger:

--- a/src/datatable/utils/fread.py
+++ b/src/datatable/utils/fread.py
@@ -283,6 +283,8 @@ def _resolve_archive(filename, subpath, tempfiles):
 
     elif ext == ".xlsx" or ext == ".xls":
         out_result = read_xls_workbook(filename, subpath)
+        if subpath:
+            filename += "/" + subpath
 
     elif ext == ".jay":
         out_result = core.open_jay(filename)

--- a/src/datatable/xls.py
+++ b/src/datatable/xls.py
@@ -22,6 +22,11 @@ import re
 def read_xls_workbook(filename, subpath):
     try:
         import xlrd
+        # Fixes the warning
+        # "PendingDeprecationWarning: This method will be removed in future
+        #  versions.  Use 'tree.iter()' or 'list(tree.iter())' instead."
+        xlrd.xlsx.ensure_elementtree_imported(False, None)
+        xlrd.xlsx.Element_has_iter = True
     except ImportError:
         raise dt.exceptions.ImportError(
             "Module `xlrd` is required in order to read Excel file '%s'"
@@ -49,7 +54,7 @@ def read_xls_workbook(filename, subpath):
             if out is None:
                 continue
             for i, frame in out.items():
-                result["%s/%s" % (ws.name, i)] = frame
+                result["%s/%s/%s" % (filename, ws.name, i)] = frame
 
     if len(result) == 0:
         return None

--- a/tests/frame/test-copy.py
+++ b/tests/frame/test-copy.py
@@ -120,3 +120,14 @@ def test_issue2179(numpy):
     DT2 = copy.deepcopy(DT)
     frame_integrity_check(DT1)
     frame_integrity_check(DT2)
+
+
+def test_copy_source(tempfile):
+    with open(tempfile, "w") as out:
+        out.write("A\n3\n1\n4\n1\n5\n")
+    DT = dt.fread(tempfile)
+    assert DT.source == tempfile
+    copy1 = DT.copy()
+    copy2 = DT.copy(deep=True)
+    assert copy1.source == tempfile
+    assert copy2.source == tempfile

--- a/tests/fread/test_fread_issues.py
+++ b/tests/fread/test_fread_issues.py
@@ -139,6 +139,7 @@ def test_issue_R2351(tempfile):
     with open(tempfile, "wb") as o:
         o.write(text)
     d0 = dt.fread(tempfile)
+    assert d0.source == tempfile
     frame_integrity_check(d0)
     assert d0[:2, :].to_list() == [["id0", "id1"], [0, 38]]
     assert d0[-2:, :].to_list() == [["id99998", "id99999"], [92, 130]]

--- a/tests/fread/test_xls.py
+++ b/tests/fread/test_xls.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #-------------------------------------------------------------------------------
+import os
 import pytest
 import random
 import datatable as dt
@@ -95,6 +96,7 @@ def test__excel_coords_to_range2d(seed):
 def test_10k_diabetes_xlsx():
     filename = find_file("h2o-3", "fread", "10k_diabetes.xlsx")
     DT = dt.fread(filename)
+    assert DT.source == filename
     assert DT.shape == (10000, 51)
     assert DT.names[:4] == ("race", "gender", "age", "weight")
     assert DT["readmitted"].stype == dt.bool8
@@ -105,6 +107,7 @@ def test_10k_diabetes_xlsx():
 def test_large_ids_xlsx():
     filename = find_file("h2o-3", "fread", "large_ids.xlsx")
     DT = dt.fread(filename)
+    assert DT.source == filename
     assert DT.shape == (53493, 3)
     assert DT.stypes == (dt.int32, dt.int32, dt.int32)
     assert DT.names == ("C1", "member_id", "loan_amnt")
@@ -114,6 +117,7 @@ def test_large_ids_xlsx():
 def test_set_xls_new_xlsx():
     filename = find_file("h2o-3", "fread", "test_set_xls_new.xlsx")
     DT = dt.fread(filename)
+    assert DT.source == filename
     assert DT.shape == (7, 1)
     assert DT.names == ("Data",)
     assert DT.to_list()[0] == ['2019-05-06 00:00:00',
@@ -129,8 +133,11 @@ def test_diabetes_tiny_two_sheets_xlsx():
     filename = find_file("h2o-3", "fread", "diabetes_tiny_two_sheets.xlsx")
     DTs = dt.fread(filename)
     assert isinstance(DTs, dict)
-    assert list(DTs.keys()) == ["Sheet1/A1:AY17", "Sheet2/A1:AY17"]
+    assert list(DTs.keys()) == [filename + "/Sheet1/A1:AY17",
+                                filename + "/Sheet2/A1:AY17"]
     DT1, DT2 = DTs.values()
+    assert DT1.source == filename + "/Sheet1/A1:AY17"
+    assert DT2.source == filename + "/Sheet2/A1:AY17"
     assert DT1.shape == DT2.shape == (16, 51)
     assert DT1.stypes == DT2.stypes
     assert DT1.to_list() == DT2.to_list()
@@ -140,6 +147,7 @@ def test_winemag_data_rate_wine_xlsx():
     filename = find_file("h2o-3", "fread", "winemag-data_rate_wine.xlsx")
     DT = dt.fread(filename)
     dt.internal.frame_integrity_check(DT)
+    assert DT.source == filename
     assert DT.shape == (2007, 9)
     assert DT.names == ('Sno', 'country', 'description', 'designation', 'points',
                         'price', 'province', 'variety', 'winery')
@@ -152,6 +160,7 @@ def test_winemag_data_rate_wine_xlsx():
 def test_excel_testbook_xlsx_1():
     filename = find_file("h2o-3", "fread", "excelTestbook.xlsx")
     DT1 = dt.fread(filename + "/Sheet1")
+    assert DT1.source == os.path.abspath(filename) + "/Sheet1"
     assert_equals(DT1, dt.Frame([("Apples", 50),
                                  ("Oranges", 20),
                                  ("Bananas", 60),
@@ -162,6 +171,7 @@ def test_excel_testbook_xlsx_1():
 def test_excel_testbook_xlsx_2():
     filename = find_file("h2o-3", "fread", "excelTestbook.xlsx")
     DT2 = dt.fread(filename + "/Sheet2")
+    assert DT2.source == os.path.abspath(filename) + "/Sheet2"
     assert_equals(DT2, dt.Frame(day=["today", "tomorrow", "yes\nter\nday",
                                      "everyday"]))
 
@@ -169,6 +179,7 @@ def test_excel_testbook_xlsx_2():
 def test_excel_testbook_xlsx_3():
     filename = find_file("h2o-3", "fread", "excelTestbook.xlsx")
     DT3 = dt.fread(filename + "/big sheet")
+    assert DT3.source == os.path.abspath(filename) + "/big sheet"
     assert DT3.shape == (20, 2)
     assert DT3.names == ("date1", "time1")
     assert DT3['date1'].to_list()[0] == ["2020-01-%02d 00:00:00" % i
@@ -181,6 +192,7 @@ def test_excel_testbook_xlsx_3():
 def test_excel_testbook_xlsx_4():
     filename = find_file("h2o-3", "fread", "excelTestbook.xlsx")
     DT3 = dt.fread(filename + "/next sheet")
+    assert DT3.source == os.path.abspath(filename) + "/next sheet"
     assert DT3.stypes == (dt.bool8, dt.int32, dt.bool8, dt.int32, dt.float64)
     assert DT3.names == ("colA", "colB", "colC", "colD", "colE")
     assert DT3.to_list() == [
@@ -194,6 +206,7 @@ def test_excel_testbook_xlsx_4():
 def test_excel_testbook_xlsx_5():
     filename = find_file("h2o-3", "fread", "excelTestbook.xlsx")
     DT3 = dt.fread(filename + "/ragged/B2:E8")
+    assert DT3.source == os.path.abspath(filename) + "/ragged/B2:E8"
     assert DT3.names == ("a", "C0", "b", "c")
     assert DT3.stype == dt.int32
     assert DT3.to_list() == [[None, 7, None, None, 0, None],

--- a/tests/ijby/test-assign.py
+++ b/tests/ijby/test-assign.py
@@ -311,3 +311,28 @@ def test_assign_in_keyed_frame():
     assert DT.key == ("A",)
     DT.key = None
     assert_equals(DT, dt.Frame(A=range(5), B=range(5)))
+
+
+def test_assign_clears_source():
+    DT = dt.fread("A\n1\n2\n3\n")
+    assert DT.source == "<text>"
+    assert DT.stype == dt.int32
+    DT[0, 1] = 1000
+    assert DT.source is None
+    assert DT.stype == dt.int32
+
+
+def test_assign_clears_source2(tempfile):
+    with open(tempfile, "w") as out:
+        out.write("foo,bar\n3,4\n")
+    DT = dt.fread(tempfile)
+    assert DT.source == tempfile
+    DT[0, 1] = -1
+    assert DT.source is None
+
+
+def test_assign_clears_source3():
+    DT = dt.fread("A\n1\n2\n3\n")
+    assert DT.source == "<text>"
+    DT['N'] = True
+    assert DT.source is None

--- a/tests/munging/test_replace.py
+++ b/tests/munging/test_replace.py
@@ -400,6 +400,15 @@ def test_replace_in_view2():
     assert DT.to_list() == [names]
 
 
+def test_replace_clears_source(tempfile):
+    dt.Frame(range(100)).to_jay(tempfile)
+    DT = dt.fread(tempfile)
+    assert DT.source == tempfile
+    DT.replace(5, None)
+    assert DT.source is None
+
+
+
 #-------------------------------------------------------------------------------
 # Replacing in a keyed frame
 #-------------------------------------------------------------------------------

--- a/tests/test_jay.py
+++ b/tests/test_jay.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #-------------------------------------------------------------------------------
-# Copyright 2018-2019 H2O.ai
+# Copyright 2018-2020 H2O.ai
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -47,6 +47,7 @@ def test_jay_simple(tempfile_jay):
     with open(tempfile_jay, "rb") as inp:
         assert inp.read(8) == b"JAY1\x00\x00\x00\x00"
     dt1 = dt.Frame(tempfile_jay)
+    assert dt1.source == tempfile_jay
     assert_equals(dt0, dt1)
 
 
@@ -55,6 +56,8 @@ def test_open(tempfile_jay):
     DT.to_jay(tempfile_jay)
     with pytest.warns(FutureWarning):
         DT2 = dt.open(tempfile_jay)
+    assert DT.source is None
+    assert DT2.source == tempfile_jay
     assert_equals(DT, DT2)
 
 
@@ -68,6 +71,8 @@ def test_fread(tempfile_jay):
         f1 = dt.fread(tempfile_jay)
         f2 = dt.fread(tempfile_joy)
         assert_equals(f1, f2)
+        assert f1.source == tempfile_jay
+        assert f2.source == tempfile_joy
     finally:
         os.remove(tempfile_joy)
 
@@ -78,6 +83,7 @@ def test_jay_empty_string_col(tempfile_jay):
     assert os.path.isfile(tempfile_jay)
     dt1 = dt.Frame(tempfile_jay)
     assert_equals(dt0, dt1)
+    assert dt1.source == tempfile_jay
 
 
 @pytest.mark.parametrize("seed", [random.getrandbits(32)])
@@ -91,6 +97,7 @@ def test_jay_view(tempfile_jay, seed):
     assert os.path.isfile(tempfile_jay)
     dt2 = dt.fread(tempfile_jay)
     assert not isview(dt2)
+    assert dt2.source == tempfile_jay
     frame_integrity_check(dt1)
     frame_integrity_check(dt2)
     assert dt1.names == dt2.names
@@ -106,6 +113,7 @@ def test_jay_unicode_names(tempfile_jay):
     dt1 = dt.fread(tempfile_jay)
     assert dt0.names == dt1.names
     assert_equals(dt0, dt1)
+    assert dt1.source == tempfile_jay
 
 
 def test_jay_object_columns(tempfile_jay):
@@ -121,6 +129,7 @@ def test_jay_object_columns(tempfile_jay):
     frame_integrity_check(d1)
     assert d1.names == ("A",)
     assert d1.to_list() == [src1]
+    assert d1.source == tempfile_jay
 
 
 def test_jay_empty_frame(tempfile_jay):
@@ -130,6 +139,7 @@ def test_jay_empty_frame(tempfile_jay):
     d1 = dt.fread(tempfile_jay)
     assert d1.shape == (0, 0)
     assert d1.names == tuple()
+    assert d1.source == tempfile_jay
 
 
 def test_jay_all_types(tempfile_jay):
@@ -155,6 +165,7 @@ def test_jay_all_types(tempfile_jay):
     assert os.path.isfile(tempfile_jay)
     d1 = dt.fread(tempfile_jay)
     assert_equals(d0, d1)
+    assert d1.source == tempfile_jay
 
 
 def test_jay_keys(tempfile_jay):
@@ -167,6 +178,7 @@ def test_jay_keys(tempfile_jay):
     d0.to_jay(tempfile_jay)
     d1 = dt.fread(tempfile_jay)
     assert d1.key == ("x",)
+    assert d1.source == tempfile_jay
     assert_equals(d0, d1)
 
 
@@ -185,6 +197,7 @@ def test_pickle(tempfile):
     assert DT.to_list() == DT2.to_list()
     assert DT.names == DT2.names
     assert DT.stypes == DT2.stypes
+    assert DT2.source == "<pickle>"
 
 
 def test_pickle2(tempfile):
@@ -221,3 +234,4 @@ def test_pickle_keyed_frame(tempfile):
     assert DT.stypes == DT2.stypes
     assert DT.to_list() == DT2.to_list()
     assert DT.key == DT2.key
+    assert DT2.source == "<pickle>"


### PR DESCRIPTION
Added new frame property: `Frame.source`. This contains the name of the file where the frame was loaded from. In some other cases it may contain a generic descriptor: `"<file>"`, `"<text>"`, `"<pickle>"` if the source cannot be identified more precisely.

The property is read-only. It will clear if the frame is modified after being loaded.