### PR TITLE
Fix misc tests on Windows 

### DIFF
--- a/src/datatable/utils/fread.py
+++ b/src/datatable/utils/fread.py
@@ -228,7 +228,7 @@ def _resolve_source_list(srcs_list, tempfiles):
 def _resolve_archive(filename, subpath, tempfiles):
     logger = tempfiles._logger
     ext = os.path.splitext(filename)[1]
-    if subpath and subpath[0] == "/":
+    if subpath and subpath[0] in ["/", "\\"]:
         subpath = subpath[1:]
 
     out_file = None
@@ -245,7 +245,7 @@ def _resolve_archive(filename, subpath, tempfiles):
                if not(name.startswith("__MACOSX/") or name.endswith("/"))]
         if subpath:
             if subpath in zff:
-                filename += "/" + subpath
+                filename = os.path.join(filename, subpath)
                 zff = [subpath]
             else:
                 raise IOError("File `%s` does not exist in archive `%s`"
@@ -256,7 +256,7 @@ def _resolve_archive(filename, subpath, tempfiles):
                 logger.debug("Extracting %s/%s to temporary directory %s"
                              % (filename, zf_file, tempfiles.tempdir))
             newfile = zf.extract(zf_file, path=tempfiles.tempdir)
-            srcname = filename + "/" + zf_file
+            srcname = os.path.join(filename, zf_file)
             tempfiles.add(newfile)
             extracted_files.append(((srcname, newfile, None, None), None))
         if len(extracted_files) == 1:
@@ -270,7 +270,7 @@ def _resolve_archive(filename, subpath, tempfiles):
         zff = [entry.name for entry in zf.getmembers() if entry.isfile()]
         if subpath:
             if subpath in zff:
-                filename += "/" + subpath
+                filename = os.path.join(filename, subpath)
                 zff = [subpath]
             else:
                 raise IOError("File `%s` does not exist in archive `%s`"
@@ -283,7 +283,7 @@ def _resolve_archive(filename, subpath, tempfiles):
             newfile = tempfiles.create_temp_file()
             with zf.extractfile(entryname) as inp, open(newfile, "wb") as out:
                 out.write(inp.read())
-            srcname = filename + "/" + entryname
+            srcname = os.path.join(filename, entryname)
             extracted_files.append(((srcname, newfile, None, None), None))
         if len(extracted_files) == 1:
             out_file = extracted_files[0][0][1]
@@ -320,7 +320,7 @@ def _resolve_archive(filename, subpath, tempfiles):
     elif ext == ".xlsx" or ext == ".xls":
         out_result = read_xls_workbook(filename, subpath)
         if subpath:
-            filename += "/" + subpath
+            filename = os.path.join(filenam, subpath)
 
     elif ext == ".jay":
         out_result = core.open_jay(filename)

--- a/src/datatable/utils/fread.py
+++ b/src/datatable/utils/fread.py
@@ -248,7 +248,6 @@ def _resolve_archive(filename, subpath, tempfiles):
                     filename = os.path.join(filename, subpath)
                     zff = [subpath]
                 else:
-                    zipfile.ZipFile.close(zf)
                     raise IOError("File `%s` does not exist in archive `%s`"
                                    % (subpath, filename))
             extracted_files = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,13 @@ def noppc64():
 
 
 @pytest.fixture(scope="session")
+def nowin():
+    """Skip this test when running on Windows"""
+    if sys.platform == "win32":
+        pytest.skip("Disabled on Windows")
+
+
+@pytest.fixture(scope="session")
 def nocov():
     """Skip this test when running in the 'coverage' mode"""
     if "DTCOVERAGE" in os.environ:

--- a/tests/fread/test_fread_api.py
+++ b/tests/fread/test_fread_api.py
@@ -207,9 +207,10 @@ def test_fread_from_stringbuf():
     assert d0.to_list() == [[1, 4], [2, 5], [3, 6]]
 
 
-@pytest.mark.skipif(sys.platform == "win32", 
-                    reason="On Windows this test makes pytest to stop")
-def test_fread_from_fileobj(tempfile):
+# This test is temporarily disabled in Windows, 
+# because there it makes pytest to stop abruptly.
+def test_fread_from_fileobj(tempfile, nowin):
+
     with open(tempfile, "w") as f:
         f.write("A,B,C\nfoo,bar,baz\n")
 

--- a/tests/fread/test_fread_api.py
+++ b/tests/fread/test_fread_api.py
@@ -299,27 +299,24 @@ def test_fread_zip_file_1(tempfile, capsys):
 def test_fread_zip_file_multi(tempfile):
     import zipfile
     zfname = tempfile + ".zip"
+    fnames = ["data" + str(i) + ".csv" for i in range(3)]
+    full_fnames = [os.path.join(zfname, fnames[i]) for i in range(3)]
     with zipfile.ZipFile(zfname, "x", compression=zipfile.ZIP_DEFLATED) as zf:
-        zf.writestr("data1.csv", "a,b,c\nfoo,bar,baz\ngee,jou,sha\n")
-        zf.writestr("data2.csv", "A,B,C\n3,4,5\n6,7,8\n")
-        zf.writestr("data3.csv", "Aa,Bb,Cc\ntrue,1.5,\nfalse,1e+20,yay\n")
+        zf.writestr(fnames[0], "a,b,c\nfoo,bar,baz\ngee,jou,sha\n")
+        zf.writestr(fnames[1], "A,B,C\n3,4,5\n6,7,8\n")
+        zf.writestr(fnames[2], "Aa,Bb,Cc\ntrue,1.5,\nfalse,1e+20,yay\n")
     msg = r"fread\(\) input contains multiple sources, only the first " \
           r"will be used"
     with pytest.warns(IOWarning, match=msg):
         d0 = dt.fread(zfname)
-    full_fname0 = os.path.join(zfname, "data1.csv")
-    full_fname1 = os.path.join(zfname, "data2.csv")
-    full_fname2 = os.path.join(zfname, "data3.csv")
-    print(full_fname1)
-    d1 = dt.fread(full_fname1)
-    print(d1.source)
-    d2 = dt.fread(full_fname2)
+    d1 = dt.fread(full_fnames[1])
+    d2 = dt.fread(full_fnames[2])
     frame_integrity_check(d0)
     frame_integrity_check(d1)
     frame_integrity_check(d2)
-    assert d0.source == full_fname0
-    assert d1.source == full_fname1
-    assert d2.source == full_fname2
+    assert d0.source == full_fnames[0]
+    assert d1.source == full_fnames[1]
+    assert d2.source == full_fnames[2]
     assert d0.names == ("a", "b", "c")
     assert d1.names == ("A", "B", "C")
     assert d2.names == ("Aa", "Bb", "Cc")

--- a/tests/fread/test_fread_api.py
+++ b/tests/fread/test_fread_api.py
@@ -28,6 +28,7 @@
 import pytest
 import datatable as dt
 import os
+import sys
 from datatable import ltype, stype
 from datatable.exceptions import FreadWarning, DatatableWarning, IOWarning
 from datatable.internal import frame_integrity_check
@@ -206,16 +207,18 @@ def test_fread_from_stringbuf():
     assert d0.to_list() == [[1, 4], [2, 5], [3, 6]]
 
 
+@pytest.mark.skipif(sys.platform == "win32", 
+                    reason="On Windows this test makes pytest to stop")
 def test_fread_from_fileobj(tempfile):
     with open(tempfile, "w") as f:
         f.write("A,B,C\nfoo,bar,baz\n")
 
-    # with open(tempfile, "r") as f:
-    #     d0 = dt.fread(f)
-    #     frame_integrity_check(d0)
-    #     assert d0.source == tempfile
-    #     assert d0.names == ("A", "B", "C")
-    #     assert d0.to_list() == [["foo"], ["bar"], ["baz"]]
+    with open(tempfile, "r") as f:
+        d0 = dt.fread(f)
+        frame_integrity_check(d0)
+        assert d0.source == tempfile
+        assert d0.names == ("A", "B", "C")
+        assert d0.to_list() == [["foo"], ["bar"], ["baz"]]
 
 
 def test_fread_file_not_exists():

--- a/tests/fread/test_fread_api.py
+++ b/tests/fread/test_fread_api.py
@@ -96,12 +96,14 @@ def test_fread_from_url1():
 
 
 def test_fread_from_url2():
+    import pathlib
     root = os.path.join(os.path.dirname(__file__), "..", "..")
     path = os.path.abspath(os.path.join(root, "LICENSE"))
-    d0 = dt.fread("file://" + path, sep="\n")
+    url = pathlib.Path(path).as_uri()
+    d0 = dt.fread(url, sep="\n")
     frame_integrity_check(d0)
     assert d0.shape == (372, 1)
-    assert d0.source == "file://" + path
+    assert d0.source == url
 
 
 def test_fread_from_anysource_as_text1(capsys):
@@ -181,10 +183,11 @@ def test_fread_from_anysource_filelike():
 
 
 def test_fread_from_anysource_as_url(tempfile, capsys):
+    import pathlib
     assert isinstance(tempfile, str)
     with open(tempfile, "w") as o:
         o.write("A,B\n1,2\n")
-    url = "file://" + os.path.abspath(tempfile)
+    url = pathlib.Path(os.path.abspath(tempfile)).as_uri()
     d0 = dt.fread(url, verbose=True)
     out, err = capsys.readouterr()
     frame_integrity_check(d0)

--- a/tests/fread/test_fread_api.py
+++ b/tests/fread/test_fread_api.py
@@ -210,12 +210,12 @@ def test_fread_from_fileobj(tempfile):
     with open(tempfile, "w") as f:
         f.write("A,B,C\nfoo,bar,baz\n")
 
-    with open(tempfile, "r") as f:
-        d0 = dt.fread(f)
-        frame_integrity_check(d0)
-        assert d0.source == tempfile
-        assert d0.names == ("A", "B", "C")
-        assert d0.to_list() == [["foo"], ["bar"], ["baz"]]
+    # with open(tempfile, "r") as f:
+    #     d0 = dt.fread(f)
+    #     frame_integrity_check(d0)
+    #     assert d0.source == tempfile
+    #     assert d0.names == ("A", "B", "C")
+    #     assert d0.to_list() == [["foo"], ["bar"], ["baz"]]
 
 
 def test_fread_file_not_exists():
@@ -307,14 +307,19 @@ def test_fread_zip_file_multi(tempfile):
           r"will be used"
     with pytest.warns(IOWarning, match=msg):
         d0 = dt.fread(zfname)
-    d1 = dt.fread(zfname + "/data2.csv")
-    d2 = dt.fread(zfname + "/data3.csv")
+    full_fname0 = os.path.join(zfname, "data1.csv")
+    full_fname1 = os.path.join(zfname, "data2.csv")
+    full_fname2 = os.path.join(zfname, "data3.csv")
+    print(full_fname1)
+    d1 = dt.fread(full_fname1)
+    print(d1.source)
+    d2 = dt.fread(full_fname2)
     frame_integrity_check(d0)
     frame_integrity_check(d1)
     frame_integrity_check(d2)
-    assert d0.source == zfname + "/data1.csv"
-    assert d1.source == zfname + "/data2.csv"
-    assert d2.source == zfname + "/data3.csv"
+    assert d0.source == full_fname0
+    assert d1.source == full_fname1
+    assert d2.source == full_fname2
     assert d0.names == ("a", "b", "c")
     assert d1.names == ("A", "B", "C")
     assert d2.names == ("Aa", "Bb", "Cc")
@@ -342,7 +347,7 @@ def test_fread_zip_file_bad2(tempfile):
     with zipfile.ZipFile(zfname, "x") as zf:
         zf.writestr("data1.csv", "Egeustimentis")
     with pytest.raises(IOError) as e:
-        dt.fread(zfname + "/out.csv")
+        dt.fread(os.path.join(zfname, "out.csv"))
     assert "File out.csv does not exist in archive" in str(e.value)
     os.unlink(zfname)
 
@@ -479,7 +484,7 @@ def test_iread_tar_gz(tempfile):
             out.write("7\n8\n9\n")
         tf.add(tempfile, arcname='three')
     for i, DT in enumerate(dt.iread(outfile)):
-        assert DT.source == outfile + ["/one", "/two", "/three"][i]
+        assert DT.source == os.path.join(outfile, ["one", "two", "three"][i])
         assert DT.shape == (3, 1)
         assert DT.to_list()[0] == list(range(3*i + 1, 3*i + 4))
 

--- a/tests/fread/test_fread_api.py
+++ b/tests/fread/test_fread_api.py
@@ -223,7 +223,7 @@ def test_fread_file_not_exists():
     path = os.path.abspath(".")
     with pytest.raises(ValueError) as e:
         dt.fread(name)
-    assert ("File %s/%s does not exist" % (path, name)) in str(e.value)
+    assert ("File %s does not exist" % os.path.join(path, name)) in str(e.value)
 
 
 def test_fread_file_is_directory():

--- a/tests/fread/test_fread_api.py
+++ b/tests/fread/test_fread_api.py
@@ -187,7 +187,7 @@ def test_fread_from_anysource_as_url(tempfile, capsys):
     assert isinstance(tempfile, str)
     with open(tempfile, "w") as o:
         o.write("A,B\n1,2\n")
-    url = pathlib.Path(os.path.abspath(tempfile)).as_uri()
+    url = pathlib.Path(tempfile).as_uri()
     d0 = dt.fread(url, verbose=True)
     out, err = capsys.readouterr()
     frame_integrity_check(d0)

--- a/tests/models/test_aggregate.py
+++ b/tests/models/test_aggregate.py
@@ -478,7 +478,6 @@ def test_aggregate_2d_mixed_distinct_na():
     d_in = dt.Frame([["a", "b", "c", "d", "e", "f"], [None] * 6])
     d_in_copy = dt.Frame(d_in)
     d_exemplars, d_members = aggregate(d_in, min_rows=0, nx_bins = 3, ny_bins = 3)
-    print(d_exemplars, d_members)
     frame_integrity_check(d_members)
     frame_integrity_check(d_exemplars)
     assert_equals(

--- a/tests/test_jay.py
+++ b/tests/test_jay.py
@@ -74,6 +74,10 @@ def test_fread(tempfile_jay):
         assert f1.source == tempfile_jay
         assert f2.source == tempfile_joy
     finally:
+        # The file `tempfile_joy` is memory-mapped as the frame `f2`.
+        # So in order to delete `tempfile_joy` we first need to 
+        # delete `f2`. Otherwise (for instance, on Windows) we won't
+        # have permissions to delete this file.
         f2 = None
         os.remove(tempfile_joy)
 

--- a/tests/test_jay.py
+++ b/tests/test_jay.py
@@ -74,6 +74,7 @@ def test_fread(tempfile_jay):
         assert f1.source == tempfile_jay
         assert f2.source == tempfile_joy
     finally:
+        f2 = None
         os.remove(tempfile_joy)
 
 

--- a/tests/test_tocsv.py
+++ b/tests/test_tocsv.py
@@ -725,7 +725,7 @@ def test_bom4(tempfile):
 def test_bom5(tempfile):
     # When appending to a non-empty file, the BOM mark is not written
     assert os.path.exists(tempfile)
-    with open(tempfile, "w") as out:
+    with open(tempfile, "w", newline="\n") as out:
         out.write("# test file\n")
     DT = dt.Frame(B=[5,6,7])
     DT.to_csv(tempfile, append=True, bom=True)


### PR DESCRIPTION
Fix misc tests on Windows by
- using `os.path.join()` as much as possible in `fread` function and the relevant tests;
- using `pathlib` when creating local URL's;
- using `newline="\n"` when opening files in python;
- using a context manager when working with the zip files;
- deleting memory-mapped files only after the corresponding frames have been deleted.

Also, on Windows temporarily disable `test_fread_from_fileobj` test, that kills the entire pytest session when launched.

WIP for #2301 