### PR TITLE
Use platform specific tolerance in certain fread tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,9 @@ pull_requests:
 
 build_script:
 - cmd: >-
-    SET PATH=C:\Python37-x64;C:\Python37-x64\Scripts;%APPVEYOR_BUILD_FOLDER%\src;%PATH%
+    SET PATH=C:\Python37-x64;C:\Python37-x64\Scripts;%PATH%
+
+    SET PYTHONPATH=%APPVEYOR_BUILD_FOLDER%\src;%PYTHONPATH%
 
     pip install pytest
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,10 +10,8 @@ pull_requests:
 
 build_script:
 - cmd: >-
-    SET PATH=C:\Python37-x64;C:\Python37-x64\Scripts;%PATH%
+    SET PATH=C:\Python37-x64;C:\Python37-x64\Scripts;%APPVEYOR_BUILD_FOLDER%\src;%PATH%
 
+    pip install pytest
     python ci/ext.py build
-
-    cd src
-
-    pytest ../tests/
+    pytest .\tests\

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,10 +12,10 @@ build_script:
 - cmd: >-
     SET PATH=C:\Python37-x64;C:\Python37-x64\Scripts;%PATH%
 
+    python ci/ext.py build
+
     SET PYTHONPATH=%APPVEYOR_BUILD_FOLDER%\src;%PYTHONPATH%
 
-    pip install pytest
-
-    python ci/ext.py build
+    pip install pytest docutils pandas numpy
 
     pytest .\tests\

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ build_script:
 
     SET PYTHONPATH=%APPVEYOR_BUILD_FOLDER%\src;%PYTHONPATH%
 
-    pip install pytest docutils pandas
+    pip install pytest docutils
 
     python ci\ext.py build
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,5 +13,7 @@ build_script:
     SET PATH=C:\Python37-x64;C:\Python37-x64\Scripts;%APPVEYOR_BUILD_FOLDER%\src;%PATH%
 
     pip install pytest
+
     python ci/ext.py build
+
     pytest .\tests\

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,4 +16,4 @@ build_script:
 
     cd src
 
-    python -c "import datatable as dt; print(dt.__version__)"
+    pytest ../tests/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,10 +12,10 @@ build_script:
 - cmd: >-
     SET PATH=C:\Python37-x64;C:\Python37-x64\Scripts;%PATH%
 
-    python ci/ext.py build
-
     SET PYTHONPATH=%APPVEYOR_BUILD_FOLDER%\src;%PYTHONPATH%
 
-    pip install pytest docutils pandas numpy
+    pip install pytest docutils pandas
+
+    python ci\ext.py build
 
     pytest .\tests\

--- a/ci/Jenkinsfile.groovy
+++ b/ci/Jenkinsfile.groovy
@@ -72,7 +72,7 @@ versionText = "unknown"
 
 isMasterJob = (env.CHANGE_BRANCH == null || env.CHANGE_BRANCH == '')
 doExtraTests = (isMasterJob || params.FORCE_ALL_TESTS) && !params.DISABLE_ALL_TESTS
-doPpcTests = doExtraTests && !params.DISABLE_PPC64LE_TESTS
+doPpcTests = (doExtraTests || params.FORCE_BUILD_PPC64LE) && !params.DISABLE_PPC64LE_TESTS
 doPpcBuild = doPpcTests || isMasterJob || params.FORCE_BUILD_PPC64LE
 doPy38Tests = doExtraTests
 doCoverage = !params.DISABLE_COVERAGE && false   // disable for now

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -89,7 +89,7 @@ def list_equals(a, b, rel_tol = 1e-7, abs_tol = None):
     The primary difference from the built-in Python equality operator is that
     this function compares floats up to a relative tolerance of `rel_tol`
     and absolute tolerance of `abs_tol`. It also compares floating NaN as
-     equal to itself (in standard Python `nan != nan`).
+    equal to itself (in standard Python `nan != nan`).
     The purpose of this function is to compare datatables' python
     representations.
     """

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -104,7 +104,7 @@ def list_equals(a, b, rel_tol = 1e-7, abs_tol = None):
             return True
     if isinstance(a, list) and isinstance(b, list):
         return (len(a) == len(b) and
-                all(list_equals(a[i], b[i], rel_tol = rel_tol, abs_tol = abs_tol) 
+                all(list_equals(a[i], b[i], rel_tol = rel_tol, abs_tol = abs_tol)
                     for i in range(len(a))))
     return False
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -93,8 +93,11 @@ def list_equals(a, b, rel_tol = 1e-7, abs_tol = None):
     The purpose of this function is to compare datatables' python
     representations.
     """
+
+    # The default value of `abs_tol` is set to `rel_tol`
     if abs_tol is None:
         abs_tol = rel_tol
+
     if a == b:
         return True
     if isinstance(a, (int, float)) and isinstance(b, (int, float)):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -82,21 +82,26 @@ def same_iterables(a, b):
 
 
 
-def list_equals(a, b):
+def list_equals(a, b, rel_tol = 1e-7, abs_tol = None):
     """
     Helper functions that tests whether two lists `a` and `b` are equal.
 
     The primary difference from the built-in Python equality operator is that
-    this function compares floats up to a relative tolerance of 1e-6, and it
-    also compares floating NaN as equal to itself (in standard Python
-    `nan != nan`).
+    this function compares floats up to a relative tolerance of `rel_tol`
+    and absolute tolerance of `abs_tol`. It also compares floating NaN as
+     equal to itself (in standard Python `nan != nan`).
     The purpose of this function is to compare datatables' python
     representations.
     """
-    if a == b: return True
+    if abs_tol is None:
+        abs_tol = rel_tol
+    if a == b:
+        return True
     if isinstance(a, (int, float)) and isinstance(b, (int, float)):
-        if isnan(a) and isnan(b): return True
-        if abs(a - b) < 1e-6 * (abs(a) + abs(b) + 1): return True
+        if isnan(a) and isnan(b):
+            return True
+        if abs(a - b) < max(rel_tol * max(abs(a), abs(b)), abs_tol):
+            return True
     if isinstance(a, list) and isinstance(b, list):
         return (len(a) == len(b) and
                 all(list_equals(a[i], b[i]) for i in range(len(a))))

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -104,7 +104,8 @@ def list_equals(a, b, rel_tol = 1e-7, abs_tol = None):
             return True
     if isinstance(a, list) and isinstance(b, list):
         return (len(a) == len(b) and
-                all(list_equals(a[i], b[i]) for i in range(len(a))))
+                all(list_equals(a[i], b[i], rel_tol = rel_tol, abs_tol = abs_tol) 
+                    for i in range(len(a))))
     return False
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,6 +54,15 @@ def nowin():
         pytest.skip("Disabled on Windows")
 
 
+
+@pytest.fixture(scope="session")
+def tol():
+    # Tolerances for float comparisons on different OS's
+    tols = {"win32": 1e-14}
+
+    return tols.get(sys.platform, 0)
+
+
 @pytest.fixture(scope="session")
 def nocov():
     """Skip this test when running in the 'coverage' mode"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ import os
 import pytest
 import shutil
 import sys
+import platform
 import tempfile as mod_tempfile
 import warnings
 
@@ -30,42 +31,41 @@ def py36():
         pytest.skip("Python3.6+ is required")
 
 
+def is_ppc64():
+    """Helper function to determine ppc64 platform"""
+    platform_hardware = [platform.machine(), platform.processor()]
+    return platform.system() == "Linux" and "ppc64le" in platform_hardware
+
+
 @pytest.fixture(scope="session")
 def noppc64():
-    """
-    Skip the test if running in PowerPC64 or Python 3.5.
-
-    The reason we include Python3.6 requirement is because in Python 3.5 it
-    is not possible to determine whether the platform is PPC64 or not. Or at
-    least I don't know how... sys.platform is "linux", and
-    sys.implementation.cache_tag is "cpython-35".
-    """
-    if sys.version_info < (3, 6):
-        pytest.skip("Python3.6+ is required")
-    impl = str(sys.implementation)
-    if "powerpc64" in impl or "ppc64le" in impl:
+    """ Skip the test if running in PowerPC64 """
+    if is_ppc64():
         pytest.skip("Disabled on PowerPC64 platform")
 
 
 @pytest.fixture(scope="session")
 def nowin():
     """Skip this test when running on Windows"""
-    if sys.platform == "win32":
+    if platform.system() == "Windows":
         pytest.skip("Disabled on Windows")
-
 
 
 @pytest.fixture(scope="session")
 def tol():
     """
-    This fixture returns a tolerance to compare floats
-    on a particular operating system. The reason we sometimes use
-    OS specific tolerance is that some platforms don't have a proper
-    long double type, resulting in a loss of precision
-    when fread converts double literals into double numbers.
+    This fixture returns a tolerance to compare floats on a particular platform.
+    The reason we need this fixture are some platforms that don't have a proper
+    long double type, resulting in a loss of precision when fread converts
+    double literals into double numbers.
     """
-    tols = {"win32": 1e-15}
-    return tols.get(sys.platform, 0)
+    platform_system = platform.system()
+
+    if is_ppc64():
+        platform_system == "PowerPC64"
+
+    tols = {"Windows": 1e-15, "PowerPC64": 1e-16}
+    return tols.get(platform_system, 0)
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,9 +57,14 @@ def nowin():
 
 @pytest.fixture(scope="session")
 def tol():
-    # Tolerances for float comparisons on different OS's
+    """
+    This fixture returns a tolerance to compare floats
+    on a particular operating system. The reason we sometimes use
+    OS specific tolerance is that some platforms don't have a proper
+    long double type, resulting in a loss of precision
+    when fread converts double literals into double numbers.
+    """
     tols = {"win32": 1e-15}
-
     return tols.get(sys.platform, 0)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,7 +58,7 @@ def nowin():
 @pytest.fixture(scope="session")
 def tol():
     # Tolerances for float comparisons on different OS's
-    tols = {"win32": 1e-14}
+    tols = {"win32": 1e-15}
 
     return tols.get(sys.platform, 0)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,13 +59,10 @@ def tol():
     long double type, resulting in a loss of precision when fread converts
     double literals into double numbers.
     """
-    platform_system = platform.system()
+    platform_tols = {"Windows": 1e-15, "PowerPC64": 1e-16}
+    platform_system = "PowerPC64" if is_ppc64() else platform.system()
 
-    if is_ppc64():
-        platform_system == "PowerPC64"
-
-    tols = {"Windows": 1e-15, "PowerPC64": 1e-16}
-    return tols.get(platform_system, 0)
+    return platform_tols.get(platform_system, 0)
 
 
 @pytest.fixture(scope="session")

--- a/tests/fread/test_fread_issues.py
+++ b/tests/fread/test_fread_issues.py
@@ -12,7 +12,7 @@ import pytest
 import random
 import re
 from datatable.internal import frame_integrity_check
-from tests import find_file, same_iterables
+from tests import find_file, same_iterables, list_equals
 
 
 def test_issue1935():
@@ -34,7 +34,7 @@ def test_issue1935():
 
 #-------------------------------------------------------------------------------
 
-def test_issue_R1113():
+def test_issue_R1113(tol):
     # Based on #1113 in R, test 1555.1-11
     txt = ("ITER    THETA1    THETA2   MCMC\n"
            "        -11000 -2.50000E+00  2.30000E+00    345678.20255 \n"
@@ -45,10 +45,12 @@ def test_issue_R1113():
     assert d0.names == ("ITER", "THETA1", "THETA2", "MCMC")
     assert d0.ltypes == (dt.ltype.int, dt.ltype.real, dt.ltype.real,
                          dt.ltype.real)
-    assert d0.to_list() == [[-11000, -10999, -10998],
-                            [-2.5, -24.9853, 0.195957],
-                            [2.3, 379.270, 4.16522],
-                            [345678.20255, -195780.43911, 7937.13048]]
+    list_equals(d0.to_list(),
+                [[-11000, -10999, -10998],
+                [-2.5, -24.9853, 0.195957],
+                [2.3, 379.270, 4.16522],
+                [345678.20255, -195780.43911, 7937.13048]],
+                rel_tol = tol)
     # `strip_whitespace` has no effect when `sep == ' '`
     d1 = dt.fread(txt, strip_whitespace=False)
     frame_integrity_check(d1)

--- a/tests/fread/test_fread_issues.py
+++ b/tests/fread/test_fread_issues.py
@@ -45,12 +45,12 @@ def test_issue_R1113(tol):
     assert d0.names == ("ITER", "THETA1", "THETA2", "MCMC")
     assert d0.ltypes == (dt.ltype.int, dt.ltype.real, dt.ltype.real,
                          dt.ltype.real)
-    list_equals(d0.to_list(),
-                [[-11000, -10999, -10998],
-                [-2.5, -24.9853, 0.195957],
-                [2.3, 379.270, 4.16522],
-                [345678.20255, -195780.43911, 7937.13048]],
-                rel_tol = tol)
+    assert list_equals(d0.to_list(),
+                       [[-11000, -10999, -10998],
+                       [-2.5, -24.9853, 0.195957],
+                       [2.3, 379.270, 4.16522],
+                       [345678.20255, -195780.43911, 7937.13048]],
+                       rel_tol = tol)
     # `strip_whitespace` has no effect when `sep == ' '`
     d1 = dt.fread(txt, strip_whitespace=False)
     frame_integrity_check(d1)

--- a/tests/fread/test_fread_small.py
+++ b/tests/fread/test_fread_small.py
@@ -139,15 +139,12 @@ def test_float_hex_invalid():
     assert d0.to_list() == [[f] for f in fields]
 
 
-def test_float_decimal0(noppc64, tol):
-    # PPC64 platform doesn't have proper long doubles, which may cause loss of
-    # precision in the last digit when converting double literals into double
-    # values.
-    assert list_equals(dt.fread("1.3485701e-303\n").to_list(), 
-                       [[1.3485701e-303]], 
+def test_float_decimal0(tol):
+    assert list_equals(dt.fread("1.3485701e-303\n").to_list(),
+                       [[1.3485701e-303]],
                        rel_tol = tol)
-    assert list_equals(dt.fread("1.46761e-313\n").to_list(), 
-                       [[1.46761e-313]], 
+    assert list_equals(dt.fread("1.46761e-313\n").to_list(),
+                       [[1.46761e-313]],
                        rel_tol = tol)
     assert (dt.fread("A\n1.23456789123456789123456999\n")[0, 0] ==
             1.23456789123456789123456999)

--- a/tests/fread/test_fread_small.py
+++ b/tests/fread/test_fread_small.py
@@ -143,11 +143,15 @@ def test_float_decimal0(noppc64, tol):
     # PPC64 platform doesn't have proper long doubles, which may cause loss of
     # precision in the last digit when converting double literals into double
     # values.
-    assert dt.fread("1.3485701e-303\n")[0, 0] == 1.3485701e-303
-    assert dt.fread("1.46761e-313\n")[0, 0] == 1.46761e-313
-    list_equals(dt.fread("A\n1.23456789123456789123456999\n").to_list(),
-                [[1.23456789123456789123456999]],
-                rel_tol = tol)
+    assert list_equals(dt.fread("1.3485701e-303\n").to_list(), 
+                       [[1.3485701e-303]], 
+                       rel_tol = tol)
+    assert list_equals(dt.fread("1.46761e-313\n").to_list(), 
+                       [[1.46761e-313]], 
+                       rel_tol = tol)
+    assert (dt.fread("A\n1.23456789123456789123456999\n")[0, 0] ==
+            1.23456789123456789123456999)
+
 
 
 def test_float_precision():
@@ -258,9 +262,9 @@ def test_int_even_longer(tol):
     text = "A,B,C,D\n%s,%s,1.%s,%s.99" % (src1, src2, src2, src2)
     d0 = dt.fread(text)
     frame_integrity_check(d0)
-    list_equals(d0.to_list(),
-                [[src1], [src2], [float("1." + src2)], [float(src2)]],
-                rel_tol = tol)
+    assert list_equals(d0.to_list(),
+                       [[src1], [src2], [float("1." + src2)], [float(src2)]],
+                       rel_tol = tol)
 
 
 def test_int_with_thousand_sep():
@@ -519,7 +523,7 @@ def test_fread1(tol):
                  "100.3")
     assert f.shape == (3, 1)
     assert f.names == ("hello", )
-    list_equals(f.to_list(), [[1.1, 200000.0, 100.3]], rel_tol = tol)
+    assert list_equals(f.to_list(), [[1.1, 200000.0, 100.3]], rel_tol = tol)
 
 
 def test_fread2():
@@ -616,7 +620,7 @@ def test_utf16(tempfile, tol):
         d0 = dt.fread(tempfile)
         frame_integrity_check(d0)
         assert d0.names == names
-        list_equals(d0.to_list(), [col1, col2, col3], rel_tol = tol)
+        assert list_equals(d0.to_list(), [col1, col2, col3], rel_tol = tol)
 
 
 def test_fread_CtrlZ():
@@ -633,7 +637,7 @@ def test_fread_NUL(tol):
     d0 = dt.fread(text=b"A,B\n2.3,5\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")
     frame_integrity_check(d0)
     assert d0.ltypes == (dt.ltype.real, dt.ltype.int)
-    list_equals(d0.to_list(), [[2.3], [5]], rel_tol = tol)
+    assert list_equals(d0.to_list(), [[2.3], [5]], rel_tol = tol)
 
 
 def test_fread_1col_a():
@@ -805,9 +809,9 @@ def test_whitespace_nas(tol):
     frame_integrity_check(d0)
     assert d0.names == ("A", "B", "C")
     assert d0.ltypes == (dt.ltype.real,) * 3
-    list_equals(d0.to_list(),
-                [[17, 3, None, 0], [34, None, 2, 0.1], [2.3, 1, None, 0]],
-                rel_tol = tol)
+    assert list_equals(d0.to_list(),
+                       [[17, 3, None, 0], [34, None, 2, 0.1], [2.3, 1, None, 0]],
+                       rel_tol = tol)
 
 
 def test_quoted_na_strings():

--- a/tests/fread/test_fread_small.py
+++ b/tests/fread/test_fread_small.py
@@ -139,14 +139,15 @@ def test_float_hex_invalid():
     assert d0.to_list() == [[f] for f in fields]
 
 
-def test_float_decimal0(noppc64):
+def test_float_decimal0(noppc64, tol):
     # PPC64 platform doesn't have proper long doubles, which may cause loss of
     # precision in the last digit when converting double literals into double
     # values.
     assert dt.fread("1.3485701e-303\n")[0, 0] == 1.3485701e-303
     assert dt.fread("1.46761e-313\n")[0, 0] == 1.46761e-313
-    assert (dt.fread("A\n1.23456789123456789123456999\n")[0, 0] ==
-            1.23456789123456789123456999)
+    list_equals(dt.fread("A\n1.23456789123456789123456999\n").to_list(),
+                [[1.23456789123456789123456999]],
+                rel_tol = tol)
 
 
 def test_float_precision():
@@ -246,7 +247,7 @@ def test_int_toolong3():
     assert d0.to_list() == [[2], ["384325987234905827340958734572934"]]
 
 
-def test_int_even_longer():
+def test_int_even_longer(tol):
     # Test that integers just above 128 or 256 characters in length parse as
     # strings, not as integers/floats (if the character counter is byte, then
     # it would overflow and fail to recognize that the integer is very long).
@@ -257,9 +258,9 @@ def test_int_even_longer():
     text = "A,B,C,D\n%s,%s,1.%s,%s.99" % (src1, src2, src2, src2)
     d0 = dt.fread(text)
     frame_integrity_check(d0)
-    assert d0.to_list() == [[src1], [src2],
-                            [float("1." + src2)],
-                            [float(src2)]]
+    list_equals(d0.to_list(),
+                [[src1], [src2], [float("1." + src2)], [float(src2)]],
+                rel_tol = tol)
 
 
 def test_int_with_thousand_sep():
@@ -511,14 +512,14 @@ def test_input_htmlfile():
 # Small files
 #-------------------------------------------------------------------------------
 
-def test_fread1():
+def test_fread1(tol):
     f = dt.fread("hello\n"
                  "1.1\n"
                  "200000\n"
                  "100.3")
     assert f.shape == (3, 1)
     assert f.names == ("hello", )
-    assert f.to_list() == [[1.1, 200000.0, 100.3]]
+    list_equals(f.to_list(), [[1.1, 200000.0, 100.3]], rel_tol = tol)
 
 
 def test_fread2():
@@ -599,7 +600,7 @@ def test_space_separated_numbers():
                          ltype.bool)
 
 
-def test_utf16(tempfile):
+def test_utf16(tempfile, tol):
     names = ("alpha", "beta", "gamma")
     col1 = [1.5, 12.999, -4e-6, 2.718281828]
     col2 = ["я", "не", "нездужаю", "нівроку"]
@@ -615,7 +616,7 @@ def test_utf16(tempfile):
         d0 = dt.fread(tempfile)
         frame_integrity_check(d0)
         assert d0.names == names
-        assert d0.to_list() == [col1, col2, col3]
+        list_equals(d0.to_list(), [col1, col2, col3], rel_tol = tol)
 
 
 def test_fread_CtrlZ():
@@ -627,12 +628,12 @@ def test_fread_CtrlZ():
     assert d0.to_list() == [[-1], [2], [3]]
 
 
-def test_fread_NUL():
+def test_fread_NUL(tol):
     """Check that NUL characters at the end of the file are removed"""
     d0 = dt.fread(text=b"A,B\n2.3,5\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")
     frame_integrity_check(d0)
     assert d0.ltypes == (dt.ltype.real, dt.ltype.int)
-    assert d0.to_list() == [[2.3], [5]]
+    list_equals(d0.to_list(), [[2.3], [5]], rel_tol = tol)
 
 
 def test_fread_1col_a():
@@ -795,7 +796,7 @@ def test_unescaping1():
                              "\r\t\v\a\b\071\uABCD"]]
 
 
-def test_whitespace_nas():
+def test_whitespace_nas(tol):
     d0 = dt.fread('A,   B,    C\n'
                   '17,  34, 2.3\n'
                   '3.,  NA,   1\n'
@@ -804,9 +805,9 @@ def test_whitespace_nas():
     frame_integrity_check(d0)
     assert d0.names == ("A", "B", "C")
     assert d0.ltypes == (dt.ltype.real,) * 3
-    assert d0.to_list() == [[17, 3, None, 0],
-                            [34, None, 2, 0.1],
-                            [2.3, 1, None, 0]]
+    list_equals(d0.to_list(),
+                [[17, 3, None, 0], [34, None, 2, 0.1], [2.3, 1, None, 0]],
+                rel_tol = tol)
 
 
 def test_quoted_na_strings():

--- a/tests/test_tocsv.py
+++ b/tests/test_tocsv.py
@@ -187,7 +187,8 @@ def test_save_double(tol):
     dd = dt.fread(text=d.to_csv())
     assert list_equals(d.to_list(), dd.to_list(), rel_tol = tol)
     # .split() in order to produce better error messages
-    assert d.to_csv(hex=True).split("\n") == dd.to_csv(hex=True).split("\n")
+    if tol == 0:
+        assert d.to_csv(hex=True).split("\n") == dd.to_csv(hex=True).split("\n")
 
 
 def test_save_double2(tol):
@@ -198,7 +199,8 @@ def test_save_double2(tol):
            ["1.0e+%02d" % i for i in range(15, 308)])
     d = dt.Frame(src)
     assert d.stypes == (stype.float64, )
-    assert d.to_csv().split("\n")[1:-1] == res
+    if tol == 0:
+        assert d.to_csv().split("\n")[1:-1] == res
 
 
 def test_save_round_doubles():

--- a/tests/test_tocsv.py
+++ b/tests/test_tocsv.py
@@ -29,7 +29,7 @@ import re
 import pytest
 from datatable import stype
 from datatable.internal import frame_integrity_check
-from tests import assert_equals
+from tests import assert_equals, list_equals
 
 
 def pyhex(v):
@@ -177,7 +177,7 @@ def test_save_int64():
     assert d.to_csv() == "C0\n" + res + "\n"
 
 
-def test_save_double():
+def test_save_double(tol):
     src = ([0.0, -0.0, 1.5, 0.0034876143, 10.3074, 83476101.13487,
             # 7.0785040837745274,
             # 23.898342808714432,
@@ -185,12 +185,12 @@ def test_save_double():
            [10**p for p in range(320) if p != 126])
     d = dt.Frame(src)
     dd = dt.fread(text=d.to_csv())
-    assert d.to_list()[0] == dd.to_list()[0]
+    list_equals(d.to_list(), dd.to_list(), rel_tol = tol)
     # .split() in order to produce better error messages
     assert d.to_csv(hex=True).split("\n") == dd.to_csv(hex=True).split("\n")
 
 
-def test_save_double2():
+def test_save_double2(tol):
     src = [10**i for i in range(-307, 308)]
     res = (["1.0e%02d" % i for i in range(-307, -4)] +
            ["0.0001", "0.001", "0.01", "0.1"] +
@@ -198,7 +198,7 @@ def test_save_double2():
            ["1.0e+%02d" % i for i in range(15, 308)])
     d = dt.Frame(src)
     assert d.stypes == (stype.float64, )
-    assert d.to_csv().split("\n")[1:-1] == res
+    list_equals(d.to_csv().split("\n")[1:-1], res, rel_tol = tol)
 
 
 def test_save_round_doubles():

--- a/tests/test_tocsv.py
+++ b/tests/test_tocsv.py
@@ -185,7 +185,7 @@ def test_save_double(tol):
            [10**p for p in range(320) if p != 126])
     d = dt.Frame(src)
     dd = dt.fread(text=d.to_csv())
-    list_equals(d.to_list(), dd.to_list(), rel_tol = tol)
+    assert list_equals(d.to_list(), dd.to_list(), rel_tol = tol)
     # .split() in order to produce better error messages
     assert d.to_csv(hex=True).split("\n") == dd.to_csv(hex=True).split("\n")
 
@@ -198,7 +198,7 @@ def test_save_double2(tol):
            ["1.0e+%02d" % i for i in range(15, 308)])
     d = dt.Frame(src)
     assert d.stypes == (stype.float64, )
-    list_equals(d.to_csv().split("\n")[1:-1], res, rel_tol = tol)
+    assert d.to_csv().split("\n")[1:-1] == res
 
 
 def test_save_round_doubles():


### PR DESCRIPTION
Not all the platforms have a proper long double type that is used by fread to convert double literals into double numbers. In this PR we make use of platform specific tolerances for Windows and PowerPC64 that allow certain fread tests to not fail. 

Also, set up AppVeyor config file to launch tests for every Windows build.

WIP for #2301 