### PR TITLE
Disable freading from file-like objects on Windows

### DIFF
--- a/src/core/csv/reader.cc
+++ b/src/core/csv/reader.cc
@@ -645,6 +645,11 @@ void GenericReader::open_input() {
   CString text;
   const char* filename = nullptr;
   if (fileno > 0) {
+    #if DT_OS_WINDOWS
+      throw NotImplError() << "Reading from file-like objects, that involves "
+        << "file descriptors, is not supported on Windows";
+    #endif
+
     const char* src = src_arg.to_cstring().ch;
     input_mbuf = Buffer::mmap(src, 0, fileno, false);
     size_t sz = input_mbuf.size();

--- a/src/core/csv/reader.cc
+++ b/src/core/csv/reader.cc
@@ -645,6 +645,11 @@ void GenericReader::open_input() {
   CString text;
   const char* filename = nullptr;
   if (fileno > 0) {
+    #if DT_OS_WINDOWS
+      throw NotImplError() << "Reading from a file descriptor is not supported "
+                           << "on Windows";
+    #endif
+
     const char* src = src_arg.to_cstring().ch;
     input_mbuf = Buffer::mmap(src, 0, fileno, false);
     size_t sz = input_mbuf.size();

--- a/src/core/csv/reader.cc
+++ b/src/core/csv/reader.cc
@@ -645,11 +645,6 @@ void GenericReader::open_input() {
   CString text;
   const char* filename = nullptr;
   if (fileno > 0) {
-    #if DT_OS_WINDOWS
-      throw NotImplError() << "Reading from a file descriptor is not supported "
-                           << "on Windows";
-    #endif
-
     const char* src = src_arg.to_cstring().ch;
     input_mbuf = Buffer::mmap(src, 0, fileno, false);
     size_t sz = input_mbuf.size();

--- a/src/datatable/utils/fread.py
+++ b/src/datatable/utils/fread.py
@@ -150,10 +150,6 @@ def _resolve_source_file(file, tempfiles):
         file = file.expanduser()
         file = str(file)
     elif hasattr(file, "read") and callable(file.read):
-        import platform
-        # if platform.system() == "Windows":
-        #     raise NotImplementedError("Reading from file-like objects is not "
-        #                               "supported on Windows") 
         out_src = None
         out_fileno = None
         out_text = None

--- a/src/datatable/utils/fread.py
+++ b/src/datatable/utils/fread.py
@@ -150,6 +150,10 @@ def _resolve_source_file(file, tempfiles):
         file = file.expanduser()
         file = str(file)
     elif hasattr(file, "read") and callable(file.read):
+        import platform
+        if platform.system() == "Windows":
+            raise NotImplementedError("Reading from a file object is not "
+                                      "supported on Windows") 
         out_src = None
         out_fileno = None
         out_text = None

--- a/src/datatable/utils/fread.py
+++ b/src/datatable/utils/fread.py
@@ -152,7 +152,7 @@ def _resolve_source_file(file, tempfiles):
     elif hasattr(file, "read") and callable(file.read):
         import platform
         if platform.system() == "Windows":
-            raise NotImplementedError("Reading from a file object is not "
+            raise NotImplementedError("Reading from file-like objects is not "
                                       "supported on Windows") 
         out_src = None
         out_fileno = None

--- a/src/datatable/utils/fread.py
+++ b/src/datatable/utils/fread.py
@@ -151,9 +151,9 @@ def _resolve_source_file(file, tempfiles):
         file = str(file)
     elif hasattr(file, "read") and callable(file.read):
         import platform
-        if platform.system() == "Windows":
-            raise NotImplementedError("Reading from file-like objects is not "
-                                      "supported on Windows") 
+        # if platform.system() == "Windows":
+        #     raise NotImplementedError("Reading from file-like objects is not "
+        #                               "supported on Windows") 
         out_src = None
         out_fileno = None
         out_text = None

--- a/tests/fread/test_fread_api.py
+++ b/tests/fread/test_fread_api.py
@@ -213,14 +213,13 @@ def test_fread_from_fileobj(tempfile):
     with open(tempfile, "w") as f:
         f.write("A,B,C\nfoo,bar,baz\n")
 
-    if platform.system() == "Windows":
-        with open(tempfile, "r") as f, \
-             pytest.raises(NotImplementedError, match="Reading from "
-                "file-like objects, that involves file descriptors, "
-                "is not supported on Windows"):
-            d0 = dt.fread(f)
-    else:
-        with open(tempfile, "r") as f:
+    with open(tempfile, "r") as f:
+        if platform.system() == "Windows":
+            msg = "Reading from file-like objects, that involves " \
+                  "file descriptors, is not supported on Windows"
+            with pytest.raises(NotImplementedError, match=msg):
+                d0 = dt.fread(f)
+        else:
             d0 = dt.fread(f)
             frame_integrity_check(d0)
             assert d0.source == tempfile

--- a/tests/fread/test_fread_api.py
+++ b/tests/fread/test_fread_api.py
@@ -28,7 +28,6 @@
 import pytest
 import datatable as dt
 import os
-import platform
 import sys
 from datatable import ltype, stype
 from datatable.exceptions import FreadWarning, DatatableWarning, IOWarning
@@ -177,15 +176,11 @@ def test_fread_from_anysource_filelike():
         def read(self):
             return "A,B,C\na,b,c\n"
 
-    if platform.system() == "Windows":
-        with pytest.raises(NotImplementedError, match="Reading from "
-            "file-like objects is not supported on Windows"):
-            d0 = dt.fread(MyFile())
-    else:
-        frame_integrity_check(d0)
-        assert d0.source == "fake file"
-        assert d0.names == ("A", "B", "C")
-        assert d0.to_list() == [["a"], ["b"], ["c"]]
+    d0 = dt.fread(MyFile())
+    frame_integrity_check(d0)
+    assert d0.source == "fake file"
+    assert d0.names == ("A", "B", "C")
+    assert d0.to_list() == [["a"], ["b"], ["c"]]
 
 
 def test_fread_from_anysource_as_url(tempfile, capsys):
@@ -205,26 +200,24 @@ def test_fread_from_anysource_as_url(tempfile, capsys):
 def test_fread_from_stringbuf():
     from io import StringIO
     s = StringIO("A,B,C\n1,2,3\n4,5,6")
-    if platform.system() == "Windows":
-        with pytest.raises(NotImplementedError, match="Reading from "
-                "file-like objects is not supported on Windows"):
-            d0 = dt.fread(s)
-    else:
-        d0 = dt.fread(s)
-        frame_integrity_check(d0)
-        assert d0.source == "<file>"
-        assert d0.names == ("A", "B", "C")
-        assert d0.to_list() == [[1, 4], [2, 5], [3, 6]]
+    d0 = dt.fread(s)
+    frame_integrity_check(d0)
+    assert d0.source == "<file>"
+    assert d0.names == ("A", "B", "C")
+    assert d0.to_list() == [[1, 4], [2, 5], [3, 6]]
 
 
 def test_fread_from_fileobj(tempfile):
+    import platform
+
     with open(tempfile, "w") as f:
         f.write("A,B,C\nfoo,bar,baz\n")
 
     if platform.system() == "Windows":
         with open(tempfile, "r") as f, \
              pytest.raises(NotImplementedError, match="Reading from "
-                "file-like objects is not supported on Windows"):
+                "file-like objects, that involves file descriptors, "
+                "is not supported on Windows"):
             d0 = dt.fread(f)
     else:
         with open(tempfile, "r") as f:

--- a/tests/fread/test_fread_api.py
+++ b/tests/fread/test_fread_api.py
@@ -213,16 +213,17 @@ def test_fread_from_fileobj(tempfile):
         f.write("A,B,C\nfoo,bar,baz\n")
 
     if platform.system() == "Windows":
-        with pytest.raises(NotImplError, match="Reading from a file descriptor "
-                                               "is not supported on Windows"):
+        with open(tempfile, "r") as f, \
+             pytest.raises(NotImplementedError, match="Reading from a file "
+                "object is not supported on Windows"):
             d0 = dt.fread(f)
-
-    with open(tempfile, "r") as f:
-        d0 = dt.fread(f)
-        frame_integrity_check(d0)
-        assert d0.source == tempfile
-        assert d0.names == ("A", "B", "C")
-        assert d0.to_list() == [["foo"], ["bar"], ["baz"]]
+    else:
+        with open(tempfile, "r") as f:
+            d0 = dt.fread(f)
+            frame_integrity_check(d0)
+            assert d0.source == tempfile
+            assert d0.names == ("A", "B", "C")
+            assert d0.to_list() == [["foo"], ["bar"], ["baz"]]
 
 
 def test_fread_file_not_exists():

--- a/tests/fread/test_fread_api.py
+++ b/tests/fread/test_fread_api.py
@@ -207,12 +207,15 @@ def test_fread_from_stringbuf():
     assert d0.to_list() == [[1, 4], [2, 5], [3, 6]]
 
 
-# This test is temporarily disabled in Windows, 
-# because there it makes pytest to stop abruptly.
-def test_fread_from_fileobj(tempfile, nowin):
-
+def test_fread_from_fileobj(tempfile):
+    import platform
     with open(tempfile, "w") as f:
         f.write("A,B,C\nfoo,bar,baz\n")
+
+    if platform.system() == "Windows":
+        with pytest.raises(NotImplError, match="Reading from a file descriptor "
+                                               "is not supported on Windows"):
+            d0 = dt.fread(f)
 
     with open(tempfile, "r") as f:
         d0 = dt.fread(f)


### PR DESCRIPTION
Right now to read data from a file object, datatable needs a file descriptor to be used on the C++ side. Since file descriptors are not native to all the platforms, this functionality doesn't work on Windows. Some workarounds are possible, however, since this feature is not so widely used, in this PR we temporarily disable it on Windows and throw `NotImplementedError` instead.

Closes #2301 