### PR TITLE
Fix warnings issued by msvc for libs, pragmas and some casts

### DIFF
--- a/ci/ext.py
+++ b/ci/ext.py
@@ -285,7 +285,7 @@ def build_extension(cmd, verbosity=3):
             ext.compiler.add_compiler_flag("-g3")
             ext.compiler.add_compiler_flag("-glldb" if macos else "-ggdb")
             ext.compiler.add_compiler_flag("-O0")
-            ext.compiler.add_compiler_flag("-DDTTEST", "-DDTDEBUG")
+            ext.compiler.add_compiler_flag("-DDTTEST", "-DDT_DEBUG")
             ext.compiler.add_linker_flag("-fsanitize=address", "-shared-libasan")
 
         if cmd == "build":
@@ -296,7 +296,7 @@ def build_extension(cmd, verbosity=3):
             ext.compiler.add_compiler_flag("-g2")
             ext.compiler.add_compiler_flag("-O0")
             ext.compiler.add_compiler_flag("--coverage")
-            ext.compiler.add_compiler_flag("-DDTTEST", "-DDTDEBUG")
+            ext.compiler.add_compiler_flag("-DDTTEST", "-DDT_DEBUG")
             ext.compiler.add_linker_flag("-O0")
             ext.compiler.add_linker_flag("--coverage")
 
@@ -304,7 +304,7 @@ def build_extension(cmd, verbosity=3):
             ext.compiler.add_compiler_flag("-g3")
             ext.compiler.add_compiler_flag("-glldb" if macos else "-ggdb")
             ext.compiler.add_compiler_flag("-O0")  # no optimization
-            ext.compiler.add_compiler_flag("-DDTTEST", "-DDTDEBUG")
+            ext.compiler.add_compiler_flag("-DDTTEST", "-DDT_DEBUG")
             if ext.compiler.flavor == "clang":
                 ext.compiler.add_compiler_flag("-fdebug-macro")
 

--- a/ci/ext.py
+++ b/ci/ext.py
@@ -214,8 +214,7 @@ def build_extension(cmd, verbosity=3):
     ext.compiler.add_default_python_include_dir()
 
     if ext.compiler.is_msvc():
-        # Common compile flags
-        ext.compiler.add_compiler_flag("/W4")
+        # General compiler flags
         ext.compiler.add_compiler_flag("/EHsc")
         ext.compiler.add_compiler_flag("/nologo")
         ext.compiler.add_include_dir(ext.compiler.path + "\\include")
@@ -223,7 +222,22 @@ def build_extension(cmd, verbosity=3):
         ext.compiler.add_include_dir(ext.compiler.winsdk_include_path + "\\shared")
         ext.compiler.add_include_dir(ext.compiler.winsdk_include_path + "\\um")
 
-        # Common link flags
+        # Compiler warnings
+        ext.compiler.add_compiler_flag(
+            "/W4",
+            # Disable C4996 warning ("This function or variable may be unsafe")
+            # issued by MSVC for a fully valid and portable code
+            "/wd4996",
+            # Disable C4127 warning ("consider using 'if constexpr' statement instead")
+            # as 'if constexpr' is not available in C++11
+            "/wd4127",
+            # Disable C4661 warning ("no suitable definition provided for
+            # explicit template instantiation request") as we really need
+            # to keep some template method definitions in separate translation units
+            "/wd4661",
+        )
+
+        # Link flags
         ext.compiler.add_linker_flag("/nologo")
         ext.compiler.add_linker_flag("/DLL")
         ext.compiler.add_linker_flag("/EXPORT:PyInit__datatable")

--- a/src/core/buffer.h
+++ b/src/core/buffer.h
@@ -259,7 +259,7 @@ class Buffer
 // Template definitions
 //------------------------------------------------------------------------------
 
-#if DTDEBUG
+#if DT_DEBUG
   inline void buffer_oob_check(size_t i, size_t size, size_t elemsize) {
     if ((i + 1) * elemsize > size) {
       throw ValueError() << "Index " << i << " is out of bounds for a buffer "

--- a/src/core/csv/reader.cc
+++ b/src/core/csv/reader.cc
@@ -705,10 +705,17 @@ void GenericReader::open_buffer(const Buffer& buf, size_t extra_byte) {
   line = 1;
   sof = static_cast<const char*>(input_mbuf.rptr());
   eof = sof + input_mbuf.size() - extra_byte;
-  if (eof) {
-    (void) eof;
-    xassert(*eof == '\0');
-  }
+
+  #if DT_OS_WINDOWS && !DT_DEBUG
+    #pragma warning(push)
+    #pragma warning(disable : 4390) // empty controlled statement found
+  #endif
+
+  if (eof) xassert(*eof == '\0');
+
+  #if DT_OS_WINDOWS && !DT_DEBUG
+    #pragma warning(pop)
+  #endif
 }
 
 

--- a/src/core/csv/reader.cc
+++ b/src/core/csv/reader.cc
@@ -505,10 +505,14 @@ void GenericReader::_message(
     msg = va_arg(args, char*);
   } else {
     msg = shared_buffer;
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wformat-nonliteral"
+    #if defined(__GNUC__)
+      #pragma GCC diagnostic push
+      #pragma GCC diagnostic ignored "-Wformat-nonliteral"
+    #endif
     vsnprintf(msg, 2000, format, args);
-    #pragma GCC diagnostic pop
+    #if defined(__GNUC__)
+      #pragma GCC diagnostic pop
+    #endif
   }
 
   if (dt::num_threads_in_team() == 0) {
@@ -655,7 +659,7 @@ void GenericReader::open_input() {
     input_mbuf = Buffer::external(text.ch, size + 1);
     input_is_string = true;
 
-  } else if ((filename = file_arg.to_cstring().ch)) {
+  } else if ((filename = file_arg.to_cstring().ch) != 0) {
     input_mbuf = Buffer::mmap(filename);
     size_t sz = input_mbuf.size();
     trace("File \"%s\" opened, size: %zu", filename, sz);
@@ -701,7 +705,10 @@ void GenericReader::open_buffer(const Buffer& buf, size_t extra_byte) {
   line = 1;
   sof = static_cast<const char*>(input_mbuf.rptr());
   eof = sof + input_mbuf.size() - extra_byte;
-  if (eof) xassert(*eof == '\0');
+  if (eof) {
+    (void) eof;
+    xassert(*eof == '\0');
+  }
 }
 
 

--- a/src/core/csv/reader.cc
+++ b/src/core/csv/reader.cc
@@ -659,7 +659,7 @@ void GenericReader::open_input() {
     input_mbuf = Buffer::external(text.ch, size + 1);
     input_is_string = true;
 
-  } else if ((filename = file_arg.to_cstring().ch) != 0) {
+  } else if ((filename = file_arg.to_cstring().ch) != nullptr) {
     input_mbuf = Buffer::mmap(filename);
     size_t sz = input_mbuf.size();
     trace("File \"%s\" opened, size: %zu", filename, sz);

--- a/src/core/csv/reader.cc
+++ b/src/core/csv/reader.cc
@@ -505,12 +505,12 @@ void GenericReader::_message(
     msg = va_arg(args, char*);
   } else {
     msg = shared_buffer;
-    #if defined(__GNUC__)
+    #if DT_COMPILER_GCC
       #pragma GCC diagnostic push
       #pragma GCC diagnostic ignored "-Wformat-nonliteral"
     #endif
     vsnprintf(msg, 2000, format, args);
-    #if defined(__GNUC__)
+    #if DT_COMPILER_GCC
       #pragma GCC diagnostic pop
     #endif
   }

--- a/src/core/csv/reader_parsers.cc
+++ b/src/core/csv/reader_parsers.cc
@@ -10,7 +10,6 @@
 #include "read/fread/fread_tokenizer.h"  // FreadTokenizer
 #include "read/constants.h"              // hexdigits, pow10lookup
 #include "utils/assert.h"                // xassert
-#include "utils/macros.h"                
 
 static constexpr int8_t   NA_BOOL8 = -128;
 static constexpr int32_t  NA_INT32 = INT32_MIN;

--- a/src/core/csv/reader_parsers.cc
+++ b/src/core/csv/reader_parsers.cc
@@ -147,8 +147,8 @@ void parse_int_simple(FreadTokenizer& ctx) {
       (sd == MAX_DIGITS && value <= MAX_VALUE))
   {
     T x = static_cast<T>(value);
-    *reinterpret_cast<T*>(ctx.target) = (x ^ -static_cast<int>(negative))
-                                        + negative;
+    T neg = static_cast<T>(negative);
+    *reinterpret_cast<T*>(ctx.target) = (x ^ -neg) + neg; // same as neg? -x : x
     ctx.ch = ch;
   } else {
     *reinterpret_cast<T*>(ctx.target) = NA_VALUE;

--- a/src/core/csv/reader_parsers.cc
+++ b/src/core/csv/reader_parsers.cc
@@ -285,7 +285,7 @@ void parse_float32_hex(FreadTokenizer& ctx) {
       else if (E == 126 && Eneg && acc) /* subnormal */ E = 0;
       else goto fail;
     } else {
-      E = 127 + (E ^ -static_cast<uint32_t>(Eneg)) + Eneg;
+      E = 127 + (E ^ -static_cast<int>(Eneg)) + Eneg;
       if (E < 1 || E > 254) goto fail;
     }
     ctx.target->uint32 = (neg << 31) | (E << 23) | (acc);
@@ -576,7 +576,7 @@ void parse_float64_hex(FreadTokenizer& ctx) {
       else if (E == 1022 && Eneg && acc) /* subnormal */ E = 0;
       else goto fail;
     } else {
-      E = 1023 + (E ^ -static_cast<uint64_t>(Eneg)) + Eneg;
+      E = 1023 + (E ^ -static_cast<int>(Eneg)) + Eneg;
       if (E < 1 || E > 2046) goto fail;
     }
     ctx.target->uint64 = (neg << 63) | (E << 52) | (acc);

--- a/src/core/csv/reader_parsers.cc
+++ b/src/core/csv/reader_parsers.cc
@@ -10,7 +10,7 @@
 #include "read/fread/fread_tokenizer.h"  // FreadTokenizer
 #include "read/constants.h"              // hexdigits, pow10lookup
 #include "utils/assert.h"                // xassert
-#include "utils/macros.h"                // xassert
+#include "utils/macros.h"                
 
 static constexpr int8_t   NA_BOOL8 = -128;
 static constexpr int32_t  NA_INT32 = INT32_MIN;

--- a/src/core/csv/reader_parsers.cc
+++ b/src/core/csv/reader_parsers.cc
@@ -284,7 +284,7 @@ void parse_float32_hex(FreadTokenizer& ctx) {
       else if (E == 126 && Eneg && acc) /* subnormal */ E = 0;
       else goto fail;
     } else {
-      E = 127 + (E ^ static_cast<uint32_t>(-static_cast<int>(Eneg))) + Eneg;
+      E = 127 + (Eneg? -E : E);
       if (E < 1 || E > 254) goto fail;
     }
     ctx.target->uint32 = (neg << 31) | (E << 23) | (acc);
@@ -575,7 +575,7 @@ void parse_float64_hex(FreadTokenizer& ctx) {
       else if (E == 1022 && Eneg && acc) /* subnormal */ E = 0;
       else goto fail;
     } else {
-      E = 1023 + (E ^ static_cast<uint64_t>(-static_cast<int>(Eneg))) + Eneg;
+      E = 1023 + (Eneg? -E : E);
       if (E < 1 || E > 2046) goto fail;
     }
     ctx.target->uint64 = (neg << 63) | (E << 52) | (acc);

--- a/src/core/csv/reader_parsers.cc
+++ b/src/core/csv/reader_parsers.cc
@@ -222,7 +222,7 @@ void parse_intNN_grouped(FreadTokenizer& ctx) {
                                             static_cast<int32_t>(acc); 
               break;
       case 8: ctx.target->int64 = negative? -static_cast<int64_t>(acc) : 
-                                            acc;
+                                            static_cast<int64_t>(acc);
     }
 
     ctx.ch = ch;
@@ -285,7 +285,7 @@ void parse_float32_hex(FreadTokenizer& ctx) {
       else if (E == 126 && Eneg && acc) /* subnormal */ E = 0;
       else goto fail;
     } else {
-      E = 127 + (E ^ -static_cast<int>(Eneg)) + Eneg;
+      E = 127 + (E ^ -static_cast<uint32_t>(Eneg)) + Eneg;
       if (E < 1 || E > 254) goto fail;
     }
     ctx.target->uint32 = (neg << 31) | (E << 23) | (acc);
@@ -576,7 +576,7 @@ void parse_float64_hex(FreadTokenizer& ctx) {
       else if (E == 1022 && Eneg && acc) /* subnormal */ E = 0;
       else goto fail;
     } else {
-      E = 1023 + (E ^ -static_cast<int>(Eneg)) + Eneg;
+      E = 1023 + (E ^ -static_cast<uint64_t>(Eneg)) + Eneg;
       if (E < 1 || E > 2046) goto fail;
     }
     ctx.target->uint64 = (neg << 63) | (E << 52) | (acc);

--- a/src/core/csv/reader_parsers.cc
+++ b/src/core/csv/reader_parsers.cc
@@ -10,6 +10,7 @@
 #include "read/fread/fread_tokenizer.h"  // FreadTokenizer
 #include "read/constants.h"              // hexdigits, pow10lookup
 #include "utils/assert.h"                // xassert
+#include "utils/macros.h"                // xassert
 
 static constexpr int8_t   NA_BOOL8 = -128;
 static constexpr int32_t  NA_INT32 = INT32_MIN;
@@ -217,12 +218,13 @@ void parse_intNN_grouped(FreadTokenizer& ctx) {
   if ((sf? sf < max_digits : ch > start) ||
       (sf == max_digits && acc <= max_value))
   {
-    switch (sizeof(T)) {
-      case 4: ctx.target->int32 = negative? -static_cast<int32_t>(acc) :
-                                            static_cast<int32_t>(acc);
-              break;
-      case 8: ctx.target->int64 = negative? -static_cast<int64_t>(acc) :
-                                            static_cast<int64_t>(acc);
+    if (sizeof(T) == 4) {
+      int32_t x = static_cast<int32_t>(acc);
+      ctx.target->int32 = negative? -x : x;
+    }
+    if (sizeof(T) == 8) {
+      int64_t x = static_cast<int64_t>(acc);
+      ctx.target->int64 = negative? -x : x;
     }
 
     ctx.ch = ch;
@@ -230,10 +232,8 @@ void parse_intNN_grouped(FreadTokenizer& ctx) {
   }
 
   fail:
-    switch (sizeof(T)) {
-      case 4: ctx.target->int32 = NA_INT32; break;
-      case 8: ctx.target->int64 = NA_INT64;
-    }
+    if (sizeof(T) == 4) ctx.target->int32 = NA_INT32;
+    if (sizeof(T) == 8) ctx.target->int64 = NA_INT64;
 }
 
 

--- a/src/core/csv/reader_parsers.cc
+++ b/src/core/csv/reader_parsers.cc
@@ -218,10 +218,10 @@ void parse_intNN_grouped(FreadTokenizer& ctx) {
       (sf == max_digits && acc <= max_value))
   {
     switch (sizeof(T)) {
-      case 4: ctx.target->int32 = negative? -static_cast<int32_t>(acc) : 
-                                            static_cast<int32_t>(acc); 
+      case 4: ctx.target->int32 = negative? -static_cast<int32_t>(acc) :
+                                            static_cast<int32_t>(acc);
               break;
-      case 8: ctx.target->int64 = negative? -static_cast<int64_t>(acc) : 
+      case 8: ctx.target->int64 = negative? -static_cast<int64_t>(acc) :
                                             static_cast<int64_t>(acc);
     }
 
@@ -285,7 +285,7 @@ void parse_float32_hex(FreadTokenizer& ctx) {
       else if (E == 126 && Eneg && acc) /* subnormal */ E = 0;
       else goto fail;
     } else {
-      E = 127 + (E ^ -static_cast<int>(Eneg)) + Eneg;
+      E = 127 + (E ^ static_cast<uint32_t>(-static_cast<int>(Eneg))) + Eneg;
       if (E < 1 || E > 254) goto fail;
     }
     ctx.target->uint32 = (neg << 31) | (E << 23) | (acc);
@@ -576,7 +576,7 @@ void parse_float64_hex(FreadTokenizer& ctx) {
       else if (E == 1022 && Eneg && acc) /* subnormal */ E = 0;
       else goto fail;
     } else {
-      E = 1023 + (E ^ -static_cast<int>(Eneg)) + Eneg;
+      E = 1023 + (E ^ static_cast<uint64_t>(-static_cast<int>(Eneg))) + Eneg;
       if (E < 1 || E > 2046) goto fail;
     }
     ctx.target->uint64 = (neg << 63) | (E << 52) | (acc);

--- a/src/core/csv/toa.h
+++ b/src/core/csv/toa.h
@@ -22,11 +22,11 @@ inline void btoa(char** pch, int8_t value)
     *ch++ = '1';
     int d = value/10;
     *ch++ = static_cast<char>(d) - 10 + '0';
-    value -= d*10;
+    value -= static_cast<int8_t>(d*10);
   } else if (value >= 10) {
     int d = value/10;
     *ch++ = static_cast<char>(d) + '0';
-    value -= d*10;
+    value -= static_cast<int8_t>(d*10);
   }
   *ch++ = static_cast<char>(value) + '0';
   *pch = ch;
@@ -49,7 +49,7 @@ inline void htoa(char** pch, int16_t value)
   for (; r; r--) {
     int d = value / DIVS32[r];
     *ch++ = static_cast<char>(d) + '0';
-    value -= d * DIVS32[r];
+    value -= static_cast<int16_t>(d * DIVS32[r]);
   }
   *ch = static_cast<char>(value) + '0';
   *pch = ch + 1;

--- a/src/core/datatable.cc
+++ b/src/core/datatable.cc
@@ -62,7 +62,7 @@ DataTable::DataTable(colvec&& cols) : DataTable()
   columns_ = std::move(cols);
   ncols_ = columns_.size();
   nrows_ = columns_[0].nrows();
-  #if DTDEBUG
+  #if DT_DEBUG
     for (const auto& col : columns_) {
       xassert(col && col.nrows() == nrows_);
     }

--- a/src/core/datatablemodule.cc
+++ b/src/core/datatablemodule.cc
@@ -142,7 +142,7 @@ static py::PKArgs args_in_debug_mode(
     "Return True if datatable was compiled in debug mode");
 
 static py::oobj in_debug_mode(const py::PKArgs&) {
-  #if DTDEBUG
+  #if DT_DEBUG
     return py::True();
   #else
     return py::False();
@@ -304,7 +304,7 @@ static void initialize_options(const py::PKArgs& args) {
 //------------------------------------------------------------------------------
 // Support memory leak detection
 //------------------------------------------------------------------------------
-#if DTDEBUG
+#if DT_DEBUG
 
 struct PtrInfo {
   size_t alloc_size;
@@ -409,7 +409,7 @@ void py::DatatableModule::init_methods() {
   #ifdef DTTEST
     init_tests();
   #endif
-  #if DTDEBUG
+  #if DT_DEBUG
     ADD_FN(&get_tracked_objects, args_get_tracked_objects);
   #endif
 }

--- a/src/core/datatablemodule.cc
+++ b/src/core/datatablemodule.cc
@@ -205,15 +205,15 @@ static py::PKArgs args_compiler_version(
 const char* get_compiler_version_string() {
   #define STR(x) STR1(x)
   #define STR1(x) #x
-  #ifdef __clang__
+  #if DT_COMPILER_CLANG
     return "CLang " STR(__clang_major__) "." STR(__clang_minor__) "."
            STR(__clang_patchlevel__);
-  #elif defined(_MSC_VER)
+  #elif DT_COMPILER_MSVC
     return "MSVC " STR(_MSC_FULL_VER);
   #elif defined(__MINGW64__)
     return "MinGW64 " STR(__MINGW64_VERSION_MAJOR) "."
            STR(__MINGW64_VERSION_MINOR);
-  #elif defined(__GNUC__)
+  #elif DT_COMPILER_GCC
     return "GCC " STR(__GNUC__) "." STR(__GNUC_MINOR__) "."
            STR(__GNUC_PATCHLEVEL__);
   #else

--- a/src/core/datatablemodule.h
+++ b/src/core/datatablemodule.h
@@ -60,7 +60,7 @@ class DatatableModule : public ExtModule<DatatableModule> {
 }  // namespace py
 
 
-#if DTDEBUG
+#if DT_DEBUG
   void TRACK(void* ptr, size_t size, const char* name);
   void UNTRACK(void* ptr);
   bool IS_TRACKED(void* ptr);

--- a/src/core/expr/fnary/fnary.cc
+++ b/src/core/expr/fnary/fnary.cc
@@ -79,7 +79,7 @@ SType detect_common_numeric_stype(const colvec& columns, const char* fnname)
                           << " had type `" << columns[i].stype() << "`";
     }
   }
-  #if DTDEBUG
+  #if DT_DEBUG
     if (!columns.empty()) {
       size_t nrows = columns[0].nrows();
       for (const auto& col : columns) xassert(col.nrows() == nrows);

--- a/src/core/expr/head_literal_int.cc
+++ b/src/core/expr/head_literal_int.cc
@@ -104,7 +104,11 @@ Workframe Head_Literal_Int::evaluate_r(
         newcol = Const_ColumnImpl::make_int_column(1, value, col.stype());
       }
       else if (ltype == LType::REAL) {
-        newcol = Const_ColumnImpl::make_float_column(1, value, col.stype());
+        newcol = Const_ColumnImpl::make_float_column(
+                   1, 
+                   static_cast<double>(value), 
+                   col.stype()
+                 );
       }
       else {
         newcol = Const_ColumnImpl::make_int_column(1, value);

--- a/src/core/frame/cast.cc
+++ b/src/core/frame/cast.cc
@@ -20,13 +20,14 @@
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #include <unordered_map>
+#include "column.h"
 #include "csv/toa.h"
+#include "datatablemodule.h"
 #include "parallel/api.h"           // dt::parallel_for_static
 #include "parallel/string_utils.h"  // dt::generate_string_column
 #include "python/_all.h"
 #include "python/string.h"
-#include "column.h"
-#include "datatablemodule.h"
+#include "utils/macros.h"
 
 
 //------------------------------------------------------------------------------

--- a/src/core/frame/cast.cc
+++ b/src/core/frame/cast.cc
@@ -27,7 +27,6 @@
 #include "parallel/string_utils.h"  // dt::generate_string_column
 #include "python/_all.h"
 #include "python/string.h"
-#include "utils/macros.h"
 
 
 //------------------------------------------------------------------------------

--- a/src/core/frame/join.cc
+++ b/src/core/frame/join.cc
@@ -28,6 +28,7 @@
 #include "python/obj.h"
 #include "python/tuple.h"
 #include "utils/assert.h"
+#include "utils/macros.h"
 #include "column.h"
 #include "datatable.h"
 #include "datatablemodule.h"

--- a/src/core/frame/join.cc
+++ b/src/core/frame/join.cc
@@ -28,7 +28,6 @@
 #include "python/obj.h"
 #include "python/tuple.h"
 #include "utils/assert.h"
-#include "utils/macros.h"
 #include "column.h"
 #include "datatable.h"
 #include "datatablemodule.h"

--- a/src/core/frame/replace.cc
+++ b/src/core/frame/replace.cc
@@ -27,6 +27,7 @@
 #include "python/dict.h"
 #include "python/list.h"
 #include "utils/assert.h"
+#include "utils/macros.h"
 
 namespace py {
 
@@ -587,7 +588,7 @@ void ReplaceAgent::process_str_column(size_t colidx) {
 // Step 4: perform actual data replacement
 //------------------------------------------------------------------------------
 // Ignore warnings in auto-generated lambda code
-#if defined(__clang__)
+#if DT_COMPILER_CLANG
   #pragma clang diagnostic push
   #pragma clang diagnostic ignored "-Wpadded"
 #endif
@@ -717,7 +718,7 @@ Column ReplaceAgent::replace_strN(CString* x, CString* y,
 }
 
 
-#if defined(__clang__)
+#if DT_COMPILER_CLANG
   #pragma clang diagnostic pop
 #endif
 

--- a/src/core/frame/replace.cc
+++ b/src/core/frame/replace.cc
@@ -27,7 +27,6 @@
 #include "python/dict.h"
 #include "python/list.h"
 #include "utils/assert.h"
-#include "utils/macros.h"
 
 namespace py {
 

--- a/src/core/frame/replace.cc
+++ b/src/core/frame/replace.cc
@@ -27,6 +27,7 @@
 #include "python/dict.h"
 #include "python/list.h"
 #include "utils/assert.h"
+#include "utils/macros.h"
 
 namespace py {
 

--- a/src/core/frame/repr/html_styles.cc
+++ b/src/core/frame/repr/html_styles.cc
@@ -24,7 +24,6 @@
 #include "datatablemodule.h"
 #include "frame/repr/html_widget.h"
 #include "python/string.h"
-#include "utils/macros.h"
 #include "utils/terminal/terminal.h"
 namespace dt {
 

--- a/src/core/frame/repr/html_styles.cc
+++ b/src/core/frame/repr/html_styles.cc
@@ -21,10 +21,11 @@
 //------------------------------------------------------------------------------
 #include <ctime>
 #include <sstream>
+#include "datatablemodule.h"
 #include "frame/repr/html_widget.h"
 #include "python/string.h"
+#include "utils/macros.h"
 #include "utils/terminal/terminal.h"
-#include "datatablemodule.h"
 namespace dt {
 
 

--- a/src/core/lib/flatbuffers/flatbuffers.h
+++ b/src/core/lib/flatbuffers/flatbuffers.h
@@ -17,7 +17,7 @@
 #ifndef FLATBUFFERS_H_
 #define FLATBUFFERS_H_
 
-#if defined(__clang__)
+#if DT_COMPILER_CLANG
   #pragma clang diagnostic push
   #pragma clang diagnostic ignored "-Wdocumentation"
   #pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
@@ -2284,12 +2284,8 @@ volatile __attribute__((weak)) const char *flatbuffer_version_string =
 /// @endcond
 }  // namespace flatbuffers
 
-#if defined(_MSC_VER)
-  #pragma warning(pop)
-#endif
-// clang-format on
 
-#if defined(__clang__)
+#if DT_COMPILER_CLANG
   #pragma clang diagnostic pop
 #endif
 

--- a/src/core/lib/mman/mman.cc
+++ b/src/core/lib/mman/mman.cc
@@ -27,6 +27,9 @@
 
 #if DT_OS_WINDOWS
 
+  #pragma warning(push)
+  #pragma warning(disable : 4100)
+
   #include <windows.h>
   #include <errno.h>
   #include <io.h>
@@ -215,5 +218,7 @@
 
       return -1;
   }
+
+  #pragma warning(pop)
 
 #endif

--- a/src/core/lib/parallel_hashmap/phmap.h
+++ b/src/core/lib/parallel_hashmap/phmap.h
@@ -47,7 +47,7 @@
 #include <cassert>
 #include "utils/macros.h"
 
-#if DT_OS_WINDOWS
+#if DT_COMPILER_MSVC
     #pragma warning(push)
     #pragma warning(disable : 4245)
     #pragma warning(disable : 4324)
@@ -4627,7 +4627,7 @@ public:
 }  // namespace phmap
 
 
-#if DT_OS_WINDOWS
+#if DT_COMPILER_MSVC
     #pragma warning(pop)
 #endif
 

--- a/src/core/lib/parallel_hashmap/phmap.h
+++ b/src/core/lib/parallel_hashmap/phmap.h
@@ -49,6 +49,7 @@
 #include "lib/parallel_hashmap/phmap_utils.h"
 #include "lib/parallel_hashmap/phmap_base.h"
 #include "lib/parallel_hashmap/phmap_fwd_decl.h"
+#include "utils/macros.h"
 
 #if PHMAP_HAVE_STD_STRING_VIEW
     #include <string_view>
@@ -326,7 +327,7 @@ struct GroupSse2Impl
         return BitMask<uint32_t, kWidth>(static_cast<uint32_t>(
             _mm_movemask_epi8(_mm_sign_epi8(ctrl, ctrl))));
 #else
-        return Match(kEmpty);
+        return Match(static_cast<phmap::container_internal::h2_t>(kEmpty));
 #endif
     }
 

--- a/src/core/lib/parallel_hashmap/phmap.h
+++ b/src/core/lib/parallel_hashmap/phmap.h
@@ -45,11 +45,17 @@
 #include <utility>
 #include <array>
 #include <cassert>
+#include "utils/macros.h"
+
+#if DT_OS_WINDOWS
+    #pragma warning(push)
+    #pragma warning(disable : 4245)
+    #pragma warning(disable : 4324)
+#endif
 
 #include "lib/parallel_hashmap/phmap_utils.h"
 #include "lib/parallel_hashmap/phmap_base.h"
 #include "lib/parallel_hashmap/phmap_fwd_decl.h"
-#include "utils/macros.h"
 
 #if PHMAP_HAVE_STD_STRING_VIEW
     #include <string_view>
@@ -327,7 +333,7 @@ struct GroupSse2Impl
         return BitMask<uint32_t, kWidth>(static_cast<uint32_t>(
             _mm_movemask_epi8(_mm_sign_epi8(ctrl, ctrl))));
 #else
-        return Match(static_cast<phmap::container_internal::h2_t>(kEmpty));
+        return Match(kEmpty);
 #endif
     }
 
@@ -4619,5 +4625,10 @@ public:
 };
 
 }  // namespace phmap
+
+
+#if DT_OS_WINDOWS
+    #pragma warning(pop)
+#endif
 
 #endif // phmap_h_guard_

--- a/src/core/lib/zlib/deflate.cc
+++ b/src/core/lib/zlib/deflate.cc
@@ -63,6 +63,11 @@ namespace zlib {
   #pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif
 
+#if DT_OS_WINDOWS
+    #pragma warning(push)
+    #pragma warning(disable : 4244)
+#endif
+
 
 const char deflate_copyright[] =
    " deflate 1.2.11 Copyright 1995-2017 Jean-loup Gailly and Mark Adler ";
@@ -1404,10 +1409,10 @@ static block_state deflate_stored(deflate_state* s, int flush)
     _tr_stored_block(s, (char *)0, 0L, last);
 
     /* Replace the lengths in the dummy stored block with len. */
-    s->pending_buf[s->pending - 4] = static_cast<zlib::Bytef>(len);
-    s->pending_buf[s->pending - 3] = static_cast<zlib::Bytef>(len >> 8);
-    s->pending_buf[s->pending - 2] = static_cast<zlib::Bytef>(~len);
-    s->pending_buf[s->pending - 1] = static_cast<zlib::Bytef>(~len >> 8);
+    s->pending_buf[s->pending - 4] = len;
+    s->pending_buf[s->pending - 3] = len >> 8;
+    s->pending_buf[s->pending - 2] = ~len;
+    s->pending_buf[s->pending - 1] = ~len >> 8;
 
     /* Write the stored block header bytes. */
     flush_pending(s->strm);
@@ -1879,4 +1884,9 @@ static block_state deflate_huff(deflate_state* s, int flush)
 #if defined(__clang__)
   #pragma clang diagnostic pop
 #endif
+
+#if DT_OS_WINDOWS
+    #pragma warning(pop)
+#endif
+
 } // namespace zlib

--- a/src/core/lib/zlib/deflate.cc
+++ b/src/core/lib/zlib/deflate.cc
@@ -50,15 +50,16 @@
 #include "lib/zlib/deflate.h"
 namespace zlib {
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wconversion"
-#pragma clang diagnostic ignored "-Wcomma"
-#pragma clang diagnostic ignored "-Wpadded"
-#pragma clang diagnostic ignored "-Wold-style-cast"
-#pragma clang diagnostic ignored "-Wsign-conversion"
-#pragma clang diagnostic ignored "-Wunused-const-variable"
-#pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
-
+#if defined(__clang__)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wconversion"
+  #pragma clang diagnostic ignored "-Wcomma"
+  #pragma clang diagnostic ignored "-Wpadded"
+  #pragma clang diagnostic ignored "-Wold-style-cast"
+  #pragma clang diagnostic ignored "-Wsign-conversion"
+  #pragma clang diagnostic ignored "-Wunused-const-variable"
+  #pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
+#endif
 
 
 const char deflate_copyright[] =
@@ -1199,7 +1200,8 @@ static void fill_window(deflate_state* s)
     more = (unsigned)(s->window_size -(ulg)s->lookahead -(ulg)s->strstart);
 
     /* Deal with !@#$% 64K limit: */
-    if (sizeof(int) <= 2) {
+    const bool small_int = sizeof(int) <= 2;
+    if (small_int) {
       if (more == 0 && s->strstart == 0 && s->lookahead == 0) {
         more = wsize;
 
@@ -1401,10 +1403,10 @@ static block_state deflate_stored(deflate_state* s, int flush)
     _tr_stored_block(s, (char *)0, 0L, last);
 
     /* Replace the lengths in the dummy stored block with len. */
-    s->pending_buf[s->pending - 4] = len;
-    s->pending_buf[s->pending - 3] = len >> 8;
-    s->pending_buf[s->pending - 2] = ~len;
-    s->pending_buf[s->pending - 1] = ~len >> 8;
+    s->pending_buf[s->pending - 4] = static_cast<zlib::Bytef>(len);
+    s->pending_buf[s->pending - 3] = static_cast<zlib::Bytef>(len >> 8);
+    s->pending_buf[s->pending - 2] = static_cast<zlib::Bytef>(~len);
+    s->pending_buf[s->pending - 1] = static_cast<zlib::Bytef>(~len >> 8);
 
     /* Write the stored block header bytes. */
     flush_pending(s->strm);
@@ -1873,6 +1875,7 @@ static block_state deflate_huff(deflate_state* s, int flush)
 }
 
 
-
-#pragma clang diagnostic pop
+#if defined(__clang__)
+  #pragma clang diagnostic pop
+#endif
 } // namespace zlib

--- a/src/core/lib/zlib/deflate.cc
+++ b/src/core/lib/zlib/deflate.cc
@@ -48,6 +48,8 @@
 //
 //------------------------------------------------------------------------------
 #include "lib/zlib/deflate.h"
+#include "utils/macros.h"
+
 namespace zlib {
 
 #if defined(__clang__)
@@ -1200,8 +1202,7 @@ static void fill_window(deflate_state* s)
     more = (unsigned)(s->window_size -(ulg)s->lookahead -(ulg)s->strstart);
 
     /* Deal with !@#$% 64K limit: */
-    const bool small_int = sizeof(int) <= 2;
-    if (small_int) {
+    if (sizeof(int) <= 2) {
       if (more == 0 && s->strstart == 0 && s->lookahead == 0) {
         more = wsize;
 

--- a/src/core/lib/zlib/deflate.cc
+++ b/src/core/lib/zlib/deflate.cc
@@ -52,7 +52,7 @@
 
 namespace zlib {
 
-#if defined(__clang__)
+#if DT_COMPILER_CLANG
   #pragma clang diagnostic push
   #pragma clang diagnostic ignored "-Wconversion"
   #pragma clang diagnostic ignored "-Wcomma"
@@ -61,11 +61,9 @@ namespace zlib {
   #pragma clang diagnostic ignored "-Wsign-conversion"
   #pragma clang diagnostic ignored "-Wunused-const-variable"
   #pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
-#endif
-
-#if DT_OS_WINDOWS
-    #pragma warning(push)
-    #pragma warning(disable : 4244)
+#elif DT_COMPILER_MSVC
+  #pragma warning(push)
+  #pragma warning(disable : 4244)
 #endif
 
 
@@ -1881,12 +1879,10 @@ static block_state deflate_huff(deflate_state* s, int flush)
 }
 
 
-#if defined(__clang__)
+#if DT_COMPILER_CLANG
   #pragma clang diagnostic pop
-#endif
-
-#if DT_OS_WINDOWS
-    #pragma warning(pop)
+#elif DT_COMPILER_MSVC
+  #pragma warning(pop)
 #endif
 
 } // namespace zlib

--- a/src/core/lib/zlib/deflate.h
+++ b/src/core/lib/zlib/deflate.h
@@ -12,7 +12,7 @@
 #include "lib/zlib/zutil.h"
 namespace zlib {
 
-#if defined(__clang__)
+#if DT_COMPILER_CLANG
   #pragma clang diagnostic push
   #pragma clang diagnostic ignored "-Wpadded"
 #endif
@@ -344,7 +344,7 @@ void _tr_stored_block(deflate_state *s, charf *buf, ulg stored_len, int last);
 
 
 
-#if defined(__clang__)
+#if DT_COMPILER_CLANG
   #pragma clang diagnostic pop
 #endif
 

--- a/src/core/lib/zlib/trees.cc
+++ b/src/core/lib/zlib/trees.cc
@@ -515,7 +515,7 @@ static void scan_tree (deflate_state *s, ct_data *tree, int max_code)
     if (++count < max_count && curlen == nextlen) {
       continue;
     } else if (count < min_count) {
-      s->bl_tree[curlen].Freq += count;
+      s->bl_tree[curlen].Freq += static_cast<zlib::ush>(count);
     } else if (curlen != 0) {
       if (curlen != prevlen) s->bl_tree[curlen].Freq++;
       s->bl_tree[REP_3_6].Freq++;

--- a/src/core/lib/zlib/trees.cc
+++ b/src/core/lib/zlib/trees.cc
@@ -30,6 +30,7 @@
 //          Addison-Wesley, 1983. ISBN 0-201-06672-6.
 //------------------------------------------------------------------------------
 #include "lib/zlib/deflate.h"
+#include "utils/macros.h"
 namespace zlib {
 
 #ifdef __clang__
@@ -43,6 +44,10 @@ namespace zlib {
   #pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif
 
+#if DT_OS_WINDOWS
+    #pragma warning(push)
+    #pragma warning(disable : 4244)
+#endif
 
 
 /* ===========================================================================
@@ -515,7 +520,7 @@ static void scan_tree (deflate_state *s, ct_data *tree, int max_code)
     if (++count < max_count && curlen == nextlen) {
       continue;
     } else if (count < min_count) {
-      s->bl_tree[curlen].Freq += static_cast<zlib::ush>(count);
+      s->bl_tree[curlen].Freq += count;
     } else if (curlen != 0) {
       if (curlen != prevlen) s->bl_tree[curlen].Freq++;
       s->bl_tree[REP_3_6].Freq++;
@@ -992,4 +997,10 @@ static void bi_windup(deflate_state *s)
 #ifdef __clang__
   #pragma clang diagnostic pop
 #endif
+
+#if DT_OS_WINDOWS
+    #pragma warning(pop)
+#endif
+
+
 }  // namespace zlib

--- a/src/core/lib/zlib/zlib.h
+++ b/src/core/lib/zlib/zlib.h
@@ -37,10 +37,12 @@
 #ifndef ZLIB_H
 #define ZLIB_H
 #include "lib/zlib/zconf.h"
+#include "utils/macros.h"
+
 namespace zlib {
 
 
-#if defined(__clang__)
+#if DT_COMPILER_CLANG
   #pragma clang diagnostic push
   #pragma clang diagnostic ignored "-Wpadded"
 #endif
@@ -416,7 +418,7 @@ int deflateInit2_(z_stream* strm, int level, int method, int windowBits,
 const char* zError(int);
 
 
-#if defined(__clang__)
+#if DT_COMPILER_CLANG
   #pragma clang diagnostic pop
 #endif
 

--- a/src/core/lib/zlib/zutil.cc
+++ b/src/core/lib/zlib/zutil.cc
@@ -6,7 +6,7 @@
 
 namespace zlib {
 
-#if defined(__clang__)
+#if DT_COMPILER_CLANG
   #pragma clang diagnostic push
   #pragma clang diagnostic ignored "-Wcast-qual"
   #pragma clang diagnostic ignored "-Wold-style-cast"
@@ -113,7 +113,7 @@ void zcfree (voidpf opaque, voidpf ptr)
 
 #endif /* !Z_SOLO */
 
-#if defined(__clang__)
+#if DT_COMPILER_CLANG
   #pragma clang diagnostic pop
 #endif
 

--- a/src/core/lib/zlib/zutil.cc
+++ b/src/core/lib/zlib/zutil.cc
@@ -3,12 +3,15 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 #include "lib/zlib/zutil.h"
+#include "utils/macros.h"
+
 namespace zlib {
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wcast-qual"
-#pragma clang diagnostic ignored "-Wold-style-cast"
-
+#if defined(__clang__)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wcast-qual"
+  #pragma clang diagnostic ignored "-Wold-style-cast"
+#endif
 
 
 const char * const z_errmsg[10] = {
@@ -110,7 +113,9 @@ void zcfree (voidpf opaque, voidpf ptr)
 #endif /* MY_ZCALLOC */
 
 #endif /* !Z_SOLO */
-#pragma clang diagnostic pop
 
+#if defined(__clang__)
+  #pragma clang diagnostic pop
+#endif
 
 } // namespace zlib

--- a/src/core/lib/zlib/zutil.cc
+++ b/src/core/lib/zlib/zutil.cc
@@ -3,7 +3,6 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 #include "lib/zlib/zutil.h"
-#include "utils/macros.h"
 
 namespace zlib {
 

--- a/src/core/models/dt_ftrl_base.h
+++ b/src/core/models/dt_ftrl_base.h
@@ -43,22 +43,22 @@ enum class FtrlModelType : size_t {
  *  that also defines their default values.
  */
 struct FtrlParams {
-    FtrlModelType model_type;
-    double alpha;
-    double beta;
-    double lambda1;
-    double lambda2;
-    uint64_t nbins;
-    double nepochs;
-    unsigned char mantissa_nbits;
-    bool double_precision;
-    bool negative_class;
-    size_t : 40;
-    FtrlParams() : model_type(FtrlModelType::AUTO),
-                   alpha(0.005), beta(1.0), lambda1(0.0), lambda2(0.0),
-                   nbins(1000000), nepochs(1.0), mantissa_nbits(10),
-                   double_precision(false), negative_class(false)
-                   {}
+  FtrlModelType model_type;
+  double alpha;
+  double beta;
+  double lambda1;
+  double lambda2;
+  uint64_t nbins;
+  double nepochs;
+  unsigned char mantissa_nbits;
+  bool double_precision;
+  bool negative_class;
+  size_t : 40;
+  FtrlParams() : model_type(FtrlModelType::AUTO),
+                 alpha(0.005), beta(1.0), lambda1(0.0), lambda2(0.0),
+                 nbins(1000000), nepochs(1.0), mantissa_nbits(10),
+                 double_precision(false), negative_class(false)
+                 {}
 };
 
 
@@ -68,8 +68,16 @@ struct FtrlParams {
  *  was provided, the corresponding final loss.
  */
 struct FtrlFitOutput {
-    double epoch;
-    double loss;
+  double epoch;
+  double loss;
+  FtrlFitOutput() {
+    epoch = std::numeric_limits<double>::quiet_NaN();
+    loss = std::numeric_limits<double>::quiet_NaN();
+  }
+  FtrlFitOutput(double epoch_, double loss_) {
+    epoch = epoch_;
+    loss = loss_;
+  }
 };
 
 

--- a/src/core/parallel/thread_pool.cc
+++ b/src/core/parallel/thread_pool.cc
@@ -34,25 +34,27 @@ namespace dt {
 // Singleton instance of the thread_pool
 thread_pool* thpool = new thread_pool;
 
-static void _child_cleanup_after_fork() {
-  // Replace the current thread pool instance with a new one, ensuring that all
-  // schedulers and workers have new mutexes/condition variables.
-  // The previous value of `thpool` is abandoned without deleting since that
-  // memory is owned by the parent process.
-  size_t n = thpool->size();
-  thpool = new thread_pool;
-  progress::manager = new progress::progress_manager;
-  thpool->resize(n);
-}
-
-
 
 //------------------------------------------------------------------------------
 // thread_pool
 //------------------------------------------------------------------------------
+
+// no fork on Windows
 #if !DT_OS_WINDOWS
-  // no fork on Windows
+
+  static void _child_cleanup_after_fork() {
+    // Replace the current thread pool instance with a new one, ensuring that all
+    // schedulers and workers have new mutexes/condition variables.
+    // The previous value of `thpool` is abandoned without deleting since that
+    // memory is owned by the parent process.
+    size_t n = thpool->size();
+    thpool = new thread_pool;
+    progress::manager = new progress::progress_manager;
+    thpool->resize(n);
+  }
+
   static bool after_fork_handler_registered = false;
+
 #endif
 
 thread_pool::thread_pool()

--- a/src/core/py_encodings.cc
+++ b/src/core/py_encodings.cc
@@ -50,7 +50,10 @@ int init_py_encodings(PyObject*) {
   for (int k = 0; k < 3; k++) {
     uint32_t* map = (k == 0)? win1252_map : (k == 1)? win1251_map : iso8859_map;
     for (unsigned int i = 0; i < 256; i++) {
-      if (i < 0x80) xassert(map[i] == i);  // check ASCII compatibility
+      if (i < 0x80) {
+        (void) i;
+        xassert(map[i] == i);  // check ASCII compatibility
+      }
       if (i && map[i] == 0) map[i] = 0x00BDBFEF;  // U+FFFD
       xassert((map[i] & 0xFF000000) == 0);
     }

--- a/src/core/py_encodings.cc
+++ b/src/core/py_encodings.cc
@@ -5,8 +5,9 @@
 //
 // © H2O.ai 2018
 //------------------------------------------------------------------------------
-#include "utils/assert.h"
 #include "py_encodings.h"
+#include "utils/assert.h"
+#include "utils/macros.h"
 
 
 static uint32_t win1252_map[256];
@@ -50,10 +51,18 @@ int init_py_encodings(PyObject*) {
   for (int k = 0; k < 3; k++) {
     uint32_t* map = (k == 0)? win1252_map : (k == 1)? win1251_map : iso8859_map;
     for (unsigned int i = 0; i < 256; i++) {
-      if (i < 0x80) {
-        (void) i;
-        xassert(map[i] == i);  // check ASCII compatibility
-      }
+
+      #if DT_OS_WINDOWS && !DT_DEBUG
+        #pragma warning(push)
+        #pragma warning(disable : 4390) // empty controlled statement found
+      #endif
+
+      if (i < 0x80) xassert(map[i] == i);  // check ASCII compatibility
+
+      #if DT_OS_WINDOWS && !DT_DEBUG
+        #pragma warning(pop)
+      #endif
+
       if (i && map[i] == 0) map[i] = 0x00BDBFEF;  // U+FFFD
       xassert((map[i] & 0xFF000000) == 0);
     }

--- a/src/core/python/args.cc
+++ b/src/core/python/args.cc
@@ -49,7 +49,11 @@ PKArgs::PKArgs(
     n_varkwds(0)
 {
   wassert(n_all_args == arg_names.size());
-  if (has_varargs) xassert(n_pos_kwd_args == 0);
+  if (has_varargs) {
+    (void) has_varargs;
+    xassert(n_pos_kwd_args == 0);
+  }
+
   bound_args.resize(n_all_args);
   for (size_t i = 0; i < n_all_args; ++i) {
     bound_args[i].init(i, this);

--- a/src/core/python/args.cc
+++ b/src/core/python/args.cc
@@ -23,6 +23,7 @@
 #include <cstring>         // std::strrchr
 #include "python/args.h"
 #include "utils/assert.h"
+#include "utils/macros.h"
 
 namespace py {
 

--- a/src/core/python/args.cc
+++ b/src/core/python/args.cc
@@ -23,7 +23,6 @@
 #include <cstring>         // std::strrchr
 #include "python/args.h"
 #include "utils/assert.h"
-#include "utils/macros.h"
 
 namespace py {
 

--- a/src/core/python/args.cc
+++ b/src/core/python/args.cc
@@ -23,6 +23,7 @@
 #include <cstring>         // std::strrchr
 #include "python/args.h"
 #include "utils/assert.h"
+#include "utils/macros.h"
 
 namespace py {
 
@@ -49,10 +50,17 @@ PKArgs::PKArgs(
     n_varkwds(0)
 {
   wassert(n_all_args == arg_names.size());
-  if (has_varargs) {
-    (void) has_varargs;
-    xassert(n_pos_kwd_args == 0);
-  }
+
+  #if DT_OS_WINDOWS && !DT_DEBUG
+    #pragma warning(push)
+    #pragma warning(disable : 4390) // empty controlled statement found
+  #endif
+
+  if (has_varargs) xassert(n_pos_kwd_args == 0);
+
+  #if DT_OS_WINDOWS && !DT_DEBUG
+    #pragma warning(pop)
+  #endif
 
   bound_args.resize(n_all_args);
   for (size_t i = 0; i < n_all_args; ++i) {

--- a/src/core/python/pybuffer.cc
+++ b/src/core/python/pybuffer.cc
@@ -25,7 +25,10 @@
 //------------------------------------------------------------------------------
 #include "python/pybuffer.h"
 #include "utils/assert.h"
+#include "utils/macros.h"
 #include "buffer.h"
+
+
 namespace py {
 
 
@@ -98,10 +101,17 @@ void buffer::_normalize_dimensions() {
     xassert(len == itemsize);
   }
   else if (ndim == 1) {
-    if (info_->shape) {
-      (void) info_->shape;
-      xassert(info_->shape[0] * itemsize == len);
-    }
+
+    #if DT_OS_WINDOWS && !DT_DEBUG
+      #pragma warning(push)
+      #pragma warning(disable : 4390) // empty controlled statement found
+    #endif
+
+    if (info_->shape) xassert(info_->shape[0] * itemsize == len);
+
+    #if DT_OS_WINDOWS && !DT_DEBUG
+      #pragma warning(pop)
+    #endif
 
     if (info_->strides) {
       xassert(info_->strides[0] % itemsize == 0);

--- a/src/core/python/pybuffer.cc
+++ b/src/core/python/pybuffer.cc
@@ -98,7 +98,11 @@ void buffer::_normalize_dimensions() {
     xassert(len == itemsize);
   }
   else if (ndim == 1) {
-    if (info_->shape) xassert(info_->shape[0] * itemsize == len);
+    if (info_->shape) {
+      (void) info_->shape;
+      xassert(info_->shape[0] * itemsize == len);
+    }
+
     if (info_->strides) {
       xassert(info_->strides[0] % itemsize == 0);
       stride_ = static_cast<size_t>(info_->strides[0] / itemsize);

--- a/src/core/python/xobject.h
+++ b/src/core/python/xobject.h
@@ -21,6 +21,7 @@
 #include "python/args.h"
 #include "python/obj.h"
 #include "utils/assert.h"
+#include "utils/macros.h"
 namespace py {
 
 
@@ -387,7 +388,7 @@ int _call_setter(void(T::*fn)(const Arg&), Arg& ARG,
 // Helper macros
 //------------------------------------------------------------------------------
 
-#if defined(__clang__)
+#if DT_COMPILER_CLANG
   #pragma clang diagnostic push
   #pragma clang diagnostic ignored "-Wunused-template"
 #endif
@@ -400,7 +401,7 @@ static T _class_of_impl(R(T::*)(Args...) const);
 
 #define CLASS_OF(METH) decltype(_class_of_impl(METH))
 
-#if defined(__clang__)
+#if DT_COMPILER_CLANG
   #pragma clang diagnostic pop
 #endif
 

--- a/src/core/rowindex.h
+++ b/src/core/rowindex.h
@@ -52,7 +52,7 @@ class RowIndex {
     static constexpr int ARR32 = 1;
     static constexpr int ARR64 = 2;
     static constexpr int SORTED = 4;
-    static_assert(int32_t(size_t(NA_ARR32)) == NA_ARR32, "Bad NA_ARR32");
+    static_assert(static_cast<int32_t>(size_t(NA_ARR32)) == NA_ARR32, "Bad NA_ARR32");
     static_assert(int64_t(size_t(NA_ARR64)) == NA_ARR64, "Bad NA_ARR64");
 
     RowIndex();

--- a/src/core/rowindex_slice.cc
+++ b/src/core/rowindex_slice.cc
@@ -41,8 +41,8 @@ bool check_slice_triple(size_t start, size_t count, size_t step, size_t max)
   return (start <= max) &&
          (count <= RowIndex::MAX) &&
          (count <= 1 || (step == 0) ||
-          (step <= RowIndex::MAX? step <= (max - start)/(count - 1)
-                                : step >= -start/(count - 1)));
+         (step <= RowIndex::MAX? step <= (max - start)/(count - 1)
+                               : step >= -start/(count - 1)));
 }
 
 

--- a/src/core/sort.cc
+++ b/src/core/sort.cc
@@ -167,7 +167,7 @@ class rmem {
   private:
   public:
     void* ptr;
-    #if DTDEBUG
+    #if DT_DEBUG
       size_t size;
     #endif
   public:
@@ -205,21 +205,21 @@ void* omem::release() {
 
 rmem::rmem() {
   ptr = nullptr;
-  #if DTDEBUG
+  #if DT_DEBUG
     size = 0;
   #endif
 }
 
 rmem::rmem(const omem& o) {
   ptr = o.ptr;
-  #if DTDEBUG
+  #if DT_DEBUG
     size = o.size;
   #endif
 }
 
 rmem::rmem(const rmem& o) {
   ptr = o.ptr;
-  #if DTDEBUG
+  #if DT_DEBUG
     size = o.size;
   #endif
 }
@@ -227,7 +227,7 @@ rmem::rmem(const rmem& o) {
 rmem::rmem(const rmem& o, size_t offset, size_t n) {
   ptr = static_cast<char*>(o.ptr) + offset;
   (void)n;
-  #if DTDEBUG
+  #if DT_DEBUG
     size = n;
     xassert(offset + n <= o.size);
   #endif
@@ -243,7 +243,7 @@ template <typename T> T* rmem::data() const noexcept {
 
 void swap(rmem& left, rmem& right) noexcept {
   std::swap(left.ptr, right.ptr);
-  #if DTDEBUG
+  #if DT_DEBUG
     std::swap(left.size, right.size);
   #endif
 }
@@ -1357,7 +1357,7 @@ RiGb group(const std::vector<Column>& columns,
   const Column& col0 = columns[0];
 
   size_t nrows = col0.nrows();
-  #if DTDEBUG
+  #if DT_DEBUG
     for (const Column& col : columns) xassert(col.nrows() == nrows);
   #endif
 

--- a/src/core/sort.cc
+++ b/src/core/sort.cc
@@ -693,7 +693,7 @@ class SortContext {
     int64_t min = column.stats()->min_int(nullptr);
     int64_t max = column.stats()->max_int(nullptr);
     nsigbits = sizeof(T) * 8;
-    nsigbits -= dt::nlz(static_cast<TU>(max - min + 1));
+    nsigbits -= static_cast<int8_t>(dt::nlz(static_cast<TU>(max - min + 1)));
     T edge = static_cast<T>(ASC? min : max);
     if (nsigbits > 32)      _initI_impl<ASC, T, TU, uint64_t>(edge);
     else if (nsigbits > 16) _initI_impl<ASC, T, TU, uint32_t>(edge);

--- a/src/core/sort.cc
+++ b/src/core/sort.cc
@@ -873,7 +873,7 @@ class SortContext {
     uint8_t nradixbits = nsigbits < sort_max_radix_bits
                          ? nsigbits : sort_over_radix_bits;
     shift = nsigbits - nradixbits;
-    nradixes = 1 << nradixbits;
+    nradixes = size_t(1) << nradixbits;
 
     // The remaining number of sig.bits is `shift`. Thus, this value will
     // determine the `next_elemsize`.

--- a/src/core/sort/sorter.h
+++ b/src/core/sort/sorter.h
@@ -102,7 +102,7 @@ class SSorter : public Sorter
         radix_sort(ordering_in, ordering_out, offset, grouper,
                    sort_mode, nullptr);
       }
-      #if DTDEBUG
+      #if DT_DEBUG
         check_sorted(ordering_out);
       #endif
     }
@@ -157,7 +157,7 @@ class SSorter : public Sorter
 
   private:
     void check_sorted(Vec ordering) const {
-      #if DTDEBUG
+      #if DT_DEBUG
         // The `ordering` vector corresponds to the ordering of the
         // original data vector. If the Sorter contains reordered
         // data, then this ordering is not valid for it.

--- a/src/core/utils/assert.h
+++ b/src/core/utils/assert.h
@@ -16,14 +16,14 @@
 // First, fix the NDEBUG macro.
 // This macro, if present, disables all assert statements. Unfortunately, python
 // may add it as a default compilation flag, so in order to combat this we have
-// defined a new `DTDEBUG` macro. This macro may be passed from the Makefile,
+// defined a new `DT_DEBUG` macro. This macro may be passed from the Makefile,
 // and if declared it means to ignore the NDEBUG macro even if it is present.
 #undef NDEBUG
-#ifdef DTDEBUG
-  #undef DTDEBUG
-  #define DTDEBUG 1
+#ifdef DT_DEBUG
+  #undef DT_DEBUG
+  #define DT_DEBUG 1
 #else
-  #define DTDEBUG 0
+  #define DT_DEBUG 0
   #define NDEBUG 1
 #endif
 
@@ -33,7 +33,7 @@
 
 // Here we also define the `xassert` macro, which behaves similarly to `assert`,
 // however it throws exceptions instead of terminating the program
-#if DTDEBUG
+#if DT_DEBUG
   #define wassert(EXPRESSION) \
     if (!(EXPRESSION)) { \
       (AssertionError() << "Assertion '" #EXPRESSION "' failed in " \

--- a/src/core/utils/exceptions.cc
+++ b/src/core/utils/exceptions.cc
@@ -28,8 +28,9 @@
 #include "python/obj.h"
 #include "python/string.h"
 #include "python/tuple.h"
-#include "utils/exceptions.h"
 #include "utils/assert.h"
+#include "utils/exceptions.h"
+#include "utils/macros.h"
 
 
 // Singleton, used to write the current "errno" into the stream

--- a/src/core/utils/exceptions.cc
+++ b/src/core/utils/exceptions.cc
@@ -75,7 +75,7 @@ static void init() {
 static bool is_string_empty(const char* msg) noexcept {
   if (!msg) return true;
   char c;
-  while ((c = *msg)) {
+  while ((c = *msg) != 0) {
     if (!(c == ' ' || c == '\t' || c == '\n' || c == '\r'))
       return false;
     msg++;

--- a/src/core/utils/exceptions.cc
+++ b/src/core/utils/exceptions.cc
@@ -30,7 +30,6 @@
 #include "python/tuple.h"
 #include "utils/assert.h"
 #include "utils/exceptions.h"
-#include "utils/macros.h"
 
 
 // Singleton, used to write the current "errno" into the stream

--- a/src/core/utils/macros.h
+++ b/src/core/utils/macros.h
@@ -172,7 +172,6 @@ struct alignas(CACHELINE_SIZE) cache_aligned {
   // Disable C4127 warning ("consider using 'if constexpr' statement instead")
   // as 'if constexpr' is not available in C++11
   #pragma warning(disable : 4127)
-  #pragma warning(disable : 4661)
 #endif
 
 #endif

--- a/src/core/utils/macros.h
+++ b/src/core/utils/macros.h
@@ -29,14 +29,10 @@
 // Operating system
 //------------------------------------------------------------------------------
 
-#define DT_OS_WINDOWS 0
 #define DT_OS_DARWIN  0
 #define DT_OS_LINUX   0
+#define DT_OS_WINDOWS 0
 
-#ifdef _WIN32
-  #undef  DT_OS_WINDOWS
-  #define DT_OS_WINDOWS 1
-#endif
 
 #if defined(__APPLE__) && defined(__MACH__)
   #undef  DT_OS_DARWIN
@@ -46,6 +42,11 @@
 #if defined(__linux) || defined(__linux__)
   #undef  DT_OS_LINUX
   #define DT_OS_LINUX 1
+#endif
+
+#ifdef _WIN32
+  #undef  DT_OS_WINDOWS
+  #define DT_OS_WINDOWS 1
 #endif
 
 #if (DT_OS_LINUX || DT_OS_DARWIN)
@@ -97,18 +98,39 @@
 // Compiler
 //------------------------------------------------------------------------------
 
-#if defined(__clang__)
+
+#define DT_COMPILER_CLANG 0
+#define DT_COMPILER_GCC   0
+#define DT_COMPILER_MSVC  0
+
+#ifdef __clang__
+  #undef  DT_COMPILER_CLANG
+  #define DT_COMPILER_CLANG __clang_major__
+#endif
+
+#ifdef __GNUC__
+  #undef  DT_COMPILER_GCC
+  #define DT_COMPILER_GCC __GNUC__
+#endif
+
+#ifdef _MSC_VER
+  #undef  DT_COMPILER_MSVC
+  #define DT_COMPILER_MSVC _MSC_VER
+#endif
+
+
+#if DT_COMPILER_CLANG
   #define FALLTHROUGH [[clang::fallthrough]]
-#elif defined(__GNUC__) && __GNUC__ >= 7
+#elif DT_COMPILER_GCC >= 7
   #define FALLTHROUGH [[gnu::fallthrough]]
 #else
   #define FALLTHROUGH
 #endif
 
 
-#if defined(__clang__) || defined(_MSC_VER)
+#if DT_COMPILER_CLANG || DT_COMPILER_MSVC
   #define REGEX_SUPPORTED 1
-#elif defined(__GNUC__) && __GNUC__ <= 4
+#elif DT_COMPILER_GCC > 0 && DT_COMPILER_GCC <= 4
   #define REGEX_SUPPORTED 0
 #else
   #define REGEX_SUPPORTED 1

--- a/src/core/utils/macros.h
+++ b/src/core/utils/macros.h
@@ -160,18 +160,4 @@ struct alignas(CACHELINE_SIZE) cache_aligned {
 #endif
 
 
-//------------------------------------------------------------------------------
-// Platform specific pragmas
-//------------------------------------------------------------------------------
-
-#if DT_OS_WINDOWS
-  // Disable C4996 warning ("This function or variable may be unsafe")
-  // issued by MSVC for a fully valid and portable code
-  #pragma warning(disable : 4996)
-
-  // Disable C4127 warning ("consider using 'if constexpr' statement instead")
-  // as 'if constexpr' is not available in C++11
-  #pragma warning(disable : 4127)
-#endif
-
 #endif

--- a/src/core/utils/macros.h
+++ b/src/core/utils/macros.h
@@ -160,4 +160,14 @@ struct alignas(CACHELINE_SIZE) cache_aligned {
 #endif
 
 
+//------------------------------------------------------------------------------
+// Platform specific pragmas
+//------------------------------------------------------------------------------
+
+#if DT_OS_WINDOWS
+  // Disable C4996 warning ("This function or variable may be unsafe")
+  // issued by MSVC for a fully valid and portable code
+  #pragma warning(disable : 4996)
+#endif
+
 #endif

--- a/src/core/utils/macros.h
+++ b/src/core/utils/macros.h
@@ -172,6 +172,7 @@ struct alignas(CACHELINE_SIZE) cache_aligned {
   // Disable C4127 warning ("consider using 'if constexpr' statement instead")
   // as 'if constexpr' is not available in C++11
   #pragma warning(disable : 4127)
+  #pragma warning(disable : 4661)
 #endif
 
 #endif

--- a/src/core/utils/macros.h
+++ b/src/core/utils/macros.h
@@ -170,7 +170,7 @@ struct alignas(CACHELINE_SIZE) cache_aligned {
   #pragma warning(disable : 4996)
 
   // Disable C4127 warning ("consider using 'if constexpr' statement instead")
-  // as 'if constexpr' is not available in C++11F
+  // as 'if constexpr' is not available in C++11
   #pragma warning(disable : 4127)
 #endif
 

--- a/src/core/utils/macros.h
+++ b/src/core/utils/macros.h
@@ -168,6 +168,10 @@ struct alignas(CACHELINE_SIZE) cache_aligned {
   // Disable C4996 warning ("This function or variable may be unsafe")
   // issued by MSVC for a fully valid and portable code
   #pragma warning(disable : 4996)
+
+  // Disable C4127 warning ("consider using 'if constexpr' statement instead")
+  // as 'if constexpr' is not available in C++11F
+  #pragma warning(disable : 4127)
 #endif
 
 #endif

--- a/src/core/utils/misc.cc
+++ b/src/core/utils/misc.cc
@@ -14,7 +14,7 @@ namespace dt {
 
 // The warning is spurious, because shifts triggering the warning are
 // within if() conditions that get statically ignored.
-#if defined(__GNUC__)
+#if DT_COMPILER_GCC
   #pragma GCC diagnostic push
   #pragma GCC diagnostic ignored "-Wshift-count-overflow"
 #endif
@@ -70,7 +70,7 @@ int nsb(T x) {
   return m + static_cast<int>(x);
 }
 
-#if defined(__GNUC__)
+#if DT_COMPILER_GCC
   #pragma GCC diagnostic pop
 #endif
 

--- a/src/core/utils/misc.cc
+++ b/src/core/utils/misc.cc
@@ -14,7 +14,7 @@ namespace dt {
 
 // The warning is spurious, because shifts triggering the warning are
 // within if() conditions that get statically ignored.
-#if !DT_OS_WINDOWS
+#if defined(__GNUC__)
   #pragma GCC diagnostic push
   #pragma GCC diagnostic ignored "-Wshift-count-overflow"
 #endif
@@ -70,7 +70,7 @@ int nsb(T x) {
   return m + static_cast<int>(x);
 }
 
-#if !DT_OS_WINDOWS
+#if defined(__GNUC__)
   #pragma GCC diagnostic pop
 #endif
 

--- a/src/core/utils/terminal/terminal.cc
+++ b/src/core/utils/terminal/terminal.cc
@@ -71,7 +71,11 @@ Terminal::Terminal(bool is_plain) : is_plain_(is_plain){
   enable_keyboard_ = false;
   is_jupyter_ = false;
   is_ipython_ = false;
-  if (!enable_ecma48_) xassert(!enable_colors_);
+  if (!enable_ecma48_) {
+    (void) enable_ecma48_;
+    xassert(!enable_colors_);
+  }
+
   if (!is_plain_) _initialize();
 }
 

--- a/src/core/utils/terminal/terminal.cc
+++ b/src/core/utils/terminal/terminal.cc
@@ -71,10 +71,17 @@ Terminal::Terminal(bool is_plain) : is_plain_(is_plain){
   enable_keyboard_ = false;
   is_jupyter_ = false;
   is_ipython_ = false;
-  if (!enable_ecma48_) {
-    (void) enable_ecma48_;
-    xassert(!enable_colors_);
-  }
+
+  #if DT_OS_WINDOWS && !DT_DEBUG
+    #pragma warning(push)
+    #pragma warning(disable : 4390) // empty controlled statement found
+  #endif
+
+  if (!enable_ecma48_) xassert(!enable_colors_);
+
+  #if DT_OS_WINDOWS && !DT_DEBUG
+    #pragma warning(pop)
+  #endif
 
   if (!is_plain_) _initialize();
 }

--- a/src/core/write/value_writer.cc
+++ b/src/core/write/value_writer.cc
@@ -23,6 +23,7 @@
 #include <cstring>   // std::memcpy
 #include "csv/toa.h"
 #include "utils/exceptions.h"
+#include "utils/macros.h"
 #include "write/value_writer.h"
 namespace dt {
 namespace write {

--- a/src/core/write/zlib_writer.h
+++ b/src/core/write/zlib_writer.h
@@ -97,7 +97,10 @@ class zlib_writer {
       if (input_size != static_cast<zlib::uLong>(input_size)) {
         throw RuntimeError() << "Cannot compress chunk of size " << input_size;
       }
-      size_t out_size = zlib::deflateBound(&stream, input_size);  // estimated
+      size_t out_size = zlib::deflateBound(
+                          &stream, 
+                          static_cast<zlib::uLong>(input_size)
+                        );  // estimated
       ensure_buffer_capacity(out_size);
 
       reset_buffer();

--- a/src/core/write/zlib_writer.h
+++ b/src/core/write/zlib_writer.h
@@ -97,10 +97,7 @@ class zlib_writer {
       if (input_size != static_cast<zlib::uLong>(input_size)) {
         throw RuntimeError() << "Cannot compress chunk of size " << input_size;
       }
-      size_t out_size = zlib::deflateBound(
-                          &stream, 
-                          static_cast<zlib::uLong>(input_size)
-                        );  // estimated
+      size_t out_size = zlib::deflateBound(&stream, input_size);  // estimated
       ensure_buffer_capacity(out_size);
 
       reset_buffer();

--- a/src/core/wstringcol.cc
+++ b/src/core/wstringcol.cc
@@ -116,10 +116,17 @@ char* writable_string_col::buffer_impl<T>::strbuf_ptr() const {
 template <typename T>
 void writable_string_col::buffer_impl<T>::write(const char* ch, size_t len) {
   if (ch) {
-    if (sizeof(T) == 4) {
-      (void) len;
-      xassert(len <= Column::MAX_ARR32_SIZE);
-    }
+
+    #if DT_OS_WINDOWS && !DT_DEBUG
+      #pragma warning(push)
+      #pragma warning(disable : 4390)
+    #endif
+
+    if (sizeof(T) == 4) xassert(len <= Column::MAX_ARR32_SIZE);
+
+    #if DT_OS_WINDOWS && !DT_DEBUG
+      #pragma warning(pop)
+    #endif
 
     strbuf.ensuresize(strbuf_used + len);
     std::memcpy(strbuf_ptr() + strbuf_used, ch, len);

--- a/src/core/wstringcol.cc
+++ b/src/core/wstringcol.cc
@@ -17,6 +17,7 @@
 #include "column.h"
 #include "datatablemodule.h"
 #include "wstringcol.h"
+#include "utils/macros.h"
 
 namespace dt {
 

--- a/src/core/wstringcol.cc
+++ b/src/core/wstringcol.cc
@@ -115,7 +115,11 @@ char* writable_string_col::buffer_impl<T>::strbuf_ptr() const {
 template <typename T>
 void writable_string_col::buffer_impl<T>::write(const char* ch, size_t len) {
   if (ch) {
-    if (sizeof(T) == 4) xassert(len <= Column::MAX_ARR32_SIZE);
+    if (sizeof(T) == 4) {
+      (void) len;
+      xassert(len <= Column::MAX_ARR32_SIZE);
+    }
+
     strbuf.ensuresize(strbuf_used + len);
     std::memcpy(strbuf_ptr() + strbuf_used, ch, len);
     strbuf_used += len;

--- a/src/core/wstringcol.cc
+++ b/src/core/wstringcol.cc
@@ -119,7 +119,7 @@ void writable_string_col::buffer_impl<T>::write(const char* ch, size_t len) {
 
     #if DT_OS_WINDOWS && !DT_DEBUG
       #pragma warning(push)
-      #pragma warning(disable : 4390)
+      #pragma warning(disable : 4390) // empty controlled statement found
     #endif
 
     if (sizeof(T) == 4) xassert(len <= Column::MAX_ARR32_SIZE);


### PR DESCRIPTION
- fix warnings issued by msvc for libs, pragmas, template definitions and some casts;
- introduce and make use of `DT_COMPILER_CLANG`, `DT_COMPILER_GCC` and `DT_COMPILER_MSVC` everywhere, except for the libs code; 
- rename `DTDEBUG` to `DT_DEBUG`.

WIP for #2413 