### PR TITLE
Fread to jay 

### DIFF
--- a/src/core/_dt.h
+++ b/src/core/_dt.h
@@ -96,6 +96,9 @@ namespace read {
   enum BT : uint8_t;
 
   struct FreadTokenizer;
+  union field64;
+
+  class ChunkCoordinates;
   class GenericReader;
   class PreColumn;
   class PreFrame;

--- a/src/core/_dt.h
+++ b/src/core/_dt.h
@@ -104,6 +104,7 @@ namespace read {
   class PreFrame;
   class ThreadContext;
 }}
+class FreadReader;
 
 
 #endif

--- a/src/core/_dt.h
+++ b/src/core/_dt.h
@@ -34,6 +34,7 @@ class DataTable;
 class Groupby;
 class RowIndex;
 class Stats;
+class TemporaryFile;
 class WritableBuffer;
 
 struct CString;

--- a/src/core/_dt.h
+++ b/src/core/_dt.h
@@ -87,6 +87,7 @@ namespace jay {
   struct Frame;
   struct Column;
   struct Buffer;
+  struct ColumnBuilder;
 }
 
 

--- a/src/core/_dt.h
+++ b/src/core/_dt.h
@@ -99,6 +99,7 @@ namespace read {
   class GenericReader;
   class PreColumn;
   class PreFrame;
+  class ThreadContext;
 }}
 
 

--- a/src/core/buffer.cc
+++ b/src/core/buffer.cc
@@ -458,7 +458,7 @@ class TemporaryFile_BufferImpl : public BufferImpl
 
 
     void* data() const override {
-      return static_cast<char*>(temporary_file_->data()) + offset_;
+      return static_cast<char*>(temporary_file_->data_r()) + offset_;
     }
 
     size_t memory_footprint() const noexcept override {
@@ -714,9 +714,9 @@ class Mmap_BufferImpl : public BufferImpl, MemoryMapWorker {
   }
 
   Buffer& Buffer::operator=(const Buffer& other) {
-    auto tmp = impl_;
+    auto old_impl = impl_;
     impl_ = other.impl_->acquire();
-    tmp->release();
+    if (old_impl) old_impl->release();
     return *this;
   }
 

--- a/src/core/buffer.h
+++ b/src/core/buffer.h
@@ -78,9 +78,10 @@ class Buffer
 
   public:
     // Basic copy & move constructors / assignment operators.
-    // The copy constructor creates a shallow copy (similar to shared_ptr).
-    // The move constructor leaves the source object in a state where the
-    // only legal operation is to destruct that object.
+    // The copy constructor creates a shallow copy (similar to
+    // shared_ptr). The move constructor leaves the source object in
+    // a state where the only legal operations are either to destruct
+    // that object, or to reinitialize using `operator=`.
     //
     Buffer();
     Buffer(const Buffer&);

--- a/src/core/buffer.h
+++ b/src/core/buffer.h
@@ -1,9 +1,23 @@
 //------------------------------------------------------------------------------
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright 2018-2020 H2O.ai
 //
-// © H2O.ai 2018-2019
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #ifndef dt_BUFFER_h
 #define dt_BUFFER_h
@@ -13,6 +27,7 @@
 #include <type_traits>        // std::is_same
 #include "utils/assert.h"
 #include "utils/exceptions.h"
+#include "_dt.h"
 #include "writebuf.h"
 
 class BufferImpl;
@@ -127,6 +142,8 @@ class Buffer
     static Buffer mmap(const std::string& path);
     static Buffer mmap(const std::string& path, size_t n, int fd = -1,
                        bool create = true);
+    static Buffer tmp(std::shared_ptr<TemporaryFile> tempfile,
+                      size_t offset, size_t length);
 
     // Basic properties of the Buffer:
     //

--- a/src/core/buffer.h
+++ b/src/core/buffer.h
@@ -89,6 +89,7 @@ class Buffer
     Buffer& operator=(const Buffer&);
     Buffer& operator=(Buffer&&);
     ~Buffer();
+    void swap(Buffer& other);
 
     // Factory constructors:
     //

--- a/src/core/column.h
+++ b/src/core/column.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2019 H2O.ai
+// Copyright 2018-2020 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -116,6 +116,15 @@ class Column
     // reference count reaches 0, the object is deleted.
     // We do not use std::shared_ptr<> here primarily because it makes it
     // harder to inspect the object in GDB / LLDB.
+    //
+    // This pointer is marked `const` in order to prevent accidental
+    // modification of the shared data. Specifically, `impl_` is
+    // potentially shared among multiple `Column` objects; and
+    // modifying one Column should not affect any other instance.
+    // Therefore, when `impl_` needs to be modified use
+    // `_get_mutable_impl()` in order to either const-cast or copy
+    // the `impl_` depending on its refcount.
+    //
     const dt::ColumnImpl* impl_;
 
   public:
@@ -316,6 +325,7 @@ class Column
         const std::string& name,
         flatbuffers::FlatBufferBuilder&,
         WritableBuffer*);
+    void write_data_to_jay(jay::ColumnBuilder&, WritableBuffer*);
 
   private:
     void _acquire_impl(const dt::ColumnImpl*);

--- a/src/core/column/column_impl.cc
+++ b/src/core/column/column_impl.cc
@@ -139,7 +139,11 @@ void ColumnImpl::materialize(Column& out, bool to_memory) {
 
 
 bool ColumnImpl::allow_parallel_access() const {
-  return (stype_ != SType::OBJ);
+  size_t n = n_children();
+  for (size_t i = 0; i < n; ++i) {
+    if (!child(i).allow_parallel_access()) return false;
+  }
+  return true;
 }
 
 
@@ -192,6 +196,9 @@ void ColumnImpl::rbind_impl(colvec&, size_t, bool, SType&) {
   throw NotImplError() << "Method ColumnImpl::rbind_impl() not implemented";
 }
 
+const Column& ColumnImpl::child(size_t) const {
+  throw RuntimeError() << "This Column object has no children";
+}
 
 void ColumnImpl::na_pad(size_t new_nrows, Column& out) {
   xassert(new_nrows > nrows());
@@ -202,6 +209,7 @@ void ColumnImpl::truncate(size_t new_nrows, Column&) {
   xassert(new_nrows < nrows());
   nrows_ = new_nrows;
 }
+
 
 
 

--- a/src/core/column/column_impl.cc
+++ b/src/core/column/column_impl.cc
@@ -22,6 +22,7 @@
 #include "column/column_impl.h"
 #include "column/nafilled.h"
 #include "column/sentinel_fw.h"
+#include "column/truncated.h"
 #include "parallel/api.h"
 #include "parallel/string_utils.h"
 namespace dt {
@@ -205,9 +206,9 @@ void ColumnImpl::na_pad(size_t new_nrows, Column& out) {
   out = Column(new NaFilled_ColumnImpl(std::move(out), new_nrows));
 }
 
-void ColumnImpl::truncate(size_t new_nrows, Column&) {
+void ColumnImpl::truncate(size_t new_nrows, Column& out) {
   xassert(new_nrows < nrows());
-  nrows_ = new_nrows;
+  out = Column(new Truncated_ColumnImpl(std::move(out), new_nrows));
 }
 
 

--- a/src/core/column/column_impl.h
+++ b/src/core/column/column_impl.h
@@ -97,6 +97,9 @@ class ColumnImpl
     virtual bool computationally_expensive() const { return false; }
     virtual size_t memory_footprint() const noexcept = 0;
 
+    virtual size_t n_children() const noexcept = 0;
+    virtual const Column& child(size_t i) const;
+
 
   //------------------------------------
   // Data buffers

--- a/src/core/column/column_impl.h
+++ b/src/core/column/column_impl.h
@@ -110,6 +110,9 @@ class ColumnImpl
     virtual void*       get_data_editable(size_t k) = 0;
     virtual Buffer      get_data_buffer(size_t k) const = 0;
 
+    virtual void write_data_to_jay(Column&, jay::ColumnBuilder&,
+                                   WritableBuffer*) const = 0;
+
 
   //------------------------------------
   // Column manipulation

--- a/src/core/column/const.cc
+++ b/src/core/column/const.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019 H2O.ai
+// Copyright 2019-2020 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -258,6 +258,9 @@ Column Const_ColumnImpl::from_1row_column(const Column& col) {
 }
 
 
+size_t Const_ColumnImpl::n_children() const noexcept {
+  return 0;
+}
 
 void Const_ColumnImpl::repeat(size_t ntimes, Column&) {
   nrows_ *= ntimes;

--- a/src/core/column/const.h
+++ b/src/core/column/const.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019 H2O.ai
+// Copyright 2019-2020 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -35,6 +35,7 @@ class Const_ColumnImpl : public Virtual_ColumnImpl {
     static Column make_string_column(size_t nrows, CString value, SType stype = SType::STR32);
     static Column from_1row_column(const Column& col);
 
+    size_t n_children() const noexcept override;
     void repeat(size_t ntimes, Column& out) override;
 };
 

--- a/src/core/column/func_binary.h
+++ b/src/core/column/func_binary.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019 H2O.ai
+// Copyright 2019-2020 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -55,7 +55,8 @@ class FuncBinary1_ColumnImpl : public Virtual_ColumnImpl {
 
     ColumnImpl* clone() const override;
     void verify_integrity() const override;
-    bool allow_parallel_access() const override;
+    size_t n_children() const noexcept override;
+    const Column& child(size_t i) const override;
 
     bool get_element(size_t i, TO* out) const override;
 };
@@ -85,7 +86,8 @@ class FuncBinary2_ColumnImpl : public Virtual_ColumnImpl {
 
     ColumnImpl* clone() const override;
     void verify_integrity() const override;
-    bool allow_parallel_access() const override;
+    size_t n_children() const noexcept override;
+    const Column& child(size_t i) const override;
 
     bool get_element(size_t i, TO* out) const override;
 };
@@ -144,8 +146,14 @@ void FuncBinary1_ColumnImpl<T1, T2, TO>::verify_integrity() const {
 
 
 template <typename T1, typename T2, typename TO>
-bool FuncBinary1_ColumnImpl<T1, T2, TO>::allow_parallel_access() const {
-  return arg1_.allow_parallel_access() && arg2_.allow_parallel_access();
+size_t FuncBinary1_ColumnImpl<T1, T2, TO>::n_children() const noexcept {
+  return 2;
+}
+
+template <typename T1, typename T2, typename TO>
+const Column& FuncBinary1_ColumnImpl<T1, T2, TO>::child(size_t i) const {
+  xassert(i < 2);
+  return (i == 0)? arg1_ : arg2_;
 }
 
 
@@ -198,8 +206,14 @@ void FuncBinary2_ColumnImpl<T1, T2, TO>::verify_integrity() const {
 
 
 template <typename T1, typename T2, typename TO>
-bool FuncBinary2_ColumnImpl<T1, T2, TO>::allow_parallel_access() const {
-  return arg1_.allow_parallel_access() && arg2_.allow_parallel_access();
+size_t FuncBinary2_ColumnImpl<T1, T2, TO>::n_children() const noexcept {
+  return 2;
+}
+
+template <typename T1, typename T2, typename TO>
+const Column& FuncBinary2_ColumnImpl<T1, T2, TO>::child(size_t i) const {
+  xassert(i < 2);
+  return (i == 0)? arg1_ : arg2_;
 }
 
 

--- a/src/core/column/func_nary.h
+++ b/src/core/column/func_nary.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019 H2O.ai
+// Copyright 2019-2020 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -44,7 +44,8 @@ class FuncNary_ColumnImpl : public Virtual_ColumnImpl
 
     ColumnImpl* clone() const override;
     void verify_integrity() const override;
-    bool allow_parallel_access() const override;
+    size_t n_children() const noexcept override;
+    const Column& child(size_t i) const override;
 
     bool get_element(size_t i, T* out) const override;
 };
@@ -86,12 +87,16 @@ void FuncNary_ColumnImpl<T>::verify_integrity() const {
 
 
 template <typename T>
-bool FuncNary_ColumnImpl<T>::allow_parallel_access() const {
-  for (const auto& col : columns_) {
-    if (!col.allow_parallel_access()) return false;
-  }
-  return true;
+size_t FuncNary_ColumnImpl<T>::n_children() const noexcept {
+  return columns_.size();
 }
+
+template <typename T>
+const Column& FuncNary_ColumnImpl<T>::child(size_t i) const {
+  xassert(i < columns_.size());
+  return columns_[i];
+}
+
 
 
 template <typename T>

--- a/src/core/column/func_unary.h
+++ b/src/core/column/func_unary.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019 H2O.ai
+// Copyright 2019-2020 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -52,7 +52,8 @@ class FuncUnary1_ColumnImpl : public Virtual_ColumnImpl {
 
     ColumnImpl* clone() const override;
     void verify_integrity() const override;
-    bool allow_parallel_access() const override;
+    size_t n_children() const noexcept override;
+    const Column& child(size_t i) const override;
 
     bool get_element(size_t i, TO* out) const override;
 };
@@ -79,7 +80,8 @@ class FuncUnary2_ColumnImpl : public Virtual_ColumnImpl {
 
     ColumnImpl* clone() const override;
     void verify_integrity() const override;
-    bool allow_parallel_access() const override;
+    size_t n_children() const noexcept override;
+    const Column& child(size_t i) const override;
 
     bool get_element(size_t i, TO* out) const override;
 };
@@ -132,9 +134,16 @@ void FuncUnary1_ColumnImpl<TI, TO>::verify_integrity() const {
 
 
 template <typename TI, typename TO>
-bool FuncUnary1_ColumnImpl<TI, TO>::allow_parallel_access() const {
-  return arg_.allow_parallel_access();
+size_t FuncUnary1_ColumnImpl<TI, TO>::n_children() const noexcept {
+  return 1;
 }
+
+template <typename TI, typename TO>
+const Column& FuncUnary1_ColumnImpl<TI, TO>::child(size_t i) const {
+  xassert(i == 0);  (void)i;
+  return arg_;
+}
+
 
 
 
@@ -179,9 +188,16 @@ void FuncUnary2_ColumnImpl<TI, TO>::verify_integrity() const {
 }
 
 
+
 template <typename TI, typename TO>
-bool FuncUnary2_ColumnImpl<TI, TO>::allow_parallel_access() const {
-  return arg_.allow_parallel_access();
+size_t FuncUnary2_ColumnImpl<TI, TO>::n_children() const noexcept {
+  return 1;
+}
+
+template <typename TI, typename TO>
+const Column& FuncUnary2_ColumnImpl<TI, TO>::child(size_t i) const {
+  xassert(i == 0);  (void)i;
+  return arg_;
 }
 
 

--- a/src/core/column/isclose.h
+++ b/src/core/column/isclose.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019 H2O.ai
+// Copyright 2019-2020 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -56,8 +56,13 @@ class IsClose_ColumnImpl : public Virtual_ColumnImpl {
                                        rtol_, atol_, nrows_);
     }
 
-    bool allow_parallel_access() const override {
-      return argx_.allow_parallel_access() && argy_.allow_parallel_access();
+    size_t n_children() const noexcept override {
+      return 2;
+    }
+
+    const Column& child(size_t i) const override {
+      xassert(i < 2);
+      return (i == 0)? argx_ : argy_;
     }
 
 

--- a/src/core/column/latent.cc
+++ b/src/core/column/latent.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019 H2O.ai
+// Copyright 2019-2020 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -65,6 +65,12 @@ void Latent_ColumnImpl::materialize(Column&, bool to_memory) {
 bool Latent_ColumnImpl::allow_parallel_access() const {
   return vivify()->allow_parallel_access();
 }
+
+
+size_t Latent_ColumnImpl::n_children() const noexcept {
+  return 0;
+}
+
 
 
 bool Latent_ColumnImpl::get_element(size_t i, int8_t* out)   const { return vivify()->get_element(i, out); }

--- a/src/core/column/latent.h
+++ b/src/core/column/latent.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019 H2O.ai
+// Copyright 2019-2020 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -52,6 +52,7 @@ class Latent_ColumnImpl : public Virtual_ColumnImpl {
     ColumnImpl* clone() const override;
     void materialize(Column&, bool) override;
     bool allow_parallel_access() const override;
+    size_t n_children() const noexcept override;
 
     bool get_element(size_t, int8_t*)   const override;
     bool get_element(size_t, int16_t*)  const override;

--- a/src/core/column/nafilled.cc
+++ b/src/core/column/nafilled.cc
@@ -26,15 +26,26 @@ namespace dt {
 
 NaFilled_ColumnImpl::NaFilled_ColumnImpl(Column&& col, size_t nrows)
   : Virtual_ColumnImpl(nrows, col.stype()),
-    arg_nrows(col.nrows()),
-    arg(std::move(col))
+    arg_nrows_(col.nrows()),
+    arg_(std::move(col))
 {
-  xassert(nrows >= arg.nrows());
+  xassert(nrows > arg_.nrows());
+}
+
+// Only used by Truncated_ColumnImpl and clone()
+NaFilled_ColumnImpl::NaFilled_ColumnImpl(Column&& col, size_t nrows,
+                                         size_t arg_nrows)
+  : Virtual_ColumnImpl(nrows, col.stype()),
+    arg_nrows_(arg_nrows),
+    arg_(std::move(col))
+{
+  xassert(nrows > arg_nrows_);
 }
 
 
+
 ColumnImpl* NaFilled_ColumnImpl::clone() const {
-  return new NaFilled_ColumnImpl(Column(arg), nrows_);
+  return new NaFilled_ColumnImpl(Column(arg_), nrows_, arg_nrows_);
 }
 
 
@@ -46,9 +57,9 @@ void NaFilled_ColumnImpl::na_pad(size_t new_nrows, Column&) {
 void NaFilled_ColumnImpl::truncate(size_t new_nrows, Column& out)
 {
   xassert(new_nrows < nrows_);
-  if (new_nrows < arg_nrows) {
-    arg.resize(new_nrows);
-    out = std::move(arg);
+  if (new_nrows <= arg_nrows_) {
+    arg_.resize(new_nrows);
+    out = std::move(arg_);
   }
   else {
     nrows_ = new_nrows;
@@ -61,42 +72,42 @@ size_t NaFilled_ColumnImpl::n_children() const noexcept {
 
 const Column& NaFilled_ColumnImpl::child(size_t i) const {
   xassert(i == 0);  (void)i;
-  return arg;
+  return arg_;
 }
 
 
 
 
 bool NaFilled_ColumnImpl::get_element(size_t i, int8_t* out)   const {
-  return (i < arg_nrows) && arg.get_element(i, out);
+  return (i < arg_nrows_) && arg_.get_element(i, out);
 }
 
 bool NaFilled_ColumnImpl::get_element(size_t i, int16_t* out)  const {
-  return (i < arg_nrows) && arg.get_element(i, out);
+  return (i < arg_nrows_) && arg_.get_element(i, out);
 }
 
 bool NaFilled_ColumnImpl::get_element(size_t i, int32_t* out)  const {
-  return (i < arg_nrows) && arg.get_element(i, out);
+  return (i < arg_nrows_) && arg_.get_element(i, out);
 }
 
 bool NaFilled_ColumnImpl::get_element(size_t i, int64_t* out)  const {
-  return (i < arg_nrows) && arg.get_element(i, out);
+  return (i < arg_nrows_) && arg_.get_element(i, out);
 }
 
 bool NaFilled_ColumnImpl::get_element(size_t i, float* out)    const {
-  return (i < arg_nrows) && arg.get_element(i, out);
+  return (i < arg_nrows_) && arg_.get_element(i, out);
 }
 
 bool NaFilled_ColumnImpl::get_element(size_t i, double* out)   const {
-  return (i < arg_nrows) && arg.get_element(i, out);
+  return (i < arg_nrows_) && arg_.get_element(i, out);
 }
 
 bool NaFilled_ColumnImpl::get_element(size_t i, CString* out)  const {
-  return (i < arg_nrows) && arg.get_element(i, out);
+  return (i < arg_nrows_) && arg_.get_element(i, out);
 }
 
 bool NaFilled_ColumnImpl::get_element(size_t i, py::robj* out) const {
-  return (i < arg_nrows) && arg.get_element(i, out);
+  return (i < arg_nrows_) && arg_.get_element(i, out);
 }
 
 

--- a/src/core/column/nafilled.cc
+++ b/src/core/column/nafilled.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019 H2O.ai
+// Copyright 2019-2020 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -53,6 +53,15 @@ void NaFilled_ColumnImpl::truncate(size_t new_nrows, Column& out)
   else {
     nrows_ = new_nrows;
   }
+}
+
+size_t NaFilled_ColumnImpl::n_children() const noexcept {
+  return 1;
+}
+
+const Column& NaFilled_ColumnImpl::child(size_t i) const {
+  xassert(i == 0);  (void)i;
+  return arg;
 }
 
 

--- a/src/core/column/nafilled.h
+++ b/src/core/column/nafilled.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019 H2O.ai
+// Copyright 2019-2020 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -41,6 +41,8 @@ class NaFilled_ColumnImpl : public Virtual_ColumnImpl {
 
     void na_pad(size_t new_nrows, Column& out) override;
     void truncate(size_t new_nrows, Column& out) override;
+    size_t n_children() const noexcept override;
+    const Column& child(size_t i) const override;
 
     bool get_element(size_t, int8_t*)   const override;
     bool get_element(size_t, int16_t*)  const override;

--- a/src/core/column/npmasked.cc
+++ b/src/core/column/npmasked.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019 H2O.ai
+// Copyright 2019-2020 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -73,6 +73,17 @@ void NpMasked_ColumnImpl::materialize(Column& out, bool to_memory) {
   }
   ColumnImpl::materialize(out, to_memory);
 }
+
+
+size_t NpMasked_ColumnImpl::n_children() const noexcept {
+  return 1;
+}
+
+const Column& NpMasked_ColumnImpl::child(size_t i) const {
+  xassert(i == 0);  (void)i;
+  return arg_;
+}
+
 
 
 

--- a/src/core/column/npmasked.h
+++ b/src/core/column/npmasked.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019 H2O.ai
+// Copyright 2019-2020 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -43,6 +43,8 @@ class NpMasked_ColumnImpl : public Virtual_ColumnImpl {
 
     ColumnImpl* clone() const override;
     void materialize(Column&, bool) override;
+    size_t n_children() const noexcept override;
+    const Column& child(size_t i) const override;
 
     bool get_element(size_t, int8_t*)  const override;
     bool get_element(size_t, int16_t*) const override;

--- a/src/core/column/pysources.cc
+++ b/src/core/column/pysources.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019 H2O.ai
+// Copyright 2019-2020 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -40,6 +40,14 @@ ColumnImpl* PyList_ColumnImpl::clone() const {
   return new PyList_ColumnImpl(list_);
 }
 
+bool PyList_ColumnImpl::allow_parallel_access() const {
+  return false;
+}
+
+size_t PyList_ColumnImpl::n_children() const noexcept {
+  return 0;
+}
+
 
 bool PyList_ColumnImpl::get_element(size_t i, py::robj* out) const {
   xassert(i < nrows_);
@@ -64,6 +72,14 @@ ColumnImpl* PyTupleList_ColumnImpl::clone() const {
   return new PyTupleList_ColumnImpl(tuple_list_, index_);
 }
 
+bool PyTupleList_ColumnImpl::allow_parallel_access() const {
+  return false;
+}
+
+size_t PyTupleList_ColumnImpl::n_children() const noexcept {
+  return 0;
+}
+
 
 bool PyTupleList_ColumnImpl::get_element(size_t i, py::robj* out) const {
   xassert(i < nrows_);
@@ -86,6 +102,14 @@ PyDictList_ColumnImpl::PyDictList_ColumnImpl(const py::olist& list, py::oobj k)
 
 ColumnImpl* PyDictList_ColumnImpl::clone() const {
   return new PyDictList_ColumnImpl(dict_list_, key_);
+}
+
+bool PyDictList_ColumnImpl::allow_parallel_access() const {
+  return false;
+}
+
+size_t PyDictList_ColumnImpl::n_children() const noexcept {
+  return 0;
 }
 
 

--- a/src/core/column/pysources.h
+++ b/src/core/column/pysources.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019 H2O.ai
+// Copyright 2019-2020 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -38,6 +38,8 @@ class PyList_ColumnImpl : public Virtual_ColumnImpl {
     explicit PyList_ColumnImpl(const py::olist&);
 
     ColumnImpl* clone() const override;
+    bool allow_parallel_access() const override;
+    size_t n_children() const noexcept override;
     bool get_element(size_t, py::robj*) const override;
 };
 
@@ -56,6 +58,8 @@ class PyTupleList_ColumnImpl : public Virtual_ColumnImpl {
     explicit PyTupleList_ColumnImpl(const py::olist&, size_t index);
 
     ColumnImpl* clone() const override;
+    bool allow_parallel_access() const override;
+    size_t n_children() const noexcept override;
     bool get_element(size_t, py::robj*) const override;
 };
 
@@ -75,6 +79,8 @@ class PyDictList_ColumnImpl : public Virtual_ColumnImpl {
     explicit PyDictList_ColumnImpl(const py::olist&, py::oobj key);
 
     ColumnImpl* clone() const override;
+    bool allow_parallel_access() const override;
+    size_t n_children() const noexcept override;
     bool get_element(size_t, py::robj*) const override;
 };
 

--- a/src/core/column/range.cc
+++ b/src/core/column/range.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019 H2O.ai
+// Copyright 2019-2020 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -135,6 +135,11 @@ void Range_ColumnImpl::verify_integrity() const {
   Virtual_ColumnImpl::verify_integrity();
   auto ltype = info(stype_).ltype();
   XAssert(ltype == LType::INT || ltype == LType::REAL);
+}
+
+
+size_t Range_ColumnImpl::n_children() const noexcept {
+  return 0;
 }
 
 

--- a/src/core/column/range.h
+++ b/src/core/column/range.h
@@ -46,6 +46,7 @@ class Range_ColumnImpl : public Virtual_ColumnImpl {
                      SType stype = SType::VOID);
 
     ColumnImpl* clone() const override;
+    size_t n_children() const noexcept override;
     size_t memory_footprint() const noexcept override;
     void materialize(Column&, bool) override;
     void verify_integrity() const override;

--- a/src/core/column/rbound.cc
+++ b/src/core/column/rbound.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019 H2O.ai
+// Copyright 2019-2020 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -47,9 +47,10 @@ static SType compute_stype(const colvec& columns) {
 
 Rbound_ColumnImpl::Rbound_ColumnImpl(const colvec& columns)
   : Virtual_ColumnImpl(compute_nrows(columns), compute_stype(columns)),
-    columns_(columns)
+    chunks_(columns)
 {
-  for (auto& col : columns_) {
+  xassert(!chunks_.empty());
+  for (auto& col : chunks_) {
     if (col.stype() != stype()) {
       col.cast_inplace(stype());
     }
@@ -58,7 +59,7 @@ Rbound_ColumnImpl::Rbound_ColumnImpl(const colvec& columns)
 
 
 ColumnImpl* Rbound_ColumnImpl::clone() const {
-  auto res = new Rbound_ColumnImpl(columns_);
+  auto res = new Rbound_ColumnImpl(chunks_);
   res->nrows_ = nrows_;
   return res;
 }
@@ -80,14 +81,14 @@ static inline bool _get(const colvec& columns, size_t i, T* out) {
   throw ValueError() << "Index " << i << " is out of range";
 }
 
-bool Rbound_ColumnImpl::get_element(size_t i, int8_t* out)   const { return _get(columns_, i, out); }
-bool Rbound_ColumnImpl::get_element(size_t i, int16_t* out)  const { return _get(columns_, i, out); }
-bool Rbound_ColumnImpl::get_element(size_t i, int32_t* out)  const { return _get(columns_, i, out); }
-bool Rbound_ColumnImpl::get_element(size_t i, int64_t* out)  const { return _get(columns_, i, out); }
-bool Rbound_ColumnImpl::get_element(size_t i, float* out)    const { return _get(columns_, i, out); }
-bool Rbound_ColumnImpl::get_element(size_t i, double* out)   const { return _get(columns_, i, out); }
-bool Rbound_ColumnImpl::get_element(size_t i, CString* out)  const { return _get(columns_, i, out); }
-bool Rbound_ColumnImpl::get_element(size_t i, py::robj* out) const { return _get(columns_, i, out); }
+bool Rbound_ColumnImpl::get_element(size_t i, int8_t* out)   const { return _get(chunks_, i, out); }
+bool Rbound_ColumnImpl::get_element(size_t i, int16_t* out)  const { return _get(chunks_, i, out); }
+bool Rbound_ColumnImpl::get_element(size_t i, int32_t* out)  const { return _get(chunks_, i, out); }
+bool Rbound_ColumnImpl::get_element(size_t i, int64_t* out)  const { return _get(chunks_, i, out); }
+bool Rbound_ColumnImpl::get_element(size_t i, float* out)    const { return _get(chunks_, i, out); }
+bool Rbound_ColumnImpl::get_element(size_t i, double* out)   const { return _get(chunks_, i, out); }
+bool Rbound_ColumnImpl::get_element(size_t i, CString* out)  const { return _get(chunks_, i, out); }
+bool Rbound_ColumnImpl::get_element(size_t i, py::robj* out) const { return _get(chunks_, i, out); }
 
 
 

--- a/src/core/column/rbound.cc
+++ b/src/core/column/rbound.cc
@@ -65,6 +65,17 @@ ColumnImpl* Rbound_ColumnImpl::clone() const {
 }
 
 
+size_t Rbound_ColumnImpl::n_children() const noexcept {
+  return chunks_.size();
+}
+
+const Column& Rbound_ColumnImpl::child(size_t i) const {
+  xassert(i < chunks_.size());
+  return chunks_[i];
+}
+
+
+
 
 //------------------------------------------------------------------------------
 // Data access

--- a/src/core/column/rbound.h
+++ b/src/core/column/rbound.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019 H2O.ai
+// Copyright 2019-2020 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -21,8 +21,6 @@
 //------------------------------------------------------------------------------
 #ifndef dt_COLUMN_RBOUND_h
 #define dt_COLUMN_RBOUND_h
-#include <memory>
-#include <vector>
 #include "column/virtual.h"
 namespace dt {
 
@@ -32,7 +30,7 @@ namespace dt {
   */
 class Rbound_ColumnImpl : public Virtual_ColumnImpl {
   private:
-    std::vector<Column> columns_;
+    std::vector<Column> chunks_;
 
   public:
     Rbound_ColumnImpl(const colvec& columns);
@@ -48,6 +46,9 @@ class Rbound_ColumnImpl : public Virtual_ColumnImpl {
     bool get_element(size_t i, double* out)   const override;
     bool get_element(size_t i, CString* out)  const override;
     bool get_element(size_t i, py::robj* out) const override;
+
+    void write_data_to_jay(Column&, jay::ColumnBuilder&,
+                           WritableBuffer*) const override;
 };
 
 

--- a/src/core/column/rbound.h
+++ b/src/core/column/rbound.h
@@ -37,6 +37,8 @@ class Rbound_ColumnImpl : public Virtual_ColumnImpl {
 
     ColumnImpl* clone() const override;
     // ColumnImpl* materialize() override;
+    size_t n_children() const noexcept override;
+    const Column& child(size_t i) const override;
 
     bool get_element(size_t i, int8_t* out)   const override;
     bool get_element(size_t i, int16_t* out)  const override;

--- a/src/core/column/repeated.cc
+++ b/src/core/column/repeated.cc
@@ -48,9 +48,16 @@ void Repeated_ColumnImpl::repeat(size_t ntimes, Column&) {
   nrows_ *= ntimes;
 }
 
-bool Repeated_ColumnImpl::allow_parallel_access() const {
-  return arg.allow_parallel_access();
+
+size_t Repeated_ColumnImpl::n_children() const noexcept {
+  return 1;
 }
+
+const Column& Repeated_ColumnImpl::child(size_t i) const {
+  xassert(i == 0);  (void)i;
+  return arg;
+}
+
 
 
 bool Repeated_ColumnImpl::get_element(size_t i, int8_t* out)   const { return arg.get_element(i % mod, out); }

--- a/src/core/column/repeated.h
+++ b/src/core/column/repeated.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019 H2O.ai
+// Copyright 2019-2020 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -39,7 +39,8 @@ class Repeated_ColumnImpl : public Virtual_ColumnImpl {
 
     ColumnImpl* clone() const override;
     void repeat(size_t ntimes, Column& out) override;
-    bool allow_parallel_access() const override;
+    size_t n_children() const noexcept override;
+    const Column& child(size_t i) const override;
 
     bool get_element(size_t, int8_t*)   const override;
     bool get_element(size_t, int16_t*)  const override;

--- a/src/core/column/sentinel.cc
+++ b/src/core/column/sentinel.cc
@@ -113,6 +113,10 @@ Sentinel_ColumnImpl::Sentinel_ColumnImpl(size_t nrows, SType stype)
   : ColumnImpl(nrows, stype) {}
 
 
+bool Sentinel_ColumnImpl::allow_parallel_access() const {
+  return (stype_ != SType::OBJ);
+}
+
 bool Sentinel_ColumnImpl::is_virtual() const noexcept {
   return false;
 }
@@ -121,6 +125,9 @@ NaStorage Sentinel_ColumnImpl::get_na_storage_method() const noexcept {
   return NaStorage::SENTINEL;
 }
 
+size_t Sentinel_ColumnImpl::n_children() const noexcept {
+  return 0;
+}
 
 
 

--- a/src/core/column/sentinel.h
+++ b/src/core/column/sentinel.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019 H2O.ai
+// Copyright 2019-2020 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -39,6 +39,9 @@ class Sentinel_ColumnImpl : public ColumnImpl
 
     bool is_virtual() const noexcept override;
     NaStorage get_na_storage_method() const noexcept override;
+
+    void write_data_to_jay(Column&, jay::ColumnBuilder&,
+                           WritableBuffer*) const override;
 
   protected:
     Sentinel_ColumnImpl(size_t nrows, SType stype);

--- a/src/core/column/sentinel.h
+++ b/src/core/column/sentinel.h
@@ -37,8 +37,10 @@ class Sentinel_ColumnImpl : public ColumnImpl
     static Column make_fw_column(size_t nrows, SType, Buffer&&);
     static Column make_str_column(size_t nrows, Buffer&&, Buffer&&);
 
+    bool allow_parallel_access() const override;
     bool is_virtual() const noexcept override;
     NaStorage get_na_storage_method() const noexcept override;
+    size_t n_children() const noexcept override;
 
     void write_data_to_jay(Column&, jay::ColumnBuilder&,
                            WritableBuffer*) const override;

--- a/src/core/column/sentinel_str.cc
+++ b/src/core/column/sentinel_str.cc
@@ -46,8 +46,8 @@ SentinelStr_ColumnImpl<T>::SentinelStr_ColumnImpl(size_t n, Buffer&& mb, Buffer&
 {
   xassert(mb);
   xassert(mb.size() >= sizeof(T) * (n + 1));
-  xassert(mb.get_element<T>(0) == 0);
-  xassert(sb.size() >= (mb.get_element<T>(n) & ~GETNA<T>()));
+  // xassert(mb.get_element<T>(0) == 0);
+  // xassert(sb.size() >= (mb.get_element<T>(n) & ~GETNA<T>()));
   offbuf_ = std::move(mb);
   strbuf_ = std::move(sb);
 }

--- a/src/core/column/sentinel_str.cc
+++ b/src/core/column/sentinel_str.cc
@@ -81,13 +81,15 @@ template <typename T>
 size_t SentinelStr_ColumnImpl<T>::get_data_size(size_t k) const {
   xassert(k <= 1);
   if (k == 0) {
-    xassert(offbuf_.size() >= (nrows_ + 1) * sizeof(T));
-    return (nrows_ + 1) * sizeof(T);
+    // xassert(offbuf_.size() >= (nrows_ + 1) * sizeof(T));
+    // return (nrows_ + 1) * sizeof(T);
+    return offbuf_.size();
   }
   else {
-    size_t sz = static_cast<const T*>(offbuf_.rptr())[nrows_] & ~GETNA<T>();
-    xassert(sz <= strbuf_.size());
-    return sz;
+    // size_t sz = static_cast<const T*>(offbuf_.rptr())[nrows_] & ~GETNA<T>();
+    // xassert(sz <= strbuf_.size());
+    // return sz;
+    return strbuf_.size();
   }
 }
 

--- a/src/core/column/shift.h
+++ b/src/core/column/shift.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019 H2O.ai
+// Copyright 2019-2020 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -52,6 +52,15 @@ class Shift_ColumnImpl : public Virtual_ColumnImpl {
 
     bool allow_parallel_access() const override {
       return arg_.allow_parallel_access();
+    }
+
+    size_t n_children() const noexcept override {
+      return 1;
+    }
+
+    const Column& child(size_t i) const override {
+      xassert(i == 0);  (void)i;
+      return arg_;
     }
 
 

--- a/src/core/column/strvec.h
+++ b/src/core/column/strvec.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019 H2O.ai
+// Copyright 2019-2020 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -55,6 +55,10 @@ class Strvec_ColumnImpl : public Virtual_ColumnImpl {
       auto res = new Strvec_ColumnImpl(vec);
       res->nrows_ = nrows_;
       return res;
+    }
+
+    size_t n_children() const noexcept override {
+      return 0;
     }
 };
 

--- a/src/core/column/truncated.cc
+++ b/src/core/column/truncated.cc
@@ -1,0 +1,106 @@
+//------------------------------------------------------------------------------
+// Copyright 2019-2020 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#include "column/nafilled.h"
+#include "column/truncated.h"
+namespace dt {
+
+
+Truncated_ColumnImpl::Truncated_ColumnImpl(Column&& col, size_t nrows)
+  : Virtual_ColumnImpl(nrows, col.stype()),
+    arg_(std::move(col))
+{
+  xassert(nrows < arg_.nrows());
+}
+
+
+ColumnImpl* Truncated_ColumnImpl::clone() const {
+  return new Truncated_ColumnImpl(Column(arg_), nrows_);
+}
+
+
+void Truncated_ColumnImpl::na_pad(size_t new_nrows, Column& out) {
+  xassert(new_nrows > nrows_);
+  out = Column(new NaFilled_ColumnImpl(std::move(arg_), new_nrows, nrows_));
+}
+
+void Truncated_ColumnImpl::truncate(size_t new_nrows, Column&)
+{
+  xassert(new_nrows < nrows_);
+  nrows_ = new_nrows;
+}
+
+size_t Truncated_ColumnImpl::n_children() const noexcept {
+  return 1;
+}
+
+const Column& Truncated_ColumnImpl::child(size_t i) const {
+  xassert(i == 0);  (void)i;
+  return arg_;
+}
+
+
+
+
+bool Truncated_ColumnImpl::get_element(size_t i, int8_t* out)   const {
+  xassert(i < nrows_);
+  return arg_.get_element(i, out);
+}
+
+bool Truncated_ColumnImpl::get_element(size_t i, int16_t* out)  const {
+  xassert(i < nrows_);
+  return arg_.get_element(i, out);
+}
+
+bool Truncated_ColumnImpl::get_element(size_t i, int32_t* out)  const {
+  xassert(i < nrows_);
+  return arg_.get_element(i, out);
+}
+
+bool Truncated_ColumnImpl::get_element(size_t i, int64_t* out)  const {
+  xassert(i < nrows_);
+  return arg_.get_element(i, out);
+}
+
+bool Truncated_ColumnImpl::get_element(size_t i, float* out)    const {
+  xassert(i < nrows_);
+  return arg_.get_element(i, out);
+}
+
+bool Truncated_ColumnImpl::get_element(size_t i, double* out)   const {
+  xassert(i < nrows_);
+  return arg_.get_element(i, out);
+}
+
+bool Truncated_ColumnImpl::get_element(size_t i, CString* out)  const {
+  xassert(i < nrows_);
+  return arg_.get_element(i, out);
+}
+
+bool Truncated_ColumnImpl::get_element(size_t i, py::robj* out) const {
+  xassert(i < nrows_);
+  return arg_.get_element(i, out);
+}
+
+
+
+
+}  // namespace dt

--- a/src/core/column/truncated.h
+++ b/src/core/column/truncated.h
@@ -19,25 +19,22 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
-#ifndef dt_COLUMN_NAFILLED_h
-#define dt_COLUMN_NAFILLED_h
-#include <memory>
+#ifndef dt_COLUMN_TRUNCATED_h
+#define dt_COLUMN_TRUNCATED_h
 #include "column/virtual.h"
 namespace dt {
 
 
 /**
-  * Virtual column representing the `arg` column padded with NAs
-  * up to `nrows_ > arg.nrows()`.
+  * Virtual column representing the `arg` truncated to
+  * `nrows_ < arg.nrows()` rows.
   */
-class NaFilled_ColumnImpl : public Virtual_ColumnImpl {
+class Truncated_ColumnImpl : public Virtual_ColumnImpl {
   private:
-    size_t arg_nrows_;
     Column arg_;
 
   public:
-    NaFilled_ColumnImpl(Column&&, size_t nrows);
-    NaFilled_ColumnImpl(Column&&, size_t nrows, size_t arg_nrows);
+    Truncated_ColumnImpl(Column&&, size_t nrows);
     ColumnImpl* clone() const override;
 
     void na_pad(size_t new_nrows, Column& out) override;

--- a/src/core/column/view.cc
+++ b/src/core/column/view.cc
@@ -49,6 +49,15 @@ bool SliceView_ColumnImpl::allow_parallel_access() const {
   return arg.allow_parallel_access();
 }
 
+size_t SliceView_ColumnImpl::n_children() const noexcept {
+  return 1;
+}
+
+const Column& SliceView_ColumnImpl::child(size_t i) const {
+  xassert(i == 0);  (void)i;
+  return arg;
+}
+
 
 bool SliceView_ColumnImpl::get_element(size_t i, int8_t* out)   const { return arg.get_element(start + i*step, out); }
 bool SliceView_ColumnImpl::get_element(size_t i, int16_t* out)  const { return arg.get_element(start + i*step, out); }
@@ -100,6 +109,17 @@ ColumnImpl* ArrayView_ColumnImpl<T>::clone() const {
 template <typename T>
 bool ArrayView_ColumnImpl<T>::allow_parallel_access() const {
   return arg.allow_parallel_access();
+}
+
+template <typename T>
+size_t ArrayView_ColumnImpl<T>::n_children() const noexcept {
+  return 1;
+}
+
+template <typename T>
+const Column& ArrayView_ColumnImpl<T>::child(size_t i) const {
+  xassert(i == 0);  (void)i;
+  return arg;
 }
 
 

--- a/src/core/column/view.h
+++ b/src/core/column/view.h
@@ -40,6 +40,8 @@ class SliceView_ColumnImpl : public Virtual_ColumnImpl {
     SliceView_ColumnImpl(Column&& col, const RowIndex& ri);
     ColumnImpl* clone() const override;
     bool allow_parallel_access() const override;
+    size_t n_children() const noexcept override;
+    const Column& child(size_t i) const override;
 
     bool get_element(size_t i, int8_t* out)   const override;
     bool get_element(size_t i, int16_t* out)  const override;
@@ -70,6 +72,8 @@ class ArrayView_ColumnImpl : public Virtual_ColumnImpl {
     ArrayView_ColumnImpl(Column&& col, const RowIndex& ri, size_t nrows);
     ColumnImpl* clone() const override;
     bool allow_parallel_access() const override;
+    size_t n_children() const noexcept override;
+    const Column& child(size_t i) const override;
 
     // defined in sort.cc
     void sort_grouped(const Groupby& gby, Column& out) override;

--- a/src/core/column/virtual.h
+++ b/src/core/column/virtual.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019 H2O.ai
+// Copyright 2019-2020 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -44,6 +44,8 @@ class Virtual_ColumnImpl : public ColumnImpl
     const void* get_data_readonly(size_t k) const override;
     void* get_data_editable(size_t k) override;
     Buffer get_data_buffer(size_t k) const override;
+    void write_data_to_jay(Column&, jay::ColumnBuilder&,
+                           WritableBuffer*) const override;
 
 };
 

--- a/src/core/csv/reader.cc
+++ b/src/core/csv/reader.cc
@@ -375,7 +375,11 @@ void GenericReader::init_logger(
 
 
 void GenericReader::init_memorybound(const py::Arg& arg) {
-  memory_bound = arg.to<size_t>(size_t(-1));
+  constexpr size_t UNLIMITED = size_t(-1);
+  memory_bound = arg.to<size_t>(UNLIMITED);
+  if (memory_bound != UNLIMITED) {
+    trace("memory_limit = %zu bytes", memory_bound);
+  }
 }
 
 

--- a/src/core/csv/reader.cc
+++ b/src/core/csv/reader.cc
@@ -527,7 +527,6 @@ void GenericReader::_message(
   if (dt::num_threads_in_team() == 0) {
     _send_message_to_python(method, msg, logger);
   } else {
-    // Any other team-wide mutex would work too
     std::lock_guard<std::mutex> lock(dt::python_mutex());
     delayed_message += msg;
   }

--- a/src/core/csv/reader.cc
+++ b/src/core/csv/reader.cc
@@ -83,6 +83,7 @@ void GenericReader::init_options() {
 //------------------------------------------------------------------------------
 
 GenericReader::GenericReader()
+  : preframe(this)
 {
   na_strings = nullptr;
   sof = nullptr;
@@ -97,6 +98,7 @@ GenericReader::GenericReader()
 
 // Copy-constructor will copy only the essential parts
 GenericReader::GenericReader(const GenericReader& g)
+  : preframe(this)
 {
   // Input parameters
   nthreads         = g.nthreads;

--- a/src/core/csv/reader.cc
+++ b/src/core/csv/reader.cc
@@ -91,6 +91,7 @@ GenericReader::GenericReader()
   cr_is_newline = 0;
   multisource_strategy = FreadMultiSourceStrategy::Warn;
   errors_strategy = IreadErrorHandlingStrategy::Error;
+  memory_bound = size_t(-1);
 }
 
 
@@ -118,6 +119,7 @@ GenericReader::GenericReader(const GenericReader& g)
   number_is_na     = g.number_is_na;
   columns_arg      = g.columns_arg;
   t_open_input     = g.t_open_input;
+  memory_bound     = g.memory_bound;
   // Runtime parameters
   job     = g.job;
   input_mbuf = g.input_mbuf;
@@ -367,6 +369,11 @@ void GenericReader::init_logger(
     logger = arg_logger.to_oobj();
     verbose = true;
   }
+}
+
+
+void GenericReader::init_memorybound(const py::Arg& arg) {
+  memory_bound = arg.to<size_t>(size_t(-1));
 }
 
 

--- a/src/core/csv/reader.cc
+++ b/src/core/csv/reader.cc
@@ -92,7 +92,7 @@ GenericReader::GenericReader()
   cr_is_newline = 0;
   multisource_strategy = FreadMultiSourceStrategy::Warn;
   errors_strategy = IreadErrorHandlingStrategy::Error;
-  memory_bound = size_t(-1);
+  memory_limit = size_t(-1);
 }
 
 
@@ -121,7 +121,7 @@ GenericReader::GenericReader(const GenericReader& g)
   number_is_na     = g.number_is_na;
   columns_arg      = g.columns_arg;
   t_open_input     = g.t_open_input;
-  memory_bound     = g.memory_bound;
+  memory_limit     = g.memory_limit;
   // Runtime parameters
   job     = g.job;
   input_mbuf = g.input_mbuf;
@@ -374,11 +374,11 @@ void GenericReader::init_logger(
 }
 
 
-void GenericReader::init_memorybound(const py::Arg& arg) {
+void GenericReader::init_memorylimit(const py::Arg& arg) {
   constexpr size_t UNLIMITED = size_t(-1);
-  memory_bound = arg.to<size_t>(UNLIMITED);
-  if (memory_bound != UNLIMITED) {
-    trace("memory_limit = %zu bytes", memory_bound);
+  memory_limit = arg.to<size_t>(UNLIMITED);
+  if (memory_limit != UNLIMITED) {
+    trace("memory_limit = %zu bytes", memory_limit);
   }
 }
 

--- a/src/core/csv/reader.h
+++ b/src/core/csv/reader.h
@@ -112,6 +112,7 @@ class GenericReader
     const char** na_strings;
     strvec  na_strings_container;
     std::unique_ptr<const char*[]> na_strings_ptr;
+    size_t  memory_bound;
 
   //---- Runtime parameters ----
   // line:
@@ -219,6 +220,7 @@ class GenericReader
     void init_skiptoline (const py::Arg&);
     void init_stripwhite (const py::Arg&);
     void init_tempdir    (const py::Arg&);
+    void init_memorybound(const py::Arg&);
 
   protected:
     void open_input();

--- a/src/core/csv/reader.h
+++ b/src/core/csv/reader.h
@@ -112,7 +112,7 @@ class GenericReader
     const char** na_strings;
     strvec  na_strings_container;
     std::unique_ptr<const char*[]> na_strings_ptr;
-    size_t  memory_bound;
+    size_t  memory_limit;
 
   //---- Runtime parameters ----
   // line:
@@ -220,7 +220,7 @@ class GenericReader
     void init_skiptoline (const py::Arg&);
     void init_stripwhite (const py::Arg&);
     void init_tempdir    (const py::Arg&);
-    void init_memorybound(const py::Arg&);
+    void init_memorylimit(const py::Arg&);
 
   protected:
     void open_input();

--- a/src/core/csv/reader_fread.cc
+++ b/src/core/csv/reader_fread.cc
@@ -22,6 +22,7 @@
 #include "csv/reader_fread.h"    // FreadReader
 #include "read/fread/fread_tokenizer.h"  // dt::read::FreadTokenizer
 #include "utils/misc.h"          // wallclock
+#include "column.h"
 #include "py_encodings.h"        // decode_win1252, check_escaped_string, ...
 
 

--- a/src/core/csv/reader_fread.cc
+++ b/src/core/csv/reader_fread.cc
@@ -625,9 +625,8 @@ void FreadReader::detect_column_types()
   meanLineLen = 0;
 
   if (n_sample_lines <= 1) {
+    // A single-row input, and that row is the header.
     if (header == 1) {
-      // A single-row input, and that row is the header. Reset all types to
-      // boolean (lowest type possible, a better guess than "string").
       preframe.reset_ptypes();
       allocnrow = 0;
     }

--- a/src/core/expr/fbinary/bitwise.cc
+++ b/src/core/expr/fbinary/bitwise.cc
@@ -133,9 +133,15 @@ class BooleanAnd_ColumnImpl : public Virtual_ColumnImpl {
       XAssert(arg2_.stype() == SType::BOOL);
     }
 
-    bool allow_parallel_access() const override {
-      return arg1_.allow_parallel_access() && arg2_.allow_parallel_access();
+    size_t n_children() const noexcept override {
+      return 2;
     }
+
+    const Column& child(size_t i) const override {
+      xassert(i < 2);
+      return (i == 0)? arg1_ : arg2_;
+    }
+
 
     bool get_element(size_t i, int8_t* out) const override {
       int8_t x, y;
@@ -244,9 +250,15 @@ class BooleanOr_ColumnImpl : public Virtual_ColumnImpl {
       XAssert(arg2_.stype() == SType::BOOL);
     }
 
-    bool allow_parallel_access() const override {
-      return arg1_.allow_parallel_access() && arg2_.allow_parallel_access();
+    size_t n_children() const noexcept override {
+      return 2;
     }
+
+    const Column& child(size_t i) const override {
+      xassert(i < 2);
+      return (i == 0)? arg1_ : arg2_;
+    }
+
 
     bool get_element(size_t i, int8_t* out) const override {
       int8_t x, y;

--- a/src/core/expr/funary/floating.cc
+++ b/src/core/expr/funary/floating.cc
@@ -183,9 +183,15 @@ class Isna_ColumnImpl : public Virtual_ColumnImpl {
       return new Isna_ColumnImpl<T>(Column(arg_), nrows_);
     }
 
-    bool allow_parallel_access() const override {
-      return arg_.allow_parallel_access();
+    size_t n_children() const noexcept override {
+      return 1;
     }
+
+    const Column& child(size_t i) const override {
+      xassert(i == 0);  (void)i;
+      return arg_;
+    }
+
 
     bool get_element(size_t i, int8_t* out) const override {
       T tmp;

--- a/src/core/expr/head_func_other.cc
+++ b/src/core/expr/head_func_other.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019 H2O.ai
+// Copyright 2019-2020 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -50,6 +50,16 @@ class re_match_vcol : public Virtual_ColumnImpl {
     ColumnImpl* clone() const override {
       return new re_match_vcol(Column(arg), regex);
     }
+
+    size_t n_children() const noexcept override {
+      return 1;
+    }
+
+    const Column& child(size_t i) const override {
+      xassert(i == 0);  (void)i;
+      return arg;
+    }
+
 
     bool get_element(size_t i, int8_t* out) const override {
       CString x;

--- a/src/core/expr/head_reduce_binary.cc
+++ b/src/core/expr/head_reduce_binary.cc
@@ -89,6 +89,16 @@ class BinaryReduced_ColumnImpl : public Virtual_ColumnImpl {
     bool computationally_expensive() const override {
       return true;
     }
+
+    size_t n_children() const noexcept override {
+      return 2;
+    }
+
+    const Column& child(size_t i) const override {
+      xassert(i < 2);
+      return (i == 0)? arg1 : arg2;
+    }
+
 };
 
 

--- a/src/core/expr/head_reduce_unary.cc
+++ b/src/core/expr/head_reduce_unary.cc
@@ -81,6 +81,16 @@ class Reduced_ColumnImpl : public Virtual_ColumnImpl {
                                           reducer);
     }
 
+    size_t n_children() const noexcept override {
+      return 1;
+    }
+
+    const Column& child(size_t i) const override {
+      xassert(i == 0);  (void)i;
+      return arg;
+    }
+
+
     bool get_element(size_t i, U* out) const override {
       size_t i0, i1;
       groupby.get_group(i, &i0, &i1);
@@ -128,6 +138,16 @@ class FirstLast_ColumnImpl : public Virtual_ColumnImpl {
     bool computationally_expensive() const override {
       return true;
     }
+
+    size_t n_children() const noexcept override {
+      return 1;
+    }
+
+    const Column& child(size_t i) const override {
+      xassert(i == 0);  (void)i;
+      return arg;
+    }
+
 
   private:
     template <typename T>
@@ -396,6 +416,16 @@ class SdGrouped_ColumnImpl : public Virtual_ColumnImpl {
       groupby.get_group(i, &i0, &i1);
       return (i1 - i0 > 1);
     }
+
+
+    size_t n_children() const noexcept override {
+      return 1;
+    }
+
+    const Column& child(size_t i) const override {
+      xassert(i == 0);  (void)i;
+      return arg;
+    }
 };
 
 
@@ -494,6 +524,16 @@ class CountGrouped_ColumnImpl : public Virtual_ColumnImpl
       }
       return true;
     }
+
+    size_t n_children() const noexcept override {
+      return 1;
+    }
+
+    const Column& child(size_t i) const override {
+      xassert(i == 0);  (void)i;
+      return arg;
+    }
+
 };
 
 
@@ -617,6 +657,16 @@ class Median_ColumnImpl : public Virtual_ColumnImpl {
         *out = (static_cast<U>(value1) + static_cast<U>(value2))/2;
       }
       return true;
+    }
+
+
+    size_t n_children() const noexcept override {
+      return 1;
+    }
+
+    const Column& child(size_t i) const override {
+      xassert(i == 0);  (void)i;
+      return arg;
     }
 };
 

--- a/src/core/parallel/api.h
+++ b/src/core/parallel/api.h
@@ -142,6 +142,7 @@ void parallel_for_ordered(size_t n_iterations,
 
 
 std::mutex& python_mutex();
+std::mutex& team_mutex();
 
 }  // namespace dt
 

--- a/src/core/parallel/api.h
+++ b/src/core/parallel/api.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019 H2O.ai
+// Copyright 2019-2020 H2O.ai
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -128,6 +128,7 @@ class ordered {
                   function<void(size_t)> do_ordered,
                   function<void(size_t)> post_ordered);
     void set_n_iterations(size_t n);
+    void wait_until_all_finalized() const;
 };
 
 void parallel_for_ordered(size_t n_iterations, NThreads NThreads_,

--- a/src/core/parallel/api.h
+++ b/src/core/parallel/api.h
@@ -129,6 +129,9 @@ class ordered {
                   function<void(size_t)> post_ordered);
     void set_n_iterations(size_t n);
     void wait_until_all_finalized() const;
+
+    size_t get_n_iterations() const;
+    size_t current_iteration() const;
 };
 
 void parallel_for_ordered(size_t n_iterations, NThreads NThreads_,

--- a/src/core/parallel/parallel_for_ordered.cc
+++ b/src/core/parallel/parallel_for_ordered.cc
@@ -263,6 +263,7 @@ void ordered_scheduler::abort_execution() {
   * READY_TO_FINISH in the meanwhile.
   */
 void ordered_scheduler::wait_until_all_finalized() const {
+  if (n_threads == 1) return;
   size_t ordering_iter;
   {
     std::lock_guard<dt::spin_mutex> lock(mutex);
@@ -282,7 +283,7 @@ void ordered_scheduler::wait_until_all_finalized() const {
   };
   // Busy-wait loop until all eligible tasks have finished their
   // "post-ordered" section.
-  while (1) {
+  while (true) {
     std::this_thread::yield();
     std::lock_guard<dt::spin_mutex> lock(mutex);
     // when `next_to_finish` becomes equal to the current ordering

--- a/src/core/parallel/parallel_for_ordered.cc
+++ b/src/core/parallel/parallel_for_ordered.cc
@@ -63,6 +63,7 @@ class ordered_task : public thread_task {
     bool ready_to_order()  const noexcept { return state == READY_TO_ORDER; }
     bool ready_to_finish() const noexcept { return state == READY_TO_FINISH; }
     bool is_finishing()    const noexcept { return state == FINISHING; }
+    size_t iteration()     const noexcept { return n_iter; }
 
     void advance_state();
     void cancel();
@@ -389,6 +390,16 @@ void ordered::set_n_iterations(size_t n) {
 
 void ordered::wait_until_all_finalized() const {
   sch->wait_until_all_finalized();
+}
+
+
+size_t ordered::get_n_iterations() const {
+  std::lock_guard<dt::spin_mutex> lock(sch->mutex);
+  return sch->n_iterations;
+}
+
+size_t ordered::current_iteration() const {
+  return sch->assigned_tasks[dt::this_thread_index()]->iteration();
 }
 
 

--- a/src/core/parallel/thread_pool.cc
+++ b/src/core/parallel/thread_pool.cc
@@ -206,6 +206,10 @@ std::mutex& python_mutex() {
   return thpool->monitor->mutex;
 }
 
+std::mutex& team_mutex() {
+  return thpool->global_mutex;
+}
+
 
 void thread_pool::init_options() {
   // By default, set the number of threads to `hardware_concurrency`

--- a/src/core/parallel/thread_pool.h
+++ b/src/core/parallel/thread_pool.h
@@ -46,6 +46,7 @@ class thread_team;
 class thread_pool {
   friend class thread_team;
   friend std::mutex& python_mutex();
+  friend std::mutex& team_mutex();
   public:
     std::unique_ptr<monitor_thread> monitor;
 

--- a/src/core/parallel/thread_worker.h
+++ b/src/core/parallel/thread_worker.h
@@ -115,7 +115,6 @@ class thread_worker {
  * `awaken`.
  */
 class idle_job : public thread_scheduler {
-  friend std::mutex& python_mutex();
   private:
     struct sleep_task : public thread_task {
       idle_job* const controller;

--- a/src/core/python/arg.h
+++ b/src/core/python/arg.h
@@ -135,6 +135,11 @@ inline int64_t Arg::to(const int64_t& deflt) const {
 }
 
 template <>
+inline size_t Arg::to(const size_t& deflt) const {
+    return is_none_or_undefined()? deflt : to_size_t();
+}
+
+template <>
 inline double Arg::to(const double& deflt) const {
   return is_none_or_undefined()? deflt : to_double();
 }

--- a/src/core/read/fread/fread_parallel_reader.cc
+++ b/src/core/read/fread/fread_parallel_reader.cc
@@ -38,7 +38,7 @@ void FreadParallelReader::adjust_chunk_coordinates(
   // Adjust the beginning of the chunk so that it is guaranteed not to be
   // on a newline.
   if (cc.is_start_approximate()) {
-    FreadTokenizer& tok = static_cast<FreadThreadContext*>(ctx)->tokenizer;
+    FreadTokenizer& tok = static_cast<FreadThreadContext*>(ctx)->get_tokenizer();
     const char* start = cc.get_start();
     while (*start=='\n' || *start=='\r') start++;
     cc.set_start_approximate(start);

--- a/src/core/read/fread/fread_parallel_reader.cc
+++ b/src/core/read/fread/fread_parallel_reader.cc
@@ -8,7 +8,6 @@
 #include "read/fread/fread_parallel_reader.h"
 #include "read/fread/fread_thread_context.h"  // FreadThreadContext
 #include "csv/reader_fread.h"                 // FreadReader
-
 namespace dt {
 namespace read {
 
@@ -34,12 +33,12 @@ std::unique_ptr<ThreadContext> FreadParallelReader::init_thread_context() {
 
 
 void FreadParallelReader::adjust_chunk_coordinates(
-  ChunkCoordinates& cc, ThreadContextPtr& ctx) const
+    ChunkCoordinates& cc, ThreadContext* ctx) const
 {
   // Adjust the beginning of the chunk so that it is guaranteed not to be
   // on a newline.
   if (cc.is_start_approximate()) {
-    FreadTokenizer& tok = static_cast<FreadThreadContext*>(ctx.get())->tokenizer;
+    FreadTokenizer& tok = static_cast<FreadThreadContext*>(ctx)->tokenizer;
     const char* start = cc.get_start();
     while (*start=='\n' || *start=='\r') start++;
     cc.set_start_approximate(start);
@@ -60,5 +59,6 @@ void FreadParallelReader::adjust_chunk_coordinates(
 }
 
 
-}  // namespace read
-}  // namespace dt
+
+
+}}  // namespace dt::read

--- a/src/core/read/fread/fread_parallel_reader.cc
+++ b/src/core/read/fread/fread_parallel_reader.cc
@@ -29,7 +29,7 @@ std::unique_ptr<ThreadContext> FreadParallelReader::init_thread_context() {
   size_t trows = std::max<size_t>(nrows_allocated / chunk_count, 4);
   size_t tcols = f.preframe.n_columns_in_buffer();
   return std::unique_ptr<ThreadContext>(
-            new FreadThreadContext(tcols, trows, f, types, shmutex));
+            new FreadThreadContext(tcols, trows, f, types));
 }
 
 

--- a/src/core/read/fread/fread_parallel_reader.cc
+++ b/src/core/read/fread/fread_parallel_reader.cc
@@ -25,7 +25,7 @@ void FreadParallelReader::read_all() {
 
 
 std::unique_ptr<ThreadContext> FreadParallelReader::init_thread_context() {
-  size_t trows = std::max<size_t>(nrows_allocated / chunk_count, 4);
+  size_t trows = std::max<size_t>(preframe.nrows_allocated() / chunk_count, 4);
   size_t tcols = f.preframe.n_columns_in_buffer();
   return std::unique_ptr<ThreadContext>(
             new FreadThreadContext(tcols, trows, f, types));

--- a/src/core/read/fread/fread_parallel_reader.h
+++ b/src/core/read/fread/fread_parallel_reader.h
@@ -36,7 +36,7 @@ class FreadParallelReader : public ParallelReader {
     virtual std::unique_ptr<ThreadContext> init_thread_context() override;
 
     virtual void adjust_chunk_coordinates(
-      ChunkCoordinates& cc, ThreadContextPtr& ctx) const override;
+      ChunkCoordinates& cc, ThreadContext* ctx) const override;
 };
 
 

--- a/src/core/read/fread/fread_thread_context.cc
+++ b/src/core/read/fread/fread_thread_context.cc
@@ -306,7 +306,7 @@ void FreadThreadContext::postprocess() {
 }
 
 
-void FreadThreadContext::orderBuffer() {
+void FreadThreadContext::order_buffer() {
   if (!used_nrows) return;
   size_t j = 0;
   for (auto& col : preframe) {

--- a/src/core/read/fread/fread_thread_context.cc
+++ b/src/core/read/fread/fread_thread_context.cc
@@ -20,12 +20,11 @@
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #include "csv/reader_fread.h"      // FreadReader
-#include "encodings.h"             // check_escaped_string, decode_escaped_csv_string
-#include "py_encodings.h"          // decode_win1252
 #include "read/fread/fread_thread_context.h"
 #include "read/parallel_reader.h"  // ChunkCoordinates
 #include "utils/misc.h"            // wallclock
-
+#include "encodings.h"             // check_escaped_string, decode_escaped_csv_string
+#include "py_encodings.h"          // decode_win1252
 namespace dt {
 namespace read {
 
@@ -346,7 +345,7 @@ void FreadThreadContext::push_buffers() {
       // any attempt to write the data may fail with data corruption
     } else if (col.is_string()) {
       WritableBuffer* wb = col.strdata_w();
-      SInfo& si = strinfo[j];
+      auto& si = strinfo[j];
       field64* lo = tbuf.data() + j;
 
       wb->write_at(si.write_at, si.size, sbuf.data() + si.start);

--- a/src/core/read/fread/fread_thread_context.cc
+++ b/src/core/read/fread/fread_thread_context.cc
@@ -32,13 +32,11 @@ namespace read {
 
 
 FreadThreadContext::FreadThreadContext(
-    size_t bcols, size_t brows, FreadReader& f, PT* types_,
-    dt::shared_mutex& mut
+    size_t bcols, size_t brows, FreadReader& f, PT* types_
   ) : ThreadContext(bcols, brows),
       types(types_),
       freader(f),
       preframe(f.preframe),
-      shmutex(mut),
       tokenizer(f.makeTokenizer(tbuf.data(), nullptr)),
       parsers(ParserLibrary::get_parser_fns())
 {
@@ -335,7 +333,6 @@ void FreadThreadContext::orderBuffer() {
 void FreadThreadContext::push_buffers() {
   // If the buffer is empty, then there's nothing to do...
   if (!used_nrows) return;
-  dt::shared_lock<dt::shared_mutex> lock(shmutex);
 
   double t0 = verbose? wallclock() : 0;
   size_t j = 0;

--- a/src/core/read/fread/fread_thread_context.h
+++ b/src/core/read/fread/fread_thread_context.h
@@ -1,21 +1,29 @@
 //------------------------------------------------------------------------------
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright 2018-2020 H2O.ai
 //
-// © H2O.ai 2018
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #ifndef dt_READ_FREAD_THREAD_CONTEXT_h
 #define dt_READ_FREAD_THREAD_CONTEXT_h
-#include "parallel/shared_mutex.h"      // dt::shared_mutex
-#include "read/preframe.h"              // PreFrame
 #include "read/fread/fread_tokenizer.h" // FreadTokenizer
 #include "read/thread_context.h"        // ThreadContext
-
-class FreadReader;
-enum PT : uint8_t;
-using ParserFnPtr = void (*)(dt::read::FreadTokenizer& ctx);
-
+#include "_dt.h"
 namespace dt {
 namespace read {
 
@@ -27,7 +35,9 @@ namespace read {
  */
 class FreadThreadContext : public ThreadContext
 {
-  public:
+  private:
+    using ParserFnPtr = void(*)(FreadTokenizer& ctx);
+
     const char* anchor;
     int quoteRule;
     char quote;
@@ -50,16 +60,18 @@ class FreadThreadContext : public ThreadContext
     FreadThreadContext(size_t bcols, size_t brows, FreadReader&, PT* types);
     FreadThreadContext(const FreadThreadContext&) = delete;
     FreadThreadContext& operator=(const FreadThreadContext&) = delete;
-    virtual ~FreadThreadContext() override;
+    ~FreadThreadContext() override;
 
-    virtual void push_buffers() override;
     void read_chunk(const ChunkCoordinates&, ChunkCoordinates&) override;
     void postprocess();
     void order_buffer() override;
+    void push_buffers() override;
+
+    FreadTokenizer& get_tokenizer() { return tokenizer; }
 };
 
 
-}  // namespace read
-}  // namespace dt
 
+
+}}  // namespace dt::read
 #endif

--- a/src/core/read/fread/fread_thread_context.h
+++ b/src/core/read/fread/fread_thread_context.h
@@ -55,7 +55,7 @@ class FreadThreadContext : public ThreadContext
     virtual void push_buffers() override;
     void read_chunk(const ChunkCoordinates&, ChunkCoordinates&) override;
     void postprocess();
-    void orderBuffer() override;
+    void order_buffer() override;
 };
 
 

--- a/src/core/read/fread/fread_thread_context.h
+++ b/src/core/read/fread/fread_thread_context.h
@@ -43,13 +43,11 @@ class FreadThreadContext : public ThreadContext
 
     FreadReader& freader;
     PreFrame& preframe;
-    dt::shared_mutex& shmutex;
     FreadTokenizer tokenizer;
     const ParserFnPtr* parsers;
 
   public:
-    FreadThreadContext(size_t bcols, size_t brows, FreadReader&, PT* types,
-                       dt::shared_mutex&);
+    FreadThreadContext(size_t bcols, size_t brows, FreadReader&, PT* types);
     FreadThreadContext(const FreadThreadContext&) = delete;
     FreadThreadContext& operator=(const FreadThreadContext&) = delete;
     virtual ~FreadThreadContext() override;

--- a/src/core/read/parallel_reader.cc
+++ b/src/core/read/parallel_reader.cc
@@ -200,16 +200,16 @@ void ParallelReader::read_all()
         },
 
         [&](size_t i) {
-          tctx->row0 = nrows_written;
+          tctx->set_row0(nrows_written);
           order_chunk(tacc, txcc, tctx.get());
 
-          size_t nrows_new = nrows_written + tctx->used_nrows;
+          size_t nrows_new = nrows_written + tctx->get_nrows();
           if (nrows_new > nrows_allocated) {
             if (nrows_new > nrows_max) {
               // more rows read than nrows_max, no need to reallocate
               // the output, just truncate the rows in the current chunk.
               xassert(nrows_max >= nrows_written);
-              tctx->used_nrows = nrows_max - nrows_written;
+              tctx->set_nrows(nrows_max - nrows_written);
               nrows_new = nrows_max;
               realloc_output_columns(i, nrows_new, o);
               o->set_n_iterations(i + 1);

--- a/src/core/read/parallel_reader.cc
+++ b/src/core/read/parallel_reader.cc
@@ -219,7 +219,7 @@ void ParallelReader::read_all()
           }
           nrows_written = nrows_new;
 
-          tctx->orderBuffer();
+          tctx->order_buffer();
         },
 
         [&](size_t) {

--- a/src/core/read/parallel_reader.cc
+++ b/src/core/read/parallel_reader.cc
@@ -270,12 +270,12 @@ void ParallelReader::realloc_output_columns(size_t ichunk, size_t new_nrows,
     // no point in allocating more than that amount.
     new_nrows = nrows_max;
   }
-  nrows_allocated = new_nrows;
 
-  g.trace("Too few rows allocated, reallocating to %zu rows", nrows_allocated);
+  g.trace("Too few rows allocated, reallocating to %zu rows", new_nrows);
 
   ordered_loop->wait_until_all_finalized();
-  g.preframe.set_nrows(nrows_allocated);
+  g.preframe.set_nrows(new_nrows, nrows_written);
+  nrows_allocated = new_nrows;
 }
 
 

--- a/src/core/read/parallel_reader.h
+++ b/src/core/read/parallel_reader.h
@@ -21,26 +21,20 @@
 //------------------------------------------------------------------------------
 #ifndef dt_READ_PARALLELREADER_h
 #define dt_READ_PARALLELREADER_h
-#include <memory>                    // std::unique_ptr
 #include "read/chunk_coordinates.h"  // ChunkCoordinates
 #include "read/thread_context.h"     // ThreadContext
 #include "parallel/api.h"
-#include "parallel/shared_mutex.h"   // shared_mutex
-
-
+#include "_dt.h"
 namespace dt {
 namespace read {
-using ThreadContextPtr = std::unique_ptr<ThreadContext>;
-
-class GenericReader;
 
 
 /**
- * This class' responsibility is to execute parallel reading of its input,
- * ensuring that the data integrity is maintained.
- */
-class ParallelReader {
-
+  * This class' responsibility is to execute parallel reading of its
+  * input, ensuring that the data integrity is maintained.
+  */
+class ParallelReader
+{
   protected:
     size_t chunk_size;
     size_t chunk_count;
@@ -74,22 +68,22 @@ class ParallelReader {
      * `start` / `end` if the flags `start_exact` / `end_exact` are set.
      */
     virtual void adjust_chunk_coordinates(
-        ChunkCoordinates&, ThreadContextPtr&) const {}
+        ChunkCoordinates&, ThreadContext*) const {}
 
     /**
      * Return an instance of a `ThreadContext` class. Implementations of
      * `ParallelReader` are expected to override this method to return
      * appropriate subclasses of `ThreadContext`.
      */
-    virtual ThreadContextPtr init_thread_context() = 0;
+    virtual std::unique_ptr<ThreadContext> init_thread_context() = 0;
 
   private:
-    ChunkCoordinates compute_chunk_boundaries(size_t, ThreadContextPtr&) const;
+    ChunkCoordinates compute_chunk_boundaries(size_t, ThreadContext*) const;
     void determine_chunking_strategy();
     double work_done_amount() const;
     void realloc_output_columns(size_t i, size_t new_nrows, ordered*);
     void order_chunk(ChunkCoordinates& acc, ChunkCoordinates& xcc,
-                     ThreadContextPtr& ctx);
+                     ThreadContext* ctx);
 };
 
 

--- a/src/core/read/parallel_reader.h
+++ b/src/core/read/parallel_reader.h
@@ -1,15 +1,30 @@
 //------------------------------------------------------------------------------
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright 2018-2020 H2O.ai
 //
-// © H2O.ai 2018
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #ifndef dt_READ_PARALLELREADER_h
 #define dt_READ_PARALLELREADER_h
 #include <memory>                    // std::unique_ptr
 #include "read/chunk_coordinates.h"  // ChunkCoordinates
 #include "read/thread_context.h"     // ThreadContext
+#include "parallel/api.h"
 #include "parallel/shared_mutex.h"   // shared_mutex
 
 
@@ -36,7 +51,6 @@ class ParallelReader {
 
   protected:
     GenericReader& g;
-    shared_mutex shmutex;
     size_t nrows_max;
     size_t nrows_allocated;
     size_t nrows_written;
@@ -73,7 +87,7 @@ class ParallelReader {
     ChunkCoordinates compute_chunk_boundaries(size_t, ThreadContextPtr&) const;
     void determine_chunking_strategy();
     double work_done_amount() const;
-    void realloc_output_columns(size_t i, size_t new_nrows);
+    void realloc_output_columns(size_t i, size_t new_nrows, ordered*);
     void order_chunk(ChunkCoordinates& acc, ChunkCoordinates& xcc,
                      ThreadContextPtr& ctx);
 };

--- a/src/core/read/parallel_reader.h
+++ b/src/core/read/parallel_reader.h
@@ -45,9 +45,7 @@ class ParallelReader
 
   protected:
     GenericReader& g;
-    size_t nrows_max;
-    size_t nrows_allocated;
-    size_t nrows_written;
+    PreFrame& preframe;
     size_t nthreads;
 
   public:

--- a/src/core/read/precolumn.cc
+++ b/src/core/read/precolumn.cc
@@ -317,14 +317,35 @@ py::oobj PreColumn::py_descriptor() const {
 
 
 size_t PreColumn::memory_footprint() const {
-  size_t sz = 0;
-  for (const auto& col : chunks_) {
-    sz += col.memory_footprint();
-  }
+  size_t sz = archived_size();
   sz += databuf_.memory_footprint();
   sz += strbuf_? strbuf_->size() : 0;
   sz += name_.size() + sizeof(*this);
   return sz;
+}
+
+
+size_t PreColumn::archived_size() const {
+  size_t sz = 0;
+  for (const auto& col : chunks_) {
+    sz += col.memory_footprint();
+  }
+  return sz;
+}
+
+
+void PreColumn::prepare_for_rereading() {
+  if (type_bumped_ && present_in_output_) {
+    present_in_buffer_ = true;
+    type_bumped_ = false;
+    chunks_.clear();
+    nrows_allocated_ = 0;
+    nrows_archived_ = 0;
+    strbuf_ = nullptr;
+  }
+  else {
+    present_in_buffer_ = false;
+  }
 }
 
 

--- a/src/core/read/precolumn.cc
+++ b/src/core/read/precolumn.cc
@@ -324,7 +324,10 @@ size_t PreColumn::memory_footprint() const {
 size_t PreColumn::archived_size() const {
   size_t sz = 0;
   for (const auto& col : chunks_) {
-    sz += col.memory_footprint();
+    size_t k = col.get_num_data_buffers();
+    for (size_t i = 0; i < k; ++i) {
+      sz += col.get_data_size(i);
+    }
   }
   return sz;
 }

--- a/src/core/read/precolumn.h
+++ b/src/core/read/precolumn.h
@@ -39,8 +39,16 @@ namespace read {
   *
   * An input column usually translates into an output column in a
   * DataTable returned to the user. The exception to this are
-  * "dropped" columns. They are marked with `presentInOutput = false`
-  * flag (and have rtype RT::RDrop).
+  * "dropped" columns. They are marked with `present_in_output_ =
+  * false` flag (and have `rtype_ = RT::RDrop`).
+  *
+  * The `present_in_buffer_` flag tracks whether the column should be
+  * read from the csv file. Normally, this flag has the same value as
+  * `present_in_output_`; however, during a reread stage we want to
+  * reread only those columns that were type-bumped while skipping the
+  * others. Thus, during a reread only type-bumped columns will be
+  * "present in buffer", while those that were read correctly on the
+  * first try will have this flag set to false.
   */
 class PreColumn
 {
@@ -48,12 +56,15 @@ class PreColumn
     std::string name_;
     Buffer databuf_;
     std::unique_ptr<MemoryWritableBuffer> strbuf_;
-    PT ptype_;
+    std::vector<Column> chunks_;
+    size_t nrows_allocated_;
+    size_t nrows_archived_;
+    PT parse_type_;
     RT rtype_;
     bool type_bumped_;
     bool present_in_output_;
     bool present_in_buffer_;
-    int32_t : 24;
+    int : 24;
 
     class ptype_iterator {
       private:
@@ -76,11 +87,11 @@ class PreColumn
     PreColumn(const PreColumn&) = delete;
 
     // Column's data
-    void allocate(size_t nrows);
     void* data_w();
     WritableBuffer* strdata_w();
-
-    Column to_column(size_t nrows) &&;
+    void allocate(size_t new_nrows);
+    void archive_data(size_t nrows_written, std::shared_ptr<TemporaryFile>&);
+    Column to_column();
 
     // Column's name
     const std::string& get_name() const noexcept;
@@ -100,17 +111,18 @@ class PreColumn
 
     // Column info
     bool is_string() const;
-    bool is_dropped() const;
-    bool is_type_bumped() const;
-    bool is_in_output() const;
-    bool is_in_buffer() const;
+    bool is_dropped() const noexcept;
+    bool is_type_bumped() const noexcept;
+    bool is_in_output() const noexcept;
+    bool is_in_buffer() const noexcept;
     size_t elemsize() const;
     void reset_type_bumped();
     void set_in_buffer(bool f);
+    size_t nrows_archived() const noexcept;
 
     // Misc
     py::oobj py_descriptor() const;
-    size_t memory_footprint() const noexcept;
+    size_t memory_footprint() const;
 };
 
 

--- a/src/core/read/precolumn.h
+++ b/src/core/read/precolumn.h
@@ -57,7 +57,6 @@ class PreColumn
     Buffer databuf_;
     std::unique_ptr<MemoryWritableBuffer> strbuf_;
     std::vector<Column> chunks_;
-    size_t nrows_allocated_;
     size_t nrows_archived_;
     PT parse_type_;
     RT rtype_;

--- a/src/core/read/precolumn.h
+++ b/src/core/read/precolumn.h
@@ -123,6 +123,8 @@ class PreColumn
     // Misc
     py::oobj py_descriptor() const;
     size_t memory_footprint() const;
+    size_t archived_size() const;
+    void prepare_for_rereading();
 };
 
 

--- a/src/core/read/preframe.cc
+++ b/src/core/read/preframe.cc
@@ -355,6 +355,7 @@ size_t PreFrame::total_allocsize() const {
 
 void PreFrame::prepare_for_rereading() {
   for (auto& col : columns_) {
+    col.archive_data(nrows_written_, tempfile_);
     col.prepare_for_rereading();
   }
   nrows_written_ = 0;

--- a/src/core/read/preframe.cc
+++ b/src/core/read/preframe.cc
@@ -370,10 +370,13 @@ dtptr PreFrame::to_datatable() && {
   ccols.reserve(n_outcols);
   names.reserve(n_outcols);
 
-  std::shared_ptr<TemporaryFile> tmp = nullptr;
+  if (tempfile_) {
+    tempfile_->data_r();  // Make sure tempfile is initialized for reading
+    tempfile_ = nullptr;
+  }
   for (auto& col : columns_) {
     if (!col.is_in_output()) continue;
-    col.archive_data(nrows_written_, tmp);
+    col.archive_data(nrows_written_, tempfile_);
     names.push_back(col.get_name());
     ccols.push_back(col.to_column());
   }

--- a/src/core/read/preframe.cc
+++ b/src/core/read/preframe.cc
@@ -28,7 +28,10 @@ namespace read {
 
 
 
-PreFrame::PreFrame() noexcept : nrows_(0) {}
+PreFrame::PreFrame() noexcept
+  : nrows_(0),
+    memory_limit_(size_t(-1)),
+    memory_remaining_(size_t(-1)) {}
 
 
 
@@ -57,6 +60,18 @@ void PreFrame::set_nrows(size_t n) {
   nrows_ = n;
 }
 
+
+void PreFrame::set_memory_bound(size_t sz) {
+  memory_limit_ = sz;
+  memory_remaining_ = sz;
+}
+
+void PreFrame::use_memory_quota(size_t sz) {
+  if (memory_remaining_ < sz) {
+    memory_remaining_ = memory_limit_;
+  }
+  memory_remaining_ -= sz;
+}
 
 
 

--- a/src/core/read/preframe.cc
+++ b/src/core/read/preframe.cc
@@ -70,7 +70,7 @@ size_t PreFrame::nrows_written() const noexcept {
 
 void PreFrame::preallocate(size_t nrows) {
   xassert(nrows_written_ == 0);
-  size_t memory_limit = g_->memory_bound;
+  size_t memory_limit = g_->memory_limit;
 
   // Possibly reduce memory allocation if there is a memory limit
   if (memory_limit != MEMORY_UNLIMITED) {
@@ -81,7 +81,7 @@ void PreFrame::preallocate(size_t nrows) {
     if (row_size * nrows > memory_limit) {
       nrows = std::max(size_t(1), memory_limit / row_size);
       if (g_->verbose) {
-        g_->trace("Allocation size reduced to %zu rows due to memory_bound "
+        g_->trace("Allocation size reduced to %zu rows due to memory_limit "
                   "parameter", nrows);
       }
     }
@@ -113,7 +113,7 @@ void PreFrame::ensure_output_nrows(size_t& nrows_in_chunk, size_t ichunk,
 {
   size_t nrows_new = nrows_written_ + nrows_in_chunk;
   size_t nrows_max = g_->max_nrows;
-  size_t memory_limit = g_->memory_bound;
+  size_t memory_limit = g_->memory_limit;
 
   // The loop is run at most once. In the most common case it doesn't
   // run at all.
@@ -182,7 +182,7 @@ void PreFrame::ensure_output_nrows(size_t& nrows_in_chunk, size_t ichunk,
 void PreFrame::archive_column_chunks(size_t expected_nrows) {
   if (nrows_written_ == 0) return;
   xassert(nrows_allocated_ > 0);
-  size_t memory_limit = g_->memory_bound;
+  size_t memory_limit = g_->memory_limit;
 
   if (!tempfile_ && memory_limit != MEMORY_UNLIMITED) {
     size_t current_memory = total_allocsize();

--- a/src/core/read/preframe.h
+++ b/src/core/read/preframe.h
@@ -29,8 +29,14 @@ namespace read {
 
 
 /**
-  * This class represents a "work-in-progress" Frame, while it is
+  * PreFrame represents a "work-in-progress" Frame, while it is
   * in the process of being read from a CSV file.
+  *
+  * This class contains a vector of `PreColumn` objects, where each
+  * PreColumn corresponds to a single column of data in the input
+  * csv file. Notably, not all of these columns will end up in the
+  * final DataTable - some columns may be excluded from the output
+  * by the user.
   *
   * At the end of this object's lifetime, call `.to_datatable()`
   * to convert it into an actual DataTable object.
@@ -44,8 +50,10 @@ class PreFrame
     std::vector<PreColumn> columns_;
     size_t nrows_;
 
+    static constexpr size_t MEMORY_UNLIMITED = size_t(-1);
     size_t memory_limit_;
     size_t memory_remaining_;
+    std::shared_ptr<TemporaryFile> tempfile_;
 
   public:
     PreFrame() noexcept;
@@ -53,7 +61,7 @@ class PreFrame
     size_t ncols() const noexcept;
     size_t nrows() const noexcept;
     void set_ncols(size_t ncols);
-    void set_nrows(size_t nrows);
+    void set_nrows(size_t new_nrows, size_t nrows_written = 0);
 
     // Column iterator / access
     const_iterator begin() const;
@@ -79,6 +87,9 @@ class PreFrame
     void use_memory_quota(size_t);
 
     std::unique_ptr<DataTable> to_datatable() &&;
+
+  private:
+    void init_tempfile();
 };
 
 

--- a/src/core/read/preframe.h
+++ b/src/core/read/preframe.h
@@ -54,7 +54,6 @@ class PreFrame
     size_t nrows_written_;
 
     static constexpr size_t MEMORY_UNLIMITED = size_t(-1);
-    size_t memory_limit_;
     std::shared_ptr<TemporaryFile> tempfile_;
 
   public:

--- a/src/core/read/preframe.h
+++ b/src/core/read/preframe.h
@@ -21,6 +21,7 @@
 //------------------------------------------------------------------------------
 #ifndef dt_READ_PREFRAME_h
 #define dt_READ_PREFRAME_h
+#include "parallel/api.h"
 #include "read/precolumn.h"
 #include "_dt.h"
 namespace dt {
@@ -29,12 +30,12 @@ namespace read {
 
 
 /**
-  * PreFrame represents a "work-in-progress" Frame, while it is
-  * in the process of being read from a CSV file.
+  * PreFrame represents a "work-in-progress" Frame, while it is in
+  * the process of being read from a CSV file.
   *
   * This class contains a vector of `PreColumn` objects, where each
   * PreColumn corresponds to a single column of data in the input
-  * csv file. Notably, not all of these columns will end up in the
+  * CSV file. However, not all of these columns will end up in the
   * final DataTable - some columns may be excluded from the output
   * by the user.
   *
@@ -47,21 +48,26 @@ class PreFrame
     using iterator = std::vector<PreColumn>::iterator;
     using const_iterator = std::vector<PreColumn>::const_iterator;
 
+    const GenericReader* g_;
     std::vector<PreColumn> columns_;
-    size_t nrows_;
+    size_t nrows_allocated_;
+    size_t nrows_written_;
 
     static constexpr size_t MEMORY_UNLIMITED = size_t(-1);
     size_t memory_limit_;
-    size_t memory_remaining_;
     std::shared_ptr<TemporaryFile> tempfile_;
 
   public:
-    PreFrame() noexcept;
+    PreFrame(const GenericReader*) noexcept;
 
     size_t ncols() const noexcept;
-    size_t nrows() const noexcept;
     void set_ncols(size_t ncols);
-    void set_nrows(size_t new_nrows, size_t nrows_written = 0);
+
+    size_t nrows_allocated() const noexcept;
+    size_t nrows_written() const noexcept;
+    void preallocate(size_t nrows);
+    void ensure_output_nrows(size_t& nrows_in_chunk, size_t ichunk, dt::ordered*);
+    void archive_column_chunks(size_t expected_nrows);
 
     // Column iterator / access
     const_iterator begin() const;
@@ -83,9 +89,7 @@ class PreFrame
     size_t n_columns_to_reread() const;
     size_t total_allocsize() const;
 
-    void set_memory_bound(size_t);
-    void use_memory_quota(size_t);
-
+    void prepare_for_rereading();
     std::unique_ptr<DataTable> to_datatable() &&;
 
   private:

--- a/src/core/read/preframe.h
+++ b/src/core/read/preframe.h
@@ -44,6 +44,9 @@ class PreFrame
     std::vector<PreColumn> columns_;
     size_t nrows_;
 
+    size_t memory_limit_;
+    size_t memory_remaining_;
+
   public:
     PreFrame() noexcept;
 
@@ -52,6 +55,7 @@ class PreFrame
     void set_ncols(size_t ncols);
     void set_nrows(size_t nrows);
 
+    // Column iterator / access
     const_iterator begin() const;
     const_iterator end() const;
     iterator begin();
@@ -70,6 +74,9 @@ class PreFrame
     size_t n_columns_in_buffer() const;
     size_t n_columns_to_reread() const;
     size_t total_allocsize() const;
+
+    void set_memory_bound(size_t);
+    void use_memory_quota(size_t);
 
     std::unique_ptr<DataTable> to_datatable() &&;
 };

--- a/src/core/read/py_fread.cc
+++ b/src/core/read/py_fread.cc
@@ -39,18 +39,19 @@ R"(fread(anysource=None, *, file=None, text=None, cmd=None, url=None,
          na_strings=None, verbose=False, fill=False, encoding=None,
          skip_to_string=None, skip_to_line=None, skip_blank_lines=False,
          strip_whitespace=True, quotechar='"', save_to=None,
-         tempdir=None, nthreads=None, logger=None, multiple_sources="warn")
+         tempdir=None, nthreads=None, logger=None, multiple_sources="warn",
+         memory_bound=None)
 --
 
 )";
 
 static py::PKArgs args_fread(
-  1, 0, 23, false, false,
+  1, 0, 24, false, false,
   {"anysource", "file", "text", "cmd", "url",
    "columns", "sep", "dec", "max_nrows", "header", "na_strings",
    "verbose", "fill", "encoding", "skip_to_string", "skip_to_line",
    "skip_blank_lines", "strip_whitespace", "quotechar", "save_to",
-   "tempdir", "nthreads", "logger", "multiple_sources"
+   "tempdir", "nthreads", "logger", "multiple_sources", "memory_bound"
    },
   "fread", doc_fread);
 
@@ -75,6 +76,7 @@ static py::oobj fread(const py::PKArgs& args) {
   const py::Arg& arg_nthreads   = args[k++];
   const py::Arg& arg_logger     = args[k++];
   const py::Arg& arg_multisrc   = args[k++];
+  const py::Arg& arg_membound   = args[k++];
 
   GenericReader rdr;
   rdr.init_logger(     arg_logger, arg_verbose);
@@ -93,6 +95,7 @@ static py::oobj fread(const py::PKArgs& args) {
   rdr.init_columns(    arg_columns);
   rdr.init_tempdir(    arg_tempdir);
   rdr.init_multisource(arg_multisrc);
+  rdr.init_memorybound(arg_membound);
   (void) arg_saveto;
   (void) arg_encoding;
 
@@ -112,18 +115,19 @@ R"(iread(anysource=None, *, file=None, text=None, cmd=None, url=None,
          na_strings=None, verbose=False, fill=False, encoding=None,
          skip_to_string=None, skip_to_line=None, skip_blank_lines=False,
          strip_whitespace=True, quotechar='"', save_to=None,
-         tempdir=None, nthreads=None, logger=None, errors="warn")
+         tempdir=None, nthreads=None, logger=None, errors="warn",
+         memory_bound=None)
 --
 
 )";
 
 static py::PKArgs args_iread(
-  1, 0, 23, false, false,
+  1, 0, 24, false, false,
   {"anysource", "file", "text", "cmd", "url",
    "columns", "sep", "dec", "max_nrows", "header", "na_strings",
    "verbose", "fill", "encoding", "skip_to_string", "skip_to_line",
    "skip_blank_lines", "strip_whitespace", "quotechar", "save_to",
-   "tempdir", "nthreads", "logger", "errors"
+   "tempdir", "nthreads", "logger", "errors", "memory_bound"
    },
   "iread", doc_iread);
 
@@ -148,6 +152,7 @@ static py::oobj iread(const py::PKArgs& args) {
   const py::Arg& arg_nthreads   = args[k++];
   const py::Arg& arg_logger     = args[k++];
   const py::Arg& arg_errors     = args[k++];
+  const py::Arg& arg_membound   = args[k++];
 
   auto rdr = std::unique_ptr<GenericReader>(new GenericReader);
   rdr->init_logger(     arg_logger, arg_verbose);
@@ -166,6 +171,7 @@ static py::oobj iread(const py::PKArgs& args) {
   rdr->init_columns(    arg_columns);
   rdr->init_tempdir(    arg_tempdir);
   rdr->init_errors(     arg_errors);
+  rdr->init_memorybound(arg_membound);
   (void) arg_saveto;
   (void) arg_encoding;
 

--- a/src/core/read/py_fread.cc
+++ b/src/core/read/py_fread.cc
@@ -40,7 +40,7 @@ R"(fread(anysource=None, *, file=None, text=None, cmd=None, url=None,
          skip_to_string=None, skip_to_line=None, skip_blank_lines=False,
          strip_whitespace=True, quotechar='"', save_to=None,
          tempdir=None, nthreads=None, logger=None, multiple_sources="warn",
-         memory_bound=None)
+         memory_limit=None)
 --
 
 )";
@@ -51,7 +51,7 @@ static py::PKArgs args_fread(
    "columns", "sep", "dec", "max_nrows", "header", "na_strings",
    "verbose", "fill", "encoding", "skip_to_string", "skip_to_line",
    "skip_blank_lines", "strip_whitespace", "quotechar", "save_to",
-   "tempdir", "nthreads", "logger", "multiple_sources", "memory_bound"
+   "tempdir", "nthreads", "logger", "multiple_sources", "memory_limit"
    },
   "fread", doc_fread);
 
@@ -76,7 +76,7 @@ static py::oobj fread(const py::PKArgs& args) {
   const py::Arg& arg_nthreads   = args[k++];
   const py::Arg& arg_logger     = args[k++];
   const py::Arg& arg_multisrc   = args[k++];
-  const py::Arg& arg_membound   = args[k++];
+  const py::Arg& arg_memlimit   = args[k++];
 
   GenericReader rdr;
   rdr.init_logger(     arg_logger, arg_verbose);
@@ -95,7 +95,7 @@ static py::oobj fread(const py::PKArgs& args) {
   rdr.init_columns(    arg_columns);
   rdr.init_tempdir(    arg_tempdir);
   rdr.init_multisource(arg_multisrc);
-  rdr.init_memorybound(arg_membound);
+  rdr.init_memorylimit(arg_memlimit);
   (void) arg_saveto;
   (void) arg_encoding;
 
@@ -116,7 +116,7 @@ R"(iread(anysource=None, *, file=None, text=None, cmd=None, url=None,
          skip_to_string=None, skip_to_line=None, skip_blank_lines=False,
          strip_whitespace=True, quotechar='"', save_to=None,
          tempdir=None, nthreads=None, logger=None, errors="warn",
-         memory_bound=None)
+         memory_limit=None)
 --
 
 )";
@@ -127,7 +127,7 @@ static py::PKArgs args_iread(
    "columns", "sep", "dec", "max_nrows", "header", "na_strings",
    "verbose", "fill", "encoding", "skip_to_string", "skip_to_line",
    "skip_blank_lines", "strip_whitespace", "quotechar", "save_to",
-   "tempdir", "nthreads", "logger", "errors", "memory_bound"
+   "tempdir", "nthreads", "logger", "errors", "memory_limit"
    },
   "iread", doc_iread);
 
@@ -152,7 +152,7 @@ static py::oobj iread(const py::PKArgs& args) {
   const py::Arg& arg_nthreads   = args[k++];
   const py::Arg& arg_logger     = args[k++];
   const py::Arg& arg_errors     = args[k++];
-  const py::Arg& arg_membound   = args[k++];
+  const py::Arg& arg_memlimit   = args[k++];
 
   auto rdr = std::unique_ptr<GenericReader>(new GenericReader);
   rdr->init_logger(     arg_logger, arg_verbose);
@@ -171,7 +171,7 @@ static py::oobj iread(const py::PKArgs& args) {
   rdr->init_columns(    arg_columns);
   rdr->init_tempdir(    arg_tempdir);
   rdr->init_errors(     arg_errors);
-  rdr->init_memorybound(arg_membound);
+  rdr->init_memorylimit(arg_memlimit);
   (void) arg_saveto;
   (void) arg_encoding;
 

--- a/src/core/read/thread_context.cc
+++ b/src/core/read/thread_context.cc
@@ -1,13 +1,28 @@
 //------------------------------------------------------------------------------
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright 2018-2020 H2O.ai
 //
-// © H2O.ai 2018
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
 //------------------------------------------------------------------------------
+#include "read/field64.h"            // field64
+#include "read/chunk_coordinates.h"  // ChunkCoordinates
 #include "read/thread_context.h"
 #include "utils/assert.h"
-
 namespace dt {
 namespace read {
 
@@ -46,5 +61,6 @@ void ThreadContext::set_nrows(size_t n) {
 }
 
 
-}  // namespace read
-}  // namespace dt
+
+
+}}  // namespace dt::read

--- a/src/core/read/thread_context.cc
+++ b/src/core/read/thread_context.cc
@@ -28,13 +28,13 @@ namespace read {
 
 
 ThreadContext::ThreadContext(size_t ncols, size_t nrows)
-  : tbuf(ncols * nrows + 1), sbuf(0), strinfo(ncols)
-{
-  tbuf_ncols = ncols;
-  tbuf_nrows = nrows;
-  used_nrows = 0;
-  row0 = 0;
-}
+  : tbuf(ncols * nrows + 1),
+    sbuf(0),
+    strinfo(ncols),
+    tbuf_ncols(ncols),
+    tbuf_nrows(nrows),
+    used_nrows(0),
+    row0(0) {}
 
 
 // Note: it is possible to have `used_nrows != 0` at the end: the content of
@@ -58,6 +58,12 @@ size_t ThreadContext::get_nrows() const {
 void ThreadContext::set_nrows(size_t n) {
   xassert(n <= used_nrows);
   used_nrows = n;
+}
+
+
+void ThreadContext::set_row0(size_t n) {
+  xassert(row0 <= n);
+  row0 = n;
 }
 
 

--- a/src/core/read/thread_context.h
+++ b/src/core/read/thread_context.h
@@ -21,37 +21,50 @@
 //------------------------------------------------------------------------------
 #ifndef dt_READ_THREADCONTEXT_h
 #define dt_READ_THREADCONTEXT_h
-#include <cstddef>
-#include <vector>                    // std::vector
-#include "read/field64.h"            // field64
-#include "read/chunk_coordinates.h"  // ChunkCoordinates
+#include "_dt.h"
 namespace dt {
 namespace read {
 
 
 /**
- * This is a helper class for ChunkedReader. It carries variables that will be
- * local to each thread during the parallel reading of the input.
- *
- * tbuf
- *   Output buffer. Within the buffer the data is stored in row-major order,
- *   i.e. in the same order as in the original CSV file. We view the buffer as
- *   a rectangular grid having `tbuf_ncols * tbuf_nrows` elements (+1 extra).
- *
- * sbuf
- *   Additional buffer, used to store string content after post-processing.
- *
- * tbuf_ncols, tbuf_nrows
- *   Dimensions of the output buffer.
- *
- * used_nrows
- *   Number of rows of data currently stored in `tbuf`. This can never exceed
- *   `tbuf_nrows`.
- *
- * row0
- *   Starting row index within the output DataTable for the current data chunk.
- */
-class ThreadContext {
+  * This is a helper class for ParallelReader. It carries variables
+  * that will be local to each thread during the parallel reading
+  * of the input.
+  *
+  * tbuf
+  *   Output buffer. Within the buffer the data is stored in row-major
+  *   order, i.e. in the same order as in the original CSV file. We
+  *   view the buffer as a rectangular grid having `tbuf_ncols *
+  *   tbuf_nrows` elements (+1 extra).
+  *
+  * sbuf
+  *   Additional buffer, used to store string content after post-
+  *   processing.
+  *
+  * strinfo
+  *   Information necessary for string columns. The number of elements
+  *   in this vector should be equal to the number of string columns
+  *   in the preframe.
+  *   Each entry is a struct:
+  *     .start    - location of this column's character data within
+  *                 the `sbuf` buffer;
+  *     .size     - size of the character data buffer;
+  *     .write_at - where the data should be written within the
+  *                 column's WritableBuffer.
+  *
+  * tbuf_ncols, tbuf_nrows
+  *   Dimensions of the output buffer.
+  *
+  * used_nrows
+  *   Number of rows of data currently stored in `tbuf`. This can
+  *   never exceed `tbuf_nrows`.
+  *
+  * row0
+  *   Starting row index within the PreFrame for the current data
+  *   chunk.
+  */
+class ThreadContext
+{
   public:
     struct SInfo { size_t start, size, write_at; };
 
@@ -69,7 +82,7 @@ class ThreadContext {
 
     virtual void push_buffers() = 0;
     virtual void read_chunk(const ChunkCoordinates&, ChunkCoordinates&) = 0;
-    virtual void orderBuffer() = 0;
+    virtual void order_buffer() = 0;
 
     size_t get_nrows() const;
     void set_nrows(size_t n);
@@ -77,7 +90,7 @@ class ThreadContext {
 };
 
 
-}  // namespace read
-}  // namespace dt
 
+
+}}  // namespace dt::read
 #endif

--- a/src/core/read/thread_context.h
+++ b/src/core/read/thread_context.h
@@ -31,6 +31,10 @@ namespace read {
   * that will be local to each thread during the parallel reading
   * of the input.
   *
+  * This class is abstract. The derived classes are expected to
+  * implement the actual logic for reading a chunk into the local
+  * buffers (tbuf/sbuf) and then saving into the output PreFrame.
+  *
   * tbuf
   *   Output buffer. Within the buffer the data is stored in row-major
   *   order, i.e. in the same order as in the original CSV file. We
@@ -65,12 +69,16 @@ namespace read {
   */
 class ThreadContext
 {
-  public:
-    struct SInfo { size_t start, size, write_at; };
+  protected:
+    struct StrInfo {
+      size_t start;
+      size_t size;
+      size_t write_at;
+    };
 
     std::vector<field64> tbuf;
     std::vector<uint8_t> sbuf;
-    std::vector<SInfo> strinfo;
+    std::vector<StrInfo> strinfo;
     size_t tbuf_ncols;
     size_t tbuf_nrows;
     size_t used_nrows;
@@ -80,12 +88,13 @@ class ThreadContext
     ThreadContext(size_t ncols, size_t nrows);
     virtual ~ThreadContext();
 
-    virtual void push_buffers() = 0;
     virtual void read_chunk(const ChunkCoordinates&, ChunkCoordinates&) = 0;
     virtual void order_buffer() = 0;
+    virtual void push_buffers() = 0;
 
     size_t get_nrows() const;
     void set_nrows(size_t n);
+    void set_row0(size_t n);
     void allocate_tbuf(size_t ncols, size_t nrows);
 };
 

--- a/src/core/utils/temporary_file.cc
+++ b/src/core/utils/temporary_file.cc
@@ -1,0 +1,100 @@
+//------------------------------------------------------------------------------
+// Copyright 2020 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#include <cstdio>                   // std::remove, std::perror
+#include <cstdlib>                  // std::rand
+#include <ctime>
+#include "python/obj.h"
+#include "utils/temporary_file.h"
+#include "utils/macros.h"
+
+
+static std::string get_temp_dir() {
+  auto gettempdirfn = py::oobj::import("tempfile", "gettempdir");
+  auto tempdir = gettempdirfn.call();
+  return tempdir.to_string();
+}
+
+// Create a temporary file name such that:
+//   - the file is in the `tempdir` directory
+//   - the file didn't exist previously
+//   - the file is physically created before this function returns
+//   - if the file cannot be created for any reason (for example, the
+//     provided temporary directory does not exist, or is readonly),
+//     then an IOError will be thrown.
+//
+static std::string get_temp_file(const std::string& tempdir) {
+  #if DT_OS_WINDOWS
+    constexpr char pathsep = '\\';
+  #else
+    constexpr char pathsep = '/';
+  #endif
+  constexpr size_t NAMELEN = 50;
+  std::srand(static_cast<unsigned int>(std::time(nullptr)));
+  static const char* LETTERS = "abcdefghijklmnopqrstuvwxyz0123456789";
+
+  while (true) {
+    std::string filename(NAMELEN, '\0');
+    for (size_t i = 0; i < NAMELEN; ++i) {
+      filename[i] = LETTERS[std::rand() % 36];
+    }
+    std::string fullname = tempdir + pathsep + filename;
+    std::FILE* fp = std::fopen(fullname.c_str(), "r");
+    if (fp) {  // file already exists, try another one
+      std::fclose(fp);
+    }
+    else {     // file doesn't exist, try creating it
+      fp = std::fopen(fullname.c_str(), "w");
+      if (fp) {
+        std::fclose(fp);
+        return fullname;
+      }
+      else {
+        throw IOError() << "Cannot create temporary file " << fullname << Errno;
+      }
+    }
+  }
+}
+
+
+//------------------------------------------------------------------------------
+// TemporaryFile
+//------------------------------------------------------------------------------
+
+TemporaryFile::TemporaryFile()
+  : filename_(get_temp_file(get_temp_dir())) {}
+
+TemporaryFile::TemporaryFile(const std::string& tempdir)
+  : filename_(get_temp_file(tempdir)) {}
+
+
+TemporaryFile::~TemporaryFile() {
+  int ret = std::remove(filename_.c_str());
+  if (ret) {
+    std::string msg = "Cannot remove temporary file " + filename_;
+    std::perror(msg.c_str());
+  }
+}
+
+
+const std::string& TemporaryFile::name() const {
+  return filename_;
+}

--- a/src/core/utils/temporary_file.h
+++ b/src/core/utils/temporary_file.h
@@ -42,6 +42,7 @@ class TemporaryFile
   private:
     std::string filename_;
     Buffer* bufferptr_;
+    WritableBuffer* writebufptr_;
 
   public:
     TemporaryFile();
@@ -50,11 +51,21 @@ class TemporaryFile
 
     const std::string& name() const;
 
-    // Open and memmap the file, returning the pointer to the file's
-    // data. Once this method is called, it is no longer safe to
-    // modify the underlying file.
-    //
-    void* data();
+    // Open the underlying file for writing and return the
+    // corresponding WritableBuffer object. This method may be
+    // called multiple times, returning the same object.
+    WritableBuffer* data_w();
+
+    // Open the file for reading, returning the pointer to the file's
+    // data. If the file was opened for writing previously, its
+    // WritableBuffer object will be finalized and closed.
+    void* data_r();
+
+  private:
+    void init_read_buffer();
+    void close_read_buffer() noexcept;
+    void init_write_buffer();
+    void close_write_buffer() noexcept;
 };
 
 

--- a/src/core/utils/temporary_file.h
+++ b/src/core/utils/temporary_file.h
@@ -41,6 +41,7 @@ class TemporaryFile
 {
   private:
     std::string filename_;
+    Buffer* bufferptr_;
 
   public:
     TemporaryFile();
@@ -48,6 +49,12 @@ class TemporaryFile
     ~TemporaryFile();
 
     const std::string& name() const;
+
+    // Open and memmap the file, returning the pointer to the file's
+    // data. Once this method is called, it is no longer safe to
+    // modify the underlying file.
+    //
+    void* data();
 };
 
 

--- a/src/core/utils/temporary_file.h
+++ b/src/core/utils/temporary_file.h
@@ -1,0 +1,55 @@
+//------------------------------------------------------------------------------
+// Copyright 2020 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#ifndef dt_UTILS_TEMPORARY_FILE_h
+#define dt_UTILS_TEMPORARY_FILE_h
+#include "_dt.h"
+
+
+/**
+  * This class represents a temporary file on disk. The file is
+  * created when an object of this class is instantiated, and deleted
+  * when the object is destroyed.
+  *
+  * The user should not attempt to keep the file open while allowing
+  * this object to be destroyed: doing so may lead to crashes on some
+  * OSes (in particular, Windows).
+  *
+  * The name of the temporary file will be generated automatically;
+  * the file will be created in the directory either specified by the
+  * user, or retrieved from Python `tempfile` module.
+  */
+class TemporaryFile
+{
+  private:
+    std::string filename_;
+
+  public:
+    TemporaryFile();
+    TemporaryFile(const std::string& temp_directory);
+    ~TemporaryFile();
+
+    const std::string& name() const;
+};
+
+
+
+#endif

--- a/src/core/utils/temporary_file.h
+++ b/src/core/utils/temporary_file.h
@@ -59,7 +59,7 @@ class TemporaryFile
     // Open the file for reading, returning the pointer to the file's
     // data. If the file was opened for writing previously, its
     // WritableBuffer object will be finalized and closed.
-    void* data_r();
+    const void* data_r();
 
   private:
     void init_read_buffer();

--- a/src/core/writebuf.h
+++ b/src/core/writebuf.h
@@ -92,15 +92,19 @@ public:
   virtual void finalize() = 0;
 
   /**
-   * Simple helper method for writing into the buffer in single-threaded
-   * context.
-   */
-  void write(size_t n, const void* src) {
-    write_at(prep_write(n, src), n, src);
+    * Simple helper method for writing into the buffer in single-
+    * threaded context. The return value is the position within the
+    * buffer where the data was written.
+    */
+  size_t write(size_t n, const void* src) {
+    size_t writepos = prep_write(n, src);
+    write_at(writepos, n, src);
+    return writepos;
   }
-  void write(const CString& src) {
-    size_t at = prep_write(static_cast<size_t>(src.size), src.ch);
-    write_at(at, static_cast<size_t>(src.size), src.ch);
+  size_t write(const CString& src) {
+    size_t writepos = prep_write(static_cast<size_t>(src.size), src.ch);
+    write_at(writepos, static_cast<size_t>(src.size), src.ch);
+    return writepos;
   }
 
   // Prevent copying / assignment for these objects

--- a/tests/test_tocsv.py
+++ b/tests/test_tocsv.py
@@ -80,10 +80,11 @@ def test_issue365():
 
 def test_write_spacestrs():
     # Test that fields having spaces at the beginning/end are auto-quoted
-    d = dt.Frame([" hello ", "world  ", " !", "!", ""])
-    assert d.to_csv() == 'C0\n" hello "\n"world  "\n" !"\n!\n""\n'
-    dd = dt.fread(text=d.to_csv(), sep='\n')
-    assert d.to_list() == dd.to_list()
+    DT1 = dt.Frame([" hello ", "world  ", " !", "!", ""])
+    text = DT1.to_csv()
+    assert text == 'C0\n" hello "\n"world  "\n" !"\n!\n""\n'
+    DT2 = dt.fread(text=text, sep='\n')
+    assert DT1.to_list() == DT2.to_list()
 
 
 def test_write_spacenames():


### PR DESCRIPTION
This is the current state of the "streaming fread to Jay" feature. It is mostly working, however one test currently still fails. The tests for the feature itself still missing.

The following features are introduced:
- [x] New `memory_limit=` argument for fread can be used as a suggestion of how much RAM can be used during reading in order to maintain intermediate results / final output. This limit is not strict;
- [x] The `dt::read::PreColumn` class maintains a vector of column chunks that were captured during the reading (this design will also allow us to eliminate rereading pass, and allow the possibility of adding new columns on-the-fly);
- [x] New `TemporaryFile` class allows to create a temporary file on disk, which will be automatically deleted when it is no longer in use. New class `TemporaryFile_BufferImpl` is similar to `Mmap_BufferImpl`, but backed by a temporary file object. When the last buffer referring to a temporary file is gc'd, the file will be deleted; 
- [x] A "chunked" PreColumn will produce an `Rbound_ColumnImpl` column in the end;
- [x] The "rbound column" can be saved to Jay file without materializing.
- [x] setting `.nrows` should create a virtual "truncated column" instead of modifying the `.nrows` parameter on the existing column;

In order to make the feature working nicely, the following still missing:

- [ ] need support for calculating basic stats while freading, at the minimum maintain na count per column (#1097), this is currently a major source of slowdown;
- [ ] when opening a Jay file, the frame should keep track of this fact, especially if the file is temporary. Saving an opened temporary Jay file into another Jay file should be done via rename.

WIP for #1750 