### PR TITLE
No pycode in random attacker

### DIFF
--- a/tests_random/attacker.py
+++ b/tests_random/attacker.py
@@ -45,7 +45,7 @@ class Attacker:
         self._seed = seed
         self._exhaustive_checks = exhaustive_checks
         random.seed(seed)
-        print("Seed: %r\n" % seed)
+        print("# Seed: %r\n" % seed)
 
     def attack(self, frame=None, rounds=None):
         t0 = time.time()
@@ -54,7 +54,7 @@ class Attacker:
         assert isinstance(rounds, int)
         if frame is None:
             frame = MetaFrame()
-        print("Launching an attack for %d rounds" % rounds)
+        print("# Launching an attack for %d rounds" % rounds)
         for _ in range(rounds):
             action = random.choices(population=ATTACK_METHODS,
                                     cum_weights=ATTACK_WEIGHTS, k=1)[0]
@@ -81,23 +81,18 @@ def resize_rows(frame):
     t = random.random()
     curr_nrows = frame.nrows
     new_nrows = int(curr_nrows * 10 / (19 * t + 1) + 1)
-    print("[01] Setting nrows to %d" % (new_nrows, ))
     frame.resize_rows(new_nrows)
 
 
 def slice_rows(frame):
     s = random_slice(frame.nrows)
     new_nrows = len(range(*s.indices(frame.nrows)))
-    print("[02] Applying row slice [%s] -> nrows = %d"
-          % (repr_slice(s), new_nrows))
     frame.slice_rows(s)
 
 
 def slice_columns(frame):
     s = random_slice(frame.ncols)
     new_ncols = len(range(*s.indices(frame.ncols)))
-    print("[03] Applying column slice [%s] -> ncols = %d"
-          % (repr_slice(s), new_ncols))
     frame.slice_cols(s)
 
 
@@ -105,23 +100,18 @@ def cbind_self(frame):
     if frame.ncols > 1000:
         return slice_columns(frame)
     t = random.randint(1, min(5, 100 // (1 + frame.ncols)) + 1)
-    print("[04] Cbinding frame with itself %d times -> ncols = %d"
-          % (t, frame.ncols * (t + 1)))
     frame.cbind([frame] * t)
 
 
 def rbind_self(frame):
     t = random.randint(1, min(5, 1000 // (1 + frame.nrows)) + 1)
     res = frame.rbind([frame] * t)
-    print("[05] Rbinding frame with itself %d times -> nrows = %d"
-          % (t, frame.nrows))
 
 
 def select_rows_array(frame):
     if frame.nrows == 0:
         return
     s = random_array(frame.nrows)
-    print("[06] Selecting a row list %r -> nrows = %d" % (s, len(s)))
     frame.slice_rows(s)
 
 
@@ -130,8 +120,6 @@ def delete_rows_array(frame):
         return
     s = random_array(frame.nrows, positive=True)
     s = sorted(set(s))
-    print("[07] Removing rows %r -> nrows = %d"
-          % (s, frame.nrows - len(s)))
     frame.delete_rows(s)
 
 
@@ -140,8 +128,6 @@ def select_rows_with_boolean_column(frame):
     if frame.ncols <= 1 or not bool_columns:
         return
     filter_column = random.choice(bool_columns)
-    print("[08] Selecting rows where column %d (%r) is True"
-          % (filter_column, frame.names[filter_column]))
     frame.filter_on_bool_column(filter_column)
 
 
@@ -155,8 +141,6 @@ def replace_nas_in_column(frame):
         replacement_value = random.random() * 1000
     elif frame.types[icol] is str:
         replacement_value = MetaFrame.random_name()
-    print("[09] Replacing NA values in column %d with %r"
-          % (icol, replacement_value))
     res = frame.replace_nas_in_column(icol, replacement_value)
 
 
@@ -165,13 +149,10 @@ def sort_columns(frame):
         return
     ncols_sort = min(int(random.expovariate(1.0)) + 1, frame.ncols)
     a = random.sample(range(0, frame.ncols), ncols_sort)
-    print("[10] Sorting %d columns in ascending order: %r" % (len(a), a))
     frame.sort_columns(a)
 
 
 def cbind_numpy_column(frame):
-    print("[11] Cbinding frame with a numpy column -> ncols = %d"
-          % (frame.ncols + 1))
     frame.cbind_numpy_column()
 
 
@@ -182,8 +163,6 @@ def add_range_column(frame):
         step = int(1 + random.random() * 3)
     stop = start + step * frame.nrows
     rangeobj = range(start, stop, step)
-    print("[12] Adding a range column %r -> ncols = %d"
-          % (rangeobj, frame.ncols + 1))
     name = MetaFrame.random_name()
     frame.add_range_column(name, rangeobj)
 
@@ -196,7 +175,6 @@ def set_key_columns(frame):
     keys = random.sample(range(0, frame.ncols), nkeys)
     names = [frame.names[i] for i in keys]
 
-    print("[13] Setting %d key column(s): %r" % (nkeys, keys))
     frame.set_key_columns(keys, names)
 
 
@@ -206,7 +184,6 @@ def delete_columns_array(frame):
     if frame.ncols < 2:
         return
     s = random_array(frame.ncols - 1, positive=True)
-    print("[14] Removing columns %r -> ncols = %d" % (s, frame.ncols))
     frame.delete_columns(s)
 
 
@@ -214,12 +191,10 @@ def join_self(frame):
     if frame.ncols > 1000:
         return slice_columns(frame)
 
-    print("[15] Joining frame with itself -> ncols = %d" % frame.ncols)
     frame.join_self()
 
 
 def shallow_copy(frame):
-    print("[16] Creating a shallow copy of a frame")
     frame.shallow_copy()
 
 

--- a/tests_random/metaframe.py
+++ b/tests_random/metaframe.py
@@ -29,7 +29,7 @@ import warnings
 from datatable import dt, f, join
 from datatable.internal import frame_integrity_check
 from tests_random.utils import (
-    assert_equals, log, repr_data, repr_row, repr_types)
+    assert_equals, repr_data, repr_row, repr_types, traced)
 
 
 class MetaFrame:
@@ -321,7 +321,7 @@ class MetaFrame:
     # Operations
     #---------------------------------------------------------------------------
 
-    @log
+    @traced
     def resize_rows(self, nrows):
         curr_nrows = self.nrows
         if self.nkeys and nrows > curr_nrows:
@@ -341,7 +341,7 @@ class MetaFrame:
                     elem[:] = elem[:nrows]
 
 
-    @log
+    @traced
     def slice_rows(self, s):
         self.df = self.df[s, :]
         if isinstance(s, slice):
@@ -355,7 +355,7 @@ class MetaFrame:
         self.nkeys = 0
 
 
-    @log
+    @traced
     def delete_rows(self, s):
         assert isinstance(s, slice) or isinstance(s, list)
         nrows = self.nrows
@@ -368,7 +368,7 @@ class MetaFrame:
             self.data[i] = [col[j] for j in index]
 
 
-    @log
+    @traced
     def delete_columns(self, s):
         assert isinstance(s, slice) or isinstance(s, list)
         if isinstance(s, slice):
@@ -391,7 +391,7 @@ class MetaFrame:
             self.nkeys -= nkeys_remove
 
 
-    @log
+    @traced
     def slice_cols(self, s):
         self.df = self.df[:, s]
         self.data = self.data[s]
@@ -400,7 +400,7 @@ class MetaFrame:
         self.nkeys = 0
 
 
-    @log
+    @traced
     def cbind(self, frames):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", dt.exceptions.DatatableWarning)
@@ -418,7 +418,7 @@ class MetaFrame:
         self.dedup_names()
 
 
-    @log
+    @traced
     def rbind(self, frames):
         if (self.nkeys > 0) and (self.nrows > 0):
             msg = "Cannot rbind to a keyed frame"
@@ -438,7 +438,7 @@ class MetaFrame:
             self.data = newdata
 
 
-    @log
+    @traced
     def filter_on_bool_column(self, icol):
         assert self.types[icol] is bool
         filter_col = self.data[icol]
@@ -448,7 +448,7 @@ class MetaFrame:
         self.nkeys = 0
 
 
-    @log
+    @traced
     def replace_nas_in_column(self, icol, replacement_value):
         assert 0 <= icol < self.ncols
         assert isinstance(replacement_value, self.types[icol])
@@ -467,7 +467,7 @@ class MetaFrame:
                     column[i] = replacement_value
 
 
-    @log
+    @traced
     def sort_columns(self, a):
         self.df = self.df.sort(a)
         if self.nrows:
@@ -477,7 +477,7 @@ class MetaFrame:
         self.nkeys = 0
 
 
-    @log
+    @traced
     def cbind_numpy_column(self):
         import numpy as np
         coltype = self.random_type()
@@ -510,7 +510,7 @@ class MetaFrame:
         self.dedup_names()
 
 
-    @log
+    @traced
     def add_range_column(self, name, rangeobj):
         self.data += [list(rangeobj)]
         self.names += [name]
@@ -519,7 +519,7 @@ class MetaFrame:
         self.df.cbind(dt.Frame(rangeobj, names=[name]))
 
 
-    @log
+    @traced
     def set_key_columns(self, keys, names):
         key_data = [self.data[i] for i in keys]
         unique_rows = set(zip(*key_data))
@@ -546,7 +546,7 @@ class MetaFrame:
 
 
 
-    @log
+    @traced
     def join_self(self):
         ncols = self.ncols
         if self.nkeys:
@@ -570,7 +570,7 @@ class MetaFrame:
 
 
     # This is a noop for the python data
-    @log
+    @traced
     def shallow_copy(self):
         self.df_shallow_copy = self.df.copy()
         self.df_deep_copy = copy.deepcopy(self.df)

--- a/tests_random/utils.py
+++ b/tests_random/utils.py
@@ -76,7 +76,7 @@ def assert_equals(frame1, frame2):
         assert same_iterables(frame1.to_list(), frame2.to_list())
 
 
-def log(fn):
+def traced(fn):
     def wrapper(self, *args, **kwds):
         sargs = ", ".join([repr(arg) for arg in args] +
                           ['%s=%r' % kw for kw in kwds.items()])

--- a/tests_random/utils.py
+++ b/tests_random/utils.py
@@ -76,6 +76,20 @@ def assert_equals(frame1, frame2):
         assert same_iterables(frame1.to_list(), frame2.to_list())
 
 
+def log(fn):
+    def wrapper(self, *args, **kwds):
+        sargs = ", ".join([repr(arg) for arg in args] +
+                          ['%s=%r' % kw for kw in kwds.items()])
+        print(f"{self}.{fn.__name__}({sargs})")
+        fn(self, *args, **kwds)
+
+    return wrapper
+
+
+
+#-------------------------------------------------------------------------------
+# Repr helpers
+#-------------------------------------------------------------------------------
 
 def repr_row(row, j):
     assert 0 <= j < len(row)
@@ -121,7 +135,7 @@ def repr_data(data, indent):
             out += " " * (indent + 1)
         out += "["
         out += textwrap.fill(", ".join(repr(e) for e in arr),
-                             width = 80, subsequent_indent=" "*(indent+2))
+                             width=160, subsequent_indent=" "*(indent+2))
         out += "]"
         if i != len(data) - 1:
             out += ",\n"


### PR DESCRIPTION
Remove python code generation from random attacker; replaced with more detailed logging.

The reason for this change is that the effort required to maintain this functionality far outweighs its benefits.