### PR TITLE
On PPC64 builds prefer installing from wheels

### DIFF
--- a/ci/Jenkinsfile.groovy
+++ b/ci/Jenkinsfile.groovy
@@ -628,6 +628,7 @@ def test_in_docker(String testtag, String pyver, String docker_image) {
             // binary wheels for pandas & numpy.
             pip_args += "-i https://h2oai.github.io/py-repo/ "
             pip_args += "--extra-index-url https://pypi.org/simple/ "
+            pip_args += "--prefer-binary "
         }
         def python = get_python_for_docker(pyver, docker_image)
         def docker_cmd = ""


### PR DESCRIPTION
The `--prefer-binary` pip flag (available from pip-18.0) will prevent pip from using newer source distributions when slightly older binaries are  available. This will prevent Jenkins from trying to rebuild pandas/numpy from source every time those packages release new versions.