### PR TITLE
Create Frame from pandas Categorical

### DIFF
--- a/docs/releases/v0.11.0.rst
+++ b/docs/releases/v0.11.0.rst
@@ -35,6 +35,9 @@
 
   -[enh] Casting a column into its own type is now a no-op. [#2425]
 
+  -[enh] It is now possible to create a Frame from a pandas DataFrame with
+    Categorical columns (which will be converted into strings). [#2407]
+
   -[api] Method :meth:`.cbind()` now throws an :exc:`InvalidOperationError`
     instead of a ``ValueError`` if the argument frames have incompatible
     shapes.

--- a/src/core/frame/__init__.cc
+++ b/src/core/frame/__init__.cc
@@ -621,13 +621,7 @@ class FrameInitializationManager {
         col = Column::from_range(r.start(), r.stop(), r.step(), s);
       }
       else if (colsrc.is_pandas_categorical()) {
-        const char* strtype = (s == SType::INT8)? "int8" :
-                              (s == SType::INT16)? "int16" :
-                              (s == SType::INT32)? "int32" :
-                              (s == SType::INT64)? "int64" :
-                              (s == SType::FLOAT32)? "float32" :
-                              (s == SType::FLOAT64)? "float64" : "str";
-        make_column(colsrc.invoke("astype", py::ostring(strtype)), s);
+        make_column(colsrc.invoke("astype", py::ostring("str")), SType::STR32);
         return;
       }
       else {

--- a/src/core/frame/__init__.cc
+++ b/src/core/frame/__init__.cc
@@ -620,6 +620,16 @@ class FrameInitializationManager {
         auto r = colsrc.to_orange();
         col = Column::from_range(r.start(), r.stop(), r.step(), s);
       }
+      else if (colsrc.is_pandas_categorical()) {
+        const char* strtype = (s == SType::INT8)? "int8" :
+                              (s == SType::INT16)? "int16" :
+                              (s == SType::INT32)? "int32" :
+                              (s == SType::INT64)? "int64" :
+                              (s == SType::FLOAT32)? "float32" :
+                              (s == SType::FLOAT64)? "float64" : "str";
+        make_column(colsrc.invoke("astype", py::ostring(strtype)), s);
+        return;
+      }
       else {
         throw TypeError() << "Cannot create a column from " << colsrc.typeobj();
       }

--- a/src/core/python/obj.cc
+++ b/src/core/python/obj.cc
@@ -33,6 +33,7 @@
 #include "utils/macros.h"
 
 namespace py {
+static PyObject* pandas_Categorical_type = nullptr;
 static PyObject* pandas_DataFrame_type = nullptr;
 static PyObject* pandas_Series_type = nullptr;
 static PyObject* numpy_Array_type = nullptr;
@@ -234,6 +235,12 @@ bool _obj::is_sort_node() const noexcept {
 
 bool _obj::is_update_node() const noexcept {
   return py::oupdate::check(v);
+}
+
+bool _obj::is_pandas_categorical() const noexcept {
+  if (!pandas_Categorical_type) init_pandas();
+  if (!v || !pandas_Categorical_type) return false;
+  return PyObject_IsInstance(v, pandas_Categorical_type);
 }
 
 bool _obj::is_pandas_frame() const noexcept {
@@ -1043,8 +1050,9 @@ oobj get_module(const char* modname) {
 static void init_pandas() {
   py::oobj pd = get_module("pandas");
   if (pd) {
-    pandas_DataFrame_type = pd.get_attr("DataFrame").release();
-    pandas_Series_type    = pd.get_attr("Series").release();
+    pandas_Categorical_type = pd.get_attr("Categorical").release();
+    pandas_DataFrame_type   = pd.get_attr("DataFrame").release();
+    pandas_Series_type      = pd.get_attr("Series").release();
   }
 }
 

--- a/src/core/python/obj.h
+++ b/src/core/python/obj.h
@@ -180,6 +180,7 @@ class _obj {
     int  is_numpy_int()     const noexcept;
     int  is_numpy_float()   const noexcept;
     bool is_numpy_marray()  const noexcept;
+    bool is_pandas_categorical() const noexcept;
     bool is_pandas_frame()  const noexcept;
     bool is_pandas_series() const noexcept;
     bool is_range()         const noexcept;

--- a/tests/frame/test-create.py
+++ b/tests/frame/test-create.py
@@ -1011,6 +1011,14 @@ def test_create_from_pandas_with_duplicate_names(pandas):
     assert X.to_list() == [[1], [2], [3]]
 
 
+def test_create_from_pandas_categorical(pandas):
+    df = pandas.cut(pandas.Series(range(10)), bins=3)
+    DT = dt.Frame(df)
+    assert_equals(DT, dt.Frame(["(-0.009, 3.0]"] * 4 +
+                               ["(3.0, 6.0]"] * 3 +
+                               ["(6.0, 9.0]"] * 3))
+
+
 
 #-------------------------------------------------------------------------------
 # Create from Numpy


### PR DESCRIPTION
`dt.Frame(df)` no longer throws an error if pandas DataFrame `df` contains Categorical columns. Those columns will be converted to string columns instead.

Closes #2407