### PR TITLE
Support building wheels on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,12 +10,18 @@ pull_requests:
 
 build_script:
 - cmd: >-
-    SET PATH=C:\Python37-x64;C:\Python37-x64\Scripts;%PATH%
+    # SET PATH=C:\Python37-x64;C:\Python37-x64\Scripts;%PATH%
 
-    SET PYTHONPATH=%APPVEYOR_BUILD_FOLDER%\src;%PYTHONPATH%
+    # SET PYTHONPATH=%APPVEYOR_BUILD_FOLDER%\src;%PYTHONPATH%
 
-    pip install pytest docutils pandas
+    # pip install pytest docutils pandas
 
-    python ci\ext.py wheel
+    C:\Python35-x64\python ci\ext.py wheel
 
-    pytest .\tests\
+    C:\Python36-x64\python ci\ext.py wheel
+
+    C:\Python37-x64\python ci\ext.py wheel
+
+    C:\Python38-x64\python ci\ext.py wheel
+
+    # pytest .\tests\

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ build_script:
 
     python ci\ext.py wheel
 
-    FOR %i in (%APPVEYOR_BUILD_FOLDER%\dist\*-cp35-*.whl) DO pip install %i
+    FOR %i in (dist\*-cp35-*.whl) DO pip install %i
 
     pip install pytest docutils pandas
 
@@ -27,7 +27,7 @@ build_script:
 
     python ci\ext.py wheel
 
-    FOR %i in (%APPVEYOR_BUILD_FOLDER%\dist\*-cp36-*.whl) DO pip install %i
+    FOR %i in (dist\*-cp36-*.whl) DO pip install %i
 
     pip install pytest docutils pandas
 
@@ -39,7 +39,7 @@ build_script:
 
     python ci\ext.py wheel
 
-    FOR %i in (%APPVEYOR_BUILD_FOLDER%\dist\*-cp37-*.whl) DO pip install %i
+    FOR %i in (dist\*-cp37-*.whl) DO pip install %i
 
     pip install pytest docutils pandas
 
@@ -51,7 +51,7 @@ build_script:
 
     python ci\ext.py wheel
 
-    FOR %i in (%APPVEYOR_BUILD_FOLDER%\dist\*-cp38-*.whl) DO pip install %i
+    FOR %i in (dist\*-cp38-*.whl) DO pip install %i
 
     pip install pytest docutils pandas
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,11 +10,6 @@ pull_requests:
 
 build_script:
 - cmd: >-
-    # SET PATH=C:\Python37-x64;C:\Python37-x64\Scripts;%PATH%
-
-    # SET PYTHONPATH=%APPVEYOR_BUILD_FOLDER%\src;%PYTHONPATH%
-
-    # pip install pytest docutils pandas
 
     C:\Python35-x64\python ci\ext.py wheel
 
@@ -24,4 +19,10 @@ build_script:
 
     C:\Python38-x64\python ci\ext.py wheel
 
-    # pytest .\tests\
+    SET PATH=C:\Python37-x64;C:\Python37-x64\Scripts;%PATH%
+
+    SET PYTHONPATH=%APPVEYOR_BUILD_FOLDER%\src;%PYTHONPATH%
+
+    pip install pytest docutils pandas
+
+    pytest .\tests\

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,6 @@ build_script:
 
     pip install pytest docutils pandas
 
-    python ci\ext.py build
+    python ci\ext.py wheel
 
     pytest .\tests\

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ build_script:
 
     python ci\ext.py wheel
 
-    FOR %%i in (%APPVEYOR_BUILD_FOLDER%\dist\*-cp35-*.whl) DO pip install %i
+    FOR %i in (%APPVEYOR_BUILD_FOLDER%\dist\*-cp35-*.whl) DO pip install %i
 
     pip install pytest docutils pandas
 
@@ -27,7 +27,7 @@ build_script:
 
     python ci\ext.py wheel
 
-    FOR %%i in (%APPVEYOR_BUILD_FOLDER%\dist\*-cp36-*.whl) DO pip install %i
+    FOR %i in (%APPVEYOR_BUILD_FOLDER%\dist\*-cp36-*.whl) DO pip install %i
 
     pip install pytest docutils pandas
 
@@ -39,7 +39,7 @@ build_script:
 
     python ci\ext.py wheel
 
-    FOR %%i in (%APPVEYOR_BUILD_FOLDER%\dist\*-cp37-*.whl) DO pip install %i
+    FOR %i in (%APPVEYOR_BUILD_FOLDER%\dist\*-cp37-*.whl) DO pip install %i
 
     pip install pytest docutils pandas
 
@@ -51,7 +51,7 @@ build_script:
 
     python ci\ext.py wheel
 
-    FOR %%i in (%APPVEYOR_BUILD_FOLDER%\dist\*-cp38-*.whl) DO pip install %i
+    FOR %i in (%APPVEYOR_BUILD_FOLDER%\dist\*-cp38-*.whl) DO pip install %i
 
     pip install pytest docutils pandas
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,18 +11,50 @@ pull_requests:
 build_script:
 - cmd: >-
 
-    C:\Python35-x64\python ci\ext.py wheel
+    SET PATH=C:\Python35-x64;C:\Python35-x64\Scripts;%PATH%
 
-    C:\Python36-x64\python ci\ext.py wheel
+    python ci\ext.py wheel
 
-    C:\Python37-x64\python ci\ext.py wheel
-
-    C:\Python38-x64\python ci\ext.py wheel
-
-    SET PATH=C:\Python37-x64;C:\Python37-x64\Scripts;%PATH%
-
-    SET PYTHONPATH=%APPVEYOR_BUILD_FOLDER%\src;%PYTHONPATH%
+    pip install %APPVEYOR_BUILD_FOLDER%\dist\*-cp35-*.whl
 
     pip install pytest docutils pandas
 
     pytest .\tests\
+
+
+
+    SET PATH=C:\Python36-x64;C:\Python36-x64\Scripts;%PATH%
+
+    python ci\ext.py wheel
+
+    pip install %APPVEYOR_BUILD_FOLDER%\dist\*-cp36-*.whl
+
+    pip install pytest docutils pandas
+
+    pytest .\tests\
+
+
+
+    SET PATH=C:\Python37-x64;C:\Python37-x64\Scripts;%PATH%
+
+    python ci\ext.py wheel
+
+    pip install %APPVEYOR_BUILD_FOLDER%\dist\*-cp37-*.whl
+
+    pip install pytest docutils pandas
+
+    pytest .\tests\
+
+
+
+    SET PATH=C:\Python38-x64;C:\Python38-x64\Scripts;%PATH%
+
+    python ci\ext.py wheel
+
+    pip install %APPVEYOR_BUILD_FOLDER%\dist\*-cp38-*.whl
+
+    pip install pytest docutils pandas
+
+    pytest .\tests\
+
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ build_script:
 
     python ci\ext.py wheel
 
-    pip install %APPVEYOR_BUILD_FOLDER%\dist\*-cp35-*.whl
+    FOR %%i in (%APPVEYOR_BUILD_FOLDER%\dist\*-cp35-*.whl) DO pip install %i
 
     pip install pytest docutils pandas
 
@@ -27,7 +27,7 @@ build_script:
 
     python ci\ext.py wheel
 
-    pip install %APPVEYOR_BUILD_FOLDER%\dist\*-cp36-*.whl
+    FOR %%i in (%APPVEYOR_BUILD_FOLDER%\dist\*-cp36-*.whl) DO pip install %i
 
     pip install pytest docutils pandas
 
@@ -39,7 +39,7 @@ build_script:
 
     python ci\ext.py wheel
 
-    pip install %APPVEYOR_BUILD_FOLDER%\dist\*-cp37-*.whl
+    FOR %%i in (%APPVEYOR_BUILD_FOLDER%\dist\*-cp37-*.whl) DO pip install %i
 
     pip install pytest docutils pandas
 
@@ -51,7 +51,7 @@ build_script:
 
     python ci\ext.py wheel
 
-    pip install %APPVEYOR_BUILD_FOLDER%\dist\*-cp38-*.whl
+    FOR %%i in (%APPVEYOR_BUILD_FOLDER%\dist\*-cp38-*.whl) DO pip install %i
 
     pip install pytest docutils pandas
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ build_script:
 
     python ci\ext.py wheel
 
-    FOR %i in (dist\*-cp35-*.whl) DO pip install %i
+    FOR %%i in (dist\*-cp35-*.whl) DO pip install %%i
 
     pip install pytest docutils pandas
 
@@ -27,7 +27,7 @@ build_script:
 
     python ci\ext.py wheel
 
-    FOR %i in (dist\*-cp36-*.whl) DO pip install %i
+    FOR %%i in (dist\*-cp36-*.whl) DO pip install %%i
 
     pip install pytest docutils pandas
 
@@ -39,7 +39,7 @@ build_script:
 
     python ci\ext.py wheel
 
-    FOR %i in (dist\*-cp37-*.whl) DO pip install %i
+    FOR %%i in (dist\*-cp37-*.whl) DO pip install %%i
 
     pip install pytest docutils pandas
 
@@ -51,7 +51,7 @@ build_script:
 
     python ci\ext.py wheel
 
-    FOR %i in (dist\*-cp38-*.whl) DO pip install %i
+    FOR %%i in (dist\*-cp38-*.whl) DO pip install %%i
 
     pip install pytest docutils pandas
 

--- a/ci/xbuild/logger.py
+++ b/ci/xbuild/logger.py
@@ -38,6 +38,7 @@ class Logger0:
     def cmd_wheel(self): pass
 
     def report_abi_mismatch(self, v1, v2): pass
+    def report_abi_variable_missing(self, v): pass
     def report_added_file_to_sdist(self, filename, size): pass
     def report_added_file_to_wheel(self, filename, size): pass
     def report_build_dir(self, dd): pass
@@ -244,6 +245,10 @@ class Logger3(Logger0):
     def report_abi_mismatch(self, v1, v2):
         self.info("Config file contains abi=`%s`, whereas current abi is `%s`"
                   % (v1, v2))
+
+    def report_abi_variable_missing(self, v):
+        self.info("Config variable `%s` is missing, ABI tag may be incorrect"
+                  % v)
 
     def report_added_file_to_sdist(self, filename, size):
         self.info("Added file `%s` of size %d" % (filename, size))

--- a/ci/xbuild/wheel.py
+++ b/ci/xbuild/wheel.py
@@ -435,16 +435,12 @@ class Wheel:
             parts = soabi.split("-")
             assert parts[0] == "cpython"
             abi = 'cp' + parts[1]
-        elif hasattr(sys, 'maxunicode'):
-            d = ''
-            m = ''
-            if get_flag('Py_DEBUG', hasattr(sys, 'gettotalrefcount')):
-                d = 'd'
-            if sys.version_info < (3, 8) and get_flag('WITH_PYMALLOC', True):
-                m = 'm'
-            abi = self._get_python_tag() + d + m
         else:
-            abi = None
+            abi = self._get_python_tag()
+            if get_flag('Py_DEBUG', hasattr(sys, 'gettotalrefcount')):
+                abi += 'd'
+            if sys.version_info < (3, 8) and get_flag('WITH_PYMALLOC', True):
+                abi += 'm'
 
         return abi
 

--- a/ci/xbuild/wheel.py
+++ b/ci/xbuild/wheel.py
@@ -410,10 +410,11 @@ class Wheel:
     #---------------------------------------------------------------------------
 
     def _get_python_tag(self):
-        from packaging import tags
         impl = sys.implementation.name
         assert impl == "cpython"
-        return "cp" + tags.interpreter_version()
+        major = sys.version_info.major
+        minor = sys.version_info.minor
+        return "cp" + str(major) + str(minor)
 
 
     def _get_abi_tag(self):


### PR DESCRIPTION
- improve `ABI` detection in xbuild to allow building wheels on Windows;
- build/test wheels for all the Python versions on AppVeyor.

Closes #2432 