### PR TITLE
csv-reading refactoring

### DIFF
--- a/src/core/_dt.h
+++ b/src/core/_dt.h
@@ -100,7 +100,7 @@ namespace read {
   enum RT : uint8_t;
   enum BT : uint8_t;
 
-  struct FreadTokenizer;
+  struct ParseContext;
   union field64;
 
   class ChunkCoordinates;
@@ -111,6 +111,7 @@ namespace read {
   class ThreadContext;
 }}
 class FreadReader;
+void parse_string(dt::read::ParseContext&);
 
 
 #endif

--- a/src/core/csv/fread.cc
+++ b/src/core/csv/fread.cc
@@ -38,7 +38,9 @@ std::unique_ptr<DataTable> FreadReader::read_all()
   if (header == 1) {
     auto _ = logger_.section("[4] Assign column names");
     dt::read::field64 tmp;
-    dt::read::FreadTokenizer fctx = makeTokenizer(&tmp, /* anchor= */ sof);
+    dt::read::FreadTokenizer fctx = makeTokenizer();
+    fctx.target = &tmp;
+    fctx.anchor = sof;
     fctx.ch = sof;
     parse_column_names(fctx);
     sof = fctx.ch;  // Update sof to point to the first line after the columns

--- a/src/core/csv/fread.cc
+++ b/src/core/csv/fread.cc
@@ -4,7 +4,7 @@
 //------------------------------------------------------------------------------
 #include "csv/reader_fread.h"                  // FreadReader
 #include "read/fread/fread_parallel_reader.h"  // FreadParallelReader
-#include "read/fread/fread_tokenizer.h"        // FreadTokenizer
+#include "read/parse_context.h"                // ParseContext
 #include "utils/misc.h"                        // wallclock
 #include "datatable.h"                         // DataTable
 
@@ -38,7 +38,7 @@ std::unique_ptr<DataTable> FreadReader::read_all()
   if (header == 1) {
     auto _ = logger_.section("[4] Assign column names");
     dt::read::field64 tmp;
-    dt::read::FreadTokenizer fctx = makeTokenizer();
+    dt::read::ParseContext fctx = makeTokenizer();
     fctx.target = &tmp;
     fctx.anchor = sof;
     fctx.ch = sof;

--- a/src/core/csv/reader_fread.cc
+++ b/src/core/csv/reader_fread.cc
@@ -481,6 +481,7 @@ int64_t FreadReader::parse_single_line(dt::read::FreadTokenizer& fctx)
   const char*& tch = fctx.ch;
 
   // detect blank lines
+  fctx.anchor = tch;
   fctx.skip_whitespace_at_line_start();
   if (tch == eof || fctx.skip_eol()) return 0;
 
@@ -896,7 +897,7 @@ void FreadReader::parse_column_names(dt::read::FreadTokenizer& ctx) {
     size_t zlen = static_cast<size_t>(ilen);
 
     if (i >= ncols) {
-      preframe.set_ncols(i);
+      preframe.set_ncols(i + 1);
     }
     if (ilen > 0) {
       const uint8_t* usrc = reinterpret_cast<const uint8_t*>(start);

--- a/src/core/csv/reader_fread.cc
+++ b/src/core/csv/reader_fread.cc
@@ -53,13 +53,12 @@ FreadReader::FreadReader(const dt::read::GenericReader& g)
 FreadReader::~FreadReader() {}
 
 
-dt::read::FreadTokenizer FreadReader::makeTokenizer(
-    dt::read::field64* target, const char* anchor) const
+dt::read::FreadTokenizer FreadReader::makeTokenizer() const
 {
   dt::read::FreadTokenizer res;
   res.ch = nullptr;
-  res.target = target;
-  res.anchor = anchor;
+  res.target = nullptr;
+  res.anchor = nullptr;
   res.eof = eof;
   res.NAstrings = na_strings;
   res.whiteChar = whiteChar;
@@ -264,8 +263,9 @@ void FreadReader::detect_sep_and_qr() {
                             //   (when fill=true, the max is usually the header row and is the longest but there are more
                             //    lines of fewer)
 
-  dt::read::field64 trash;
-  dt::read::FreadTokenizer ctx = makeTokenizer(&trash, nullptr);
+  dt::read::field64 tmp;
+  dt::read::FreadTokenizer ctx = makeTokenizer();
+  ctx.target = &tmp;
   const char*& tch = ctx.ch;
 
   // We will scan the input line-by-line (at most `JUMPLINES + 1` lines; "+1"
@@ -561,7 +561,8 @@ void FreadReader::detect_column_types()
   int64_t sncols = static_cast<int64_t>(ncols);
 
   dt::read::field64 tmp;
-  dt::read::FreadTokenizer fctx = makeTokenizer(&tmp, nullptr);
+  dt::read::FreadTokenizer fctx = makeTokenizer();
+  fctx.target = &tmp;
   const char*& tch = fctx.ch;
 
   ColumnTypeDetectionChunkster chunkster(*this, fctx);
@@ -682,7 +683,8 @@ void FreadReader::detect_header() {
   int64_t sncols = static_cast<int64_t>(ncols);
 
   dt::read::field64 tmp;
-  dt::read::FreadTokenizer fctx = makeTokenizer(&tmp, nullptr);
+  dt::read::FreadTokenizer fctx = makeTokenizer();
+  fctx.target = &tmp;
   const char*& tch = fctx.ch;
 
   // Detect types in the header column
@@ -821,7 +823,8 @@ void FreadReader::skip_preamble() {
   }
 
   dt::read::field64 tmp;
-  auto fctx = makeTokenizer(&tmp, /* anchor = */ nullptr);
+  auto fctx = makeTokenizer();
+  fctx.target = &tmp;
   const char*& ch = fctx.ch;
 
   char comment_char = '\xFF';  // meaning "auto"

--- a/src/core/csv/reader_fread.cc
+++ b/src/core/csv/reader_fread.cc
@@ -21,7 +21,7 @@
 //------------------------------------------------------------------------------
 #include <iomanip>
 #include "csv/reader_fread.h"    // FreadReader
-#include "read/fread/fread_tokenizer.h"  // dt::read::FreadTokenizer
+#include "read/parse_context.h"  // dt::read::ParseContext
 #include "utils/logger.h"
 #include "utils/misc.h"          // wallclock
 #include "column.h"
@@ -53,9 +53,9 @@ FreadReader::FreadReader(const dt::read::GenericReader& g)
 FreadReader::~FreadReader() {}
 
 
-dt::read::FreadTokenizer FreadReader::makeTokenizer() const
+dt::read::ParseContext FreadReader::makeTokenizer() const
 {
-  dt::read::FreadTokenizer res;
+  dt::read::ParseContext res;
   res.ch = nullptr;
   res.target = nullptr;
   res.anchor = nullptr;
@@ -87,13 +87,13 @@ class HypothesisPool;
 
 class Hypothesis {
   protected:
-    FreadTokenizer& ctx;
+    ParseContext& ctx;
     size_t nlines;
     bool invalid;
     int64_t : 56;
 
   public:
-    Hypothesis(FreadTokenizer& c) : ctx(c), nlines(0), invalid(false) {}
+    Hypothesis(ParseContext& c) : ctx(c), nlines(0), invalid(false) {}
     virtual ~Hypothesis() {}
     virtual void parse_next_line(HypothesisPool&) = 0;
     virtual double score() = 0;
@@ -121,7 +121,7 @@ class HypothesisQC : public Hypothesis {
     char qc;
     int64_t : 56;
   public:
-    HypothesisQC(FreadTokenizer& c, char q, HypothesisNoQC* p)
+    HypothesisQC(ParseContext& c, char q, HypothesisNoQC* p)
       : Hypothesis(c), parent(p), qc(q) {}
     void parse_next_line(HypothesisPool&) override {
       (void) parent;
@@ -139,7 +139,7 @@ class HypothesisNoQC : public Hypothesis {
     bool singleQuoteSeen;
     int64_t : 48;
   public:
-    HypothesisNoQC(FreadTokenizer& ctx)
+    HypothesisNoQC(ParseContext& ctx)
       : Hypothesis(ctx), chcounts(MaxSeps * HypothesisPool::MaxLines),
         doubleQuoteSeen(false), singleQuoteSeen(false) {}
 
@@ -223,7 +223,7 @@ class HypothesisNoQC : public Hypothesis {
  * H1: QC = «"», starting with QR1 = 0
  * H2: QC = «'», starting with QR2 = 0
  */
-void FreadReader::detect_sep(dt::read::FreadTokenizer&) {
+void FreadReader::detect_sep(dt::read::ParseContext&) {
 }
 
 /**
@@ -264,7 +264,7 @@ void FreadReader::detect_sep_and_qr() {
                             //    lines of fewer)
 
   dt::read::field64 tmp;
-  dt::read::FreadTokenizer ctx = makeTokenizer();
+  dt::read::ParseContext ctx = makeTokenizer();
   ctx.target = &tmp;
   const char*& tch = ctx.ch;
 
@@ -384,12 +384,12 @@ void FreadReader::detect_sep_and_qr() {
 class ColumnTypeDetectionChunkster {
   public:
     const FreadReader& f;
-    dt::read::FreadTokenizer fctx;
+    dt::read::ParseContext fctx;
     size_t nchunks;
     size_t chunk_distance;
     const char* last_row_end;
 
-    ColumnTypeDetectionChunkster(FreadReader& fr, dt::read::FreadTokenizer& ft)
+    ColumnTypeDetectionChunkster(FreadReader& fr, dt::read::ParseContext& ft)
         : f(fr), fctx(ft)
     {
       nchunks = 0;
@@ -476,7 +476,7 @@ class ColumnTypeDetectionChunkster {
  * If the line cannot be parsed (because it contains a string that is not
  * parseable under the current quoting rule), then return -1.
  */
-int64_t FreadReader::parse_single_line(dt::read::FreadTokenizer& fctx)
+int64_t FreadReader::parse_single_line(dt::read::ParseContext& fctx)
 {
   const char*& tch = fctx.ch;
 
@@ -561,7 +561,7 @@ void FreadReader::detect_column_types()
   int64_t sncols = static_cast<int64_t>(ncols);
 
   dt::read::field64 tmp;
-  dt::read::FreadTokenizer fctx = makeTokenizer();
+  dt::read::ParseContext fctx = makeTokenizer();
   fctx.target = &tmp;
   const char*& tch = fctx.ch;
 
@@ -683,7 +683,7 @@ void FreadReader::detect_header() {
   int64_t sncols = static_cast<int64_t>(ncols);
 
   dt::read::field64 tmp;
-  dt::read::FreadTokenizer fctx = makeTokenizer();
+  dt::read::ParseContext fctx = makeTokenizer();
   fctx.target = &tmp;
   const char*& tch = fctx.ch;
 
@@ -878,7 +878,7 @@ void FreadReader::skip_preamble() {
  * not, a `IOError` will be thrown.
  */
 // TODO name-cleaning should be a method of dt::read::Column
-void FreadReader::parse_column_names(dt::read::FreadTokenizer& ctx) {
+void FreadReader::parse_column_names(dt::read::ParseContext& ctx) {
   const char*& ch = ctx.ch;
 
   // Skip whitespace at the beginning of a line.

--- a/src/core/csv/reader_fread.h
+++ b/src/core/csv/reader_fread.h
@@ -137,18 +137,18 @@ public:
   double get_mean_line_len() const { return meanLineLen; }
   size_t get_ncols() const { return preframe.ncols(); }
 
-  dt::read::FreadTokenizer makeTokenizer() const;
+  dt::read::ParseContext makeTokenizer() const;
 
 private:
-  void parse_column_names(dt::read::FreadTokenizer& ctx);
-  void detect_sep(dt::read::FreadTokenizer& ctx);
+  void parse_column_names(dt::read::ParseContext& ctx);
+  void detect_sep(dt::read::ParseContext& ctx);
 
   void detect_lf();
   void skip_preamble();
   void detect_sep_and_qr();
   void detect_column_types();
   void detect_header();
-  int64_t parse_single_line(dt::read::FreadTokenizer&);
+  int64_t parse_single_line(dt::read::ParseContext&);
 
   friend dt::read::FreadThreadContext;
   friend dt::read::FreadParallelReader;

--- a/src/core/csv/reader_fread.h
+++ b/src/core/csv/reader_fread.h
@@ -137,7 +137,7 @@ public:
   double get_mean_line_len() const { return meanLineLen; }
   size_t get_ncols() const { return preframe.ncols(); }
 
-  dt::read::FreadTokenizer makeTokenizer(dt::read::field64* target, const char* anchor) const;
+  dt::read::FreadTokenizer makeTokenizer() const;
 
 private:
   void parse_column_names(dt::read::FreadTokenizer& ctx);

--- a/src/core/csv/reader_parsers.cc
+++ b/src/core/csv/reader_parsers.cc
@@ -646,7 +646,7 @@ static void parse_string_unquoted(ParseContext& ctx) {
     if (static_cast<uint8_t>(c) <= 13) {  // probably a newline
       if (c == '\n') {
         // Move back to the beginning of \r+\n sequence
-        while (ch >= field_start && ch[-1] == '\r') ch--;
+        while (ch > field_start && ch[-1] == '\r') ch--;
         break;
       }
       if (c == '\r' && ctx.cr_is_newline) break;
@@ -809,6 +809,7 @@ void parse_string(ParseContext& ctx) {
   }
   auto len = ctx.target->str32.length;
   auto ptr = ctx.target->str32.offset + ctx.anchor;
+  xassert(len >= 0 || ctx.target->str32.isna());
   if (len == 0? ctx.blank_is_na
               : ctx.end_NA_string(ptr) == ptr + len) {
     ctx.target->str32.setna();

--- a/src/core/csv/reader_parsers.cc
+++ b/src/core/csv/reader_parsers.cc
@@ -725,6 +725,29 @@ static void parse_string_quoted(FreadTokenizer& ctx) {
 }
 
 
+/**
+  * Parse a "naively" quoted string. This quoting rule means that
+  * the string which potentially has embedded quotes was written
+  * without any consideration for the need to escape inner quote
+  * marks. Such string is obviously broken. This parse rule attempts
+  * to fix this situation by following a heuristic:
+  *
+  *   - assume the field has no newlines;
+  *   - the field may or may not contain quote marks;
+  *   - if the field contains a quote mark, it is not followed
+  *     by the sep;
+  *   - when we see quote+(sep|eol) in the input, it means this is
+  *     the actual field end; any quote that is not followed by
+  *     either sep or eol is assumed to be part of the field;
+  *   - if the input starts and ends with a quote, those quotes are
+  *     not considered part of the field;
+  *   - if the input starts with a quote but doesn't end with a
+  *     quote, then the first quote is presumed to be part of the
+  *     field.
+  *
+  * Note: this parser is very hacky, and might as well be removed
+  * in the future entirely.
+  */
 static void parse_string_naive(FreadTokenizer& ctx) {
   const char* ch = ctx.ch;
   const char* end = ctx.eof;

--- a/src/core/csv/reader_parsers.cc
+++ b/src/core/csv/reader_parsers.cc
@@ -610,142 +610,185 @@ void parse_float64_hex(FreadTokenizer& ctx) {
 //------------------------------------------------------------------------------
 // String
 //------------------------------------------------------------------------------
+// static constexpr int SIMPLE = 0;
+static constexpr int DOUBLED = 1;
+static constexpr int ESCAPED = 2;
 
-// TODO: refactor into smaller pieces
-void parse_string(FreadTokenizer& ctx) {
+/**
+  * Parse simple unquoted string field. The field terminates when we
+  * encounter either sep or a newline.
+  *
+  * The QUOTES_FORBIDDEN flag controls the meaning of the quotes
+  * found inside the field. If the flag is true, then any quotes will
+  * result in the error condition (target set to NA, `ch` not
+  * advanced); if the flag is false then the quote chars are treated
+  * as any other regular character.
+  *
+  * This function
+  *   - WILL NOT check for NA strings;
+  *   - WILL NOT check for UTF8 validity;
+  *   - WILL strip the leading/trailing whitespace if requested.
+  */
+template <bool QUOTES_FORBIDDEN>
+static void parse_string_unquoted(FreadTokenizer& ctx) {
   const char* ch = ctx.ch;
+  const char* end = ctx.eof;
   const char quote = ctx.quote;
   const char sep = ctx.sep;
 
-  // need to skip_whitespace first for the reason that a quoted field might have space before the
-  // quote; e.g. test 1609. We need to skip the space(s) to then switch on quote or not.
   if (ctx.strip_whitespace) {
-    // if sep==' ' the space would have been skipped already and we wouldn't be on space now.
-    while (ch < ctx.eof && *ch == ' ') ch++;
+    while (ch < end && *ch == ' ') ch++;
   }
-
-  const char* fieldStart = ch;
-  if (ch == ctx.eof || *ch!=quote || ctx.quoteRule==3) {
-    // Most common case: unambiguously not quoted. Simply search for sep|eol.
-    // If field contains sep|eol then it should have been quoted and we do not
-    // try to heal that.
-    while (ch < ctx.eof) {
-      if (*ch == sep) break;
-      if (static_cast<uint8_t>(*ch) <= 13) {
-        if (*ch == '\n' || ch == ctx.eof) break;
-        if (*ch == '\r') {
-          if (ctx.cr_is_newline || (ch + 1 < ctx.eof && ch[1] == '\n')) break;
-          const char *tch = ch + 1;
-          while (tch < ctx.eof && *tch == '\r') tch++;
-          if (tch < ctx.eof && *tch == '\n') break;
-        }
-      }
-      ch++;  // sep, \r, \n or \0 will end
-    }
-    ctx.ch = ch;
-    int fieldLen = static_cast<int>(ch - fieldStart);
-    if (ctx.strip_whitespace) {   // TODO:  do this if and the next one together once in bulk afterwards before push
-      while(fieldLen>0 && ch[-1]==' ') { fieldLen--; ch--; }
-      // this space can't be sep otherwise it would have stopped the field earlier inside at_end_of_field()
-    }
-    if (fieldLen ? ctx.end_NA_string(fieldStart)==ch : ctx.blank_is_na) {
-      // TODO - speed up by avoiding end_NA_string when there are none
-      ctx.target->str32.setna();
-    } else {
-      ctx.target->str32.offset = static_cast<uint32_t>(fieldStart - ctx.anchor);
-      ctx.target->str32.length = fieldLen;
-    }
-    return;
-  }
-  // else *ch==quote (we don't mind that quoted fields are a little slower e.g. no desire to save switch)
-  //    the field is quoted and quotes are correctly escaped (quoteRule 0 and 1)
-  // or the field is quoted but quotes are not escaped (quoteRule 2)
-  // or the field is not quoted but the data contains a quote at the start (quoteRule 2 too)
-  fieldStart++;  // step over opening quote
-  switch(ctx.quoteRule) {
-  case 0:  // quoted with embedded quotes doubled; the final unescaped " must be followed by sep|eol
-    while (true) {
-      ch++;
-      if (ch == ctx.eof) {
+  const char* field_start = ch;
+  while (ch < end) {
+    char c = *ch;
+    if (c == sep) break;  // end of field
+    if (static_cast<uint8_t>(c) <= 13) {  // probably a newline
+      if (c == '\n') {
+        // Move back to the beginning of \r+\n sequence
+        while (ch >= field_start && ch[-1] == '\r') ch--;
         break;
-      } else if (*ch == quote) {
-        if (ch + 1 < ctx.eof && ch[1] == quote) { ch++; continue; }
-        break;  // found undoubled closing quote
       }
+      if (c == '\r' && ctx.cr_is_newline) break;
     }
-    break;
-  case 1:  // quoted with embedded quotes escaped; the final unescaped " must be followed by sep|eol
-    while (true) {
-      ch++;
-      if (ch == ctx.eof) break;
-      if (ch + 1 < ctx.eof && *ch=='\\' && (ch[1]==quote || ch[1]=='\\')) { ch++; continue; }
-      if (*ch==quote) break;
+    else if (c == quote && QUOTES_FORBIDDEN) {
+      ctx.target->str32.setna();
+      return;
     }
-    break;
-  case 2:
-    // (i) quoted (perhaps because the source system knows sep is present) but any quotes were not escaped at all,
-    // so look for ", to define the end.   (There might not be any quotes present to worry about, anyway).
-    // (ii) not-quoted but there is a quote at the beginning so it should have been; look for , at the end
-    // If no eol are present inside quoted fields (i.e. rows are simple rows), then this should work ok e.g. test 1453
-    // since we look for ", and the source system quoted when , is present, looking for ", should work well.
-    // Under this rule, no eol may occur inside fields.
-    {
-      const char* ch2 = ch;
-      ch++;
-      while (ch < ctx.eof && *ch!='\n' && *ch!='\r') {
-        if (ch + 1 < ctx.eof && *ch==quote && (ch[1]==sep || ch[1]=='\r' || ch[1]=='\n')) {
-          // (*1) regular ", ending; leave *ch on closing quote
-          ch2 = ch;
-          break;
-        }
-        if (*ch==sep) {
-          // first sep in this field
-          // if there is a ", afterwards but before the next \n, use that; the field was quoted and it's still case (i) above.
-          // Otherwise break here at this first sep as it's case (ii) above (the data contains a quote at the start and no sep)
-          ch2 = ch + 1;
-          while (ch2 < ctx.eof && *ch2!='\n' && *ch2!='\r') {
-            if (ch2 + 1 < ctx.eof && *ch2==quote && (ch2[1]==sep || ch2[1]=='\r' || ch2[1]=='\n')) {
-              // (*2) move on to that first ", -- that's this field's ending
-              ch = ch2;
-              break;
-            }
-            ch2++;
-          }
-          break;
-        }
-        ch++;
+    ch++;
+  }
+  // end of field reached
+  auto field_size = ch - field_start;
+  if (ctx.strip_whitespace) {
+    const char* fch = ch - 1;
+    while (field_size > 0 && *fch == ' ') {
+      fch--;
+      field_size--;
+    }
+  }
+  ctx.target->str32.offset = static_cast<uint32_t>(field_start - ctx.anchor);
+  ctx.target->str32.length = static_cast<int32_t>(field_size);
+  ctx.ch = ch;
+}
+
+
+/**
+  * Parse a "quoted" string, this function handles QRs 1 and 2. More
+  * precisely, if the current field begins with a quote, then it will
+  * be parsed as a quoted field, using the supplied QR MODE. However,
+  * if the field does not start with a quote, then we will defer to
+  * the `parse_string_unquoted<false>()` function instead.
+  *
+  * The following MODEs are supported:
+  *   - SIMPLE: no quotes inside field are allowed,
+  *   - DOUBLED: any quotes inside the field are doubled,
+  *   - ESCAPED: any quotes inside the field are escaped with a
+  *              backslash.
+  */
+template <int MODE>
+static void parse_string_quoted(FreadTokenizer& ctx) {
+  const char* ch = ctx.ch;
+  const char* end = ctx.eof;
+  const char quote = ctx.quote;
+
+  if (ctx.strip_whitespace) {
+    while (ch < end && *ch == ' ') ch++;
+  }
+  if (ch < end && *ch == quote) {
+    ch++;  // skip the quote symbol
+    const char* field_start = ch;
+    while (ch < end) {
+      if (*ch == quote) {
+        if (MODE == DOUBLED && ch + 1 < end && ch[1] == quote) ch++;
+        else break;  // undoubled quote: end of field
       }
-      if (ch!=ch2) fieldStart--;   // field ending is this sep|eol; neither (*1) or (*2) happened; opening quote wasn't really an opening quote
+      if (MODE == ESCAPED && *ch == '\\') ch++;
+      ch++;
     }
-    break;
-  default:
-    return;  // Internal error: undefined quote rule
-  }
-  int32_t fieldLen = static_cast<int32_t>(ch - fieldStart);
-  if (fieldLen ? ctx.end_NA_string(fieldStart)==ch : ctx.blank_is_na) {
-    // TODO - speed up by avoiding end_NA_string when there are none
-    ctx.target->str32.setna();
-  } else {
-    ctx.target->str32.length = fieldLen;
-    ctx.target->str32.offset = static_cast<uint32_t>(fieldStart - ctx.anchor);
-  }
-  if (*ch==quote) {
-    ctx.ch = ch + 1;
-    ctx.skip_whitespace();
-  } else {
+    if (ch >= end) {
+      ctx.target->str32.setna();
+      return;
+    }
+    xassert(field_start < ctx.anchor + (1ull << 32));
+    ctx.target->str32.offset = static_cast<uint32_t>(field_start - ctx.anchor);
+    ctx.target->str32.length = static_cast<int32_t>(ch - field_start);
+    xassert(*ch == quote);
+    ch++;  // skip over the quote
+    if (ctx.strip_whitespace) {
+      while (ch < end && *ch == ' ') ch++;
+    }
     ctx.ch = ch;
-    if (ch == ctx.eof) {
-      if (ctx.quoteRule!=2) {  // see test 1324 where final field has open quote but not ending quote; include the open quote like quote rule 2
-        ctx.target->str32.offset--;
-        ctx.target->str32.length++;
+  }
+  else {
+    parse_string_unquoted<true>(ctx);
+  }
+}
+
+
+static void parse_string_naive(FreadTokenizer& ctx) {
+  const char* ch = ctx.ch;
+  const char* end = ctx.eof;
+  const char quote = ctx.quote;
+  const char sep = ctx.sep;
+
+  if (ctx.strip_whitespace) {
+    while (ch < end && *ch == ' ') ch++;
+  }
+  const char* field_end = nullptr;
+  const char* field_start = ch;
+  bool quoted = false;
+  if (ch < end && *ch == quote) {
+    quoted = true;
+    ch++;
+  }
+  while (ch < end) {
+    char c = *ch;
+    if (c == sep) {
+      // this is a field end if either (1) the field did not start with a quote,
+      // or (2) a matching closing quote will not be found on the line
+      if (!field_end) field_end = ch;  // tentative
+      if (!quoted) break;
+    }
+    else if (c == quote && quoted) {
+      // a quote closes the field only if the field started with a quote, and
+      // only if this quote is followed with a valid sep
+      if (ch + 1 == end || ch[1] == sep || ch[1] == '\n' || ch[1] == '\r') {
+        field_end = ch;
+        field_start++;
+        ch++;  // skip over the final quote
+        break;
       }
     }
-    if (ctx.strip_whitespace) {  // see test 1551.6; trailing whitespace in field [67,V37] == "\"\"A\"\" ST       "
-      while (ctx.target->str32.length>0 && ch[-1]==' ') {
-        ctx.target->str32.length--;
-        ch--;
+    else if (static_cast<uint8_t>(c) <= 13) {  // probably a newline
+      if (c == '\n') {
+        // Move back to the beginning of \r+\n sequence
+        while (ch >= field_start && ch[-1] == '\r') ch--;
+        break;
       }
+      if (c == '\r' && ctx.cr_is_newline) break;
     }
+    ch++;
+  }
+  if (!field_end) field_end = ch;
+  ctx.target->str32.offset = static_cast<uint32_t>(field_start - ctx.anchor);
+  ctx.target->str32.length = static_cast<int32_t>(field_end - field_start);
+  ctx.ch = ch;
+}
+
+
+
+void parse_string(FreadTokenizer& ctx) {
+  switch (ctx.quoteRule) {
+    case 0: parse_string_quoted<DOUBLED>(ctx); break;
+    case 1: parse_string_quoted<ESCAPED>(ctx); break;
+    case 2: parse_string_naive(ctx);           break;
+    case 3: parse_string_unquoted<false>(ctx); break;
+  }
+  auto len = ctx.target->str32.length;
+  auto ptr = ctx.target->str32.offset + ctx.anchor;
+  if (len == 0? ctx.blank_is_na
+              : ctx.end_NA_string(ptr) == ptr + len) {
+    ctx.target->str32.setna();
   }
 }
 

--- a/src/core/csv/reader_parsers.h
+++ b/src/core/csv/reader_parsers.h
@@ -11,29 +11,29 @@
 #include <vector>
 #include "_dt.h"
 
-typedef void (*ParserFnPtr)(dt::read::FreadTokenizer& ctx);
+typedef void (*ParserFnPtr)(dt::read::ParseContext& ctx);
 typedef PyObject* (*FormatGeneratorFn)(dt::read::InputColumn& col);
 
 
 // In order to add a new type:
-//   - implement a new parser function `void (*)(dt::read::FreadTokenizer&)`
+//   - implement a new parser function `void (*)(dt::read::ParseContext&)`
 //   - add a new identifier into `enum PT`
 //   - declare this parser in `ParserLibrary::init_parsers()`
 //   - update `test_fread_fillna1` in test_fread.py to include the new type
 //
 
-void parse_mu(dt::read::FreadTokenizer&);
-void parse_bool8_numeric(dt::read::FreadTokenizer&);
-void parse_bool8_uppercase(dt::read::FreadTokenizer&);
-void parse_bool8_lowercase(dt::read::FreadTokenizer&);
-void parse_bool8_titlecase(dt::read::FreadTokenizer&);
-void parse_int32_simple(dt::read::FreadTokenizer&);
-void parse_int64_simple(dt::read::FreadTokenizer&);
-void parse_float32_hex(dt::read::FreadTokenizer&);
-void parse_float64_simple(dt::read::FreadTokenizer& ctx);
-void parse_float64_extended(dt::read::FreadTokenizer& ctx);
-void parse_float64_hex(dt::read::FreadTokenizer&);
-void parse_string(dt::read::FreadTokenizer&);
+void parse_mu(dt::read::ParseContext&);
+void parse_bool8_numeric(dt::read::ParseContext&);
+void parse_bool8_uppercase(dt::read::ParseContext&);
+void parse_bool8_lowercase(dt::read::ParseContext&);
+void parse_bool8_titlecase(dt::read::ParseContext&);
+void parse_int32_simple(dt::read::ParseContext&);
+void parse_int64_simple(dt::read::ParseContext&);
+void parse_float32_hex(dt::read::ParseContext&);
+void parse_float64_simple(dt::read::ParseContext& ctx);
+void parse_float64_extended(dt::read::ParseContext& ctx);
+void parse_float64_hex(dt::read::ParseContext&);
+void parse_string(dt::read::ParseContext&);
 
 
 //------------------------------------------------------------------------------

--- a/src/core/jay/save_jay.cc
+++ b/src/core/jay/save_jay.cc
@@ -235,7 +235,7 @@ void dt::Rbound_ColumnImpl::write_data_to_jay(
 static jay::Buffer saveMemoryRange(
     const void* data, size_t len, WritableBuffer* wb)
 {
-  size_t pos = wb->prep_write(len, data);
+  size_t pos = wb->prepare_write(len, data);
   wb->write_at(pos, len, data);
   xassert(pos >= 8);
   if (len & 7) {  // Align the buffer to 8-byte boundary

--- a/src/core/read/fread/fread_parallel_reader.cc
+++ b/src/core/read/fread/fread_parallel_reader.cc
@@ -38,7 +38,7 @@ void FreadParallelReader::adjust_chunk_coordinates(
   // Adjust the beginning of the chunk so that it is guaranteed not to be
   // on a newline.
   if (cc.is_start_approximate()) {
-    FreadTokenizer& tok = static_cast<FreadThreadContext*>(ctx)->get_tokenizer();
+    ParseContext& tok = static_cast<FreadThreadContext*>(ctx)->get_tokenizer();
     const char* start = cc.get_start();
     while (*start=='\n' || *start=='\r') start++;
     cc.set_start_approximate(start);

--- a/src/core/read/fread/fread_parallel_reader.h
+++ b/src/core/read/fread/fread_parallel_reader.h
@@ -13,7 +13,7 @@
 #include "_dt.h"
 
 class FreadReader;
-struct FreadTokenizer;
+struct ParseContext;
 
 namespace dt {
 namespace read {

--- a/src/core/read/fread/fread_thread_context.cc
+++ b/src/core/read/fread/fread_thread_context.cc
@@ -209,7 +209,7 @@ void FreadThreadContext::read_chunk(
         while (tokenizer.skip_eol()) {
           tokenizer.skip_whitespace();
         }
-        if (tokenizer.at_eof()) break;
+        if (tokenizer.ch == tokenizer.eof) break;
       }
 
       // not enough columns observed (including empty line). If fill==true,

--- a/src/core/read/fread/fread_thread_context.cc
+++ b/src/core/read/fread/fread_thread_context.cc
@@ -304,29 +304,6 @@ void FreadThreadContext::postprocess() {
 }
 
 
-void FreadThreadContext::order_buffer() {
-  if (!used_nrows) return;
-  size_t j = 0;
-  for (auto& col : preframe_) {
-    if (!col.is_in_buffer()) continue;
-    if (col.is_string() && !col.is_type_bumped()) {
-      auto& outcol = col.outcol();
-      // Compute the size of the string content in the buffer `sz` from the
-      // offset of the last element. This quantity cannot be calculated in the
-      // postprocess() step, since `used_nrows` may sometimes change, affecting
-      // this size after the post-processing.
-      uint32_t offset0 = static_cast<uint32_t>(strinfo[j].start);
-      uint32_t offsetL = tbuf[j + tbuf_ncols * (used_nrows - 1)].str32.offset;
-      size_t sz = (offsetL - offset0) & ~GETNA<uint32_t>();
-      strinfo[j].size = sz;
-
-      WritableBuffer* wb = outcol.strdata_w();
-      size_t write_at = wb->prep_write(sz, sbuf.data() + offset0);
-      strinfo[j].write_at = write_at;
-    }
-    ++j;
-  }
-}
 
 
 void FreadThreadContext::push_buffers() {

--- a/src/core/read/fread/fread_thread_context.cc
+++ b/src/core/read/fread/fread_thread_context.cc
@@ -35,9 +35,10 @@ FreadThreadContext::FreadThreadContext(
   ) : ThreadContext(bcols, brows, f.preframe),
       types(types_),
       freader(f),
-      tokenizer(f.makeTokenizer(tbuf.data(), nullptr)),
+      tokenizer(f.makeTokenizer()),
       parsers(ParserLibrary::get_parser_fns())
 {
+  tokenizer.target = tbuf.data();
   ttime_push = 0;
   ttime_read = 0;
   anchor = nullptr;

--- a/src/core/read/fread/fread_thread_context.h
+++ b/src/core/read/fread/fread_thread_context.h
@@ -64,7 +64,7 @@ class FreadThreadContext : public ThreadContext
 
     void read_chunk(const ChunkCoordinates&, ChunkCoordinates&) override;
     void postprocess();
-    void order_buffer() override;
+    // void order_buffer() override;
     void push_buffers() override;
 
     FreadTokenizer& get_tokenizer() { return tokenizer; }

--- a/src/core/read/fread/fread_thread_context.h
+++ b/src/core/read/fread/fread_thread_context.h
@@ -52,7 +52,7 @@ class FreadThreadContext : public ThreadContext
     PT* types;
 
     FreadReader& freader;
-    PreFrame& preframe;
+    // PreFrame& preframe;
     FreadTokenizer tokenizer;
     const ParserFnPtr* parsers;
 

--- a/src/core/read/fread/fread_thread_context.h
+++ b/src/core/read/fread/fread_thread_context.h
@@ -21,7 +21,7 @@
 //------------------------------------------------------------------------------
 #ifndef dt_READ_FREAD_THREAD_CONTEXT_h
 #define dt_READ_FREAD_THREAD_CONTEXT_h
-#include "read/fread/fread_tokenizer.h" // FreadTokenizer
+#include "read/parse_context.h"         // ParseContext
 #include "read/thread_context.h"        // ThreadContext
 #include "_dt.h"
 namespace dt {
@@ -36,7 +36,7 @@ namespace read {
 class FreadThreadContext : public ThreadContext
 {
   private:
-    using ParserFnPtr = void(*)(FreadTokenizer& ctx);
+    using ParserFnPtr = void(*)(ParseContext& ctx);
 
     const char* anchor;
     int quoteRule;
@@ -53,7 +53,7 @@ class FreadThreadContext : public ThreadContext
 
     FreadReader& freader;
     // PreFrame& preframe;
-    FreadTokenizer tokenizer;
+    ParseContext tokenizer;
     const ParserFnPtr* parsers;
 
   public:
@@ -67,7 +67,7 @@ class FreadThreadContext : public ThreadContext
     // void order_buffer() override;
     void push_buffers() override;
 
-    FreadTokenizer& get_tokenizer() { return tokenizer; }
+    ParseContext& get_tokenizer() { return tokenizer; }
 };
 
 

--- a/src/core/read/fread/fread_tokenizer.cc
+++ b/src/core/read/fread/fread_tokenizer.cc
@@ -153,6 +153,7 @@ void FreadTokenizer::skip_whitespace_at_line_start() {
 int FreadTokenizer::countfields()
 {
   const char* ch0 = ch;
+  anchor = ch0;
   if (sep==' ') while (ch < eof && *ch==' ') ch++;  // multiple sep==' ' at the start does not mean sep
   skip_whitespace();
   if (skip_eol() || ch==eof) {

--- a/src/core/read/parse_context.h
+++ b/src/core/read/parse_context.h
@@ -1,22 +1,39 @@
 //------------------------------------------------------------------------------
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright 2018-2020 H2O.ai
 //
-// © H2O.ai 2018
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
 //------------------------------------------------------------------------------
-#ifndef dt_READ_FREAD_TOKENIZER_h
-#define dt_READ_FREAD_TOKENIZER_h
+#ifndef dt_READ_PARSE_CONTEXT_h
+#define dt_READ_PARSE_CONTEXT_h
 #include "read/field64.h"            // field64
 #include "read/parallel_reader.h"    // ChunkCoordinates
 namespace dt {
 namespace read {
 
 
-struct FreadTokenizer
+struct ParseContext
 {
   // Pointer to the current parsing location
   const char* ch;
+
+  // Only range of bytes [ch; eof) is available for reading
+  const char* eof;
 
   // Where to write the parsed value. The pointer will be incremented after
   // each successful read.
@@ -25,8 +42,6 @@ struct FreadTokenizer
   // Anchor pointer for string parser, this pointer is the starting point
   // relative to which `str32.offset` is defined.
   const char* anchor;
-
-  const char* eof;
 
   const char* const* NAstrings;
 
@@ -63,7 +78,6 @@ struct FreadTokenizer
   const char* end_NA_string(const char*);
   int countfields();
   bool skip_eol();
-  bool at_eof() const { return ch == eof; }
 
   bool next_good_line_start(
     const ChunkCoordinates& cc, int ncols, bool fill,

--- a/src/core/read/parse_context.h
+++ b/src/core/read/parse_context.h
@@ -27,12 +27,23 @@ namespace dt {
 namespace read {
 
 
+/**
+  * This struct carries information needed by various field parsers
+  * to correctly read their values. Different values may be used by
+  * different parsers, some may not need any extra values at all.
+  *
+  * The most important variables, however, which are used by all
+  * parsers, are: `ch`, `eof` and `target`.
+  */
 struct ParseContext
 {
-  // Pointer to the current parsing location
-  const char* ch;
+  // Pointer to the current parsing location within the input stream.
+  // All parsers are expected to advance this pointer when they
+  // successfully read a value from the stream.
+  mutable const char* ch;
 
-  // Only range of bytes [ch; eof) is available for reading
+  // The end of the range of bytes available for reading. Only bytes
+  // up to but excluding `eof` may be accessed by a parser.
   const char* eof;
 
   // Where to write the parsed value. The pointer will be incremented after

--- a/src/core/read/thread_context.cc
+++ b/src/core/read/thread_context.cc
@@ -86,7 +86,7 @@ void ThreadContext::order_buffer() {
       strinfo[j].size = sz;
 
       WritableBuffer* wb = outcol.strdata_w();
-      size_t write_at = wb->prep_write(sz, sbuf.data() + offset0);
+      size_t write_at = wb->prepare_write(sz, sbuf.data() + offset0);
       strinfo[j].write_at = write_at;
     }
     ++j;

--- a/src/core/read/thread_context.cc
+++ b/src/core/read/thread_context.cc
@@ -21,6 +21,7 @@
 //------------------------------------------------------------------------------
 #include "read/field64.h"            // field64
 #include "read/chunk_coordinates.h"  // ChunkCoordinates
+#include "read/preframe.h"
 #include "read/thread_context.h"
 #include "utils/assert.h"
 namespace dt {
@@ -65,6 +66,31 @@ void ThreadContext::set_nrows(size_t n) {
 void ThreadContext::set_row0(size_t n) {
   xassert(row0 <= n);
   row0 = n;
+}
+
+
+void ThreadContext::order_buffer() {
+  if (!used_nrows) return;
+  size_t j = 0;
+  for (auto& col : preframe_) {
+    if (!col.is_in_buffer()) continue;
+    if (col.is_string() && !col.is_type_bumped()) {
+      auto& outcol = col.outcol();
+      // Compute the size of the string content in the buffer `sz` from the
+      // offset of the last element. This quantity cannot be calculated in the
+      // postprocess() step, since `used_nrows` may sometimes change, affecting
+      // this size after the post-processing.
+      uint32_t offset0 = static_cast<uint32_t>(strinfo[j].start);
+      uint32_t offsetL = tbuf[j + tbuf_ncols * (used_nrows - 1)].str32.offset;
+      size_t sz = (offsetL - offset0) & ~GETNA<uint32_t>();
+      strinfo[j].size = sz;
+
+      WritableBuffer* wb = outcol.strdata_w();
+      size_t write_at = wb->prep_write(sz, sbuf.data() + offset0);
+      strinfo[j].write_at = write_at;
+    }
+    ++j;
+  }
 }
 
 

--- a/src/core/read/thread_context.cc
+++ b/src/core/read/thread_context.cc
@@ -96,4 +96,79 @@ void ThreadContext::order_buffer() {
 
 
 
+void ThreadContext::push_buffers() {
+  // If the buffer is empty, then there's nothing to do...
+  if (!used_nrows) return;
+
+  size_t j = 0;
+  for (auto& col : preframe_) {
+    if (!col.is_in_buffer()) continue;
+    auto& outcol = col.outcol();
+    void* data = outcol.data_w();
+    int8_t elemsize = static_cast<int8_t>(col.elemsize());
+    size_t effective_row0 = row0 - col.nrows_archived();
+
+    if (col.is_type_bumped()) {
+      // do nothing: the column was not properly allocated for its type, so
+      // any attempt to write the data may fail with data corruption
+    } else if (col.is_string()) {
+      WritableBuffer* wb = outcol.strdata_w();
+      auto& si = strinfo[j];
+      field64* lo = tbuf.data() + j;
+
+      wb->write_at(si.write_at, si.size, sbuf.data() + si.start);
+
+      if (elemsize == 4) {
+        uint32_t* dest = static_cast<uint32_t*>(data) + effective_row0 + 1;
+        uint32_t delta = static_cast<uint32_t>(si.write_at - si.start);
+        for (size_t n = 0; n < used_nrows; ++n) {
+          uint32_t soff = lo->str32.offset;
+          *dest++ = soff + delta;
+          lo += tbuf_ncols;
+        }
+      } else {
+        uint64_t* dest = static_cast<uint64_t*>(data) + effective_row0 + 1;
+        uint64_t delta = static_cast<uint64_t>(si.write_at - si.start);
+        for (size_t n = 0; n < used_nrows; ++n) {
+          uint64_t soff = lo->str32.offset;
+          *dest++ = soff + delta;
+          lo += tbuf_ncols;
+        }
+      }
+
+    } else {
+      const field64* src = tbuf.data() + j;
+      if (elemsize == 8) {
+        uint64_t* dest = static_cast<uint64_t*>(data) + effective_row0;
+        for (size_t r = 0; r < used_nrows; r++) {
+          *dest = src->uint64;
+          src += tbuf_ncols;
+          dest++;
+        }
+      } else
+      if (elemsize == 4) {
+        uint32_t* dest = static_cast<uint32_t*>(data) + effective_row0;
+        for (size_t r = 0; r < used_nrows; r++) {
+          *dest = src->uint32;
+          src += tbuf_ncols;
+          dest++;
+        }
+      } else
+      if (elemsize == 1) {
+        uint8_t* dest = static_cast<uint8_t*>(data) + effective_row0;
+        for (size_t r = 0; r < used_nrows; r++) {
+          *dest = src->uint8;
+          src += tbuf_ncols;
+          dest++;
+        }
+      }
+    }
+    j++;
+  }
+  used_nrows = 0;
+}
+
+
+
+
 }}  // namespace dt::read

--- a/src/core/read/thread_context.cc
+++ b/src/core/read/thread_context.cc
@@ -27,14 +27,15 @@ namespace dt {
 namespace read {
 
 
-ThreadContext::ThreadContext(size_t ncols, size_t nrows)
+ThreadContext::ThreadContext(size_t ncols, size_t nrows, PreFrame& preframe)
   : tbuf(ncols * nrows + 1),
     sbuf(0),
     strinfo(ncols),
     tbuf_ncols(ncols),
     tbuf_nrows(nrows),
     used_nrows(0),
-    row0(0) {}
+    row0(0),
+    preframe_(preframe) {}
 
 
 // Note: it is possible to have `used_nrows != 0` at the end: the content of

--- a/src/core/read/thread_context.h
+++ b/src/core/read/thread_context.h
@@ -91,7 +91,7 @@ class ThreadContext    // TODO: rename
     virtual ~ThreadContext();
 
     virtual void read_chunk(const ChunkCoordinates&, ChunkCoordinates&) = 0;
-    virtual void order_buffer() = 0;
+    virtual void order_buffer();
     virtual void push_buffers() = 0;
 
     size_t get_nrows() const;

--- a/src/core/read/thread_context.h
+++ b/src/core/read/thread_context.h
@@ -92,7 +92,7 @@ class ThreadContext    // TODO: rename
 
     virtual void read_chunk(const ChunkCoordinates&, ChunkCoordinates&) = 0;
     virtual void order_buffer();
-    virtual void push_buffers() = 0;
+    virtual void push_buffers();
 
     size_t get_nrows() const;
     void set_nrows(size_t n);

--- a/src/core/read/thread_context.h
+++ b/src/core/read/thread_context.h
@@ -67,7 +67,7 @@ namespace read {
   *   Starting row index within the PreFrame for the current data
   *   chunk.
   */
-class ThreadContext
+class ThreadContext    // TODO: rename
 {
   protected:
     struct StrInfo {
@@ -84,8 +84,10 @@ class ThreadContext
     size_t used_nrows;
     size_t row0;
 
+    PreFrame& preframe_;
+
   public:
-    ThreadContext(size_t ncols, size_t nrows);
+    ThreadContext(size_t ncols, size_t nrows, PreFrame&);
     virtual ~ThreadContext();
 
     virtual void read_chunk(const ChunkCoordinates&, ChunkCoordinates&) = 0;

--- a/src/core/write/write_manager.cc
+++ b/src/core/write/write_manager.cc
@@ -146,7 +146,7 @@ void write_manager::write_rows()
         [&](size_t) {  // ordered
           CString buf = ctx.get_buffer();
           th_write_size = static_cast<size_t>(buf.size);
-          th_write_at = wb->prep_write(th_write_size, buf.ch);
+          th_write_at = wb->prepare_write(th_write_size, buf.ch);
         },
 
         [&](size_t) {  // post-ordered

--- a/src/core/writebuf.h
+++ b/src/core/writebuf.h
@@ -1,12 +1,26 @@
 //------------------------------------------------------------------------------
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright 2018-2020 H2O.ai
 //
-// © H2O.ai 2018
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
 //------------------------------------------------------------------------------
-#ifndef dt_WRITEBUF_H
-#define dt_WRITEBUF_H
+#ifndef dt_WRITEBUF_h
+#define dt_WRITEBUF_h
 #include <memory>      // std::unique_ptr
 #include <string>      // std::string
 #include "parallel/shared_mutex.h"
@@ -17,99 +31,99 @@
 
 class WritableBuffer
 {
-protected:
-  size_t bytes_written;
+  protected:
+    size_t bytes_written_;
 
-public:
-  enum class Strategy : int8_t { Unknown, Auto, Mmap, Write };
+  public:
+    enum class Strategy : int8_t { Unknown, Auto, Mmap, Write };
 
-  WritableBuffer();
-  virtual ~WritableBuffer();
+    WritableBuffer();
+    virtual ~WritableBuffer();
 
-  /**
-   * Factory method for instantiating one of the `WritableBuffer` derived
-   * classes based on the strategy and the current platform.
-   *
-   * @param path
-   *     Name of the file to write to. If empty, then we will be writing into
-   *     the memory, and MemoryWritableBuffer is returned.
-   *
-   * @param size
-   *     Expected size of the data to be written. This doesn't have to be the
-   *     exact amount, however having a good estimate may improve efficiency.
-   *     This may also have effect on the choice of the writing strategy.
-   *
-   * @param strategy
-   *     Which subclass of `WritableBuffer` to construct. This could be `Auto`
-   *     (choose the best subclass automatically), while all  other values
-   *     force the choice of a particular subclass.
-   *
-   * @param append
-   *     If true, the file will be opened in append mode ("a"); if false, the
-   *     file will be opened in overwrite mode ("w").
-   */
-  static std::unique_ptr<WritableBuffer> create_target(
-    const std::string& path, size_t size, Strategy strategy = Strategy::Auto,
-    bool append = false
-  );
+    /**
+     * Factory method for instantiating one of the `WritableBuffer` derived
+     * classes based on the strategy and the current platform.
+     *
+     * @param path
+     *     Name of the file to write to. If empty, then we will be writing into
+     *     the memory, and MemoryWritableBuffer is returned.
+     *
+     * @param size
+     *     Expected size of the data to be written. This doesn't have to be the
+     *     exact amount, however having a good estimate may improve efficiency.
+     *     This may also have effect on the choice of the writing strategy.
+     *
+     * @param strategy
+     *     Which subclass of `WritableBuffer` to construct. This could be `Auto`
+     *     (choose the best subclass automatically), while all  other values
+     *     force the choice of a particular subclass.
+     *
+     * @param append
+     *     If true, the file will be opened in append mode ("a"); if false, the
+     *     file will be opened in overwrite mode ("w").
+     */
+    static std::unique_ptr<WritableBuffer> create_target(
+      const std::string& path, size_t size, Strategy strategy = Strategy::Auto,
+      bool append = false
+    );
 
-  /**
-   * Return the current size of the writable buffer -- i.e. the amount of bytes
-   * written into it. Note that this is different from the current buffer's
-   * "capacity" (i.e. the size it was pre-allocated for).
-   */
-  size_t size() const { return bytes_written; }
+    // Return the current size of the writable buffer -- i.e. the
+    // number of bytes written into it. Note that this is different
+    // from the current buffer's "capacity" (i.e. the size it was
+    // pre-allocated for).
+    //
+    size_t size() const;
 
-  /**
-   * Prepare to write buffer `src` of size `n`. This method is expected to be
-   * called by no more than one thread at a time (for example from the OMP
-   * "ordered" section). The value returned by this method should be passed to
-   * the subsequent `write_at()` call.
-   *
-   * Implementations are encouraged to perform as little work as possible within
-   * this method, and instead defer most writing to the `write_at()` method.
-   * However in case when this is not possible, an implementation may actually
-   * write out the provided buffer `src`.
-   */
-  virtual size_t prep_write(size_t n, const void* src) = 0;
+    /**
+     * Prepare to write buffer `src` of size `n`. This method is expected to be
+     * called by no more than one thread at a time (for example from the OMP
+     * "ordered" section). The value returned by this method should be passed to
+     * the subsequent `write_at()` call.
+     *
+     * Implementations are encouraged to perform as little work as possible within
+     * this method, and instead defer most writing to the `write_at()` method.
+     * However in case when this is not possible, an implementation may actually
+     * write out the provided buffer `src`.
+     */
+    virtual size_t prepare_write(size_t n, const void* src) = 0;
 
-  /**
-   * Write buffer `src` of size `n` at the position `pos` (this position should
-   * have previously been returned from `pre_write()`, which also ensured that
-   * there is enough space to perform the writing).
-   *
-   * This call is safe to invoke from multiple threads simultaneously. It is
-   * also allowed to call this method when another thread is performing
-   * `prep_write()`.
-   */
-  virtual void write_at(size_t pos, size_t n, const void* src) = 0;
+    /**
+     * Write buffer `src` of size `n` at the position `pos` (this position should
+     * have previously been returned from `pre_write()`, which also ensured that
+     * there is enough space to perform the writing).
+     *
+     * This call is safe to invoke from multiple threads simultaneously. It is
+     * also allowed to call this method when another thread is performing
+     * `prepare_write()`.
+     */
+    virtual void write_at(size_t pos, size_t n, const void* src) = 0;
 
-  /**
-   * This method should be called when you're done writing to the buffer. It is
-   * distinct from the destructor in that it is not expected to free any
-   * resources, but rather make the object read-only.
-   */
-  virtual void finalize() = 0;
+    /**
+     * This method should be called when you're done writing to the buffer. It is
+     * distinct from the destructor in that it is not expected to free any
+     * resources, but rather make the object read-only.
+     */
+    virtual void finalize() = 0;
 
-  /**
-    * Simple helper method for writing into the buffer in single-
-    * threaded context. The return value is the position within the
-    * buffer where the data was written.
-    */
-  size_t write(size_t n, const void* src) {
-    size_t writepos = prep_write(n, src);
-    write_at(writepos, n, src);
-    return writepos;
-  }
-  size_t write(const CString& src) {
-    size_t writepos = prep_write(static_cast<size_t>(src.size), src.ch);
-    write_at(writepos, static_cast<size_t>(src.size), src.ch);
-    return writepos;
-  }
+    /**
+      * Simple helper method for writing into the buffer in single-
+      * threaded context. The return value is the position within the
+      * buffer where the data was written.
+      */
+    size_t write(size_t n, const void* src) {
+      size_t writepos = prepare_write(n, src);
+      write_at(writepos, n, src);
+      return writepos;
+    }
+    size_t write(const CString& src) {
+      size_t writepos = prepare_write(static_cast<size_t>(src.size), src.ch);
+      write_at(writepos, static_cast<size_t>(src.size), src.ch);
+      return writepos;
+    }
 
-  // Prevent copying / assignment for these objects
-  WritableBuffer(const WritableBuffer&) = delete;
-  WritableBuffer& operator=(const WritableBuffer&) = delete;
+    // Prevent copying / assignment for these objects
+    WritableBuffer(const WritableBuffer&) = delete;
+    WritableBuffer& operator=(const WritableBuffer&) = delete;
 };
 
 
@@ -118,15 +132,16 @@ public:
 
 class FileWritableBuffer : public WritableBuffer
 {
-  File* file;
+  private:
+    File* file_;  // owned
 
-public:
-  FileWritableBuffer(const std::string& path, bool append = false);
-  virtual ~FileWritableBuffer() override;
+  public:
+    FileWritableBuffer(const std::string& path, bool append = false);
+    virtual ~FileWritableBuffer() override;
 
-  virtual size_t prep_write(size_t n, const void* src) override;
-  virtual void write_at(size_t pos, size_t n, const void* src) override;
-  virtual void finalize() override;
+    virtual size_t prepare_write(size_t n, const void* src) override;
+    virtual void write_at(size_t pos, size_t n, const void* src) override;
+    virtual void finalize() override;
 };
 
 
@@ -135,20 +150,19 @@ public:
 
 class ThreadsafeWritableBuffer : public WritableBuffer
 {
-protected:
-  void*  buffer;
-  size_t allocsize;
-  dt::shared_mutex shmutex;
+  protected:
+    void*  data_;     // owned, managed by child classes
+    size_t allocsize_;
+    dt::shared_mutex shmutex_;
 
-  virtual void realloc(size_t newsize) = 0;
+    virtual void realloc(size_t newsize) = 0;
 
-public:
-  ThreadsafeWritableBuffer();
-  virtual ~ThreadsafeWritableBuffer() override;
+  public:
+    ThreadsafeWritableBuffer();
 
-  virtual size_t prep_write(size_t n, const void* src) override;
-  virtual void write_at(size_t pos, size_t n, const void* src) override;
-  virtual void finalize() override;
+    virtual size_t prepare_write(size_t n, const void* src) override;
+    virtual void write_at(size_t pos, size_t n, const void* src) override;
+    virtual void finalize() override;
 };
 
 
@@ -157,20 +171,22 @@ public:
 
 class MemoryWritableBuffer : public ThreadsafeWritableBuffer
 {
-public:
-  MemoryWritableBuffer(size_t size);
-  ~MemoryWritableBuffer() override;
+  public:
+    MemoryWritableBuffer(size_t size);
+    ~MemoryWritableBuffer() override;
 
-  /**
-   * Return memory buffer that was written. This method may only be called
-   * after `finalize()`. This class surrenders ownership of the buffer, and
-   * it will be the responsibility of the caller to handle it.
-   */
-  Buffer get_mbuf();
-  std::string get_string();
+    // Return memory buffer that was written. This method may only be
+    // called after `finalize()`.
+    Buffer get_mbuf();
+    std::string get_string();
 
-private:
-  void realloc(size_t newsize) override;
+    // Pretend that the buffer is empty, so that any subsequent writes
+    // will start from the beginning. This method does not actually
+    // erase any data, nor does any reallocation.
+    void clear();
+
+  private:
+    void realloc(size_t newsize) override;
 };
 
 
@@ -179,19 +195,22 @@ private:
 
 class MmapWritableBuffer : public ThreadsafeWritableBuffer
 {
-  std::string filename;
+  private:
+    std::string filename_;
 
-public:
-  MmapWritableBuffer(const std::string& path, size_t size, bool append = false);
-  ~MmapWritableBuffer() override;
+  public:
+    MmapWritableBuffer(const std::string& path, size_t size, bool append = false);
+    ~MmapWritableBuffer() override;
 
-  void finalize() override;
+    void finalize() override;
 
-private:
-  void realloc(size_t newsize) override;
-  void map(int fd, size_t size);
-  void unmap();
+  private:
+    void realloc(size_t newsize) override;
+    void map(int fd, size_t size);
+    void unmap();
 };
+
+
 
 
 #endif

--- a/src/core/wstringcol.cc
+++ b/src/core/wstringcol.cc
@@ -132,7 +132,7 @@ void writable_string_col::buffer_impl<T>::write(const char* ch, size_t len) {
 
 template <typename T>
 void writable_string_col::buffer_impl<T>::order() {
-  strbuf_write_pos = col.strdata.prep_write(strbuf_used, strbuf_ptr());
+  strbuf_write_pos = col.strdata.prepare_write(strbuf_used, strbuf_ptr());
 }
 
 

--- a/tests/fread/test_fread_issues.py
+++ b/tests/fread/test_fread_issues.py
@@ -59,7 +59,7 @@ def test_issue_R1113(tol):
     # Check that whitespace is not removed from column names either
     d2 = dt.fread(text=" ITER,    THETA1,       THETA2", strip_whitespace=False)
     d3 = dt.fread(text=" ITER  ,  THETA1   ,    THETA2", strip_whitespace=False)
-    d4 = dt.fread(text=' ITER  ,  THETA1  ,   "THETA2"', strip_whitespace=False)
+    d4 = dt.fread(text=' ITER  ,  THETA1  ,   "THETA2"', strip_whitespace=False, sep=',')
     assert d2.names == (" ITER", "    THETA1", "       THETA2")
     assert d3.names == (" ITER  ", "  THETA1   ", "    THETA2")
     assert d4.names == (' ITER  ', '  THETA1  ', '   "THETA2"')

--- a/tests/fread/test_fread_small.py
+++ b/tests/fread/test_fread_small.py
@@ -543,9 +543,8 @@ def test_runaway_quote():
 
 
 def test_unmatched_quotes():
-    # Should instead all quotes remain around 'aa', 'bb' and 'cc' ?
     assert dt.fread('A,B\n"aa",1\n"bb,2\n"cc",3\n') \
-             .to_list() == [['aa', '"bb', 'cc'], [1, 2, 3]]
+             .to_list() == [['"aa"', '"bb', '"cc"'], [1, 2, 3]]
     assert dt.fread('A,B\n"aa",1\n""bb",2\n"cc",3\n') \
              .to_list() == [['aa', '"bb', 'cc'], [1, 2, 3]]
     assert dt.fread('A,B\n"aa",1\nbb",2\n"cc",3\n') \

--- a/tests/fread/test_fread_small.py
+++ b/tests/fread/test_fread_small.py
@@ -16,7 +16,7 @@ import random
 import re
 import time
 from datatable.internal import frame_integrity_check
-from tests import random_string, list_equals
+from tests import random_string, list_equals, assert_equals
 
 
 
@@ -533,6 +533,13 @@ def test_fread2():
     assert f.shape == (3, 4)
     assert f.names == ("A", "B", "C", "D")
     assert f.ltypes == (ltype.int, ltype.int, ltype.int, ltype.real)
+
+
+@pytest.mark.parametrize('newline', ["\n", "\r", "\r\n", "\n\r"])
+def test_fread3(newline):
+    src = newline.join(['COL', "abc", "def", "", "ijk", ""])
+    DT = dt.fread(text=src)
+    assert_equals(DT, dt.Frame(COL=["abc", "def", "", "ijk"]))
 
 
 def test_runaway_quote():


### PR DESCRIPTION
- Moved non-fread-specific functions from FreadThreadContext into the parent class;
- `FreadTokenizer` class renamed into `ParseContext` (so that it can be reused in places other than fread);
- Refactor string parsing code into separate parsers for each QR;
- Code style changes in "writebuf.*"