### PR TITLE
Temporarily downgrade sphinx  on readthedocs

### DIFF
--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,5 +1,5 @@
 docutils>=0.15
-sphinx>=2.3
+sphinx>=1.8
 sphinx_rtd_theme
 nbsphinx>=0.5
 datatable

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,5 +1,5 @@
 docutils>=0.15
-sphinx>=1.8
+sphinx<3.0
 sphinx_rtd_theme
 nbsphinx>=0.5
 datatable

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,5 +1,5 @@
 docutils>=0.15
-sphinx<3.0
+sphinx>=1.8,<3.0
 sphinx_rtd_theme
 nbsphinx>=0.5
 datatable


### PR DESCRIPTION
The latest sphinx `3.0.3` seems to be [incompatible](https://readthedocs.org/projects/datatable/builds/11101225/) with our docs. While we are researching this issue, temporarily downgrade sphinx on readthedocs. Any version prior to `3.0` will work just fine.