### PR TITLE
Fix slow reading of string columns by fread

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -113,7 +113,7 @@ Troubleshooting
 
 - If you see an error ``'Python.h' file not found``, then it means you have an incomplete version of Python installed. This is known to sometimes happen on Ubuntu systems. The solution is to run ``apt-get install python-dev`` or ``apt-get install python3.6-dev``.
 
-- On OS X, if you are getting an error ``fatal error: 'sys/mman.h' file not found``, this can be fixed by installing the Xcode Command Line Tools:
+- On macOS, if you are getting an error ``fatal error: 'sys/mman.h' file not found``, this can be fixed by installing the Xcode Command Line Tools:
 
   .. code-block:: bash
 

--- a/src/core/csv/fread.cc
+++ b/src/core/csv/fread.cc
@@ -40,7 +40,6 @@ std::unique_ptr<DataTable> FreadReader::read_all()
     dt::read::field64 tmp;
     dt::read::ParseContext fctx = makeTokenizer();
     fctx.target = &tmp;
-    fctx.anchor = sof;
     fctx.ch = sof;
     parse_column_names(fctx);
     sof = fctx.ch;  // Update sof to point to the first line after the columns

--- a/src/core/csv/reader_fread.cc
+++ b/src/core/csv/reader_fread.cc
@@ -59,7 +59,6 @@ dt::read::ParseContext FreadReader::makeTokenizer() const
   dt::read::ParseContext res;
   res.ch = nullptr;
   res.target = nullptr;
-  res.anchor = nullptr;
   res.eof = eof;
   res.NAstrings = na_strings;
   res.whiteChar = whiteChar;
@@ -267,7 +266,6 @@ void FreadReader::detect_sep_and_qr() {
   dt::read::field64 tmp;
   dt::read::ParseContext ctx = makeTokenizer();
   ctx.target = &tmp;
-  ctx.anchor = sof;
   const char*& tch = ctx.ch;
 
   // We will scan the input line-by-line (at most `JUMPLINES + 1` lines; "+1"
@@ -431,7 +429,6 @@ class ColumnTypeDetectionChunkster {
 
     dt::read::ChunkCoordinates compute_chunk_boundaries(size_t j) {
       dt::read::ChunkCoordinates cc(f.eof, f.eof);
-      fctx.anchor = f.sof;
       if (j == 0) {
         if (f.header == 0) {
           cc.set_start_exact(f.sof);
@@ -484,7 +481,6 @@ int64_t FreadReader::parse_single_line(dt::read::ParseContext& fctx)
   const char*& tch = fctx.ch;
 
   // detect blank lines
-  fctx.anchor = tch;
   fctx.skip_whitespace_at_line_start();
   if (tch == eof || fctx.skip_eol()) return 0;
 

--- a/src/core/csv/reader_fread.cc
+++ b/src/core/csv/reader_fread.cc
@@ -895,8 +895,8 @@ void FreadReader::parse_column_names(dt::read::ParseContext& ctx) {
     // Parse string field, but do not advance `ctx.target`: on the next
     // iteration we will write into the same place.
     dt::read::parse_string(ctx);
-    const char* start = static_cast<const char*>(ctx.strbuf.data())
-                        + ctx.target->str32.offset;
+    auto start = static_cast<const char*>(ctx.strbuf.rptr())
+                 + ctx.target->str32.offset;
     int32_t ilen = ctx.target->str32.length;
 
     if (i >= ncols) {

--- a/src/core/read/fread/fread_parallel_reader.cc
+++ b/src/core/read/fread/fread_parallel_reader.cc
@@ -40,7 +40,6 @@ void FreadParallelReader::adjust_chunk_coordinates(
   if (cc.is_start_approximate()) {
     ParseContext& tok = static_cast<FreadThreadContext*>(ctx)->get_tokenizer();
     const char* start = cc.get_start();
-    tok.anchor = start;
     while (*start=='\n' || *start=='\r') start++;
     cc.set_start_approximate(start);
     int ncols = static_cast<int>(f.get_ncols());

--- a/src/core/read/fread/fread_thread_context.cc
+++ b/src/core/read/fread/fread_thread_context.cc
@@ -75,6 +75,7 @@ void FreadThreadContext::read_chunk(
   used_nrows = 0;
   parse_ctx_.target = tbuf.data();
   parse_ctx_.anchor = anchor = tch;
+  parse_ctx_.bytes_written = 0;
 
   while (tch < cc.get_end()) {
     if (used_nrows == tbuf_nrows) {

--- a/src/core/read/fread/fread_thread_context.cc
+++ b/src/core/read/fread/fread_thread_context.cc
@@ -41,7 +41,6 @@ FreadThreadContext::FreadThreadContext(
   parse_ctx_.target = tbuf.data();
   ttime_push = 0;
   ttime_read = 0;
-  anchor = nullptr;
   quote = f.quote;
   quoteRule = f.quoteRule;
   sep = f.sep;
@@ -74,7 +73,6 @@ void FreadThreadContext::read_chunk(
   tch = cc.get_start();
   used_nrows = 0;
   parse_ctx_.target = tbuf.data();
-  parse_ctx_.anchor = anchor = tch;
   parse_ctx_.bytes_written = 0;
 
   while (tch < cc.get_end()) {

--- a/src/core/read/fread/fread_thread_context.h
+++ b/src/core/read/fread/fread_thread_context.h
@@ -29,8 +29,6 @@ namespace read {
 
 
 /**
- * anchor
- *   Pointer that serves as a starting point for all offsets in "RelStr" fields.
  *
  */
 class FreadThreadContext : public ThreadContext
@@ -38,7 +36,6 @@ class FreadThreadContext : public ThreadContext
   private:
     using ParserFnPtr = void(*)(const ParseContext& ctx);
 
-    const char* anchor;
     int quoteRule;
     char quote;
     char sep;

--- a/src/core/read/parse_context.cc
+++ b/src/core/read/parse_context.cc
@@ -35,7 +35,6 @@ ParseContext::ParseContext()
     target(nullptr),
     strbuf(),
     bytes_written(0),
-    anchor(nullptr),
     NAstrings(nullptr),
     whiteChar('\0'),
     dec('.'),
@@ -53,7 +52,6 @@ ParseContext::ParseContext(const ParseContext& o)
     target(o.target),
     strbuf(),
     bytes_written(0),
-    anchor(o.anchor),
     NAstrings(o.NAstrings),
     whiteChar(o.whiteChar),
     dec(o.dec),
@@ -71,7 +69,6 @@ ParseContext& ParseContext::operator=(const ParseContext& o) {
   target = o.target;
   // strbuf is not assigned, just "emptied"
   bytes_written = 0;
-  anchor = o.anchor;
   NAstrings = o.NAstrings;
   whiteChar = o.whiteChar;
   dec = o.dec;

--- a/src/core/read/parse_context.cc
+++ b/src/core/read/parse_context.cc
@@ -25,6 +25,72 @@ namespace dt {
 namespace read {
 
 
+//------------------------------------------------------------------------------
+// Constructors
+//------------------------------------------------------------------------------
+
+ParseContext::ParseContext()
+  : ch(nullptr),
+    eof(nullptr),
+    target(nullptr),
+    strbuf(),
+    bytes_written(0),
+    anchor(nullptr),
+    NAstrings(nullptr),
+    whiteChar('\0'),
+    dec('.'),
+    sep(','),
+    quote('"'),
+    quoteRule(0),
+    strip_whitespace(true),
+    blank_is_na(false),
+    cr_is_newline(true) {}
+
+
+ParseContext::ParseContext(const ParseContext& o)
+  : ch(o.ch),
+    eof(o.eof),
+    target(o.target),
+    strbuf(),
+    bytes_written(0),
+    anchor(o.anchor),
+    NAstrings(o.NAstrings),
+    whiteChar(o.whiteChar),
+    dec(o.dec),
+    sep(o.sep),
+    quote(o.quote),
+    quoteRule(o.quoteRule),
+    strip_whitespace(o.strip_whitespace),
+    blank_is_na(o.blank_is_na),
+    cr_is_newline(o.cr_is_newline) {}
+
+
+ParseContext& ParseContext::operator=(const ParseContext& o) {
+  ch = o.ch;
+  eof = o.eof;
+  target = o.target;
+  // strbuf is not assigned, just "emptied"
+  bytes_written = 0;
+  anchor = o.anchor;
+  NAstrings = o.NAstrings;
+  whiteChar = o.whiteChar;
+  dec = o.dec;
+  sep = o.sep;
+  quote = o.quote;
+  quoteRule = o.quoteRule;
+  strip_whitespace = o.strip_whitespace;
+  blank_is_na = o.blank_is_na;
+  cr_is_newline = o.cr_is_newline;
+  return *this;
+}
+
+
+
+
+//------------------------------------------------------------------------------
+// Parse helpers
+//------------------------------------------------------------------------------
+
 /**
  * skip_eol() is used to consume a "newline" token from the current parsing
  * location (`ch`). Specifically,

--- a/src/core/read/parse_context.h
+++ b/src/core/read/parse_context.h
@@ -49,10 +49,12 @@ struct ParseContext
   // Where to write the parsed value.
   mutable field64* target;
 
-
+  // Buffer where string parser will be saving its data. Theoretically,
+  // some other parsers may store their values in here too.
   mutable Buffer strbuf;
   mutable size_t bytes_written;
 
+  // TODO: remove from here
   const char* const* NAstrings;
 
   // what to consider as whitespace to skip: ' ', '\t' or 0 means both

--- a/src/core/read/parse_context.h
+++ b/src/core/read/parse_context.h
@@ -53,10 +53,6 @@ struct ParseContext
   mutable Buffer strbuf;
   mutable size_t bytes_written;
 
-  // Anchor pointer for string parser, this pointer is the starting point
-  // relative to which `str32.offset` is defined.
-  const char* anchor;
-
   const char* const* NAstrings;
 
   // what to consider as whitespace to skip: ' ', '\t' or 0 means both

--- a/src/core/read/parse_context.h
+++ b/src/core/read/parse_context.h
@@ -21,7 +21,7 @@
 //------------------------------------------------------------------------------
 #ifndef dt_READ_PARSE_CONTEXT_h
 #define dt_READ_PARSE_CONTEXT_h
-#include "writebuf.h"
+#include "buffer.h"
 #include "_dt.h"
 namespace dt {
 namespace read {
@@ -46,12 +46,12 @@ struct ParseContext
   // up to but excluding `eof` may be accessed by a parser.
   const char* eof;
 
-  // Where to write the parsed value. The pointer will be incremented after
-  // each successful read.
+  // Where to write the parsed value.
   mutable field64* target;
 
 
-  mutable MemoryWritableBuffer strbuf;
+  mutable Buffer strbuf;
+  mutable size_t bytes_written;
 
   // Anchor pointer for string parser, this pointer is the starting point
   // relative to which `str32.offset` is defined.
@@ -86,50 +86,23 @@ struct ParseContext
   // Whether to consider a standalone '\r' a newline character
   bool cr_is_newline;
 
-  void skip_whitespace() const;
-  void skip_whitespace_at_line_start() const;
-  bool at_end_of_field() const;
-  const char* end_NA_string(const char*) const;
-  bool is_na_string(const char* start, const char* end) const;
-  int countfields() const;
-  bool skip_eol() const;
 
-  bool next_good_line_start(
-    const ChunkCoordinates& cc, int ncols, bool fill,
-    bool skipEmptyLines) const;
+  public:
+    ParseContext();
+    ParseContext(const ParseContext& o);
+    ParseContext& operator=(const ParseContext& o);
 
+    void skip_whitespace() const;
+    void skip_whitespace_at_line_start() const;
+    bool at_end_of_field() const;
+    const char* end_NA_string(const char*) const;
+    bool is_na_string(const char* start, const char* end) const;
+    int countfields() const;
+    bool skip_eol() const;
 
-  ParseContext() = default;
-  ParseContext(const ParseContext& o)
-    : ch(o.ch),
-      eof(o.eof),
-      target(o.target),
-      anchor(o.anchor),
-      NAstrings(o.NAstrings),
-      whiteChar(o.whiteChar),
-      dec(o.dec),
-      sep(o.sep),
-      quote(o.quote),
-      quoteRule(o.quoteRule),
-      strip_whitespace(o.strip_whitespace),
-      blank_is_na(o.blank_is_na),
-      cr_is_newline(o.cr_is_newline) {}
-  ParseContext& operator=(const ParseContext& o) {
-    ch = o.ch;
-    eof = o.eof;
-    target = o.target;
-    anchor = o.anchor;
-    NAstrings = o.NAstrings;
-    whiteChar = o.whiteChar;
-    dec = o.dec;
-    sep = o.sep;
-    quote = o.quote;
-    quoteRule = o.quoteRule;
-    strip_whitespace = o.strip_whitespace;
-    blank_is_na = o.blank_is_na;
-    cr_is_newline = o.cr_is_newline;
-    return *this;
-  }
+    bool next_good_line_start(
+      const ChunkCoordinates& cc, int ncols, bool fill,
+      bool skipEmptyLines) const;
 };
 
 

--- a/src/core/read/thread_context.cc
+++ b/src/core/read/thread_context.cc
@@ -237,7 +237,7 @@ void ThreadContext::postorder() {
 
 
 void ThreadContext::postorder_string_column(OutputColumn& col, size_t j) {
-  auto src_strbuf = static_cast<char*>(parse_ctx_.strbuf.data());
+  auto src_strbuf = static_cast<const char*>(parse_ctx_.strbuf.rptr());
   auto out_strbuf = col.strdata_w();
   auto src_data = tbuf.data() + j;
   auto out_data = static_cast<uint32_t*>(col.data_w());

--- a/src/core/read/thread_context.cc
+++ b/src/core/read/thread_context.cc
@@ -237,26 +237,30 @@ void ThreadContext::postorder() {
 
 
 void ThreadContext::postorder_string_column(OutputColumn& col, size_t j) {
+  // Note: `out_strbuf` is a Writer object, which holds a non-exclusive
+  //       lock on the underlying buffer for the duration of its lifetime.
+  auto pos0 = colinfo_[j].str.write_at;
+  auto len0 = colinfo_[j].str.size;
   auto src_strbuf = static_cast<const char*>(parse_ctx_.strbuf.rptr());
-  auto out_strbuf = col.strdata_w();
+  auto out_strbuf = col.strdata_w()->writer(pos0, pos0 + len0);
   auto src_data = tbuf.data() + j;
   auto out_data = static_cast<uint32_t*>(col.data_w());
 
-  auto pos0 = static_cast<uint32_t>(colinfo_[j].str.write_at);
   auto dest = out_data + (row0_ - col.nrows_archived()) + 1;
   for (size_t i = 0; i < used_nrows; ++i) {
     uint32_t offset = src_data->str32.offset;
     int32_t length = src_data->str32.length;
     if (length > 0) {
-      out_strbuf->write_at(pos0, static_cast<size_t>(length), src_strbuf + offset);
-      pos0 += static_cast<uint32_t>(length);
-      *dest++ = pos0;
+      auto zlength = static_cast<size_t>(length);
+      out_strbuf.write_at(pos0, src_strbuf + offset, zlength);
+      pos0 += zlength;
+      *dest++ = static_cast<uint32_t>(pos0);
     }
     else {
       static_assert(static_cast<uint32_t>(NA_I4) == NA_S4,
                     "incompatible int32 and uint32 NA values");
       xassert(length == 0 || length == NA_I4);
-      *dest++ = pos0 ^ static_cast<uint32_t>(length);
+      *dest++ = static_cast<uint32_t>(pos0) ^ static_cast<uint32_t>(length);
     }
     src_data += tbuf_ncols;
   }

--- a/src/core/writebuf.cc
+++ b/src/core/writebuf.cc
@@ -268,19 +268,6 @@ void* MemoryWritableBuffer::data() const {
 }
 
 
-size_t MemoryWritableBuffer::prepare_for_external_write(size_t expected_length) {
-  size_t pos = ThreadsafeWritableBuffer::prepare_write(expected_length, nullptr);
-  bytes_written_ = pos;
-  return pos;
-}
-
-
-void MemoryWritableBuffer::finish_external_write(size_t actual_length) {
-  bytes_written_ += actual_length;
-  xassert(bytes_written_ <= allocsize_);
-}
-
-
 
 
 //==============================================================================

--- a/src/core/writebuf.cc
+++ b/src/core/writebuf.cc
@@ -223,6 +223,44 @@ void ThreadsafeWritableBuffer::finalize() {
 
 
 //==============================================================================
+// Writer (helper for MemoryWritableBuffer)
+//==============================================================================
+
+MemoryWritableBuffer::Writer::Writer(MemoryWritableBuffer* parent,
+                                     size_t start, size_t end)
+  : mbuf_(parent),
+    pos_start_(start),
+    pos_end_(end)
+{
+  XAssert(mbuf_ && pos_end_ <= mbuf_->allocsize_);
+  mbuf_->shmutex_.lock_shared();
+}
+
+MemoryWritableBuffer::Writer::Writer(Writer&& o)
+  : mbuf_(o.mbuf_),
+    pos_start_(o.pos_start_),
+    pos_end_(o.pos_end_)
+{
+  o.mbuf_ = nullptr;
+}
+
+
+MemoryWritableBuffer::Writer::~Writer() {
+  if (mbuf_) mbuf_->shmutex_.unlock_shared();
+}
+
+
+void MemoryWritableBuffer::Writer::write_at(size_t pos,
+                                            const char* src, size_t len)
+{
+  xassert(pos >= pos_start_ && pos + len <= pos_end_);
+  std::memcpy(static_cast<char*>(mbuf_->data_) + pos, src, len);
+}
+
+
+
+
+//==============================================================================
 // MemoryWritableBuffer
 //==============================================================================
 
@@ -265,6 +303,11 @@ void MemoryWritableBuffer::clear() {
 
 void* MemoryWritableBuffer::data() const {
   return data_;
+}
+
+
+MemoryWritableBuffer::Writer MemoryWritableBuffer::writer(size_t start, size_t end) {
+  return MemoryWritableBuffer::Writer(this, start, end);
 }
 
 

--- a/src/core/writebuf.h
+++ b/src/core/writebuf.h
@@ -172,8 +172,24 @@ class ThreadsafeWritableBuffer : public WritableBuffer
 
 //==============================================================================
 
+
+
 class MemoryWritableBuffer : public ThreadsafeWritableBuffer
 {
+  class Writer {
+    MemoryWritableBuffer* mbuf_;
+    size_t pos_start_;
+    size_t pos_end_;
+
+    public:
+      Writer(MemoryWritableBuffer* parent, size_t start, size_t end);
+      Writer(const Writer&) = delete;
+      Writer(Writer&&);
+      ~Writer();
+
+      void write_at(size_t offset, const char* content, size_t len);
+  };
+
   public:
     MemoryWritableBuffer(size_t size = 0);
     ~MemoryWritableBuffer() override;
@@ -189,6 +205,8 @@ class MemoryWritableBuffer : public ThreadsafeWritableBuffer
     void clear();
 
     void* data() const;
+
+    Writer writer(size_t start, size_t end);
 
   private:
     void realloc(size_t newsize) override;

--- a/src/core/writebuf.h
+++ b/src/core/writebuf.h
@@ -190,9 +190,6 @@ class MemoryWritableBuffer : public ThreadsafeWritableBuffer
 
     void* data() const;
 
-    size_t prepare_for_external_write(size_t expected_length);
-    void finish_external_write(size_t actual_length);
-
   private:
     void realloc(size_t newsize) override;
 };

--- a/tests/fread/test_fread_issues.py
+++ b/tests/fread/test_fread_issues.py
@@ -523,3 +523,15 @@ def test_issue1803():
                                       'IND', 182, None, None, False, None,
                                       False, None, None, None, None, None,
                                       'NO', 'YES')]
+
+
+
+def test_issue2458(capsys):
+    # Check the step "saving into the output frame" doesn't take too long
+    src = "foo\n"*1000000
+    DT = dt.fread(src, verbose=True)
+    out, err = capsys.readouterr()
+    assert not err
+    mm = re.search(r"\(\s?(\d+)%\) saving into the output frame", out)
+    time_percent = int(mm.group(1))
+    assert time_percent < 20


### PR DESCRIPTION
The issue was that the mutex in `MemoryWritableBuffer` was acquired too often, causing major slowdown as multiple threads were trying to access it at the same time. The solution was to create a helper `Writer` class that acquires the mutex for the duration of multiple writes (note: this doesn't cause unnecessary contention, since the lock is acquired in "read-only" mode, and multiple threads can do that at the same time).

In addition, `ParseContext` now uses simple `Buffer` instead of `MemoryWritableBuffer` for its string content. That buffer is cleared when we start reading a chunk.

Also: `ParseContext.anchor` was removed, since it is no longer needed.

Closes #2458