### PR TITLE
Str->numeric converters

### DIFF
--- a/docs/releases/v0.11.0.rst
+++ b/docs/releases/v0.11.0.rst
@@ -16,6 +16,9 @@
     columns in the Frame. This allows the Frame to be used in contexts where
     an iterable might be expected.
 
+  -[new] Added ability to cast string columns into numeric types: int, float
+    or boolean. [#1313]
+
   -[enh] String columns now support comparison operators ``<``, ``>``, ``<=``
     and ``>=``. [#2274]
 

--- a/src/core/csv/reader_parsers.cc
+++ b/src/core/csv/reader_parsers.cc
@@ -158,6 +158,9 @@ void parse_int_simple(const ParseContext& ctx) {
   }
 }
 
+template void parse_int_simple<int32_t, true>(const dt::read::ParseContext&);
+template void parse_int_simple<int64_t, true>(const dt::read::ParseContext&);
+
 
 // Parse integers where thousands are separated into groups, eg
 //   1,000,000

--- a/src/core/csv/reader_parsers.h
+++ b/src/core/csv/reader_parsers.h
@@ -33,6 +33,13 @@ void parse_float32_hex(const dt::read::ParseContext&);
 void parse_float64_simple(const dt::read::ParseContext& ctx);
 void parse_float64_extended(const dt::read::ParseContext& ctx);
 void parse_float64_hex(const dt::read::ParseContext&);
+
+template <typename T, bool ALLOW_LEADING_ZEROES>
+void parse_int_simple(const dt::read::ParseContext&);
+
+extern template void parse_int_simple<int32_t, true>(const dt::read::ParseContext&);
+extern template void parse_int_simple<int64_t, true>(const dt::read::ParseContext&);
+
 namespace dt {
 namespace read {
 

--- a/tests/munging/test_cast.py
+++ b/tests/munging/test_cast.py
@@ -135,9 +135,18 @@ def test_cast_float_to_int(source_stype, target_stype):
     assert RES.to_list()[0] == [0, None, 7, -4, 111, 28]
 
 
-@pytest.mark.parametrize("source_stype", ltype.str.stypes + [stype.obj64])
+@pytest.mark.parametrize("source_stype", ltype.str.stypes)
+@pytest.mark.parametrize("target_stype", ltype.int.stypes)
+def test_cast_str_to_int(source_stype, target_stype):
+    DT = dt.Frame(W=["0", "23", "+56", "-17", "101"], stype=source_stype)
+    assert DT.stype == source_stype
+    RES = DT[:, target_stype(f.W)]
+    assert_equals(RES, dt.Frame(W=[0, 23, 56, -17, 101] / target_stype))
+
+
+@pytest.mark.parametrize("source_stype", [stype.obj64])
 @pytest.mark.parametrize("target_stype", numeric_stypes)
-def test_cast_other_to_numeric(source_stype, target_stype):
+def test_cast_object_to_numeric(source_stype, target_stype):
     DT = dt.Frame(W=[0, 1, 2], stype=source_stype)
     assert DT.stypes == (source_stype,)
     with pytest.raises(NotImplementedError) as e:

--- a/tests/munging/test_cast.py
+++ b/tests/munging/test_cast.py
@@ -86,6 +86,12 @@ def test_cast_float_to_bool(source_stype):
     assert RES.to_list()[0] == [True, True, None, False, True, True, True, True]
 
 
+def test_cast_str_to_bool():
+    DT = dt.Frame(['True', "False", "bah", None, "true"])
+    DT[0] = bool
+    assert_equals(DT, dt.Frame([1, 0, None, None, None] / dt.bool8))
+
+
 
 
 #-------------------------------------------------------------------------------

--- a/tests/munging/test_cast.py
+++ b/tests/munging/test_cast.py
@@ -144,6 +144,12 @@ def test_cast_str_to_int(source_stype, target_stype):
     assert_equals(RES, dt.Frame(W=[0, 23, 56, -17, 101] / target_stype))
 
 
+def test_cast_badstr_to_int():
+    DT = dt.Frame(["345", "10000000000", "24e100", "abc500", None, "--5"])
+    RES = DT[:, dt.int32(f[0])]
+    assert_equals(RES, dt.Frame([345, None, None, None, None, None]))
+
+
 @pytest.mark.parametrize("source_stype", [stype.obj64])
 @pytest.mark.parametrize("target_stype", numeric_stypes)
 def test_cast_object_to_numeric(source_stype, target_stype):

--- a/tests/munging/test_cast.py
+++ b/tests/munging/test_cast.py
@@ -208,6 +208,13 @@ def test_cast_double_to_float():
                                 math.inf, -6.50000007168e+11]
 
 
+@pytest.mark.parametrize("target_stype", ltype.real.stypes)
+def test_cast_str_to_double(target_stype):
+    DT = dt.Frame(A=["2.45", "-3.333", "0.13e+29", "boo", None, "-4e-4"])
+    DT["A"] = target_stype
+    assert_equals(DT, dt.Frame(A=[2.45, -3.333, 1.3e28, None, None, -0.0004],
+                               stype=target_stype))
+
 
 
 #-------------------------------------------------------------------------------

--- a/tests/munging/test_cast.py
+++ b/tests/munging/test_cast.py
@@ -135,6 +135,12 @@ def test_cast_float_to_int(source_stype, target_stype):
     assert RES.to_list()[0] == [0, None, 7, -4, 111, 28]
 
 
+def test_cast_str_to_int_simple():
+    DT = dt.Frame(A=[str(i) for i in range(100001)])
+    DT["A"] = dt.int32
+    assert_equals(DT, dt.Frame(A=range(100001)))
+
+
 @pytest.mark.parametrize("source_stype", ltype.str.stypes)
 @pytest.mark.parametrize("target_stype", ltype.int.stypes)
 def test_cast_str_to_int(source_stype, target_stype):


### PR DESCRIPTION
Implemented conversion of string columns into `bool`, `int8`, `int16`, `int32`, `int64`, `float32` and `float64`. If invalid values are encountered, they become NAs. When converting integer strings that are larger than can be fit in the target stype, the behavior is undefined: some values may be wrap-around, even larger ones may be turned into NAs. This may change in the future.

Closes #1313 