### PR TITLE
Adjustments to docs/api of Frame.to_csv()

### DIFF
--- a/docs/releases/v0.11.0.rst
+++ b/docs/releases/v0.11.0.rst
@@ -58,6 +58,10 @@
   -[api] Expression `f[:]` now excludes groupby columns when used in a
     groupby context. [#2460]
 
+  -[api] Parameters ``_strategy=`` in :meth:`.to_csv()` and :meth:`.to_jay()`
+    were renamed into ``method=``. The old parameter name still works, so this
+    change is not breaking.
+
   -[bug] Deleting a key from the Frame (``del DT.key``) no longer causes a
     seg.fault. [#2357]
 
@@ -73,6 +77,9 @@
 
   -[bug] Fixed crash when writing to CSV a frame with many boolean columns
     when the option ``quoting="all"`` is used. [#2382]
+
+  -[bug] It is no longer allowed to combine ``compression="gzip"`` and
+    ``append=True`` in :meth:`.to_csv()`.
 
 
   Fread

--- a/src/core/frame/to_csv.cc
+++ b/src/core/frame/to_csv.cc
@@ -43,7 +43,7 @@ static void change_to_lowercase(std::string& str) {
 static const char* doc_to_csv =
 R"(to_csv(self, path=None, *, quoting="minimal", append=False,
        header=..., bom=False, hex=False, compression=None,
-       verbose=False, _strategy="auto")
+       verbose=False, method="auto")
 --
 
 Write the Frame into the provided file in CSV format.
@@ -115,7 +115,7 @@ verbose: bool
     If True, some extra information will be printed to the console,
     which may help to debug the inner workings of the algorithm.
 
-_strategy: "mmap" | "write" | "auto"
+method: "mmap" | "write" | "auto"
     Which method to use for writing to disk. On certain systems 'mmap'
     gives a better performance; on other OSes 'mmap' may not work at
     all.
@@ -132,7 +132,7 @@ _strategy: "mmap" | "write" | "auto"
 static PKArgs args_to_csv(
     0, 1, 8, false, false,
     {"path", "quoting", "append", "header", "bom", "hex", "compression",
-     "verbose", "_strategy"},
+     "verbose", "method"},
     "to_csv", doc_to_csv);
 
 
@@ -247,6 +247,7 @@ oobj Frame::to_csv(const PKArgs& args)
 //------------------------------------------------------------------------------
 
 void Frame::_init_tocsv(XTypeMaker& xt) {
+  args_to_csv.add_synonym_arg("_strategy", "method");
   xt.add(METHOD(&Frame::to_csv, args_to_csv));
 }
 

--- a/src/core/frame/to_csv.cc
+++ b/src/core/frame/to_csv.cc
@@ -42,7 +42,7 @@ static void change_to_lowercase(std::string& str) {
 
 static const char* doc_to_csv =
 R"(to_csv(self, path=None, *, quoting="minimal", append=False,
-       header=..., bom=False, hex=False, compression=None,
+       header="auto", bom=False, hex=False, compression=None,
        verbose=False, method="auto")
 --
 
@@ -79,7 +79,7 @@ append: bool
     If False (default), the file given in the `path` will be
     overwritten if it already exists.
 
-header: bool | ...
+header: bool | "auto"
     This option controls whether or not to write headers into the
     output file. If this option is not given (or equal to ...), then
     the headers will be written unless the option `append` is True
@@ -187,7 +187,9 @@ oobj Frame::to_csv(const PKArgs& args)
 
   // header
   bool header;
-  if (arg_header.is_none_or_undefined() || arg_header.is_ellipsis()) {
+  if (arg_header.is_none_or_undefined() || arg_header.is_auto() ||
+      arg_header.is_ellipsis())
+  {
     header = !(append && File::nonempty(filename));
   } else {
     header = arg_header.to<bool>(true);

--- a/src/core/frame/to_csv.cc
+++ b/src/core/frame/to_csv.cc
@@ -113,10 +113,10 @@ hex: bool
     representation, so its use is recommended if you need maximum
     speed.
 
-compression: None | "gzip" | "infer"
+compression: None | "gzip" | "auto"
     Which compression method to use for the output stream. The default
-    is "infer", which tries to guess the compression method from the
-    output file name. The only compression format currently supported
+    is "auto", which tries to infer the compression method from the
+    output file's name. The only compression format currently supported
     is "gzip". Compression may not be used when `append` is True.
 
 verbose: bool
@@ -213,9 +213,9 @@ oobj Frame::to_csv(const PKArgs& args)
   bool hex = arg_hex.to<bool>(false);
 
   // compress
-  auto compress_str = arg_compress.to<std::string>("infer");
+  auto compress_str = arg_compress.to<std::string>("auto");
   bool compress = false;  // eventually this will be an Enum
-  if (compress_str == "infer") {
+  if (compress_str == "auto" || compress_str == "infer") {
     size_t n = filename.size();
     compress = !append && (n > 3 && filename[n-3] == '.' &&
                                     filename[n-2] == 'g' &&

--- a/src/core/python/arg.cc
+++ b/src/core/python/arg.cc
@@ -1,9 +1,23 @@
 //------------------------------------------------------------------------------
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright 2018-2020 H2O.ai
 //
-// © H2O.ai 2018-2019
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #include <cstdio>
 #include "python/arg.h"
@@ -90,6 +104,11 @@ bool Arg::is_frame()             const { return pyobj.is_frame(); }
 bool Arg::is_pandas_frame()      const { return pyobj.is_pandas_frame(); }
 bool Arg::is_pandas_series()     const { return pyobj.is_pandas_series(); }
 bool Arg::is_numpy_array()       const { return pyobj.is_numpy_array(); }
+
+bool Arg::is_auto() const {
+  return pyobj.is_string() &&
+         PyUnicode_CompareWithASCIIString(pyobj.get(), "auto") == 0;
+}
 
 
 

--- a/src/core/python/arg.h
+++ b/src/core/python/arg.h
@@ -1,9 +1,23 @@
 //------------------------------------------------------------------------------
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright 2018-2020 H2O.ai
 //
-// © H2O.ai 2018-2019
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #ifndef dt_PYTHON_ARG_h
 #define dt_PYTHON_ARG_h
@@ -36,6 +50,7 @@ class Arg : public _obj::error_manager {
     void set(PyObject* value);
 
     //---- Type checks -----------------
+    bool is_auto() const;  // check for string "auto"
     bool is_bool() const;
     bool is_bytes() const;
     bool is_defined() const;

--- a/src/core/python/args.h
+++ b/src/core/python/args.h
@@ -1,17 +1,23 @@
 //------------------------------------------------------------------------------
-// Copyright 2018 H2O.ai
+// Copyright 2018-2020 H2O.ai
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
 //
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #ifndef dt_PYTHON_ARGS_h
 #define dt_PYTHON_ARGS_h
@@ -76,7 +82,8 @@ class PKArgs {
     const size_t n_all_args;
     const bool   has_varargs;
     const bool   has_varkwds;
-    size_t : 48;
+    bool         has_renamed_args;
+    size_t : 40;
     const std::vector<const char*> arg_names;
 
     // Runtime arguments
@@ -104,6 +111,7 @@ class PKArgs {
     PKArgs(const PKArgs&) = delete;
     PKArgs(PKArgs&&) = delete;
     ~PKArgs();
+    void add_synonym_arg(const char* new_name, const char* old_name);
 
     void bind(PyObject* _args, PyObject* _kws);
 

--- a/tests/test_tocsv.py
+++ b/tests/test_tocsv.py
@@ -558,10 +558,14 @@ def test_compress_invalid():
         DT.to_csv(compression=0)
     assert ("Argument compression in Frame.to_csv() should be a string, "
             "instead got <class 'int'>" in str(e.value))
-    with pytest.raises(ValueError) as e:
+
+    msg = r"Unsupported compression method 'rar' in Frame\.to_csv\(\)"
+    with pytest.raises(ValueError, match=msg):
         DT.to_csv(compression="rar")
-    assert ("Unsupported compression method 'rar' in Frame.to_csv()"
-            == str(e.value))
+
+    msg = r"Compression cannot be used in the 'append' mode"
+    with pytest.raises(ValueError, match=msg):
+        DT.to_csv("test.csv", compression="gzip", append=True)
 
 
 

--- a/tests/test_tocsv.py
+++ b/tests/test_tocsv.py
@@ -590,6 +590,7 @@ def test_header_valid():
     assert DT.to_csv(header=True) == 'Q\n'
     assert DT.to_csv(header=None) == 'Q\n'
     assert DT.to_csv(header=...) == 'Q\n'
+    assert DT.to_csv(header="auto") == 'Q\n'
 
 
 def test_header_invalid():

--- a/tests/test_tocsv.py
+++ b/tests/test_tocsv.py
@@ -431,9 +431,18 @@ def test_issue2382():
 # Test options
 #-------------------------------------------------------------------------------
 
-def test_strategy(capsys, tempfile):
-    """Check that the _strategy parameter is respected."""
+def test_method(capsys, tempfile):
+    """Check that the method parameter is respected."""
     DT = dt.Frame(A=[5, 6, 10, 12], B=["one", "two", "tree", "for"])
+    DT.to_csv(tempfile, method="mmap", verbose=True)
+    out, err = capsys.readouterr()
+    assert out
+    assert err == ""
+    DT.to_csv(tempfile, method="write", verbose=True)
+    out, err = capsys.readouterr()
+    assert out
+    assert err == ""
+    # Check that the old parameter's name still working
     DT.to_csv(tempfile, _strategy="mmap", verbose=True)
     out, err = capsys.readouterr()
     assert out
@@ -670,9 +679,9 @@ def test_append_with_headers(tempfile):
 def test_append_strategy(tempfile):
     DT = dt.Frame(D=[3])
     DT.to_csv(tempfile)
-    DT.to_csv(tempfile, append=True, _strategy="write")
+    DT.to_csv(tempfile, append=True, method="write")
     assert readfile(tempfile) == "D\n3\n3\n"
-    DT.to_csv(tempfile, append=True, _strategy="mmap")
+    DT.to_csv(tempfile, append=True, method="mmap")
     assert readfile(tempfile) == "D\n3\n3\n3\n"
 
 
@@ -681,9 +690,9 @@ def test_append_large(tempfile):
     n = 10000
     DT = dt.Frame([word] * n, names=["..."])
     DT.to_csv(tempfile)
-    DT.to_csv(tempfile, append=True, _strategy="write")
+    DT.to_csv(tempfile, append=True, method="write")
     assert readfile(tempfile) == "...\n" + (word + "\n") * (2*n)
-    DT.to_csv(tempfile, append=True, _strategy="mmap")
+    DT.to_csv(tempfile, append=True, method="mmap")
     assert readfile(tempfile) == "...\n" + (word + "\n") * (3*n)
 
 


### PR DESCRIPTION
- Created ability to specify argument synonyms in `py::PKArgs`;
- Arguments `_strategy=` in `.to_csv()` and `.to_jay()` are renamed into `method=`;
  + The idea here is that (1) an argument's name really shouldn't start with an underscore. And the only reason why it did up to now is because this was intended as a "hidden" argument, not visible to users. But seems like this is not how it ended up... Secondly, the name "method" seems to be more appropriate here, because there is hardly anything strategic in the underlying algorithm. 
  + Previous argument name is still accepted, and means the same as `method=` (thus, this is not a breaking API change).
- Argument `header=` in `.to_csv()` now accepts the value `"auto"`, which is the default. 
Previously, the default value was `...` (Ellipsis). However, "auto" is much more understandable and  more widespread. The value `...` is still accepted, and means the same as `"auto"` (thus, this is not a breaking change).
- The default value of `compression=` parameter is now `"auto"` instead of `"infer"` (the value "infer" still works, and means the same as "auto").
- It is no longer allowed to combine `compression="gzip"` with `append=True`, because the end result of this is an invalid file.
- Small adjustments of documentation.

 
