### PR TITLE
Finish fread-to-file functionality; added documentation

### DIFF
--- a/docs/api/api-index.rst
+++ b/docs/api/api-index.rst
@@ -1,0 +1,9 @@
+
+.. toctree::
+    :hidden:
+
+    Frame           <frame>
+    FTRL            <ftrl>
+    math.           <math>
+    fread()         <dt/fread>
+    iread()         <dt/iread>

--- a/docs/api/dt/fread.rst
+++ b/docs/api/dt/fread.rst
@@ -1,0 +1,3 @@
+
+.. xfunction:: datatable.fread
+    :src: src/core/read/py_fread.cc fread

--- a/docs/api/dt/iread.rst
+++ b/docs/api/dt/iread.rst
@@ -1,0 +1,3 @@
+
+.. xfunction:: datatable.iread
+    :src: src/core/read/py_fread.cc iread

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -99,9 +99,8 @@ messages, and powerful API similar to R ``data.table``'s.
     :caption: API reference
     :hidden:
 
-    api/frame
-    api/ftrl
-    api/math
+    api/api-index
+
 
 .. toctree::
     :maxdepth: 2

--- a/docs/releases/v0.11.0.rst
+++ b/docs/releases/v0.11.0.rst
@@ -108,6 +108,11 @@
     single-threaded. The parameter accepts any value available via the standard
     python library ``codecs``. [#2395]
 
+  -[new] Added parameter ``memory_limit`` which instructs fread to try to limit
+    the amount of memory used when reading the input. This parameter is
+    especially useful when reading files that are larger than the amount of
+    available memory. [#1750]
+
   -[enh] Added parameter ``multiple_sources`` which controls fread's
     behavior when multiple input sources are detected (for example, if you
     pass a name of an archive, and the archive contains multiple files).

--- a/src/core/csv/reader_fread.cc
+++ b/src/core/csv/reader_fread.cc
@@ -838,7 +838,13 @@ void FreadReader::skip_preamble() {
     fctx.skip_whitespace_at_line_start();
     if (fctx.skip_eol()) continue;
     if (comment_char == '\xFF') {
-      if (*ch == '#' || *ch == '%') comment_char = *ch;
+      if (*ch == '#' || *ch == '%' || *ch == ';') {
+        char c = ch+1 < eof? ch[1] : ' ';
+        if (c == ' ' || c == '\t' || c == '\n' || c == '\r' ||
+            c == '-' || c == '=' || c == '~' || c == '*') {
+          comment_char = *ch;
+        }
+      }
     }
     if (*ch == comment_char) {
       comment_lines++;

--- a/src/core/read/output_column.cc
+++ b/src/core/read/output_column.cc
@@ -87,8 +87,10 @@ void OutputColumn::archive_data(size_t nrows_written,
     if (is_string) {
       strbuf_->finalize();
       Buffer tmpbuf = strbuf_->get_mbuf();
-      size_t offset = writebuf->write(tmpbuf.size(), tmpbuf.rptr());
-      stored_strbuf = Buffer::tmp(tempfile, offset, tmpbuf.size());
+      if (tmpbuf.size() > 0) {
+        size_t offset = writebuf->write(tmpbuf.size(), tmpbuf.rptr());
+        stored_strbuf = Buffer::tmp(tempfile, offset, tmpbuf.size());
+      }
       strbuf_ = nullptr;
     }
   }

--- a/src/core/read/output_column.cc
+++ b/src/core/read/output_column.cc
@@ -66,8 +66,12 @@ MemoryWritableBuffer* OutputColumn::strdata_w() {
 void OutputColumn::archive_data(size_t nrows_written,
                                 std::shared_ptr<TemporaryFile>& tempfile)
 {
-  if (nrows_written == nrows_in_chunks_) return;
-  if (type_bumped_ || !present_in_buffer_) return;
+  if (nrows_written == nrows_in_chunks_ ||
+      type_bumped_ || !present_in_buffer_) {
+    databuf_ = Buffer();
+    strbuf_ = nullptr;
+    return;
+  }
   xassert(nrows_written > nrows_in_chunks_);
 
   size_t is_string = (stype_ == SType::STR32 || stype_ == SType::STR64);

--- a/src/core/read/py_fread.cc
+++ b/src/core/read/py_fread.cc
@@ -37,20 +37,201 @@ static const char* doc_fread =
 R"(fread(anysource=None, *, file=None, text=None, cmd=None, url=None,
          columns=None, sep=None, dec=".", max_nrows=None, header=None,
          na_strings=None, verbose=False, fill=False, encoding=None,
-         skip_to_string=None, skip_to_line=None, skip_blank_lines=False,
-         strip_whitespace=True, quotechar='"', save_to=None,
-         tempdir=None, nthreads=None, logger=None, multiple_sources="warn",
+         skip_to_string=None, skip_to_line=0, skip_blank_lines=False,
+         strip_whitespace=True, quotechar='"', tempdir=None,
+         nthreads=None, logger=None, multiple_sources="warn",
          memory_limit=None)
 --
+
+This function is capable of reading data from a variety of input formats,
+producing a :class:`Frame` as the result. The recognized formats are:
+CSV, Jay, XLSX, and plain text. In addition, the data may be inside an
+archive such as .tar, .gz, .zip, .gz2.
+
+
+Parameters
+----------
+anysource: str | bytes | file | Pathlike | List
+    The first (unnamed) argument to fread is the *input source*.
+    Multiple types of sources are supported, and they can be named
+    explicitly: `file`, `text`, `cmd`, and `url`. When the source is
+    not named, fread will attempt to guess its type. The most common
+    type is `file`, but sometimes the argument is resolved as `text`
+    (if the string contains newlines) or `url` (if the string starts
+    with `https://` or similar).
+
+    Only one argument out of `anysource`, `file`, `text`, `cmd` or
+    `url` can be specified at once.
+
+file: str | file | Pathlike
+    A file source can be either the name of the file on disk, or a
+    python "file-like" object -- i.e. any object having method
+    ``.read()``.
+
+    Generally specifying a file name should be preferred, since
+    reading from a Python ``file`` can only be done in single-threaded
+    mode.
+
+    This argument also supports addressing files inside an archive,
+    or sheets inside an Excel workbook. Simply write the name of the
+    file as if the archive was a folder: `"data.zip/train.csv"`.
+
+text: str | bytes
+    Instead of reading data from file, this argument provides the data
+    as a simple in-memory blob.
+
+cmd: str
+    A command that will be executed in the shell and its output then
+    read as text.
+
+url: str
+    This parameter can be used to specify the URL of the input file.
+    The data will first be downloaded into a temporary directory and
+    then read from there. In the end the temporary files will be
+    removed.
+
+    We use the standard ``urllib.request`` module to download the
+    data. Changing the settings of that module, for example installing
+    proxy, password, or cookie managers will allow you to customize
+    the download process.
+
+columns: ...
+    Limit which columns to read from the input file.
+
+sep: str | None
+    Field separator in the input file. If this value is `None`
+    (default) then the separator will be auto-detected. Otherwise it
+    must be a single-character string. When ``sep='\n'``, then the
+    data will be read in *single-column* mode. Characters
+    ``["'`0-9a-zA-Z]`` are not allowed as the separator, as well as
+    any non-ASCII characters.
+
+dec: "." | ","
+    Decimal point symbol for floating-point numbers.
+
+max_nrows: int
+    The maximum number of rows to read from the file. Setting this
+    parameter to any negative number is equivalent to have no limit
+    at all. Currently this parameter doesn't always work correctly.
+
+header: bool | None
+    If True then the first line of the CSV file contains the header.
+    If False then there is no header. By default the presence of the
+    header is heuristically determined from the contents of the file.
+
+na_strings: List[str]
+    The list of strings that were used in the input file to represent
+    NA values.
+
+fill: bool
+    If True then the lines of the CSV file are allowed to have uneven
+    number of fields. All missing fields will be filled with NAs in
+    the resulting frame.
+
+encoding: str | None
+    If this parameter is provided, then the input will be recoded
+    from this encoding into UTF-8 before reading. Any encoding
+    registered with the python ``codec`` module can be used.
+
+skip_to_string: str | None
+    Start reading the file from the line containing this string. All
+    previous lines will be skipped and discarded. This parameter
+    cannot be used together with `skip_to_line`.
+
+skip_to_line: int
+    If this setting is given, then this many lines in the file will
+    be skipped before we start to parse the file. This can be used
+    for example when several first lines in the file contain non-CSV
+    data and therefore must be skipped. This parameter cannot be
+    used together with `skip_to_string`.
+
+skip_blank_lines: bool
+    If `True` then any empty lines in the input will be skipped. If
+    this parameter is `False` then: (a) in single-column mode empty
+    lines are kept as empty lines; otherwise (b) if `fill=True` then
+    empty lines produce a single line filled with NAs in the output;
+    otherwise (c) an :exc:`IOError` is raised.
+
+strip_whitespace: bool
+    If True, then the leading/trailing whitespace will be stripped
+    from unquoted string fields. Whitespace is always skipped from
+    numeric fields.
+
+quotechar: '"' | "'" | "`"
+    The character that was used to quote fields in the CSV file. By
+    default the double-quote mark `'"'` is assumed.
+
+tempdir: str | None
+    Use this directory for storing temporary files as needed. If not
+    provided then the system temporary directory will be used, as
+    determined via the :mod:`tempfile` Python module.
+
+nthreads: int | None
+    Number of threads to use when reading the file. This number cannot
+    exceed the number of threads in the pool ``dt.options.nthreads``.
+    If 0 or negative number of threads is requested, then it will be
+    treated as that many threads less than the maximum. By default
+    all threads in the thread pool are used.
+
+verbose: bool
+    If `True`, then print detailed information about the internal
+    workings of fread to stdout (or to `logger` if provided).
+
+logger: object
+    Logger object that will receive verbose information about fread's
+    progress. When this parameter is specified, `verbose` mode will
+    be turned on automatically.
+
+multiple_sources: "warn" | "error" | "ignore"
+    Action that should be taken when the input resolves to multiple
+    distinct sources. By default (`"warn"`) a warning will be issued
+    and only the first source will be read and returned as a Frame.
+    The `"ignore"` action is similar, except that the extra sources
+    will be discarded without a warning. Lastly, an :exc:`IOError`
+    can be raised if the value of this parameter is `"error"`.
+
+    If you want all sources to be read instead of only the first one
+    then consider using :func:`iread()`.
+
+memory_limit: int
+    Try not to exceed this amount of memory allocation (in bytes)
+    when reading the data. This limit is advisory and not enforced
+    very strictly.
+
+    This setting is useful when reading data from a file that is
+    substantially larger than the amount of RAM available on your
+    machine.
+
+    When this parameter is specified and fread sees that it needs
+    more RAM than the limit in order to read the input file, then
+    it will dump the data that was read so far into a temporary file
+    in binary format. In the end the returned Frame will be partially
+    composed from data located on disk, and partially from the data
+    in memory. It is advised to either store this data as a Jay file
+    or filter and materialize the frame (if not the performance may
+    be slow).
+
+(return): Frame
+    A single :class:`Frame` object is always returned.
+
+    .. versionchanged:: 0.11.0
+        Previously a ``dict`` of Frames was returned when multiple
+        input sources were provided.
+
+(except): IOError
+
+See Also
+--------
+- :func:`iread()`
 
 )";
 
 static py::PKArgs args_fread(
-  1, 0, 24, false, false,
+  1, 0, 23, false, false,
   {"anysource", "file", "text", "cmd", "url",
    "columns", "sep", "dec", "max_nrows", "header", "na_strings",
    "verbose", "fill", "encoding", "skip_to_string", "skip_to_line",
-   "skip_blank_lines", "strip_whitespace", "quotechar", "save_to",
+   "skip_blank_lines", "strip_whitespace", "quotechar",
    "tempdir", "nthreads", "logger", "multiple_sources", "memory_limit"
    },
   "fread", doc_fread);
@@ -71,7 +252,6 @@ static py::oobj fread(const py::PKArgs& args) {
   const py::Arg& arg_skipblanks = args[k++];
   const py::Arg& arg_stripwhite = args[k++];
   const py::Arg& arg_quotechar  = args[k++];
-  const py::Arg& arg_saveto     = args[k++];
   const py::Arg& arg_tempdir    = args[k++];
   const py::Arg& arg_nthreads   = args[k++];
   const py::Arg& arg_logger     = args[k++];
@@ -99,7 +279,6 @@ static py::oobj fread(const py::PKArgs& args) {
     rdr.init_multisource(arg_multisrc);
     rdr.init_memorylimit(arg_memlimit);
     rdr.init_encoding(   arg_encoding);
-    (void) arg_saveto;
   }
 
   MultiSource multisource(args, rdr);
@@ -117,19 +296,59 @@ R"(iread(anysource=None, *, file=None, text=None, cmd=None, url=None,
          columns=None, sep=None, dec=".", max_nrows=None, header=None,
          na_strings=None, verbose=False, fill=False, encoding=None,
          skip_to_string=None, skip_to_line=None, skip_blank_lines=False,
-         strip_whitespace=True, quotechar='"', save_to=None,
+         strip_whitespace=True, quotechar='"',
          tempdir=None, nthreads=None, logger=None, errors="warn",
          memory_limit=None)
 --
 
+This function is similar to :func:`fread()`, but allows reading
+multiple sources at once. For example, this can be used when the
+input is a list of files, or a glob pattern, or a multi-file archive,
+or multi-sheet XLSX file, etc.
+
+
+Parameters
+----------
+...: ...
+    Most parameters are the same as in :func:`fread()`. All parse
+    parameters will be applied to all input files.
+
+errors: "warn" | "raise" | "ignore" | "store"
+    What action to take when one of the input sources produces an
+    error. Possible actions are: `"warn"` -- each error is converted
+    into a warning and emitted to user, the source that produced the
+    error is then skipped; `"raise"` -- the errors are raised
+    immediately and the iteration stops; `"ignore"` -- the erroneous
+    sources are silently ignored; `"store"` -- when an error is
+    raised, it is captured and returned to the user, then the iterator
+    continues reading the subsequent sources.
+
+(return): Iterator[Frame] | Iterator[Frame|Exception]
+    The returned object is an iterator that produces :class:`Frame` s.
+    The iterator is lazy: each frame is read only as needed, after the
+    previous frame was "consumed" by the user. Thus, the user can
+    interrupt the iterator without having to read all the frames.
+
+    Each :class:`Frame` produced by the iterator has a ``.source``
+    attribute that describes the source of each frame as best as
+    possible. Each source depends on the type of the input: either a
+    file name, or a URL, or the name of the file in an archive, etc.
+
+    If the `errors` parameter is `"store"` then the iterator may
+    produce either Frames or exception objects.
+
+
+See Also
+--------
+- :func:`fread()`
 )";
 
 static py::PKArgs args_iread(
-  1, 0, 24, false, false,
+  1, 0, 23, false, false,
   {"anysource", "file", "text", "cmd", "url",
    "columns", "sep", "dec", "max_nrows", "header", "na_strings",
    "verbose", "fill", "encoding", "skip_to_string", "skip_to_line",
-   "skip_blank_lines", "strip_whitespace", "quotechar", "save_to",
+   "skip_blank_lines", "strip_whitespace", "quotechar",
    "tempdir", "nthreads", "logger", "errors", "memory_limit"
    },
   "iread", doc_iread);
@@ -150,7 +369,6 @@ static py::oobj iread(const py::PKArgs& args) {
   const py::Arg& arg_skipblanks = args[k++];
   const py::Arg& arg_stripwhite = args[k++];
   const py::Arg& arg_quotechar  = args[k++];
-  const py::Arg& arg_saveto     = args[k++];
   const py::Arg& arg_tempdir    = args[k++];
   const py::Arg& arg_nthreads   = args[k++];
   const py::Arg& arg_logger     = args[k++];
@@ -178,7 +396,6 @@ static py::oobj iread(const py::PKArgs& args) {
     rdr->init_errors(     arg_errors);
     rdr->init_memorylimit(arg_memlimit);
     rdr->init_encoding(   arg_encoding);
-    (void) arg_saveto;
   }
 
   auto ms = std::make_unique<MultiSource>(args, *rdr);

--- a/src/core/read/py_fread.cc
+++ b/src/core/read/py_fread.cc
@@ -68,7 +68,7 @@ file: str | file | Pathlike
     python "file-like" object -- i.e. any object having method
     ``.read()``.
 
-    Generally specifying a file name should be preferred, since
+    Generally, specifying a file name should be preferred, since
     reading from a Python ``file`` can only be done in single-threaded
     mode.
 
@@ -115,8 +115,8 @@ max_nrows: int
     at all. Currently this parameter doesn't always work correctly.
 
 header: bool | None
-    If True then the first line of the CSV file contains the header.
-    If False then there is no header. By default the presence of the
+    If `True` then the first line of the CSV file contains the header.
+    If `False` then there is no header. By default the presence of the
     header is heuristically determined from the contents of the file.
 
 na_strings: List[str]
@@ -124,9 +124,9 @@ na_strings: List[str]
     NA values.
 
 fill: bool
-    If True then the lines of the CSV file are allowed to have uneven
-    number of fields. All missing fields will be filled with NAs in
-    the resulting frame.
+    If `True` then the lines of the CSV file are allowed to have
+    uneven number of fields. All missing fields will be filled with
+    NAs in the resulting frame.
 
 encoding: str | None
     If this parameter is provided, then the input will be recoded
@@ -153,7 +153,7 @@ skip_blank_lines: bool
     otherwise (c) an :exc:`IOError` is raised.
 
 strip_whitespace: bool
-    If True, then the leading/trailing whitespace will be stripped
+    If `True`, then the leading/trailing whitespace will be stripped
     from unquoted string fields. Whitespace is always skipped from
     numeric fields.
 
@@ -169,7 +169,7 @@ tempdir: str | None
 nthreads: int | None
     Number of threads to use when reading the file. This number cannot
     exceed the number of threads in the pool ``dt.options.nthreads``.
-    If 0 or negative number of threads is requested, then it will be
+    If `0` or negative number of threads is requested, then it will be
     treated as that many threads less than the maximum. By default
     all threads in the thread pool are used.
 

--- a/src/core/read/py_fread.cc
+++ b/src/core/read/py_fread.cc
@@ -46,7 +46,7 @@ R"(fread(anysource=None, *, file=None, text=None, cmd=None, url=None,
 This function is capable of reading data from a variety of input formats,
 producing a :class:`Frame` as the result. The recognized formats are:
 CSV, Jay, XLSX, and plain text. In addition, the data may be inside an
-archive such as .tar, .gz, .zip, .gz2.
+archive such as ``.tar``, ``.gz``, ``.zip``, ``.gz2``, and ``.tgz``.
 
 
 Parameters

--- a/src/datatable/sphinxext/xfunction.py
+++ b/src/datatable/sphinxext/xfunction.py
@@ -61,7 +61,7 @@ rx_cc_id = re.compile(r"(?:\w+::)*\w+")
 rx_py_id = re.compile(r"(?:\w+\.)*\w+")
 rx_param = re.compile(r"(?:"
                       r"(\w+)(?:\s*=\s*("
-                      r"\"[^\"]*\"|\([^\(\)]*\)|\[[^\[\]]*\]|[^,\[\(\"]*"
+                      r"\"[^\"]*\"|'[^']*'|\([^\(\)]*\)|\[[^\[\]]*\]|[^,\[\(\"]*"
                       r"))?"
                       r"|([\*/]|\*\*?\w+)"
                       r")\s*(?:,\s*|$)")
@@ -449,6 +449,8 @@ class XobjectDirective(SphinxDirective):
             return
 
         tmp = self.doc_text.split("--\n", 1)
+        if len(tmp) == 1 and self.doc_text.endswith("--"):
+            tmp = [self.doc_text[:-2], ""]
         if len(tmp) == 1:
             raise self.error("Docstring for `%s` does not contain '--\\n'"
                              % self.obj_name)
@@ -548,7 +550,7 @@ class XobjectDirective(SphinxDirective):
         fnparams = [(p if isinstance(p, str) else p[0]).lstrip('*')
                     for p in self.parsed_params]
         rx_codeblock = re.compile(
-            r"``([^`]+)``|"
+            r"``(.*?)``|"
             r":`([^`]+)`|"
             r"`([^`]+)`"
         )
@@ -893,13 +895,11 @@ class XparamDirective(SphinxDirective):
         bracket_level = 0
         i = 0
         while i < len(args):  # iterate by characters
-            if args[i] in "[({":
+            if args[i] in "[({'\"":
                 bracket_level += 1
-            elif args[i] in "})]":
+            elif args[i] in "\"'})]":
                 bracket_level -= 1
-            elif bracket_level > 0:
-                pass
-            else:
+            elif bracket_level == 0:
                 mm = re.match(rx_separator, args[i:])
                 if mm:
                     self.types.append(args[i0:i])

--- a/src/datatable/utils/fread.py
+++ b/src/datatable/utils/fread.py
@@ -159,6 +159,8 @@ def _resolve_source_file(file, tempfiles):
         # more direct access to the underlying file.
         # noinspection PyBroadException
         try:
+            if sys.platform == "win32":
+                raise Exception("Do not use file descriptors on Windows")
             # .fileno can be either a method, or a property
             # The implementation of .fileno may raise an exception too
             # (indicating that no file descriptor is available)

--- a/src/datatable/utils/fread.py
+++ b/src/datatable/utils/fread.py
@@ -238,6 +238,7 @@ def _resolve_archive(filename, subpath, tempfiles):
     out_file = None
     out_text = None
     out_result = None
+    # TODO: file extarction should be lazy
     if ext == ".zip":
         import zipfile
         with zipfile.ZipFile(filename) as zf:
@@ -269,7 +270,7 @@ def _resolve_archive(filename, subpath, tempfiles):
             else:
                 return (None, None, None, None), extracted_files
 
-    elif filename.endswith(".tar.gz"):
+    elif filename.endswith(".tar.gz") or filename.endswith(".tgz"):
         import tarfile
         zf = tarfile.open(filename, mode="r:gz")
         zff = [entry.name for entry in zf.getmembers() if entry.isfile()]

--- a/tests/fread/test_fread_api.py
+++ b/tests/fread/test_fread_api.py
@@ -208,8 +208,6 @@ def test_fread_from_stringbuf():
 
 
 def test_fread_from_fileobj(tempfile):
-    import platform
-
     with open(tempfile, "w") as f:
         f.write("A,B,C\nfoo,bar,baz\n")
 

--- a/tests/fread/test_fread_api.py
+++ b/tests/fread/test_fread_api.py
@@ -214,17 +214,11 @@ def test_fread_from_fileobj(tempfile):
         f.write("A,B,C\nfoo,bar,baz\n")
 
     with open(tempfile, "r") as f:
-        if platform.system() == "Windows":
-            msg = "Reading from file-like objects, that involves " \
-                  "file descriptors, is not supported on Windows"
-            with pytest.raises(NotImplementedError, match=msg):
-                d0 = dt.fread(f)
-        else:
-            d0 = dt.fread(f)
-            frame_integrity_check(d0)
-            assert d0.source == tempfile
-            assert d0.names == ("A", "B", "C")
-            assert d0.to_list() == [["foo"], ["bar"], ["baz"]]
+        d0 = dt.fread(f)
+        frame_integrity_check(d0)
+        assert d0.source == tempfile
+        assert d0.names == ("A", "B", "C")
+        assert d0.to_list() == [["foo"], ["bar"], ["baz"]]
 
 
 def test_fread_file_not_exists():

--- a/tests/fread/test_fread_large.py
+++ b/tests/fread/test_fread_large.py
@@ -18,7 +18,7 @@ from tests import find_file
 
 env_coverage = "DTCOVERAGE"
 root_env_name = "DT_LARGE_TESTS_ROOT"
-MEMORY_LIMIT = None
+MEMORY_LIMIT = 2 * (1 << 30)   # 2Gb
 
 
 #-------------------------------------------------------------------------------

--- a/tests/fread/test_fread_large.py
+++ b/tests/fread/test_fread_large.py
@@ -126,6 +126,7 @@ def test_h2o3_smalldata(f):
         os.path.join("parser", "hexdev_497", "airlines_first_header.zip"),
         os.path.join("parser", "hexdev_497", "airlines_small_csv.zip"),
         os.path.join("prostate", "prostate.bin.csv.zip"),
+        os.path.join("smalldata", "images", "cat_dog_tiny_thumbnails.zip")
         # Others
         os.path.join("arff", "folder1", "iris0.csv"),
         os.path.join("jira", "pubdev_2897.csv"),

--- a/tests/fread/test_fread_large.py
+++ b/tests/fread/test_fread_large.py
@@ -149,9 +149,9 @@ def test_h2o3_smalldata(f):
             frame_integrity_check(DT)
 
 
-@pytest.mark.parametrize("filename", get_file_list("h2o-3", "bigdata", "laptop"),
+@pytest.mark.parametrize("f", get_file_list("h2o-3", "bigdata", "laptop"),
                          indirect=True)
-def test_h2o3_bigdata(filename):
+def test_h2o3_bigdata(f):
     ignored_files = {
         # Feather files
         os.path.join("ipums_feather.gz"),
@@ -196,19 +196,19 @@ def test_h2o3_bigdata(filename):
         os.path.join("Kaggle_Product_BO_Test_v2.csv.zip"),
         os.path.join("Kaggle_Product_BO_Training_v2.csv.zip"),
     }
-    if any(ff in filename for ff in ignored_files):
+    if any(ff in f for ff in ignored_files):
         pytest.skip("On the ignored files list")
         return
 
     params = {"memory_limit": MEMORY_LIMIT}
-    if any(ff in filename for ff in filledna_files):
+    if any(ff in f for ff in filledna_files):
         params["fill"] = True
-    if "imagenet/cat_dog_mouse.tgz" in filename:
-        filename = os.path.join(filename, "cat_dog_mouse.csv")
+    if "imagenet/cat_dog_mouse.tgz" in f:
+        f = os.path.join(f, "cat_dog_mouse.csv")
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        DT = dt.fread(filename, **params)
+        DT = dt.fread(f, **params)
         frame_integrity_check(DT)
 
 

--- a/tests/fread/test_fread_large.py
+++ b/tests/fread/test_fread_large.py
@@ -18,7 +18,7 @@ from tests import find_file
 
 env_coverage = "DTCOVERAGE"
 root_env_name = "DT_LARGE_TESTS_ROOT"
-
+MEMORY_LIMIT = None
 
 
 #-------------------------------------------------------------------------------
@@ -108,7 +108,7 @@ def f(request):
                          indirect=True)
 def test_h2oai_benchmarks(f):
     try:
-        d = dt.fread(f)
+        d = dt.fread(f, memory_limit=MEMORY_LIMIT)
         frame_integrity_check(d)
     except zipfile.BadZipFile:
         pytest.skip("Bad zip file error")
@@ -199,7 +199,7 @@ def test_h2o3_bigdata(f):
     if any(ff in f for ff in ignored_files):
         pytest.skip("On the ignored files list")
     else:
-        params = {}
+        params = {"memory_limit": MEMORY_LIMIT}
         if any(ff in f for ff in filledna_files):
             params["fill"] = True
         with warnings.catch_warnings():

--- a/tests/fread/test_fread_large.py
+++ b/tests/fread/test_fread_large.py
@@ -126,7 +126,7 @@ def test_h2o3_smalldata(f):
         os.path.join("parser", "hexdev_497", "airlines_first_header.zip"),
         os.path.join("parser", "hexdev_497", "airlines_small_csv.zip"),
         os.path.join("prostate", "prostate.bin.csv.zip"),
-        os.path.join("smalldata", "images", cat_dog_tiny_thumbnails.zip),
+        os.path.join("smalldata", "images", "cat_dog_tiny_thumbnails.zip"),
         # Others
         os.path.join("arff", "folder1", "iris0.csv"),
         os.path.join("jira", "pubdev_2897.csv"),

--- a/tests/fread/test_fread_large.py
+++ b/tests/fread/test_fread_large.py
@@ -149,9 +149,9 @@ def test_h2o3_smalldata(f):
             frame_integrity_check(DT)
 
 
-@pytest.mark.parametrize("f", get_file_list("h2o-3", "bigdata", "laptop"),
+@pytest.mark.parametrize("filename", get_file_list("h2o-3", "bigdata", "laptop"),
                          indirect=True)
-def test_h2o3_bigdata(f):
+def test_h2o3_bigdata(filename):
     ignored_files = {
         # Feather files
         os.path.join("ipums_feather.gz"),
@@ -196,16 +196,20 @@ def test_h2o3_bigdata(f):
         os.path.join("Kaggle_Product_BO_Test_v2.csv.zip"),
         os.path.join("Kaggle_Product_BO_Training_v2.csv.zip"),
     }
-    if any(ff in f for ff in ignored_files):
+    if any(ff in filename for ff in ignored_files):
         pytest.skip("On the ignored files list")
-    else:
-        params = {"memory_limit": MEMORY_LIMIT}
-        if any(ff in f for ff in filledna_files):
-            params["fill"] = True
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            DT = dt.fread(f, **params)
-            frame_integrity_check(DT)
+        return
+
+    params = {"memory_limit": MEMORY_LIMIT}
+    if any(ff in filename for ff in filledna_files):
+        params["fill"] = True
+    if "imagenet/cat_dog_mouse.tgz" in filename:
+        filename = os.path.join(filename, "cat_dog_mouse.csv")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        DT = dt.fread(filename, **params)
+        frame_integrity_check(DT)
 
 
 

--- a/tests/fread/test_fread_large.py
+++ b/tests/fread/test_fread_large.py
@@ -126,7 +126,7 @@ def test_h2o3_smalldata(f):
         os.path.join("parser", "hexdev_497", "airlines_first_header.zip"),
         os.path.join("parser", "hexdev_497", "airlines_small_csv.zip"),
         os.path.join("prostate", "prostate.bin.csv.zip"),
-        os.path.join("smalldata", "images", "cat_dog_tiny_thumbnails.zip")
+        os.path.join("smalldata", "images", cat_dog_tiny_thumbnails.zip),
         # Others
         os.path.join("arff", "folder1", "iris0.csv"),
         os.path.join("jira", "pubdev_2897.csv"),

--- a/tests/fread/test_fread_small.py
+++ b/tests/fread/test_fread_small.py
@@ -542,6 +542,15 @@ def test_fread3(newline):
     assert_equals(DT, dt.Frame(COL=["abc", "def", "", "ijk"]))
 
 
+def test_comments_only_file():
+    text = ("# one\n"
+            "# two\n"
+            "#~~~~~~~~~~\n")
+    DT = dt.fread(text)
+    # Not clear why it has 1 column instead of 0
+    assert_equals(DT, dt.Frame([]))
+
+
 def test_runaway_quote():
     d0 = dt.fread('"A,B,C\n1,2,3\n4,5,6')
     assert d0.shape == (2, 3)

--- a/tests/fread/test_fread_small.py
+++ b/tests/fread/test_fread_small.py
@@ -548,7 +548,7 @@ def test_comments_only_file():
             "#~~~~~~~~~~\n")
     DT = dt.fread(text)
     # Not clear why it has 1 column instead of 0
-    assert_equals(DT, dt.Frame([]))
+    assert_equals(DT, dt.Frame([[]]))
 
 
 def test_runaway_quote():


### PR DESCRIPTION
- Fixed few minor bugs related to streaming reading in fread;
- The "streaming read" functionality is now officially released, as announced in the release notes;
- The "large fread tests" now run under the memory limit of 2Gb in order to test the functionality of `memory_limit` parameter;
- Added documentation for fread() and iread();
- `save_to=` parameter in fread removed. This parameter was declared but not used, so no reason to keep it;

Closes #75
Closes #1750