### PR TITLE
Remove macros TRACK/UNTRACK

### DIFF
--- a/src/core/buffer.cc
+++ b/src/core/buffer.cc
@@ -28,7 +28,6 @@
 #include "utils/macros.h"
 #include "utils/misc.h"        // malloc_size
 #include "utils/temporary_file.h"
-#include "datatablemodule.h"   // TRACK, UNTRACK, IS_TRACKED
 #include "buffer.h"
 #include "mmm.h"               // MemoryMapWorker, MemoryMapManager
 

--- a/src/core/datatablemodule.h
+++ b/src/core/datatablemodule.h
@@ -59,16 +59,6 @@ class DatatableModule : public ExtModule<DatatableModule> {
 }  // namespace py
 
 
-#if DT_DEBUG
-  void TRACK(void* ptr, size_t size, const char* name);
-  void UNTRACK(void* ptr);
-  bool IS_TRACKED(void* ptr);
-#else
-  #define TRACK(ptr, size, name)
-  #define UNTRACK(ptr)
-  #define IS_TRACKED(ptr) 1
-#endif
-
 
 namespace pybuffers {
   extern size_t single_col;  // Declared in py_buffers

--- a/src/core/py_buffers.cc
+++ b/src/core/py_buffers.cc
@@ -242,11 +242,6 @@ struct XInfo {
     shape[0] = shape[1] = 0;
     strides[0] = strides[1] = 0;
     stype = dt::SType::VOID;
-    TRACK(this, sizeof(*this), "py-buffer");
-  }
-
-  ~XInfo() {
-    UNTRACK(this);
   }
 };
 

--- a/src/core/sort.cc
+++ b/src/core/sort.cc
@@ -1237,7 +1237,6 @@ class SortContext {
       // } else {
       own_tmp = true;
       tmp = new int32_t[size0 * nth];
-      TRACK(tmp, sizeof(tmp), "sort.tmp");
       // }
     }
 
@@ -1288,7 +1287,6 @@ class SortContext {
 
     if (own_tmp) {
       delete[] tmp;
-      UNTRACK(tmp);
     }
   }
 

--- a/src/core/utils/alloc.cc
+++ b/src/core/utils/alloc.cc
@@ -60,7 +60,6 @@ void* _realloc(void* ptr, size_t n) {
 void free(void* ptr) {
   if (!ptr) return;
   std::free(ptr);
-  // UNTRACK(ptr);
 }
 
 

--- a/src/core/wstringcol.cc
+++ b/src/core/wstringcol.cc
@@ -15,7 +15,6 @@
 //------------------------------------------------------------------------------
 #include <cstring>        // std::memcpy
 #include "column.h"
-#include "datatablemodule.h"
 #include "stype.h"
 #include "wstringcol.h"
 namespace dt {
@@ -66,13 +65,8 @@ pbuf writable_string_col::make_buffer() {
 // writable_string_col::buffer
 //------------------------------------------------------------------------------
 
-writable_string_col::buffer::buffer() {
-  TRACK(this, sizeof(*this), "writable_string_col::buffer");
-}
-
-writable_string_col::buffer::~buffer() {
-  UNTRACK(this);
-}
+writable_string_col::buffer::buffer() {}
+writable_string_col::buffer::~buffer() {}
 
 
 void writable_string_col::buffer::write(const CString& str) {


### PR DESCRIPTION
The macros are no longer in use. Instead we use AddressSanitizer to detect leaks.