### PR TITLE
Macros for compiler warnings handling

### DIFF
--- a/src/core/column/sentinel_fw.cc
+++ b/src/core/column/sentinel_fw.cc
@@ -139,11 +139,8 @@ size_t SentinelFw_ColumnImpl<T>::memory_footprint() const noexcept {
 // Data access
 //------------------------------------------------------------------------------
 
-#if DT_COMPILER_MSVC
-  #pragma warning(push)
-  // unreachable code
-  #pragma warning(disable : 4702)
-#endif
+DISABLE_MSVC_WARNING(4702)
+
 
 template <typename T>
 bool SentinelFw_ColumnImpl<T>::get_element(size_t i, int8_t* out) const {
@@ -201,9 +198,8 @@ bool SentinelObj_ColumnImpl::get_element(size_t i, py::robj* out) const {
   return !x.is_none();
 }
 
-#if DT_COMPILER_MSVC
-  #pragma warning(pop)
-#endif
+
+RESTORE_MSVC_WARNING(4702)
 
 
 

--- a/src/core/column/sentinel_fw.cc
+++ b/src/core/column/sentinel_fw.cc
@@ -139,6 +139,7 @@ size_t SentinelFw_ColumnImpl<T>::memory_footprint() const noexcept {
 // Data access
 //------------------------------------------------------------------------------
 
+// 4702 : unreachable code
 DISABLE_MSVC_WARNING(4702)
 
 

--- a/src/core/frame/replace.cc
+++ b/src/core/frame/replace.cc
@@ -588,10 +588,8 @@ void ReplaceAgent::process_str_column(size_t colidx) {
 // Step 4: perform actual data replacement
 //------------------------------------------------------------------------------
 // Ignore warnings in auto-generated lambda code
-#if DT_COMPILER_CLANG
-  #pragma clang diagnostic push
-  #pragma clang diagnostic ignored "-Wpadded"
-#endif
+DISABLE_CLANG_WARNING("-Wpadded")
+
 
 template <typename T>
 void ReplaceAgent::replace_fw(T* x, T* y, size_t nrows, T* data, size_t n)
@@ -718,8 +716,7 @@ Column ReplaceAgent::replace_strN(CString* x, CString* y,
 }
 
 
-#if DT_COMPILER_CLANG
-  #pragma clang diagnostic pop
-#endif
 
+
+RESTORE_CLANG_WARNING()
 }  // namespace py

--- a/src/core/parallel/monitor_thread.cc
+++ b/src/core/parallel/monitor_thread.cc
@@ -30,7 +30,7 @@
     #define _XOPEN_SOURCE
   #endif
   #include <unistd.h>                   // nice
-  RESTORE_CLANG_WARNING()
+  RESTORE_CLANG_WARNING("-Wunused-macros")
 #endif
 
 

--- a/src/core/parallel/monitor_thread.h
+++ b/src/core/parallel/monitor_thread.h
@@ -36,10 +36,10 @@ void enable_monitor(bool) noexcept;
   */
 class monitor_thread {
   private:
-    std::thread thread;
-    idle_job* controller;
-    std::condition_variable sleep_state_cv;
-    bool running;
+    std::thread             thread_;
+    idle_job*               controller_;
+    std::condition_variable sleep_state_cv_;
+    bool                    running_;
     size_t : 56;
 
   public:
@@ -63,13 +63,11 @@ class monitor_thread {
 
 class MonitorGuard {
   public:
-    MonitorGuard() {
-      enable_monitor(true);
-    }
-    ~MonitorGuard() {
-      enable_monitor(false);  // noexcept
-    }
+    MonitorGuard();
+    ~MonitorGuard();
 };
+
+
 
 
 } // namespace dt

--- a/src/core/parallel/semaphore.h
+++ b/src/core/parallel/semaphore.h
@@ -90,7 +90,7 @@ class Semaphore {
 // Can't use POSIX semaphores due to
 // http://lists.apple.com/archives/darwin-kernel/2009/Apr/msg00010.html
 //------------------------------------------------------------------------------
-#elif DT_OS_DARWIN
+#elif DT_OS_MACOS
 #include <mach/mach.h>
 
 class Semaphore {

--- a/src/core/python/xobject.h
+++ b/src/core/python/xobject.h
@@ -417,10 +417,7 @@ int _call_setter(void(T::*fn)(const Arg&), Arg& ARG,
 // Helper macros
 //------------------------------------------------------------------------------
 
-#if DT_COMPILER_CLANG
-  #pragma clang diagnostic push
-  #pragma clang diagnostic ignored "-Wunused-template"
-#endif
+DISABLE_CLANG_WARNING("-Wunused-template")
 
 template <typename T, typename R, typename... Args>
 static T _class_of_impl(R(T::*)(Args...));
@@ -430,9 +427,7 @@ static T _class_of_impl(R(T::*)(Args...) const);
 
 #define CLASS_OF(METH) decltype(_class_of_impl(METH))
 
-#if DT_COMPILER_CLANG
-  #pragma clang diagnostic pop
-#endif
+RESTORE_CLANG_WARNING("-Wunused-template")
 
 
 #define CONSTRUCTOR(METH, ARGS)                                                \

--- a/src/core/utils/assert.h
+++ b/src/core/utils/assert.h
@@ -25,7 +25,7 @@
 #include "macros.h"
 #include "utils/exceptions.h"
 
-#if DT_OS_DARWIN
+#if DT_OS_MACOS
   #include <unistd.h>
 #endif
 

--- a/src/core/utils/macros.h
+++ b/src/core/utils/macros.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018 H2O.ai
+// Copyright 2018-2020 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -29,14 +29,14 @@
 // Operating system
 //------------------------------------------------------------------------------
 
-#define DT_OS_DARWIN  0
+#define DT_OS_MACOS  0
 #define DT_OS_LINUX   0
 #define DT_OS_WINDOWS 0
 
 
 #if defined(__APPLE__) && defined(__MACH__)
-  #undef  DT_OS_DARWIN
-  #define DT_OS_DARWIN 1
+  #undef  DT_OS_MACOS
+  #define DT_OS_MACOS 1
 #endif
 
 #if defined(__linux) || defined(__linux__)
@@ -49,13 +49,13 @@
   #define DT_OS_WINDOWS 1
 #endif
 
-#if (DT_OS_LINUX || DT_OS_DARWIN)
+#if (DT_OS_LINUX || DT_OS_MACOS)
   #define DT_UNIX 1
 #else
   #define DT_UNIX 0
 #endif
 
-#if DT_OS_WINDOWS + DT_OS_DARWIN + DT_OS_LINUX != 1
+#if DT_OS_WINDOWS + DT_OS_MACOS + DT_OS_LINUX != 1
   #error Unknown operating system
 #endif
 
@@ -167,6 +167,27 @@ struct alignas(CACHELINE_SIZE) cache_aligned {
   cache_aligned(const T& v_) : v(v_) {}
   cache_aligned(T&& v_) : v(std::move(v_)) {}
 };
+
+
+
+
+//------------------------------------------------------------------------------
+// Disable macros
+//------------------------------------------------------------------------------
+#define ___STRINGIFY(TEXT) #TEXT
+
+#if DT_COMPILER_CLANG
+  #define DISABLE_CLANG_WARNING(N) \
+    _Pragma("clang diagnostic push") \
+    _Pragma(___STRINGIFY(clang diagnostic ignored N))
+
+  #define RESTORE_CLANG_WARNING() \
+    _Pragma("clang diagnostic pop")
+#else
+  #define DISABLE_CLANG_WARNING(N)
+  #define RESTORE_CLANG_WARNING()
+#endif
+
 
 
 //------------------------------------------------------------------------------

--- a/src/core/utils/macros.h
+++ b/src/core/utils/macros.h
@@ -172,7 +172,7 @@ struct alignas(CACHELINE_SIZE) cache_aligned {
 
 
 //------------------------------------------------------------------------------
-// Disable macros
+// Disable warnings
 //------------------------------------------------------------------------------
 #define ___STRINGIFY(TEXT) #TEXT
 
@@ -181,12 +181,40 @@ struct alignas(CACHELINE_SIZE) cache_aligned {
     _Pragma("clang diagnostic push") \
     _Pragma(___STRINGIFY(clang diagnostic ignored N))
 
-  #define RESTORE_CLANG_WARNING() \
+  #define RESTORE_CLANG_WARNING(N) \
     _Pragma("clang diagnostic pop")
 #else
   #define DISABLE_CLANG_WARNING(N)
-  #define RESTORE_CLANG_WARNING()
+  #define RESTORE_CLANG_WARNING(N)
 #endif
+
+
+#if DT_COMPILER_GCC
+  #define DISABLE_GCC_WARNING(N) \
+    _Pragma("GCC diagnostic push") \
+    _Pragma(___STRINGIFY(GCC diagnostic ignored N))
+
+  #define RESTORE_GCC_WARNING(N) \
+    _Pragma("GCC diagnostic pop")
+#else
+  #define DISABLE_GCC_WARNING(N)
+  #define RESTORE_GCC_WARNING(N)
+#endif
+
+
+#if DT_COMPILER_MSVC
+  #define DISABLE_MSVC_WARNING(N) \
+    _Pragma("warning(push)") \
+    _Pragma(___STRINGIFY(warning(disable : N)))
+
+  #define RESTORE_MSVC_WARNING(N) \
+    _Pragma("warning(pop)")
+
+#else
+  #define DISABLE_MSVC_WARNING(N)
+  #define RESTORE_MSVC_WARNING(N)
+#endif
+
 
 
 

--- a/src/core/utils/misc.cc
+++ b/src/core/utils/misc.cc
@@ -264,3 +264,9 @@ repr_utf8(const unsigned char* ptr0, const unsigned char* ptr1) {
     buf[i] = '\0';
     return buf;
 }
+
+
+
+RESTORE_MSVC_WARNING(4333)
+RESTORE_MSVC_WARNING(4293)
+RESTORE_GCC_WARNING("-Wshift-count-overflow")

--- a/src/core/utils/misc.cc
+++ b/src/core/utils/misc.cc
@@ -23,16 +23,16 @@
 #include "utils/misc.h"
 #include <stdint.h>
 #include <cstring>    // std::memcpy
-
-
 namespace dt {
+
 
 // The warning is spurious, because shifts triggering the warning are
 // within if() conditions that get statically ignored.
-#if DT_COMPILER_GCC
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wshift-count-overflow"
-#endif
+DISABLE_GCC_WARNING("-Wshift-count-overflow")
+// 4293: shift count negative or too big, undefined behavior
+DISABLE_MSVC_WARNING(4293)
+// 4333: right shift by too large amount, data loss
+DISABLE_MSVC_WARNING(4333)
 
 
 /**
@@ -46,14 +46,6 @@ int nlz(T x) {
   T y;
   int n = sizeof(T) * 8;
 
-  #if DT_COMPILER_MSVC
-    #pragma warning(push)
-    // shift count negative or too big, undefined behavior
-    #pragma warning(disable : 4293)
-    // right shift by too large amount, data loss
-    #pragma warning(disable : 4333) 
-  #endif 
-
   if (sizeof(T) >= 8) {
     y = x >> 32; if (y != 0) { n = n -32;  x = y; }
   }
@@ -63,11 +55,6 @@ int nlz(T x) {
   if (sizeof(T) >= 2) {
     y = x >> 8;  if (y != 0) { n = n - 8;  x = y; }
   }
-  
-  #if DT_COMPILER_MSVC
-    #pragma warning(pop)
-  #endif
-
   if (sizeof(T) >= 1) {
     y = x >> 4;  if (y != 0) { n = n - 4;  x = y; }
     y = x >> 2;  if (y != 0) { n = n - 2;  x = y; }
@@ -83,14 +70,6 @@ int nsb(T x) {
   T y;
   int m = 0;
 
-  #if DT_COMPILER_MSVC
-    #pragma warning(push)
-    // shift count negative or too big, undefined behavior
-    #pragma warning(disable : 4293)
-    // right shift by too large amount, data loss
-    #pragma warning(disable : 4333) 
-  #endif
-
   if (sizeof(T) >= 8) {
     y = x >> 32; if (y) { m += 32;  x = y; }
   }
@@ -100,11 +79,6 @@ int nsb(T x) {
   if (sizeof(T) >= 2) {
     y = x >> 8;  if (y) { m += 8;  x = y; }
   }
-
-  #if DT_COMPILER_MSVC
-    #pragma warning(pop)
-  #endif
-  
   if (sizeof(T) >= 1) {
     y = x >> 4;  if (y) { m += 4;  x = y; }
     y = x >> 2;  if (y) { m += 2;  x = y; }
@@ -113,9 +87,7 @@ int nsb(T x) {
   return m + static_cast<int>(x);
 }
 
-#if DT_COMPILER_GCC
-  #pragma GCC diagnostic pop
-#endif
+
 
 template int nlz(uint64_t);
 template int nlz(uint32_t);
@@ -126,7 +98,7 @@ template int nsb(uint32_t);
 template int nsb(uint16_t);
 template int nsb(uint8_t);
 
-};  // namespace dt
+}  // namespace dt
 
 
 /**

--- a/src/core/utils/misc.h
+++ b/src/core/utils/misc.h
@@ -58,7 +58,7 @@ void set_value(void* ptr, const void* value, size_t sz, size_t count);
 
 
 
-#if DT_OS_DARWIN
+#if DT_OS_MACOS
   #include <malloc/malloc.h>  // size_t malloc_size(const void *)
 #elif DT_OS_WINDOWS
   #include <malloc.h>  // size_t _msize(void *)

--- a/src/core/writebuf.cc
+++ b/src/core/writebuf.cc
@@ -72,7 +72,7 @@ std::unique_ptr<WritableBuffer> WritableBuffer::create_target(
     res = new MemoryWritableBuffer(size);
   } else {
     if (strategy == Strategy::Auto) {
-      #if DT_OS_DARWIN
+      #if DT_OS_MACOS
         strategy = Strategy::Write;
       #else
         strategy = Strategy::Mmap;


### PR DESCRIPTION
- Defined macros `DISABLE_CLANG_WARNING(N)`, `DISABLE_GCC_WARNING(N)`, `DISABLE_MSVC_WARNING(N)` and corresponding `RESTORE_*` macros, to reduce the amount of boilerplate needed to switch off a warning for a portion of code;
- Renamed `DT_OS_DARWIN` -> `DT_OS_MACOS`;
- Rename member variables in class `monitor_thread`;