### PR TITLE
Fix some compiler warnings produced by Clang-10

### DIFF
--- a/src/core/python/args.cc
+++ b/src/core/python/args.cc
@@ -75,7 +75,7 @@ void PKArgs::add_synonym_arg(const char* new_name, const char* old_name) {
     if (std::strcmp(name, new_name) == 0) inew = i;
   }
   xassert(iold != NPOS);  // make sure that `old_name` exists
-  xassert(inew == NPOS);
+  xassert(inew == NPOS);  (void)inew;
   PyObject* py_new_name = PyUnicode_FromString(new_name);
   xassert(py_new_name);
   kwd_map[py_new_name] = iold;

--- a/src/core/stype.h
+++ b/src/core/stype.h
@@ -239,7 +239,7 @@ using read_t = typename _rdt<s>::t;
   * Approximate inverse of `read_t<SType>`: given a type T, returns
   * the "most typical" SType that represents type T.
   */
-template <typename T> constexpr SType _sfr  = SType::VOID;
+template <typename T> static constexpr SType _sfr = SType::VOID;
 template <> constexpr SType _sfr<bool>      = SType::BOOL;
 template <> constexpr SType _sfr<int8_t>    = SType::INT8;
 template <> constexpr SType _sfr<int16_t>   = SType::INT16;
@@ -252,7 +252,7 @@ template <> constexpr SType _sfr<PyObject*> = SType::OBJ;
 template <> constexpr SType _sfr<py::robj>  = SType::OBJ;
 
 template <typename T>
-constexpr SType stype_from = _sfr<T>;
+static constexpr SType stype_from = _sfr<T>;
 
 
 /**

--- a/src/core/utils/assert.h
+++ b/src/core/utils/assert.h
@@ -55,7 +55,7 @@
     if (!(EXPRESSION)) { \
       (AssertionError() << "Assertion '" #EXPRESSION "' failed in " \
           << __FILE__ << ", line " << __LINE__).to_stderr(); \
-    }
+    } ((void)(0))
 
   #define xassert(EXPRESSION) \
     if (!(EXPRESSION)) { \
@@ -74,7 +74,7 @@
   if (!(EXPRESSION)) { \
     throw AssertionError() << "Assertion '" #EXPRESSION "' failed in " \
         << __FILE__ << ", line " << __LINE__; \
-  }
+  } ((void)(0))
 
 
 


### PR DESCRIPTION
Removes warnings such as
```
In file included from src/core/expr/fnary/rowcount.cc:26:
src/core/column/func_nary.h:81:22: warning: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Wextra-semi-stmt]
  XAssert(evaluator_);
```
as well as tries to address
```
src/core/stype.h:243:29: warning: no previous extern declaration for non-static variable '_sfr<bool>' [-Wmissing-variable-declarations]
template <> constexpr SType _sfr<bool> = SType::BOOL;
```