### PR TITLE
Add Clang Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,6 @@ jobs:
       osx_image: xcode11.6
       compiler:
         - gcc
-      language: shell
 
 cache:
   pip: true
@@ -49,11 +48,11 @@ git:
 
 install:
   - pip install --upgrade pip
-  - pip install -r requirements_tests.txt
-  - pip install -r requirements_extra.txt
 
 script:
   - python ci/ext.py wheel
   - pip install --upgrade dist/*.whl
+  - pip install -r requirements_tests.txt
+  - pip install -r requirements_extra.txt
   - python -m pytest -ra --showlocals -Werror tests
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ jobs:
         - LLVM_CONFIG=$LLVM7/bin/llvm-config
         - CLANG=$LLVM7/bin/clang
         - LD_LIBRARY_PATH=$LLVM7/lib:$LD_LIBRARY_PATH
+        - CXX=$LLVM7/bin/clang
 
     - name: "Python 3.6 on Linux with LLVM7"
       python: 3.6
@@ -28,6 +29,7 @@ jobs:
         - LLVM_CONFIG=$LLVM7/bin/llvm-config
         - CLANG=$LLVM7/bin/clang
         - LD_LIBRARY_PATH=$LLVM7/lib:$LD_LIBRARY_PATH
+        - CXX=$LLVM7/bin/clang
 
     - name: "Python 3.6 on Linux with LLVM10"
       python: 3.6
@@ -38,6 +40,7 @@ jobs:
         - LLVM_CONFIG=$LLVM10/bin/llvm-config
         - CLANG=$LLVM10/bin/clang
         - LD_LIBRARY_PATH=$LLVM10/lib:$LD_LIBRARY_PATH
+        - CXX=$LLVM10/bin/clang
 
 cache:
   pip: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,12 +30,12 @@ jobs:
         - LD_LIBRARY_PATH=$LLVM10/lib:$LD_LIBRARY_PATH
         - CXX=$LLVM10/bin/clang
 
-    - name: "Python 3.6 on macOS with gcc"
+    - name: "Python 3.x on macOS with gcc"
       os: osx
       osx_image: xcode11.6
       compiler:
         - gcc
-      python: 3.6
+      language: shell
 
 cache:
   pip: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,12 +30,6 @@ jobs:
         - LD_LIBRARY_PATH=$LLVM10/lib:$LD_LIBRARY_PATH
         - CXX=$LLVM10/bin/clang
 
-    - name: "Python 3.x on macOS with gcc"
-      os: osx
-      osx_image: xcode11.6
-      compiler:
-        - gcc
-
 cache:
   pip: true
   ccache: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,17 @@ jobs:
         - LD_LIBRARY_PATH=$LLVM7/lib:$LD_LIBRARY_PATH
         - CXX=$LLVM7/bin/clang
 
-    - name: "Python 3.6 on Linux with LLVM10"
-      python: 3.6
+    - name: "Python 3.7 on Linux with LLVM10"
+      python: 3.7
+      before_install:
+        - ( test -d "$LLVM10" && test "$(ls -A $LLVM10)") || ( wget -O llvm10.tar.xz "https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz" && mkdir -p "$LLVM10" && tar xf llvm10.tar.xz -C "$LLVM10" --strip-components 1 )
+      env:
+        - LLVM10=$HOME/LLVM10
+        - LD_LIBRARY_PATH=$LLVM10/lib:$LD_LIBRARY_PATH
+        - CXX=$LLVM10/bin/clang
+
+    - name: "Python 3.8 on Linux with LLVM10"
+      python: 3.8
       before_install:
         - ( test -d "$LLVM10" && test "$(ls -A $LLVM10)") || ( wget -O llvm10.tar.xz "https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz" && mkdir -p "$LLVM10" && tar xf llvm10.tar.xz -C "$LLVM10" --strip-components 1 )
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ jobs:
         - ( test -d "$LLVM7" && test "$(ls -A $LLVM7)") || ( wget -O llvm7.tar.xz "http://releases.llvm.org/7.0.1/clang+llvm-7.0.1-x86_64-linux-gnu-ubuntu-16.04.tar.xz" && mkdir -p "$LLVM7" && tar xf llvm7.tar.xz -C "$LLVM7" --strip-components 1 )
       env:
         - LLVM7=$HOME/LLVM7
-        - LLVM_CONFIG=$LLVM7/bin/llvm-config
-        - CLANG=$LLVM7/bin/clang
         - LD_LIBRARY_PATH=$LLVM7/lib:$LD_LIBRARY_PATH
         - CXX=$LLVM7/bin/clang
 
@@ -20,8 +18,6 @@ jobs:
         - ( test -d "$LLVM7" && test "$(ls -A $LLVM7)") || ( wget -O llvm7.tar.xz "http://releases.llvm.org/7.0.1/clang+llvm-7.0.1-x86_64-linux-gnu-ubuntu-16.04.tar.xz" && mkdir -p "$LLVM7" && tar xf llvm7.tar.xz -C "$LLVM7" --strip-components 1 )
       env:
         - LLVM7=$HOME/LLVM7
-        - LLVM_CONFIG=$LLVM7/bin/llvm-config
-        - CLANG=$LLVM7/bin/clang
         - LD_LIBRARY_PATH=$LLVM7/lib:$LD_LIBRARY_PATH
         - CXX=$LLVM7/bin/clang
 
@@ -31,8 +27,6 @@ jobs:
         - ( test -d "$LLVM10" && test "$(ls -A $LLVM10)") || ( wget -O llvm10.tar.xz "https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz" && mkdir -p "$LLVM10" && tar xf llvm10.tar.xz -C "$LLVM10" --strip-components 1 )
       env:
         - LLVM10=$HOME/LLVM10
-        - LLVM_CONFIG=$LLVM10/bin/llvm-config
-        - CLANG=$LLVM10/bin/clang
         - LD_LIBRARY_PATH=$LLVM10/lib:$LD_LIBRARY_PATH
         - CXX=$LLVM10/bin/clang
 
@@ -42,6 +36,9 @@ cache:
   directories:
     - $LLVM7
     - $LLVM10
+
+git:
+  depth: false
 
 script:
   - pip install --upgrade pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,13 @@ jobs:
         - LD_LIBRARY_PATH=$LLVM10/lib:$LD_LIBRARY_PATH
         - CXX=$LLVM10/bin/clang
 
+    - name: "Python 3.6 on macOS with gcc"
+      os: osx
+      osx_image: xcode11.6
+      compiler:
+        - gcc
+      python: 3.6
+
 cache:
   pip: true
   ccache: true
@@ -40,11 +47,13 @@ cache:
 git:
   depth: false
 
-script:
+install:
   - pip install --upgrade pip
-  - python ci/ext.py wheel
-  - pip install --upgrade dist/*.whl
   - pip install -r requirements_tests.txt
   - pip install -r requirements_extra.txt
+
+script:
+  - python ci/ext.py wheel
+  - pip install --upgrade dist/*.whl
   - python -m pytest -ra --showlocals -Werror tests
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,5 @@
 dist: bionic
-sudo: true
-
 language: python
-
-env:
-  global:
-    - TRAVIS=1
 
 jobs:
   include:
@@ -56,7 +50,4 @@ script:
   - pip install -r requirements_tests.txt
   - pip install -r requirements_extra.txt
   - python -m pytest -ra --showlocals -Werror tests
-
-git:
-  depth: 2
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,29 +3,48 @@ sudo: true
 
 language: python
 
-compiler:
-  - gcc
-
-before_install:
-  - ( test -d "$LLVM7" && test "$(ls -A $LLVM7)") || ( wget -O llvm7.tar.xz "http://releases.llvm.org/7.0.1/clang+llvm-7.0.1-x86_64-linux-gnu-ubuntu-16.04.tar.xz" && mkdir -p "$LLVM7" && tar xf llvm7.tar.xz -C "$LLVM7" --strip-components 1 )
-
 env:
   global:
     - TRAVIS=1
-    - LLVM7=$HOME/LLVM7
-    - LLVM_CONFIG=$LLVM7/bin/llvm-config
-    - CLANG=$LLVM7/bin/clang
-    - LD_LIBRARY_PATH=$LLVM7/lib:$LD_LIBRARY_PATH
+
+jobs:
+  include:
+    - name: "Python 3.5 on Linux with LLVM7"
+      python: 3.5
+      before_install:
+        - ( test -d "$LLVM7" && test "$(ls -A $LLVM7)") || ( wget -O llvm7.tar.xz "http://releases.llvm.org/7.0.1/clang+llvm-7.0.1-x86_64-linux-gnu-ubuntu-16.04.tar.xz" && mkdir -p "$LLVM7" && tar xf llvm7.tar.xz -C "$LLVM7" --strip-components 1 )
+      env:
+        - LLVM7=$HOME/LLVM7
+        - LLVM_CONFIG=$LLVM7/bin/llvm-config
+        - CLANG=$LLVM7/bin/clang
+        - LD_LIBRARY_PATH=$LLVM7/lib:$LD_LIBRARY_PATH
+
+    - name: "Python 3.6 on Linux with LLVM7"
+      python: 3.6
+      before_install:
+        - ( test -d "$LLVM7" && test "$(ls -A $LLVM7)") || ( wget -O llvm7.tar.xz "http://releases.llvm.org/7.0.1/clang+llvm-7.0.1-x86_64-linux-gnu-ubuntu-16.04.tar.xz" && mkdir -p "$LLVM7" && tar xf llvm7.tar.xz -C "$LLVM7" --strip-components 1 )
+      env:
+        - LLVM7=$HOME/LLVM7
+        - LLVM_CONFIG=$LLVM7/bin/llvm-config
+        - CLANG=$LLVM7/bin/clang
+        - LD_LIBRARY_PATH=$LLVM7/lib:$LD_LIBRARY_PATH
+
+    - name: "Python 3.6 on Linux with LLVM10"
+      python: 3.6
+      before_install:
+        - ( test -d "$LLVM10" && test "$(ls -A $LLVM10)") || ( wget -O llvm10.tar.xz "https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz" && mkdir -p "$LLVM10" && tar xf llvm10.tar.xz -C "$LLVM10" --strip-components 1 )
+      env:
+        - LLVM10=$HOME/LLVM10
+        - LLVM_CONFIG=$LLVM10/bin/llvm-config
+        - CLANG=$LLVM10/bin/clang
+        - LD_LIBRARY_PATH=$LLVM10/lib:$LD_LIBRARY_PATH
 
 cache:
   pip: true
   ccache: true
   directories:
     - $LLVM7
-
-python:
-  - "3.5"
-  - "3.6"
+    - $LLVM10
 
 script:
   - pip install --upgrade pip

--- a/ci/xbuild/compiler.py
+++ b/ci/xbuild/compiler.py
@@ -138,6 +138,7 @@ class Compiler:
                                      "variable `%s` failed to compile an "
                                      "empty file" % (compiler, envvar))
                 self.executable = compiler
+                self.linker = compiler
                 self.log.report_compiler_executable(compiler, env=envvar)
                 return
 


### PR DESCRIPTION
- configure Travis to make builds with Clang7 and Clang10 on Linux;
- fix a linker bug when `CC` or `CXX` environment variables are present.