### PR TITLE
Shut down threads during forking

### DIFF
--- a/docs/releases/v0.11.0.rst
+++ b/docs/releases/v0.11.0.rst
@@ -168,6 +168,10 @@
     datatable was built, and ``.git_diff`` which will be non-empty for builds
     from code that was modified compared to the git revision they are based on.
 
+  -[enh] During a fork the thread pool will now shut down completely, together
+    with the monitor thread. The threads will then restart in both the parent
+    and the child, when needed. [#2438]
+
   -[fix] Internal function :func:`frame_column_data_r` now works properly with
     virtual columns. [#2269]
 

--- a/src/core/parallel/thread_worker.cc
+++ b/src/core/parallel/thread_worker.cc
@@ -203,8 +203,8 @@ void idle_job::set_master_worker(thread_worker* worker) noexcept {
 
 
 void idle_job::on_before_thread_removed() {
+  xassert(n_threads_running > 0);
   n_threads_running--;
-
 }
 
 void idle_job::on_before_thread_added() {
@@ -255,7 +255,7 @@ thread_shutdown_scheduler::thread_shutdown_scheduler(
 
 
 thread_task* thread_shutdown_scheduler::get_next_task(size_t thread_index) {
-  if (thread_index < n_threads_to_keep) {
+  if (thread_index < n_threads_to_keep || thread_index == 0) {
     return nullptr;  // thread goes back to sleep
   }
   controller->on_before_thread_removed();

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -52,7 +52,9 @@ def test_multiprocessing_threadpool():
         assert len(child_threads) == n
         for chthreads in child_threads:
             assert len(parent_threads) == len(chthreads)
-            assert chthreads != parent_threads
+            # After a fork the child may or may not get the same thread IDs
+            # as the parent (this is implementation-dependent)
+            # assert chthreads != parent_threads
 
 
 @cpp_test


### PR DESCRIPTION
The fork handler was changed so that now all threads are stopped and joined before the fork.

Closes #2438