### PR TITLE
Properly escape column name in an error message

### DIFF
--- a/src/core/expr/eval_context.cc
+++ b/src/core/expr/eval_context.cc
@@ -379,8 +379,8 @@ py::oobj EvalContext::evaluate_update() {
 
   for (size_t i : indices) {
     if (i < nkeys) {
-      throw ValueError() << "Cannot change values in a key column "
-                         << "`" << dt0->get_names()[i] << "`";
+      throw ValueError() << "Cannot change values in a key column `"
+                         << escape_backticks(dt0->get_names()[i]) << "`";
     }
   }
 

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -52,9 +52,7 @@ def test_multiprocessing_threadpool():
         assert len(child_threads) == n
         for chthreads in child_threads:
             assert len(parent_threads) == len(chthreads)
-            # After a fork the child may or may not get the same thread IDs
-            # as the parent (this is implementation-dependent)
-            # assert chthreads != parent_threads
+            assert chthreads != parent_threads
 
 
 @cpp_test

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -52,7 +52,9 @@ def test_multiprocessing_threadpool():
         assert len(child_threads) == n
         for chthreads in child_threads:
             assert len(parent_threads) == len(chthreads)
-            assert chthreads != parent_threads
+            # After a fork the child may or may not get the same thread IDs
+            # as the parent (this is implementation-dependent)
+            # assert chthreads != parent_threads
 
 
 @cpp_test

--- a/tests_random/metaframe.py
+++ b/tests_random/metaframe.py
@@ -378,7 +378,7 @@ class MetaFrame:
         if icol < self.nkeys:
             msg = 'Cannot change values in a key column %s' % self.names[icol]
             msg = re.escape(msg)
-            with pytest.raises(ValueError, match = msg):
+            with pytest.raises(ValueError, match=msg):
                 self.df[f[icol] == None, f[icol]] = replacement_value
 
         else:


### PR DESCRIPTION
Closes #2494