### PR TITLE
Minor adjustment to the docs format

### DIFF
--- a/docs/develop/documentation.rst
+++ b/docs/develop/documentation.rst
@@ -276,13 +276,13 @@ The effect of this declaration is the following:
 Documenting API
 ---------------
 
-When it comes to documenting specific functions / classes / methods of the
+When it comes to documenting specific functions/classes/methods of the
 ``datatable`` module, we use another extension: ``.. xfunction::`` (or
 ``.. xclass::``, ``.. xmethod::``, etc). This is because this part of the
 documentation is declared within the C++ code, so that it can be available
 from within a regular python session.
 
-Inside the documentation tree, each function / method / etc that has to be
+Inside the documentation tree, each function/method/etc that has to be
 documented is declared as follows::
 
     .. xfunction:: datatable.rbind

--- a/docs/releases/v0.10.0.rst
+++ b/docs/releases/v0.10.0.rst
@@ -28,7 +28,7 @@
         float if select_floats else
         None]
 
-  In addition, columnsets can be added / subtracted, allowing to express a richer
+  In addition, columnsets can be added/subtracted, allowing to express a richer
   selection of columns::
 
       f[int].extend(f[float])   # all integers and floating point columns

--- a/docs/releases/v0.11.0.rst
+++ b/docs/releases/v0.11.0.rst
@@ -50,7 +50,7 @@
     given a numeric column index outside of the allowed range. Previously it
     was throwing a ``ValueError`` in both cases.
 
-  -[api] When creating a Frame from a list containing mixed integers / floats
+  -[api] When creating a Frame from a list containing mixed integers/floats
     and strings, the resulting Frame will now have stype ``str32``. Previously
     an ``obj64`` column was created instead. The new behavior is more
     consistent with fread's behavior when reading CSV files.

--- a/docs/releases/v0.2.1.rst
+++ b/docs/releases/v0.2.1.rst
@@ -18,7 +18,7 @@
     ``countna`` for numeric and boolean columns.
 
   -[new] Getter ``df.internal.rowindex`` allows access to the RowIndex on the
-    DataTable (for inspection / reuse).
+    DataTable (for inspection/reuse).
 
   -[enh] In addition to LLVM4 environmental variable, datatable will now also
     look for the ``llvm4`` folder within the package's directory.

--- a/docs/releases/v0.2.2.rst
+++ b/docs/releases/v0.2.2.rst
@@ -21,7 +21,7 @@
   -[enh] Fread now prints file sizes in "human-readable" form, i.e. KB/MB/GB
     instead of bytes.
 
-  -[enh] Fread can now understand a variety of "NaN" / "Inf" literals produced
+  -[enh] Fread can now understand a variety of "NaN"/"Inf" literals produced
     by different systems.
 
   -[enh] Add option ``hex`` to csv writer, which controls whether floats will

--- a/docs/releases/v0.3.1.rst
+++ b/docs/releases/v0.3.1.rst
@@ -52,7 +52,7 @@
   -[api] function-valued ``columns`` parameter in :func:`fread` has been
     changed: if previously the function was invoked for every column, now it
     receives the list of all columns at once, and is expected to return a
-    modified list (or dict / set / etc). Each column description in the list
+    modified list (or dict/set/etc). Each column description in the list
     that the function receives carries the columns name and stype, in the
     future ``format`` field will also be added.
 

--- a/docs/releases/v0.4.0.rst
+++ b/docs/releases/v0.4.0.rst
@@ -15,7 +15,7 @@
   -[enh] Added option ``fread.anonymize`` which forces fread to anonymize all
     user input in the verbose logs / error messages.
 
-  -[enh] Allow type-casts from booleans / integers / floats into strings.
+  -[enh] Allow type-casts from booleans/integers/floats into strings.
 
 
   .. contributors::

--- a/docs/releases/v0.6.0.rst
+++ b/docs/releases/v0.6.0.rst
@@ -38,7 +38,7 @@
   -[fix] If the input contains excessively long lines, :func:`fread()` will no
     longer waste time printing a sample of first 5 lines in verbose mode.
 
-  -[fix] Fixed wrong calculation of mean/standard deviation of line length in
+  -[fix] Fixed wrong calculation of mean / standard deviation of line length in
     :func:`fread` if the sample contained broken lines.
 
   -[fix] Frame view will no longer get stuck in a Jupyter notebook.

--- a/docs/releases/v0.6.0.rst
+++ b/docs/releases/v0.6.0.rst
@@ -38,7 +38,7 @@
   -[fix] If the input contains excessively long lines, :func:`fread()` will no
     longer waste time printing a sample of first 5 lines in verbose mode.
 
-  -[fix] Fixed wrong calculation of mean / standard deviation of line length in
+  -[fix] Fixed wrong calculation of mean/standard deviation of line length in
     :func:`fread` if the sample contained broken lines.
 
   -[fix] Frame view will no longer get stuck in a Jupyter notebook.

--- a/docs/start/quick-start.rst
+++ b/docs/start/quick-start.rst
@@ -201,7 +201,7 @@ used to refer to the columns of the joined frame.
 
 
 
-Groupbys / joins
+Groupbys/joins
 ----------------
 
 In the `Data Manipulation`_ section we mentioned that the ``DT[i, j, ...]`` selector

--- a/docs/start/using-datatable.rst
+++ b/docs/start/using-datatable.rst
@@ -201,7 +201,7 @@ Perform groupby calculations using::
 Append Rows/Columns
 -------------------
 
-Append rows / columns to a Frame using :meth:`Frame.cbind() <datatable.Frame.cbind>`::
+Append rows/columns to a Frame using :meth:`Frame.cbind() <datatable.Frame.cbind>`::
 
     DT1.cbind(DT2, DT3)
     DT1.rbind(DT4, force=True)


### PR DESCRIPTION
A minor consistency change: do not use spaces around slashes, if a particular slash separates two words.