### PR TITLE
Temporarily disable monitor thread

### DIFF
--- a/src/core/parallel/api.h
+++ b/src/core/parallel/api.h
@@ -141,8 +141,20 @@ void parallel_for_ordered(size_t n_iterations,
                           function<void(ordered*)> fn);
 
 
-std::mutex& python_mutex();
+// std::mutex& python_mutex();
 std::mutex& team_mutex();
+
+
+class PythonLock {
+  private:
+    std::lock_guard<std::recursive_mutex>  lock_;
+
+  public:
+    PythonLock();
+};
+
+
+
 
 }  // namespace dt
 

--- a/src/core/parallel/monitor_thread.cc
+++ b/src/core/parallel/monitor_thread.cc
@@ -97,7 +97,7 @@ void monitor_thread::run() noexcept {
 
   _set_thread_num(size_t(-1));
 
-  std::unique_lock<std::mutex> lock(dt::python_mutex());
+  std::unique_lock<std::recursive_mutex> lock(thpool->python_mutex);
   while (running_) {
     // Sleep state
     while (!monitor_thread_active && running_) {
@@ -144,7 +144,8 @@ void monitor_thread::set_active(bool a) noexcept {
 
 
 void monitor_thread::stop_running() {
-  std::lock_guard<std::mutex> lock(dt::python_mutex());
+  // std::lock_guard<std::mutex> lock(dt::python_mutex());
+  PythonLock pylock;
   running_ = false;
   monitor_thread_active = 0;
   sleep_state_cv_.notify_one();

--- a/src/core/parallel/monitor_thread.h
+++ b/src/core/parallel/monitor_thread.h
@@ -38,7 +38,7 @@ class monitor_thread {
   private:
     std::thread             thread_;
     idle_job*               controller_;
-    std::condition_variable sleep_state_cv_;
+    std::condition_variable_any sleep_state_cv_;
     bool                    running_;
     size_t : 56;
 

--- a/src/core/parallel/parallel_for_ordered.cc
+++ b/src/core/parallel/parallel_for_ordered.cc
@@ -364,9 +364,10 @@ void ordered::parallel(function<void(size_t)> pre_ordered,
       do_ordered(i);
       post_ordered(i);
       sch->work.add_done_amount(1);
-      if (progress::manager->is_interrupt_occurred()) {
-        progress::manager->handle_interrupt();
-      }
+      progress::manager->check_interrupts_main();
+      // if (progress::manager->is_interrupt_occurred()) {
+      //   progress::manager->handle_interrupt();
+      // }
     }
     return;
   }

--- a/src/core/parallel/parallel_for_static.h
+++ b/src/core/parallel/parallel_for_static.h
@@ -130,6 +130,7 @@ void parallel_for_static(size_t n_iterations,
         func(i);
       }
       i0 += chunk_size_;
+      progress::manager->check_interrupts_main();
       if (progress::manager->is_interrupt_occurred()) {
         i0 = n_iterations;
         progress::manager->handle_interrupt();
@@ -141,6 +142,7 @@ void parallel_for_static(size_t n_iterations,
   parallel_region(
     NThreads(num_threads),
     [=] {
+      const bool is_main_thread = (this_thread_index() == 0);
       size_t i0 = chunk_size_ * this_thread_index();
       size_t di = chunk_size_ * num_threads;
       while (i0 < n_iterations) {
@@ -149,7 +151,10 @@ void parallel_for_static(size_t n_iterations,
           func(i);
         }
         i0 += di;
-      if (progress::manager->is_interrupt_occurred()) {
+        if (is_main_thread) {
+          progress::manager->check_interrupts_main();
+        }
+        if (progress::manager->is_interrupt_occurred()) {
           i0 = n_iterations;
         }
       }

--- a/src/core/parallel/thread_pool.cc
+++ b/src/core/parallel/thread_pool.cc
@@ -41,6 +41,15 @@ thread_pool* thpool = new thread_pool;
 
 
 //------------------------------------------------------------------------------
+// PythonLock
+//------------------------------------------------------------------------------
+
+PythonLock::PythonLock()
+  : lock_(thpool->python_mutex) {}
+
+
+
+//------------------------------------------------------------------------------
 // thread_pool
 //------------------------------------------------------------------------------
 
@@ -224,9 +233,10 @@ size_t get_hardware_concurrency() noexcept {
 }
 
 
-std::mutex& python_mutex() {
-  return thpool->python_mutex;
-}
+// std::mutex& python_mutex() {
+//   return thpool->python_mutex;
+// }
+
 
 std::mutex& team_mutex() {
   return thpool->global_mutex;

--- a/src/core/parallel/thread_pool.cc
+++ b/src/core/parallel/thread_pool.cc
@@ -185,6 +185,7 @@ thread_team* thread_pool::get_team_unchecked() noexcept {
 
 
 void thread_pool::enable_monitor(bool a) noexcept {
+  (void) a;
   // init_monitor_thread();
   // monitor->set_active(a);
 }

--- a/src/core/parallel/thread_pool.cc
+++ b/src/core/parallel/thread_pool.cc
@@ -1,17 +1,23 @@
 //------------------------------------------------------------------------------
-// Copyright 2019 H2O.ai
+// Copyright 2019-2020 H2O.ai
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
 //
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #include <thread>      // std::thread::hardware_concurrency
 #include "parallel/api.h"
@@ -27,8 +33,6 @@
 #if !DT_OS_WINDOWS
   #include <pthread.h>   // pthread_atfork
 #endif
-
-
 namespace dt {
 
 
@@ -70,6 +74,8 @@ thread_pool* thpool = new thread_pool;
   static bool fork_handlers_registered = false;
 
 #endif
+
+
 
 thread_pool::thread_pool()
   : num_threads_requested(0),
@@ -137,11 +143,11 @@ void thread_pool::instantiate_threads() {
 
 
 void thread_pool::init_monitor_thread() noexcept {
-  if (!monitor) {
-    monitor = std::unique_ptr<monitor_thread>(
-                new monitor_thread(&controller)
-              );
-  }
+  // if (!monitor) {
+  //   monitor = std::unique_ptr<monitor_thread>(
+  //               new monitor_thread(&controller)
+  //             );
+  // }
 }
 
 
@@ -170,8 +176,8 @@ thread_team* thread_pool::get_team_unchecked() noexcept {
 
 
 void thread_pool::enable_monitor(bool a) noexcept {
-  init_monitor_thread();
-  monitor->set_active(a);
+  // init_monitor_thread();
+  // monitor->set_active(a);
 }
 
 

--- a/src/core/parallel/thread_pool.h
+++ b/src/core/parallel/thread_pool.h
@@ -1,17 +1,23 @@
 //------------------------------------------------------------------------------
-// Copyright 2019 H2O.ai
+// Copyright 2019-2020 H2O.ai
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
 //
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #ifndef dt_PARALLEL_THREAD_POOL_h
 #define dt_PARALLEL_THREAD_POOL_h
@@ -23,6 +29,8 @@
 namespace dt {
 
 class thread_team;
+class PythonLock;
+
 
 
 /**
@@ -45,7 +53,9 @@ class thread_team;
  */
 class thread_pool {
   friend class thread_team;
-  friend std::mutex& python_mutex();
+  friend class monitor_thread;
+  friend class PythonLock;
+  // friend std::recursive_mutex& python_mutex();
   friend std::mutex& team_mutex();
   public:
     std::unique_ptr<monitor_thread> monitor;
@@ -77,7 +87,7 @@ class thread_pool {
     std::mutex global_mutex;
 
     // Mutex that guards access to python runtime
-    std::mutex python_mutex;
+    std::recursive_mutex python_mutex;
 
     // TODO: merge thread_team functionality into the pool?
     thread_team* current_team;

--- a/src/core/parallel/thread_worker.cc
+++ b/src/core/parallel/thread_worker.cc
@@ -75,7 +75,7 @@ void thread_worker::run() noexcept {
         scheduler = controller;
       }
     } catch (...) {
-      enable_monitor(false);
+      // enable_monitor(false);
       controller->catch_exception();
       scheduler->abort_execution();
     }
@@ -98,8 +98,9 @@ void thread_worker::run_master(thread_scheduler* job) noexcept {
       thread_task* task = job->get_next_task(0);
       if (!task) break;
       task->execute(this);
+      progress::manager->check_interrupts_main();
     } catch (...) {
-      enable_monitor(false);
+      // enable_monitor(false);
       controller->catch_exception();
       job->abort_execution();
     }
@@ -174,7 +175,7 @@ void idle_job::awaken_and_run(thread_scheduler* job, size_t nthreads) {
 
   prev_sleep_task->next_scheduler = job;
   prev_sleep_task->semaphore.signal(nth);
-  enable_monitor(true);
+  // enable_monitor(true);
   master_worker->run_master(job);
 }
 
@@ -188,7 +189,7 @@ void idle_job::join() {
   // Clear `.next_scheduler` flag of the previous sleep task, indicating that
   // we no longer run in a parallel region (see `is_running()`).
   prev_sleep_task->next_scheduler = nullptr;
-  enable_monitor(false);
+  // enable_monitor(false);
 
   if (saved_exception) {
     progress::manager->reset_interrupt_status();

--- a/src/core/parallel/thread_worker.cc
+++ b/src/core/parallel/thread_worker.cc
@@ -162,6 +162,7 @@ thread_task* idle_job::get_next_task(size_t) {
  */
 void idle_job::awaken_and_run(thread_scheduler* job, size_t nthreads) {
   xassert(job);
+  xassert(this_thread_index() == 0);
   xassert(n_threads_running == 0);
   xassert(prev_sleep_task->next_scheduler == nullptr);
   xassert(curr_sleep_task->next_scheduler == nullptr);
@@ -180,6 +181,7 @@ void idle_job::awaken_and_run(thread_scheduler* job, size_t nthreads) {
 
 // Wait until all threads go back to sleep (which would mean the job is done)
 void idle_job::join() {
+  xassert(this_thread_index() == 0);
   // Busy-wait until all threads finish running
   while (n_threads_running.load() != 0);
 

--- a/src/core/progress/progress_bar.cc
+++ b/src/core/progress/progress_bar.cc
@@ -134,6 +134,7 @@ void progress_bar_enabled::refresh() {
 
   if (force_redraw || now >= time_next_update) {
     time_next_update = now + update_interval;
+    HidePythonError hpe;
     if (pyfn_external)
       _report_to_python();
     else

--- a/src/core/progress/progress_manager.cc
+++ b/src/core/progress/progress_manager.cc
@@ -119,6 +119,21 @@ void progress_manager::set_status_cancelled() noexcept {
 }
 
 
+void progress_manager::check_interrupts_main() {
+  xassert(dt::this_thread_index() == 0);
+  std::lock_guard<std::mutex> lock(dt::python_mutex());
+
+  if (PyErr_CheckSignals()) {
+    if (pbar) pbar->set_status_error(true);
+    interrupt_status = InterruptStatus::ABORT_EXECUTION;
+    throw PyError();
+  }
+  if (pbar) {
+    pbar->refresh();
+  }
+}
+
+
 
 
 }} // namespace dt::progress

--- a/src/core/progress/progress_manager.cc
+++ b/src/core/progress/progress_manager.cc
@@ -121,7 +121,8 @@ void progress_manager::set_status_cancelled() noexcept {
 
 void progress_manager::check_interrupts_main() {
   xassert(dt::this_thread_index() == 0);
-  std::lock_guard<std::mutex> lock(dt::python_mutex());
+  // std::lock_guard<std::recursive_mutex> lock(dt::python_mutex());
+  PythonLock pylock;
 
   if (PyErr_CheckSignals()) {
     if (pbar) pbar->set_status_error(true);

--- a/src/core/progress/progress_manager.h
+++ b/src/core/progress/progress_manager.h
@@ -100,6 +100,8 @@ class progress_manager {
     void reset_interrupt_status() const noexcept;
     void handle_interrupt() const;
     void set_status_cancelled() noexcept;
+
+    void check_interrupts_main();
 };
 
 

--- a/src/core/utils/logger.cc
+++ b/src/core/utils/logger.cc
@@ -286,7 +286,8 @@ void Logger::end_section() noexcept {
 
 
 void Logger::emit(std::string&& msg, bool warning) {
-  std::lock_guard<std::mutex> pylock(dt::python_mutex());
+  // std::lock_guard<std::mutex> pylock(dt::python_mutex());
+  PythonLock pylock;
   CallLoggerLock loglock;
   // Use user-defined logger object
   if (pylogger_) {

--- a/src/core/utils/temporary_file.cc
+++ b/src/core/utils/temporary_file.cc
@@ -30,7 +30,7 @@
 
 
 static std::string get_temp_dir() {
-  std::lock_guard<std::mutex> lock(dt::python_mutex());
+  dt::PythonLock lock;
   auto gettempdirfn = py::oobj::import("tempfile", "gettempdir");
   auto tempdir = gettempdirfn.call();
   return tempdir.to_string();


### PR DESCRIPTION
- `monitor_thread` is disabled for now, in order to check whether it has any effect on datatable's stability;
- without the monitor thread, the race condition in #2510 should no longer occur;
- `python_mutex` is converted into an `std::recursive_mutex`, in order to avoid potential deadlocks on the main thread;

If extensive testing shows this approach to be more viable than the previous ones, we'll remove the monitor thread's code entirely. For now it is merely commented out.

Closes #2510