### PR TITLE
Fix faulty assert in py_buffers

### DIFF
--- a/src/core/py_buffers.cc
+++ b/src/core/py_buffers.cc
@@ -191,7 +191,7 @@ static void try_to_resolve_object_column(Column& col)
       }
     }
 
-    xassert(offset < strbuf.size());
+    xassert(offset <= strbuf.size());
     strbuf.resize(offset);
     col = Column::new_string_column(nrows, std::move(offbuf), std::move(strbuf));
   }

--- a/tests/frame/test-create.py
+++ b/tests/frame/test-create.py
@@ -1019,6 +1019,12 @@ def test_create_from_pandas_categorical(pandas):
                                ["(6.0, 9.0]"] * 3))
 
 
+def test_issue2517(pandas):
+    DT = dt.Frame(pandas.DataFrame(['секрет秘密']))
+    assert_equals(DT, dt.Frame(['секрет秘密'], names=["0"]))
+
+
+
 
 #-------------------------------------------------------------------------------
 # Create from Numpy


### PR DESCRIPTION
It is perfectly valid for the last `offset` to be equal to the size of `strbuf`.

Closes #2517