### PR TITLE
Fix predict progress in FTRL, adjust nested_for_static

### DIFF
--- a/src/core/models/dt_ftrl.cc
+++ b/src/core/models/dt_ftrl.cc
@@ -823,7 +823,8 @@ dtptr Ftrl<T>::predict(const DataTable* dt_X) {
   bool k_binomial;
 
   // Set progress reporting
-  size_t work_total = dt_X->nrows() / nthreads.get();
+  size_t work_total = get_work_amount(dt_X->nrows());
+
   dt::progress::work job(work_total);
   job.set_message("Predicting...");
 
@@ -831,7 +832,9 @@ dtptr Ftrl<T>::predict(const DataTable* dt_X) {
     uint64ptr x = uint64ptr(new uint64_t[nfeatures]);
     tptr<T> w = tptr<T>(new T[nfeatures]);
 
-    dt::nested_for_static(dt_X->nrows(), [&](size_t i) {
+    dt::nested_for_static(dt_X->nrows(),
+                          ChunkSize(MIN_ROWS_PER_THREAD),
+                          [&](size_t i) {
       // Predicting for all the `nlabels`
       hash_row(x, hashers, i);
       for (size_t k = 0; k < nlabels; ++k) {

--- a/src/core/models/dt_ftrl.cc
+++ b/src/core/models/dt_ftrl.cc
@@ -832,9 +832,7 @@ dtptr Ftrl<T>::predict(const DataTable* dt_X) {
     uint64ptr x = uint64ptr(new uint64_t[nfeatures]);
     tptr<T> w = tptr<T>(new T[nfeatures]);
 
-    dt::nested_for_static(dt_X->nrows(),
-                          ChunkSize(MIN_ROWS_PER_THREAD),
-                          [&](size_t i) {
+    dt::nested_for_static(dt_X->nrows(), ChunkSize(MIN_ROWS_PER_THREAD), [&](size_t i) {
       // Predicting for all the `nlabels`
       hash_row(x, hashers, i);
       for (size_t k = 0; k < nlabels; ++k) {

--- a/src/core/parallel/parallel_for_static.h
+++ b/src/core/parallel/parallel_for_static.h
@@ -226,12 +226,17 @@ void nested_for_static(size_t n_iterations, ChunkSize chunk_size, F func)
   size_t chsize = chunk_size.get();
   size_t i0 = chsize * this_thread_index();
   size_t di = chsize * num_threads_in_team();
+  const bool is_main_thread = (this_thread_index() == 0);
+
   while (i0 < n_iterations) {
     size_t i1 = std::min(i0 + chsize, n_iterations);
     for (size_t i = i0; i < i1; ++i) {
       func(i);
     }
     i0 += di;
+    if (is_main_thread) {
+      progress::manager->check_interrupts_main();
+    }
     if (progress::manager->is_interrupt_occurred()) {
       i0 = n_iterations;
     }


### PR DESCRIPTION
- fix predict progress in FTRL;
- add interrupts check to the `nested_for_static` (follow-up for #2516).

Closes #2519 