### PR TITLE
Fix deadlock in barrier when an exception occurs

### DIFF
--- a/src/core/parallel/thread_team.cc
+++ b/src/core/parallel/thread_team.cc
@@ -49,8 +49,9 @@ size_t thread_team::size() const noexcept {
 void thread_team::wait_at_barrier() {
   size_t n = barrier_counter.fetch_add(1);
   size_t n_target = n - (n % nthreads) + nthreads;
-  while (barrier_counter.load() < n_target &&
-         !progress::manager->is_interrupt_occurred());
+  while (barrier_counter.load() < n_target) {
+    if (progress::manager->is_interrupt_occurred()) throw std::exception();
+  }
 }
 
 

--- a/src/core/parallel/thread_team.cc
+++ b/src/core/parallel/thread_team.cc
@@ -49,7 +49,8 @@ size_t thread_team::size() const noexcept {
 void thread_team::wait_at_barrier() {
   size_t n = barrier_counter.fetch_add(1);
   size_t n_target = n - (n % nthreads) + nthreads;
-  while (barrier_counter.load() < n_target);
+  while (barrier_counter.load() < n_target &&
+         !progress::manager->is_interrupt_occurred());
 }
 
 

--- a/src/core/parallel/thread_worker.cc
+++ b/src/core/parallel/thread_worker.cc
@@ -224,6 +224,7 @@ void idle_job::on_before_thread_added() {
 void idle_job::catch_exception() noexcept {
   try {
     std::lock_guard<std::mutex> lock(mutex);
+    progress::manager->set_interrupt();
     if (!saved_exception) {
       saved_exception = std::current_exception();
     }

--- a/src/core/progress/progress_manager.cc
+++ b/src/core/progress/progress_manager.cc
@@ -126,7 +126,11 @@ void progress_manager::check_interrupts_main() {
 
   if (PyErr_CheckSignals()) {
     if (pbar) pbar->set_status_error(true);
-    interrupt_status = InterruptStatus::ABORT_EXECUTION;
+    // Do not set interrupt status here, otherwise another thread
+    // might see that status and throw its own exception before this
+    // one has a chance of getting processed.
+    // Instead, the interrupt status will be set in
+    // `Job_Idle::catch_exception()`
     throw PyError();
   }
   if (pbar) {


### PR DESCRIPTION
The problem may happen if some of the threads arrive at a barrier, while some other thread throws an exception. In such a case the threads at a barrier will be left waiting forever...

This fixes test `tests/test_parallel.py::test_progress_interrupt[nested-6]`.