### PR TITLE
Exception initialization is now done at datatable import

### DIFF
--- a/docs/releases/v0.11.0.rst
+++ b/docs/releases/v0.11.0.rst
@@ -191,6 +191,9 @@
   -[fix] Column names containing backticks now display properly in error
     messages. [#2406]
 
+  -[fix] Fixed rare race condition when multiple threads tried to throw an
+    exception at the same time. [#2526]
+
   -[api] All exceptions thrown by datatable are now declared in the
     ``datatable.exceptions`` module. These exceptions are now organized to
     derive from the common base class ``DtException``.

--- a/src/core/datatablemodule.cc
+++ b/src/core/datatablemodule.cc
@@ -51,6 +51,7 @@
 #include "read/py_read_iterator.h"
 #include "sort.h"
 #include "utils/assert.h"
+#include "utils/exceptions.h"
 #include "utils/macros.h"
 #include "utils/terminal/terminal.h"
 #include "utils/terminal/terminal_stream.h"
@@ -333,6 +334,14 @@ static void initialize_options(const py::PKArgs& args) {
 }
 
 
+static py::PKArgs args_initialize_final(
+  0, 0, 0, false, false, {}, "initialize_final", "");
+
+static void initialize_final(const py::PKArgs&) {
+  init_exceptions();
+}
+
+
 
 
 //------------------------------------------------------------------------------
@@ -347,6 +356,7 @@ void py::DatatableModule::init_methods() {
   ADD_FN(&frame_integrity_check, args_frame_integrity_check);
   ADD_FN(&get_thread_ids, args_get_thread_ids);
   ADD_FN(&initialize_options, args_initialize_options);
+  ADD_FN(&initialize_final, args_initialize_final);
   ADD_FN(&compiler_version, args_compiler_version);
   ADD_FN(&regex_supported, args_regex_supported);
   ADD_FN(&apply_color, args_apply_color);

--- a/src/core/options.cc
+++ b/src/core/options.cc
@@ -106,10 +106,10 @@ void config_option::impl_init_type(XTypeMaker& xt) {
 namespace dt {
 
 
-static py::oobj dt_options = nullptr;
+static PyObject* dt_options = nullptr;
 
 void use_options_store(py::oobj options) {
-  dt_options = options;
+  dt_options = std::move(options).release();
 }
 
 
@@ -130,12 +130,12 @@ void register_option(const char* name,
   p->getter = std::move(getter);
   p->setter = std::move(setter);
   p->arg = new py::Arg(name);
-  dt_options.invoke("register", opt);
+  py::robj(dt_options).invoke("register", opt);
 }
 
 
 py::oobj get_option(const char* name) {
-  return dt_options.invoke("get", py::ostring(name));
+  return py::robj(dt_options).invoke("get", py::ostring(name));
 }
 
 void init_config_option(void* module) {

--- a/src/core/utils/exceptions.h
+++ b/src/core/utils/exceptions.h
@@ -33,6 +33,9 @@ void exception_to_python(const std::exception&) noexcept;
 
 std::string escape_backticks(const std::string&);
 
+void init_exceptions();  // called during module initialization
+
+
 
 //------------------------------------------------------------------------------
 
@@ -40,13 +43,12 @@ class Error : public std::exception
 {
   protected:
     std::ostringstream error;
-    // Owned reference; however do not use a py::oobj here in order
+    // Borrowed reference; however do not use a py::robj here in order
     // to avoid circular dependencies
-    PyObject* pycls;
+    PyObject* pycls_;
 
 public:
   Error(PyObject* cls);
-  Error(py::oobj cls);
   Error(const Error& other);
   Error(Error&& other);
   Error& operator=(Error&& other);
@@ -132,7 +134,6 @@ Error ValueError();
 class Warning : public Error {
   public:
     Warning(PyObject* cls);
-    Warning(py::oobj cls);
     Warning(const Warning&) = default;
 
     void emit();

--- a/src/datatable/__init__.py
+++ b/src/datatable/__init__.py
@@ -52,12 +52,12 @@ from .lib._datatable import (
     unique,
     update,
 )
-from .options import options
 from .str import split_into_nhot
 from .types import stype, ltype
 import datatable.math
 import datatable.internal
 import datatable.exceptions
+import datatable.options
 try:
     from ._build_info import build_info
     __version__ = build_info.version
@@ -128,6 +128,9 @@ dt = datatable
 # This will run only in Jupyter notebook
 init_styles()
 
+options = datatable.options.Config(options={}, prefix="")
+datatable.lib._datatable.initialize_options(options)
+datatable.lib._datatable.initialize_final()
 
 def open(path):
     """

--- a/src/datatable/options.py
+++ b/src/datatable/options.py
@@ -259,13 +259,3 @@ class Option:
         self._value = x
         if self._onchange is not None:
             self._onchange(x)
-
-
-
-
-#-------------------------------------------------------------------------------
-# Global options store
-#-------------------------------------------------------------------------------
-
-options = Config(options={}, prefix="")
-core.initialize_options(options)


### PR DESCRIPTION
Previously, we had function `init()` in exceptions.cc trying to initialize exception objects when they were first needed (i.e. when an exception was first thrown). However, because this was not done in thread-safe manner, it was possible to get a situation when multiple threads are trying to initialize those exception objects at the same time, resulting in undefined behavior, up to and including a segfault.

In order to avoid this, now we initialize all exception objects upon module import (in the special "after-import" stage), when no threads are in play, and consequently there is no possibility for any race conditions.

In addition, initialization of python `options` object moved to `__init__.py` in order to make the initialization sequence more well-defined.

Closes #2526