### PR TITLE
Created ..xcode::shell Sphinx directive

### DIFF
--- a/docs/_static/xcode.css
+++ b/docs/_static/xcode.css
@@ -21,25 +21,25 @@ div.document p + .xcode {
 
 
 /*------------------------------------------------------------------------------
- * shell
+ * console
  *-----------------------------------------------------------------------------*/
 
-.xcode.shell {
+.xcode.console {
 	background-color: #444;
 	border: none;
-	color: #c1c1c1;
+	color: #dadada;
 }
 
-.xcode.shell .prompt {
-	opacity: 0.5;
+.xcode.console .prompt {
+	opacity: 0.35;
 	user-select: none;
 }
 
-.xcode.shell .program {
+.xcode.console .program {
 	color: #ffffae;
 }
 
-.xcode.shell .comment {
+.xcode.console .comment {
 	color: #558080;
 	font-style: italic;
 }

--- a/docs/_static/xcode.css
+++ b/docs/_static/xcode.css
@@ -1,0 +1,45 @@
+
+.xcode {
+	font-family: SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, Courier New, Courier, monospace;
+	font-size: 12px;
+	line-height: 1.4;
+	margin: 0 0 12pt 36pt;
+	overflow-x: auto;
+	padding: 8px 12px;
+	white-space: pre;
+}
+
+div.document p + .xcode {
+	margin-top: -22px;
+}
+
+.rst-content .section ol li>p + .xcode,
+.rst-content .section ul li>p + .xcode {
+	margin-left: 24px;
+	margin-top: -10px;
+}
+
+
+/*------------------------------------------------------------------------------
+ * shell
+ *-----------------------------------------------------------------------------*/
+
+.xcode.shell {
+	background-color: #444;
+	border: none;
+	color: #c1c1c1;
+}
+
+.xcode.shell .prompt {
+	opacity: 0.5;
+	user-select: none;
+}
+
+.xcode.shell .program {
+	color: #ffffae;
+}
+
+.xcode.shell .comment {
+	color: #558080;
+	font-style: italic;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,6 +50,7 @@ needs_sphinx = '1.8'
 # ones.
 extensions = [
     'sphinxext.dtframe_directive',
+    'sphinxext.xcode',
     'sphinxext.xcontributors',
     'sphinxext.xfunction',
     'sphinxext.dt_changelog',

--- a/docs/develop/contrib.rst
+++ b/docs/develop/contrib.rst
@@ -37,19 +37,19 @@ these steps in order to set up your local development environment:
 
 3. Clone the repository on your local computer:
 
-   .. code-block:: bash
+   .. xcode:: shell
 
-      git clone https://github.com/your_user_name/datatable
+      $ git clone https://github.com/your_user_name/datatable
 
 4. Lastly, add the original ``datatable`` repository as the upstream:
 
-   .. code-block:: bash
+   .. xcode:: shell
 
-      cd datatable
-      git remote add upstream https://github.com/h2oai/datatable
-      git fetch upstream
-      git config branch.master.remote upstream
-      git config branch.master.merge refs/heads/master
+      $ cd datatable
+      $ git remote add upstream https://github.com/h2oai/datatable
+      $ git fetch upstream
+      $ git config branch.master.remote upstream
+      $ git config branch.master.merge refs/heads/master
 
 This completes the setup of your local datatable fork. Make sure to note
 the location of the ``datatable/`` directory that you created in step 3.
@@ -63,10 +63,10 @@ Creating a contribution
 Start by fetching any changes that might have occurred since the last time
 you were working with the repository:
 
-.. code-block:: bash
+.. xcode:: shell
 
-   git checkout master
-   git pull
+   $ git checkout master
+   $ git pull
 
 
 Then create a new local branch where you will be working on your changes.
@@ -75,9 +75,9 @@ recognize what this branch is about. It's a good idea to prefix the branch
 name with your initials so that it doesn't conflict with branches from other
 developers:
 
-.. code-block:: bash
+.. xcode:: shell
 
-   git checkout -b your_branch_name
+   $ git checkout -b your_branch_name
 
 
 After this it is time to make the desired changes to the project. There are
@@ -94,9 +94,9 @@ order by running ``git status`` -- it should say "nothing to commit, working
 tree clean". At this point the changes need to be pushed into the "origin",
 which is your repository fork:
 
-.. code-block:: bash
+.. xcode:: shell
 
-   git push origin your_branch_name
+   $ git push origin your_branch_name
 
 Then go back to the GitHub website to your fork of the datatable repository
 https://github.com/your_user_name/datatable. There you should see a pop-up

--- a/docs/develop/documentation.rst
+++ b/docs/develop/documentation.rst
@@ -10,9 +10,9 @@ The basic workflow for developing documentation, after
 :ref:`setting up a local datatable repository <local-setup>`, is to go into
 the ``docs/`` directory and run
 
-.. code-block:: bash
+.. xcode:: shell
 
-    make html
+    $ make html
 
 After that, if there were no errors, the documentation can be viewed locally
 by opening the file ``docs/_build/html/index.html`` in a browser.
@@ -96,15 +96,15 @@ paragraph (code) indented with 4 spaces::
         print("Hello, world!", flush=True)
 
 
-A slightly more advanced method is to use an explicit ``code-block`` directive::
+A slightly more advanced method is to use an explicit ``xcode`` directive::
 
-    .. code-block:: bash
+    .. xcode:: shell
 
         $ pip install datatable
 
 This directive allows you to explicitly select the language of your code snippet,
-which will affect how it is highlighted. The code inside ``code-block`` must be
-indented, and there has to be an empty line between the ``.. code-block::``
+which will affect how it is highlighted. The code inside ``xcode`` must be
+indented, and there has to be an empty line between the ``.. xcode::``
 declaration and the actual code.
 
 

--- a/docs/start/install.rst
+++ b/docs/start/install.rst
@@ -8,15 +8,16 @@ Prerequisites
 
 Python 3.5 or newer is a prerequisite. You can check your python version via
 
-.. code-block:: bash
+.. xcode:: shell
 
    $ python --version
+
 
 If you don't have Python 3.5 or later, you may want to download and install
 the newest version of Python, and then create and activate a virtual
 environment for that Python. For example:
 
-.. code-block:: bash
+.. xcode:: shell
 
    $ virtualenv --python=python3.6 ~/py36
    $ source ~/py36/bin/activate
@@ -28,7 +29,7 @@ Install on macOS and Linux
 
 Run the following command to install ``datatable`` on macOS and Linux:
 
-.. code-block:: bash
+.. xcode:: shell
 
   $ pip install datatable
 
@@ -48,7 +49,7 @@ To do so, simply click on the master build of your choice and
 then navigate to ``Artifacts``. Copy the wheel URL that corresponds
 to your version of Python and then install it as:
 
-.. code-block:: bash
+.. xcode:: shell
 
    C:\> pip install YOUR_WHEEL_URL
 
@@ -60,7 +61,7 @@ Build from Source
 In order to install the latest development version of `datatable` directly
 from GitHub, run the following command:
 
-.. code-block:: bash
+.. xcode:: shell
 
    $ pip install git+https://github.com/h2oai/datatable
 
@@ -78,20 +79,20 @@ own functionality, you are welcome to do so.
 
 1. First, clone ``datatable`` repository from GitHub:
 
-   .. code-block:: bash
+   .. xcode:: shell
 
       $ git clone https://github.com/h2oai/datatable
 
 2. Make ``datatable``:
 
-   .. code-block:: bash
+   .. xcode:: shell
 
       $ make test_install
       $ make
 
 3. Additional commands you may find occasionally interesting:
 
-   .. code-block:: bash
+   .. xcode:: shell
 
      # Build a debug version of datatable (for example suitable for ``gdb`` debugging)
      $ make debug
@@ -121,7 +122,7 @@ Troubleshooting
 - On macOS, if you are getting an error ``fatal error: 'sys/mman.h' file not
   found``, this can be fixed by installing the Xcode Command Line Tools:
 
-  .. code-block:: bash
+  .. xcode:: shell
 
      $ xcode-select --install
 

--- a/docs/start/install.rst
+++ b/docs/start/install.rst
@@ -49,7 +49,7 @@ To do so, simply click on the master build of your choice and
 then navigate to ``Artifacts``. Copy the wheel URL that corresponds
 to your version of Python and then install it as:
 
-.. xcode:: shell
+.. xcode:: winshell
 
    C:\> pip install YOUR_WHEEL_URL
 
@@ -94,15 +94,15 @@ own functionality, you are welcome to do so.
 
    .. xcode:: shell
 
-     # Build a debug version of datatable (for example suitable for ``gdb`` debugging)
+     $ # Build a debug version of datatable (for example suitable for ``gdb`` debugging)
      $ make debug
 
-     # Generate code coverage report
+     $ # Generate code coverage report
      $ make coverage
 
-     # Build a debug version of datatable using an auto-generated makefile.
-     # This does not work on all systems, but when it does it will work
-     # much faster than standard "make debug".
+     $ # Build a debug version of datatable using an auto-generated makefile.
+     $ # This does not work on all systems, but when it does it will work
+     $ # much faster than standard "make debug".
      $ make fast
 
 

--- a/docs/start/quick-start.rst
+++ b/docs/start/quick-start.rst
@@ -7,7 +7,7 @@ Install datatable
 
 Let's begin by installing the latest stable version of ``datatable`` from PyPI:
 
-.. code-block:: bash
+.. xcode:: shell
 
     $ pip install datatable
 

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,4 +1,5 @@
 docutils>=0.15
+pygments
 sphinx>=1.8,<3.0
 sphinx_rtd_theme
 nbsphinx>=0.5

--- a/src/datatable/sphinxext/xcode.py
+++ b/src/datatable/sphinxext/xcode.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#-------------------------------------------------------------------------------
+# Copyright 2019-2020 H2O.ai
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#-------------------------------------------------------------------------------
+import re
+from docutils import nodes
+from sphinx.util.docutils import SphinxDirective
+from . import xnodes
+
+rx_shell_program = re.compile(r"[\w\.\/\-]+")
+
+
+
+class XcodeDirective(SphinxDirective):
+    has_content = True
+    required_arguments = 0
+    optional_arguments = 1
+    final_argument_whitespace = False
+    option_spec = {}
+
+    def run(self):
+        self.parse_arguments()
+        if self._lang == "shell":
+            return self.process_lang_shell()
+
+
+    def parse_arguments(self):
+        assert len(self.arguments) <= 1
+        lang = self.arguments[0] if self.arguments else "python"
+        if lang not in ["shell", "python", "text"]:
+            raise self.error("Invalid language in ..xcode directive: `%s`. "
+                             "Only 'shell', 'python' and 'text' are recognized."
+                             % lang)
+        self._lang = lang
+
+
+    def process_lang_shell(self):
+        out_node = xnodes.div(classes=["xcode", "shell"])
+        for line in self.content.data:
+            prompt = ""
+            comment = ""
+            if line[:2] == "$ ":
+                prompt = line[:2]
+                line = line[2:]
+            if line[1:5] == ":\\> ":
+                prompt = line[:5]
+                line = line[5:]
+            if prompt:
+                out_node += nodes.inline("", prompt, classes=["prompt"])
+            mm_program = re.match(rx_shell_program, line)
+            if mm_program:
+                iend = mm_program.end()
+                out_node += nodes.inline("", line[:iend], classes=["program"])
+                line = line[iend:]
+            if "#" in line:
+                istart = line.find("#")
+                comment = line[istart:]
+                line = line[:istart]
+            out_node += nodes.Text(line)
+            if comment:
+                out_node += nodes.inline("", comment, classes=["comment"])
+            out_node += nodes.Text("\n")
+        return [out_node]
+
+
+
+def setup(app):
+    app.setup_extension("sphinxext.xnodes")
+    app.add_css_file("xcode.css")
+    app.add_directive("xcode", XcodeDirective)
+    return {"parallel_read_safe": True, "parallel_write_safe": True}

--- a/src/datatable/sphinxext/xcode.py
+++ b/src/datatable/sphinxext/xcode.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #-------------------------------------------------------------------------------
-# Copyright 2019-2020 H2O.ai
+# Copyright 2020 H2O.ai
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -25,6 +25,7 @@ from docutils import nodes
 from sphinx.util.docutils import SphinxDirective
 from . import xnodes
 
+supported_languages = ["shell"]
 rx_shell_program = re.compile(r"[\w\.\/\-]+")
 
 
@@ -45,10 +46,10 @@ class XcodeDirective(SphinxDirective):
     def parse_arguments(self):
         assert len(self.arguments) <= 1
         lang = self.arguments[0] if self.arguments else "python"
-        if lang not in ["shell", "python", "text"]:
+        if lang not in supported_languages:
             raise self.error("Invalid language in ..xcode directive: `%s`. "
-                             "Only 'shell', 'python' and 'text' are recognized."
-                             % lang)
+                             "Only %r languages are recognized."
+                             % (lang, supported_languages))
         self._lang = lang
 
 


### PR DESCRIPTION
The new directive should be used for all code blocks with shell commands, e.g:
```rst
.. xcode:: shell

    $ pip install datatable
```
Unlike the traditional `.. code-block::` we have full control over lexing / styling the final output. In particular, with this patch the shell prompt is distinct from the rest of the command line; and it is also marked with `user-select: none` in CSS, meaning it won't get in the way when a user tries to copy the commands.

Most importantly, we will extend the `.. xcode::` directive in the future to python languages, in particular allowing for automatic detection of datatable frames in the output.