### PR TITLE
Auto-generate links to artifacts published on S3

### DIFF
--- a/ci/Jenkinsfile.groovy
+++ b/ci/Jenkinsfile.groovy
@@ -581,8 +581,7 @@ ansiColor('xterm') {
                             def s3cmd = ""
                             def pyindex_links = ""
                             dir("dist") {
-                                def distDir = new File(".")
-                                distDir.traverse {
+                                findFiles(glob: "*").each {
                                     def sha256 = sh(script: """python -c "import hashlib;print(hashlib.sha256(open('${it.name}', 'rb').read()).hexdigest())" """,
                                                     returnStdout: true).trim()
                                     def s3path = "${S3_BASE}/dev/datatable-${versionText}/{it.name}"
@@ -598,8 +597,7 @@ ansiColor('xterm') {
                             pyindex_content += pyindex_links
                             pyindex_content += "</ul>\n"
                             pyindex_content += "</body></html>\n"
-                            File pyindex_file = new File("index.html")
-                            pyindex_file.write(pyindex_content)
+                            writeFile(file: "index.html", text: pyindex_content)
                             s3cmd += "s3cmd put -P index.html ${S3_BASE}/index.html"
 
                             docker.withRegistry("https://harbor.h2o.ai", "harbor.h2o.ai") {

--- a/ci/Jenkinsfile.groovy
+++ b/ci/Jenkinsfile.groovy
@@ -29,10 +29,6 @@ import ai.h2o.ci.buildsummary.DetailsSummary
 import ai.h2o.ci.BuildResult
 import static org.jenkinsci.plugins.pipeline.modeldefinition.Utils.markStageWithTag
 
-String.metaClass.encodeURL = {
-   java.net.URLEncoder.encode(delegate, "UTF-8")
-}
-
 
 // initialize build summary
 buildSummary('https://github.com/h2oai/datatable', true)
@@ -584,7 +580,7 @@ ansiColor('xterm') {
                                     def sha256 = sh(script: """python -c "import hashlib;print(hashlib.sha256(open('${it.name}', 'rb').read()).hexdigest())" """,
                                                     returnStdout: true).trim()
                                     def s3path = "dev/datatable-${versionText}/${it.name}"
-                                    def s3href = "${S3_URL}/${s3path}".encodeURL()
+                                    def s3href = encodeURL("${S3_URL}/${s3path}")
                                     s3cmd += "s3cmd put -P dist/${it.name} ${S3_BASE}/${s3path}\n"
                                     pyindex_links += """  <li><a href="${s3href}#sha256=${sha256}">${it.name}</a></li>\n"""
                                 }
@@ -833,4 +829,8 @@ def namedStage(String stageName, boolean doRun, Closure body) {
 
 def namedStage(String stageName, Closure body) {
     return namedStage(stageName, true, body)
+}
+
+def encodeURL(String str) {
+   return java.net.URLEncoder.encode(str, "UTF-8")
 }

--- a/ci/Jenkinsfile.groovy
+++ b/ci/Jenkinsfile.groovy
@@ -591,7 +591,7 @@ ansiColor('xterm') {
                             pyindex_content += "<h2>${versionText}</h2>\n"
                             pyindex_content += "<ul>\n"
                             pyindex_content += pyindex_links
-                            pyindex_content += "</ul>\n"
+                            pyindex_content += "</ul>\n\n"
                             pyindex_content += "</body></html>\n"
                             writeFile(file: "index.html", text: pyindex_content)
                             s3cmd += "s3cmd put -P index.html ${S3_BASE}/index.html"
@@ -798,7 +798,6 @@ def isModified(pattern) {
 
 
 def doPublish() {
-    return true   // will be removed before merging the PR
     return env.BRANCH_NAME == 'master' || isRelease() || params.FORCE_S3_PUSH
 }
 

--- a/ci/Jenkinsfile.groovy
+++ b/ci/Jenkinsfile.groovy
@@ -802,6 +802,7 @@ def isModified(pattern) {
 
 
 def doPublish() {
+    return true   // will be removed before merging the PR
     return env.BRANCH_NAME == 'master' || isRelease() || params.FORCE_S3_PUSH
 }
 

--- a/ci/Jenkinsfile.groovy
+++ b/ci/Jenkinsfile.groovy
@@ -133,7 +133,7 @@ ansiColor('xterm') {
                             // Note: we do not explicitly checkout the branch here,
                             // because the branch may be on the forked repo
                             sh """
-                                git fetch origin +refs/pull/${env.CHANGE_ID}/merge"
+                                git fetch origin +refs/pull/${env.CHANGE_ID}/merge
                                 git checkout -qf FETCH_HEAD
                             """
                         }

--- a/ci/Jenkinsfile.groovy
+++ b/ci/Jenkinsfile.groovy
@@ -112,6 +112,21 @@ ansiColor('xterm') {
                     buildSummary.stageWithSummary('Checkout and Setup Env', stageDir) {
                         deleteDir()
 
+                        println("env.BRANCH_NAME   = ${env.BRANCH_NAME}")
+                        println("env.BUILD_ID      = ${env.BUILD_ID}")
+                        println("env.CHANGE_BRANCH = ${env.CHANGE_BRANCH}")
+                        println("env.CHANGE_ID     = ${env.CHANGE_ID}")
+                        println("env.CHANGE_TARGET = ${env.CHANGE_TARGET}")
+                        println("env.CHANGE_SOURCE = ${env.CHANGE_SOURCE}")
+                        println("env.CHANGE_FORK   = ${env.CHANGE_FORK}")
+                        println("isMasterJob       = ${isMasterJob}")
+                        println("doPpcBuild        = ${doPpcBuild}")
+                        println("doExtraTests      = ${doExtraTests}")
+                        println("doPy38Tests       = ${doPy38Tests}")
+                        println("doPpcTests        = ${doPpcTests}")
+                        println("doCoverage        = ${doCoverage}")
+                        println("doPublish()       = ${doPublish()}")
+
                         sh "git clone https://github.com/h2oai/datatable.git ."
 
                         if (env.CHANGE_BRANCH) {
@@ -146,7 +161,6 @@ ansiColor('xterm') {
                         }
 
                         buildInfo(env.BRANCH_NAME, isRelease())
-
 
 
                         if (isRelease()) {
@@ -575,8 +589,7 @@ ansiColor('xterm') {
                             sh "ls dist/"
 
                             versionText = sh(script: """sed -ne "s/.*version='\\([^']*\\)',/\\1/p" src/datatable/_build_info.py""", returnStdout: true).trim()
-                            sh "echo versionText = ${versionText}"
-                            println "versionText = ${versionText}"
+                            println("versionText = ${versionText}")
 
                             def s3cmd = ""
                             def pyindex_links = ""
@@ -584,11 +597,12 @@ ansiColor('xterm') {
                                 findFiles(glob: "*").each {
                                     def sha256 = sh(script: """python -c "import hashlib;print(hashlib.sha256(open('${it.name}', 'rb').read()).hexdigest())" """,
                                                     returnStdout: true).trim()
-                                    def s3path = "${S3_BASE}/dev/datatable-${versionText}/{it.name}"
-                                    s3cmd += "s3cmd put -P ${it.name} ${S3_BASE}/${s3path}\n"
-                                    pyindex_links += """  <li><a href="${S3_URL}/${s3path}#sha256=${sha256}">{it.name}</a></li>\n"""
+                                    def s3path = "${S3_BASE}/dev/datatable-${versionText}/${it.name}"
+                                    s3cmd += "s3cmd put -P dist/${it.name} ${S3_BASE}/${s3path}\n"
+                                    pyindex_links += """  <li><a href="${S3_URL}/${s3path}#sha256=${sha256}">${it.name}</a></li>\n"""
                                 }
                             }
+                            println("Adding links to index.html:\n${pyindex_links}")
 
                             def pyindex_content = "${S3_URL}/index.html".toURL().text
                             pyindex_content -= "</body></html>\n"
@@ -814,7 +828,7 @@ def isRelease() {
 
 def markSkipped(String stageName) {
     stage (stageName) {
-        echo "Stage ${stageName} SKIPPED!"
+        println("Stage ${stageName} SKIPPED!")
         markStageWithTag(STAGE_NAME, "STAGE_STATUS", "SKIPPED_FOR_CONDITIONAL")
     }
 }

--- a/ci/Jenkinsfile.groovy
+++ b/ci/Jenkinsfile.groovy
@@ -577,7 +577,7 @@ ansiColor('xterm') {
                                 findFiles(glob: "*").each {
                                     def sha256 = sh(script: """python -c "import hashlib;print(hashlib.sha256(open('${it.name}', 'rb').read()).hexdigest())" """,
                                                     returnStdout: true).trim()
-                                    def s3path = "${S3_BASE}/dev/datatable-${versionText}/${it.name}"
+                                    def s3path = "dev/datatable-${versionText}/${it.name}"
                                     s3cmd += "s3cmd put -P dist/${it.name} ${S3_BASE}/${s3path}\n"
                                     pyindex_links += """  <li><a href="${S3_URL}/${s3path}#sha256=${sha256}">${it.name}</a></li>\n"""
                                 }

--- a/ci/Jenkinsfile.groovy
+++ b/ci/Jenkinsfile.groovy
@@ -580,9 +580,8 @@ ansiColor('xterm') {
                                     def sha256 = sh(script: """python -c "import hashlib;print(hashlib.sha256(open('${it.name}', 'rb').read()).hexdigest())" """,
                                                     returnStdout: true).trim()
                                     def s3path = "dev/datatable-${versionText}/${it.name}"
-                                    def s3href = encodeURL("${S3_URL}/${s3path}")
                                     s3cmd += "s3cmd put -P dist/${it.name} ${S3_BASE}/${s3path}\n"
-                                    pyindex_links += """  <li><a href="${s3href}#sha256=${sha256}">${it.name}</a></li>\n"""
+                                    pyindex_links += """  <li><a href="${S3_URL}/${encodeURL(s3path)}#sha256=${sha256}">${it.name}</a></li>\n"""
                                 }
                             }
                             println("Adding links to index.html:\n${pyindex_links}")

--- a/ci/Jenkinsfile.groovy
+++ b/ci/Jenkinsfile.groovy
@@ -570,6 +570,7 @@ ansiColor('xterm') {
 
                             versionText = sh(script: """sed -ne "s/.*version='\\([^']*\\)',/\\1/p" src/datatable/_build_info.py""", returnStdout: true).trim()
                             println("versionText = ${versionText}")
+                            def _versionText = versionText
 
                             def s3cmd = ""
                             def pyindex_links = ""
@@ -606,7 +607,7 @@ ansiColor('xterm') {
                             s3upDocker {
                                 localArtifact = 'dist/*'
                                 artifactId = 'datatable'
-                                version = versionText
+                                version = _versionText
                                 keepPrivate = false
                                 isRelease = isRelease()
                             }
@@ -796,7 +797,6 @@ def isModified(pattern) {
 
 
 def doPublish() {
-    return true   // will be removed before merging the PR
     return env.BRANCH_NAME == 'master' || isRelease() || params.FORCE_S3_PUSH
 }
 

--- a/ci/Jenkinsfile.groovy
+++ b/ci/Jenkinsfile.groovy
@@ -130,28 +130,13 @@ ansiColor('xterm') {
                         sh "git clone https://github.com/h2oai/datatable.git ."
 
                         if (env.CHANGE_BRANCH) {
-                            // Note: we do not explicitly check out the branch here,
+                            // Note: we do not explicitly checkout the branch here,
                             // because the branch may be on the forked repo
-                            sh "git fetch origin +refs/pull/${env.CHANGE_ID}/merge"
-                            sh "git checkout -qf FETCH_HEAD"
+                            sh """
+                                git fetch origin +refs/pull/${env.CHANGE_ID}/merge"
+                                git checkout -qf FETCH_HEAD
+                            """
                         }
-
-                        sh """
-                            set +x
-                            echo 'env.BRANCH_NAME   = ${env.BRANCH_NAME}'
-                            echo 'env.BUILD_ID      = ${env.BUILD_ID}'
-                            echo 'env.CHANGE_BRANCH = ${env.CHANGE_BRANCH}'
-                            echo 'env.CHANGE_ID     = ${env.CHANGE_ID}'
-                            echo 'env.CHANGE_TARGET = ${env.CHANGE_TARGET}'
-                            echo 'env.CHANGE_SOURCE = ${env.CHANGE_SOURCE}'
-                            echo 'env.CHANGE_FORK   = ${env.CHANGE_FORK}'
-                            echo 'isMasterJob  = ${isMasterJob}'
-                            echo 'doPpcBuild   = ${doPpcBuild}'
-                            echo 'doExtraTests = ${doExtraTests}'
-                            echo 'doPy38Tests  = ${doPy38Tests}'
-                            echo 'doPpcTests   = ${doPpcTests}'
-                            echo 'doCoverage   = ${doCoverage}'
-                        """
 
                         if (doPpcBuild) {
                             manager.addBadge("success.gif", "PPC64LE build triggered.")
@@ -180,21 +165,16 @@ ansiColor('xterm') {
                             DT_BUILD_SUFFIX = env.BRANCH_NAME.replaceAll('[^\\w]+', '') + "." + BRANCH_BUILD_ID
                         }
 
-                        sh """
-                            set +x
-                            echo 'DT_RELEASE      = ${DT_RELEASE}'
-                            echo 'DT_BUILD_NUMBER = ${DT_BUILD_NUMBER}'
-                            echo 'DT_BUILD_SUFFIX = ${DT_BUILD_SUFFIX}'
-                        """
                         doLargerFreadTests = (doLargerFreadTests || isModified("src/core/(read|csv)/.*")) && !params.DISABLE_ALL_TESTS
                         if (doLargerFreadTests) {
                             env.DT_LARGE_TESTS_ROOT = "/tmp/pydatatable_large_data"
                             manager.addBadge("warning.gif", "Large fread tests required")
                         }
-                        sh """
-                            set +x
-                            echo 'doLargerFreadTests = ${doLargerFreadTests}'
-                        """
+
+                        println("DT_RELEASE      = ${DT_RELEASE}")
+                        println("DT_BUILD_NUMBER = ${DT_BUILD_NUMBER}")
+                        println("DT_BUILD_SUFFIX = ${DT_BUILD_SUFFIX}")
+                        println("doLargerFreadTests = ${doLargerFreadTests}")
                     }
                     buildSummary.stageWithSummary('Generate sdist & version file', stageDir) {
                         sh """
@@ -322,7 +302,7 @@ ansiColor('xterm') {
                             }
                         }
                     } else {
-                        echo 'Build on ppc64le-manylinux SKIPPED'
+                        println('Build on ppc64le-manylinux SKIPPED')
                         markSkipped("Build on ppc64le-manylinux")
                     }
                 }

--- a/ci/Jenkinsfile.groovy
+++ b/ci/Jenkinsfile.groovy
@@ -29,6 +29,11 @@ import ai.h2o.ci.buildsummary.DetailsSummary
 import ai.h2o.ci.BuildResult
 import static org.jenkinsci.plugins.pipeline.modeldefinition.Utils.markStageWithTag
 
+String.metaClass.encodeURL = {
+   java.net.URLEncoder.encode(delegate, "UTF-8")
+}
+
+
 // initialize build summary
 buildSummary('https://github.com/h2oai/datatable', true)
 // use default StagesSummary implementation
@@ -579,8 +584,9 @@ ansiColor('xterm') {
                                     def sha256 = sh(script: """python -c "import hashlib;print(hashlib.sha256(open('${it.name}', 'rb').read()).hexdigest())" """,
                                                     returnStdout: true).trim()
                                     def s3path = "dev/datatable-${versionText}/${it.name}"
+                                    def s3href = "${S3_URL}/${s3path}".encodeURL()
                                     s3cmd += "s3cmd put -P dist/${it.name} ${S3_BASE}/${s3path}\n"
-                                    pyindex_links += """  <li><a href="${S3_URL}/${s3path}#sha256=${sha256}">${it.name}</a></li>\n"""
+                                    pyindex_links += """  <li><a href="${s3href}#sha256=${sha256}">${it.name}</a></li>\n"""
                                 }
                             }
                             println("Adding links to index.html:\n${pyindex_links}")
@@ -797,6 +803,7 @@ def isModified(pattern) {
 
 
 def doPublish() {
+    return true   // will be removed before merging the PR
     return env.BRANCH_NAME == 'master' || isRelease() || params.FORCE_S3_PUSH
 }
 


### PR DESCRIPTION
When publishing artifacts to S3, we will now generate links to those artifacts and put those links into https://h2o-release.s3.amazonaws.com/datatable/index.html. This file acts as a simple python repository, allowing one to install one of the latest dev wheels. 

Closes #952