### PR TITLE
Fix saving an Rbound string column to Jay

### DIFF
--- a/src/core/column.cc
+++ b/src/core/column.cc
@@ -125,8 +125,10 @@ dt::ColumnImpl* Column::_get_mutable_impl(bool keep_stats) {
   xassert(impl_);
   if (impl_->refcount_ > 1) {
     auto newimpl = impl_->clone();
-    xassert(!newimpl->stats_);
-    if (keep_stats && impl_->stats_) {
+    if (newimpl->stats_) {
+      if (!keep_stats) newimpl->stats_ = nullptr;
+    }
+    else if (keep_stats && impl_->stats_) {
       newimpl->stats_ = impl_->stats_->clone();
       newimpl->stats_->column = newimpl;
     }

--- a/src/core/column/column_impl.h
+++ b/src/core/column/column_impl.h
@@ -114,7 +114,7 @@ class ColumnImpl
     virtual Buffer      get_data_buffer(size_t k) const = 0;
 
     virtual void write_data_to_jay(Column&, jay::ColumnBuilder&,
-                                   WritableBuffer*) const = 0;
+                                   WritableBuffer*) = 0;
 
 
   //------------------------------------

--- a/src/core/column/rbound.h
+++ b/src/core/column/rbound.h
@@ -50,13 +50,18 @@ class Rbound_ColumnImpl : public Virtual_ColumnImpl {
     bool get_element(size_t i, py::robj* out) const override;
 
     void write_data_to_jay(Column&, jay::ColumnBuilder&,
-                           WritableBuffer*) const override;
+                           WritableBuffer*) override;
 
   private:
     void calculate_nacount();
     void calculate_boolean_stats();
     void calculate_integer_stats();
     void calculate_float_stats();
+
+    // defined in save_jay.cc
+    void _write_fw_to_jay(jay::ColumnBuilder&, WritableBuffer*);
+    void _write_str_offsets_to_jay(jay::ColumnBuilder&, WritableBuffer*);
+    void _write_str_data_to_jay(jay::ColumnBuilder&, WritableBuffer*);
 };
 
 

--- a/src/core/column/sentinel.h
+++ b/src/core/column/sentinel.h
@@ -43,7 +43,7 @@ class Sentinel_ColumnImpl : public ColumnImpl
     size_t n_children() const noexcept override;
 
     void write_data_to_jay(Column&, jay::ColumnBuilder&,
-                           WritableBuffer*) const override;
+                           WritableBuffer*) override;
 
   protected:
     Sentinel_ColumnImpl(size_t nrows, SType stype);

--- a/src/core/column/virtual.h
+++ b/src/core/column/virtual.h
@@ -45,7 +45,7 @@ class Virtual_ColumnImpl : public ColumnImpl
     void* get_data_editable(size_t k) override;
     Buffer get_data_buffer(size_t k) const override;
     void write_data_to_jay(Column&, jay::ColumnBuilder&,
-                           WritableBuffer*) const override;
+                           WritableBuffer*) override;
 
 };
 

--- a/src/core/jay/save_jay.cc
+++ b/src/core/jay/save_jay.cc
@@ -25,6 +25,7 @@
 #include "column/virtual.h"
 #include "frame/py_frame.h"
 #include "jay/jay_generated.h"
+#include "parallel/api.h"
 #include "python/_all.h"
 #include "python/args.h"
 #include "python/string.h"
@@ -173,12 +174,12 @@ flatbuffers::Offset<jay::Column> Column::write_to_jay(
 
 
 void Column::write_data_to_jay(jay::ColumnBuilder& cbb, WritableBuffer* wb) {
-  impl_->write_data_to_jay(*this, cbb, wb);
+  const_cast<dt::ColumnImpl*>(impl_)->write_data_to_jay(*this, cbb, wb);
 }
 
 
 void dt::Sentinel_ColumnImpl::write_data_to_jay(
-    Column&, jay::ColumnBuilder& cbb, WritableBuffer* wb) const
+    Column&, jay::ColumnBuilder& cbb, WritableBuffer* wb)
 {
   size_t nbufs = get_num_data_buffers();
   for (size_t i = 0; i < nbufs; ++i) {
@@ -192,47 +193,164 @@ void dt::Sentinel_ColumnImpl::write_data_to_jay(
 
 
 void dt::Virtual_ColumnImpl::write_data_to_jay(
-    Column& thiscol, jay::ColumnBuilder& cbb, WritableBuffer* wb) const
+    Column& thiscol, jay::ColumnBuilder& cbb, WritableBuffer* wb)
 {
   thiscol.materialize(false);
   thiscol.write_data_to_jay(cbb, wb);
 }
 
 
-void dt::Rbound_ColumnImpl::write_data_to_jay(
-    Column&, jay::ColumnBuilder& cbb, WritableBuffer* wb) const
+
+void dt::Rbound_ColumnImpl::_write_fw_to_jay(
+    jay::ColumnBuilder& cbb, WritableBuffer* wb)
 {
+  size_t pos0 = 0;
+  size_t size_total = 0;
   for (const Column& col : chunks_) {
-    const_cast<Column*>(&col)->materialize();
+    xassert(col.stype() == stype_);
+    xassert(col.get_num_data_buffers() == 1);
+    const void* data = col.get_data_readonly(0);
+    size_t size = col.get_data_size(0);
+    size_t pos = wb->write(size, data);
+    if (pos0) {
+      xassert(pos == pos0 + size_total);
+    } else {
+      pos0 = pos;
+    }
+    size_total += size;
   }
-  size_t nbufs = chunks_[0].get_num_data_buffers();
-  for (size_t i = 0; i < nbufs; ++i) {
-    size_t pos0 = 0;
-    size_t size0 = 0;
-    for (const Column& col : chunks_) {
-      const void* data = col.get_data_readonly(i);
-      size_t size = col.get_data_size(i);
-      // When rbinding string columns, the offsets buffer contains an extra
-      // 0 at the beginning. This 0 should be stripped from all chunks except
-      // the first one.
-      if (pos0 && i == 0 && col.ltype() == dt::LType::STRING) {
-        size_t elemsize = stype_elemsize(col.stype());
-        xassert(size == (col.nrows() + 1) * elemsize);
-        size -= elemsize;
-        data = static_cast<const char*>(data) + elemsize;
+  if (size_total & 7) {
+    size_t zero = 0;
+    wb->write(8 - (size_total & 7), &zero);
+  }
+  xassert(pos0 >= 8);
+  jay::Buffer saved_buf(pos0 - 8, size_total);
+  cbb.add_data(&saved_buf);
+}
+
+
+template <typename TIN, typename TOUT>
+static Buffer _recode_offsets(const void* data, size_t n, size_t offset0) {
+  Buffer outbuf = Buffer::mem(n * sizeof(TOUT));
+  auto offsets_in = static_cast<const TIN*>(data);
+  auto offsets_out = static_cast<TOUT*>(outbuf.xptr());
+  dt::parallel_for_static(n,
+    [=](size_t i) {
+      offsets_out[i] = static_cast<TOUT>(offsets_in[i]) + static_cast<TOUT>(offset0);
+      if (!std::is_same<TIN, TOUT>::value && (offsets_in[i] & dt::GETNA<TIN>())) {
+        offsets_out[i] += dt::GETNA<TOUT>() - dt::GETNA<TIN>();
       }
-      size_t pos = wb->write(size, data);
-      xassert(pos >= 8);
-      if (!pos0) pos0 = pos;
-      size0 += size;
+    });
+  return outbuf;
+}
+
+
+void dt::Rbound_ColumnImpl::_write_str_offsets_to_jay(
+    jay::ColumnBuilder& cbb, WritableBuffer* wb)
+{
+  // Check whether the column may end up being over the maximum
+  // allowed size for the STR32 stype.
+  if (stype() == dt::SType::STR32) {
+    size_t strdata_size = 0;
+    for (const Column& col : chunks_) {
+      xassert(!col.is_virtual());
+      strdata_size += col.get_data_size(1);
     }
-    if (size0 & 7) {
-      size_t zero = 0;
-      wb->write(8 - (size0 & 7), &zero);
+    if (strdata_size > Column::MAX_ARR32_SIZE ||
+        nrows_ > Column::MAX_ARR32_SIZE) {
+      stype_ = SType::STR64;
+      cbb.add_type(stype_to_jaytype[static_cast<int>(SType::STR64)]);
     }
-    jay::Buffer saved_buf(pos0 - 8, size0);
-    if (i == 0) cbb.add_data(&saved_buf);
-    if (i == 1) cbb.add_strdata(&saved_buf);
+  }
+
+  // Write initial zero
+  size_t pos0 = 0;
+  size_t elemsize0 = stype_elemsize(stype_);
+  pos0 = wb->write(elemsize0, &pos0);
+
+  size_t offsets_size = elemsize0;  // total size of all offsets written so far
+  size_t strdata_size = 0;          // total size of strdata chunks
+  for (const Column& col : chunks_) {
+    xassert(col.get_num_data_buffers() == 2);
+    size_t elemsize = stype_elemsize(col.stype());
+    auto data = static_cast<const char*>(col.get_data_readonly(0)) + elemsize;
+    auto size = col.get_data_size(0) - elemsize;
+
+    // If no strdata has been written yet, either because this is the first
+    // chunk or because the first chunk was empty, then the offsets buffer
+    // can be written into the output as-is without the need for additional
+    // offsetting. However, this wouldn't apply in a case of a STR32->STR64
+    // type bump.
+    if (strdata_size == 0 && col.stype() == stype_) {
+      wb->write(size, data);
+      offsets_size += size;
+    }
+    // For all subsequent chunks we need to modify the offsets and
+    // remove the initial 0 from the `data` array.
+    else {
+      xassert((col.stype() == stype_) ||
+              (col.stype() == SType::STR32 && stype_ == SType::STR64));
+      size_t n = col.nrows();
+      Buffer newbuf = (col.stype() == dt::SType::STR32)
+          ? (stype_ == dt::SType::STR32
+              ? _recode_offsets<uint32_t, uint32_t>(data, n, strdata_size)
+              : _recode_offsets<uint32_t, uint64_t>(data, n, strdata_size))
+          : _recode_offsets<uint64_t, uint64_t>(data, n, strdata_size);
+      wb->write(newbuf.size(), newbuf.rptr());
+      offsets_size += newbuf.size();
+    }
+    strdata_size += col.get_data_size(1);
+  }
+  if (offsets_size & 7) {
+    size_t zero = 0;
+    wb->write(8 - (offsets_size & 7), &zero);
+  }
+  xassert(pos0 >= 8);
+  jay::Buffer saved_buf(pos0 - 8, offsets_size);
+  cbb.add_data(&saved_buf);
+}
+
+
+void dt::Rbound_ColumnImpl::_write_str_data_to_jay(
+    jay::ColumnBuilder& cbb, WritableBuffer* wb)
+{
+  size_t pos0 = 0;
+  size_t size_total = 0;
+  for (const Column& col : chunks_) {
+    xassert(col.get_num_data_buffers() == 2);
+    const void* data = col.get_data_readonly(1);
+    size_t size = col.get_data_size(1);
+    size_t pos = wb->write(size, data);
+    if (pos0) {
+      xassert(pos == pos0 + size_total);
+    } else {
+      pos0 = pos;
+    }
+    size_total += size;
+  }
+  if (size_total & 7) {
+    size_t zero = 0;
+    wb->write(8 - (size_total & 7), &zero);
+  }
+  xassert(pos0 >= 8);
+  jay::Buffer saved_buf(pos0 - 8, size_total);
+  cbb.add_strdata(&saved_buf);
+}
+
+
+
+void dt::Rbound_ColumnImpl::write_data_to_jay(
+    Column&, jay::ColumnBuilder& cbb, WritableBuffer* wb)
+{
+  for (Column& col : chunks_) {
+    col.materialize();
+  }
+
+  if (stype_ == dt::SType::STR32 || stype_ == dt::SType::STR64) {
+    _write_str_offsets_to_jay(cbb, wb);
+    _write_str_data_to_jay(cbb, wb);
+  } else {
+    _write_fw_to_jay(cbb, wb);
   }
 }
 

--- a/tests/test_jay.py
+++ b/tests/test_jay.py
@@ -193,7 +193,7 @@ def test_jay_rbound_column(tempfile_jay):
     src = "Z\n%s\n" % "\n".join(data)
     DT = dt.fread(src)
     assert dt.internal.frame_columns_virtual(DT)[0] is True
-    DT.to_jay(RES)
+    DT.to_jay(tempfile_jay)
     RES = dt.fread(tempfile_jay)
     frame_integrity_check(RES)
     assert_equals(RES, dt.Frame(Z=data))

--- a/tests/test_jay.py
+++ b/tests/test_jay.py
@@ -193,6 +193,7 @@ def test_jay_rbound_column(tempfile_jay):
     src = "Z\n%s\n" % "\n".join(data)
     DT = dt.fread(src)
     assert dt.internal.frame_columns_virtual(DT)[0] is True
+    DT.to_jay(RES)
     RES = dt.fread(tempfile_jay)
     frame_integrity_check(RES)
     assert_equals(RES, dt.Frame(Z=data))

--- a/tests/test_jay.py
+++ b/tests/test_jay.py
@@ -75,7 +75,7 @@ def test_fread(tempfile_jay):
         assert f2.source == tempfile_joy
     finally:
         # The file `tempfile_joy` is memory-mapped as the frame `f2`.
-        # So in order to delete `tempfile_joy` we first need to 
+        # So in order to delete `tempfile_joy` we first need to
         # delete `f2`. Otherwise (for instance, on Windows) we won't
         # have permissions to delete this file.
         f2 = None
@@ -185,6 +185,18 @@ def test_jay_keys(tempfile_jay):
     assert d1.key == ("x",)
     assert d1.source == tempfile_jay
     assert_equals(d0, d1)
+
+
+def test_jay_rbound_column(tempfile_jay):
+    # See issue #2543
+    data = ["loooooooooooooooooooooooong"] * 10000 + ["A"] * 30000
+    src = "Z\n%s\n" % "\n".join(data)
+    DT = dt.fread(src)
+    assert dt.internal.frame_columns_virtual(DT)[0] is True
+    RES = dt.fread(tempfile_jay)
+    frame_integrity_check(RES)
+    assert_equals(RES, dt.Frame(Z=data))
+
 
 
 


### PR DESCRIPTION
When an rbound string column was saved to Jay, the offsets were not properly concatenated, creating a corrupted column.

Closes #2543