### PR TITLE
Fix loading a Frame from a temporary bytes Jay object

### DIFF
--- a/docs/releases/v0.11.0.rst
+++ b/docs/releases/v0.11.0.rst
@@ -19,14 +19,14 @@
   -[new] Added ability to cast string columns into numeric types: int, float
     or boolean. [#1313]
 
+  -[new] String columns now support comparison operators ``<``, ``>``, ``<=``
+    and ``>=``. [#2274]
+
   -[new] String columns can now be added together, similarly to how strings
     can be added in Python. [#1839]
 
   -[new] Added a new function :func:`cut()` to bin numeric data
    to equal-width discrete intervals.
-
-  -[enh] String columns now support comparison operators ``<``, ``>``, ``<=``
-    and ``>=``. [#2274]
 
   -[enh] Method :meth:`Frame.colindex()` now accepts a column selector
     f-expression as an argument.
@@ -68,26 +68,26 @@
     were renamed into ``method=``. The old parameter name still works, so this
     change is not breaking.
 
-  -[bug] Deleting a key from the Frame (``del DT.key``) no longer causes a
+  -[fix] Deleting a key from the Frame (``del DT.key``) no longer causes a
     seg.fault. [#2357]
 
-  -[bug] Casting a 0-row ``str32`` column into ``str64`` stype no longer goes
+  -[fix] Casting a 0-row ``str32`` column into ``str64`` stype no longer goes
     into an infinite loop. [#2369]
 
-  -[bug] Fixed creation of a ``str64`` column from a python list of strings
+  -[fix] Fixed creation of a ``str64`` column from a python list of strings
     when the total size of all strings is greater than 2GB. [#2368]
 
-  -[bug] Rbinding several ``str32`` columns such that their combined string
+  -[fix] Rbinding several ``str32`` columns such that their combined string
     buffers have size over 2GB now properly creates a ``str64`` column as a
     result. [#2367]
 
-  -[bug] Fixed crash when writing to CSV a frame with many boolean columns
+  -[fix] Fixed crash when writing to CSV a frame with many boolean columns
     when the option ``quoting="all"`` is used. [#2382]
 
-  -[bug] It is no longer allowed to combine ``compression="gzip"`` and
+  -[fix] It is no longer allowed to combine ``compression="gzip"`` and
     ``append=True`` in :meth:`.to_csv()`.
 
-  -[bug] Empty strings no longer get confused with NA strings in
+  -[fix] Empty strings no longer get confused with NA strings in
     :meth:`.replace()`. [#2502]
 
 
@@ -140,6 +140,9 @@
 
   -[fix] Fread now properly detects ``\r``-newlines in the presence of fields
     with quoted ``\n``-newlines. [#1343]
+
+  -[fix] Opening Jay file from a bytes object now produces a Frame that
+    remains valid even after the bytes object is deleted. [#2547]
 
   -[api] Function :func:`fread()` now always returns a single Frame object;
     previously it could return a dict of Frames if multiple sources were

--- a/src/core/buffer.h
+++ b/src/core/buffer.h
@@ -140,6 +140,7 @@ class Buffer
     static Buffer external(void* ptr, size_t n);
     static Buffer external(const void* ptr, size_t n);
     static Buffer external(const void* ptr, size_t n, py::buffer&& pybuf);
+    static Buffer pybytes(const py::oobj& src);
     static Buffer view(const Buffer& src, size_t n, size_t offset);
     static Buffer mmap(const std::string& path);
     static Buffer mmap(const std::string& path, size_t n, int fd = -1,

--- a/src/core/read/source.cc
+++ b/src/core/read/source.cc
@@ -134,8 +134,7 @@ Source_Text::Source_Text(py::robj textsrc)
 
 py::oobj Source_Text::read(GenericReader& reader) {
   reader.source_name = &name_;
-  auto text = src_.to_cstring();
-  auto buf = Buffer::external(text.data(), text.size() + 1);
+  auto buf = Buffer::pybytes(src_);
   auto res = reader.read_buffer(buf, 1);
   reader.source_name = nullptr;
   return res;

--- a/tests/test_jay.py
+++ b/tests/test_jay.py
@@ -75,11 +75,20 @@ def test_fread(tempfile_jay):
         assert f2.source == tempfile_joy
     finally:
         # The file `tempfile_joy` is memory-mapped as the frame `f2`.
-        # So in order to delete `tempfile_joy` we first need to 
+        # So in order to delete `tempfile_joy` we first need to
         # delete `f2`. Otherwise (for instance, on Windows) we won't
         # have permissions to delete this file.
         f2 = None
         os.remove(tempfile_joy)
+
+
+def test_jay_bytes_object():
+    # Make sure that opening a Jay bytes object produces a valid object
+    # even after the original bytes object is garbage-collected.
+    # See issue #2547
+    DT = dt.Frame(["abcd"] * 100000)
+    RES = dt.fread(DT.to_jay())
+    assert_equals(RES, DT)
 
 
 def test_jay_empty_string_col(tempfile_jay):


### PR DESCRIPTION
Before, when fread was given a string/bytes object, we were creating a `Buffer::external` view on that object, and then read that data. This worked fine when reading CSVs, but if the file in fact is a Jay file, then we end up creating columns that are direct views on that data. These columns are then put together in a Frame and returned to the user. The problem is that `Buffer::external` is not designed for long-term data storage: it does not own its memory region. So, when the original bytes object is gc'd, we end up with a Frame that contains dangling pointers. 

Now, I've created a new type of `Buffer`: `PyBytes_BufferImpl`, which keeps the source py object inside it, ensuring that the memory region wouldn't get deallocated prematurely.

The impact of this bug is uncler: on one hand, users usually save Jay into a file instead of a bytes object; on the other hand, pickling might in theory do exactly that.

Closes #2547