### PR TITLE
Make ..xfunction compatible with Sphinx 3

### DIFF
--- a/docs/api/frame.rst
+++ b/docs/api/frame.rst
@@ -26,7 +26,7 @@ Frame
     .head()          <frame/head>
     .key             <frame/key>
     .ltypes          <frame/ltypes>
-    .materialize     <frame/materialize>
+    .materialize()   <frame/materialize>
     .names           <frame/names>
     .ncols           <frame/ncols>
     .nrows           <frame/nrows>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -160,4 +160,4 @@ html_static_path = ['_static']
 # -- Custom setup ------------------------------------------------------------
 
 def setup(app):
-    app.add_stylesheet("code.css")
+    app.add_css_file("code.css")

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,6 +1,6 @@
 docutils>=0.15
 pygments
-sphinx>=1.8,<3.0
+sphinx>=3.0
 sphinx_rtd_theme
 nbsphinx>=0.5
 datatable

--- a/src/datatable/sphinxext/xfunction.py
+++ b/src/datatable/sphinxext/xfunction.py
@@ -732,8 +732,10 @@ class XobjectDirective(SphinxDirective):
 
         # Tell Sphinx that this is a target for `:py:obj:` references
         self.state.document.note_explicit_target(sig_node)
-        inv = self.env.domaindata["py"]["objects"]
-        inv[targetname] = (self.env.docname, self.name[1:])
+        domain = self.env.get_domain("py")
+        domain.note_object(name=targetname,        # e.g. "datatable.Frame.cbind"
+                           objtype=self.name[1:],  # remove initial 'x'
+                           node_id=targetname)
         return [sig_node]
 
 


### PR DESCRIPTION
Use `PythonDomain.note_object()` instead of manipulating domain's data explicitly.
As a side-effect, this change is incompatible with Sphinx prior to version 3.0 (there was no `node_id=` back then). So, whoever works on documentation will need to upgrade their Sphinx installation.