### PR TITLE
Upgrade pygments and sphinx_rtd_theme versions

### DIFF
--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,6 +1,6 @@
 docutils>=0.15
-pygments
+pygments>=2.6
 sphinx>=3.0
-sphinx_rtd_theme
+sphinx_rtd_theme>=0.5
 nbsphinx>=0.5
 datatable

--- a/src/datatable/sphinxext/xcode.py
+++ b/src/datatable/sphinxext/xcode.py
@@ -143,9 +143,9 @@ class XcodeDirective(SphinxDirective):
             formatter = SphinxFormatter("console")
             # Update prompt regexp so that it would include the whitespace too
             tail = r")(.*\n?)"
-            ps1 = lexer._ps1rgx
+            ps1 = lexer._ps1rgx.pattern
             assert ps1.endswith(tail)
-            lexer._ps1rgx = ps1[:-len(tail)] + r"\s*" + ps1[-len(tail):]
+            lexer._ps1rgx = re.compile(ps1[:-len(tail)] + r"\s*" + tail)
 
         outfile = type("", (object,), dict(result=None))()
         pygments.highlight(code, lexer, formatter, outfile)


### PR DESCRIPTION
By default readthedocs installs old versions of pygments and sphinx_rtd_theme plugins, which causes inconsistencies in documentation style.