### PR TITLE
Encode unsafe characters in URLs passed to fread

### DIFF
--- a/docs/releases/v0.11.0.rst
+++ b/docs/releases/v0.11.0.rst
@@ -134,6 +134,9 @@
     them in per-column stats. For integer and floating point columns we also
     compute min/max value in each column. [#1097]
 
+  -[enh] When reading from a URL, fread will now escape url-unsafe characters
+    in that URL, so that the user doesn't have to.
+
   -[fix] When reading Excel files, the cells with datetime or boolean types
     are now handled correctly, in particular a datetime value is converted
     into its string representation. [#1701]

--- a/src/core/python/dict.cc
+++ b/src/core/python/dict.cc
@@ -44,7 +44,9 @@ rdict::rdict(const robj& src) : robj(src) {}
 odict::odict(std::initializer_list<oobj> args)
   : odict()
 {
-  xassert(args.size() % 2 == 0);  // number of elements must be even
+  // Entries in the initializer list are key=value pairs, so their
+  // total count must be even:
+  xassert(args.size() % 2 == 0);
   for (size_t i = 0; i < args.size(); i += 2) {
     set(args.begin()[i], args.begin()[i + 1]);
   }

--- a/src/core/python/dict.cc
+++ b/src/core/python/dict.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018 H2O.ai
+// Copyright 2018-2020 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -23,6 +23,7 @@
 // for the details of Python API
 //------------------------------------------------------------------------------
 #include "python/dict.h"
+#include "utils/assert.h"
 namespace py {
 
 
@@ -39,6 +40,16 @@ odict::odict() {
 odict::odict(oobj&& src) : oobj(std::move(src)) {}
 odict::odict(const robj& src) : oobj(src) {}
 rdict::rdict(const robj& src) : robj(src) {}
+
+odict::odict(std::initializer_list<oobj> args)
+  : odict()
+{
+  xassert(args.size() % 2 == 0);  // number of elements must be even
+  for (size_t i = 0; i < args.size(); i += 2) {
+    set(args.begin()[i], args.begin()[i + 1]);
+  }
+}
+
 
 rdict rdict::unchecked(const robj& src) {
   return rdict(src);

--- a/src/core/python/dict.h
+++ b/src/core/python/dict.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018 H2O.ai
+// Copyright 2018-2020 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -81,6 +81,7 @@ class odict : public oobj {
     odict(odict&&) = default;
     odict& operator=(const odict&) = default;
     odict& operator=(odict&&) = default;
+    odict(std::initializer_list<oobj>);
 
     odict copy() const;
 

--- a/src/datatable/utils/fread.py
+++ b/src/datatable/utils/fread.py
@@ -355,11 +355,12 @@ def _resolve_source_cmd(cmd):
         return (cmd, None, None, msgout), None
 
 
+# see `Source_Url::read()` instead
 def _resolve_source_url(url, tempfiles, reporthook=None):
     assert url is not None
     import urllib.request
     targetfile = tempfiles.create_temp_file()
-    encoded_url = urllib.parse.quote(url, safe=":/")
+    encoded_url = urllib.parse.quote(url, safe=":/%")
     urllib.request.urlretrieve(encoded_url, filename=targetfile,
                                reporthook=reporthook)
     # src, file, fileno, text, result

--- a/src/datatable/utils/fread.py
+++ b/src/datatable/utils/fread.py
@@ -359,7 +359,9 @@ def _resolve_source_url(url, tempfiles, reporthook=None):
     assert url is not None
     import urllib.request
     targetfile = tempfiles.create_temp_file()
-    urllib.request.urlretrieve(url, filename=targetfile, reporthook=reporthook)
+    encoded_url = urllib.parse.quote(url, safe=":/")
+    urllib.request.urlretrieve(encoded_url, filename=targetfile,
+                               reporthook=reporthook)
     # src, file, fileno, text, result
     return (url, targetfile, None, None), None
 


### PR DESCRIPTION
If the user passes a URL with unsafe characters (such as spaces) to fread, then such URLs will now be read correctly. For example:
```
import datatable as dt
dt.fread("https://github.com/OpportunityInsights/EconomicTracker/raw/main/data/Google Mobility - County - Daily.csv")
```