### PR TITLE
Fix warnings produced by Clang 10

### DIFF
--- a/ci/ext.py
+++ b/ci/ext.py
@@ -342,7 +342,6 @@ def build_extension(cmd, verbosity=3):
                 "-Wno-switch-enum",
                 "-Wno-weak-template-vtables",
                 "-Wno-weak-vtables",
-                # "-Wno-implicit-int-float-conversion"
             )
         else:
             ext.compiler.add_compiler_flag(

--- a/src/core/column/qcut.h
+++ b/src/core/column/qcut.h
@@ -28,8 +28,8 @@
 #include "models/utils.h"
 #include "parallel/api.h"
 #include "sort.h"
-
 namespace dt {
+
 
 /**
   *  Virtual column to bin input data into equal-population
@@ -118,7 +118,7 @@ class Qcut_ColumnImpl : public Virtual_ColumnImpl {
         a = 0;
         b = (nquantiles_ - 1) / 2;
       } else {
-        a =  nquantiles_ * (1 - epsilon) / (ngroups - 1);
+        a =  nquantiles_ * (1 - epsilon) / static_cast<double>(ngroups - 1);
         b = -a * has_na_group;
       }
 
@@ -128,7 +128,7 @@ class Qcut_ColumnImpl : public Virtual_ColumnImpl {
           size_t j0, j1;
 
           auto q = is_na_group? GETNA<int32_t>()
-                              : static_cast<int32_t>(a * i + b);
+                              : static_cast<int32_t>(a * static_cast<double>(i) + b);
 
           gb.get_group(i, &j0, &j1);
 

--- a/src/core/column/rbound.cc
+++ b/src/core/column/rbound.cc
@@ -91,7 +91,7 @@ void Rbound_ColumnImpl::calculate_boolean_stats() {
     auto chunk_stats = dynamic_cast<BooleanStats*>(col.get_stats_if_exist());
     if (!chunk_stats) return;
     double sum = chunk_stats->sum(&is_valid);
-    xassert(sum == static_cast<size_t>(sum));
+    xassert(sum == static_cast<double>(static_cast<size_t>(sum)));
     count1 += static_cast<size_t>(sum);
     if (!is_valid) return;
   }

--- a/src/core/column_from_python.cc
+++ b/src/core/column_from_python.cc
@@ -298,7 +298,7 @@ static size_t parse_as_str(const Column& inputcol, Buffer& offbuf,
         // Resize the strbuf if necessary
         if (strbuf.size() < static_cast<size_t>(next_offset)) {
           double newsize = static_cast<double>(next_offset) *
-                           (static_cast<double>(nrows) / (i + 1)) * 1.1;
+              (static_cast<double>(nrows) / static_cast<double>(i + 1)) * 1.1;
           strbuf.resize(static_cast<size_t>(newsize));
           strptr = static_cast<char*>(strbuf.xptr());
         }
@@ -382,7 +382,7 @@ static void force_as_str(const Column& inputcol, Buffer& offbuf,
         }
         if (strbuf.size() < static_cast<size_t>(next_offset)) {
           double newsize = static_cast<double>(next_offset) *
-                           (static_cast<double>(nrows) / (i + 1)) * 1.1;
+              (static_cast<double>(nrows) / static_cast<double>(i + 1)) * 1.1;
           strbuf.resize(static_cast<size_t>(newsize));
           strptr = static_cast<char*>(strbuf.xptr());
         }

--- a/src/core/expr/fnary/rowmean.cc
+++ b/src/core/expr/fnary/rowmean.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019 H2O.ai
+// Copyright 2019-2020 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -58,7 +58,7 @@ static bool op_rowmean(size_t i, T* out, const colvec& columns) {
     count++;
   }
   if (count && !std::isnan(sum)) {
-    *out = sum/count;
+    *out = sum/static_cast<T>(count);
     return true;
   } else {
     return false;

--- a/src/core/expr/fnary/rowsd.cc
+++ b/src/core/expr/fnary/rowsd.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019 H2O.ai
+// Copyright 2019-2020 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -57,12 +57,12 @@ static bool op_rowsd(size_t i, T* out, const colvec& columns) {
     if (!xvalid) continue;
     count++;
     T tmp1 = value - mean;
-    mean += tmp1 / count;
+    mean += tmp1 / static_cast<T>(count);
     T tmp2 = value - mean;
     m2 += tmp1 * tmp2;
   }
   if (count > 1 && !std::isnan(m2)) {
-    *out = (m2 >= 0)? std::sqrt(m2 / (count - 1)) : 0;
+    *out = (m2 >= 0)? std::sqrt(m2 / static_cast<T>(count - 1)) : 0;
     return true;
   } else {
     return false;

--- a/src/core/expr/head_reduce_binary.cc
+++ b/src/core/expr/head_reduce_binary.cc
@@ -126,14 +126,14 @@ static bool cov_reducer(const Column& col1, const Column& col2,
       n++;
       T delta1 = value1 - mean1;
       T delta2 = value2 - mean2;
-      mean1 += delta1 / n;
-      mean2 += delta2 / n;
+      mean1 += delta1 / static_cast<T>(n);
+      mean2 += delta2 / static_cast<T>(n);
       T tmp1 = value1 - mean1;  // effectively, this is delta1*(n-1)/n
       cov += tmp1 * delta2;
     }
   }
   if (n <= 1) return false;
-  *out = cov/(n - 1);
+  *out = cov / static_cast<T>(n - 1);
   return true;  // *out is not NA
 }
 
@@ -181,8 +181,8 @@ static bool corr_reducer(const Column& col1, const Column& col2,
       n++;
       T delta1 = value1 - mean1;
       T delta2 = value2 - mean2;
-      mean1 += delta1 / n;
-      mean2 += delta2 / n;
+      mean1 += delta1 / static_cast<T>(n);
+      mean2 += delta2 / static_cast<T>(n);
       T tmp1 = value1 - mean1;  // effectively, this is delta1*(n-1)/n
       T tmp2 = value2 - mean2;
       cov += tmp1 * delta2;

--- a/src/core/expr/head_reduce_unary.cc
+++ b/src/core/expr/head_reduce_unary.cc
@@ -271,18 +271,18 @@ static Column compute_gsum(Column&& arg, const Groupby& gby) {
 
 template <typename T, typename U>
 bool mean_reducer(const Column& col, size_t i0, size_t i1, U* out) {
-  U sum = 0;
+  double sum = 0;
   int64_t count = 0;
   for (size_t i = i0; i < i1; ++i) {
     T value;
     bool isvalid = col.get_element(i, &value);
     if (isvalid) {
-      sum += static_cast<U>(value);
+      sum += static_cast<double>(value);
       count++;
     }
   }
   if (!count) return false;
-  *out = sum / count;
+  *out = static_cast<U>(sum / static_cast<double>(count));
   return true;  // *out is not NA
 }
 
@@ -335,24 +335,25 @@ static Column compute_gmean(Column&& arg, const Groupby&) {
 
 template <typename T, typename U>
 bool sd_reducer(const Column& col, size_t i0, size_t i1, U* out) {
-  U mean = 0;
-  U m2 = 0;
+  double mean = 0;
+  double m2 = 0;
   T value;
   int64_t count = 0;
   for (size_t i = i0; i < i1; ++i) {
     bool isvalid = col.get_element(i, &value);
     if (isvalid) {
       count++;
-      U tmp1 = static_cast<U>(value) - mean;
-      mean += tmp1 / count;
-      U tmp2 = static_cast<U>(value) - mean;
+      double tmp1 = static_cast<double>(value) - mean;
+      mean += tmp1 / static_cast<double>(count);
+      double tmp2 = static_cast<double>(value) - mean;
       m2 += tmp1 * tmp2;
     }
   }
   if (count <= 1) return false;
   // In theory, m2 should always be positive, but perhaps it could
   // occasionally become negative due to round-off errors?
-  *out = (m2 >= 0)? std::sqrt(m2/(count - 1)) : U(0);
+  *out = static_cast<U>(m2 >= 0? std::sqrt(m2/static_cast<double>(count - 1))
+                               : 0.0);
   return true;  // *out is not NA
 }
 

--- a/src/core/lib/zlib/adler32.cc
+++ b/src/core/lib/zlib/adler32.cc
@@ -10,11 +10,11 @@ namespace zlib {
 #define NMAX 5552
 /* NMAX is the largest n such that 255n(n+1)/2 + (n+1)(BASE-1) <= 2^32-1 */
 
-#define DO1(buf,i)  {adler += (buf)[i]; sum2 += adler;}
-#define DO2(buf,i)  DO1(buf,i); DO1(buf,i+1);
-#define DO4(buf,i)  DO2(buf,i); DO2(buf,i+2);
-#define DO8(buf,i)  DO4(buf,i); DO4(buf,i+4);
-#define DO16(buf)   DO8(buf,0); DO8(buf,8);
+#define DO1(buf,i)  do {adler += (buf)[i]; sum2 += adler;} while(0)
+#define DO2(buf,i)  DO1(buf,i); DO1(buf,i+1)
+#define DO4(buf,i)  DO2(buf,i); DO2(buf,i+2)
+#define DO8(buf,i)  DO4(buf,i); DO4(buf,i+4)
+#define DO16(buf)   DO8(buf,0); DO8(buf,8)
 
 #define MOD(a) a %= BASE
 #define MOD28(a) a %= BASE

--- a/src/core/lib/zlib/deflate.cc
+++ b/src/core/lib/zlib/deflate.cc
@@ -197,7 +197,7 @@ static const config configuration_table[10] = {
  */
 #define CLEAR_HASH(s) \
   s->head[s->hash_size-1] = NIL; \
-  zmemzero((Bytef *)s->head, (unsigned)(s->hash_size-1)*sizeof(*s->head));
+  zmemzero((Bytef *)s->head, (unsigned)(s->hash_size-1)*sizeof(*s->head))
 
 /* ===========================================================================
  * Slide the hash table when sliding the window down (could be avoided with 32
@@ -1318,7 +1318,7 @@ static void fill_window(deflate_state* s)
  * Flush the current block, with given end-of-file flag.
  * IN assertion: strstart is set to the end of the current match.
  */
-#define FLUSH_BLOCK_ONLY(s, last) { \
+#define FLUSH_BLOCK_ONLY(s, last) do { \
    _tr_flush_block(s, (s->block_start >= 0L ? \
            (charf *)&s->window[(unsigned)s->block_start] : \
            (charf *)Z_NULL), \
@@ -1327,13 +1327,13 @@ static void fill_window(deflate_state* s)
    s->block_start = s->strstart; \
    flush_pending(s->strm); \
    Tracev((stderr,"[FLUSH]")); \
-}
+} while(0)
 
 /* Same but force premature exit if necessary. */
-#define FLUSH_BLOCK(s, last) { \
+#define FLUSH_BLOCK(s, last) do { \
    FLUSH_BLOCK_ONLY(s, last); \
    if (s->strm->avail_out == 0) return (last) ? finish_started : need_more; \
-}
+} while(0)
 
 /* Maximum stored block length in deflate format (not including header). */
 #define MAX_STORED 65535

--- a/src/core/lib/zlib/deflate.h
+++ b/src/core/lib/zlib/deflate.h
@@ -282,7 +282,7 @@ struct deflate_state {
 /* Output a byte on the stream.
  * IN assertion: there is enough room in pending_buf.
  */
-#define put_byte(s, c) {s->pending_buf[s->pending++] = (Bytef)(c);}
+#define put_byte(s, c) do {s->pending_buf[s->pending++] = (Bytef)(c);} while(0)
 
 
 #define MIN_LOOKAHEAD (MAX_MATCH+MIN_MATCH+1)
@@ -324,14 +324,14 @@ void _tr_stored_block(deflate_state *s, charf *buf, ulg stored_len, int last);
 #endif
 
 #define _tr_tally_lit(s, c, flush) \
-  { uch cc = (c); \
+  do { uch cc = (c); \
     s->d_buf[s->last_lit] = 0; \
     s->l_buf[s->last_lit++] = cc; \
     s->dyn_ltree[cc].Freq++; \
     flush = (s->last_lit == s->lit_bufsize-1); \
-   }
+  } while(0)
 #define _tr_tally_dist(s, distance, length, flush) \
-  { uch len = (uch)(length); \
+  do { uch len = (uch)(length); \
     ush dist = (ush)(distance); \
     s->d_buf[s->last_lit] = dist; \
     s->l_buf[s->last_lit++] = len; \
@@ -339,7 +339,7 @@ void _tr_stored_block(deflate_state *s, charf *buf, ulg stored_len, int last);
     s->dyn_ltree[_length_code[len]+LITERALS+1].Freq++; \
     s->dyn_dtree[d_code(dist)].Freq++; \
     flush = (s->last_lit == s->lit_bufsize-1); \
-  }
+  } while(0)
 
 
 

--- a/src/core/lib/zlib/trees.cc
+++ b/src/core/lib/zlib/trees.cc
@@ -146,10 +146,10 @@ static void bi_flush       (deflate_state *s);
  * Output a short LSB first on the stream.
  * IN assertion: there is enough room in pendingBuf.
  */
-#define put_short(s, w) { \
+#define put_short(s, w) do { \
   put_byte(s, (uch)((w) & 0xff)); \
   put_byte(s, (uch)((ush)(w) >> 8)); \
-}
+} while(0)
 
 
 
@@ -158,7 +158,7 @@ static void bi_flush       (deflate_state *s);
  * IN assertion: length <= 16 and value fits in length bits.
  */
 #define send_bits(s, value, length) \
-{ int len = length;\
+do { int len = length;\
   if (s->bi_valid > (int)Buf_size - len) {\
   int val = (int)value;\
   s->bi_buf |= (ush)val << s->bi_valid;\
@@ -169,7 +169,7 @@ static void bi_flush       (deflate_state *s);
   s->bi_buf |= (ush)(value) << s->bi_valid;\
   s->bi_valid += len;\
   }\
-}
+} while(0)
 
 
 
@@ -225,11 +225,11 @@ static void init_block(deflate_state *s)
  * one less element. Updates heap and heap_len.
  */
 #define pqremove(s, tree, top) \
-  {\
+  do {\
     top = s->heap[SMALLEST]; \
     s->heap[SMALLEST] = s->heap[s->heap_len--]; \
     pqdownheap(s, tree, SMALLEST); \
-  }
+  } while(0)
 
 
 

--- a/src/core/lib/zlib/zutil.h
+++ b/src/core/lib/zlib/zutil.h
@@ -143,7 +143,7 @@ namespace zlib {
 #define ZALLOC(strm, items, size) \
            (*((strm)->zalloc))((strm)->opaque, (items), (size))
 #define ZFREE(strm, addr)  (*((strm)->zfree))((strm)->opaque, (voidpf)(addr))
-#define TRY_FREE(s, p) {if (p) ZFREE(s, p);}
+#define TRY_FREE(s, p) do {if (p) ZFREE(s, p);} while(0)
 
 /* Reverse the bytes in a 32-bit value */
 #define ZSWAP32(q) ((((q) >> 24) & 0xff) + (((q) >> 8) & 0xff00) + \

--- a/src/core/models/aggregator.cc
+++ b/src/core/models/aggregator.cc
@@ -982,7 +982,7 @@ void Aggregator<T>::adjust_delta(T& delta, std::vector<exptr>& exemplars,
   }
 
   // Use `delta_merge` for merging exemplars.
-  T delta_merge = pow(T(0.5) * total_distance / n_distances, T(2));
+  T delta_merge = pow(T(0.5) * total_distance / static_cast<T>(n_distances), T(2));
 
   // When exemplars are merged, all members will be within their `delta`,
   // not `delta_merge`. For that, update delta by taking into account size
@@ -1068,7 +1068,7 @@ T Aggregator<T>::calculate_distance(tptr<T>& e1, tptr<T>& e2,
   }
 
   if (n != 0) {
-    distance *= static_cast<T>(ndims) / n;
+    distance *= static_cast<T>(ndims) / static_cast<T>(n);
   }
 
   return distance;
@@ -1119,7 +1119,7 @@ void Aggregator<T>::project_row(tptr<T>& r, size_t row, size_t ncols, tptr<T>& p
   if (n == 0) return;
 
   for (size_t j = 0; j < max_dimensions; ++j) {
-    r[j] /= n;
+    r[j] /= static_cast<T>(n);
   }
 }
 
@@ -1163,12 +1163,12 @@ std::unique_ptr<T[]> Aggregator<T>::generate_pmatrix(size_t ncols) {
 template <typename T>
 void Aggregator<T>::set_norm_coeffs(T& norm_factor, T& norm_shift,
                                     T c_min, T c_max, size_t c_bins) {
-  if (fabs(c_max - c_min) > epsilon) {
-    norm_factor = c_bins * (1 - epsilon) / (c_max - c_min);
+  if (std::fabs(c_max - c_min) > epsilon) {
+    norm_factor = static_cast<T>(c_bins) * (1 - epsilon) / (c_max - c_min);
     norm_shift = -norm_factor * c_min;
   } else {
     norm_factor = T(0.0);
-    norm_shift =  T(0.5) * c_bins;
+    norm_shift =  T(0.5) * static_cast<T>(c_bins);
   }
 }
 

--- a/src/core/models/dt_ftrl.h
+++ b/src/core/models/dt_ftrl.h
@@ -104,7 +104,7 @@ class Ftrl : public dt::FtrlBase {
     FtrlFitOutput fit_multinomial();
     template <typename U> FtrlFitOutput fit_regression();
     template <typename U, typename V>
-    FtrlFitOutput fit(T(*)(T), U(*)(U, size_t), V(*)(V, size_t), T(*)(T, V));
+    FtrlFitOutput fit(T(*)(T), U(*)(U, size_t), V(*)(V, size_t), T(*)(T, T));
     template <typename U>
     void update(const uint64ptr&, const tptr<T>&, T, U, size_t);
 

--- a/src/core/models/utils.h
+++ b/src/core/models/utils.h
@@ -79,22 +79,20 @@ inline T identity(T x) {
  *    to prevent logloss being undefined;
  *  - simplify the logloss formula to more compact branchless code.
  */
-template<typename T1, typename T2>
-inline T1 log_loss(T1 p, T2 y) {
-  constexpr T1 epsilon = std::numeric_limits<T1>::epsilon();
+template<typename T>
+inline T log_loss(T p, T y) {
+  constexpr T epsilon = std::numeric_limits<T>::epsilon();
   p = std::max(std::min(p, 1 - epsilon), epsilon);
   return -std::log(p * (2*y - 1) + 1 - y);
 }
 
 
 /**
- *  Squared loss, T1 is either float or double,
- *  T2 is any other numerical type.
+ *  Squared loss, T is either float or double,
  */
-template<typename T1, typename T2>
-inline T1 squared_loss(T1 p, T2 y) {
-  T1 y_T1 = static_cast<T1>(y);
-  return (p - y_T1) * (p - y_T1);
+template<typename T>
+inline T squared_loss(T p, T y) {
+  return (p - y) * (p - y);
 }
 
 

--- a/src/core/py_buffers.cc
+++ b/src/core/py_buffers.cc
@@ -194,7 +194,8 @@ static void try_to_resolve_object_column(Column& col)
         PyObject *z = PyUnicode_AsEncodedString(v, "utf-8", "strict");
         size_t sz = static_cast<size_t>(PyBytes_Size(z));
         if (offset + sz > strbuf_size) {
-          strbuf_size = static_cast<size_t>(1.5 * strbuf_size + sz);
+          strbuf_size = static_cast<size_t>(
+              1.5 * static_cast<double>(strbuf_size) + static_cast<double>(sz));
           strbuf.resize(strbuf_size);
           strs = static_cast<char*>(strbuf.xptr());
         }

--- a/src/core/read/parallel_reader.cc
+++ b/src/core/read/parallel_reader.cc
@@ -53,9 +53,9 @@ void ParallelReader::determine_chunking_strategy() {
   size_t input_size = static_cast<size_t>(input_end - input_start);
   size_t nrows_max = g.max_nrows;
 
-  double maxrows_size = nrows_max * approximate_line_length;
+  double maxrows_size = static_cast<double>(nrows_max) * approximate_line_length;
   bool input_size_reduced = false;
-  if (nrows_max < 1000000 && maxrows_size < input_size) {
+  if (nrows_max < 1000000 && maxrows_size < static_cast<double>(input_size)) {
     input_size = static_cast<size_t>(maxrows_size * 1.5) + 1;
     input_size_reduced = true;
   }

--- a/src/core/read/preframe.cc
+++ b/src/core/read/preframe.cc
@@ -135,7 +135,9 @@ size_t PreFrame::ensure_output_nrows(size_t nrows_in_chunk0, size_t ichunk,
           nrows_max,
           std::max(
               1024 + nrows_allocated_,
-              static_cast<size_t>(1.2 * nrows_new * nchunks / (ichunk + 1))
+              static_cast<size_t>(1.2 * static_cast<double>(nrows_new)
+                                      * static_cast<double>(nchunks)
+                                      / static_cast<double>(ichunk + 1))
       ));
     }
 
@@ -151,11 +153,13 @@ size_t PreFrame::ensure_output_nrows(size_t nrows_in_chunk0, size_t ichunk,
       for (const auto& col : columns_) {
         archived_size += col.archived_size();
       }
-      double avg_size_per_row = 1.0 * archived_size / nrows_written_;
-      if (nrows_extra * avg_size_per_row > memory_limit) {
+      double avg_size_per_row = static_cast<double>(archived_size)
+                                / static_cast<double>(nrows_written_);
+      if (static_cast<double>(nrows_extra) * avg_size_per_row > static_cast<double>(memory_limit)) {
         nrows_extra = std::max(
             nrows_in_chunk,
-            static_cast<size_t>(memory_limit / avg_size_per_row)
+            static_cast<size_t>(static_cast<double>(memory_limit)
+                                / avg_size_per_row)
         );
         nrows_new = nrows_written_ + nrows_extra;
       }
@@ -189,8 +193,10 @@ void PreFrame::archive_column_chunks(size_t expected_nrows) {
 
   if (!tempfile_ && memory_limit != MEMORY_UNLIMITED) {
     size_t current_memory = total_allocsize();
-    double new_memory = 1.0 * expected_nrows / nrows_allocated_ * current_memory;
-    if (new_memory > 0.95 * memory_limit) {
+    double new_memory = static_cast<double>(expected_nrows)
+        / static_cast<double>(nrows_allocated_)
+        * static_cast<double>(current_memory);
+    if (new_memory > 0.95 * static_cast<double>(memory_limit)) {
       init_tempfile();
     }
   }

--- a/src/core/utils/misc.cc
+++ b/src/core/utils/misc.cc
@@ -148,7 +148,8 @@ void set_value(void* ptr, const void* value, size_t sz, size_t count) {
       if (__builtin_available(macos 10.12, *))
     #endif
     ret = clock_gettime(CLOCK_REALTIME, &tp);
-    return ret == 0? 1.0 * tp.tv_sec + 1e-9 * tp.tv_nsec : 0;
+    return ret == 0? 1.0 * static_cast<double>(tp.tv_sec) +
+                     1e-9 * static_cast<double>(tp.tv_nsec) : 0.0;
   }
 #else
   #include <sys/time.h>
@@ -197,7 +198,7 @@ const char* filesize_to_str(size_t fsize)
       }
     } else {
       snprintf(output, BUFFSIZE, "%.*f%cB",
-               ndigits, static_cast<double>(fsize) / (1LL << shift),
+               ndigits, static_cast<double>(fsize) / static_cast<double>(1LL << shift),
                suffixes[i]);
       return output;
     }

--- a/src/core/write/write_manager.cc
+++ b/src/core/write/write_manager.cc
@@ -215,7 +215,8 @@ void write_manager::determine_chunking_strategy()
   size_t nrows = dt->nrows();
   if (nrows == 0 || dt->ncols() == 0) return;
   xassert(estimated_output_size > 0);
-  const double bytes_per_row = 1.0 * estimated_output_size / nrows;
+  const double bytes_per_row = static_cast<double>(estimated_output_size) /
+                               static_cast<double>(nrows);
 
   static constexpr size_t max_chunk_size = 1024 * 1024;
   static constexpr size_t min_chunk_size = 1024;
@@ -229,7 +230,7 @@ void write_manager::determine_chunking_strategy()
 
   int attempts = 5;
   while (attempts--) {
-    double rows_per_chunk = 1.0 * (nrows + 1) / nchunks;
+    double rows_per_chunk = static_cast<double>(nrows + 1) / static_cast<double>(nchunks);
     auto bytes_per_chunk = static_cast<size_t>(bytes_per_row * rows_per_chunk);
     if (rows_per_chunk < 1.0) {
       // If each row's size is too large, then parse 1 row at a time.


### PR DESCRIPTION
After switching to the recent version of Clang compiler, there were over 1000 warnings, mostly from the `-Wimplicit-int-float-conversion` category. These warning are now fixed and the source compiles cleanly with the recent Clang.