### PR TITLE
Do not use Sphinx 3.2.0 for doc builds

### DIFF
--- a/docs/api/dt/qcut.rst
+++ b/docs/api/dt/qcut.rst
@@ -1,0 +1,6 @@
+.. py:currentmodule:: datatable
+
+.. xfunction:: datatable.qcut
+    :src: src/core/expr/head_func_qcut.cc pyfn_qcut
+    :doc: src/core/expr/head_func_qcut.cc doc_qcut
+    :tests: tests/ijby/test-qcut.py

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,6 +1,6 @@
 docutils>=0.15
 pygments>=2.6
-sphinx>=3.0
+sphinx>=3.0,!=3.2.0
 sphinx_rtd_theme>=0.5
 nbsphinx>=0.5
 datatable


### PR DESCRIPTION
- Due to a bug in Sphinx, version 3.2.0 cannot be used to build our documentation, so we exclude it in the requirements file;
- Added missing file `qcut.rst`.

Closes #2568 