### PR TITLE
Add checks to allow compilation on FreeBSD

### DIFF
--- a/src/core/buffer.cc
+++ b/src/core/buffer.cc
@@ -40,7 +40,9 @@
   #include <sys/mman.h>        // mmap, munmap
 #endif
 
-
+#ifndef MAP_NORESERVE
+#define MAP_NORESERVE 0 // does not exist in FreeBSD 11.x
+#endif
 
 //------------------------------------------------------------------------------
 // BufferImpl

--- a/src/core/parallel/semaphore.h
+++ b/src/core/parallel/semaphore.h
@@ -131,7 +131,7 @@ class Semaphore {
 //------------------------------------------------------------------------------
 // Semaphore (POSIX, Linux)
 //------------------------------------------------------------------------------
-#elif DT_OS_LINUX
+#elif (DT_OS_LINUX || DT_OS_FREEBSD)
 #include <semaphore.h>
 
 class Semaphore {

--- a/src/core/utils/macros.h
+++ b/src/core/utils/macros.h
@@ -29,9 +29,10 @@
 // Operating system
 //------------------------------------------------------------------------------
 
-#define DT_OS_MACOS  0
+#define DT_OS_MACOS   0
 #define DT_OS_LINUX   0
 #define DT_OS_WINDOWS 0
+#define DT_OS_FREEBSD 0
 
 
 #if defined(__APPLE__) && defined(__MACH__)
@@ -44,18 +45,23 @@
   #define DT_OS_LINUX 1
 #endif
 
+#if defined(__FreeBSD__)
+  #undef  DT_OS_FREEBSD
+  #define DT_OS_FREEBSD 1
+#endif
+
 #ifdef _WIN32
   #undef  DT_OS_WINDOWS
   #define DT_OS_WINDOWS 1
 #endif
 
-#if (DT_OS_LINUX || DT_OS_MACOS)
+#if (DT_OS_LINUX || DT_OS_MACOS || DT_OS_FREEBSD)
   #define DT_UNIX 1
 #else
   #define DT_UNIX 0
 #endif
 
-#if DT_OS_WINDOWS + DT_OS_MACOS + DT_OS_LINUX != 1
+#if DT_OS_WINDOWS + DT_UNIX != 1
   #error Unknown operating system
 #endif
 

--- a/src/core/utils/misc.h
+++ b/src/core/utils/misc.h
@@ -63,7 +63,7 @@ void set_value(void* ptr, const void* value, size_t sz, size_t count);
 #elif DT_OS_WINDOWS
   #include <malloc.h>  // size_t _msize(void *)
   #define malloc_size  _msize
-#elif DT_OS_LINUX
+#elif (DT_OS_LINUX || DT_OS_FREEBSD)
   #include <malloc.h>  // size_t malloc_usable_size(void *) __THROW
   #define malloc_size  malloc_usable_size
 #else


### PR DESCRIPTION
These minor changes allow successful compilation on FreeBSD. "gmake test" only fails `test_save_double2`, which doesn't look serious:

`E           AssertionError: assert ['1.0e-307', ....0e-302', ...] == ['1.0e-307', ....0e-302', ...]`
`E             At index 4 diff: '1.0000000000000001e-303' != '1.0e-303'`
`E             Use -v to get the full diff`
