### PR TITLE
py::XArgs class

### DIFF
--- a/docs/develop/create-fexpr.rst
+++ b/docs/develop/create-fexpr.rst
@@ -207,12 +207,9 @@ python's ``PyObject*``.
 
 .. code-block:: C++
 
-    static py::oobj py_gcd(const py::PKArgs& args) {
+    static py::oobj py_gcd(const py::XArgs& args) {
       auto a = args[0].to_oobj();
       auto b = args[1].to_oobj();
-      if (!b) {
-        throw TypeError() << "Function `gcd()` requires 2 positional arguments";
-      }
       return PyFExpr::make(new FExpr_Gcd(as_fexpr(a), as_fexpr(b)));
     }
 
@@ -242,25 +239,12 @@ python function:
         of type int64, or otherwise it will be int32.
     )";
 
-    static py::PKArgs args_gcd(
-        2, 0, 0, false, false, {"a", "b"}, "gcd", doc_gcd);
-
-The next step is to "tell" python runtime about this function, by attaching
-it to the module object. We do this by creating a method ``init_gcd()`` in
-``DatatableModule`` class (see ``src/core/datatablemodule.h``), then calling
-that method from within ``py::DatatableModule::init_methods()`` (see
-``src/core/datatablemodule.cc``), and the ``init_gcd()`` method itself should
-simply say
-
-.. code-block:: C++
-
-    void py::DatatableModule::init_gcd() {
-      ADD_FN(&py_gcd, args_gcd);
-    }
-
-That is, we declare here that our ``py_gcd()`` function has arguments that are
-described by the ``args_gcd`` object, and that this function should be added to
-the ``_datatable`` module.
+    DECLARE_PYFN(&py_gcd)
+        ->name("gcd")
+        ->docs(doc_gcd)
+        ->arg_names({"a", "b"})
+        ->n_positional_args(2)
+        ->n_required_args(2);
 
 At this point the method will be visible from python in the ``_datatable``
 module. So the next step is to import it into the main ``datatable`` module.

--- a/src/core/_dt.h
+++ b/src/core/_dt.h
@@ -63,6 +63,7 @@ namespace py {
   class Frame;
   class GSArgs;
   class PKArgs;
+  class XArgs;
   class obool;
   class oby;
   class odict;

--- a/src/core/call_logger.cc
+++ b/src/core/call_logger.cc
@@ -28,6 +28,7 @@
 #include "python/args.h"
 #include "python/bool.h"
 #include "python/string.h"
+#include "python/xargs.h"
 #include "utils/function.h"
 #include "utils/logger.h"   // dt::log::Logger
 namespace dt {
@@ -253,6 +254,7 @@ class CallLogger::Impl
   public:
     Impl(size_t i);
     void init_function  (const py::PKArgs* pkargs, py::robj args, py::robj kwds) noexcept;
+    void init_function  (const py::XArgs* xargs, py::robj args, py::robj kwds) noexcept;
     void init_method    (const py::PKArgs* pkargs, py::robj obj, py::robj args, py::robj kwds) noexcept;
     void init_dealloc   (py::robj obj) noexcept;
     void init_getset    (py::robj obj, py::robj val, void* closure) noexcept;
@@ -300,6 +302,17 @@ void CallLogger::Impl::init_function(
 {
   safe_init([&] {
     *out_ << "dt." << pkargs->get_short_name() << '(';
+    print_arguments(args, kwds);
+    *out_ << ')';
+  });
+}
+
+
+void CallLogger::Impl::init_function(
+    const py::XArgs* xargs, py::robj args, py::robj kwds) noexcept
+{
+  safe_init([&] {
+    *out_ << xargs->qualified_name() << '(';
     print_arguments(args, kwds);
     *out_ << ')';
   });
@@ -526,6 +539,17 @@ CallLogger CallLogger::function(
   CallLogger cl;
   if (cl.impl_) {
     cl.impl_->init_function(pkargs, py::robj(pyargs), py::robj(pykwds));
+  }
+  return cl;
+}
+
+
+CallLogger CallLogger::function(
+    const py::XArgs* xargs, PyObject* pyargs, PyObject* pykwds) noexcept
+{
+  CallLogger cl;
+  if (cl.impl_) {
+    cl.impl_->init_function(xargs, py::robj(pyargs), py::robj(pykwds));
   }
   return cl;
 }

--- a/src/core/call_logger.h
+++ b/src/core/call_logger.h
@@ -75,6 +75,7 @@ class CallLogger {
     ~CallLogger();
 
     static CallLogger function  (const py::PKArgs*, PyObject* pyargs, PyObject* pykwds) noexcept;
+    static CallLogger function  (const py::XArgs*, PyObject* pyargs, PyObject* pykwds) noexcept;
     static CallLogger method    (const py::PKArgs*, PyObject* pyobj, PyObject* pyargs, PyObject* pykwds) noexcept;
     static CallLogger dealloc   (PyObject* pyobj) noexcept;
     static CallLogger getset    (PyObject* pyobj, PyObject* val, void* closure) noexcept;

--- a/src/core/datatablemodule.cc
+++ b/src/core/datatablemodule.cc
@@ -381,7 +381,6 @@ void py::DatatableModule::init_methods() {
   init_methods_shift();
   init_methods_str();
   init_methods_styles();
-  init_methods_qcut();
 
   init_fbinary();
   init_fnary();

--- a/src/core/datatablemodule.cc
+++ b/src/core/datatablemodule.cc
@@ -371,7 +371,6 @@ void py::DatatableModule::init_methods() {
   init_methods_buffers();
   init_methods_cbind();
   init_methods_csv();
-  init_methods_cut();
   init_methods_isclose();
   init_methods_jay();
   init_methods_join();

--- a/src/core/datatablemodule.cc
+++ b/src/core/datatablemodule.cc
@@ -372,7 +372,6 @@ void py::DatatableModule::init_methods() {
   init_methods_cbind();
   init_methods_csv();
   init_methods_cut();
-  init_methods_ifelse();
   init_methods_isclose();
   init_methods_jay();
   init_methods_join();

--- a/src/core/datatablemodule.cc
+++ b/src/core/datatablemodule.cc
@@ -50,6 +50,7 @@
 #include "py_encodings.h"
 #include "python/_all.h"
 #include "python/string.h"
+#include "python/xargs.h"
 #include "read/py_read_iterator.h"
 #include "sort.h"
 #include "utils/assert.h"
@@ -361,6 +362,10 @@ void py::DatatableModule::init_methods() {
   ADD_FN(&compiler_version, args_compiler_version);
   ADD_FN(&regex_supported, args_regex_supported);
   ADD_FN(&apply_color, args_apply_color);
+
+  for (py::XArgs* xarg : py::XArgs::store()) {
+    add(xarg->get_method_def());
+  }
 
   init_methods_aggregate();
   init_methods_buffers();

--- a/src/core/datatablemodule.h
+++ b/src/core/datatablemodule.h
@@ -44,7 +44,6 @@ class DatatableModule : public ExtModule<DatatableModule> {
     void init_methods_jay();       // open_jay.cc
     void init_methods_join();      // frame/join.cc
     void init_methods_kfold();     // models/kfold.cc
-    void init_methods_qcut();      // expr/head_func_qcut.cc
     void init_methods_rbind();     // frame/rbind.cc
     void init_methods_repeat();    // frame/repeat.cc
     void init_methods_sets();      // set_funcs.cc

--- a/src/core/datatablemodule.h
+++ b/src/core/datatablemodule.h
@@ -35,7 +35,6 @@ class DatatableModule : public ExtModule<DatatableModule> {
     void init_methods_cbind();     // frame/cbind.cc
     void init_methods_csv();       // csv/py_csv.cc
     void init_methods_cut();       // expr/head_func_cut.cc
-    void init_methods_ifelse();    // expr/head_func_ifelse.cc
     void init_methods_isclose();   // expr/head_func_isclose.cc
     void init_methods_jay();       // open_jay.cc
     void init_methods_join();      // frame/join.cc

--- a/src/core/datatablemodule.h
+++ b/src/core/datatablemodule.h
@@ -1,17 +1,23 @@
 //------------------------------------------------------------------------------
-// Copyright 2018 H2O.ai
+// Copyright 2018-2020 H2O.ai
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
 //
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #ifndef dt_DATATABLEMODULE_h
 #define dt_DATATABLEMODULE_h
@@ -34,7 +40,6 @@ class DatatableModule : public ExtModule<DatatableModule> {
     void init_methods_buffers();   // py_buffers.cc
     void init_methods_cbind();     // frame/cbind.cc
     void init_methods_csv();       // csv/py_csv.cc
-    void init_methods_cut();       // expr/head_func_cut.cc
     void init_methods_isclose();   // expr/head_func_isclose.cc
     void init_methods_jay();       // open_jay.cc
     void init_methods_join();      // frame/join.cc

--- a/src/core/expr/fexpr_cut.cc
+++ b/src/core/expr/fexpr_cut.cc
@@ -20,11 +20,11 @@
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #include "_dt.h"
-#include "datatablemodule.h"
 #include "column/cut.h"
 #include "expr/eval_context.h"
 #include "expr/fexpr_func.h"
 #include "frame/py_frame.h"
+#include "python/xargs.h"
 namespace dt {
 namespace expr {
 
@@ -42,7 +42,7 @@ class FExpr_Cut : public FExpr_Func {
     size_t: 56;
 
   public:
-    FExpr_Cut(py::oobj arg, py::robj py_nbins, bool right_closed)
+    FExpr_Cut(py::robj arg, py::robj py_nbins, bool right_closed)
       : arg_(as_fexpr(arg)),
         py_nbins_(py_nbins),
         right_closed_(right_closed)
@@ -164,19 +164,7 @@ See also
 
 )";
 
-static py::PKArgs args_cut(
-  1, 0, 2, false, false,
-  {
-    "cols", "nbins", "right_closed"
-  },
-  "cut", doc_cut
-);
-
-static py::oobj pyfn_cut(const py::PKArgs& args) {
-  if (args[0].is_none_or_undefined()) {
-    throw TypeError() << "Function `cut()` requires one positional argument, "
-                         "but none were given";
-  }
+static py::oobj pyfn_cut(const py::XArgs& args) {
   py::oobj arg0 = args[0].to_oobj();
   py::oobj arg1 = args[1].is_none_or_undefined()? py::None() : args[1].to_oobj();
   bool arg2 = args[2].is_none_or_undefined()? true : args[2].to_bool_strict();
@@ -184,11 +172,14 @@ static py::oobj pyfn_cut(const py::PKArgs& args) {
   return PyFExpr::make(new FExpr_Cut(arg0, arg1, arg2));
 }
 
+DECLARE_PYFN(&pyfn_cut)
+    ->name("cut")
+    ->docs(doc_cut)
+    ->arg_names({"cols", "nbins", "right_closed"})
+    ->n_positional_args(1)
+    ->n_keyword_args(2)
+    ->n_required_args(1);
+
 
 
 }}  // dt::expr
-
-
-void py::DatatableModule::init_methods_cut() {
-  ADD_FN(&dt::expr::pyfn_cut, dt::expr::args_cut);
-}

--- a/src/core/expr/fexpr_cut.cc
+++ b/src/core/expr/fexpr_cut.cc
@@ -141,6 +141,7 @@ Parameters
 ----------
 cols: FExpr
     Input data for equal-width interval binning.
+
 nbins: int | List[int]
     When a single number is specified, this number of bins
     will be used to bin each column of `cols`.
@@ -148,6 +149,7 @@ nbins: int | List[int]
     by using its own number of bins. In the latter case,
     the list/tuple length must be equal to the number of columns
     in `cols`.
+
 right_closed: bool
     Each binning interval is `half-open`_. This flag indicates which
     side of the interval is closed.
@@ -165,11 +167,10 @@ See also
 )";
 
 static py::oobj pyfn_cut(const py::XArgs& args) {
-  py::oobj arg0 = args[0].to_oobj();
-  py::oobj arg1 = args[1].is_none_or_undefined()? py::None() : args[1].to_oobj();
-  bool arg2 = args[2].is_none_or_undefined()? true : args[2].to_bool_strict();
-
-  return PyFExpr::make(new FExpr_Cut(arg0, arg1, arg2));
+  auto arg0         = args[0].to_oobj();
+  auto nbins        = args[1].to<py::oobj>(py::None());
+  auto right_closed = args[2].to<bool>(true);
+  return PyFExpr::make(new FExpr_Cut(arg0, nbins, right_closed));
 }
 
 DECLARE_PYFN(&pyfn_cut)

--- a/src/core/expr/fexpr_ifelse.cc
+++ b/src/core/expr/fexpr_ifelse.cc
@@ -20,10 +20,11 @@
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #include "column/ifelse.h"        // IfElse_ColumnImpl
+#include "datatablemodule.h"      // DatatableModule
 #include "expr/eval_context.h"    // EvalContext
 #include "expr/fexpr_func.h"      // FExpr_Func
 #include "expr/workframe.h"       // Workframe
-#include "datatablemodule.h"      // DatatableModule
+#include "python/xargs.h"         // DECLARE_PYFN
 #include "stype.h"                // SType
 namespace dt {
 namespace expr {
@@ -145,26 +146,40 @@ return: FExpr
     upcasted.
 )";
 
-static PKArgs args_ifelse(
-    3, 0, 0, false, false,
-    {"condition", "expr_if_true", "expr_if_false"},
-    "ifelse", doc_ifelse);
+// static PKArgs args_ifelse(
+//     3, 0, 0, false, false,
+//     {"condition", "expr_if_true", "expr_if_false"},
+//     "ifelse", doc_ifelse);
 
-static oobj ifelse(const PKArgs& args) {
-  robj arg_cond = args[0].to_robj();
-  robj arg_true = args[1].to_robj();
-  robj arg_false = args[2].to_robj();
-  if (!arg_cond || !arg_true || !arg_false) {
-    throw TypeError() << "Function `ifelse()` requires 3 arguments";
-  }
+// static oobj ifelse(const PKArgs& args) {
+//   robj arg_cond = args[0].to_robj();
+//   robj arg_true = args[1].to_robj();
+//   robj arg_false = args[2].to_robj();
+//   if (!arg_cond || !arg_true || !arg_false) {
+//     throw TypeError() << "Function `ifelse()` requires 3 arguments";
+//   }
+//   return dt::expr::PyFExpr::make(
+//               new dt::expr::FExpr_IfElse(arg_cond, arg_true, arg_false));
+// }
+
+static oobj ifelse(const XArgs& args) {
   return dt::expr::PyFExpr::make(
-              new dt::expr::FExpr_IfElse(arg_cond, arg_true, arg_false));
+              new dt::expr::FExpr_IfElse(args[0].to_robj(),
+                                         args[1].to_robj(),
+                                         args[2].to_robj())
+         );
 }
+
+DECLARE_PYFN(ifelse, &ifelse)
+    ->n_positional_args(3)
+    ->n_required_args(3)
+    ->arg_names({"condition", "expr_if_true", "expr_if_false"})
+    ->documentation(doc_ifelse);
 
 
 
 void DatatableModule::init_methods_ifelse() {
-  ADD_FN(&ifelse, args_ifelse);
+  // ADD_FN(&ifelse, args_ifelse);
 }
 
 

--- a/src/core/expr/fexpr_ifelse.cc
+++ b/src/core/expr/fexpr_ifelse.cc
@@ -104,14 +104,9 @@ std::string FExpr_IfElse::repr() const {
 
 
 
-}}  // dt::expr
-
-
 //------------------------------------------------------------------------------
 // Python interface
 //------------------------------------------------------------------------------
-namespace py {
-
 
 static const char* doc_ifelse =
 R"(ifelse(condition, expr_if_true, expr_if_false)
@@ -145,7 +140,7 @@ return: FExpr
     upcasted.
 )";
 
-static oobj ifelse(const XArgs& args) {
+static py::oobj ifelse(const py::XArgs& args) {
   return dt::expr::PyFExpr::make(
               new dt::expr::FExpr_IfElse(args[0].to_robj(),
                                          args[1].to_robj(),
@@ -162,4 +157,4 @@ DECLARE_PYFN(&ifelse)
 
 
 
-}
+}}  // dt::expr

--- a/src/core/expr/fexpr_ifelse.cc
+++ b/src/core/expr/fexpr_ifelse.cc
@@ -20,7 +20,6 @@
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #include "column/ifelse.h"        // IfElse_ColumnImpl
-#include "datatablemodule.h"      // DatatableModule
 #include "expr/eval_context.h"    // EvalContext
 #include "expr/fexpr_func.h"      // FExpr_Func
 #include "expr/workframe.h"       // Workframe
@@ -146,22 +145,6 @@ return: FExpr
     upcasted.
 )";
 
-// static PKArgs args_ifelse(
-//     3, 0, 0, false, false,
-//     {"condition", "expr_if_true", "expr_if_false"},
-//     "ifelse", doc_ifelse);
-
-// static oobj ifelse(const PKArgs& args) {
-//   robj arg_cond = args[0].to_robj();
-//   robj arg_true = args[1].to_robj();
-//   robj arg_false = args[2].to_robj();
-//   if (!arg_cond || !arg_true || !arg_false) {
-//     throw TypeError() << "Function `ifelse()` requires 3 arguments";
-//   }
-//   return dt::expr::PyFExpr::make(
-//               new dt::expr::FExpr_IfElse(arg_cond, arg_true, arg_false));
-// }
-
 static oobj ifelse(const XArgs& args) {
   return dt::expr::PyFExpr::make(
               new dt::expr::FExpr_IfElse(args[0].to_robj(),
@@ -170,17 +153,12 @@ static oobj ifelse(const XArgs& args) {
          );
 }
 
-DECLARE_PYFN(ifelse, &ifelse)
-    ->n_positional_args(3)
-    ->n_required_args(3)
+DECLARE_PYFN(&ifelse)
+    ->name("ifelse")
+    ->docs(doc_ifelse)
     ->arg_names({"condition", "expr_if_true", "expr_if_false"})
-    ->documentation(doc_ifelse);
-
-
-
-void DatatableModule::init_methods_ifelse() {
-  // ADD_FN(&ifelse, args_ifelse);
-}
+    ->n_positional_args(3)
+    ->n_required_args(3);
 
 
 

--- a/src/core/expr/fexpr_qcut.cc
+++ b/src/core/expr/fexpr_qcut.cc
@@ -23,11 +23,11 @@
 #include "column/latent.h"
 #include "column/sentinel_fw.h"
 #include "column/qcut.h"
-#include "datatablemodule.h"
 #include "expr/eval_context.h"
 #include "expr/fexpr_func.h"
 #include "frame/py_frame.h"
 #include "parallel/api.h"
+#include "python/xargs.h"
 namespace dt {
 namespace expr {
 
@@ -167,32 +167,21 @@ return: FExpr
     with the respective quantile ids.
 )";
 
-static py::PKArgs args_qcut(
-  1, 0, 1, false, false,
-  {
-    "cols", "nquantiles"
-  },
-  "qcut", doc_qcut
-);
-
-static py::oobj pyfn_qcut(const py::PKArgs& args) {
-  if (args[0].is_none_or_undefined()) {
-    throw TypeError() << "Function `qcut()` requires one positional argument, "
-      << "but none were given";
-  }
-
-  auto arg0 = args[0].to_oobj();
-  auto arg1 = args[1].is_none_or_undefined()? py::None() : args[1].to_oobj();
-
-  return PyFExpr::make(new FExpr_Qcut(arg0, arg1));
+static py::oobj pyfn_qcut(const py::XArgs& args) {
+  auto cols       = args[0].to_oobj();
+  auto nquantiles = args[1].to<py::oobj>(py::None());
+  return PyFExpr::make(new FExpr_Qcut(cols, nquantiles));
 }
+
+DECLARE_PYFN(&pyfn_qcut)
+    ->name("qcut")
+    ->docs(doc_qcut)
+    ->arg_names({"cols", "nquantiles"})
+    ->n_positional_args(1)
+    ->n_keyword_args(1)
+    ->n_required_args(1);
 
 
 
 
 }}  // dt::expr
-
-
-void py::DatatableModule::init_methods_qcut() {
-  ADD_FN(&dt::expr::pyfn_qcut, dt::expr::args_qcut);
-}

--- a/src/core/python/arg.cc
+++ b/src/core/python/arg.cc
@@ -22,7 +22,7 @@
 #include <cstdio>
 #include "cstring.h"
 #include "python/arg.h"
-#include "python/args.h"        // py::PKArgs
+#include "python/args.h"        // py::ArgParent
 #include "python/dict.h"
 #include "python/int.h"
 #include "python/list.h"
@@ -55,7 +55,7 @@ Arg::Arg(const std::string& cached_name_)
 Arg::~Arg() {}
 
 
-void Arg::init(size_t i, PKArgs* args) {
+void Arg::init(size_t i, ArgParent* args) {
   pos = i;
   parent = args;
 }

--- a/src/core/python/arg.cc
+++ b/src/core/python/arg.cc
@@ -68,13 +68,31 @@ void Arg::set(PyObject* value) {
 
 const std::string& Arg::name() const {
   if (cached_name.empty()) {
-    cached_name = parent->make_arg_name(pos);
+    bool single_arg = (pos == 0) &&
+                      parent->n_positional_args() == 1 &&
+                      parent->n_keyword_args() == 0 &&
+                      parent->n_positional_or_keyword_args() == 0 &&
+                      !parent->has_varargs() &&
+                      !parent->has_varkwds();
+    if (single_arg) {
+      cached_name = "The argument";
+    }
+    else if (pos < parent->n_positional_args()) {
+      cached_name = (pos == 0)? "First" :
+            (pos == 1)? "Second" :
+            (pos == 2)? "Third" :
+            std::to_string(pos + 1) + "th";
+      cached_name += " argument";
+    } else {
+      cached_name = std::string("Argument `") + parent->arg_name(pos) + '`';
+    }
+    cached_name += std::string(" in ") + parent->descriptive_name(true);
   }
   return cached_name;
 }
 
 const char* Arg::short_name() const {
-  return parent->get_arg_short_name(pos);
+  return parent->arg_name(pos);
 }
 
 

--- a/src/core/python/arg.h
+++ b/src/core/python/arg.h
@@ -27,6 +27,7 @@
 #include "python/list.h"
 namespace py {
 
+class ArgParent;
 
 /**
  * The argument may be in "undefined" state, meaning the user did not provide
@@ -36,7 +37,7 @@ namespace py {
 class Arg : public _obj::error_manager {
   private:
     size_t pos;
-    PKArgs* parent;
+    ArgParent* parent;
     py::robj pyobj;
     mutable std::string cached_name;
 
@@ -46,7 +47,7 @@ class Arg : public _obj::error_manager {
     Arg(py::_obj, const std::string&);
     Arg(const Arg&) = default;
     virtual ~Arg() override;
-    void init(size_t i, PKArgs* args);
+    void init(size_t i, ArgParent* args);
     void set(PyObject* value);
 
     //---- Type checks -----------------

--- a/src/core/python/args.h
+++ b/src/core/python/args.h
@@ -31,6 +31,14 @@
 namespace py {
 
 
+class ArgParent {
+  public:
+    virtual ~ArgParent() = default;
+    virtual std::string make_arg_name(size_t i) const = 0;
+    virtual const char* get_arg_short_name(size_t i) const = 0;
+};
+
+
 
 //------------------------------------------------------------------------------
 // GSArgs
@@ -71,7 +79,7 @@ class VarKwdsIterable;
  * args-related functions, each designed to handle different calling
  * convention.
  */
-class PKArgs {
+class PKArgs : public ArgParent {
   private:
     const char* cls_name;
     const char* fun_name;
@@ -111,7 +119,7 @@ class PKArgs {
            const char* name = nullptr, const char* doc = nullptr);
     PKArgs(const PKArgs&) = delete;
     PKArgs(PKArgs&&) = delete;
-    ~PKArgs();
+    ~PKArgs() override;
     void add_synonym_arg(const char* new_name, const char* old_name);
 
     void bind(PyObject* _args, PyObject* _kws);
@@ -147,8 +155,8 @@ class PKArgs {
      * This name can also be obtained as
      *    args[i].name()
      */
-    std::string make_arg_name(size_t i) const;
-    const char* get_arg_short_name(size_t i) const;
+    std::string make_arg_name(size_t i) const override;
+    const char* get_arg_short_name(size_t i) const override;
 
     //---- User API --------------------
     void check_posonly_args() const;

--- a/src/core/python/args.h
+++ b/src/core/python/args.h
@@ -34,8 +34,13 @@ namespace py {
 class ArgParent {
   public:
     virtual ~ArgParent() = default;
-    virtual std::string make_arg_name(size_t i) const = 0;
-    virtual const char* get_arg_short_name(size_t i) const = 0;
+    virtual std::string descriptive_name(bool lowercase = false) const = 0;
+    virtual const char* arg_name(size_t i) const = 0;
+    virtual size_t n_positional_args() const = 0;
+    virtual size_t n_positional_or_keyword_args() const = 0;
+    virtual size_t n_keyword_args() const = 0;
+    virtual bool has_varargs() const = 0;
+    virtual bool has_varkwds() const = 0;
 };
 
 
@@ -89,8 +94,8 @@ class PKArgs : public ArgParent {
     const size_t n_posonly_args;
     const size_t n_pos_kwd_args;
     const size_t n_all_args;
-    const bool   has_varargs;
-    const bool   has_varkwds;
+    const bool   has_varargs_;
+    const bool   has_varkwds_;
     bool         has_renamed_args;
     size_t : 40;
     const std::vector<const char*> arg_names;
@@ -155,8 +160,13 @@ class PKArgs : public ArgParent {
      * This name can also be obtained as
      *    args[i].name()
      */
-    std::string make_arg_name(size_t i) const override;
-    const char* get_arg_short_name(size_t i) const override;
+    const char* arg_name(size_t i) const override;
+    std::string descriptive_name(bool lowercase = false) const override;
+    size_t n_positional_args() const override;
+    size_t n_positional_or_keyword_args() const override;
+    size_t n_keyword_args() const override;
+    bool has_varargs() const override;
+    bool has_varkwds() const override;
 
     //---- User API --------------------
     void check_posonly_args() const;

--- a/src/core/python/dict.h
+++ b/src/core/python/dict.h
@@ -21,7 +21,8 @@
 //------------------------------------------------------------------------------
 #ifndef dt_PYTHON_DICT_h
 #define dt_PYTHON_DICT_h
-#include <iterator>        // std::input_iterator_tag
+#include <initializer_list>  // std::initializer_list
+#include <iterator>          // std::input_iterator_tag
 #include "python/obj.h"
 #include "python/python.h"
 namespace py {

--- a/src/core/python/xargs.cc
+++ b/src/core/python/xargs.cc
@@ -30,10 +30,9 @@ namespace py {
 // Construction
 //------------------------------------------------------------------------------
 
-XArgs::XArgs(const char* fnname, implfn_t fn)
+XArgs::XArgs(implfn_t fn)
   : ccfn_(fn),
     pyfn_(nullptr),
-    function_name_(fnname),
     docstring_(nullptr),
     nargs_required_(0),
     nargs_posonly_(0),
@@ -92,6 +91,11 @@ XArgs* XArgs::pyfunction(PyCFunctionWithKeywords f) {
   return this;
 }
 
+XArgs* XArgs::name(const char* name) {
+  function_name_ = name;
+  return this;
+}
+
 XArgs* XArgs::arg_names(std::initializer_list<const char*> names) {
   arg_names_ = std::vector<const char*>(names);
   return this;
@@ -117,7 +121,7 @@ XArgs* XArgs::n_keyword_only_args(size_t n) {
   return this;
 }
 
-XArgs* XArgs::documentation(const char* str) {
+XArgs* XArgs::docs(const char* str) {
   docstring_ = str;
   return this;
 }
@@ -324,12 +328,12 @@ const Arg& XArgs::operator[](size_t i) const {
   return bound_args_[i];
 }
 
-size_t XArgs::num_vararg_args() const noexcept {
-  return static_cast<size_t>(n_varargs_);
+size_t XArgs::num_varargs() const noexcept {
+  return n_varargs_;
 }
 
-size_t XArgs::num_varkwd_args() const noexcept {
-  return static_cast<size_t>(n_varkwds_);
+size_t XArgs::num_varkwds() const noexcept {
+  return n_varkwds_;
 }
 
 

--- a/src/core/python/xargs.cc
+++ b/src/core/python/xargs.cc
@@ -116,7 +116,7 @@ XArgs* XArgs::n_positional_or_keyword_args(size_t n) {
   return this;
 }
 
-XArgs* XArgs::n_keyword_only_args(size_t n) {
+XArgs* XArgs::n_keyword_args(size_t n) {
   nargs_kwdonly_ = n;
   return this;
 }
@@ -192,7 +192,7 @@ Error XArgs::error_too_few_args(size_t i) const {
     err << descriptive_name() << " requires "
         << (exact? "exactly " : "at least ")
         << nreq << " positional argument" << (nreq==1? "" : "s")
-        << " but ";
+        << ", but ";
     if (i == 0) err << "none were given";
     else if (i == 1) err << "only 1 was given";
     else {

--- a/src/core/python/xargs.cc
+++ b/src/core/python/xargs.cc
@@ -19,6 +19,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
+#include <algorithm>             // std::min
 #include "call_logger.h"
 #include "python/xargs.h"
 #include "utils/assert.h"

--- a/src/core/python/xargs.cc
+++ b/src/core/python/xargs.cc
@@ -1,0 +1,339 @@
+//------------------------------------------------------------------------------
+// Copyright 2018-2020 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#include "call_logger.h"
+#include "python/xargs.h"
+#include "utils/assert.h"
+#include "utils/exceptions.h"
+namespace py {
+
+
+//------------------------------------------------------------------------------
+// Construction
+//------------------------------------------------------------------------------
+
+XArgs::XArgs(const char* fnname, implfn_t fn)
+  : ccfn_(fn),
+    pyfn_(nullptr),
+    function_name_(fnname),
+    docstring_(nullptr),
+    nargs_required_(0),
+    nargs_posonly_(0),
+    nargs_pos_kwd_(0),
+    nargs_kwdonly_(0),
+    nargs_all_(0),
+    has_varargs_(false),
+    has_varkwds_(false),
+    has_renamed_args_(false)
+{
+  store().push_back(this);
+}
+
+
+std::vector<XArgs*>& XArgs::store() {
+  static std::vector<XArgs*> xargs_repo;
+  return xargs_repo;
+}
+
+
+PyMethodDef XArgs::get_method_def() {
+  finish_initialization();
+  return PyMethodDef {
+    function_name_.data(),
+    reinterpret_cast<PyCFunction>(pyfn_),
+    METH_VARARGS | METH_KEYWORDS,
+    docstring_
+  };
+}
+
+
+void XArgs::finish_initialization() {
+  nargs_all_ = nargs_posonly_ + nargs_pos_kwd_ + nargs_kwdonly_;
+  bound_args_.resize(nargs_all_);
+  for (size_t i = 0; i < nargs_all_; ++i) {
+    bound_args_[i].init(i, this);
+  }
+
+  xassert(arg_names_.size() == nargs_all_);
+  xassert(nargs_required_ <= nargs_all_);
+  xassert(ccfn_);
+  xassert(pyfn_);
+  xassert(!function_name_.empty());
+  xassert(function_name_.find('.') == std::string::npos);
+  if (has_varargs_) xassert(nargs_pos_kwd_ == 0);
+}
+
+
+
+//------------------------------------------------------------------------------
+// Properties
+//------------------------------------------------------------------------------
+
+XArgs* XArgs::pyfunction(PyCFunctionWithKeywords f) {
+  pyfn_ = f;
+  return this;
+}
+
+XArgs* XArgs::arg_names(std::initializer_list<const char*> names) {
+  arg_names_ = std::vector<const char*>(names);
+  return this;
+}
+
+XArgs* XArgs::n_required_args(size_t n) {
+  nargs_required_ = n;
+  return this;
+}
+
+XArgs* XArgs::n_positional_args(size_t n) {
+  nargs_posonly_ = n;
+  return this;
+}
+
+XArgs* XArgs::n_positional_or_keyword_args(size_t n) {
+  nargs_pos_kwd_ = n;
+  return this;
+}
+
+XArgs* XArgs::n_keyword_only_args(size_t n) {
+  nargs_kwdonly_ = n;
+  return this;
+}
+
+XArgs* XArgs::documentation(const char* str) {
+  docstring_ = str;
+  return this;
+}
+
+
+
+
+//------------------------------------------------------------------------------
+// Names
+//------------------------------------------------------------------------------
+
+std::string XArgs::proper_name() const {
+  return function_name_;
+}
+
+std::string XArgs::qualified_name() const {
+  std::string out = "datatable.";
+  if (!class_name_.empty()) {
+    out += class_name_;
+    out += '.';
+  }
+  out += function_name_;
+  return out;
+}
+
+std::string XArgs::descriptive_name(bool lowercase) const {
+  if (function_name_ == "__init__") {
+    return "`datatable." + class_name_ + "()` constructor";
+  }
+  std::string out = lowercase? (class_name_.empty()? "function" : "method")
+                             : (class_name_.empty()? "Function" : "Method");
+  out += " `";
+  out += qualified_name();
+  out += "()`";
+  return out;
+}
+
+
+std::string XArgs::make_arg_name(size_t i) const {
+  (void) i;
+  return "";
+}
+
+const char* XArgs::get_arg_short_name(size_t i) const {
+  xassert(i < arg_names_.size());
+  return arg_names_[i];
+}
+
+
+
+//------------------------------------------------------------------------------
+// Evaluation
+//------------------------------------------------------------------------------
+
+// `i` is the index of the first required argument that wasn't
+// provided by the user
+//
+Error XArgs::error_too_few_args(size_t i) const {
+  xassert(i < nargs_required_);
+  auto err = TypeError();
+  if (i >= nargs_posonly_) {
+    err << "Argument `" << arg_names_[i] << "` in " << descriptive_name(true)
+        << " is required";
+  }
+  else {
+    bool exact = (nargs_required_ >= nargs_posonly_) && (nargs_pos_kwd_ == 0);
+    size_t nreq = std::min(nargs_required_, nargs_posonly_);
+    err << descriptive_name() << " requires "
+        << (exact? "exactly " : "at least ")
+        << nreq << " positional argument" << (nreq==1? "" : "s")
+        << " but ";
+    if (i == 0) err << "none were given";
+    else if (i == 1) err << "only 1 was given";
+    else {
+      err << "only " << i << " were given";
+    }
+  }
+  return err;
+}
+
+
+Error XArgs::error_too_many_args(size_t nargs) const {
+  size_t max_args = nargs_posonly_ + nargs_pos_kwd_;
+  auto err = TypeError();
+  err << descriptive_name();
+  if (max_args == 0) {
+    err << " takes no positional arguments";
+  } else if (max_args == 1) {
+    err << " takes only one positional argument";
+  } else {
+    err << " takes at most " << max_args << " positional arguments";
+  }
+  err << ", but " << nargs << (nargs == 1? " was given" : " were given");
+  return err;
+}
+
+
+size_t XArgs::find_kwd(PyObject* kwd) {
+  auto item = kwd_map_.find(kwd);
+  if (item != kwd_map_.end()) {
+    return item->second;
+  }
+  size_t i = 0;
+  for (const char* name : arg_names_) {
+    if (PyUnicode_CompareWithASCIIString(kwd, name) == 0) {
+      // We store the reference to `kwd` and increase its refcount, making
+      // `kwd` effectively immortal. Usually this shouldn't matter -- strings
+      // that are used as keyword are normally static in the program. However
+      // in the extremely rare cases when the keywords are dynamic, we don't
+      // want a PyObject* to be gc-ed, then re-created with the content of
+      // another string while `kwd_map_` would still map it to the original
+      // index...
+      Py_INCREF(kwd);
+      kwd_map_[kwd] = i;
+      return i;
+    }
+    ++i;
+  }
+  if (has_renamed_args_) {
+    for (const auto& pair : kwd_map_) {
+      if (PyUnicode_Compare(kwd, pair.first) == 0) {
+        Py_INCREF(kwd);
+        kwd_map_[kwd] = pair.second;
+        return pair.second;
+      }
+    }
+  }
+  return size_t(-1);
+}
+
+
+
+void XArgs::bind(PyObject* args, PyObject* kwds) {
+  size_t nargs = args? static_cast<size_t>(Py_SIZE(args)) : 0;
+
+  size_t max_pos_args = nargs_posonly_ + nargs_pos_kwd_;
+  size_t n_bound_args = std::min(nargs, max_pos_args);
+  n_varargs_ = nargs - n_bound_args;
+  if (n_varargs_ && !has_varargs_) {
+    throw error_too_many_args(nargs);
+  }
+
+  size_t i = 0;
+  while (i < n_bound_args) {
+    PyObject* item = PyTuple_GET_ITEM(args, i);
+    bound_args_[static_cast<size_t>(i++)].set(item);
+  }
+  while (i < nargs_all_) {
+    bound_args_[static_cast<size_t>(i++)].set(nullptr);
+  }
+
+  n_varkwds_ = 0;
+  if (kwds) {
+    PyObject* key, *value;
+    Py_ssize_t pos = 0;
+    while (PyDict_Next(kwds, &pos, &key, &value)) {
+      size_t ikey = find_kwd(key);
+      if (ikey == size_t(-1)) {
+        n_varkwds_++;
+        if (has_varkwds_) continue;
+        throw TypeError() << descriptive_name() << " got an unexpected keyword "
+          "argument `" << PyUnicode_AsUTF8(key) << "`";
+      }
+      if (ikey < n_bound_args) {
+        throw TypeError() << descriptive_name() << " got multiple values for "
+          "argument `" << PyUnicode_AsUTF8(key) << "`";
+      }
+      if (ikey < nargs_posonly_) {
+        throw TypeError() << descriptive_name() << " got argument `"
+          << PyUnicode_AsUTF8(key) << "` as a keyword, but it should be "
+            "positional-only";
+      }
+      bound_args_[ikey].set(value);
+    }
+  }
+  if (n_bound_args < nargs_required_) {
+    for (i = n_bound_args; i < nargs_all_; ++i) {
+      if (bound_args_[i].is_undefined()) {
+        throw error_too_few_args(i);
+      }
+    }
+  }
+  kwds_dict_ = kwds;
+  args_tuple_ = args;
+}
+
+
+
+
+PyObject* XArgs::exec_function(PyObject* args, PyObject* kwds) noexcept {
+  auto cl = dt::CallLogger::function(this, args, kwds);
+  try {
+    bind(args, kwds);
+    return ccfn_(*this).release();
+
+  } catch (const std::exception& e) {
+    exception_to_python(e);
+    return nullptr;
+  }
+}
+
+
+const Arg& XArgs::operator[](size_t i) const {
+  return bound_args_[i];
+}
+
+size_t XArgs::num_vararg_args() const noexcept {
+  return static_cast<size_t>(n_varargs_);
+}
+
+size_t XArgs::num_varkwd_args() const noexcept {
+  return static_cast<size_t>(n_varkwds_);
+}
+
+
+
+
+
+}  // namespace py

--- a/src/core/python/xargs.cc
+++ b/src/core/python/xargs.cc
@@ -121,9 +121,45 @@ XArgs* XArgs::n_keyword_args(size_t n) {
   return this;
 }
 
+XArgs* XArgs::allow_varargs() {
+  has_varargs_ = true;
+  return this;
+}
+
+XArgs* XArgs::allow_varkwds() {
+  has_varkwds_ = true;
+  return this;
+}
+
 XArgs* XArgs::docs(const char* str) {
   docstring_ = str;
   return this;
+}
+
+
+size_t XArgs::n_positional_args() const {
+  return nargs_posonly_;
+}
+
+size_t XArgs::n_positional_or_keyword_args() const {
+  return nargs_pos_kwd_;
+}
+
+size_t XArgs::n_keyword_args() const {
+  return nargs_kwdonly_;
+}
+
+bool XArgs::has_varargs() const {
+  return has_varargs_;
+}
+
+bool XArgs::has_varkwds() const {
+  return has_varkwds_;
+}
+
+const char* XArgs::arg_name(size_t i) const {
+  xassert(i < arg_names_.size());
+  return arg_names_[i];
 }
 
 
@@ -159,16 +195,6 @@ std::string XArgs::descriptive_name(bool lowercase) const {
   return out;
 }
 
-
-std::string XArgs::make_arg_name(size_t i) const {
-  (void) i;
-  return "";
-}
-
-const char* XArgs::get_arg_short_name(size_t i) const {
-  xassert(i < arg_names_.size());
-  return arg_names_[i];
-}
 
 
 

--- a/src/core/python/xargs.h
+++ b/src/core/python/xargs.h
@@ -74,7 +74,7 @@ class XArgs : public ArgParent {
     XArgs* n_required_args(size_t n);
     XArgs* n_positional_args(size_t n);
     XArgs* n_positional_or_keyword_args(size_t n);
-    XArgs* n_keyword_only_args(size_t n);
+    XArgs* n_keyword_args(size_t n);
     XArgs* docs(const char*);
 
     // Return the name of the method/function:

--- a/src/core/python/xargs.h
+++ b/src/core/python/xargs.h
@@ -67,15 +67,24 @@ class XArgs : public ArgParent {
     XArgs(implfn_t fn);
     XArgs(const XArgs&) = delete;
     XArgs(XArgs&&) = delete;
+    XArgs* pyfunction(PyCFunctionWithKeywords f);  // "private"
 
-    XArgs* pyfunction(PyCFunctionWithKeywords f);
     XArgs* name(const char* name);
     XArgs* arg_names(std::initializer_list<const char*> names);
     XArgs* n_required_args(size_t n);
     XArgs* n_positional_args(size_t n);
     XArgs* n_positional_or_keyword_args(size_t n);
     XArgs* n_keyword_args(size_t n);
+    XArgs* allow_varargs();
+    XArgs* allow_varkwds();
     XArgs* docs(const char*);
+
+    size_t n_positional_args() const override;
+    size_t n_positional_or_keyword_args() const override;
+    size_t n_keyword_args() const override;
+    bool has_varargs() const override;
+    bool has_varkwds() const override;
+    const char* arg_name(size_t i) const override;
 
     // Return the name of the method/function:
     //   proper_name()
@@ -93,9 +102,7 @@ class XArgs : public ArgParent {
     //
     std::string proper_name() const;
     std::string qualified_name() const;
-    std::string descriptive_name(bool lowercase = false) const;
-    std::string make_arg_name(size_t i) const override;
-    const char* get_arg_short_name(size_t i) const override;
+    std::string descriptive_name(bool lowercase = false) const override;
 
     static std::vector<XArgs*>& store();
     PyMethodDef get_method_def();
@@ -117,7 +124,6 @@ class XArgs : public ArgParent {
     // const char* get_short_name() const;
     // const char* get_docstring() const;
 
-    // std::string make_arg_name(size_t i) const;
     // const char* get_arg_short_name(size_t i) const;
 
     // //---- User API --------------------

--- a/src/core/python/xargs.h
+++ b/src/core/python/xargs.h
@@ -1,0 +1,152 @@
+//------------------------------------------------------------------------------
+// Copyright 2018-2020 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#ifndef dt_PYTHON_XARGS_h
+#define dt_PYTHON_XARGS_h
+#include <iterator>        // std::input_iterator_tag
+#include <string>          // std::string
+#include <unordered_map>   // std::unordered_map
+#include <vector>          // std::vector
+#include "python/arg.h"
+#include "python/args.h"   // ArgParent
+namespace py {
+
+
+
+/**
+  * Class that encapsulates arguments passed to a python function
+  * and helps verify / parse them.
+  */
+class XArgs : public ArgParent {
+  using implfn_t = oobj(*)(const XArgs&);
+  private:
+    implfn_t                ccfn_;
+    PyCFunctionWithKeywords pyfn_;
+    std::string class_name_;
+    std::string function_name_;
+    const char* docstring_;
+
+    std::vector<const char*> arg_names_;
+    size_t nargs_required_;
+    size_t nargs_posonly_;
+    size_t nargs_pos_kwd_;
+    size_t nargs_kwdonly_;
+    size_t nargs_all_;
+    bool has_varargs_;
+    bool has_varkwds_;
+    bool has_renamed_args_;
+    size_t : 40;
+
+    // Runtime arguments
+    std::vector<Arg> bound_args_;
+    std::unordered_map<PyObject*, size_t> kwd_map_;
+    size_t n_varargs_;
+    size_t n_varkwds_;
+    PyObject* args_tuple_;  // for var-args iteration
+    PyObject* kwds_dict_;   // for var-kwds iteration
+
+  public:
+    XArgs(const char* fnname, implfn_t fn);
+    XArgs(const XArgs&) = delete;
+    XArgs(XArgs&&) = delete;
+
+    XArgs* pyfunction(PyCFunctionWithKeywords f);
+    XArgs* arg_names(std::initializer_list<const char*> names);
+    XArgs* n_required_args(size_t n);
+    XArgs* n_positional_args(size_t n);
+    XArgs* n_positional_or_keyword_args(size_t n);
+    XArgs* n_keyword_only_args(size_t n);
+    XArgs* documentation(const char*);
+
+    // Return the name of the method/function:
+    //   proper_name() returns the simple name like "sin"
+    //   qualified_name() returns module+[class]+name, like "datatable.math.sin"
+    //   descriptive_name() returns qualified name with a description:
+    //       "Function `datatable.math.sin()`" or
+    //       "Method `datatable.Frame.cbind()`"
+    //
+    std::string proper_name() const;
+    std::string qualified_name() const;
+    std::string descriptive_name(bool lowercase = false) const;
+    std::string make_arg_name(size_t i) const override;
+    const char* get_arg_short_name(size_t i) const override;
+
+    static std::vector<XArgs*>& store();
+    PyMethodDef get_method_def();
+
+    // void add_synonym_arg(const char* new_name, const char* old_name);
+
+
+    PyObject* exec_function(PyObject* args, PyObject* kwds) noexcept;
+
+    // //---- API for XTypeMaker ----------
+    // void set_class_name(const char* name);
+
+    // // Each `Args` object describes a certain function, or method in a class.
+    // // This will return the name of that function/method, in the form "foo()"
+    // // or "Class.foo()".
+    // const char* get_long_name() const;
+
+    // const char* get_class_name() const;
+    // const char* get_short_name() const;
+    // const char* get_docstring() const;
+
+    // std::string make_arg_name(size_t i) const;
+    // const char* get_arg_short_name(size_t i) const;
+
+    // //---- User API --------------------
+    const Arg& operator[](size_t i) const;
+    size_t num_vararg_args() const noexcept;
+    size_t num_varkwd_args() const noexcept;
+    // VarKwdsIterable varkwds() const noexcept;
+    // VarArgsIterable varargs() const noexcept;
+
+    // template <typename T> T get(size_t i) const;
+    // template <typename T> T get(size_t i, T default_value) const;
+
+  private:
+    void finish_initialization();
+
+    Error error_too_few_args(size_t) const;
+    Error error_too_many_args(size_t) const;
+
+    void bind(PyObject* args, PyObject* kwds);
+    size_t find_kwd(PyObject* kwd);
+
+    // friend class VarArgsIterable;
+    // friend class VarArgsIterator;
+    // friend class VarKwdsIterator;
+};
+
+
+#define ARGS(name)   args_ ## name
+#define DECLARE_PYFN(name, fn)                                                 \
+    static py::XArgs* ARGS(name) = (new py::XArgs(#name, fn))                  \
+      ->pyfunction(                                                            \
+          [](PyObject*, PyObject* args, PyObject* kwds) -> PyObject* {         \
+            return ARGS(name)->exec_function(args, kwds);                      \
+          })
+
+
+
+
+}  // namespace py
+#endif

--- a/tests/expr/test-cut.py
+++ b/tests/expr/test-cut.py
@@ -33,7 +33,8 @@ from tests import assert_equals
 #-------------------------------------------------------------------------------
 
 def test_cut_error_noargs():
-    msg = r"Function cut\(\) requires one positional argument, but none were given"
+    msg = r"Function datatable\.cut\(\) requires exactly 1 positional " \
+          r"argument, but none were given"
     with pytest.raises(TypeError, match=msg):
         cut()
 

--- a/tests/expr/test-cut.py
+++ b/tests/expr/test-cut.py
@@ -92,8 +92,8 @@ def test_cut_error_inconsistent_nbins():
 
 
 def test_cut_error_wrong_right():
-    msg = r"Argument right_closed in cut\(\) should be a boolean, instead got " \
-          "<class 'int'>"
+    msg = r"Argument right_closed in function datatable\.cut\(\) should " \
+          r"be a boolean, instead got <class 'int'>"
     DT = dt.Frame(range(10))
     with pytest.raises(TypeError, match=msg):
         DT[:, cut(DT, right_closed = 1492)]

--- a/tests/expr/test-ifelse.py
+++ b/tests/expr/test-ifelse.py
@@ -28,7 +28,8 @@ from tests import assert_equals
 
 def test_ifelse_bad_signature():
     DT = dt.Frame(A=range(10))
-    msg = r"Function ifelse\(\) requires 3 arguments"
+    msg = r"Function datatable\.ifelse\(\) requires exactly 3 positional " \
+          r"arguments"
     with pytest.raises(TypeError, match=msg):
         DT[:, ifelse()]
     with pytest.raises(TypeError, match=msg):

--- a/tests/expr/test-qcut.py
+++ b/tests/expr/test-qcut.py
@@ -34,8 +34,8 @@ from tests import assert_equals
 #-------------------------------------------------------------------------------
 
 def test_qcut_error_noargs():
-    msg = r"Function qcut\(\) requires one positional argument, " \
-           "but none were given"
+    msg = r"Function datatable\.qcut\(\) requires exactly 1 positional " \
+           "argument, but none were given"
     with pytest.raises(TypeError, match=msg):
         qcut()
 


### PR DESCRIPTION
Added new class `py::XArgs`, as a replacement for current `py::PKArgs`.

This new class is used together with the `DECLARE_PYFN` macro like this:
```
DECLARE_PYFN(&py_gcd)
        ->name("gcd")
        ->docs(doc_gcd)
        ->arg_names({"a", "b"})
        ->n_positional_args(2)
        ->n_required_args(2);
```

Compared to our current approach with `PKArgs`, this has several advantages:
  - the arguments are named explicitly, making it easy to understand what each means;
  - the arguments that you don't need don't have to be specified;
  - this system is more extensible: new arguments can be added without having to change every existing `PKArgs` variable;
  - **it is more automatic**: there is no need to declare anything in the `DatatableModule` module -- the declared function will be attached to the module automatically.
  - **new `n_required_args` parameter** will check whether the user passed the parameters that have no default values (before we had to check this manually in each function).

The `XArgs` class may still require some polishing (say, it doesn't support varargs/varkwds just yet), but this can be deferred for a future PR.

Functions `cut()`, `qcut()` and `ifelse()` were converted to use the new `XArgs` class, as a proof of concept.

The old `py::PKArgs` class remains as it was, so that the conversion from old to new system may happen gradually.