### PR TITLE
Implement function round()

### DIFF
--- a/docs/api/math.rst
+++ b/docs/api/math.rst
@@ -73,6 +73,7 @@ math                numpy                 datatable
 ``modf(x)``         ``modf(x)``
 \                   ``nextafter(x, y)``
 \                   ``rint(x)``           :func:`rint(x) <rint>`
+``round(x)``        ``round(x)``          :func:`round(x) <datatable.math.round>`
 \                   ``sign(x)``           :func:`sign(x) <sign>`
 \                   ``signbit(x)``        :func:`signbit(x) <signbit>`
 \                   ``spacing(x)``
@@ -555,3 +556,9 @@ Mathematical constants
 .. _`math module`: https://docs.python.org/3/library/math.html
 .. _`numpy math functions`: https://docs.scipy.org/doc/numpy-1.13.0/reference/routines.math.html
 .. _`true circle constant`: https://hexnet.org/files/documents/tau-manifesto.pdf
+
+
+.. toctree::
+    :hidden:
+
+    round    <math/round>

--- a/docs/api/math/round.rst
+++ b/docs/api/math/round.rst
@@ -1,0 +1,7 @@
+
+.. py:currentmodule:: datatable
+
+.. xfunction:: datatable.math.round
+    :doc: src/core/expr/fexpr_round.cc doc_round
+    :src: src/core/expr/fexpr_round.cc pyfn_round
+    :tests: tests/expr/math/test-round.py

--- a/docs/releases/v0.11.0.rst
+++ b/docs/releases/v0.11.0.rst
@@ -26,10 +26,13 @@
     can be added in Python. [#1839]
 
   -[new] Added a new function :func:`cut()` to bin numeric data
-    to equal-width discrete intervals.
+    to equal-width discrete intervals. [#2483]
 
   -[new] Added a new function :func:`qcut()` to bin data
-    to equal-population discrete intervals.
+    to equal-population discrete intervals. [#1680]
+
+  -[new] Added function :func:`round() <datatable.math.round>` which is the
+    equivalent of Python's built-in ``round()``. [#2285]
 
   -[enh] Method :meth:`Frame.colindex()` now accepts a column selector
     f-expression as an argument.

--- a/src/core/expr/fexpr_func_unary.cc
+++ b/src/core/expr/fexpr_func_unary.cc
@@ -1,0 +1,54 @@
+//------------------------------------------------------------------------------
+// Copyright 2020 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#include "expr/eval_context.h"
+#include "expr/fexpr_func_unary.h"
+#include "expr/workframe.h"
+namespace dt {
+namespace expr {
+
+
+FExpr_FuncUnary::FExpr_FuncUnary(ptrExpr&& arg)
+  : arg_(std::move(arg)) {}
+
+
+std::string FExpr_FuncUnary::repr() const {
+  std::string out = name();
+  out += '(';
+  out += arg_->repr();
+  out += ')';
+  return out;
+}
+
+
+Workframe FExpr_FuncUnary::evaluate_n(EvalContext& ctx) const {
+  Workframe wf = arg_->evaluate_n(ctx);
+  for (size_t i = 0; i < wf.ncols(); ++i) {
+    Column col = wf.retrieve_column(i);
+    wf.replace_column(i, evaluate1(std::move(col)));
+  }
+  return wf;
+}
+
+
+
+
+}}  // namespace dt::expr

--- a/src/core/expr/fexpr_func_unary.h
+++ b/src/core/expr/fexpr_func_unary.h
@@ -1,0 +1,51 @@
+//------------------------------------------------------------------------------
+// Copyright 2020 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#ifndef dt_EXPR_FEXPR_FUNC_UNARY_h
+#define dt_EXPR_FEXPR_FUNC_UNARY_h
+#include "expr/fexpr_func.h"
+namespace dt {
+namespace expr {
+
+
+/**
+  * Base class for the functions that have only a single argument.
+  *
+  */
+class FExpr_FuncUnary : public FExpr_Func {
+  protected:
+    ptrExpr arg_;
+
+  public:
+    FExpr_FuncUnary(ptrExpr&&);
+    Workframe evaluate_n(EvalContext&) const override;
+    std::string repr() const override;
+
+    // API for the derived classes
+    virtual Column evaluate1(Column&& col) const = 0;
+    virtual std::string name() const = 0;
+};
+
+
+
+
+}}  // namespace dt::expr
+#endif

--- a/src/core/expr/fexpr_round.cc
+++ b/src/core/expr/fexpr_round.cc
@@ -37,6 +37,26 @@ static constexpr int NODIGITS = std::numeric_limits<int>::min();
 // RoundNeg_ColumnImpl
 //------------------------------------------------------------------------------
 
+/**
+  * Virtual column that implements rounding to a negative `ndigits`.
+  * The parameter `scale_` should be equal to `10 ** |ndigits|`.
+  *
+  * In order to perform rounding this function applies the transform
+  *
+  *     std::rint(value / scale) * scale
+  *
+  * where `std::rint()` rounds to the nearest integer. For example,
+  * when `ndigits=-1`, then `scale` is 10 and rounding 12345 yields
+  * `rint(1234.5) * 10 = 12340`.
+  *
+  * We use floating-point arithmetics even when dealing with integer
+  * values because of the way C implements integer division of
+  * negatives: truncation towards 0 instead of flooring. Also,
+  * rounding towards the nearest even integer is not trivial either.
+  *
+  * The stype of this column is always the same as the stype of its
+  * argument `arg_`.
+  */
 template <typename T>
 class RoundNeg_ColumnImpl : public Virtual_ColumnImpl {
   private:
@@ -76,8 +96,24 @@ class RoundNeg_ColumnImpl : public Virtual_ColumnImpl {
 // RoundPos_ColumnImpl
 //------------------------------------------------------------------------------
 
+/**
+  * Virtual column that implements rounding to a positive `ndigits`.
+  * The parameter `scale_` should be equal to `10 ** ndigits`.
+  *
+  * In order to perform rounding this function applies the transform
+  *
+  *     std::rint(value * scale) / scale
+  *
+  * For example, when `ndigits=1`, then `scale` is 10 and rounding
+  * 12.345 yields `rint(123.45) / 10 = 12.3`.
+  *
+  * The stype of this column is always the same as the stype of its
+  * argument `arg_`. This virtual column is used for floating-point
+  * columns only.
+  */
 template <typename T>
 class RoundPos_ColumnImpl : public Virtual_ColumnImpl {
+  static_assert(std::is_floating_point<T>::value, "");
   private:
     Column arg_;
     double scale_;
@@ -104,6 +140,52 @@ class RoundPos_ColumnImpl : public Virtual_ColumnImpl {
       if (isvalid) {
         *out = static_cast<T>(
                 std::rint(static_cast<double>(value) * scale_) / scale_);
+      }
+      return isvalid;
+    }
+};
+
+
+
+//------------------------------------------------------------------------------
+// Round_ColumnImpl
+//------------------------------------------------------------------------------
+
+/**
+  * Virtual column that implements rounding towards 0 digits.
+  * Unlike the previous classes, it allows the type of the output
+  * to be different from the type of the input, accommodating both
+  * the case `ndigits=0` and `ndigits=None`.
+  */
+template <typename TI, typename TO>
+class Round_ColumnImpl : public Virtual_ColumnImpl {
+  static_assert(std::is_floating_point<TI>::value, "");
+  static_assert(std::is_same<TO, TI>::value ||
+                std::is_same<TO, int64_t>::value, "");
+  private:
+    Column arg_;
+
+  public:
+    Round_ColumnImpl(Column&& arg, SType out_stype)
+      : Virtual_ColumnImpl(arg.nrows(), out_stype),
+        arg_(std::move(arg))
+    {
+      xassert(compatible_type<TI>(arg_.stype()));
+      xassert(compatible_type<TO>(out_stype));
+    }
+
+    ColumnImpl* clone() const override {
+      return new Round_ColumnImpl(Column(arg_), stype_);
+    }
+
+    size_t n_children() const noexcept override { return 1; }
+    const Column& child(size_t) const override { return arg_; }
+
+    bool get_element(size_t i, TO* out) const override {
+      TI value;
+      bool isvalid = arg_.get_element(i, &value);
+      if (isvalid) {
+        *out = static_cast<TO>(std::rint(value));
       }
       return isvalid;
     }
@@ -143,55 +225,69 @@ class FExpr_Round : public FExpr_FuncUnary {
 
 
     Column evaluate1(Column&& col) const override {
-      auto nrows = col.nrows();
-      auto stype = col.stype();
-
-      switch (stype) {
-        case SType::VOID: return std::move(col);
-        case SType::BOOL:
-        case SType::INT8:
-        case SType::INT16:
-        case SType::INT32:
-        case SType::INT64: {
-          if (ndigits_ >= 0 || ndigits_ == NODIGITS) {
-            return std::move(col);
-          }
-          int maxdigits = (stype == SType::INT64)? 19 :
-                          (stype == SType::INT32)? 9 :
-                          (stype == SType::INT16)? 4 :
-                          (stype == SType::INT8)?  2 : 0;
-          if (-ndigits_ <= maxdigits) {
-            return Column(new RoundNeg_ColumnImpl<int8_t>(
-                                std::move(col),
-                                std::pow(10.0, -ndigits_)
-                          ));
-          }
-          if (stype == SType::BOOL) {
-            return Const_ColumnImpl::make_bool_column(nrows, false);
-          } else {
-            return Const_ColumnImpl::make_int_column(nrows, 0, stype);
-          }
-        }
-        case SType::FLOAT64: {
-          if (ndigits_ >= 19) return std::move(col);
-          if (ndigits_ >= 0) {
-            return Column(new RoundPos_ColumnImpl<double>(
-                                std::move(col),
-                                std::pow(10.0, ndigits_)
-                          ));
-          }
-          if (ndigits_ >= -19) {
-            return Column(new RoundNeg_ColumnImpl<double>(
-                                std::move(col),
-                                std::pow(10.0, -ndigits_)
-                          ));
-          }
-          return Const_ColumnImpl::make_float_column(nrows, 0);  // ???
-        }
+      switch (col.stype()) {
+        case SType::VOID:    return std::move(col);
+        case SType::BOOL:    return eval_bool(std::move(col));
+        case SType::INT8:    return eval_int<int8_t,   2>(std::move(col));
+        case SType::INT16:   return eval_int<int16_t,  4>(std::move(col));
+        case SType::INT32:   return eval_int<int32_t,  9>(std::move(col));
+        case SType::INT64:   return eval_int<int64_t, 19>(std::move(col));
+        case SType::FLOAT32: return eval_float<float>(std::move(col));
+        case SType::FLOAT64: return eval_float<double>(std::move(col));
         default:
           throw TypeError()
             << "Function datatable.math.round() cannot be applied to a column "
                "of type `" << col.stype() << "`";
+      }
+    }
+
+  private:
+    Column eval_bool(Column&& col) const {
+      if (ndigits_ >= 0 || ndigits_ == NODIGITS) {
+        return std::move(col);
+      }
+      return Const_ColumnImpl::make_bool_column(col.nrows(), false);
+    }
+
+    template <typename T, int MAXDIGITS>
+    Column eval_int(Column&& col) const {
+      if (ndigits_ >= 0 || ndigits_ == NODIGITS) {
+        return std::move(col);
+      }
+      if (-ndigits_ <= MAXDIGITS) {
+        return Column(new RoundNeg_ColumnImpl<T>(
+                            std::move(col),
+                            std::pow(10.0, -ndigits_)
+                      ));
+      }
+      return Const_ColumnImpl::make_int_column(col.nrows(), 0, col.stype());
+    }
+
+    template <typename T>
+    Column eval_float(Column&& col) const {
+      if (ndigits_ == NODIGITS) {
+        return Column(new Round_ColumnImpl<T, int64_t>(
+                          std::move(col),
+                          SType::INT64
+                      ));
+      }
+      if (ndigits_ == 0) {
+        auto stype = col.stype();
+        return Column(new Round_ColumnImpl<T, T>(
+                          std::move(col), stype
+                      ));
+      }
+      if (ndigits_ > 0) {
+        return Column(new RoundPos_ColumnImpl<double>(
+                            std::move(col),
+                            std::pow(10.0, ndigits_)
+                      ));
+      }
+      else {
+        return Column(new RoundNeg_ColumnImpl<double>(
+                            std::move(col),
+                            std::pow(10.0, -ndigits_)
+                      ));
       }
     }
 };
@@ -211,16 +307,61 @@ Round the values in `cols` up to the specified number of the digits
 of precision `ndigits`. If the number of digits is omitted, rounds
 to the nearest integer.
 
+The parameter `ndigits` can be either
+
+Generally, this operation is equivalent to::
+
+    rint(col * 10**ndigits) / 10**ndigits
+
+where function `rint()` rounds to the nearest integer.
+
 Parameters
 ----------
 cols: FExpr
-    Input data for rounding.
+    Input data for rounding. This could be an expression yielding
+    either a single or multiple columns. The `round()` function will
+    apply to each column independently and produce as many columns
+    in the output as there were in the input.
+
+    Only numeric columns are allowed: boolean, integer or floating.
+    An exception will be raised if `cols` contains a non-numeric
+    column.
 
 ndigits: int | None
+    The number of precision digits to retain. This parameter could
+    be either positive or negative (or None). If positive then it
+    gives the number of digits after the decimal point. If negative,
+    then it rounds the result up to the corresponding power of 10.
+
+    For example, `123.45` rounded to `ndigits=1` is `123.4`, whereas
+    rounded to `ndigits=-1` it becomes `120.0`.
 
 return: FExpr
     f-expression that rounds the values in its first argument to
     the specified number of precision digits.
+
+    Each input column will produce the column of the same stype in
+    the output; except for the case when `ndigits` is `None` and
+    the input is either `float32` or `float64`, in which case an
+    `int64` column is produced (similarly to python's `round()`).
+
+Notes
+-----
+Values that are exactly half way in between their rounded neighbors
+are converted towards their nearest even value. For example, both
+`7.5` and `8.5` are rounded into `8`, whereas `6.5` is rounded as `6`.
+
+Rounding integer columns may produce unexpected results for values
+that are close to the min/max value of that column's storage type.
+For example, when an `int8` value `127` is rounded to nearest 10, it
+becomes `130`. However, since `130` cannot be represented as `int8` a
+warp-around occurs and the result becomes `-126`.
+
+Rounding an integer column to a positive `ndigits` is a noop: the
+column will be returned unchanged.
+
+Rounding an integer column to a large negative `ndigits` will produce
+a constant all-0 column.
 )";
 
 static py::oobj pyfn_round(const py::XArgs& args) {

--- a/src/core/expr/fexpr_round.cc
+++ b/src/core/expr/fexpr_round.cc
@@ -307,8 +307,6 @@ Round the values in `cols` up to the specified number of the digits
 of precision `ndigits`. If the number of digits is omitted, rounds
 to the nearest integer.
 
-The parameter `ndigits` can be either
-
 Generally, this operation is equivalent to::
 
     rint(col * 10**ndigits) / 10**ndigits
@@ -323,7 +321,7 @@ cols: FExpr
     apply to each column independently and produce as many columns
     in the output as there were in the input.
 
-    Only numeric columns are allowed: boolean, integer or floating.
+    Only numeric columns are allowed: boolean, integer or float.
     An exception will be raised if `cols` contains a non-numeric
     column.
 
@@ -353,9 +351,9 @@ are converted towards their nearest even value. For example, both
 
 Rounding integer columns may produce unexpected results for values
 that are close to the min/max value of that column's storage type.
-For example, when an `int8` value `127` is rounded to nearest 10, it
+For example, when an `int8` value `127` is rounded to nearest `10`, it
 becomes `130`. However, since `130` cannot be represented as `int8` a
-warp-around occurs and the result becomes `-126`.
+wrap-around occurs and the result becomes `-126`.
 
 Rounding an integer column to a positive `ndigits` is a noop: the
 column will be returned unchanged.

--- a/src/core/expr/fexpr_round.cc
+++ b/src/core/expr/fexpr_round.cc
@@ -1,0 +1,274 @@
+//------------------------------------------------------------------------------
+// Copyright 2020 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#include <type_traits>
+#include <limits>
+#include "_dt.h"
+#include "column/const.h"
+#include "column/virtual.h"
+#include "expr/eval_context.h"
+#include "expr/fexpr_func_unary.h"
+#include "python/xargs.h"
+namespace dt {
+namespace expr {
+
+
+static constexpr int NODIGITS = std::numeric_limits<int>::min();
+
+static const int64_t pow10s[] = {
+  1,
+  10,
+  100,
+  1000,
+  10000,
+  100000,
+  1000000,
+  10000000,
+  100000000,
+  1000000000,
+  10000000000,
+  100000000000,
+  1000000000000,
+  10000000000000,
+  100000000000000,
+  1000000000000000,
+  10000000000000000,
+  100000000000000000,
+  1000000000000000000,
+  9223372036854775807,
+};
+
+
+
+//------------------------------------------------------------------------------
+// RoundNeg_ColumnImpl
+//------------------------------------------------------------------------------
+
+template <typename T>
+class RoundNeg_ColumnImpl : public Virtual_ColumnImpl {
+  private:
+    Column arg_;
+    int64_t scale_;
+
+  public:
+    RoundNeg_ColumnImpl(Column&& arg, int64_t scale)
+      : Virtual_ColumnImpl(arg.nrows(), arg.stype()),
+        arg_(std::move(arg)),
+        scale_(scale)
+    {
+      xassert(compatible_type<T>(arg_.stype()));
+    }
+
+    ColumnImpl* clone() const override {
+      return new RoundNeg_ColumnImpl(Column(arg_), scale_);
+    }
+
+    size_t n_children() const noexcept override { return 1; }
+    const Column& child(size_t) const override { return arg_; }
+
+    bool get_element(size_t i, T* out) const override {
+      T value;
+      bool isvalid = arg_.get_element(i, &value);
+      if (isvalid) {
+        *out = static_cast<T>((value + scale_/2) / scale_ * scale_);
+      }
+      return isvalid;
+    }
+};
+
+
+
+//------------------------------------------------------------------------------
+// RoundPos_ColumnImpl
+//------------------------------------------------------------------------------
+
+template <typename T>
+class RoundPos_ColumnImpl : public Virtual_ColumnImpl {
+  using S = std::conditional_t<std::is_same<T, int64_t>::value, T, int32_t>;
+  private:
+    Column arg_;
+    S scale_;
+    size_t : 64 - 8*sizeof(S);
+
+  public:
+    RoundPos_ColumnImpl(Column&& arg, S scale)
+      : Virtual_ColumnImpl(arg.nrows(), arg.stype()),
+        arg_(std::move(arg)),
+        scale_(scale)
+    {
+      xassert(compatible_type<T>(arg_.stype()));
+    }
+
+    ColumnImpl* clone() const override {
+      return new RoundPos_ColumnImpl(Column(arg_), scale_);
+    }
+
+    size_t n_children() const noexcept override { return 1; }
+    const Column& child(size_t) const override { return arg_; }
+
+    bool get_element(size_t i, T* out) const override {
+      T value;
+      bool isvalid = arg_.get_element(i, &value);
+      if (isvalid) {
+        *out = static_cast<T>((value * scale_ + scale_/2) / scale_);
+      }
+      return isvalid;
+    }
+};
+
+
+
+//------------------------------------------------------------------------------
+// FExpr_Round
+//------------------------------------------------------------------------------
+
+class FExpr_Round : public FExpr_FuncUnary {
+  private:
+    int ndigits_;
+    int : 32;
+
+  public:
+    FExpr_Round(ptrExpr&& arg, int ndigits)
+      : FExpr_FuncUnary(std::move(arg)),
+        ndigits_(ndigits)
+    {}
+
+    std::string name() const override {
+      return "round";
+    }
+
+    std::string repr() const override {
+      std::string out = FExpr_FuncUnary::repr();
+      if (ndigits_ != NODIGITS) {
+        out.erase(out.size() - 1);  // remove ')'
+        out += ", ndigits=";
+        out += std::to_string(ndigits_);
+        out += ")";
+      }
+      return out;
+    }
+
+
+    Column evaluate1(Column&& col) const override {
+      size_t nrows = col.nrows();
+      switch (col.stype()) {
+        case SType::BOOL: {
+          if (ndigits_ >= 0) return std::move(col);
+          return Const_ColumnImpl::make_bool_column(nrows, false);
+        }
+        case SType::INT8: {
+          if (ndigits_ >= 0) return std::move(col);
+          if (ndigits_ >= -2) {
+            return Column(new RoundNeg_ColumnImpl<int8_t>(
+                                std::move(col),
+                                pow10s[-ndigits_]
+                          ));
+          }
+          return Const_ColumnImpl::make_int_column(nrows, 0, SType::INT8);
+        }
+        case SType::INT32: {
+          if (ndigits_ >= 0) return std::move(col);
+          if (ndigits_ >= -9) {
+            return Column(new RoundNeg_ColumnImpl<int32_t>(
+                                std::move(col),
+                                pow10s[-ndigits_]
+                          ));
+          }
+          return Const_ColumnImpl::make_int_column(nrows, 0, SType::INT32);
+        }
+        case SType::INT64: {
+          if (ndigits_ >= 0) return std::move(col);
+          if (ndigits_ >= -19) {
+            return Column(new RoundNeg_ColumnImpl<int64_t>(
+                                std::move(col),
+                                pow10s[-ndigits_]
+                          ));
+          }
+          return Const_ColumnImpl::make_int_column(nrows, 0, SType::INT64);
+        }
+        case SType::FLOAT64: {
+          if (ndigits_ >= 19) return std::move(col);
+          if (ndigits_ >= 0) {
+            return Column(new RoundPos_ColumnImpl<double>(
+                                std::move(col),
+                                static_cast<double>(pow10s[ndigits_])
+                          ));
+          }
+          if (ndigits_ >= -19) {
+            return Column(new RoundNeg_ColumnImpl<double>(
+                                std::move(col),
+                                pow10s[-ndigits_]
+                          ));
+          }
+          return Const_ColumnImpl::make_float_column(nrows, 0);  // ???
+        }
+        default: {
+          return std::move(col);
+        }
+      }
+    }
+};
+
+
+
+
+//------------------------------------------------------------------------------
+// Python-facing `round()` function
+//------------------------------------------------------------------------------
+
+static const char* doc_round =
+R"(round(cols, ndigits=None)
+--
+
+Round the values in `cols` up to the specified number of the digits
+of precision `ndigits`. If the number of digits is omitted, rounds
+to the nearest integer.
+
+Parameters
+----------
+cols: FExpr
+    Input data for rounding.
+
+ndigits: int | None
+
+return: FExpr
+    f-expression that rounds the values in its first argument to
+    the specified number of precision digits.
+)";
+
+static py::oobj pyfn_round(const py::XArgs& args) {
+  auto cols    = args[0].to_oobj();
+  auto ndigits = args[1].to<int>(NODIGITS);
+  return PyFExpr::make(new FExpr_Round(as_fexpr(cols), ndigits));
+}
+
+DECLARE_PYFN(&pyfn_round)
+    ->name("round")
+    ->docs(doc_round)
+    ->arg_names({"cols", "ndigits"})
+    ->n_positional_args(1)
+    ->n_keyword_args(1)
+    ->n_required_args(1);
+
+
+
+
+}}  // dt::expr

--- a/src/datatable/math.py
+++ b/src/datatable/math.py
@@ -62,6 +62,7 @@ from .lib._datatable import (
     pow,
     rad2deg,
     rint,
+    round,
     sign,
     signbit,
     sin,

--- a/tests/expr/math/test-round.py
+++ b/tests/expr/math/test-round.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#-------------------------------------------------------------------------------
+# Copyright 2020 H2O.ai
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#-------------------------------------------------------------------------------
+import pytest
+from datatable import dt, f
+from datatable.math import round as dtround
+from tests import assert_equals
+
+
+def test_round_noargs():
+    msg = r"Function datatable.round\(\) requires exactly 1 positional " \
+          r"argument, but none were given"
+    with pytest.raises(TypeError, match=msg):
+        assert dtround()
+
+
+def test_round_ndigits_expr():
+    msg = r"Argument ndigits in function datatable.round\(\) should be an " \
+          r"integer, instead got <class 'datatable.FExpr'>"
+    with pytest.raises(TypeError, match=msg):
+        assert dtround(f.A, ndigits=f.B)
+
+
+def test_round_expr_instance():
+    assert isinstance(dtround(f.A), dt.FExpr)
+    assert isinstance(dtround(2.5), dt.FExpr)
+    assert isinstance(dtround(2.5, ndigits=1), dt.FExpr)
+
+
+def test_round_expr_str():
+    assert str(dtround(1)) == "FExpr<round(1)>"
+    assert str(dtround(f.A)) == "FExpr<round(f.A)>"
+    assert str(dtround(f.A, ndigits=None)) == "FExpr<round(f.A)>"
+    assert str(dtround(f.A, ndigits=0)) == "FExpr<round(f.A, ndigits=0)>"
+    assert str(dtround(f[:], ndigits=-5)) == "FExpr<round(f[:], ndigits=-5)>"
+
+
+
+#-------------------------------------------------------------------------------
+# SType::BOOL
+#-------------------------------------------------------------------------------
+
+def test_round_bool_positive_ndigits():
+    DT = dt.Frame(A=[True, False, None])
+    assert_equals(DT[:, dtround(f.A)], DT)
+    assert_equals(DT[:, dtround(f.A, ndigits=0)], DT)
+    assert_equals(DT[:, dtround(f.A, ndigits=1)], DT)
+    assert_equals(DT[:, dtround(f.A, ndigits=2)], DT)
+    assert_equals(DT[:, dtround(f.A, ndigits=3)], DT)
+    assert_equals(DT[:, dtround(f.A, ndigits=5)], DT)
+    assert_equals(DT[:, dtround(f.A, ndigits=9)], DT)
+    assert_equals(DT[:, dtround(f.A, ndigits=19)], DT)
+    assert_equals(DT[:, dtround(f.A, ndigits=999999)], DT)
+
+
+def test_round_bool_negative_ndigits():
+    DT = dt.Frame(A=[True, False, None])
+    D0 = dt.Frame(A=[False, False, False])
+    assert_equals(DT[:, dtround(f.A, ndigits=-1)], D0)
+    assert_equals(DT[:, dtround(f.A, ndigits=-2)], D0)
+    assert_equals(DT[:, dtround(f.A, ndigits=-3)], D0)
+    assert_equals(DT[:, dtround(f.A, ndigits=-7)], D0)
+    assert_equals(DT[:, dtround(f.A, ndigits=-19)], D0)
+    assert_equals(DT[:, dtround(f.A, ndigits=-1234567)], D0)
+
+
+
+#-------------------------------------------------------------------------------
+# SType::INT8
+#-------------------------------------------------------------------------------
+
+def test_round_int8_positive_ndigits():
+    DT = dt.Frame(A=[None] + list(range(-127, 128)), stype=dt.int8)
+    assert_equals(DT[:, dtround(f.A)], DT)
+    assert_equals(DT[:, dtround(f.A, ndigits=0)], DT)
+    assert_equals(DT[:, dtround(f.A, ndigits=1)], DT)
+    assert_equals(DT[:, dtround(f.A, ndigits=2)], DT)
+    assert_equals(DT[:, dtround(f.A, ndigits=3)], DT)
+    assert_equals(DT[:, dtround(f.A, ndigits=5)], DT)
+    assert_equals(DT[:, dtround(f.A, ndigits=9)], DT)
+    assert_equals(DT[:, dtround(f.A, ndigits=17)], DT)
+    assert_equals(DT[:, dtround(f.A, ndigits=987654321)], DT)
+
+
+@pytest.mark.parametrize('nd', [-1, -2])
+def test_round_int8_negative1(nd):
+    DT = dt.Frame(A=[None] + list(range(-127, 128)), stype=dt.int8)
+    RES = DT[:, dtround(f.A, ndigits=nd)]
+    EXP = dt.Frame(A=[None] + [round(x, nd) for x in range(-127, 128)],
+                   stype=dt.int8)
+    assert_equals(RES, EXP)

--- a/tests/expr/math/test-round.py
+++ b/tests/expr/math/test-round.py
@@ -103,9 +103,128 @@ def test_round_int8_positive_ndigits():
 
 
 @pytest.mark.parametrize('nd', [-1, -2])
-def test_round_int8_negative1(nd):
+def test_round_int8_negative_ndigits_small(nd):
     DT = dt.Frame(A=[None] + list(range(-127, 128)), stype=dt.int8)
     RES = DT[:, dtround(f.A, ndigits=nd)]
     EXP = dt.Frame(A=[None] + [round(x, nd) for x in range(-127, 128)],
                    stype=dt.int8)
+    assert_equals(RES, EXP)
+
+
+@pytest.mark.parametrize('nd', [-3, -5, -17])
+def test_round_int8_negative_ndigits_large(nd):
+    DT = dt.Frame(A=[None] + list(range(-127, 128)), stype=dt.int8)
+    RES = DT[:, dtround(f.A, ndigits=nd)]
+    assert_equals(RES, dt.Frame(A=[0] * 256 / dt.int8))
+
+
+
+#-------------------------------------------------------------------------------
+# SType::INT16
+#-------------------------------------------------------------------------------
+
+def test_round_int16_positive_ndigits():
+    DT = dt.Frame(A=[None, 12, 0, 34, -999, 32767, 10001, -32767] / dt.int16)
+    assert_equals(DT[:, dtround(f.A)], DT)
+    assert_equals(DT[:, dtround(f.A, ndigits=0)], DT)
+    assert_equals(DT[:, dtround(f.A, ndigits=1)], DT)
+    assert_equals(DT[:, dtround(f.A, ndigits=2)], DT)
+    assert_equals(DT[:, dtround(f.A, ndigits=3)], DT)
+    assert_equals(DT[:, dtround(f.A, ndigits=5)], DT)
+    assert_equals(DT[:, dtround(f.A, ndigits=9)], DT)
+    assert_equals(DT[:, dtround(f.A, ndigits=17)], DT)
+    assert_equals(DT[:, dtround(f.A, ndigits=314)], DT)
+
+
+@pytest.mark.parametrize('nd', [-1, -2, -3, -4])
+def test_round_int16_negative_ndigits_small(nd):
+    src = [1, 3, 5, 6, 9, 12, 15, 20, 25, 35, 34, 45, 95, 1115, 11115, 0,
+           -5, -15, -25, -24, -26, -999, -9999, -1005, -1015, -10005, -32767,
+           32767, 32760, 32765, 10001, 10003]
+    DT = dt.Frame(src / dt.int16)
+    RES = DT[:, dtround(f[0], ndigits=nd)]
+    EXP = dt.Frame([round(x, nd) for x in src] / dt.int16)
+    assert_equals(RES, EXP)
+
+
+
+#-------------------------------------------------------------------------------
+# SType::INT32
+#-------------------------------------------------------------------------------
+
+def test_round_int32_positive_ndigits():
+    m = 2**31 - 1
+    DT = dt.Frame(A=[None, 12, 0, 34, -999, m, 15, 1001, 123456, -m])
+    assert DT.stype == dt.int32
+    assert_equals(DT[:, dtround(f.A)], DT)
+    assert_equals(DT[:, dtround(f.A, ndigits=0)], DT)
+    assert_equals(DT[:, dtround(f.A, ndigits=1)], DT)
+    assert_equals(DT[:, dtround(f.A, ndigits=2)], DT)
+    assert_equals(DT[:, dtround(f.A, ndigits=3)], DT)
+    assert_equals(DT[:, dtround(f.A, ndigits=5)], DT)
+    assert_equals(DT[:, dtround(f.A, ndigits=9)], DT)
+    assert_equals(DT[:, dtround(f.A, ndigits=17)], DT)
+    assert_equals(DT[:, dtround(f.A, ndigits=314)], DT)
+
+
+@pytest.mark.parametrize('nd', [-1, -2, -3, -4, -5, -6, -7, -8, -9])
+def test_round_int32_negative_ndigits_small(nd):
+    src = [1, 3, 5, 6, 9, 12, 15, 20, 25, 35, 34, 45, 95, 1115, 11115, 0,
+           -5, -15, -25, -24, -26, -999, -9999, -1005, -1015, -10005, -32767,
+           32767, 32760, 32765, 10001, 10003, 1000005, 3017097, 3198734,
+           34982340, 34982345, 34982355, 34982365, 34982375, 34982385]
+    DT = dt.Frame(src / dt.int32)
+    RES = DT[:, dtround(f[0], ndigits=nd)]
+    EXP = dt.Frame([round(x, nd) for x in src] / dt.int32)
+    assert_equals(RES, EXP)
+
+
+@pytest.mark.parametrize('nd', [-10, -11, -13, -997])
+def test_round_int32_negative_ndigits_large(nd):
+    src = [None, 0, 1, 12, 34083, 1082745, 59845702, 2**31-1, 1-2**31]
+    DT = dt.Frame(src / dt.int32)
+    RES = DT[:, dtround(f[0], ndigits=nd)]
+    EXP = dt.Frame([0] * len(src) / dt.int32)
+    assert_equals(RES, EXP)
+
+
+
+#-------------------------------------------------------------------------------
+# SType::INT64
+#-------------------------------------------------------------------------------
+
+def test_round_int64_positive_ndigits():
+    m = 2**63 - 1
+    DT = dt.Frame(A=[None, 12, 0, 34, -999, m, 15, 1001, 123456, -m])
+    assert DT.stype == dt.int64
+    assert_equals(DT[:, dtround(f.A)], DT)
+    assert_equals(DT[:, dtround(f.A, ndigits=0)], DT)
+    assert_equals(DT[:, dtround(f.A, ndigits=1)], DT)
+    assert_equals(DT[:, dtround(f.A, ndigits=2)], DT)
+    assert_equals(DT[:, dtround(f.A, ndigits=3)], DT)
+    assert_equals(DT[:, dtround(f.A, ndigits=5)], DT)
+    assert_equals(DT[:, dtround(f.A, ndigits=9)], DT)
+    assert_equals(DT[:, dtround(f.A, ndigits=17)], DT)
+    assert_equals(DT[:, dtround(f.A, ndigits=314)], DT)
+
+
+@pytest.mark.parametrize('nd', [-1, -2, -3, -4, -7, -9, -12, -16, -17, -19])
+def test_round_int32_negative_ndigits_small(nd):
+    src = [1, 3, 5, 6, 9, 12, 15, 20, 25, 35, 34, 45, 95, 1115, 11115, 0,
+           -5, -15, -25, -24, -26, -999, -9999, -1005, -1015, -10005, -32767,
+           32767, 32760, 32765, 10001, 10003, 1000005, 3017097, 3198734,
+           349823445870, 34982341365, 3498223675355, 3493497682365,
+           349346782375, 33464982385]
+    DT = dt.Frame(src / dt.int64)
+    RES = DT[:, dtround(f[0], ndigits=nd)]
+    EXP = dt.Frame([round(x, nd) for x in src] / dt.int64)
+    assert_equals(RES, EXP)
+
+
+@pytest.mark.parametrize('nd', [-20, -21, -1337])
+def test_round_int32_negative_ndigits_large(nd):
+    src = [None, 1, -1, 12, 34083, 123082745, 5123659845702, 2**63-1, 1-2**63]
+    DT = dt.Frame(src / dt.int64)
+    RES = DT[:, dtround(f[0], ndigits=nd)]
+    EXP = dt.Frame([0] * len(src) / dt.int64)
     assert_equals(RES, EXP)


### PR DESCRIPTION
The function is equivalent to standard python's `round()`. It allows rounding to the specified number of decimal digits (see the included documentation for details). 

Closes #2285