### PR TITLE
Expand tests for binary operations

### DIFF
--- a/tests/expr/fbinary/test-add.py
+++ b/tests/expr/fbinary/test-add.py
@@ -32,7 +32,7 @@ from tests import assert_equals
 
 @pytest.mark.parametrize("type", [dt.obj64])
 def test_add_error_wrong_one_type(type):
-    DT = dt.Frame(A=[[None]*100]/type, B=[range(100)]/dt.int32)
+    DT = dt.Frame(A=[]/type, B=[]/dt.int32)
     type_str = str(type)[6:]
     msg = r"Operator \+ cannot be applied to columns of types %s and int32" % \
           (type_str,)
@@ -42,7 +42,7 @@ def test_add_error_wrong_one_type(type):
 
 @pytest.mark.parametrize("type", [dt.obj64])
 def test_add_error_wrong_both_types(type):
-    DT = dt.Frame(A=[range(100)]/type, B=[[None]*100]/type)
+    DT = dt.Frame(A=[]/type, B=[]/type)
     type_str = str(type)[6:]
     msg = r"Operator \+ cannot be applied to columns of types %s and %s" % \
           (type_str, type_str)

--- a/tests/expr/fbinary/test-add.py
+++ b/tests/expr/fbinary/test-add.py
@@ -21,9 +21,38 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 #-------------------------------------------------------------------------------
+import pytest
 from datatable import dt, f
 from tests import assert_equals
 
+
+#-------------------------------------------------------------------------------
+# Errors
+#-------------------------------------------------------------------------------
+
+@pytest.mark.parametrize("type", [dt.obj64])
+def test_add_error_wrong_one_type(type):
+    DT = dt.Frame(A=[[None]*100]/type, B=[range(100)]/dt.int32)
+    type_str = str(type)[6:]
+    msg = r"Operator \+ cannot be applied to columns of types %s and int32" % \
+          (type_str,)
+    with pytest.raises(TypeError, match=msg):
+        DT[:, f.A + f.B]
+
+
+@pytest.mark.parametrize("type", [dt.obj64])
+def test_add_error_wrong_both_types(type):
+    DT = dt.Frame(A=[range(100)]/type, B=[[None]*100]/type)
+    type_str = str(type)[6:]
+    msg = r"Operator \+ cannot be applied to columns of types %s and %s" % \
+          (type_str, type_str)
+    with pytest.raises(TypeError, match=msg):
+        DT[:, f.A + f.B]
+
+
+#-------------------------------------------------------------------------------
+# Normal
+#-------------------------------------------------------------------------------
 
 def test_add_stringify():
   assert str(f.A + 1) == "FExpr<f.A + 1>"

--- a/tests/expr/fbinary/test-floordiv.py
+++ b/tests/expr/fbinary/test-floordiv.py
@@ -27,7 +27,36 @@ from datatable import dt, f
 from tests import assert_equals
 
 
-def test_idiv_stringify():
+#-------------------------------------------------------------------------------
+# Errors
+#-------------------------------------------------------------------------------
+
+@pytest.mark.parametrize("type", [dt.float32, dt.float64, dt.str32, dt.str64, dt.obj64])
+def test_floordiv_error_wrong_one_type(type):
+    DT = dt.Frame(A=[[None]*100]/type, B=[range(100)]/dt.int32)
+    type_str = str(type)[6:]
+    msg = "Operator // cannot be applied to columns of types %s and int32" % \
+          (type_str,)
+    with pytest.raises(TypeError, match=msg):
+        DT[:, f.A // f.B]
+
+
+@pytest.mark.parametrize("type", [dt.float32, dt.float64, dt.str32, dt.str64, dt.obj64])
+def test_floordiv_error_wrong_both_types(type):
+    DT = dt.Frame(A=[range(100)]/type, B=[[None]*100]/type)
+    type_str = str(type)[6:]
+    msg = "Operator // cannot be applied to columns of types %s and %s" % \
+          (type_str, type_str)
+    with pytest.raises(TypeError, match=msg):
+        DT[:, f.A // f.B]
+
+
+
+#-------------------------------------------------------------------------------
+# Normal
+#-------------------------------------------------------------------------------
+
+def test_floordiv_stringify():
     assert str(f.A // 10) == "FExpr<f.A // 10>"
     assert str(f.A // f.B) == "FExpr<f.A // f.B>"
     assert str(f.A // f.B // f.C) == "FExpr<f.A // f.B // f.C>"
@@ -38,15 +67,50 @@ def test_idiv_stringify():
     assert str(f.A // (f[1]*3) // f.Z) == "FExpr<f.A // (f[1] * 3) // f.Z>"
 
 
+def test_floordiv_boolean_columns():
+    DT = dt.Frame(x=[True, True, True, False, False, False, None, None, None],
+                  y=[True, False, None] * 3)
+    RES = DT[:, f.x // f.y]
+    EXP = dt.Frame([1, None, None, 0, None, None, None, None, None]/dt.int32)
+    assert_equals(RES, EXP)
+
+
+def test_floordiv_boolean_column_scalar():
+    DT = dt.Frame(x=[True, False, None])
+    RES = DT[:, [f.x // True, f.x // False, f.x // None]]
+    EXP = dt.Frame([[1, 0, None]/dt.int32,
+                   [None, None, None]/dt.int32,
+                   [None, None, None]/dt.bool8])
+    assert_equals(RES, EXP)
+
+
 @pytest.mark.parametrize("seed", [random.getrandbits(63)])
-def test_idiv_integers(seed):
+def test_floordiv_integers(seed):
     random.seed(seed)
     n = 1000
     src1 = [random.randint(-100, 100) for _ in range(n)]
     src2 = [random.randint(-10, 10) for _ in range(n)]
 
     DT = dt.Frame(x=src1, y=src2)
-    RES = DT[:, f.x // f.y]
-    EXP = dt.Frame([None if src2[i] == 0 else src1[i] // src2[i]
-                    for i in range(n)])
+    RES = DT[:, [f.x // f.y, f.x // 100]]
+    EXP = dt.Frame([
+            [None if src2[i] == 0 else src1[i] // src2[i] for i in range(n)],
+            [src1[i] // 100 for i in range(n)]
+          ])
+    assert_equals(RES, EXP)
+
+
+@pytest.mark.parametrize("seed", [random.getrandbits(63)])
+def test_floordiv_integers_booleans(seed):
+    random.seed(seed)
+    n = 1000
+    src1 = [random.randint(0, 1) for _ in range(n)]
+    src2 = [random.randint(-10, 10) for _ in range(n)]
+
+    DT = dt.Frame(x=src1/dt.bool8, y=src2)
+    RES = DT[:, [f.x // f.y, f.y // f.x]]
+    EXP = dt.Frame([
+            [None if src2[i] == 0 else src1[i] // src2[i] for i in range(n)],
+            [None if src1[i] == False else src2[i] // src1[i] for i in range(n)]
+          ])
     assert_equals(RES, EXP)

--- a/tests/expr/fbinary/test-floordiv.py
+++ b/tests/expr/fbinary/test-floordiv.py
@@ -33,7 +33,7 @@ from tests import assert_equals
 
 @pytest.mark.parametrize("type", [dt.float32, dt.float64, dt.str32, dt.str64, dt.obj64])
 def test_floordiv_error_wrong_one_type(type):
-    DT = dt.Frame(A=[[None]*100]/type, B=[range(100)]/dt.int32)
+    DT = dt.Frame(A=[]/type, B=[]/dt.int32)
     type_str = str(type)[6:]
     msg = "Operator // cannot be applied to columns of types %s and int32" % \
           (type_str,)
@@ -43,7 +43,7 @@ def test_floordiv_error_wrong_one_type(type):
 
 @pytest.mark.parametrize("type", [dt.float32, dt.float64, dt.str32, dt.str64, dt.obj64])
 def test_floordiv_error_wrong_both_types(type):
-    DT = dt.Frame(A=[range(100)]/type, B=[[None]*100]/type)
+    DT = dt.Frame(A=[]/type, B=[]/type)
     type_str = str(type)[6:]
     msg = "Operator // cannot be applied to columns of types %s and %s" % \
           (type_str, type_str)

--- a/tests/expr/fbinary/test-mod.py
+++ b/tests/expr/fbinary/test-mod.py
@@ -27,6 +27,34 @@ from datatable import dt, f
 from tests import assert_equals
 
 
+#-------------------------------------------------------------------------------
+# Errors
+#-------------------------------------------------------------------------------
+
+@pytest.mark.parametrize("type", [dt.float32, dt.float64, dt.str32, dt.str64, dt.obj64])
+def test_mod_error_wrong_one_type(type):
+    DT = dt.Frame(A=[[None]*100]/type, B=[range(100)]/dt.int32)
+    type_str = str(type)[6:]
+    msg = "Operator %% cannot be applied to columns of types %s and int32" % \
+          (type_str,)
+    with pytest.raises(TypeError, match=msg):
+        DT[:, f.A % f.B]
+
+
+@pytest.mark.parametrize("type", [dt.float32, dt.float64, dt.str32, dt.str64, dt.obj64])
+def test_mod_error_wrong_both_types(type):
+    DT = dt.Frame(A=[range(100)]/type, B=[[None]*100]/type)
+    type_str = str(type)[6:]
+    msg = "Operator %% cannot be applied to columns of types %s and %s" % \
+          (type_str, type_str)
+    with pytest.raises(TypeError, match=msg):
+        DT[:, f.A % f.B]
+
+
+#-------------------------------------------------------------------------------
+# Normal
+#-------------------------------------------------------------------------------
+
 def test_mod_stringify():
     assert str(f.A % 10) == "FExpr<f.A % 10>"
     assert str(f.A % f.B) == "FExpr<f.A % f.B>"
@@ -38,15 +66,37 @@ def test_mod_stringify():
     assert str(f.A % (f[1]*3) % f.Z) == "FExpr<f.A % (f[1] * 3) % f.Z>"
 
 
+def test_mod_boolean_columns():
+    DT = dt.Frame(x=[True, True, True, False, False, False, None, None, None],
+                  y=[True, False, None] * 3)
+    RES = DT[:, f.x % f.y]
+    EXP = dt.Frame([0, None, None, 0, None, None, None, None, None]/dt.int32)
+    assert_equals(RES, EXP)
+
+
+def test_mod_boolean_column_scalar():
+    DT = dt.Frame(x=[True, False, None])
+    RES = DT[:, [f.x % True, f.x % False, f.x % None]]
+    EXP = dt.Frame([[0, 0, None]/dt.int32,
+                   [None, None, None]/dt.int32,
+                   [None, None, None]/dt.bool8])
+    assert_equals(RES, EXP)
+
+
 @pytest.mark.parametrize("seed", [random.getrandbits(63)])
-def test_mod_integers(seed):
+def test_mod_booleans_integers(seed):
     random.seed(seed)
     n = 1000
     src1 = [random.randint(-100, 100) for _ in range(n)]
     src2 = [random.randint(-10, 10) for _ in range(n)]
+    src3 = [random.randint(0, 1) for _ in range(n)]
 
-    DT = dt.Frame(x=src1, y=src2)
-    RES = DT[:, f.x % f.y]
-    EXP = dt.Frame([None if src2[i] == 0 else src1[i] % src2[i]
-                    for i in range(n)])
+    DT = dt.Frame(x=src1, y=src2, z=src3)
+    RES = DT[:, [f.x % 100, f.x % f.y, f.y % f.z, f.z % f.x]]
+    EXP = dt.Frame([
+            [src1[i] % 100 for i in range(n)],
+            [None if src2[i] == 0 else src1[i] % src2[i] for i in range(n)],
+            [None if src3[i] == False else src2[i] % src3[i] for i in range(n)]/dt.int32,
+            [None if src1[i] == 0 else src3[i] % src1[i] for i in range(n)]
+          ])
     assert_equals(RES, EXP)

--- a/tests/expr/fbinary/test-mod.py
+++ b/tests/expr/fbinary/test-mod.py
@@ -33,7 +33,7 @@ from tests import assert_equals
 
 @pytest.mark.parametrize("type", [dt.float32, dt.float64, dt.str32, dt.str64, dt.obj64])
 def test_mod_error_wrong_one_type(type):
-    DT = dt.Frame(A=[[None]*100]/type, B=[range(100)]/dt.int32)
+    DT = dt.Frame(A=[]/type, B=[]/dt.int32)
     type_str = str(type)[6:]
     msg = "Operator %% cannot be applied to columns of types %s and int32" % \
           (type_str,)
@@ -43,7 +43,7 @@ def test_mod_error_wrong_one_type(type):
 
 @pytest.mark.parametrize("type", [dt.float32, dt.float64, dt.str32, dt.str64, dt.obj64])
 def test_mod_error_wrong_both_types(type):
-    DT = dt.Frame(A=[range(100)]/type, B=[[None]*100]/type)
+    DT = dt.Frame(A=[]/type, B=[]/type)
     type_str = str(type)[6:]
     msg = "Operator %% cannot be applied to columns of types %s and %s" % \
           (type_str, type_str)

--- a/tests/expr/fbinary/test-mul.py
+++ b/tests/expr/fbinary/test-mul.py
@@ -33,7 +33,7 @@ from tests import assert_equals
 
 @pytest.mark.parametrize("type", [dt.str32, dt.str64, dt.obj64])
 def test_mod_error_wrong_one_type(type):
-    DT = dt.Frame(A=[[None]*100]/type, B=[range(100)]/dt.int32)
+    DT = dt.Frame(A=[]/type, B=[]/dt.int32)
     type_str = str(type)[6:]
     msg = r"Operator \* cannot be applied to columns of types %s and int32" % \
           (type_str,)
@@ -43,7 +43,7 @@ def test_mod_error_wrong_one_type(type):
 
 @pytest.mark.parametrize("type", [dt.str32, dt.str64, dt.obj64])
 def test_mod_error_wrong_both_types(type):
-    DT = dt.Frame(A=[range(100)]/type, B=[[None]*100]/type)
+    DT = dt.Frame(A=[]/type, B=[]/type)
     type_str = str(type)[6:]
     msg = r"Operator \* cannot be applied to columns of types %s and %s" % \
           (type_str, type_str)

--- a/tests/expr/fbinary/test-mul.py
+++ b/tests/expr/fbinary/test-mul.py
@@ -21,9 +21,39 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 #-------------------------------------------------------------------------------
+import pytest
+import random
 from datatable import dt, f
 from tests import assert_equals
 
+
+#-------------------------------------------------------------------------------
+# Errors
+#-------------------------------------------------------------------------------
+
+@pytest.mark.parametrize("type", [dt.str32, dt.str64, dt.obj64])
+def test_mod_error_wrong_one_type(type):
+    DT = dt.Frame(A=[[None]*100]/type, B=[range(100)]/dt.int32)
+    type_str = str(type)[6:]
+    msg = r"Operator \* cannot be applied to columns of types %s and int32" % \
+          (type_str,)
+    with pytest.raises(TypeError, match=msg):
+        DT[:, f.A * f.B]
+
+
+@pytest.mark.parametrize("type", [dt.str32, dt.str64, dt.obj64])
+def test_mod_error_wrong_both_types(type):
+    DT = dt.Frame(A=[range(100)]/type, B=[[None]*100]/type)
+    type_str = str(type)[6:]
+    msg = r"Operator \* cannot be applied to columns of types %s and %s" % \
+          (type_str, type_str)
+    with pytest.raises(TypeError, match=msg):
+        DT[:, f.A * f.B]
+
+
+#-------------------------------------------------------------------------------
+# Normal
+#-------------------------------------------------------------------------------
 
 def test_mul_stringify():
     assert str(f.A * 5) == "FExpr<f.A * 5>"
@@ -32,3 +62,77 @@ def test_mul_stringify():
     assert str((f.A * f.B) * f.C) == "FExpr<f.A * f.B * f.C>"
     assert str(f.A * (f.B * f.C)) == "FExpr<f.A * (f.B * f.C)>"
     assert str(f.A * (f[1] + 3) * f.Z) == "FExpr<f.A * (f[1] + 3) * f.Z>"
+
+
+def test_mul_booleans():
+    DT = dt.Frame(x=[True, True, True, False, False, False, None, None, None],
+                  y=[True, False, None] * 3)
+    RES = DT[:, f.x * f.y]
+    EXP = dt.Frame([1, 0, None, 0, 0, None, None, None, None]/dt.int32)
+    assert_equals(RES, EXP)
+
+
+def test_mul_integers_with_upcast():
+    # int8 * int8 = int32
+    # int8 * int16 = int32
+    # int16 * int16 = int32
+    DT = dt.Frame(A=[100, 111]/dt.int8,
+                  B=[-17, 28]/dt.int8,
+                  C=[32000, -29999]/dt.int16,
+                  D=[12345, 314]/dt.int16)
+    assert_equals(DT[:, [f.A * f.B, f.B * f.C, f.C * f.D]],
+                  dt.Frame([
+                    [-1700, 3108]/dt.int32,
+                    [-544000, -839972]/dt.int32,
+                    [395040000, -9419686]/dt.int32,
+                  ]))
+
+@pytest.mark.parametrize("seed", [random.getrandbits(63)])
+def test_mul_integers_random(seed):
+    random.seed(seed)
+    n = 1000
+    src1 = [random.randint(-100, 100) for _ in range(n)]
+    src2 = [random.randint(-1000, 1000) for _ in range(n)]
+
+    DT = dt.Frame(x=src1, y=src2)
+    RES = DT[:, [f.x * f.y, f.y * f.x]]
+    EXP = dt.Frame([
+            [src1[i] * src2[i] for i in range(n)],
+          ])[:, [0, 0]]
+    assert_equals(RES, EXP)
+
+
+@pytest.mark.parametrize("seed", [random.getrandbits(63)])
+def test_mul_floats_random(seed):
+    random.seed(seed)
+    n = 1000
+    src1 = [random.random() * 100 - 50 for _ in range(n)]
+    src2 = [random.random() * 1000 - 500 for _ in range(n)]
+
+    DT = dt.Frame(x=src1, y=src2)
+    RES = DT[:, [f.x * f.y, f.y * f.x]]
+    EXP = dt.Frame([
+            [src1[i] * src2[i] for i in range(n)],
+          ])[:, [0, 0]]
+    assert_equals(RES, EXP)
+
+
+@pytest.mark.parametrize("seed", [random.getrandbits(63)])
+def test_mul_booleans_integers_floats_random(seed):
+    random.seed(seed)
+    n = 1000
+    src1 = [random.randint(-100, 100) for _ in range(n)]
+    src2 = [random.randint(0, 1) for _ in range(n)]
+    src3 = [random.random() * 1000 - 500 for _ in range(n)]
+
+    DT = dt.Frame(x=src1, y=src2/dt.bool8, z=src3)
+    RES = DT[:, [f.x * f.y, f.y * f.x,
+                 f.y * f.z, f.z * f.y,
+                 f.z * f.x, f.x * f.z]]
+    EXP = dt.Frame([
+            [src1[i] * src2[i] for i in range(n)],
+            [src2[i] * src3[i] for i in range(n)],
+            [src3[i] * src1[i] for i in range(n)]
+          ])[:, [0, 0, 1, 1, 2, 2]]
+    assert_equals(RES, EXP)
+

--- a/tests/expr/fbinary/test-pow.py
+++ b/tests/expr/fbinary/test-pow.py
@@ -23,9 +23,37 @@
 #-------------------------------------------------------------------------------
 import pytest
 import random
-from datatable import dt, f
+from datatable import dt, f, math
 from tests import assert_equals
 
+
+#-------------------------------------------------------------------------------
+# Errors
+#-------------------------------------------------------------------------------
+
+@pytest.mark.parametrize("type", [dt.str32, dt.str64, dt.obj64])
+def test_mod_error_wrong_one_type(type):
+    DT = dt.Frame(A=[[None]*100]/type, B=[range(100)]/dt.int32)
+    type_str = str(type)[6:]
+    msg = r"Operator \*\* cannot be applied to columns of types %s and int32" % \
+          (type_str,)
+    with pytest.raises(TypeError, match=msg):
+        DT[:, f.A ** f.B]
+
+
+@pytest.mark.parametrize("type", [dt.str32, dt.str64, dt.obj64])
+def test_mod_error_wrong_both_types(type):
+    DT = dt.Frame(A=[range(100)]/type, B=[[None]*100]/type)
+    type_str = str(type)[6:]
+    msg = r"Operator \*\* cannot be applied to columns of types %s and %s" % \
+          (type_str, type_str)
+    with pytest.raises(TypeError, match=msg):
+        DT[:, f.A ** f.B]
+
+
+#-------------------------------------------------------------------------------
+# Normal
+#-------------------------------------------------------------------------------
 
 def test_pow_stringify():
     assert str(f.A ** 10) == "FExpr<f.A ** 10>"
@@ -36,6 +64,21 @@ def test_pow_stringify():
     assert str((f.A + f.B) ** f.C) == "FExpr<(f.A + f.B) ** f.C>"
     assert str(f.A ** (f.B / f.C)) == "FExpr<f.A ** (f.B / f.C)>"
     assert str(f.A ** (f[1]*3) ** f.Z) == "FExpr<f.A ** ((f[1] * 3) ** f.Z)>"
+
+
+def test_pow_boolean_columns():
+    DT = dt.Frame(x=[True, True, True, False, False, False, None, None, None],
+                  y=[True, False, None] * 3)
+    RES = DT[:, f.x ** f.y]
+    EXP = dt.Frame([1, 1, None, 0, 1, None, None, None, None]/dt.int32)
+    assert_equals(RES, EXP)
+
+
+def test_pow_boolean_column_scalar():
+    DT = dt.Frame(x=[True, False, None]/dt.bool8)
+    RES = DT[:, f.x ** 2]
+    EXP = dt.Frame([1, 0, None]/dt.int32)
+    assert_equals(RES, EXP)
 
 
 def test_pow_integers():
@@ -56,3 +99,43 @@ def test_pow_integer_negative():
     DT = dt.Frame(range(1, 10))
     RES = DT[:, f[0] ** -1]
     assert_equals(RES, dt.Frame([1/i for i in range(1, 10)]))
+
+
+def test_pow_float_columns():
+    DT = dt.Frame(x=[3, .14, 15.92, 6, 23.53], y=range(5))
+    RES = DT[:, f.x**f.y]
+    assert_equals(RES, dt.Frame([1, .14, 15.92**2, 216, 23.53**4]))
+
+
+def test_pow_float_column_scalar():
+    src = [0, 3, .14, 15.92, 6, 23.53]
+    DT = dt.Frame(x=src)
+    RES = DT[:, [f.x**2, f.x**-1]]
+    assert_equals(RES,
+                  dt.Frame([
+                    [x**2 for x in src],
+                    [math.inf if x == 0 else 1/x for x in src]
+                  ]))
+
+
+@pytest.mark.parametrize("seed", [random.getrandbits(63)])
+def test_pow_booleans_integers_floats_random(seed):
+    random.seed(seed)
+    n = 1000
+    src1 = [random.randint(-100, 100) for _ in range(n)]
+    src2 = [random.randint(0, 1) for _ in range(n)]
+    src3 = [random.random() * 10 - 5 for _ in range(n)]
+
+    DT = dt.Frame(x=src1, y=src2/dt.bool8, z=src3)
+    RES = DT[:, [f.x ** f.y, f.y ** math.abs(f.x),
+                 f.y ** math.abs(f.z), f.z ** f.y,
+                 f.z ** f.x, math.abs(f.x) ** math.abs(f.z)]]
+    EXP = dt.Frame([
+            [src1[i] ** src2[i] for i in range(n)],
+            [src2[i] ** abs(src1[i]) for i in range(n)]/dt.int32,
+            [src2[i] ** abs(src3[i]) for i in range(n)],
+            [src3[i] ** src2[i] for i in range(n)],
+            [src3[i] ** src1[i] for i in range(n)],
+            [abs(src1[i]) ** abs(src3[i]) for i in range(n)],
+          ])
+    assert_equals(RES, EXP)

--- a/tests/expr/fbinary/test-pow.py
+++ b/tests/expr/fbinary/test-pow.py
@@ -33,7 +33,7 @@ from tests import assert_equals
 
 @pytest.mark.parametrize("type", [dt.str32, dt.str64, dt.obj64])
 def test_mod_error_wrong_one_type(type):
-    DT = dt.Frame(A=[[None]*100]/type, B=[range(100)]/dt.int32)
+    DT = dt.Frame(A=[]/type, B=[]/dt.int32)
     type_str = str(type)[6:]
     msg = r"Operator \*\* cannot be applied to columns of types %s and int32" % \
           (type_str,)
@@ -43,7 +43,7 @@ def test_mod_error_wrong_one_type(type):
 
 @pytest.mark.parametrize("type", [dt.str32, dt.str64, dt.obj64])
 def test_mod_error_wrong_both_types(type):
-    DT = dt.Frame(A=[range(100)]/type, B=[[None]*100]/type)
+    DT = dt.Frame(A=[]/type, B=[]/type)
     type_str = str(type)[6:]
     msg = r"Operator \*\* cannot be applied to columns of types %s and %s" % \
           (type_str, type_str)

--- a/tests/expr/fbinary/test-sub.py
+++ b/tests/expr/fbinary/test-sub.py
@@ -33,7 +33,7 @@ from tests import assert_equals
 
 @pytest.mark.parametrize("type", [dt.str32, dt.str64, dt.obj64])
 def test_sub_error_wrong_one_type(type):
-    DT = dt.Frame(A=[[None]*100]/type, B=[range(100)]/dt.int32)
+    DT = dt.Frame(A=[]/type, B=[]/dt.int32)
     type_str = str(type)[6:]
     msg = r"Operator \- cannot be applied to columns of types %s and int32" % \
           (type_str,)
@@ -43,7 +43,7 @@ def test_sub_error_wrong_one_type(type):
 
 @pytest.mark.parametrize("type", [dt.str32, dt.str64, dt.obj64])
 def test_sub_error_wrong_both_types(type):
-    DT = dt.Frame(A=[range(100)]/type, B=[[None]*100]/type)
+    DT = dt.Frame(A=[]/type, B=[]/type)
     type_str = str(type)[6:]
     msg = r"Operator \- cannot be applied to columns of types %s and %s" % \
           (type_str, type_str)

--- a/tests/expr/fbinary/test-sub.py
+++ b/tests/expr/fbinary/test-sub.py
@@ -21,9 +21,39 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 #-------------------------------------------------------------------------------
+import pytest
+import random
 from datatable import dt, f
 from tests import assert_equals
 
+
+#-------------------------------------------------------------------------------
+# Errors
+#-------------------------------------------------------------------------------
+
+@pytest.mark.parametrize("type", [dt.str32, dt.str64, dt.obj64])
+def test_sub_error_wrong_one_type(type):
+    DT = dt.Frame(A=[[None]*100]/type, B=[range(100)]/dt.int32)
+    type_str = str(type)[6:]
+    msg = r"Operator \- cannot be applied to columns of types %s and int32" % \
+          (type_str,)
+    with pytest.raises(TypeError, match=msg):
+        DT[:, f.A - f.B]
+
+
+@pytest.mark.parametrize("type", [dt.str32, dt.str64, dt.obj64])
+def test_sub_error_wrong_both_types(type):
+    DT = dt.Frame(A=[range(100)]/type, B=[[None]*100]/type)
+    type_str = str(type)[6:]
+    msg = r"Operator \- cannot be applied to columns of types %s and %s" % \
+          (type_str, type_str)
+    with pytest.raises(TypeError, match=msg):
+        DT[:, f.A - f.B]
+
+
+#-------------------------------------------------------------------------------
+# Normal
+#-------------------------------------------------------------------------------
 
 def test_sub_stringify():
     assert str(f.A - 1) == "FExpr<f.A - 1>"
@@ -32,3 +62,55 @@ def test_sub_stringify():
     assert str((f.A - f.B) - f.C) == "FExpr<f.A - f.B - f.C>"
     assert str(f.A - (f.B - f.C)) == "FExpr<f.A - (f.B - f.C)>"
     assert str(f.A - f[1]*3 - f.Z) == "FExpr<f.A - f[1] * 3 - f.Z>"
+
+
+def test_sub_booleans():
+    DT = dt.Frame(A=[True, True, True, False, False, False, None, None, None],
+                  B=[True, False, None] * 3)
+    assert_equals(DT[:, f.A - f.B],
+                  dt.Frame([0, 1, None, -1, 0, None, None, None, None]))
+
+
+def test_sub_integers():
+    DT = dt.Frame(A=[3, 12, 724, None], B=[0, -11, 2, 9])
+    assert_equals(DT[:, f.A - f.B],
+                  dt.Frame([3, 23, 722, None]))
+
+
+def test_sub_integers_with_upcast():
+    # int8 + int8 = int32
+    DT = dt.Frame(A=[17, 111]/dt.int8, B=[-17, -28]/dt.int8)
+    assert_equals(DT[:, f.A - f.B],
+                  dt.Frame([34, 139]/dt.int32))
+
+
+def test_integer_sub_scalar():
+    DT = dt.Frame(i8=[77, 101, 127]/dt.int8,
+                  i32=[14, None, 99]/dt.int32,
+                  i64=[7923, -121, 903]/dt.int64)
+    assert_equals(DT[:, f[:] - 1],
+                  dt.Frame([[76, 100, 126]/dt.int32,
+                            [13, None, 98]/dt.int32,
+                            [7922, -122, 902]/dt.int64]))
+
+
+@pytest.mark.parametrize("seed", [random.getrandbits(63)])
+def test_sub_booleans_integers_floats_random(seed):
+    random.seed(seed)
+    n = 1000
+    src1 = [random.randint(-100, 100) for _ in range(n)]
+    src2 = [random.randint(0, 1) for _ in range(n)]
+    src3 = [random.random() * 1000 - 500 for _ in range(n)]
+
+    DT = dt.Frame(x=src1, y=src2/dt.bool8, z=src3)
+    RES = DT[:, [f.x - f.y, f.y - f.x,
+                 f.y - f.z, f.z - f.y,
+                 f.z - f.x, f.x - f.z]]
+    EXP = dt.Frame(
+            C0=[src1[i] - src2[i] for i in range(n)],
+            C2=[src2[i] - src3[i] for i in range(n)],
+            C4=[src3[i] - src1[i] for i in range(n)]
+          )
+    assert_equals(RES[:, [0, 2, 4]], EXP)
+    assert_equals(RES[:, [0, 2, 4]],
+                  RES[:, {"C0":-f[1], "C2":-f[3], "C4":-f[5]}])

--- a/tests/expr/fbinary/test-truediv.py
+++ b/tests/expr/fbinary/test-truediv.py
@@ -33,7 +33,7 @@ from tests import assert_equals
 
 @pytest.mark.parametrize("type", [dt.str32, dt.str64, dt.obj64])
 def test_div_error_wrong_one_type(type):
-    DT = dt.Frame(A=[[None]*100]/type, B=[range(100)]/dt.int32)
+    DT = dt.Frame(A=[]/type, B=[]/dt.int32)
     type_str = str(type)[6:]
     msg = "Operator / cannot be applied to columns of types %s and int32" % \
           (type_str,)
@@ -43,7 +43,7 @@ def test_div_error_wrong_one_type(type):
 
 @pytest.mark.parametrize("type", [dt.str32, dt.str64, dt.obj64])
 def test_div_error_wrong_both_types(type):
-    DT = dt.Frame(A=[range(100)]/type, B=[[None]*100]/type)
+    DT = dt.Frame(A=[]/type, B=[]/type)
     type_str = str(type)[6:]
     msg = "Operator / cannot be applied to columns of types %s and %s" % \
           (type_str, type_str)

--- a/tests/expr/fbinary/test-truediv.py
+++ b/tests/expr/fbinary/test-truediv.py
@@ -27,6 +27,34 @@ from datatable import dt, f
 from tests import assert_equals
 
 
+#-------------------------------------------------------------------------------
+# Errors
+#-------------------------------------------------------------------------------
+
+@pytest.mark.parametrize("type", [dt.str32, dt.str64, dt.obj64])
+def test_div_error_wrong_one_type(type):
+    DT = dt.Frame(A=[[None]*100]/type, B=[range(100)]/dt.int32)
+    type_str = str(type)[6:]
+    msg = "Operator / cannot be applied to columns of types %s and int32" % \
+          (type_str,)
+    with pytest.raises(TypeError, match=msg):
+        DT[:, f.A / f.B]
+
+
+@pytest.mark.parametrize("type", [dt.str32, dt.str64, dt.obj64])
+def test_div_error_wrong_both_types(type):
+    DT = dt.Frame(A=[range(100)]/type, B=[[None]*100]/type)
+    type_str = str(type)[6:]
+    msg = "Operator / cannot be applied to columns of types %s and %s" % \
+          (type_str, type_str)
+    with pytest.raises(TypeError, match=msg):
+        DT[:, f.A / f.B]
+
+
+#-------------------------------------------------------------------------------
+# Normal
+#-------------------------------------------------------------------------------
+
 def test_div_stringify():
     assert str(f.A / 10) == "FExpr<f.A / 10>"
     assert str(f.A / f.B) == "FExpr<f.A / f.B>"
@@ -38,9 +66,21 @@ def test_div_stringify():
     assert str(f.A / (f[1]-3) / f.Z) == "FExpr<f.A / (f[1] - 3) / f.Z>"
 
 
-def test_div_issue1562():
-    DT = dt.Frame(A=[-8], B=[1677])
-    assert DT[:, f.A / f.B][0, 0] == -(8.0 / 1677.0)
+def test_div_boolean_columns():
+    DT = dt.Frame(x=[True, True, True, False, False, False, None, None, None],
+                  y=[True, False, None] * 3)
+    RES = DT[:, f.x / f.y]
+    EXP = dt.Frame([1, None, None, 0, None, None, None, None, None]/dt.float64)
+    assert_equals(RES, EXP)
+
+
+def test_div_boolean_column_scalar():
+    DT = dt.Frame(x=[True, False, None])
+    RES = DT[:, [f.x / True, f.x / False, f.x / None]]
+    EXP = dt.Frame([[1, 0, None]/dt.float64,
+                   [None, None, None]/dt.float64,
+                   [None, None, None]/dt.bool8])
+    assert_equals(RES, EXP)
 
 
 @pytest.mark.parametrize("seed", [random.getrandbits(63)])
@@ -55,3 +95,50 @@ def test_div_integers(seed):
     EXP = dt.Frame([None if src2[i] == 0 else src1[i] / src2[i]
                    for i in range(n)])
     assert_equals(RES, EXP)
+
+
+@pytest.mark.parametrize("seed", [random.getrandbits(63)])
+def test_div_floats_random(seed):
+    random.seed(seed)
+    n = 1000
+    src1 = [random.random() * 100 - 50 for _ in range(n)]
+    src2 = [random.random() * 1000 - 500 for _ in range(n)]
+
+    DT = dt.Frame(x=src1, y=src2)
+    RES = DT[:, [f.x / f.y]]
+    EXP = dt.Frame([
+            [None if src2[i] == 0 else src1[i] / src2[i] for i in range(n)]/dt.float64
+          ])
+    assert_equals(RES, EXP)
+
+
+@pytest.mark.parametrize("seed", [random.getrandbits(63)])
+def test_mul_booleans_integers_floats_random(seed):
+    random.seed(seed)
+    n = 1000
+    src1 = [random.randint(-100, 100) for _ in range(n)]
+    src2 = [random.randint(0, 1) for _ in range(n)]
+    src3 = [random.random() * 1000 - 500 for _ in range(n)]
+
+    DT = dt.Frame(x=src1, y=src2/dt.bool8, z=src3)
+    RES = DT[:, [f.x / f.y, f.y / f.x,
+                 f.y / f.z, f.z / f.y,
+                 f.z / f.x, f.x / f.z]]
+    EXP = dt.Frame([
+            [None if src2[i]==0 else src1[i]/src2[i] for i in range(n)],
+            [None if src1[i]==0 else src2[i]/src1[i] for i in range(n)],
+            [None if src3[i]==0 else src2[i]/src3[i] for i in range(n)],
+            [None if src2[i]==0 else src3[i]/src2[i] for i in range(n)],
+            [None if src1[i]==0 else src3[i]/src1[i] for i in range(n)],
+            [None if src3[i]==0 else src1[i]/src3[i] for i in range(n)]
+          ])
+    assert_equals(RES, EXP)
+
+
+#-------------------------------------------------------------------------------
+# Issues
+#-------------------------------------------------------------------------------
+
+def test_div_issue1562():
+    DT = dt.Frame(A=[-8], B=[1677])
+    assert DT[:, f.A / f.B][0, 0] == -(8.0 / 1677.0)


### PR DESCRIPTION
This set of tests covers the basic binary operations on columns and scalars, it is not fully comprehensive though.