### PR TITLE
Convert FTRL docs to xfunction/xclass format

### DIFF
--- a/docs/api/models/Ftrl/__init__.rst
+++ b/docs/api/models/Ftrl/__init__.rst
@@ -1,0 +1,4 @@
+
+.. xmethod:: datatable.models.Ftrl.__init__
+    :src: src/core/models/py_ftrl.cc Ftrl::m__init__
+    :doc: src/core/models/py_ftrl.cc doc___init__

--- a/docs/api/models/Ftrl/alpha.rst
+++ b/docs/api/models/Ftrl/alpha.rst
@@ -1,0 +1,5 @@
+
+.. xdata:: datatable.models.Ftrl.alpha
+    :src: src/core/models/py_ftrl.cc Ftrl::get_alpha Ftrl::set_alpha
+    :doc: src/core/models/py_ftrl.cc doc_alpha
+    :settable: newalpha

--- a/docs/api/models/Ftrl/beta.rst
+++ b/docs/api/models/Ftrl/beta.rst
@@ -1,0 +1,5 @@
+
+.. xdata:: datatable.models.Ftrl.beta
+    :src: src/core/models/py_ftrl.cc Ftrl::get_beta Ftrl::set_beta
+    :doc: src/core/models/py_ftrl.cc doc_beta
+    :settable: newbeta

--- a/docs/api/models/Ftrl/colname_hashes.rst
+++ b/docs/api/models/Ftrl/colname_hashes.rst
@@ -1,0 +1,4 @@
+
+.. xdata:: datatable.models.Ftrl.colname_hashes
+    :src: src/core/models/py_ftrl.cc Ftrl::get_colname_hashes
+    :doc: src/core/models/py_ftrl.cc doc_colname_hashes

--- a/docs/api/models/Ftrl/colnames.rst
+++ b/docs/api/models/Ftrl/colnames.rst
@@ -1,0 +1,4 @@
+
+.. xdata:: datatable.models.Ftrl.colnames
+    :src: src/core/models/py_ftrl.cc Ftrl::get_colnames
+    :doc: src/core/models/py_ftrl.cc doc_colnames

--- a/docs/api/models/Ftrl/double_precision.rst
+++ b/docs/api/models/Ftrl/double_precision.rst
@@ -1,0 +1,5 @@
+
+.. xdata:: datatable.models.Ftrl.double_precision
+    :src: src/core/models/py_ftrl.cc Ftrl::get_double_precision Ftrl::set_double_precision
+    :doc: src/core/models/py_ftrl.cc doc_double_precision
+    :settable: newdouble_precision

--- a/docs/api/models/Ftrl/feature_importances.rst
+++ b/docs/api/models/Ftrl/feature_importances.rst
@@ -1,0 +1,4 @@
+
+.. xdata:: datatable.models.Ftrl.feature_importances
+    :src: src/core/models/py_ftrl.cc Ftrl::get_fi
+    :doc: src/core/models/py_ftrl.cc doc_fi

--- a/docs/api/models/Ftrl/fit.rst
+++ b/docs/api/models/Ftrl/fit.rst
@@ -1,0 +1,4 @@
+
+.. xmethod:: datatable.models.Ftrl.fit
+    :src: src/core/models/py_ftrl.cc Ftrl::fit
+    :doc: src/core/models/py_ftrl.cc doc_fit

--- a/docs/api/models/Ftrl/interactions.rst
+++ b/docs/api/models/Ftrl/interactions.rst
@@ -1,0 +1,5 @@
+
+.. xdata:: datatable.models.Ftrl.interactions
+    :src: src/core/models/py_ftrl.cc Ftrl::get_interactions Ftrl::set_interactions
+    :doc: src/core/models/py_ftrl.cc doc_interactions
+    :settable: newinteractions

--- a/docs/api/models/Ftrl/labels.rst
+++ b/docs/api/models/Ftrl/labels.rst
@@ -1,0 +1,4 @@
+
+.. xdata:: datatable.models.Ftrl.labels
+    :src: src/core/models/py_ftrl.cc Ftrl::get_labels
+    :doc: src/core/models/py_ftrl.cc doc_labels

--- a/docs/api/models/Ftrl/lambda1.rst
+++ b/docs/api/models/Ftrl/lambda1.rst
@@ -1,0 +1,5 @@
+
+.. xdata:: datatable.models.Ftrl.lambda1
+    :src: src/core/models/py_ftrl.cc Ftrl::get_lambda1 Ftrl::set_lambda1
+    :doc: src/core/models/py_ftrl.cc doc_lambda1
+    :settable: newlambda1

--- a/docs/api/models/Ftrl/lambda2.rst
+++ b/docs/api/models/Ftrl/lambda2.rst
@@ -1,0 +1,5 @@
+
+.. xdata:: datatable.models.Ftrl.lambda2
+    :src: src/core/models/py_ftrl.cc Ftrl::get_lambda2 Ftrl::set_lambda2
+    :doc: src/core/models/py_ftrl.cc doc_lambda2
+    :settable: newlambda2

--- a/docs/api/models/Ftrl/mantissa_nbits.rst
+++ b/docs/api/models/Ftrl/mantissa_nbits.rst
@@ -1,0 +1,5 @@
+
+.. xdata:: datatable.models.Ftrl.mantissa_nbits
+    :src: src/core/models/py_ftrl.cc Ftrl::get_mantissa_nbits Ftrl::set_mantissa_nbits
+    :doc: src/core/models/py_ftrl.cc doc_mantissa_nbits
+    :settable: newmantissa_nbits

--- a/docs/api/models/Ftrl/model.rst
+++ b/docs/api/models/Ftrl/model.rst
@@ -1,0 +1,4 @@
+
+.. xdata:: datatable.models.Ftrl.model
+    :src: src/core/models/py_ftrl.cc Ftrl::get_model
+    :doc: src/core/models/py_ftrl.cc doc_model

--- a/docs/api/models/Ftrl/model_type.rst
+++ b/docs/api/models/Ftrl/model_type.rst
@@ -1,0 +1,5 @@
+
+.. xdata:: datatable.models.Ftrl.model_type
+    :src: src/core/models/py_ftrl.cc Ftrl::get_model_type Ftrl::set_model_type
+    :doc: src/core/models/py_ftrl.cc doc_model_type
+    :settable: newmodel_type

--- a/docs/api/models/Ftrl/model_type_trained.rst
+++ b/docs/api/models/Ftrl/model_type_trained.rst
@@ -1,0 +1,4 @@
+
+.. xdata:: datatable.models.Ftrl.model_type_trained
+    :src: src/core/models/py_ftrl.cc Ftrl::get_model_type_trained
+    :doc: src/core/models/py_ftrl.cc doc_model_type_trained

--- a/docs/api/models/Ftrl/nbins.rst
+++ b/docs/api/models/Ftrl/nbins.rst
@@ -1,0 +1,5 @@
+
+.. xdata:: datatable.models.Ftrl.nbins
+    :src: src/core/models/py_ftrl.cc Ftrl::get_nbins Ftrl::set_nbins
+    :doc: src/core/models/py_ftrl.cc doc_nbins
+    :settable: newnbins

--- a/docs/api/models/Ftrl/negative_class.rst
+++ b/docs/api/models/Ftrl/negative_class.rst
@@ -1,0 +1,5 @@
+
+.. xdata:: datatable.models.Ftrl.negative_class
+    :src: src/core/models/py_ftrl.cc Ftrl::get_negative_class Ftrl::set_negative_class
+    :doc: src/core/models/py_ftrl.cc doc_negative_class
+    :settable: newnegative_class

--- a/docs/api/models/Ftrl/nepochs.rst
+++ b/docs/api/models/Ftrl/nepochs.rst
@@ -1,0 +1,5 @@
+
+.. xdata:: datatable.models.Ftrl.nepochs
+    :src: src/core/models/py_ftrl.cc Ftrl::get_nepochs Ftrl::set_nepochs
+    :doc: src/core/models/py_ftrl.cc doc_nepochs
+    :settable: newnepochs

--- a/docs/api/models/Ftrl/params.rst
+++ b/docs/api/models/Ftrl/params.rst
@@ -1,0 +1,5 @@
+
+.. xdata:: datatable.models.Ftrl.params
+    :src: src/core/models/py_ftrl.cc Ftrl::get_params_namedtuple Ftrl::set_params_namedtuple
+    :doc: src/core/models/py_ftrl.cc doc_params
+    :settable: newparams

--- a/docs/api/models/Ftrl/predict.rst
+++ b/docs/api/models/Ftrl/predict.rst
@@ -1,0 +1,4 @@
+
+.. xmethod:: datatable.models.Ftrl.predict
+    :src: src/core/models/py_ftrl.cc Ftrl::predict
+    :doc: src/core/models/py_ftrl.cc doc_predict

--- a/docs/api/models/Ftrl/reset.rst
+++ b/docs/api/models/Ftrl/reset.rst
@@ -1,0 +1,4 @@
+
+.. xmethod:: datatable.models.Ftrl.reset
+    :src: src/core/models/py_ftrl.cc Ftrl::reset
+    :doc: src/core/models/py_ftrl.cc doc_reset

--- a/docs/api/models/ftrl.rst
+++ b/docs/api/models/ftrl.rst
@@ -10,6 +10,7 @@ datatable.models.Ftrl
 .. toctree::
     :hidden:
 
+    .__init__()               <Ftrl/__init__>
     .alpha                    <Ftrl/alpha>
     .beta                     <Ftrl/beta>
     .colnames                 <Ftrl/colnames>

--- a/docs/api/models/ftrl.rst
+++ b/docs/api/models/ftrl.rst
@@ -1,6 +1,7 @@
+datatable.models.Ftrl
+---------------------
 
-Ftrl
-====
-
-.. autoclass:: datatable.models.Ftrl
-    :members:
+.. xclass:: Ftrl
+    :src: src/core/models/py_ftrl.h Ftrl
+    :doc: src/core/models/py_ftrl.cc doc_Ftrl
+    :notitle:

--- a/docs/api/models/ftrl.rst
+++ b/docs/api/models/ftrl.rst
@@ -1,11 +1,11 @@
 datatable.models.Ftrl
 ---------------------
 
-.. xclass:: Ftrl
+.. xclass:: models.Ftrl
     :src: src/core/models/py_ftrl.h Ftrl
     :doc: src/core/models/py_ftrl.cc doc_Ftrl
     :tests: tests/models/test-ftrl.py
-
+    :notitle:
 
 .. toctree::
     :hidden:

--- a/docs/api/models/ftrl.rst
+++ b/docs/api/models/ftrl.rst
@@ -4,4 +4,31 @@ datatable.models.Ftrl
 .. xclass:: Ftrl
     :src: src/core/models/py_ftrl.h Ftrl
     :doc: src/core/models/py_ftrl.cc doc_Ftrl
-    :notitle:
+    :tests: tests/models/test-ftrl.py
+
+
+.. toctree::
+    :hidden:
+
+    .alpha                    <Ftrl/alpha>
+    .beta                     <Ftrl/beta>
+    .colnames                 <Ftrl/colnames>
+    .colname_hashes           <Ftrl/colname_hashes>
+    .double_precision         <Ftrl/double_precision>
+    .feature_importances      <Ftrl/feature_importances>
+    .fit()                    <Ftrl/fit>
+    .interactions             <Ftrl/interactions>
+    .labels                   <Ftrl/labels>
+    .lambda1                  <Ftrl/lambda1>
+    .lambda2                  <Ftrl/lambda2>
+    .nbins                    <Ftrl/nbins>
+    .nepochs                  <Ftrl/nepochs>
+    .model                    <Ftrl/model>
+    .model_type               <Ftrl/model_type>
+    .model_type_trained       <Ftrl/model_type_trained>
+    .mantissa_nbits           <Ftrl/mantissa_nbits>
+    .negative_class           <Ftrl/negative_class>
+    .params                   <Ftrl/params>
+    .predict()                <Ftrl/predict>
+    .reset()                  <Ftrl/reset>
+

--- a/src/core/models/py_ftrl.cc
+++ b/src/core/models/py_ftrl.cc
@@ -1364,7 +1364,7 @@ oobj Ftrl::get_model_type_trained() const {
 static const char* doc_params =
 R"(
 `Ftrl` model parameters as a named tuple `FtrlParams`,
-see :class:`datatable.models.Ftrl()` for more details.
+see :meth:`.Ftrl.__init__` for more details.
 This option is read-only for a trained model.
 
 Parameters

--- a/src/core/models/py_ftrl.cc
+++ b/src/core/models/py_ftrl.cc
@@ -124,7 +124,7 @@ params: FtrlParams
     or any combination of the individual parameters to the constructor,
     but not both at the same time.
 
-except: TypeError
+except: ValueError
     The exception is raised if both the `params` and one of the
     individual model parameters are passed at the same time.
 
@@ -180,7 +180,7 @@ void Ftrl::m__init__(const PKArgs& args) {
 
   if (defined_params) {
     if (defined_individual_param) {
-      throw TypeError() << "You can either pass all the parameters with "
+      throw ValueError() << "You can either pass all the parameters with "
         << "`params` or any of the individual parameters with `alpha`, "
         << "`beta`, `lambda1`, `lambda2`, `nbins`, `mantissa_nbits`, `nepochs`, "
         << "`double_precision`, `negative_class`, `interactions` or `model_type` "

--- a/src/core/models/py_ftrl.cc
+++ b/src/core/models/py_ftrl.cc
@@ -1169,9 +1169,8 @@ void Ftrl::m__setstate__(const PKArgs& args) {
 // py::Ftrl::Type
 //------------------------------------------------------------------------------
 
-void Ftrl::impl_init_type(XTypeMaker& xt) {
-  xt.set_class_name("datatable.models.Ftrl");
-  xt.set_class_doc(R"(Follow the Regularized Leader (FTRL) model.
+static const char* doc_Ftrl =
+R"(Follow the Regularized Leader (FTRL) model.
 
 FTRL model is a datatable implementation of the FTRL-Proximal online
 learning algorithm for binomial logistic regression. It uses a hashing
@@ -1228,7 +1227,11 @@ model_type : str
     'regression' for numeric regression. Defaults to 'auto', meaning
     that the model type will be automatically selected based on
     the target column `stype`.
-)");
+)";
+
+void Ftrl::impl_init_type(XTypeMaker& xt) {
+  xt.set_class_name("datatable.models.Ftrl");
+  xt.set_class_doc(doc_Ftrl);
 
   xt.add(CONSTRUCTOR(&Ftrl::m__init__, args___init__));
   xt.add(DESTRUCTOR(&Ftrl::m__dealloc__));

--- a/src/core/models/py_ftrl.cc
+++ b/src/core/models/py_ftrl.cc
@@ -243,11 +243,17 @@ validation_average_niterations: int
     Number of iterations that is used to calculate average loss. Here, each
     iteration corresponds to `nepochs_validation` epochs.
 
-return: Tuple[float, float]
-    A tuple consisting of two elements: `epoch` and `loss`, where
-    `epoch` is the epoch at which model fitting stopped, and `loss` is the final
-    loss. When validation dataset is not provided, `epoch` returned is equal to
-    `nepochs`, and `loss` is `float('nan')`.
+return: FtrlFitOutput
+    `FtrlFitOutput` is a `Tuple[float, float]` with two fields: `epoch` and `loss`,
+    representing the final fitting epoch and the final loss, respectively.
+    If validation dataset is not provided, the returned `epoch` equals to
+    `nepochs` and the `loss` is just `float('nan')`.
+
+See also
+--------
+- :meth:`.predict`: predict on a dataset
+- :meth:`.reset`: reset the model
+
 )";
 
 static PKArgs args_fit(2, 5, 0, false, false, {"X_train", "y_train",
@@ -422,6 +428,12 @@ X: Frame
 return: Frame
     A new frame of shape `(nrows, nlabels)` with the predicted probabilities
     for each row of frame `X` and each label the model was trained for.
+
+See also
+--------
+- :meth:`.fit`: train model on a dataset
+- :meth:`.reset`: reset the model
+
 )";
 
 static PKArgs args_predict(1, 0, 0, false, false, {"X"}, "predict",
@@ -483,12 +495,18 @@ static const char* doc_reset =
 R"(reset(self)
 --
 
-Reset FTRL model by resetting all the model weights, labels and
+Reset FTRL model by resetting all the model coefficients, labels and
 feature importance information.
 
 Parameters
 ----------
 return: None
+
+See also
+--------
+- :meth:`.fit`: train model on a dataset
+- :meth:`.predict`: predict on a dataset
+
 )";
 
 static PKArgs args_reset(0, 0, 0, false, false, {}, "reset", doc_reset);
@@ -1227,7 +1245,9 @@ oobj Ftrl::get_model_type_trained() const {
 
 static const char* doc_params =
 R"(
-`Ftrl` model parameters. This option is read-only for a trained model.
+`Ftrl` model parameters as a named tuple `FtrlParams`,
+see :class:`datatable.models.Ftrl()` for more details.
+This option is read-only for a trained model.
 
 Parameters
 ----------

--- a/src/core/models/py_ftrl.cc
+++ b/src/core/models/py_ftrl.cc
@@ -1442,45 +1442,45 @@ https://www.eecs.tufts.edu/~dsculley/papers/ad-click-prediction.pdf
 
 Parameters
 ----------
-alpha : float
+alpha: float
     `alpha` in per-coordinate learning rate formula, defaults to `0.005`.
 
-beta : float
+beta: float
     `beta` in per-coordinate learning rate formula, defaults to `1`.
 
-lambda1 : float
+lambda1: float
     L1 regularization parameter, defaults to `0`.
 
-lambda2 : float
+lambda2: float
     L2 regularization parameter, defaults to `0`.
 
-nbins : int
+nbins: int
     Number of bins to be used for the hashing trick, defaults to `10**6`.
 
-mantissa_nbits : int
+mantissa_nbits: int
     Number of bits from mantissa to be used for hashing floats,
     defaults to `10`.
 
-nepochs : float
+nepochs: float
     Number of training epochs, defaults to `1`. When `nepochs` is
     an integer number, the model will train on all the data provided
     to `.fit()` method `nepochs` times. If `nepochs` has
     a fractional component, the model's last iteration will only
     be done on the fraction of data.
 
-double_precision : bool
+double_precision: bool
     Whether to use double precision arithmetic or not, defaults to `False`.
 
-negative_class : bool
+negative_class: bool
     Whether to create and train on a 'negative' class in the case of
     multinomial classification.
 
-interactions : list or tuple
+interactions: list or tuple
     A list or a tuple of interactions. In turn, each interaction
     should be a list or a tuple of feature names, where each feature
     name is a column name from the training frame.
 
-model_type : str
+model_type: str
     Model type can be one of the following: `binomial` for binomial
     classification, `multinomial` for multinomial classification, and
     `regression` for numeric regression. Defaults to `auto`, meaning

--- a/src/core/models/py_ftrl.cc
+++ b/src/core/models/py_ftrl.cc
@@ -251,8 +251,8 @@ return: FtrlFitOutput
 
 See also
 --------
-- :meth:`.predict`: predict on a dataset
-- :meth:`.reset`: reset the model
+- :meth:`.predict` -- predict on a dataset.
+- :meth:`.reset` -- reset the model.
 
 )";
 
@@ -431,8 +431,8 @@ return: Frame
 
 See also
 --------
-- :meth:`.fit`: train model on a dataset
-- :meth:`.reset`: reset the model
+- :meth:`.fit` -- train model on a dataset.
+- :meth:`.reset` -- reset the model.
 
 )";
 
@@ -504,8 +504,8 @@ return: None
 
 See also
 --------
-- :meth:`.fit`: train model on a dataset
-- :meth:`.predict`: predict on a dataset
+- :meth:`.fit` -- train model on a dataset.
+- :meth:`.predict` -- predict on a dataset.
 
 )";
 
@@ -1182,6 +1182,11 @@ return: str
 newmodel_type: str
     New `model_type` value, should be one of the following:
     `binomial`, `multinomial`, `regression` or `auto`.
+
+See also
+--------
+- :data:`.model_type_trained` -- the model type `Ftrl` has build.
+
 )";
 
 static GSArgs args_model_type(
@@ -1217,13 +1222,18 @@ void Ftrl::set_model_type(const Arg& py_model_type) {
 
 static const char* doc_model_type_trained =
 R"(
-The model type `Ftrl` has already built.
+The model type `Ftrl` has built.
 
 Parameters
 ----------
 return: str
     Could be one of the following: `regression`, `binomial`,
     `multinomial` or `none` for untrained model.
+
+See also
+--------
+- :data:`.model_type` -- the model type `Ftrl` should build.
+
 )";
 
 static GSArgs args_model_type_trained(
@@ -1484,7 +1494,7 @@ mantissa_nbits: int
 nepochs: float
     Number of training epochs, defaults to `1`. When `nepochs` is
     an integer number, the model will train on all the data provided
-    to `.fit()` method `nepochs` times. If `nepochs` has
+    to :meth:`.fit` method `nepochs` times. If `nepochs` has
     a fractional component, the model's last iteration will only
     be done on the fraction of data.
 

--- a/src/core/models/py_ftrl.cc
+++ b/src/core/models/py_ftrl.cc
@@ -115,7 +115,7 @@ void Ftrl::m__init__(const PKArgs& args) {
         << "`params` or any of the individual parameters with `alpha`, "
         << "`beta`, `lambda1`, `lambda2`, `nbins`, `mantissa_nbits`, `nepochs`, "
         << "`double_precision`, `negative_class`, `interactions` or `model_type` "
-        << "to Ftrl constructor, but not both at the same time";
+        << "to `Ftrl` constructor, but not both at the same time";
     }
 
     py::otuple py_params_in = arg_params.to_otuple();
@@ -1481,11 +1481,16 @@ interactions : list or tuple
     name is a column name from the training frame.
 
 model_type : str
-    Model type can be one of the following: 'binomial' for binomial
-    classification, 'multinomial' for multinomial classification, and
-    'regression' for numeric regression. Defaults to 'auto', meaning
+    Model type can be one of the following: `binomial` for binomial
+    classification, `multinomial` for multinomial classification, and
+    `regression` for numeric regression. Defaults to `auto`, meaning
     that the model type will be automatically selected based on
     the target column `stype`.
+
+params: FtrlParams
+    Named tuple of the above parameters. One can pass either this tuple,
+    or any combination of the individual parameters to the constructor,
+    but not both at the same time.
 )";
 
 void Ftrl::impl_init_type(XTypeMaker& xt) {

--- a/src/core/models/py_ftrl.cc
+++ b/src/core/models/py_ftrl.cc
@@ -58,19 +58,88 @@ std::map<dt::FtrlModelType, std::string> Ftrl::create_model_type_name() {
 }
 
 
+/**
+ *  Ftrl(...)
+ *  Initialize Ftrl object with the provided parameters.
+ */
+
+static const char* doc___init__ =
+R"(__init__(self, alpha=0.005, beta=1, lambda1=0, lambda2=0, nbins=10**6,
+mantissa_nbits=10, nepochs=1, double_precision=False, negative_class=False,
+interactions=None, model_type='auto', params=None)
+--
+
+Create a new :class:`datatable.models.Ftrl()` model.
+
+Parameters
+----------
+alpha: float
+    `alpha` in per-coordinate learning rate formula, should be positive.
+
+beta: float
+    `beta` in per-coordinate learning rate formula, should be non-negative.
+
+lambda1: float
+    L1 regularization parameter, should be non-negative.
+
+lambda2: float
+    L2 regularization parameter, should be non-negative.
+
+nbins: int
+    Number of bins to be used for the hashing trick, should be positive.
+
+mantissa_nbits: int
+    Number of bits from mantissa to be used for hashing floats.
+    It should be non-negative and less than or equal to `52`, that
+    is a number of mantissa bits in a C++ 64-bit `double`.
+
+nepochs: float
+    Number of training epochs, should be non-negative. When `nepochs` is
+    an integer number, the model will train on all the data provided
+    to :meth:`.fit` method `nepochs` times. If `nepochs` has
+    a fractional component, the model's last iteration will only
+    be done on the fraction of data.
+
+double_precision: bool
+    An option to indicate whether double precision arithmetic
+    should be used or not.
+
+negative_class: bool
+    An option to indicate if a 'negative’ class should be created
+    in the case of multinomial classification.
+
+interactions: List[List | Tuple] | Tuple[List | Tuple]
+    A list or a tuple of interactions. In turn, each interaction
+    should be a list or a tuple of feature names, where each feature
+    name is a column name from the training frame.
+
+model_type: str
+    Model type can be one of the following: `binomial` for binomial
+    classification, `multinomial` for multinomial classification,
+    `regression` for numeric regression, and `auto` for automatic
+    model type selection based on the target column `stype`.
+
+params: FtrlParams
+    Named tuple of the above parameters. One can pass either this tuple,
+    or any combination of the individual parameters to the constructor,
+    but not both at the same time.
+
+except: TypeError
+    The exception is raised if both the `params` and one of the
+    individual model parameters are passed at the same time.
+
+)";
+
 static PKArgs args___init__(0, 1, 11, false, false,
                                  {"params", "alpha", "beta", "lambda1",
                                  "lambda2", "nbins", "mantissa_nbits",
                                  "nepochs", "double_precision",
                                  "negative_class", "interactions",
                                  "model_type"},
-                                 "__init__", nullptr);
+                                 "__init__", doc___init__);
 
 
-/**
- *  Ftrl(...)
- *  Initialize Ftrl object with the provided parameters.
- */
+
 void Ftrl::m__init__(const PKArgs& args) {
   m__dealloc__();
   double_precision = dt::FtrlParams().double_precision;
@@ -642,12 +711,17 @@ oobj Ftrl::get_normalized_fi(bool normalize) const {
 
 static const char* doc_colnames =
 R"(
-Column names of the training frame.
+Column names of the training frame that are used as feature names.
 
 Parameters
 ----------
 return: List
     A list of the column names.
+
+See also
+--------
+- :data:`.colname_hashes` -- the hashed column names.
+
 )";
 
 static GSArgs args_colnames(
@@ -697,6 +771,11 @@ Parameters
 ----------
 return: List
     A list of the column name hashes.
+
+See also
+--------
+- :data:`.colnames` -- the column names of the training frame, i.e. the feature names.
+
 )";
 
 static GSArgs args_colname_hashes(
@@ -735,7 +814,7 @@ return: float
     Current `alpha` value.
 
 newalpha: float
-    New `alpha` value, should be positive and finite.
+    New `alpha` value, should be positive.
 )";
 
 static GSArgs args_alpha(
@@ -772,7 +851,7 @@ return: float
     Current `beta` value.
 
 newbeta: float
-    New `beta` value, should be non-negative and finite.
+    New `beta` value, should be non-negative.
 )";
 
 static GSArgs args_beta(
@@ -809,7 +888,7 @@ return: float
     Current `lambda1` value.
 
 newlambda1: float
-    New `lambda1` value, should be non-negative and finite.
+    New `lambda1` value, should be non-negative.
 )";
 
 static GSArgs args_lambda1(
@@ -846,7 +925,7 @@ return: float
     Current `lambda2` value.
 
 newlambda2: float
-    New `lambda2` value, should be non-negative and finite.
+    New `lambda2` value, should be non-negative.
 )";
 
 static GSArgs args_lambda2(
@@ -885,6 +964,11 @@ return: int
 
 newnbins: int
     New `nbins` value, should be positive.
+
+except: ValueError
+    The exception is raised when trying to change this option
+    for a model that has already been trained.
+
 )";
 
 static GSArgs args_nbins(
@@ -930,6 +1014,11 @@ newmantissa_nbits: int
     New `mantissa_nbits` value, should be non-negative and
     less than or equal to `52`, that is a number of
     mantissa bits in a C++ 64-bit `double`.
+
+except: ValueError
+    The exception is raised when trying to change this option
+    for a model that has already been trained.
+
 )";
 
 static GSArgs args_mantissa_nbits(
@@ -976,7 +1065,7 @@ return: float
     Current `nepochs` value.
 
 newnepochs: float
-    New `nepochs` value, should be non-negative and finite.
+    New `nepochs` value, should be non-negative.
 )";
 
 static GSArgs args_nepochs(
@@ -1014,6 +1103,11 @@ return: bool
 
 newdouble_precision: bool
     New `double_precision` value.
+
+except: ValueError
+    The exception is raised when trying to change this option
+    for a model that has already been trained.
+
 )";
 
 static GSArgs args_double_precision(
@@ -1054,6 +1148,11 @@ return: bool
 
 newnegative_class: bool
     New `negative_class` value.
+
+except: ValueError
+    The exception is raised when trying to change this option
+    for a model that has already been trained.
+
 )";
 
 static GSArgs args_negative_class(
@@ -1097,6 +1196,11 @@ newinteractions: Tuple | List
     New `interactions` value. Each particular interaction
     should be a list or a tuple of feature names, where each feature
     name is a column name from the training frame.
+
+except: ValueError
+    The exception is raised when trying to change this option
+    for a model that has already been trained.
+
 )";
 
 static GSArgs args_interactions(
@@ -1183,6 +1287,10 @@ newmodel_type: str
     New `model_type` value, should be one of the following:
     `binomial`, `multinomial`, `regression` or `auto`.
 
+except: ValueError
+    The exception is raised when trying to change this option
+    for a model that has already been trained.
+
 See also
 --------
 - :data:`.model_type_trained` -- the model type `Ftrl` has build.
@@ -1266,6 +1374,11 @@ return: FtrlParams
 
 newparams: FtrlParams
     New `params` value.
+
+except: ValueError
+    The exception is raised when trying to change this option
+    for a model that has alerady been trained.
+
 )";
 
 static GSArgs args_params(
@@ -1469,58 +1582,6 @@ continuous targets are implemented experimentally.
 
 See this reference for more details:
 https://www.eecs.tufts.edu/~dsculley/papers/ad-click-prediction.pdf
-
-Parameters
-----------
-alpha: float
-    `alpha` in per-coordinate learning rate formula, defaults to `0.005`.
-
-beta: float
-    `beta` in per-coordinate learning rate formula, defaults to `1`.
-
-lambda1: float
-    L1 regularization parameter, defaults to `0`.
-
-lambda2: float
-    L2 regularization parameter, defaults to `0`.
-
-nbins: int
-    Number of bins to be used for the hashing trick, defaults to `10**6`.
-
-mantissa_nbits: int
-    Number of bits from mantissa to be used for hashing floats,
-    defaults to `10`.
-
-nepochs: float
-    Number of training epochs, defaults to `1`. When `nepochs` is
-    an integer number, the model will train on all the data provided
-    to :meth:`.fit` method `nepochs` times. If `nepochs` has
-    a fractional component, the model's last iteration will only
-    be done on the fraction of data.
-
-double_precision: bool
-    Whether to use double precision arithmetic or not, defaults to `False`.
-
-negative_class: bool
-    Whether to create and train on a 'negative' class in the case of
-    multinomial classification.
-
-interactions: list or tuple
-    A list or a tuple of interactions. In turn, each interaction
-    should be a list or a tuple of feature names, where each feature
-    name is a column name from the training frame.
-
-model_type: str
-    Model type can be one of the following: `binomial` for binomial
-    classification, `multinomial` for multinomial classification, and
-    `regression` for numeric regression. Defaults to `auto`, meaning
-    that the model type will be automatically selected based on
-    the target column `stype`.
-
-params: FtrlParams
-    Named tuple of the above parameters. One can pass either this tuple,
-    or any combination of the individual parameters to the constructor,
-    but not both at the same time.
 )";
 
 void Ftrl::impl_init_type(XTypeMaker& xt) {

--- a/tests/expr/fbinary/test-pow.py
+++ b/tests/expr/fbinary/test-pow.py
@@ -129,13 +129,13 @@ def test_pow_booleans_integers_floats_random(seed):
     DT = dt.Frame(x=src1, y=src2/dt.bool8, z=src3)
     RES = DT[:, [f.x ** f.y, f.y ** math.abs(f.x),
                  f.y ** math.abs(f.z), f.z ** f.y,
-                 f.z ** f.x, math.abs(f.x) ** math.abs(f.z)]]
+                 f.z ** math.abs(f.x), math.abs(f.x) ** math.abs(f.z)]]
     EXP = dt.Frame([
             [src1[i] ** src2[i] for i in range(n)],
             [src2[i] ** abs(src1[i]) for i in range(n)]/dt.int32,
             [src2[i] ** abs(src3[i]) for i in range(n)],
             [src3[i] ** src2[i] for i in range(n)],
-            [src3[i] ** src1[i] for i in range(n)],
+            [src3[i] ** abs(src1[i]) for i in range(n)],
             [abs(src1[i]) ** abs(src3[i]) for i in range(n)],
           ])
     assert_equals(RES, EXP)

--- a/tests/models/test-ftrl.py
+++ b/tests/models/test-ftrl.py
@@ -145,7 +145,7 @@ def test_ftrl_construct_wrong_interactions_from_itertools():
 
 
 def test_ftrl_construct_wrong_combination():
-    with pytest.raises(TypeError) as e:
+    with pytest.raises(ValueError) as e:
         noop(Ftrl(params=tparams, alpha = tparams.alpha))
     assert ("You can either pass all the parameters with params or any of "
             "the individual parameters with alpha, beta, lambda1, "


### PR DESCRIPTION
- create FTRL reference under the API section;
- overall improvement of FTRL docs, though it may still lack some info on exceptions.

Also, with the new system I'm not sure what is the best way to document the named tuples `FtrlParams` and `FtrlFitOutput`, that we use in `Ftrl` class.

WIP for #2586