### PR TITLE
Change np.array to np.asfortranarray in to_numpy for performance

### DIFF
--- a/src/core/frame/to_numpy.cc
+++ b/src/core/frame/to_numpy.cc
@@ -109,7 +109,7 @@ static PKArgs args_to_numpy(
 
 oobj Frame::to_numpy(const PKArgs& args) {
   oobj numpy = oobj::import("numpy");
-  oobj nparray = numpy.get_attr("array");
+  oobj nparray = numpy.get_attr("asfortranarray");
   dt::SType stype      = args.get<dt::SType>(0, dt::SType::VOID);
   size_t force_col = args.get<size_t>(1, size_t(-1));
 


### PR DESCRIPTION
When creating a numpy array, numpy provides a variety of parameter options, including Specify the memory layout of the array.Because the datatable frame is based on column storage, I found that if specified as fortran order, the performance will be improved.
The performance of `np.asfortranarray`  relative to `np.array` can be improved by about 40%, especially on large frames.
Generated a simple frame test, the overall performance of to_numpy on my machine can be improved by 20%.

`letters = "abcdefghijklmn"`
`n = 10000000`
`col0 = [random.choice([True, False]) for _ in range(n)]`
`col1 = [random.randint(-100, 100) for _ in range(n)]`
`col2 = [random.choice(letters) for _ in range(n)]`
`col3 = [random.random() for _ in range(n)]`

`DT0 = dt.Frame([col0, col1, col2, col3,`
`                col0, col1, col2, col3,`
`                col0, col1, col2, col3,`
`                col0, col1, col2, col3,`
 `              col0, col1, col2, col3,`
`                col0, col1, col2, col3,`
`                col0, col1, col2, col3,])`

`DT0.to_numpy()`