### PR TITLE
Handle multi-params in function 'Parameters' section

### DIFF
--- a/docs/_static/xfunction.css
+++ b/docs/_static/xfunction.css
@@ -182,7 +182,9 @@
 .xparam-head {
     align-items: baseline;
     background: #f5f5f5;
+    color: #ddd;  /* affects only the separators */
     display: flex;
+    font-family: "SF Mono", Menlo, monospace;
 }
 
 .xparam-head .param {
@@ -191,7 +193,6 @@
     color: #d7ffff;
     cursor: default;
     display: inline-block;
-    font-family: "SF Mono", Menlo, monospace;
     font-size: 85%;
     padding: 3px 6px;
 }
@@ -207,7 +208,6 @@
 }
 
 .xparam-head .types {
-    color: #ddd;  /* affects only the separators */
     line-height: 14px;
     padding: 3px 10px;
 }

--- a/src/datatable/sphinxext/xnodes.py
+++ b/src/datatable/sphinxext/xnodes.py
@@ -28,10 +28,10 @@ docutils / Sphinx.
 from docutils import nodes
 
 __all__ = (
-	"table",
-	"td",
-	"th",
-	"tr",
+    "table",
+    "td",
+    "th",
+    "tr",
 )
 
 
@@ -46,15 +46,15 @@ __all__ = (
 #        ])
 #
 class xElement(nodes.Element):
-	def __init__(self, *args, rawtext="", children=[], **attributes):
-		assert isinstance(children, list)
-		if args:
-			assert not children
-			children = list(args)
-		for i, child in enumerate(children):
-			if isinstance(child, str):
-				children[i] = nodes.Text(child)
-		super().__init__(rawtext, *children, **attributes)
+    def __init__(self, *args, rawtext="", children=[], **attributes):
+        assert isinstance(children, list)
+        if args:
+            assert not children
+            children = [a for a in args if a is not None]
+        for i, child in enumerate(children):
+            if isinstance(child, str):
+                children[i] = nodes.Text(child)
+        super().__init__(rawtext, *children, **attributes)
 
 
 
@@ -132,15 +132,15 @@ def depart_div(self, node):
 #-------------------------------------------------------------------------------
 
 def setup(app):
-	# Set custom names for the node classes, otherwise Sphinx
-	# complains that the node with same name already registered.
-	table.__name__ = "xtable"
-	tr.__name__ = "xtr"
-	th.__name__ = "xth"
-	td.__name__ = "xtd"
-	div.__name__ = "xdiv"
-	app.add_node(table, html=(visit_table, depart_table))
-	app.add_node(tr, html=(visit_tr, depart_tr))
-	app.add_node(td, html=(visit_tdth, depart_tdth))
-	app.add_node(th, html=(visit_tdth, depart_tdth))
-	app.add_node(div, html=(visit_div, depart_div))
+    # Set custom names for the node classes, otherwise Sphinx
+    # complains that the node with same name already registered.
+    table.__name__ = "xtable"
+    tr.__name__ = "xtr"
+    th.__name__ = "xth"
+    td.__name__ = "xtd"
+    div.__name__ = "xdiv"
+    app.add_node(table, html=(visit_table, depart_table))
+    app.add_node(tr, html=(visit_tr, depart_tr))
+    app.add_node(td, html=(visit_tdth, depart_tdth))
+    app.add_node(th, html=(visit_tdth, depart_tdth))
+    app.add_node(div, html=(visit_div, depart_div))


### PR DESCRIPTION
This PR allows to declare multiple parameters at once in the "parameters" section of documentation, e.g.
```
Parameters
----------
x, y, z: float
    (description of parameters)
```

WIP for #2605