### PR TITLE
Fix style of multi-params in documentation

### DIFF
--- a/docs/_static/xfunction.css
+++ b/docs/_static/xfunction.css
@@ -182,7 +182,7 @@
 .xparam-head {
     align-items: baseline;
     background: #f5f5f5;
-    color: #ddd;  /* affects only the separators */
+    color: rgba(0, 0, 0, 25%);  /* affects only the separators */
     display: flex;
     font-family: "SF Mono", Menlo, monospace;
 }
@@ -205,6 +205,11 @@
 .xparam-head .param.except {
     background-color: #C50000;
     color: #FFF;
+}
+
+.xparam-head .sep {
+    font-size: 85%;
+    padding-right: 2pt;
 }
 
 .xparam-head .types {

--- a/src/datatable/sphinxext/xfunction.py
+++ b/src/datatable/sphinxext/xfunction.py
@@ -1133,7 +1133,7 @@ class XparamDirective(SphinxDirective):
             id0 = param.strip("*/()[]")
             root = xnodes.div(root, ids=[id0], classes=["xparam-box"])
             if i > 0:
-                head += nodes.Text(", ")
+                head += xnodes.div(", ", classes=["sep"])
             if id0 in ["return", "except"]:
                 head += xnodes.div(id0, classes=["param", id0])
             else:


### PR DESCRIPTION
This is a follow up for https://github.com/h2oai/datatable/pull/2620#issuecomment-692892056