### PR TITLE
Documentation for stype/ltype

### DIFF
--- a/docs/api/dt/build_info.rst
+++ b/docs/api/dt/build_info.rst
@@ -1,6 +1,6 @@
 
 .. xdata:: datatable.build_info
-    :src: src/datatable/_build_info.py build_info
+    :src: --
 
     This is a python struct that contains information about the installed
     datatable module. The following fields are available:

--- a/docs/api/index-api.rst
+++ b/docs/api/index-api.rst
@@ -173,11 +173,12 @@ Other
 .. toctree::
     :hidden:
 
-    models.           <models>
     math.             <math>
-    Frame             <frame>
+    models.           <models>
     FExpr             <fexpr>
+    Frame             <frame>
     Namespace         <namespace>
+    stype             <stype>
     build_info        <dt/build_info>
     by()              <dt/by>
     cbind()           <dt/cbind>

--- a/docs/api/index-api.rst
+++ b/docs/api/index-api.rst
@@ -177,6 +177,7 @@ Other
     models.           <models>
     FExpr             <fexpr>
     Frame             <frame>
+    ltype             <ltype>
     Namespace         <namespace>
     stype             <stype>
     build_info        <dt/build_info>

--- a/docs/api/ltype.rst
+++ b/docs/api/ltype.rst
@@ -1,0 +1,48 @@
+
+.. xclass:: datatable.ltype
+    :src: src/datatable/types.py ltype
+
+    Values
+    ------
+    The following ltype values are currently available:
+
+        - `ltype.bool`
+        - `ltype.int`
+        - `ltype.real`
+        - `ltype.str`
+        - `ltype.time`
+        - `ltype.obj`
+
+
+    Methods
+    -------
+    .. list-table::
+        :widths: auto
+        :class: api-table
+
+        * - :meth:`ltype(x) <datatable.ltype.__new__>`
+          - Find ltype corresponding to value ``x``.
+
+        * - :attr:`.stypes <datatable.ltype.stypes>`
+          - The list of :class:`stype`s that correspond to this ltype.
+
+    Examples
+    --------
+    >>> dt.ltype.bool
+    ltype.bool
+    >>> dt.ltype("int32")
+    ltype.int
+
+    For each ltype, you can find the set of stypes that correspond to it:
+
+    >>> dt.ltype.real.stypes
+    [stype.float32, stype.float64]
+    >>> dt.ltype.time.stypes
+    []
+
+
+.. toctree::
+    :hidden:
+
+    .__new__()    <ltype/__new__>
+    .stypes       <ltype/stypes>

--- a/docs/api/ltype/__new__.rst
+++ b/docs/api/ltype/__new__.rst
@@ -1,0 +1,11 @@
+
+.. xmethod:: datatable.ltype.__new__
+    :src: src/datatable/types.py ___new___
+
+    __new__(self, value)
+    --
+
+    Find an ltype corresponding to `value`.
+
+    This method is similar to :meth:`stype.__new__()`, except that it
+    returns an ltype instead of an stype.

--- a/docs/api/ltype/stypes.rst
+++ b/docs/api/ltype/stypes.rst
@@ -1,0 +1,3 @@
+
+.. xmethod:: datatable.ltype.stypes
+    :src: src/datatable/types.py stypes

--- a/docs/api/stype.rst
+++ b/docs/api/stype.rst
@@ -1,0 +1,12 @@
+
+.. xclass:: datatable.stype
+    :src: src/datatable/types.py stype
+
+
+
+
+
+.. toctree::
+    :hidden:
+
+    .__call__()   <stype/__call__>

--- a/docs/api/stype.rst
+++ b/docs/api/stype.rst
@@ -2,11 +2,69 @@
 .. xclass:: datatable.stype
     :src: src/datatable/types.py stype
 
+    Values
+    ------
+    The following stype values are currently available:
 
+        - `stype.bool8`
+        - `stype.int8`
+        - `stype.int16`
+        - `stype.int32`
+        - `stype.int64`
+        - `stype.float32`
+        - `stype.float64`
+        - `stype.str32`
+        - `stype.str64`
+        - `stype.obj64`
 
+    They are available either as properties of the `dt.stype` class,
+    or directly as constants in the :mod:`dt. <datatable>` namespace.
+    For example::
+
+        >>> dt.stype.int32
+        stype.int32
+        >>> dt.int64
+        stype.int64
+
+    Methods
+    -------
+    .. list-table::
+        :widths: auto
+        :class: api-table
+
+        * - :meth:`stype(x) <datatable.stype.__new__>`
+          - Find stype corresponding to value ``x``.
+
+        * - :meth:`<stype>(col) <datatable.stype.__call__>`
+          - Cast a column into the specific stype.
+
+        * - :attr:`.ctype <datatable.stype.ctype>`
+          - **ctypes** type corresponding to this stype.
+
+        * - :attr:`.dtype <datatable.stype.dtype>`
+          - **numpy** dtype corresponding to this stype.
+
+        * - :attr:`.ltype <datatable.stype.ltype>`
+          - :class:`ltype` corresponding to this stype.
+
+        * - :attr:`.struct <datatable.stype.struct>`
+          - :mod:`struct` string corresponding to this stype.
+
+        * - :attr:`.min <datatable.stype.min>`
+          - The smallest numeric value for this stype.
+
+        * - :attr:`.max <datatable.stype.max>`
+          - The largest numeric value for this stype.
 
 
 .. toctree::
     :hidden:
 
     .__call__()   <stype/__call__>
+    .__new__()    <stype/__new__>
+    .ctype        <stype/ctype>
+    .dtype        <stype/dtype>
+    .ltype        <stype/ltype>
+    .max          <stype/max>
+    .min          <stype/min>
+    .struct       <stype/struct>

--- a/docs/api/stype/__call__.rst
+++ b/docs/api/stype/__call__.rst
@@ -1,0 +1,22 @@
+
+.. xmethod:: datatable.stype.__call__
+    :src: src/datatable/types.py __call__
+
+    __call__(self, col)
+    --
+
+    Cast column `col` into the new stype.
+
+    An stype can be used as a function that converts columns into that
+    specific stype. In the same way as you could write `int(3.14)` in
+    Python to convert a float value into integer, you can likewise
+    write `dt.int32(f.A)` to convert column `A` into stype `int32`.
+
+    Parameters
+    ----------
+    col: FExpr
+        A single- or multi- column expression. All columns will be
+        converted into the desired stype.
+
+    return: FExpr
+        Expression that converts its inputs into the current stype.

--- a/docs/api/stype/__new__.rst
+++ b/docs/api/stype/__new__.rst
@@ -1,0 +1,42 @@
+
+.. xmethod:: datatable.stype.__new__
+    :src: src/datatable/types.py ___new___
+
+    __new__(self, value)
+    --
+
+    Find an stype corresponding to `value`.
+
+    This method is called when you attempt to construct a new
+    :class:`stype` object, for example ``dt.stype(int)``. Instead of
+    actually creating any new stypes, we return one of the existing
+    stype values.
+
+
+    Parameters
+    ----------
+    value: str | type | np.dtype
+        An object that will be converted into an stype. This could be
+        a string such as `"integer"` or `"int"` or `"int8"`, a python
+        type such as `bool` or `float`, or a numpy dtype.
+
+    return: stype
+        An :class:`stype` that corresponds to the input `value`.
+
+    except: ValueError
+        Raised if `value` does not correspond to any stype.
+
+
+    Examples
+    --------
+    >>> dt.stype(str)
+    stype.str64
+
+    >>> dt.stype("double")
+    stype.float64
+
+    >>> dt.stype(numpy.dtype("object"))
+    stype.obj64
+
+    >>> dt.stype("int64")
+    stype.int64

--- a/docs/api/stype/ctype.rst
+++ b/docs/api/stype/ctype.rst
@@ -1,0 +1,3 @@
+
+.. xattr:: datatable.stype.ctype
+    :src: src/datatable/types.py ctype

--- a/docs/api/stype/dtype.rst
+++ b/docs/api/stype/dtype.rst
@@ -1,0 +1,3 @@
+
+.. xattr:: datatable.stype.dtype
+    :src: src/datatable/types.py dtype

--- a/docs/api/stype/ltype.rst
+++ b/docs/api/stype/ltype.rst
@@ -1,0 +1,3 @@
+
+.. xattr:: datatable.stype.ltype
+    :src: src/datatable/types.py ltype

--- a/docs/api/stype/max.rst
+++ b/docs/api/stype/max.rst
@@ -1,0 +1,3 @@
+
+.. xattr:: datatable.stype.max
+    :src: src/datatable/types.py max

--- a/docs/api/stype/min.rst
+++ b/docs/api/stype/min.rst
@@ -1,0 +1,3 @@
+
+.. xattr:: datatable.stype.min
+    :src: src/datatable/types.py min

--- a/docs/api/stype/struct.rst
+++ b/docs/api/stype/struct.rst
@@ -1,0 +1,3 @@
+
+.. xattr:: datatable.stype.struct
+    :src: src/datatable/types.py struct

--- a/src/datatable/types.py
+++ b/src/datatable/types.py
@@ -46,37 +46,6 @@ class stype(enum.Enum):
 
     Notably, :mod:`datatable` does not support arbitrary structures as
     elements of a Column, so the set of stypes is small.
-
-    Examples
-    --------
-    >>> import datatable as dt
-    >>> dt.stype.int16
-    stype.int16
-
-    You can convert strings and Python primitive types (and even numpy dtypes)
-    into stypes:
-
-    >>> dt.stype(str)
-    stype.str64
-    >>> dt.stype("double")
-    stype.float64
-    >>> dt.stype(numpy.dtype("object"))
-    stype.obj64
-    >>> dt.stype("i4")
-    stype.int32
-
-    Each stype has the following properties: `.ltype` returns the corresponding
-    :class:`ltype`, `.code` gives 2-character short code of the stype, and
-    `.ctype` returns the `ctypes` object that describes the underlying data.
-
-    >>> dt.stype.int16.code
-    'i2'
-    >>> dt.stype.int16.ltype
-    ltype.int
-    >>> dt.stype.int16.ctype
-    <class 'ctypes.c_short'>
-    >>> dt.stype.int16.struct
-    '=h'
     """
     bool8 = 1
     int8 = 2
@@ -113,7 +82,7 @@ class stype(enum.Enum):
     @property
     def ctype(self):
         """
-        :module:`ctypes` class that describes the C-level type of each element
+        :mod:`ctypes` class that describes the C-level type of each element
         in a column with this stype.
 
         For non-fixed-width columns (such as `str32`) this will return the ctype
@@ -124,6 +93,9 @@ class stype(enum.Enum):
 
     @property
     def dtype(self):
+        """
+        ``numpy.dtype`` object that corresponds to this stype.
+        """
         if not _numpy_init_attempted:
             _init_numpy_transforms()
         return _stype_2_dtype[self]
@@ -132,7 +104,7 @@ class stype(enum.Enum):
     @property
     def struct(self):
         """
-        :module:`struct` format string corresponding to this stype.
+        :mod:`struct` format string corresponding to this stype.
 
         For non-fixed-width columns (such as `str32`) this will return the
         format string of only the fixed-width component of that column. Thus,

--- a/src/datatable/types.py
+++ b/src/datatable/types.py
@@ -44,7 +44,7 @@ class stype(enum.Enum):
     such as ``int32_t`` or ``double``. However some stypes (corresponding to
     strings and categoricals) have a more complicated underlying structure.
 
-    Notably, :module:`datatable` does not support arbitrary structures as
+    Notably, :mod:`datatable` does not support arbitrary structures as
     elements of a Column, so the set of stypes is small.
 
     Examples

--- a/src/datatable/types.py
+++ b/src/datatable/types.py
@@ -148,20 +148,6 @@ class ltype(enum.Enum):
     this integer can be stored in several "physical" formats: from
     ``stype.int8`` to ``stype.int64``. Thus, there is a one-to-many relationship
     between ltypes and stypes.
-
-    Examples
-    --------
-    >>> dt.ltype.bool
-    ltype.bool
-    >>> dt.ltype("int32")
-    ltype.int
-
-    For each ltype, you can find the set of stypes that correspond to it:
-
-    >>> dt.ltype.real.stypes
-    [stype.float32, stype.float64]
-    >>> dt.ltype.time.stypes
-    []
     """
     bool = 1
     int = 2
@@ -175,7 +161,13 @@ class ltype(enum.Enum):
 
     @property
     def stypes(self):
-        """List of stypes that represent this ltype."""
+        """
+        List of stypes that represent this ltype.
+
+        Parameters
+        ----------
+        return: List[stype]
+        """
         return [k for k, v in _stype_2_ltype.items() if v == self]
 
 

--- a/tests/test-docs.py
+++ b/tests/test-docs.py
@@ -55,7 +55,7 @@ def test_xfunction_paths():
                         outside = False
             else:
                 mm = re.match(re_path, line)
-                if mm:
+                if mm and mm.group(1) != "--":
                     fullpath = ROOT_PATH / mm.group(1)
                     assert fullpath.is_file(), (
                            "Path %s does not exist, found on line %d of %s"


### PR DESCRIPTION
- Added documentation for classes `stype` and `ltype`;
- Implemented extracting docstrings from python code;
- Allow possibility to have a method/function without the source (this allows the docs for `.build_info` to build properly).

WIP for #2586
Closes #2628
Closes #2633