### PR TITLE
Documentation for internal. submodule

### DIFF
--- a/docs/api/index-api.rst
+++ b/docs/api/index-api.rst
@@ -14,11 +14,14 @@ Submodules
     :widths: auto
     :class: api-table
 
-    * - :mod:`.math <datatable.math>`
-      - Mathematical functions, similar to python's ``math`` module.
+    * - :mod:`math. <datatable.math>`
+      - Mathematical functions, similar to python's :mod:`math` module.
 
-    * - :mod:`.models <datatable.models>`
+    * - :mod:`models. <datatable.models>`
       - A small set of data analysis tools.
+
+    * - :mod:`internal. <datatable.internal>`
+      - Access to some internal details of :mod:`datatable` module.
 
 
 Classes
@@ -173,6 +176,7 @@ Other
 .. toctree::
     :hidden:
 
+    internal.         <internal>
     math.             <math>
     models.           <models>
     FExpr             <fexpr>

--- a/docs/api/internal.rst
+++ b/docs/api/internal.rst
@@ -1,0 +1,45 @@
+
+.. py:module:: datatable.internal
+
+datatable.internal
+==================
+
+The functions in this sub-module are considered to be "internal" and
+not useful for day-to-day work with :mod:`datatable` module.
+
+.. list-table::
+    :widths: auto
+    :class: api-table
+
+    * - :func:`compiler_version()`
+      - Compiler used when building datatable.
+
+    * - :func:`frame_column_data_r()`
+      - C pointer to column's data
+
+    * - :func:`frame_columns_virtual()`
+      - Indicators of which columns in the frame are virtual.
+
+    * - :func:`frame_integrity_check()`
+      - Run checks on whether the frame's state is corrupted.
+
+    * - :func:`get_thread_ids()`
+      - Get ids of threads spawned by datatable.
+
+    * - :func:`in_debug_mode()`
+      - Was datatable built in debug mode?
+
+    * - :func:`regex_supported()`
+      - Was datatable built with support for regular expressions?
+
+
+.. toctree::
+    :hidden:
+
+    compiler_version()       <internal/compiler_version>
+    frame_column_data_r()    <internal/frame_column_data_r>
+    frame_columns_virtual()  <internal/frame_columns_virtual>
+    frame_integrity_check()  <internal/frame_integrity_check>
+    get_thread_ids()         <internal/get_thread_ids>
+    in_debug_mode()          <internal/in_debug_mode>
+    regex_supported()        <internal/regex_supported>

--- a/docs/api/internal/compiler_version.rst
+++ b/docs/api/internal/compiler_version.rst
@@ -1,0 +1,4 @@
+
+.. xfunction:: datatable.internal.compiler_version
+    :src: src/core/datatablemodule.cc get_compiler_version_string
+    :doc: src/core/datatablemodule.cc doc_compiler_version

--- a/docs/api/internal/frame_column_data_r.rst
+++ b/docs/api/internal/frame_column_data_r.rst
@@ -1,0 +1,4 @@
+
+.. xfunction:: datatable.internal.frame_column_data_r
+    :src: src/core/datatablemodule.cc frame_column_data_r
+    :doc: src/core/datatablemodule.cc doc_frame_column_data_r

--- a/docs/api/internal/frame_columns_virtual.rst
+++ b/docs/api/internal/frame_columns_virtual.rst
@@ -1,0 +1,4 @@
+
+.. xfunction:: datatable.internal.frame_columns_virtual
+    :src: src/core/datatablemodule.cc frame_columns_virtual
+    :doc: src/core/datatablemodule.cc doc_frame_columns_virtual

--- a/docs/api/internal/frame_integrity_check.rst
+++ b/docs/api/internal/frame_integrity_check.rst
@@ -1,0 +1,4 @@
+
+.. xfunction:: datatable.internal.frame_integrity_check
+    :src: src/core/datatablemodule.cc frame_integrity_check
+    :doc: src/core/datatablemodule.cc doc_frame_integrity_check

--- a/docs/api/internal/get_thread_ids.rst
+++ b/docs/api/internal/get_thread_ids.rst
@@ -1,0 +1,4 @@
+
+.. xfunction:: datatable.internal.get_thread_ids
+    :src: src/core/datatablemodule.cc get_thread_ids
+    :doc: src/core/datatablemodule.cc doc_get_thread_ids

--- a/docs/api/internal/in_debug_mode.rst
+++ b/docs/api/internal/in_debug_mode.rst
@@ -1,0 +1,4 @@
+
+.. xfunction:: datatable.internal.in_debug_mode
+    :src: src/core/datatablemodule.cc in_debug_mode
+    :doc: src/core/datatablemodule.cc doc_in_debug_mode

--- a/docs/api/internal/regex_supported.rst
+++ b/docs/api/internal/regex_supported.rst
@@ -1,0 +1,4 @@
+
+.. xfunction:: datatable.internal.regex_supported
+    :src: src/core/datatablemodule.cc regex_supported
+    :doc: src/core/datatablemodule.cc doc_regex_supported

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -109,7 +109,7 @@ xf_module_name = "datatable"
 xf_project_root = ".."
 
 try:
-    _ghcommit = subprocess.check_output(["git", "rev-parse", "master"],
+    _ghcommit = subprocess.check_output(["git", "rev-parse", "HEAD"],
                                         universal_newlines=True).strip()
     xf_permalink_url0 = ("https://github.com/h2oai/datatable/blob/" +
                          _ghcommit + "/{filename}")

--- a/src/core/datatablemodule.cc
+++ b/src/core/datatablemodule.cc
@@ -115,7 +115,7 @@ static const char* doc_frame_columns_virtual =
 R"(frame_columns_virtual(frame)
 --
 
-Return the list indicating which columns in the Frame are virtual.
+Return the list indicating which columns in the `frame` are virtual.
 
 Parameters
 ----------
@@ -186,17 +186,17 @@ R"(frame_integrity_check(frame)
 
 This function performs a range of tests on the `frame` to verify
 that its internal state is consistent. It returns None on success,
-or throws an AssertionError if any problems were found.
+or throws an :exc:`AssertionError` if any problems were found.
 
 Parameters
 ----------
 frame: Frame
-    A :class:`Frame` that needs to be checked for internal consistency.
+    A :class:`Frame` object that needs to be checked for internal consistency.
 
 return: None
 
 except: AssertionError
-    An error is raised if there were any issues with the `frame`.
+    An exception is raised if there were any issues with the `frame`.
 )";
 
 static py::PKArgs args_frame_integrity_check(
@@ -215,7 +215,7 @@ static void frame_integrity_check(const py::PKArgs& args) {
 
 static const char* doc_in_debug_mode =
 R"(
-Return True if datatable was compiled in debug mode.
+Return `True` if :mod:`datatable` was compiled in debug mode.
 
 .. deprecated:: 0.11.0
 )";
@@ -245,6 +245,11 @@ Parameters
 return: List[str]
     The list of thread ids used by the datatable. The first element
     in the list is the id of the main thread.
+
+See Also
+--------
+- :attr:`dt.options.nthreads <datatable.options.nthreads>` -- global option
+  that controls the number of threads in use.
 )";
 
 static py::PKArgs args_get_thread_ids(
@@ -294,7 +299,7 @@ static void _register_function(const py::PKArgs& args) {
 
 static const char* doc_compiler_version =
 R"(
-Return the version of the C++ compiler used to compile this module
+Return the version of the C++ compiler used to compile this module.
 
 .. deprecated:: 0.11.0
 )";

--- a/src/core/datatablemodule.cc
+++ b/src/core/datatablemodule.cc
@@ -111,18 +111,32 @@ _unpack_frame_column_args(const py::PKArgs& args)
 }
 
 
-static py::PKArgs args_frame_columns_virtual(
-    1, 0, 0, false, false, {"frame"},
-    "frame_columns_virtual",
+static const char* doc_frame_columns_virtual =
 R"(frame_columns_virtual(frame)
 --
 
-Return the tuple of which columns in the Frame are virtual.
-)");
+Return the list indicating which columns in the Frame are virtual.
+
+Parameters
+----------
+return: List[bool]
+    Each element in the list indicates whether the corresponding column
+    is virtual or not.
+
+Notes
+-----
+.. deprecated:: 0.11.0
+
+This function will be expanded and moved into the main :class:`Frame` class.
+)";
+
+static py::PKArgs args_frame_columns_virtual(
+    1, 0, 0, false, false, {"frame"},
+    "frame_columns_virtual", doc_frame_columns_virtual);
 
 static py::oobj frame_columns_virtual(const py::PKArgs& args) {
   DataTable* dt = args[0].to_datatable();
-  py::otuple virtuals(dt->ncols());
+  py::olist virtuals(dt->ncols());
   for (size_t i = 0; i < dt->ncols(); ++i) {
     virtuals.set(i, py::obool(dt->get_column(i).is_virtual()));
   }
@@ -130,15 +144,28 @@ static py::oobj frame_columns_virtual(const py::PKArgs& args) {
 }
 
 
-static py::PKArgs args_frame_column_data_r(
-    2, 0, 0, false, false, {"frame", "i"},
-    "frame_column_data_r",
+static const char* doc_frame_column_data_r =
 R"(frame_column_data_r(frame, i)
 --
 
-Return C pointer to the main data array of the column `frame[i]`. The pointer
-is returned as a `ctypes.c_void_p` object.
-)");
+Return C pointer to the main data array of the column `frame[i]`.
+The column will be materialized if it was virtual.
+
+Parameters
+----------
+frame: Frame
+    The :class:`Frame` where to look up the column.
+
+i: int
+    The index of a column, in the range ``[0; ncols)``.
+
+return: ctypes.c_void_p
+    The pointer to the column's internal data.
+)";
+
+static py::PKArgs args_frame_column_data_r(
+    2, 0, 0, false, false, {"frame", "i"},
+    "frame_column_data_r", frame_column_data_r);
 
 static py::oobj frame_column_data_r(const py::PKArgs& args) {
   static py::oobj c_void_p = py::oobj::import("ctypes", "c_void_p");
@@ -153,15 +180,28 @@ static py::oobj frame_column_data_r(const py::PKArgs& args) {
 }
 
 
-static py::PKArgs args_frame_integrity_check(
-  1, 0, 0, false, false, {"frame"}, "frame_integrity_check",
+static const char* doc_frame_integrity_check =
 R"(frame_integrity_check(frame)
 --
 
 This function performs a range of tests on the `frame` to verify
 that its internal state is consistent. It returns None on success,
 or throws an AssertionError if any problems were found.
-)");
+
+Parameters
+----------
+frame: Frame
+    A :class:`Frame` that needs to be checked for internal consistency.
+
+return: None
+
+except: AssertionError
+    An error is raised if there were any issues with the `frame`.
+)";
+
+static py::PKArgs args_frame_integrity_check(
+  1, 0, 0, false, false, {"frame"}, "frame_integrity_check",
+  doc_frame_integrity_check);
 
 static void frame_integrity_check(const py::PKArgs& args) {
   if (!args[0].is_frame()) {
@@ -173,10 +213,16 @@ static void frame_integrity_check(const py::PKArgs& args) {
 }
 
 
+static const char* doc_in_debug_mode =
+R"(
+Return True if datatable was compiled in debug mode.
+
+.. deprecated:: 0.11.0
+)";
 
 static py::PKArgs args_in_debug_mode(
     0, 0, 0, false, false, {}, "in_debug_mode",
-    "Return True if datatable was compiled in debug mode");
+    doc_in_debug_mode);
 
 static py::oobj in_debug_mode(const py::PKArgs&) {
   #if DT_DEBUG
@@ -187,10 +233,22 @@ static py::oobj in_debug_mode(const py::PKArgs&) {
 }
 
 
+static const char* doc_get_thread_ids =
+R"(
+Return system ids of all threads used internally by datatable.
+
+Calling this function will cause the threads to spawn if they
+haven't done already. (This behavior may change in the future).
+
+Parameters
+----------
+return: List[str]
+    The list of thread ids used by the datatable. The first element
+    in the list is the id of the main thread.
+)";
 
 static py::PKArgs args_get_thread_ids(
-    0, 0, 0, false, false, {}, "get_thread_ids",
-R"(Return system ids of all threads used internally by datatable)");
+    0, 0, 0, false, false, {}, "get_thread_ids", doc_get_thread_ids);
 
 static py::oobj get_thread_ids(const py::PKArgs&) {
   std::mutex m;
@@ -234,10 +292,16 @@ static void _register_function(const py::PKArgs& args) {
 }
 
 
+static const char* doc_compiler_version =
+R"(
+Return the version of the C++ compiler used to compile this module
+
+.. deprecated:: 0.11.0
+)";
 
 static py::PKArgs args_compiler_version(
   0, 0, 0, false, false, {}, "compiler_version",
-  "Return the version of the C++ compiler used to compile this module");
+  doc_compiler_version);
 
 const char* get_compiler_version_string() {
   #define STR(x) STR1(x)
@@ -266,9 +330,16 @@ static py::oobj compiler_version(const py::PKArgs&) {
 
 
 
+static const char* doc_regex_supported =
+R"(
+Was the datatable built with regular expression support?
+
+.. deprecated:: 0.11.0
+)";
+
 static py::PKArgs args_regex_supported(
   0, 0, 0, false, false, {}, "regex_supported",
-  "Was the datatable built with regular expression support?");
+  doc_regex_supported);
 
 static py::oobj regex_supported(const py::PKArgs&) {
   return py::obool(REGEX_SUPPORTED);

--- a/src/core/datatablemodule.cc
+++ b/src/core/datatablemodule.cc
@@ -165,7 +165,7 @@ return: ctypes.c_void_p
 
 static py::PKArgs args_frame_column_data_r(
     2, 0, 0, false, false, {"frame", "i"},
-    "frame_column_data_r", frame_column_data_r);
+    "frame_column_data_r", doc_frame_column_data_r);
 
 static py::oobj frame_column_data_r(const py::PKArgs& args) {
   static py::oobj c_void_p = py::oobj::import("ctypes", "c_void_p");

--- a/tests/munging/test-cbind.py
+++ b/tests/munging/test-cbind.py
@@ -215,7 +215,7 @@ def test_cbind_views3():
     assert d0.to_list() == [list(range(10))[::-1],
                             list("abcde" * 2),
                             [14, 19, 35, 17, 3, 0, 1, 0, 10, 777]]
-    assert frame_columns_virtual(d0) == (True, False, True)
+    assert frame_columns_virtual(d0) == [True, False, True]
 
 
 

--- a/tests/munging/test-dt-combo.py
+++ b/tests/munging/test-dt-combo.py
@@ -32,7 +32,7 @@ def test_columns_rows():
 def test_issue1225():
     f0 = dt.Frame(A=[1, 2, 3], B=[5, 6, 8], stypes = {"B": "int8"})
     f1 = f0[::-1, :][:, [dt.float64(f.A), f.B]]
-    assert frame_columns_virtual(f1) == (True, True)
+    assert frame_columns_virtual(f1) == [True, True]
     f1.materialize()
     assert f1.stypes == (stype.float64, stype.int8)
     assert f1.to_list() == [[3.0, 2.0, 1.0], [8, 6, 5]]

--- a/tests/test-dt.py
+++ b/tests/test-dt.py
@@ -1132,9 +1132,9 @@ def test_materialize():
     DT2 = dt.repeat(dt.Frame(B=["red", "green", "blue"]), 2)
     DT3 = dt.Frame(C=[4, 2, 9.1, 12, 0])
     DT = dt.cbind(DT1, DT2, DT3, force=True)
-    assert frame_columns_virtual(DT) == (True, True, True)
+    assert frame_columns_virtual(DT) == [True, True, True]
     DT.materialize()
-    assert frame_columns_virtual(DT) == (False, False, False)
+    assert frame_columns_virtual(DT) == [False, False, False]
 
 
 def test_materialize_object_col():
@@ -1193,8 +1193,8 @@ def test_export_names(dt0):
 def test_internal_rowindex():
     d0 = dt.Frame(list(range(100)))
     d1 = d0[:20, :]
-    assert frame_columns_virtual(d0) == (False,)
-    assert frame_columns_virtual(d1) == (True,)
+    assert frame_columns_virtual(d0) == [False]
+    assert frame_columns_virtual(d1) == [True]
 
 
 def test_issue898():


### PR DESCRIPTION
- Create documentation for the function in the `datatable.internal.` module;

- Adjusted permalink URLs so that they would be based off the HEAD commit instead of master. This means that in order for the links to work one would need to commit and push the local changes to GitHub first.

WIP for #2586