### PR TITLE
Code cleanup in fread

### DIFF
--- a/src/core/csv/reader.cc
+++ b/src/core/csv/reader.cc
@@ -148,6 +148,7 @@ GenericReader::GenericReader(const GenericReader& g)
   line    = g.line;
   logger_ = g.logger_;
   source_name = g.source_name;
+  tempfiles = g.tempfiles;
 }
 
 GenericReader::~GenericReader() {}

--- a/src/core/csv/reader.h
+++ b/src/core/csv/reader.h
@@ -157,6 +157,7 @@ class GenericReader
   public:
     GenericReader();
     GenericReader(const GenericReader&);
+    GenericReader(GenericReader&&) = default;
     GenericReader& operator=(const GenericReader&) = delete;
     virtual ~GenericReader();
 

--- a/src/core/read/multisource.cc
+++ b/src/core/read/multisource.cc
@@ -55,9 +55,11 @@ static SourceVec single_source(Source* src) {
 // Constructors
 //------------------------------------------------------------------------------
 
-MultiSource::MultiSource(const py::PKArgs& args, const GenericReader& rdr)
+MultiSource::MultiSource(const py::PKArgs& args, GenericReader&& rdr)
+  : reader_(std::move(rdr)),
+    sources_(),
+    iteration_index_(0)
 {
-  iteration_index_ = 0;
   const char* fnname = args.get_long_name();
   const py::Arg& src_any  = args[0];
   const py::Arg& src_file = args[1];
@@ -93,11 +95,11 @@ MultiSource::MultiSource(const py::PKArgs& args, const GenericReader& rdr)
     }
   }
 
-  if (src_any.is_defined())  sources_ = _from_any(src_any.to_oobj(), rdr);
-  if (src_file.is_defined()) sources_ = _from_file(src_file.to_oobj(), rdr);
-  if (src_text.is_defined()) sources_ = _from_text(src_text, rdr);
-  if (src_cmd.is_defined())  sources_ = _from_cmd(src_cmd.to_oobj(), rdr);
-  if (src_url.is_defined())  sources_ = _from_url(src_url.to_oobj(), rdr);
+  if (src_any.is_defined())  sources_ = _from_any(src_any.to_oobj(), reader_);
+  if (src_file.is_defined()) sources_ = _from_file(src_file.to_oobj(), reader_);
+  if (src_text.is_defined()) sources_ = _from_text(src_text, reader_);
+  if (src_cmd.is_defined())  sources_ = _from_cmd(src_cmd.to_oobj(), reader_);
+  if (src_url.is_defined())  sources_ = _from_url(src_url.to_oobj(), reader_);
 }
 
 
@@ -265,17 +267,17 @@ static void emit_badsrc_warning(const std::string& name, const Error& e) {
 
 
 // for fread
-py::oobj MultiSource::read_single(const GenericReader& reader) {
+py::oobj MultiSource::read_single() {
   xassert(iteration_index_ == 0);
   if (sources_.empty()) {
     return py::Frame::oframe(new DataTable);
   }
 
-  bool err = (reader.multisource_strategy == FreadMultiSourceStrategy::Error);
-  bool warn = (reader.multisource_strategy == FreadMultiSourceStrategy::Warn);
+  bool err = (reader_.multisource_strategy == FreadMultiSourceStrategy::Error);
+  bool warn = (reader_.multisource_strategy == FreadMultiSourceStrategy::Warn);
   if (sources_.size() > 1 && err) throw _multisrc_error();
 
-  py::oobj res = read_next(reader);
+  py::oobj res = read_next();
   if (iteration_index_ < sources_.size()) {
     if (err) throw _multisrc_error();
     if (warn) emit_multisrc_warning();
@@ -285,15 +287,15 @@ py::oobj MultiSource::read_single(const GenericReader& reader) {
 
 
 
-py::oobj MultiSource::read_next(const GenericReader& reader)
+py::oobj MultiSource::read_next()
 {
   start:
   if (iteration_index_ >= sources_.size()) return py::oobj();
 
   py::oobj res;
-  GenericReader new_reader(reader);
+  GenericReader new_reader(reader_);
   auto& src = sources_[iteration_index_];
-  if (reader.errors_strategy == IreadErrorHandlingStrategy::Error) {
+  if (reader_.errors_strategy == IreadErrorHandlingStrategy::Error) {
     res = src->read(new_reader);
     py::Frame::cast_from(res)->set_source(src->name());
   }
@@ -303,10 +305,10 @@ py::oobj MultiSource::read_next(const GenericReader& reader)
       py::Frame::cast_from(res)->set_source(src->name());
     }
     catch (const Error& e) {
-      if (reader.errors_strategy == IreadErrorHandlingStrategy::Warn) {
+      if (reader_.errors_strategy == IreadErrorHandlingStrategy::Warn) {
         emit_badsrc_warning(src->name(), e);
       }
-      if (reader.errors_strategy == IreadErrorHandlingStrategy::Store) {
+      if (reader_.errors_strategy == IreadErrorHandlingStrategy::Store) {
         exception_to_python(e);
         PyObject* etype = nullptr;
         PyObject* evalue = nullptr;

--- a/src/core/read/multisource.cc
+++ b/src/core/read/multisource.cc
@@ -55,17 +55,6 @@ static SourceVec single_source(Source* src) {
 // Constructors
 //------------------------------------------------------------------------------
 
-MultiSource::MultiSource(SourceVec&& srcs)
-  : sources_(std::move(srcs)),
-    iteration_index(0) {}
-
-
-MultiSource::MultiSource(SourcePtr&& src) {
-  sources_.emplace_back(std::move(src));
-  iteration_index = 0;
-}
-
-
 // Main MultiSource constructor
 MultiSource::MultiSource(const py::PKArgs& args, const GenericReader& rdr)
 {

--- a/src/core/read/multisource.cc
+++ b/src/core/read/multisource.cc
@@ -55,10 +55,9 @@ static SourceVec single_source(Source* src) {
 // Constructors
 //------------------------------------------------------------------------------
 
-// Main MultiSource constructor
 MultiSource::MultiSource(const py::PKArgs& args, const GenericReader& rdr)
 {
-  iteration_index = 0;
+  iteration_index_ = 0;
   const char* fnname = args.get_long_name();
   const py::Arg& src_any  = args[0];
   const py::Arg& src_file = args[1];
@@ -267,7 +266,7 @@ static void emit_badsrc_warning(const std::string& name, const Error& e) {
 
 // for fread
 py::oobj MultiSource::read_single(const GenericReader& reader) {
-  xassert(iteration_index == 0);
+  xassert(iteration_index_ == 0);
   if (sources_.empty()) {
     return py::Frame::oframe(new DataTable);
   }
@@ -277,7 +276,7 @@ py::oobj MultiSource::read_single(const GenericReader& reader) {
   if (sources_.size() > 1 && err) throw _multisrc_error();
 
   py::oobj res = read_next(reader);
-  if (iteration_index < sources_.size()) {
+  if (iteration_index_ < sources_.size()) {
     if (err) throw _multisrc_error();
     if (warn) emit_multisrc_warning();
   }
@@ -289,11 +288,11 @@ py::oobj MultiSource::read_single(const GenericReader& reader) {
 py::oobj MultiSource::read_next(const GenericReader& reader)
 {
   start:
-  if (iteration_index >= sources_.size()) return py::oobj();
+  if (iteration_index_ >= sources_.size()) return py::oobj();
 
   py::oobj res;
   GenericReader new_reader(reader);
-  auto& src = sources_[iteration_index];
+  auto& src = sources_[iteration_index_];
   if (reader.errors_strategy == IreadErrorHandlingStrategy::Error) {
     res = src->read(new_reader);
     py::Frame::cast_from(res)->set_source(src->name());
@@ -323,9 +322,9 @@ py::oobj MultiSource::read_next(const GenericReader& reader)
   }
   SourcePtr next = src->continuation();
   if (next) {
-    sources_[iteration_index] = std::move(next);
+    sources_[iteration_index_] = std::move(next);
   } else {
-    iteration_index++;
+    iteration_index_++;
   }
   if (!res) goto start;
   return res;

--- a/src/core/read/multisource.h
+++ b/src/core/read/multisource.h
@@ -64,14 +64,9 @@ class MultiSource
     size_t iteration_index;
 
   public:
-    MultiSource() = default;
-    MultiSource(MultiSource&&) = default;
-    MultiSource(const MultiSource&) = delete;
-    MultiSource& operator=(MultiSource&&) = default;
-
-    MultiSource(SourceVec&&);
-    MultiSource(SourcePtr&&);
     MultiSource(const py::PKArgs&, const GenericReader&);
+    MultiSource(const MultiSource&) = delete;
+    MultiSource(MultiSource&&) = delete;
 
     py::oobj read_single(const GenericReader&);
     py::oobj read_next(const GenericReader&);

--- a/src/core/read/multisource.h
+++ b/src/core/read/multisource.h
@@ -60,16 +60,17 @@ class MultiSource
     using SourcePtr = std::unique_ptr<Source>;
     using SourceVec = std::vector<SourcePtr>;
 
-    SourceVec sources_;
-    size_t iteration_index_;
+    GenericReader reader_;
+    SourceVec     sources_;
+    size_t        iteration_index_;
 
   public:
-    MultiSource(const py::PKArgs&, const GenericReader&);
+    MultiSource(const py::PKArgs&, GenericReader&&);
     MultiSource(const MultiSource&) = delete;
     MultiSource(MultiSource&&) = delete;
 
-    py::oobj read_single(const GenericReader&);
-    py::oobj read_next(const GenericReader&);
+    py::oobj read_single();
+    py::oobj read_next();
 };
 
 

--- a/src/core/read/multisource.h
+++ b/src/core/read/multisource.h
@@ -21,8 +21,8 @@
 //------------------------------------------------------------------------------
 #ifndef dt_READ_MULTISOURCE_h
 #define dt_READ_MULTISOURCE_h
-#include "read/source.h"      // Source
 #include "_dt.h"
+#include "read/source.h"      // Source
 namespace dt {
 namespace read {
 
@@ -61,7 +61,7 @@ class MultiSource
     using SourceVec = std::vector<SourcePtr>;
 
     SourceVec sources_;
-    size_t iteration_index;
+    size_t iteration_index_;
 
   public:
     MultiSource(const py::PKArgs&, const GenericReader&);

--- a/src/core/read/py_fread.cc
+++ b/src/core/read/py_fread.cc
@@ -281,8 +281,8 @@ static py::oobj fread(const py::PKArgs& args) {
     rdr.init_encoding(   arg_encoding);
   }
 
-  MultiSource multisource(args, rdr);
-  return multisource.read_single(rdr);
+  MultiSource multisource(args, std::move(rdr));
+  return multisource.read_single();
 }
 
 
@@ -375,31 +375,31 @@ static py::oobj iread(const py::PKArgs& args) {
   const py::Arg& arg_errors     = args[k++];
   const py::Arg& arg_memlimit   = args[k++];
 
-  auto rdr = std::make_unique<GenericReader>();
-  rdr->init_logger(arg_logger, arg_verbose);
+  GenericReader rdr;
+  rdr.init_logger(arg_logger, arg_verbose);
   {
-    auto section = rdr->logger_.section("[*] Process input parameters");
-    rdr->init_nthreads(   arg_nthreads);
-    rdr->init_fill(       arg_fill);
-    rdr->init_maxnrows(   arg_maxnrows);
-    rdr->init_skiptoline( arg_skiptoline);
-    rdr->init_sep(        arg_sep);
-    rdr->init_dec(        arg_dec);
-    rdr->init_quote(      arg_quotechar);
-    rdr->init_header(     arg_header);
-    rdr->init_nastrings(  arg_nastrings);
-    rdr->init_skipstring( arg_skiptostr);
-    rdr->init_stripwhite( arg_stripwhite);
-    rdr->init_skipblanks( arg_skipblanks);
-    rdr->init_columns(    arg_columns);
-    rdr->init_tempdir(    arg_tempdir);
-    rdr->init_errors(     arg_errors);
-    rdr->init_memorylimit(arg_memlimit);
-    rdr->init_encoding(   arg_encoding);
+    auto section = rdr.logger_.section("[*] Process input parameters");
+    rdr.init_nthreads(   arg_nthreads);
+    rdr.init_fill(       arg_fill);
+    rdr.init_maxnrows(   arg_maxnrows);
+    rdr.init_skiptoline( arg_skiptoline);
+    rdr.init_sep(        arg_sep);
+    rdr.init_dec(        arg_dec);
+    rdr.init_quote(      arg_quotechar);
+    rdr.init_header(     arg_header);
+    rdr.init_nastrings(  arg_nastrings);
+    rdr.init_skipstring( arg_skiptostr);
+    rdr.init_stripwhite( arg_stripwhite);
+    rdr.init_skipblanks( arg_skipblanks);
+    rdr.init_columns(    arg_columns);
+    rdr.init_tempdir(    arg_tempdir);
+    rdr.init_errors(     arg_errors);
+    rdr.init_memorylimit(arg_memlimit);
+    rdr.init_encoding(   arg_encoding);
   }
 
-  auto ms = std::make_unique<MultiSource>(args, *rdr);
-  return py::ReadIterator::make(std::move(rdr), std::move(ms));
+  auto ms = std::make_unique<MultiSource>(args, std::move(rdr));
+  return py::ReadIterator::make(std::move(ms));
 }
 
 

--- a/src/core/read/py_read_iterator.cc
+++ b/src/core/read/py_read_iterator.cc
@@ -27,23 +27,20 @@ namespace py {
 void ReadIterator::m__init__(const PKArgs&) {}
 
 void ReadIterator::m__dealloc__() {
-  reader_ = nullptr;
   multisource_ = nullptr;
 }
 
 
 oobj ReadIterator::m__next__() {
-  return multisource_->read_next(*reader_);
+  return multisource_->read_next();
 }
 
 
-oobj ReadIterator::make(std::unique_ptr<dt::read::GenericReader>&& reader,
-                        std::unique_ptr<dt::read::MultiSource>&& multisource)
+oobj ReadIterator::make(std::unique_ptr<dt::read::MultiSource>&& multisource)
 {
   robj rtype(reinterpret_cast<PyObject*>(&ReadIterator::type));
   oobj resobj = rtype.call();
   ReadIterator* iterator = ReadIterator::cast_from(resobj);
-  iterator->reader_ = std::move(reader);
   iterator->multisource_ = std::move(multisource);
   return resobj;
 }

--- a/src/core/read/py_read_iterator.h
+++ b/src/core/read/py_read_iterator.h
@@ -30,7 +30,6 @@ namespace py {
 class ReadIterator : public XObject<ReadIterator>
 {
   private:
-    std::unique_ptr<dt::read::GenericReader> reader_;
     std::unique_ptr<dt::read::MultiSource> multisource_;
 
     void m__init__(const PKArgs& args);
@@ -38,8 +37,7 @@ class ReadIterator : public XObject<ReadIterator>
     oobj m__next__();
 
   public:
-    static oobj make(std::unique_ptr<dt::read::GenericReader>&& reader,
-                     std::unique_ptr<dt::read::MultiSource>&& multisource);
+    static oobj make(std::unique_ptr<dt::read::MultiSource>&& multisource);
     static void impl_init_type(XTypeMaker& xt);
 };
 


### PR DESCRIPTION
Class `MultiSource` simplified:
  - removed several unused constructors;
  - the `reader` is now owned by MultiSource instead of passing it as a parameter every time;
  - `ReadIterator` no longer needs to own the `reader`;
  - renamed `iteration_index` -> `iteration_index_`.