### PR TITLE
Do not test API docs if API path doesn't exist

### DIFF
--- a/tests/test-docs.py
+++ b/tests/test-docs.py
@@ -28,6 +28,7 @@
 #
 #-------------------------------------------------------------------------------
 import pathlib
+import pytest
 import re
 
 # First .parent removes the file name, second goes up to the root level
@@ -35,14 +36,13 @@ ROOT_PATH = pathlib.Path(__file__).parent.parent
 API_PATH = ROOT_PATH / "docs" / "api"
 
 
-
+@pytest.mark.skipif(not API_PATH.is_dir(), reason="API docs folder doesn't exist")
 def test_xfunction_paths():
     """
     This test looks at all `.. xfunction::` directives and checks
     that the paths specified for `:src:` / `:doc:` / `:tests:`
     options are valid.
     """
-    assert API_PATH.is_dir()
     re_path = re.compile(r"\s+:(?:src|docs?|tests?): (\S*)")
     for filepath in API_PATH.glob("**/*.rst"):
         text = filepath.read_text(encoding="utf-8")


### PR DESCRIPTION
When we do `make sdist` we do not include the `docs/api` folder, but we do include all the tests meaning that the `test-docs.py` is also included. Since we don't want this test to fail for no reason, in this PR we disable it, as it will otherwise fail when no `docs/api` folder is present on the system.