### PR TITLE
Expanded ifelse() function to allow multiple conditions

### DIFF
--- a/docs/manual/comparison_with_rdatatable.rst
+++ b/docs/manual/comparison_with_rdatatable.rst
@@ -517,9 +517,6 @@ This is a list of some functions in ``data.table`` that do not have an equivalen
    - `between <https://rdatatable.gitlab.io/data.table/reference/between.html>`__
    - `%chin% <https://rdatatable.gitlab.io/data.table/reference/chmatch.html>`__
 
-- Conditional functions
-   - `fcase <https://rdatatable.gitlab.io/data.table/reference/fcase.html>`__
-
 - Duplicate functions
    - `duplicated <https://rdatatable.gitlab.io/data.table/reference/duplicated.html>`__
    - `unique <https://rdatatable.gitlab.io/data.table/reference/duplicated.html>`__  in ``data.table`` returns unique rows, while :func:`unique()` in ``datatable`` returns a single column of unique values in the entire dataframe.

--- a/docs/releases/v1.0.0.rst
+++ b/docs/releases/v1.0.0.rst
@@ -6,6 +6,15 @@
     .. ref-context:: datatable.Frame
 
 
+    FExpr
+    -----
+    .. ref-context:: datatable
+
+    -[new] Function :func:`ifelse()` can now accept more than 3 arguments,
+      implementing a chained-if functionality. This is equivalent to
+      ``CASE WHEN`` in SQL. [#2656]
+
+
     General
     -------
 

--- a/src/core/column/ifelsen.cc
+++ b/src/core/column/ifelsen.cc
@@ -1,0 +1,86 @@
+//------------------------------------------------------------------------------
+// Copyright 2020 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#include "column/ifelsen.h"
+#include "stype.h"
+namespace dt {
+
+
+IfElseN_ColumnImpl::IfElseN_ColumnImpl(colvec&& cond, colvec&& vals)
+  : Virtual_ColumnImpl(vals[0].nrows(), vals[0].stype()),
+    conditions_(std::move(cond)),
+    values_(std::move(vals))
+{
+  xassert(conditions_.size() == values_.size() - 1);
+  for (const Column& cnd : conditions_) {
+    xassert(cnd.stype() == SType::BOOL);
+    xassert(cnd.nrows() == nrows_);
+  }
+  for (const Column& val : values_) {
+    xassert(val.stype() == stype_);
+    xassert(val.nrows() == nrows_);
+  }
+}
+
+
+ColumnImpl* IfElseN_ColumnImpl::clone() const {
+  return new IfElseN_ColumnImpl(colvec(conditions_), colvec(values_));
+}
+
+
+size_t IfElseN_ColumnImpl::n_children() const noexcept {
+  return conditions_.size() + values_.size();
+}
+
+const Column& IfElseN_ColumnImpl::child(size_t i) const {
+  return i < conditions_.size()? conditions_[i]
+                               : values_[i - conditions_.size()];
+}
+
+
+
+//------------------------------------------------------------------------------
+// Element access
+//------------------------------------------------------------------------------
+template <typename T>
+inline bool IfElseN_ColumnImpl::_get(size_t i, T* out) const {
+  for (size_t j = 0; j < conditions_.size(); ++j) {
+    int8_t condition_value;
+    bool valid = conditions_[j].get_element(i, &condition_value);
+    if (!valid) return false;
+    if (condition_value) return values_[j].get_element(i, out);
+  }
+  return values_.back().get_element(i, out);
+}
+
+bool IfElseN_ColumnImpl::get_element(size_t i, int8_t* out)   const { return _get(i, out); }
+bool IfElseN_ColumnImpl::get_element(size_t i, int16_t* out)  const { return _get(i, out); }
+bool IfElseN_ColumnImpl::get_element(size_t i, int32_t* out)  const { return _get(i, out); }
+bool IfElseN_ColumnImpl::get_element(size_t i, int64_t* out)  const { return _get(i, out); }
+bool IfElseN_ColumnImpl::get_element(size_t i, float* out)    const { return _get(i, out); }
+bool IfElseN_ColumnImpl::get_element(size_t i, double* out)   const { return _get(i, out); }
+bool IfElseN_ColumnImpl::get_element(size_t i, CString* out)  const { return _get(i, out); }
+bool IfElseN_ColumnImpl::get_element(size_t i, py::oobj* out) const { return _get(i, out); }
+
+
+
+
+}  // namespace dt

--- a/src/core/column/ifelsen.h
+++ b/src/core/column/ifelsen.h
@@ -1,0 +1,63 @@
+//------------------------------------------------------------------------------
+// Copyright 2020 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#ifndef dt_COLUMN_IFELSEN_h
+#define dt_COLUMN_IFELSEN_h
+#include "column/virtual.h"
+namespace dt {
+
+
+/**
+  * Virtual column that implements n-element if-else (aka "case").
+  *
+  * If the condition evaluates to NA then an NA value is returned.
+  */
+class IfElseN_ColumnImpl : public Virtual_ColumnImpl {
+  private:
+    colvec conditions_;
+    colvec values_;
+
+  public:
+    IfElseN_ColumnImpl(colvec&&, colvec&&);
+
+    ColumnImpl* clone() const override;
+
+    size_t n_children() const noexcept override;
+    const Column& child(size_t i) const override;
+
+    bool get_element(size_t, int8_t*)   const override;
+    bool get_element(size_t, int16_t*)  const override;
+    bool get_element(size_t, int32_t*)  const override;
+    bool get_element(size_t, int64_t*)  const override;
+    bool get_element(size_t, float*)    const override;
+    bool get_element(size_t, double*)   const override;
+    bool get_element(size_t, CString*)  const override;
+    bool get_element(size_t, py::oobj*) const override;
+
+  private:
+    template <typename T> inline bool _get(size_t i, T* out) const;
+};
+
+
+
+
+}  // namespace dt
+#endif

--- a/src/core/expr/fexpr_ifelse.cc
+++ b/src/core/expr/fexpr_ifelse.cc
@@ -109,11 +109,18 @@ std::string FExpr_IfElse::repr() const {
 //------------------------------------------------------------------------------
 
 static const char* doc_ifelse =
-R"(ifelse(condition, expr_if_true, expr_if_false)
+R"(ifelse(condition1, value1, condition2, value2, ..., default)
 --
 
-Produce a column that chooses one of the two values based on the
-condition.
+An expression that chooses its value based on one or more
+conditions.
+
+This is roughly equivalent to the following Python code::
+
+    result = value1 if condition1 else \
+             value2 if condition2 else \
+             ...                  else \
+             default
 
 This function will only compute those values that are needed for
 the result. Thus, for each row we will evaluate either `expr_if_true`
@@ -122,14 +129,14 @@ This may be relevant for those cases
 
 Parameters
 ----------
-condition: FExpr
+condition1, condition2, ...: FExpr[bool]
     An expression yielding a single boolean column.
 
-expr_if_true: FExpr
+value1, value2, ...: FExpr
     Values that will be used when the condition evaluates to True.
     This must be a single column.
 
-expr_if_false: FExpr
+default: FExpr
     Values that will be used when the condition evaluates to False.
     This must be a single column.
 
@@ -151,9 +158,7 @@ static py::oobj ifelse(const py::XArgs& args) {
 DECLARE_PYFN(&ifelse)
     ->name("ifelse")
     ->docs(doc_ifelse)
-    ->arg_names({"condition", "expr_if_true", "expr_if_false"})
-    ->n_positional_args(3)
-    ->n_required_args(3);
+    ->allow_varargs(3);
 
 
 

--- a/src/core/expr/fexpr_ifelse.cc
+++ b/src/core/expr/fexpr_ifelse.cc
@@ -20,6 +20,7 @@
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #include "column/ifelse.h"        // IfElse_ColumnImpl
+#include "column/ifelsen.h"       // IfElseN_ColumnImpl
 #include "expr/eval_context.h"    // EvalContext
 #include "expr/fexpr_func.h"      // FExpr_Func
 #include "expr/workframe.h"       // Workframe
@@ -36,67 +37,99 @@ namespace expr {
 
 class FExpr_IfElse : public FExpr_Func {
   private:
-    ptrExpr cond_;
-    ptrExpr true_;
-    ptrExpr false_;
+    // The number of conditions is 1 less than the number of values
+    vecExpr conditions_;
+    vecExpr values_;
 
   public:
-    FExpr_IfElse(py::robj, py::robj, py::robj);
+    FExpr_IfElse(vecExpr&&, vecExpr&&);
     Workframe evaluate_n(EvalContext&) const override;
     std::string repr() const override;
 };
 
 
 
-FExpr_IfElse::FExpr_IfElse(py::robj c, py::robj t, py::robj f)
-  : cond_(as_fexpr(c)),
-    true_(as_fexpr(t)),
-    false_(as_fexpr(f)) {}
+FExpr_IfElse::FExpr_IfElse(vecExpr&& conditions, vecExpr&& values)
+  : conditions_(std::move(conditions)),
+    values_(std::move(values))
+{
+  xassert(conditions_.size() == values_.size() - 1);
+}
 
 
 Workframe FExpr_IfElse::evaluate_n(EvalContext& ctx) const {
-  Workframe wf_cond = cond_->evaluate_n(ctx);
-  Workframe wf_true = true_->evaluate_n(ctx);
-  Workframe wf_false = false_->evaluate_n(ctx);
-  if (wf_cond.ncols() != 1 || wf_true.ncols() != 1 || wf_false.ncols() != 1) {
-    throw TypeError() << "Multi-column expressions are not supported in "
-        "`ifelse()` function";
-  }
-  wf_cond.sync_grouping_mode(wf_true);
-  wf_cond.sync_grouping_mode(wf_false);
-  wf_true.sync_grouping_mode(wf_false);
-  auto gmode = wf_cond.get_grouping_mode();
+  size_t n = conditions_.size();
+  xassert(n >= 1);
 
-  Column col_cond = wf_cond.retrieve_column(0);
-  Column col_true = wf_true.retrieve_column(0);
-  Column col_false= wf_false.retrieve_column(0);
-
-  if (col_cond.stype() != SType::BOOL) {
-    throw TypeError()
-        << "The `condition` argument in ifelse() must be a boolean column";
+  std::vector<Workframe> all_workframes;
+  for (const auto& cond : conditions_) {
+    all_workframes.push_back(cond->evaluate_n(ctx));
   }
-  SType out_stype = common_stype(col_true.stype(), col_false.stype());
-  col_true.cast_inplace(out_stype);
-  col_false.cast_inplace(out_stype);
-  Column out_col {new IfElse_ColumnImpl(
-      std::move(col_cond),
-      std::move(col_true),
-      std::move(col_false))
-  };
+  for (const auto& value : values_) {
+    all_workframes.push_back(value->evaluate_n(ctx));
+  }
+  xassert(all_workframes.size() == 2*n + 1);
+  for (size_t j = 0; j < all_workframes.size(); ++j) {
+    if (all_workframes[j].ncols() != 1) {
+      auto jj = (j < n)? j : j - n;
+      throw TypeError() << "The `" << (j==jj? "condition" : "value")
+          << (jj+1) << "` argument in ifelse() cannot be a multi-column "
+                       "expression";
+    }
+  }
+  auto gmode = Workframe::sync_grouping_mode(all_workframes);
+
+  colvec condition_cols;
+  for (size_t j = 0; j < n; ++j) {
+    Column col = all_workframes[j].retrieve_column(0);
+    if (col.stype() != SType::BOOL) {
+      throw TypeError()
+          << "The `condition" << (j+1)
+          << "` argument in ifelse() must be a boolean column";
+    }
+    condition_cols.push_back(std::move(col));
+  }
+
+  colvec value_cols;
+  SType out_stype = SType::VOID;
+  for (size_t j = n; j < all_workframes.size(); ++j) {
+    Column col = all_workframes[j].retrieve_column(0);
+    out_stype = common_stype(out_stype, col.stype());
+    value_cols.push_back(std::move(col));
+  }
+  for (Column& col : value_cols) {
+    col.cast_inplace(out_stype);
+  }
 
   Workframe wf_out(ctx);
-  wf_out.add_column(std::move(out_col), std::string(), gmode);
+  if (n == 1) {
+    wf_out.add_column(Column{
+      new IfElse_ColumnImpl(
+          std::move(condition_cols[0]),
+          std::move(value_cols[0]),
+          std::move(value_cols[1]))
+      }, std::string(), gmode
+    );
+  } else {
+    wf_out.add_column(
+      Column{
+        new IfElseN_ColumnImpl(std::move(condition_cols), std::move(value_cols))
+      }, std::string(), gmode
+    );
+  }
   return wf_out;
 }
 
 
 std::string FExpr_IfElse::repr() const {
   std::string out = "ifelse(";
-  out += cond_->repr();
-  out += ", ";
-  out += true_->repr();
-  out += ", ";
-  out += false_->repr();
+  for (size_t i = 0; i < conditions_.size(); ++i) {
+    out += conditions_[i]->repr();
+    out += ", ";
+    out += values_[i]->repr();
+    out += ", ";
+  }
+  out += values_.back()->repr();
   out += ')';
   return out;
 }
@@ -148,17 +181,33 @@ return: FExpr
 )";
 
 static py::oobj ifelse(const py::XArgs& args) {
+  auto n = args.num_varargs();
+  if (n < 3) {
+    throw TypeError()
+      << "Function `datatable.ifelse()` requires at least 3 arguments";
+  }
+  if (n % 2 != 1) {
+    throw TypeError()
+      << "Missing the required `default` argument in function "
+         "`datatable.ifelse()`";
+  }
+  vecExpr conditions;
+  vecExpr values;
+  for (size_t i = 0; i < n/2; i++) {
+    conditions.push_back(as_fexpr(args.vararg(i*2)));
+    values.push_back(as_fexpr(args.vararg(i*2 + 1)));
+  }
+  values.push_back(as_fexpr(args.vararg(n - 1)));
   return dt::expr::PyFExpr::make(
-              new dt::expr::FExpr_IfElse(args[0].to_robj(),
-                                         args[1].to_robj(),
-                                         args[2].to_robj())
+              new dt::expr::FExpr_IfElse(std::move(conditions),
+                                         std::move(values))
          );
 }
 
 DECLARE_PYFN(&ifelse)
     ->name("ifelse")
     ->docs(doc_ifelse)
-    ->allow_varargs(3);
+    ->allow_varargs();
 
 
 

--- a/src/core/expr/fexpr_ifelse.cc
+++ b/src/core/expr/fexpr_ifelse.cc
@@ -144,6 +144,7 @@ std::string FExpr_IfElse::repr() const {
 static const char* doc_ifelse =
 R"(ifelse(condition1, value1, condition2, value2, ..., default)
 --
+.. xversionadded:: 0.11.0
 
 An expression that chooses its value based on one or more
 conditions.
@@ -155,29 +156,41 @@ This is roughly equivalent to the following Python code::
              ...                  else \
              default
 
-This function will only compute those values that are needed for
-the result. Thus, for each row we will evaluate either `expr_if_true`
-or `expr_if_false` (based on the `condition` value) but not both.
-This may be relevant for those cases
+For every row this function evaluates the smallest number of expressions
+necessary to get the result. Thus, it evaluates `condition1`, `condition2`,
+and so on until it finds the first condition that evaluates to `True`.
+It then computes and returns the corresponding `value`. If all conditions
+evaluate to `False`, then the `default` value is computed and returned.
+
+Also, if any of the conditions produces NA then the result of the expression
+also becomes NA without evaluating any further conditions or values.
+
 
 Parameters
 ----------
 condition1, condition2, ...: FExpr[bool]
-    An expression yielding a single boolean column.
+    Expressions each producing a single boolean column. These conditions
+    will be evaluated in order until we find the one equal to `True`.
 
 value1, value2, ...: FExpr
-    Values that will be used when the condition evaluates to True.
-    This must be a single column.
+    Values that will be used when the corresponding condition evaluates
+    to `True`. These must be single columns.
 
 default: FExpr
-    Values that will be used when the condition evaluates to False.
+    Value that will be used when all conditions evaluate to `False`.
     This must be a single column.
 
 return: FExpr
     The resulting expression is a single column whose stype is the
-    stype which is common for `expr_if_true` and `expr_if_false`,
-    i.e. it is the smallest stype into which both exprs can be
-    upcasted.
+    common stype for all `value1`, ..., `default` columns.
+
+
+Notes
+-----
+.. versionchanged:: 1.0.0
+
+    Earlier this function accepted a single condition only.
+
 )";
 
 static py::oobj ifelse(const py::XArgs& args) {

--- a/src/core/expr/workframe.cc
+++ b/src/core/expr/workframe.cc
@@ -321,6 +321,20 @@ void Workframe::sync_grouping_mode(Column& col, Grouping gmode) {
 }
 
 
+Grouping Workframe::sync_grouping_mode(std::vector<Workframe>& workframes) {
+  Grouping gmode = Grouping::SCALAR;
+  for (const auto& wf : workframes) {
+    if (static_cast<size_t>(wf.grouping_mode_) > static_cast<size_t>(gmode)) {
+      gmode = wf.grouping_mode_;
+    }
+  }
+  for (auto& wf : workframes) {
+    wf.increase_grouping_mode(gmode);
+  }
+  return gmode;
+}
+
+
 void Workframe::increase_grouping_mode(Grouping gmode) {
   if (grouping_mode_ == gmode) return;
   for (auto& item : entries_) {

--- a/src/core/expr/workframe.h
+++ b/src/core/expr/workframe.h
@@ -129,6 +129,7 @@ class Workframe {
     void sync_grouping_mode(Column& col, Grouping gmode);
     Grouping get_grouping_mode() const;
     void increase_grouping_mode(Grouping g);
+    static Grouping sync_grouping_mode(std::vector<Workframe>& wokframes);
 
   private:
     void column_increase_grouping_mode(Column&, Grouping from, Grouping to);

--- a/src/core/python/xargs.cc
+++ b/src/core/python/xargs.cc
@@ -331,6 +331,7 @@ void XArgs::bind(PyObject* args, PyObject* kwds) {
       }
     }
   }
+  n_bound_args_ = n_bound_args;
   kwds_dict_ = kwds;
   args_tuple_ = args;
 }
@@ -352,6 +353,7 @@ PyObject* XArgs::exec_function(PyObject* args, PyObject* kwds) noexcept {
 
 
 const Arg& XArgs::operator[](size_t i) const {
+  xassert(i < bound_args_.size());
   return bound_args_[i];
 }
 
@@ -363,6 +365,13 @@ size_t XArgs::num_varkwds() const noexcept {
   return n_varkwds_;
 }
 
+
+py::robj XArgs::vararg(size_t i) const {
+  xassert(i < n_varargs_);
+  auto j = static_cast<Py_ssize_t>(i + n_bound_args_);
+  // PyTuple_GET_ITEM() returns a borrowed reference
+  return py::robj(PyTuple_GET_ITEM(args_tuple_, j));
+}
 
 
 

--- a/src/core/python/xargs.h
+++ b/src/core/python/xargs.h
@@ -58,6 +58,7 @@ class XArgs : public ArgParent {
     // Runtime arguments
     std::vector<Arg> bound_args_;
     std::unordered_map<PyObject*, size_t> kwd_map_;
+    size_t n_bound_args_;
     size_t n_varargs_;
     size_t n_varkwds_;
     PyObject* args_tuple_;  // for var-args iteration
@@ -130,6 +131,8 @@ class XArgs : public ArgParent {
     const Arg& operator[](size_t i) const;
     size_t num_varargs() const noexcept;
     size_t num_varkwds() const noexcept;
+    py::robj vararg(size_t i) const;
+
     // VarKwdsIterable varkwds() const noexcept;
     // VarArgsIterable varargs() const noexcept;
 

--- a/tests/expr/test-ifelse.py
+++ b/tests/expr/test-ifelse.py
@@ -28,8 +28,7 @@ from tests import assert_equals
 
 def test_ifelse_bad_signature():
     DT = dt.Frame(A=range(10))
-    msg = r"Function datatable\.ifelse\(\) requires exactly 3 positional " \
-          r"arguments"
+    msg = r"Function datatable\.ifelse\(\) requires at least 3 arguments"
     with pytest.raises(TypeError, match=msg):
         DT[:, ifelse()]
     with pytest.raises(TypeError, match=msg):
@@ -37,8 +36,8 @@ def test_ifelse_bad_signature():
     with pytest.raises(TypeError, match=msg):
         DT[:, ifelse(f.A > 0, f.A)]
 
-    msg = r"ifelse\(\) takes at most 3 positional arguments, " \
-          r"but 4 were given"
+    msg = r"Missing the required default argument in function " \
+          r"datatable\.ifelse\(\)"
     with pytest.raises(TypeError, match=msg):
         DT[:, ifelse(f.A > 0, f.A, f.A, f.A)]
 
@@ -46,7 +45,7 @@ def test_ifelse_bad_signature():
 def test_ifelse_wrong_type():
     DT = dt.Frame(A=range(10))
     DT["B"] = dt.str32(f.A)
-    msg = r"The condition argument in ifelse\(\) must be a boolean column"
+    msg = r"The condition1 argument in ifelse\(\) must be a boolean column"
     with pytest.raises(TypeError, match=msg):
         DT[:, ifelse(f.A, f.A, f.A)]
     with pytest.raises(TypeError, match=msg):
@@ -55,16 +54,22 @@ def test_ifelse_wrong_type():
 
 def test_ifelse_columnsets():
     DT = dt.Frame(A=range(10), B=[7]*10, C=list('abcdefghij'))
-    msg = r"Multi-column expressions are not supported in ifelse\(\) function"
+    msg = r"The condition1 argument in ifelse\(\) cannot be a multi-column " \
+          r"expression"
     with pytest.raises(TypeError, match=msg):
         DT[:, ifelse(f[:], 0, 1)]
     with pytest.raises(TypeError, match=msg):
+        DT[:, ifelse(f[int] > 3, 3, f[int])]
+
+    msg = r"The value1 argument in ifelse\(\) cannot be a multi-column " \
+          r"expression"
+    with pytest.raises(TypeError, match=msg):
         DT[:, ifelse(f.A > 3, f[:], f.A)]
+
+    msg = r"The value2 argument in ifelse\(\) cannot be a multi-column " \
+          r"expression"
     with pytest.raises(TypeError, match=msg):
         DT[:, ifelse(f.A > 3, f.A, f[:])]
-    # We could in theory make this work...
-    with pytest.raises(TypeError, match=msg):
-        DT[:, ifelse(f[int] > 3, 3, f[int])]
 
 
 


### PR DESCRIPTION
New ifelse() function allows chained evaluation of several conditions, making it the equivalent of SQL's CASE WHEN.

 - The evaluation is "lazy": only the smallest amount of expressions needed to get the result is computed for each row;
 - Both `condition_i` and `value_i` can have unequal but compatible shapes: some of them can be full-sized, others grouped, yet others simple scalars;
  - The value columns will be upcasted into the smallest common stype as necessary.

Closes #2656