### PR TITLE
Create directory /tmp/cores on macOS before running tests

### DIFF
--- a/ci/Jenkinsfile.groovy
+++ b/ci/Jenkinsfile.groovy
@@ -730,6 +730,7 @@ def test_macos(String pyver) {
     try {
         def pyenv = get_env_for_macos(pyver)
         sh """
+            mkdir -p /tmp/cores
             rm -f /tmp/cores/*
             env
             . /Users/jenkins/anaconda/bin/activate ${pyenv}


### PR DESCRIPTION
If for whatever reason the directory was deleted, then we should recreate it before starting the job.