### PR TITLE
Double quoted strings

### DIFF
--- a/src/core/read/parsers/parse_string.cc
+++ b/src/core/read/parsers/parse_string.cc
@@ -193,12 +193,17 @@ static void parse_string_unquoted(const ParseContext& ctx) {
   const char quote = ctx.quote;
   const char sep = ctx.sep;
   bool found_matching_quote = true;
+  bool single_quouted_string = false;
   if (ctx.strip_whitespace) {
     while (ch < end && *ch == ' ') ch++;
   }
   const char* field_start = ch;
   while (ch < end) {
     char c = *ch;
+    if (c == '\"' && single_quouted_string) {
+      ch++;
+      continue;
+    }
     if (c == '\"' && found_matching_quote) {
       found_matching_quote = false;
     }
@@ -217,6 +222,12 @@ static void parse_string_unquoted(const ParseContext& ctx) {
     else if (c == quote && QUOTES_FORBIDDEN) {
       ctx.target->str32.setna();
       return;
+    }
+    if (*(ch+1) == '\n' && !found_matching_quote) {
+      ch = ctx.ch;
+      found_matching_quote = true;
+      single_quouted_string = true;
+      continue;
     }
     ch++;
   }

--- a/src/core/read/parsers/parse_string.cc
+++ b/src/core/read/parsers/parse_string.cc
@@ -193,7 +193,6 @@ static void parse_string_unquoted(const ParseContext& ctx) {
   const char quote = ctx.quote;
   const char sep = ctx.sep;
   bool found_matching_quote = true;
-  bool use_sep = true;
   if (ctx.strip_whitespace) {
     while (ch < end && *ch == ' ') ch++;
   }
@@ -202,13 +201,11 @@ static void parse_string_unquoted(const ParseContext& ctx) {
     char c = *ch;
     if (c == '\"' && found_matching_quote) {
       found_matching_quote = false;
-      use_sep = false;
     }
     else if (c == '\"' && !found_matching_quote) {
       found_matching_quote = true;
-      use_sep = true;
     }
-    if (c == sep && use_sep) break;  // end of field
+    if (c == sep && found_matching_quote) break;  // end of field
     if (static_cast<uint8_t>(c) <= 13) {  // probably a newline
       if (c == '\n') {
         // Move back to the beginning of \r+\n sequence

--- a/src/core/read/parsers/parse_string.cc
+++ b/src/core/read/parsers/parse_string.cc
@@ -192,14 +192,23 @@ static void parse_string_unquoted(const ParseContext& ctx) {
   const char* end = ctx.eof;
   const char quote = ctx.quote;
   const char sep = ctx.sep;
-
+  bool found_matching_quote = true;
+  bool use_sep = true;
   if (ctx.strip_whitespace) {
     while (ch < end && *ch == ' ') ch++;
   }
   const char* field_start = ch;
   while (ch < end) {
     char c = *ch;
-    if (c == sep) break;  // end of field
+    if (c == '\"' && found_matching_quote) {
+      found_matching_quote = false;
+      use_sep = false;
+    }
+    else if (c == '\"' && !found_matching_quote) {
+      found_matching_quote = true;
+      use_sep = true;
+    }
+    if (c == sep && use_sep) break;  // end of field
     if (static_cast<uint8_t>(c) <= 13) {  // probably a newline
       if (c == '\n') {
         // Move back to the beginning of \r+\n sequence


### PR DESCRIPTION
"partially" Closes #491 

This branch allows treating entries with a double-quote as a single entity. For example, `fread`ing [apa.txt](https://github.com/Rdatatable/data.table/files/3478066/apa.txt) previously will end up as 2 columns because the double quoted string does not prevent the action of separator (space in this case).
```python
12 | M5EN3U5SW4  NA
 13 | LCUIX02FBP  NA
 14 | 0U5N3PO5R5  NA
  … | …           … 
 96 | "QXI04X6F1  " 
 97 | MD9167JW4F  NA
 98 | LCUIX02FBP  NA
 99 | "QXI04X6F1  " 
100 | 0U5N3PO5R5  NA
```
So logic has been added to prevent using separator until a matching double quote is found. It defaults to true for parsing unquoted strings. `fread`ing [apa.txt](https://github.com/Rdatatable/data.table/files/3478066/apa.txt) will now be
```python
12 | LCUIX02FBP
13 | 0U5N3PO5R5
14 | LCUIX02FBP
 … | …         
95 | QXI04X6F1 
96 | MD9167JW4F
97 | LCUIX02FBP
98 | QXI04X6F1 
99 | 0U5N3PO5R5
```
Tested also on [transformer_mojo.csv.zip](https://github.com/h2oai/datatable/files/3479240/transformer_mojo_input.csv.zip)

This logic broke a couple of test cases `test_runaway_quote()` and `test_unmatched_quotes()` in `tests/fread/test-fread-small.py`
They are both examples of `fread`ing strings with a single double quote. More logic is added to deal with this. After parsing a string that does not contain a matching double quote, parse the string from the beginning again, only this time using separator  and by skipping all double quotes.