### PR TITLE
[DOC] update to docs highlighting difference in row selection

### DIFF
--- a/docs/manual/comparison_with_rdatatable.rst
+++ b/docs/manual/comparison_with_rdatatable.rst
@@ -54,9 +54,66 @@ Sort by column ``x`` ascending, ``y`` descending     ``DT[order(x, -y)]``       
                                                                                                   | ``DT[:, :, sort(f.x, -f.y)]``
 =================================================  ============================================ =====================================
 
-Note the use of the ``f`` symbol when performing computations or sorting in descending order. You can read more about :ref:`f-expressions`.
+.. note:: Note the use of the ``f`` symbol when performing computations or sorting in descending order. You can read more about :ref:`f-expressions`.
 
-Note: In ``data.table``, ``DT[2]`` would mean ``2nd row``, whereas in ``datatable``, ``DT[2]`` would select the 3rd column.
+In ``data.table``, ``DT[2]`` would mean ``2nd row``, whereas in ``datatable``, ``DT[2]`` would select the 3rd column.
+
+In ``data.table``, when selecting rows you do not need to indicate the columns. So, something like the code below works fine :
+
+.. code-block:: R
+
+    # data.table
+    DT[y==3]
+
+       x y v
+    1: b 3 2
+    2: a 3 5
+    3: c 3 8
+
+In ``datatable`` however, when selecting rows, there has to be a column selector, or you get an error message : 
+
+.. code-block:: python
+
+    # datatable
+    DT[f.y==3]
+
+    ---------------------------------------------------------------------------
+    TypeError                                 Traceback (most recent call last)
+    <ipython-input-210-e82acc31577f> in <module>
+    -   ---> 1 DT[f.y==3]
+
+    TypeError: Column selector must be an integer or a string, not <class 'datatable.FExpr'>
+
+The code above fails because ``datatable`` only allows single column selection using the style above:
+
+.. code-block:: python
+
+    DT['y']
+
+    	y
+    0	1
+    1	3
+    2	6
+    3	1
+    4	3
+    5	6
+    6	1
+    7	3
+    8	6
+
+As such, when ``datatable`` sees an :ref:`f-expressions`, it thinks you are selecting a column, and appropriately errors out.
+
+
+Since, in this case, we are selecting all columns, we can use either a colon (``:``), or ``None`` or the Ellipsis symbol(``...``):
+
+.. code-block:: python
+
+    # datatable
+    DT[f.y==3, :]
+    # or DT[f.y==3, None]
+    # or DT[f.y==3, ...]
+
+
 
 Selecting Columns
 -----------------
@@ -297,7 +354,7 @@ Similar operation for the above in ``datatable``
     DT[cols] = 4242
     # or  DT[:, update(cols=4242)]
 
-Note that the :func:`update` function, as well as the ``del`` function (a `python keyword <https://docs.python.org/3/reference/lexical_analysis.html#keywords>`__) operates in-place; there is no need for reassignment. Another advantage of the :func:`update` method is that the row order of the dataframe is not changed, even in a groupby; this comes in handy in a lot of transformation operations.
+.. note:: The :func:`update` function, as well as the ``del`` function (a `python keyword <https://docs.python.org/3/reference/lexical_analysis.html#keywords>`__) operates in-place; there is no need for reassignment.  Another advantage of the :func:`update` method is that the row order of the dataframe is not changed, even in a groupby; this comes in handy in a lot of transformation operations.
 
 
 Joins


### PR DESCRIPTION
This is in response to a comment on #2611  [link](https://github.com/h2oai/datatable/pull/2611#issuecomment-705817227). 

It shows the difference in row selections between `data.table` and `datable`, when selecting all columns 