### PR TITLE
Update with by

### DIFF
--- a/docs/releases/v1.0.0.rst
+++ b/docs/releases/v1.0.0.rst
@@ -14,6 +14,8 @@
       implementing a chained-if functionality. This is equivalent to
       ``CASE WHEN`` in SQL. [#2656]
 
+    -[fix] When a whole column is updated within a ``DT[i, j, by()]`` call,
+      the stype/ltype of that column us now allowed to change. [#2685]
 
     fread
     -----

--- a/src/core/expr/eval_context.cc
+++ b/src/core/expr/eval_context.cc
@@ -431,7 +431,8 @@ void EvalContext::typecheck_for_update(
     Workframe& replframe, const sztvec& indices)
 {
   DataTable* dt0 = get_datatable(0);
-  bool allrows = !(get_rowindex(0));
+  Kind ikind = iexpr_->get_expr_kind();
+  bool allrows = (ikind == Kind::SliceAll || ikind == Kind::None);
   bool repl_1row = replframe.get_grouping_mode() == Grouping::SCALAR;
   size_t n = indices.size();
   xassert(replframe.ncols() == indices.size());

--- a/tests/ijby/test-update.py
+++ b/tests/ijby/test-update.py
@@ -98,4 +98,8 @@ def test_update_misplaced():
         DT[:, :, update(B=0)]
 
 
-
+def test_update_with_groupby():
+    DT = dt.Frame(A=range(5), B=[1, 2, 2, 2, 1])
+    assert DT.stype == dt.int32
+    DT[:, update(A=f.A*100/dt.sum(f.A)), by(f.B)]
+    assert_equals(DT, dt.Frame(A=[0, 100/6, 100/3, 50, 100], B=[1, 2, 2, 2, 1]))


### PR DESCRIPTION
When a whole column is updated within a `DT[i, j, by()]` call, the stype/ltype of that column us now allowed to change. This is consistent with the same behavior in the absense of `by()`.

Closes #2685