### PR TITLE
Delete rows from an unsorted array

### DIFF
--- a/docs/releases/v1.0.0.rst
+++ b/docs/releases/v1.0.0.rst
@@ -5,7 +5,7 @@
     -----
     .. current-class:: datatable.Frame
 
-    -[fix] The row selector ``i`` in the delete operation ``del DT[i, :]``
+    -[enh] The row selector ``i`` in the delete operation ``del DT[i, :]``
       can now be an unsorted list. The list can also contain duplicate
       values.
 

--- a/docs/releases/v1.0.0.rst
+++ b/docs/releases/v1.0.0.rst
@@ -5,6 +5,9 @@
     -----
     .. current-class:: datatable.Frame
 
+    -[fix] The row selector ``i`` in the delete operation ``del DT[i, :]``
+      can now be an unsorted list. The list can also contain duplicate
+      values.
 
     FExpr
     -----

--- a/src/core/expr/fexpr_list.cc
+++ b/src/core/expr/fexpr_list.cc
@@ -24,8 +24,7 @@
 #include "expr/workframe.h"
 #include "utils/assert.h"
 #include "utils/exceptions.h"
-#include <algorithm>
-#include <iostream>
+#include <algorithm>             // std::sort
 namespace dt {
 namespace expr {
 

--- a/src/core/expr/fexpr_list.cc
+++ b/src/core/expr/fexpr_list.cc
@@ -262,12 +262,12 @@ static RowIndex _evaluate_i_ints(const vecExpr& args, EvalContext& ctx) {
   int32_t* data = static_cast<int32_t*>(databuf.xptr());
   bool is_list_to_negate_sorted = true;
   EvalMode eval_mode = ctx.get_mode();
-  int32_t max_value = args[0]->evaluate_int();
+  int64_t max_value = args[0]->evaluate_int();
   size_t data_index = 0;
   for (size_t i = 0; i < args.size(); ++i) {
     auto ikind = args[i]->get_expr_kind();
     if (ikind == Kind::Int) {
-      int32_t x = args[i]->evaluate_int();
+      int64_t x = args[i]->evaluate_int();
       if (x < -inrows || x >= inrows) {
         throw ValueError() << "Index " << x << " is invalid for a Frame with "
             << inrows << " rows";

--- a/src/core/rowindex_array.cc
+++ b/src/core/rowindex_array.cc
@@ -31,7 +31,6 @@
 #include "utils/assert.h"
 #include "utils/macros.h"
 #include "stype.h"
-#include <algorithm>
 #if DT_DEBUG
   inline static void test(ArrayRowIndexImpl* o) {
     o->refcount++;
@@ -346,7 +345,7 @@ RowIndexImpl* ArrayRowIndexImpl::negate_impl(size_t nrows) const
       outputs[k++] = i;
     }
   }
-
+  xassert(nrows >= count_indices_to_skip);
   int flags = RowIndex::SORTED;
   flags |= (sizeof(TO) == sizeof(int32_t))? RowIndex::ARR32 : RowIndex::ARR64;
   outbuf.resize((newsize - count_indices_to_skip) * sizeof(TO));
@@ -355,7 +354,6 @@ RowIndexImpl* ArrayRowIndexImpl::negate_impl(size_t nrows) const
 
 
 RowIndexImpl* ArrayRowIndexImpl::negate(size_t nrows) const {
-  xassert(nrows >= length);
   if (type == RowIndexType::ARR32) {
     if (nrows <= INT32_MAX)
       return negate_impl<int32_t, int32_t>(nrows);

--- a/tests/munging/test-delete.py
+++ b/tests/munging/test-delete.py
@@ -309,32 +309,35 @@ def test_del_rows_slice_step():
     assert d0.to_list() == [[1, 2, 4, 5, 7, 8]]
 
 
-def test_del_rows_array():
-    d0 = dt.Frame(range(10))
-    del d0[[0, 7, 8], :]
+def setdiff(rows, del_array):
+    del_array = [rows[i] for i in del_array]
+    res = list(set(rows) - set(del_array))
+    res.sort()
+    return res
+
+
+@pytest.mark.parametrize('del_array', [[0,7,8],
+                                       [3,1,5,2,2,0,-1],
+                                       [-1,3,0,0,3,-1,4,1,1],
+                                       [5,6,5,8,5,-1,3,0,0,3,-1,4,1,1],
+                                       [3],
+                                       [],
+                                       [3]*1000])
+def test_del_rows_array_unsorted_1(del_array):
+    rows = range(10)
+    d0 = dt.Frame(rows)
+    del d0[del_array, :]
     frame_integrity_check(d0)
-    assert d0.to_list() == [[1, 2, 3, 4, 5, 6, 9]]
+    assert d0.to_list() == [setdiff(rows,del_array)]
 
 
-def test_del_rows_array_unordered():
-    d0 = dt.Frame(range(10))
-    del d0[[3, 1, 5, 2, 2, 0, -1], :]
+@pytest.mark.parametrize('del_array',[[3,2,0,2,0,1,4,4,0]])
+def test_del_rows_array_unsorted_2(del_array):
+    rows = range(5)
+    d0 = dt.Frame(rows)
+    del d0[del_array, :]
     frame_integrity_check(d0)
-    assert d0.to_list() == [[4, 6, 7, 8]]
-
-
-def test_del_rows_array_unordered_index_duplicated():
-    d0 = dt.Frame(range(10))
-    del d0[[-1, 3, 0, 0, 3, -1, 4, 1, 1], :]
-    frame_integrity_check(d0)
-    assert d0.to_list() == [[2, 5, 6, 7, 8]]
-
-
-def test_del_rows_array_unordered_larger_than_frame():
-    d0 = dt.Frame(range(10))
-    del d0[[5, 6, 5, 8, 5, -1, 3, 0, 0, 3, -1, 4, 1, 1], :]
-    frame_integrity_check(d0)
-    assert d0.to_list() == [[2, 7]]
+    assert d0.to_list() == [setdiff(rows,del_array)]
 
 
 def test_del_rows_filter():

--- a/tests/munging/test-delete.py
+++ b/tests/munging/test-delete.py
@@ -316,12 +316,25 @@ def test_del_rows_array():
     assert d0.to_list() == [[1, 2, 3, 4, 5, 6, 9]]
 
 
-@pytest.mark.skip("Issue #805")
 def test_del_rows_array_unordered():
     d0 = dt.Frame(range(10))
     del d0[[3, 1, 5, 2, 2, 0, -1], :]
     frame_integrity_check(d0)
     assert d0.to_list() == [[4, 6, 7, 8]]
+
+
+def test_del_rows_array_unordered_index_duplicated():
+    d0 = dt.Frame(range(10))
+    del d0[[-1, 3, 0, 0, 3, -1, 4, 1, 1], :]
+    frame_integrity_check(d0)
+    assert d0.to_list() == [[2, 5, 6, 7, 8]]
+
+
+def test_del_rows_array_unordered_larger_than_frame():
+    d0 = dt.Frame(range(10))
+    del d0[[5, 6, 5, 8, 5, -1, 3, 0, 0, 3, -1, 4, 1, 1], :]
+    frame_integrity_check(d0)
+    assert d0.to_list() == [[2, 7]]
 
 
 def test_del_rows_filter():


### PR DESCRIPTION
Closes #805 

The rows to be deleted can be an unsorted array.
The array can contain duplicate values. 
Size of the array to be deleted can be larger than the size of the frame as long as the index to be deleted does not exceed the number of rows on the frame. 