### PR TITLE
Improve exception sections in the docs

### DIFF
--- a/docs/api/frame/__getitem__.rst
+++ b/docs/api/frame/__getitem__.rst
@@ -242,13 +242,18 @@
         Single-column frame containing the column at the specified index or
         with the given name.
 
-    except: KeyError
-        The exception is raised if the column with the given name does not
-        exist in the frame.
+    except: KeyError | IndexError
+        .. list-table::
+            :widths: auto
+            :class: api-table
 
-    except: IndexError
-        The exception is raised if the column does not exist at the provided
-        index `j`.
+            * - :exc:`KeyError`
+              - raised if the column with the given name does not
+                exist in the frame.
+
+            * - :exc:`IndexError`
+              - raised if the column does not exist at the provided
+                index `j`.
 
 
 

--- a/src/core/frame/names.cc
+++ b/src/core/frame/names.cc
@@ -159,17 +159,20 @@ return: int
     The numeric index of the provided `column`. This will be an
     integer between `0` and `self.ncols - 1`.
 
-except: dt.exceptions.KeyError | dt.exceptions.IndexError
-    If the `column` argument is a string, and the column with such
-    name does not exist in the frame, then a :exc:`dt.exceptions.KeyError` is raised.
-    When this exception is thrown, the error message may contain
-    suggestions for up to 3 similarly looking column names that
-    actually exist in the Frame.
+except: KeyError | IndexError
+    .. list-table::
+        :widths: auto
+        :class: api-table
 
-    If the `column` argument is an integer that is either greater
-    than or equal to :attr:`.ncols` or less than
-    `-ncols`, then an :exc:`dt.exceptions.IndexError` is raised.
+        * - :exc:`KeyError`
+          - raised if the `column` argument is a string, and the column with
+            such name does not exist in the frame. When this exception is
+            thrown, the error message may contain suggestions for up to 3
+            similarly looking column names that actually exist in the Frame.
 
+        * - :exc:`IndexError`
+          - raised if the `column` argument is an integer that is either greater
+            than or equal to :attr:`.ncols` or less than `-ncols`.
 
 Examples
 --------
@@ -288,13 +291,19 @@ new_names: List[str?] | Tuple[str?, ...] | Dict[str, str?] | None
     ``del`` keyword: the names will be set to their default values,
     which are usually ``C0, C1, ...``.
 
-except: ValueError
-    If the length of the list/tuple `new_names` does not match the
-    number of columns in the frame.
 
-except: KeyError
-    If `new_names` is a dictionary containing entries that do not
-    match any of the existing columns in the frame.
+except: ValueError | KeyError
+    .. list-table::
+        :widths: auto
+        :class: api-table
+
+        * - :exc:`ValueError`
+          - raised If the length of the list/tuple `new_names` does not match the
+            number of columns in the frame.
+
+        * - :exc:`KeyError`
+          - raised If `new_names` is a dictionary containing entries that do not
+            match any of the existing columns in the frame.
 
 Examples
 --------

--- a/src/core/models/aggregate.cc
+++ b/src/core/models/aggregate.cc
@@ -117,12 +117,10 @@ return: Tuple[Frame, Frame]
     the exemplar's rows from the input frame.
 
 
-except: ValueError
-    The exception is raised if the input frame is missing.
-
 except: TypeError
     The exception is raised when one of the `frame`'s columns has an
-    unsupported stype, i.e. the column is both non-numeric and non-string.
+    unsupported stype, i.e. there is a column that is both non-numeric
+    and non-string.
 
 )";
 

--- a/src/core/models/py_ftrl.cc
+++ b/src/core/models/py_ftrl.cc
@@ -1273,10 +1273,6 @@ except: ValueError
     - trying to change this option for a model that has already been trained;
     - one of the interactions has zero features.
 
-except: TypeError
-    The exception is raised when `new_interactions` has a wrong type.
-
-
 )";
 
 static GSArgs args_interactions(
@@ -1455,7 +1451,6 @@ except: ValueError
     The exception is raised when
 
     - trying to change this option for a model that has already been trained;
-
     - individual parameter values are incompatible with the corresponding setters.
 
 )";

--- a/src/core/set_funcs.cc
+++ b/src/core/set_funcs.cc
@@ -238,12 +238,16 @@ return: Frame
     A single-column frame. The column stype is the smallest common
     stype of columns in the `frames`.
 
-except: ValueError
-    The exception is raised when one of the input frames has more than
-    one column.
+except: ValueError | NotImplementedError
+    .. list-table::
+        :widths: auto
+        :class: api-table
 
-except: NotImplementedError
-    The exception is raised when one of the frame columns has stype `obj64`.
+        * - :exc:`ValueError`
+          - raised when one of the input frames has more than one column.
+
+        * - :exc:`NotImplementedError`
+          - raised when one of the columns has stype `obj64`.
 
 See Also
 --------
@@ -357,13 +361,16 @@ return: Frame
     A single-column frame. The column stype is the smallest common
     stype of columns in the `frames`.
 
-except: ValueError
-    The exception is raised when one of the input frames has more than
-    one column.
+except: ValueError | NotImplementedError
+    .. list-table::
+        :widths: auto
+        :class: api-table
 
-except: NotImplementedError
-    The exception is raised when one of the frame columns has stype
-    `obj64`.
+        * - :exc:`ValueError`
+          - raised when one of the input frames has more than one column.
+
+        * - :exc:`NotImplementedError`
+          - raised when one of the columns has stype `obj64`.
 
 See Also
 --------
@@ -453,12 +460,17 @@ return: Frame
     A single-column frame. The column stype is the smallest common
     stype of columns from the `frames`.
 
-except: ValueError
-    The exception is raised when one of the input frames, i.e. `frame0`
-    or any from the `frames`, has more than one column.
+except: ValueError | NotImplementedError
+    .. list-table::
+        :widths: auto
+        :class: api-table
 
-except: NotImplementedError
-    The exception is raised when one frame columns has stype `obj64`.
+        * - :exc:`ValueError`
+          - raised when one of the input frames, i.e. `frame0`
+            or any one from the `frames`, has more than one column.
+
+        * - :exc:`NotImplementedError`
+          - raised when one of the columns has stype `obj64`.
 
 
 See Also
@@ -572,12 +584,16 @@ return: Frame
     A single-column frame. The column stype is the smallest common
     stype of columns from the `frames`.
 
-except: ValueError
-    The exception is raised when one of the input frames has more
-    than one column.
+except: ValueError | NotImplementedError
+    .. list-table::
+        :widths: auto
+        :class: api-table
 
-except: NotImplementedError
-    The exception is raised when one of the frame columns has stype `obj64`.
+        * - :exc:`ValueError`
+          - raised when one of the input frames has more than one column.
+
+        * - :exc:`NotImplementedError`
+          - raised when one of the columns has stype `obj64`.
 
 
 See Also

--- a/src/core/str/py_str.cc
+++ b/src/core/str/py_str.cc
@@ -59,14 +59,18 @@ return: Frame
     and as many boolean columns as there were unique labels found.
     The labels will also become the output column names.
 
-except: ValueError
-    The exception is raised if the input frame is missing or it has more
-    than one column. It is also raised if `sep` is not a single-character
-    string.
+except: ValueError | TypeError
+    .. list-table::
+        :widths: auto
+        :class: api-table
 
-except: TypeError
-    The exception is raised if the single column of `frame` has a type
-    different from string.
+        * - :exc:`ValueError`
+          - raised if the input frame is missing or it has more
+            than one column. It is also raised if `sep` is not a single-character
+            string.
+
+        * - :exc:`TypeError`
+          - raised if the single column of `frame` has non-string stype.
 
 
 Examples


### PR DESCRIPTION
Use a single exception section on the documentation pages, so that a link to the`#except` anchor would properly reference the whole section.