### PR TITLE
Fix a memory leak

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ test:
 
 # In order to run with Address Sanitizer:
 #   $ make asan
-#   $ DYLD_INSERT_LIBRARIES=/usr/local/opt/llvm/lib/clang/7.0.0/lib/darwin/libclang_rt.asan_osx_dynamic.dylib ASAN_OPTIONS=detect_leaks=1 python -m pytest
+#   $ DYLD_INSERT_LIBRARIES=/usr/local/opt/llvm/lib/clang/10.0.0/lib/darwin/libclang_rt.asan_osx_dynamic.dylib ASAN_OPTIONS=detect_leaks=1 python -m pytest
 #
 .PHONY: asan
 asan:

--- a/docs/releases/v1.0.0.rst
+++ b/docs/releases/v1.0.0.rst
@@ -31,3 +31,6 @@
       has reached its end of life on 2020-09-13 and will no longer be
       supported. If you are still using Python 3.5, please consider upgrading.
       [#2642]
+
+    -[fix] Fixed a memory leak when creating a large number of datatable
+      objects. [#2701]

--- a/src/core/python/args.cc
+++ b/src/core/python/args.cc
@@ -371,7 +371,7 @@ VarArgsIterator VarArgsIterable::end() const {
 
 
 VarKwdsIterator::VarKwdsIterator(const PKArgs& args, Py_ssize_t i0)
-    : parent(args), pos(i0), curr_value(py::robj(nullptr), py::robj(nullptr))
+    : parent(args), pos(i0)
 {
   if (parent.kwds_dict) {
     advance();

--- a/src/core/python/xobject.h
+++ b/src/core/python/xobject.h
@@ -270,7 +270,9 @@ template <typename T, void(T::*METH)()>
 void _safe_dealloc(PyObject* self) noexcept {
   auto cl = dt::CallLogger::dealloc(self);
   try {
+    PyTypeObject* tp = Py_TYPE(self);
     (static_cast<T*>(self)->*METH)();
+    tp->tp_free(self);
   }
   catch (const std::exception& e) {
     exception_to_python(e);


### PR DESCRIPTION
It took a long time to figure out, but apparently we were not calling the "free" function of the base type object during the destruction: https://docs.python.org/3/c-api/typeobj.html#c.PyTypeObject.tp_dealloc

Closes  #2701