### PR TITLE
Allow str64 in a call to fread

### DIFF
--- a/docs/releases/v1.0.0.rst
+++ b/docs/releases/v1.0.0.rst
@@ -27,6 +27,9 @@
     -[fix] Fix an error when reading a file with uneven number of fields
       and having Windows-style newlines. [#2681]
 
+    -[fix] Fread no longer throws an exception when the list of column types
+      passed to parameter `columns=` contains `str64`. [#2704]
+
 
     General
     -------

--- a/src/core/read/input_column.cc
+++ b/src/core/read/input_column.cc
@@ -105,7 +105,7 @@ void InputColumn::set_rtype(int64_t it) {
     case RFloat64: parse_type_ = PT::Float64Plain; break;
     case RStr:     parse_type_ = PT::Str32; break;
     case RStr32:   parse_type_ = PT::Str32; break;
-    case RStr64:   parse_type_ = PT::Str64; break;
+    case RStr64:   parse_type_ = PT::Str32; break;  // ?
   }
 }
 

--- a/src/core/read/input_column.cc
+++ b/src/core/read/input_column.cc
@@ -105,7 +105,10 @@ void InputColumn::set_rtype(int64_t it) {
     case RFloat64: parse_type_ = PT::Float64Plain; break;
     case RStr:     parse_type_ = PT::Str32; break;
     case RStr32:   parse_type_ = PT::Str32; break;
-    case RStr64:   parse_type_ = PT::Str32; break;  // ?
+    // If at some point we implement creating str64 columns from fread directly,
+    // then this line will have to be changed. For now, though, if the user
+    // requests a str64 column type, we'll create a regular str32 instead.
+    case RStr64:   parse_type_ = PT::Str32; break;
   }
 }
 

--- a/src/core/read/thread_context.cc
+++ b/src/core/read/thread_context.cc
@@ -266,7 +266,8 @@ void ThreadContext::postorder() {
       case SType::FLOAT64: postorder_float64_column(outcol, j); break;
       case SType::STR32:   postorder_string_column(outcol, j); break;
       default:
-        throw RuntimeError() << "Unknown column SType in fread";
+        throw RuntimeError() << "Unknown column of type "
+            << col.get_stype() << " in fread";
     }
     j++;
   }

--- a/tests/fread/test-fread-api.py
+++ b/tests/fread/test-fread-api.py
@@ -705,6 +705,13 @@ def test_fread_columns_empty(columns):
     assert d0.to_list() == [[1], [2], [3]]
 
 
+def test_fread_str64_type():
+    DT = dt.fread("a\n1\n2\n3\n", columns=[dt.str64])
+    # Note: currently fread does not support creating str64 columns directly,
+    #       so we fall back to str32 here. (see #2704)
+    assert_equals(DT, dt.Frame(a=['1', '2', '3']/dt.str32))
+
+
 
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
I made it so str64 falls back into str32, because implementing a new stype for fread seems excessive at this moment.

Closes #2704