### PR TITLE
Nested menu indicators in the documentation

### DIFF
--- a/docs/_static/wren.css
+++ b/docs/_static/wren.css
@@ -197,6 +197,7 @@ div.nav-left > ul {
 
 div.nav-left li {
   list-style-type: none;
+  position: relative;
 }
 
 div.nav-left li > a {
@@ -204,13 +205,27 @@ div.nav-left li > a {
   color: #696e8e;
   display: block;
   font-size: 13px;
-  margin-left: -10px;
-  padding: 2px 0 2px 10px;
+  margin-left: -12px;
+  padding: 2px 0 2px 12px;
   text-decoration: none;
 }
 
 div.nav-left li > a:hover {
   background-color: #E5E5E5;
+}
+
+div.nav-left li > a:not(:only-child)::before {
+  color: #b1cbde;
+  content: "\f0da";
+  font-family: 'FontAwesome';
+  font-size: 70%;
+  left: -7px;
+  position: absolute;
+  top: 5px;
+}
+
+div.nav-left li > a:not(:only-child):not(.current):hover::before {
+  color: #69698e;
 }
 
 div.nav-left li.current > a.current {
@@ -221,6 +236,11 @@ div.nav-left li.current > a.current {
   /* Ensure that box-shadow is above the adjacent list items,
      even when they are hovered */
   z-index: 1001;
+}
+
+div.nav-left li.current > a.current:not(:only-child)::before {
+  content: "\f0d7";
+  left: 4px;
 }
 
 div.nav-left li.current > ul {

--- a/docs/_static/wren.css
+++ b/docs/_static/wren.css
@@ -11,6 +11,9 @@
   --right-menu-width: 240px;
   --document-width: 900px;
   --document-x-margin: clamp(10px, 2.5vw, 40px);
+
+  --font-sans: Lato,proxima-nova,"Segoe UI",Roboto,Helvetica Neue,Arial,sans-serif;
+  --font-mono: SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;
 }
 
 
@@ -26,7 +29,7 @@ html {
 body {
   background-color: #E5E5E5;
   counter-reset: cc;
-  font-family: Lato,proxima-nova,"Segoe UI",Roboto,Helvetica Neue,Arial,sans-serif;
+  font-family: var(--font-sans);
   font-size: 14px;
   /* required for ScrollSpy plugin */
   position: relative;

--- a/docs/_static/wren.css
+++ b/docs/_static/wren.css
@@ -241,8 +241,12 @@ div.nav-left li.current > a.current {
   z-index: 1001;
 }
 
-div.nav-left li.current > a.current:not(:only-child)::before {
+div.nav-left li.current > a:not(:only-child)::before {
   content: "\f0d7";
+  left: -8px;
+}
+
+div.nav-left li.current > a.current:not(:only-child)::before {
   left: 4px;
 }
 


### PR DESCRIPTION
old|new
---|---
<img width="270" alt="Screen Shot 2020-10-28 at 11 18 01 AM" src="https://user-images.githubusercontent.com/4231472/97479299-4e12f080-190f-11eb-85ff-d0df10a300da.png">|<img width="269" alt="Screen Shot 2020-10-28 at 11 18 16 AM" src="https://user-images.githubusercontent.com/4231472/97479309-510de100-190f-11eb-9ce7-5fb402e6c10c.png">


Closes #2714