### PR TITLE
Adjust ppc builds

### DIFF
--- a/ci/Jenkinsfile.groovy
+++ b/ci/Jenkinsfile.groovy
@@ -71,11 +71,11 @@ DOCKER_IMAGE_X86_64_MANYLINUX = "quay.io/pypa/manylinux2010_x86_64"
 
 // These variables will be initialized at the <checkout> stage
 doLargeFreadTests = false
-isMainJob       = false
+isMainJob         = false
 isRelease         = false
 doExtraTests      = false
 doPpcTests        = false
-doPpcBuild        = true
+doPpcBuild        = false
 doPy38Tests       = false
 doCoverage        = false
 doPublish         = false

--- a/ci/Jenkinsfile.groovy
+++ b/ci/Jenkinsfile.groovy
@@ -146,7 +146,7 @@ ansiColor('xterm') {
                                                   params.FORCE_ALL_TESTS)
                             doExtraTests       = (isMainJob || isRelease || params.FORCE_ALL_TESTS)
                             doPpcTests         = (doExtraTests || params.FORCE_BUILD_PPC64LE) && !params.DISABLE_PPC64LE_TESTS
-                            doPpcBuild         = doPpcTests || isMainJob || isRelease || params.FORCE_BUILD_PPC64LE
+                            doPpcBuild         = doPpcBuild || doPpcTests || isMainJob || isRelease || params.FORCE_BUILD_PPC64LE
                             doPy38Tests        = doExtraTests
                             doCoverage         = !params.DISABLE_COVERAGE && false   // disable for now
                         }

--- a/ci/Jenkinsfile.groovy
+++ b/ci/Jenkinsfile.groovy
@@ -302,8 +302,9 @@ ansiColor('xterm') {
                                 dir(stageDir) {
                                     unstash 'datatable-sources'
                                     sh """
-                                        podman run --rm --init \
-                                            --security-opt="label=disable" \
+                                        podman run \
+                                            --userns=keep-id --security-opt="label=disable" \
+                                            --rm --init \
                                             -v `pwd`:/dot \
                                             -e DT_RELEASE=${DT_RELEASE} \
                                             -e DT_BUILD_SUFFIX=${DT_BUILD_SUFFIX} \

--- a/ci/Jenkinsfile.groovy
+++ b/ci/Jenkinsfile.groovy
@@ -75,7 +75,7 @@ isMainJob       = false
 isRelease         = false
 doExtraTests      = false
 doPpcTests        = false
-doPpcBuild        = false
+doPpcBuild        = true
 doPy38Tests       = false
 doCoverage        = false
 doPublish         = false
@@ -302,7 +302,7 @@ ansiColor('xterm') {
                                 dir(stageDir) {
                                     unstash 'datatable-sources'
                                     sh """
-                                        docker run --rm --init \
+                                        podman run --rm --init \
                                             --userns=keep-id --security-opt="label=disable" \
                                             -v `pwd`:/dot \
                                             -e DT_RELEASE=${DT_RELEASE} \

--- a/ci/Jenkinsfile.groovy
+++ b/ci/Jenkinsfile.groovy
@@ -303,7 +303,6 @@ ansiColor('xterm') {
                                     unstash 'datatable-sources'
                                     sh """
                                         docker run \
-                                            --userns=keep-id --security-opt="label=disable" \
                                             --rm --init \
                                             -v `pwd`:/dot \
                                             -e DT_RELEASE=${DT_RELEASE} \

--- a/ci/Jenkinsfile.groovy
+++ b/ci/Jenkinsfile.groovy
@@ -302,7 +302,7 @@ ansiColor('xterm') {
                                 dir(stageDir) {
                                     unstash 'datatable-sources'
                                     sh """
-                                        podman run \
+                                        docker run \
                                             --userns=keep-id --security-opt="label=disable" \
                                             --rm --init \
                                             -v `pwd`:/dot \

--- a/ci/Jenkinsfile.groovy
+++ b/ci/Jenkinsfile.groovy
@@ -303,7 +303,7 @@ ansiColor('xterm') {
                                     unstash 'datatable-sources'
                                     sh """
                                         podman run --rm --init \
-                                            --userns=keep-id --security-opt="label=disable" \
+                                            --security-opt="label=disable" \
                                             -v `pwd`:/dot \
                                             -e DT_RELEASE=${DT_RELEASE} \
                                             -e DT_BUILD_SUFFIX=${DT_BUILD_SUFFIX} \


### PR DESCRIPTION
New machines, that caused build errors on ppc, are temporarily disabled by @abal5, so in this PR we just revert some docker related changes and make minor improvements to `Jenkinsfile.groovy`.