### PR TITLE
Fix numerous warnings in documentation build

### DIFF
--- a/docs/_static/wren.css
+++ b/docs/_static/wren.css
@@ -78,6 +78,10 @@ a {
   color: #6395d4;
 }
 
+a:hover {
+  text-decoration: none;
+}
+
 a.reference.external::after {
   content: "\f08e";
   font-family: 'FontAwesome';

--- a/docs/_static/wren.css
+++ b/docs/_static/wren.css
@@ -462,6 +462,7 @@ div.highlight-box button.close {
 
 table.api-table {
   border: none;
+  margin-bottom: 18px;
 }
 
 table.api-table tr td {
@@ -493,7 +494,6 @@ table.api-table td:first-child a code.literal {
 
 table.api-table td:first-child a:hover code.literal {
   color: #223d5a;
-  text-decoration: underline;
 }
 
 

--- a/docs/_static/wren.css
+++ b/docs/_static/wren.css
@@ -303,11 +303,23 @@ div.nav-right > #toc-local {
 div.nav-right > #toc-local a.list-group-item {
   background: transparent;
   border: none;
+  border-left: 4px solid transparent;
   color: #696e8e;
   font-size: 13px;
   line-height: 1.2;
   list-style-type: none;
-  padding: 4px 0;
+  padding: 4px 0 4px 6px;
+  margin-left: -9px;
+}
+
+div.nav-right > #toc-local a.list-group-item.level-2 {
+  padding-left: 15px;
+  font-size: 12px;
+}
+
+div.nav-right > #toc-local a.list-group-item.level-3 {
+  padding-left: 25px;
+  font-size: 11px;
 }
 
 div.nav-right > #toc-local a:first-child {
@@ -324,10 +336,8 @@ div.nav-right > #toc-local a:hover {
 }
 
 div.nav-right > #toc-local a.list-group-item.active {
-  border-left: 4px solid #4684b6;
+  border-left-color: #4684b6;
   color: #212529;
-  margin-left: -9px;
-  padding-left: 5px;
 }
 
 

--- a/docs/api/exceptions.rst
+++ b/docs/api/exceptions.rst
@@ -59,16 +59,15 @@ Warnings
 
 Warnings are issued when it is helpful to inform the user of some condition
 in a program, that doesn't result in an exception and the program termination.
-``datatable`` may issue the following warnings:
+We may issue the following warnings:
 
 
 .. list-table::
     :widths: auto
     :class: api-table
 
-    * - :exc:`FutureWarning`
-      - A built-in python `warning <https://docs.python.org/3/library/exceptions.html#FutureWarning>`_
-        about deprecated features.
+    * - :py:exc:`FutureWarning`
+      - A built-in python warning about deprecated features.
 
     * - :exc:`DatatableWarning`
       - A ``datatable`` generic warning.
@@ -82,10 +81,12 @@ in a program, that doesn't result in an exception and the program termination.
     :hidden:
 
     DtException            <exceptions/dtexception>
+    DtWarning              <exceptions/dtwarning>
     ImportError            <exceptions/importerror>
     InvalidOperationError  <exceptions/invalidoperationerror>
     IndexError             <exceptions/indexerror>
     IOError                <exceptions/ioerror>
+    IOWarning              <exceptions/iowarning>
     KeyError               <exceptions/keyerror>
     MemoryError            <exceptions/memoryerror>
     NotImplementedError    <exceptions/notimplementederror>

--- a/docs/api/exceptions.rst
+++ b/docs/api/exceptions.rst
@@ -5,30 +5,9 @@
 datatable.exceptions
 ====================
 
-This module contains warnings and exceptions that ``datatable`` may
+This module contains warnings and exceptions that :mod:`datatable` may
 throw during runtime.
 
-Warnings
---------
-
-Warnings are issued when it is helpful to inform the user of some condition
-in a program, that doesn't result in an exception and the program termination.
-``datatable`` may issue the following warnings:
-
-
-.. list-table::
-    :widths: auto
-    :class: api-table
-
-    * - :exc:`FutureWarning`
-      - A built-in python `warning <https://docs.python.org/3/library/exceptions.html#FutureWarning>`_
-        about deprecated features.
-
-    * - :exc:`DatatableWarning`
-      - A ``datatable`` generic warning.
-
-    * - :exc:`IOWarning`
-      - A warning regarding the input/output operation.
 
 
 Exceptions
@@ -72,6 +51,31 @@ The following exceptions may be thrown:
 
     * - :exc:`ValueError`
       - Equivalient to the built-in :py:exc:`ValueError`.
+
+
+
+Warnings
+--------
+
+Warnings are issued when it is helpful to inform the user of some condition
+in a program, that doesn't result in an exception and the program termination.
+``datatable`` may issue the following warnings:
+
+
+.. list-table::
+    :widths: auto
+    :class: api-table
+
+    * - :exc:`FutureWarning`
+      - A built-in python `warning <https://docs.python.org/3/library/exceptions.html#FutureWarning>`_
+        about deprecated features.
+
+    * - :exc:`DatatableWarning`
+      - A ``datatable`` generic warning.
+
+    * - :exc:`IOWarning`
+      - A warning regarding the input/output operation.
+
 
 
 .. toctree::

--- a/docs/api/exceptions.rst
+++ b/docs/api/exceptions.rst
@@ -44,40 +44,47 @@ The following exceptions may be thrown:
     :class: api-table
 
     * - :exc:`ImportError`
-      - inherited from the built-in
-        `ImportError <https://docs.python.org/3/library/exceptions.html#ImportError>`_.
+      - Equivalient to the built-in :py:exc:`ImportError`.
 
     * - :exc:`IndexError`
-      - inherited from the built-in
-        `IndexError <https://docs.python.org/3/library/exceptions.html#IndexError>`_.
+      - Equivalient to the built-in :py:exc:`IndexError`.
 
     * - :exc:`InvalidOperationError`
       - The operation requested is illegal for the given combination of parameters.
 
     * - :exc:`IOError`
-      - inherited from the built-in
-        `IOError <https://docs.python.org/3/library/exceptions.html#IOError>`_.
+      - Equivalient to the built-in :py:exc:`IOError`.
 
     * - :exc:`KeyError`
-      - inherited from the built-in
-        `KeyError <https://docs.python.org/3/library/exceptions.html#KeyError>`_.
+      - Equivalient to the built-in :py:exc:`KeyError`.
 
     * - :exc:`MemoryError`
-      - inherited from the built-in
-        `MemoryError <https://docs.python.org/3/library/exceptions.html#MemoryError>`_.
+      - Equivalient to the built-in :py:exc:`MemoryError`.
 
     * - :exc:`NotImplementedError`
-      - inherited from the built-in
-        `NotImplementedError <https://docs.python.org/3/library/exceptions.html#NotImplementedError>`_.
+      - Equivalient to the built-in :py:exc:`NotImplementedError`.
 
     * - :exc:`OverflowError`
-      - inherited from the built-in
-        `OverflowError <https://docs.python.org/3/library/exceptions.html#OverflowError>`_.
+      - Equivalient to the built-in :py:exc:`OverflowError`.
 
     * - :exc:`TypeError`
-      - inherited from the built-in
-        `TypeError <https://docs.python.org/3/library/exceptions.html#TypeError>`_.
+      - Equivalient to the built-in :py:exc:`TypeError`.
 
     * - :exc:`ValueError`
-      - inherited from the built-in
-        `ValueError <https://docs.python.org/3/library/exceptions.html#ValueError>`_.
+      - Equivalient to the built-in :py:exc:`ValueError`.
+
+
+.. toctree::
+    :hidden:
+
+    DtException            <exceptions/dtexception>
+    ImportError            <exceptions/importerror>
+    InvalidOperationError  <exceptions/invalidoperationerror>
+    IndexError             <exceptions/indexerror>
+    IOError                <exceptions/ioerror>
+    KeyError               <exceptions/keyerror>
+    MemoryError            <exceptions/memoryerror>
+    NotImplementedError    <exceptions/notimplementederror>
+    OverflowError          <exceptions/overflowerror>
+    TypeError              <exceptions/typeerror>
+    ValueError             <exceptions/valueerror>

--- a/docs/api/exceptions/dtexception.rst
+++ b/docs/api/exceptions/dtexception.rst
@@ -1,0 +1,5 @@
+
+.. xexc:: datatable.exceptions.DtException
+    :src: --
+
+    Base class for all other exceptions raised by ``datatable``.

--- a/docs/api/exceptions/dtexception.rst
+++ b/docs/api/exceptions/dtexception.rst
@@ -2,4 +2,4 @@
 .. xexc:: datatable.exceptions.DtException
     :src: --
 
-    Base class for all other exceptions raised by ``datatable``.
+    Base class for all exceptions raised by ``datatable``.

--- a/docs/api/exceptions/dtwarning.rst
+++ b/docs/api/exceptions/dtwarning.rst
@@ -2,4 +2,4 @@
 .. xexc:: datatable.exceptions.DatatableWarning
     :src: --
 
-    Generic warning from the datatable.
+    Generic warning from the :mod:`datatable`.

--- a/docs/api/exceptions/dtwarning.rst
+++ b/docs/api/exceptions/dtwarning.rst
@@ -1,0 +1,5 @@
+
+.. xexc:: datatable.exceptions.DatatableWarning
+    :src: --
+
+    Generic warning from the datatable.

--- a/docs/api/exceptions/importerror.rst
+++ b/docs/api/exceptions/importerror.rst
@@ -5,6 +5,6 @@
     This exception may be raised when a datatable operation requires an external
     module or library, but that module is not available. Examples of such
     operations include: converting a Frame into a pandas DataFrame, or into an
-    arrow Table, or reading an Excel file.
+    Arrow Table, or reading an Excel file.
 
     Inherits from Python :py:exc:`ImportError` and :exc:`datatable.exceptions.DtException`.

--- a/docs/api/exceptions/importerror.rst
+++ b/docs/api/exceptions/importerror.rst
@@ -1,0 +1,10 @@
+
+.. xexc:: datatable.exceptions.ImportError
+    :src: --
+
+    This exception may be raised when a datatable operation requires an external
+    module or library, but that module is not available. Examples of such
+    operations include: converting a Frame into a pandas DataFrame, or into an
+    arrow Table, or reading an Excel file.
+
+    Inherits from Python :py:exc:`ImportError` and :exc:`datatable.exceptions.DtException`.

--- a/docs/api/exceptions/indexerror.rst
+++ b/docs/api/exceptions/indexerror.rst
@@ -1,0 +1,5 @@
+
+.. xexc:: datatable.exceptions.IndexError
+    :src: --
+
+    Inherits from Python :py:exc:`IndexError` and :exc:`datatable.exceptions.DtException`.

--- a/docs/api/exceptions/indexerror.rst
+++ b/docs/api/exceptions/indexerror.rst
@@ -2,4 +2,7 @@
 .. xexc:: datatable.exceptions.IndexError
     :src: --
 
+    Raised when accessing an element of a frame by index, but the value of the
+    index falls outside of the boundaries of the frame.
+
     Inherits from Python :py:exc:`IndexError` and :exc:`datatable.exceptions.DtException`.

--- a/docs/api/exceptions/invalidoperationerror.rst
+++ b/docs/api/exceptions/invalidoperationerror.rst
@@ -1,0 +1,5 @@
+
+.. xexc:: datatable.exceptions.InvalidOperationError
+    :src: --
+
+    Inherits from :exc:`datatable.exceptions.DtException`.

--- a/docs/api/exceptions/invalidoperationerror.rst
+++ b/docs/api/exceptions/invalidoperationerror.rst
@@ -5,7 +5,7 @@
     Raised in multiple scenarios whenever the requested operation is
     logically invalid with the given combination of parameters.
 
-    For example, :func:`cbind <dt.Frame.cbind>`-ing several frames with
+    For example, :meth:`cbind <dt.Frame.cbind>`-ing several frames with
     incompatible shapes.
 
     Inherits from :exc:`datatable.exceptions.DtException`.

--- a/docs/api/exceptions/invalidoperationerror.rst
+++ b/docs/api/exceptions/invalidoperationerror.rst
@@ -2,4 +2,10 @@
 .. xexc:: datatable.exceptions.InvalidOperationError
     :src: --
 
+    Raised in multiple scenarios whenever the requested operation is
+    logically invalid with the given combination of parameters.
+
+    For example, :func:`cbind <dt.Frame.cbind>`-ing several frames with
+    incompatible shapes.
+
     Inherits from :exc:`datatable.exceptions.DtException`.

--- a/docs/api/exceptions/ioerror.rst
+++ b/docs/api/exceptions/ioerror.rst
@@ -2,4 +2,7 @@
 .. xexc:: datatable.exceptions.IOError
     :src: --
 
+    Raised during any IO operation, such as reading/writing CSV or Jay files.
+    The most common cause for such an error is an invalid input file.
+
     Inherits from Python :py:exc:`IOError` and :exc:`datatable.exceptions.DtException`.

--- a/docs/api/exceptions/ioerror.rst
+++ b/docs/api/exceptions/ioerror.rst
@@ -1,0 +1,5 @@
+
+.. xexc:: datatable.exceptions.IOError
+    :src: --
+
+    Inherits from Python :py:exc:`IOError` and :exc:`datatable.exceptions.DtException`.

--- a/docs/api/exceptions/iowarning.rst
+++ b/docs/api/exceptions/iowarning.rst
@@ -1,0 +1,7 @@
+
+.. xexc:: datatable.exceptions.IOWarning
+    :src: --
+
+    This warning is raised whenever you read an input file and there are some
+    irregularities in the input that we can recover from, but perhaps the user
+    should be informed that something wasn't quite right.

--- a/docs/api/exceptions/keyerror.rst
+++ b/docs/api/exceptions/keyerror.rst
@@ -2,4 +2,7 @@
 .. xexc:: datatable.exceptions.KeyError
     :src: --
 
+    Raised when accessing a column of a frame by name, but the name lookup
+    fails to find such a column.
+
     Inherits from Python :py:exc:`KeyError` and :exc:`datatable.exceptions.DtException`.

--- a/docs/api/exceptions/keyerror.rst
+++ b/docs/api/exceptions/keyerror.rst
@@ -1,0 +1,5 @@
+
+.. xexc:: datatable.exceptions.KeyError
+    :src: --
+
+    Inherits from Python :py:exc:`KeyError` and :exc:`datatable.exceptions.DtException`.

--- a/docs/api/exceptions/memoryerror.rst
+++ b/docs/api/exceptions/memoryerror.rst
@@ -2,4 +2,7 @@
 .. xexc:: datatable.exceptions.MemoryError
     :src: --
 
+    This exception is raised whenever any operation fails to allocate the
+    required amount of memory.
+
     Inherits from Python :py:exc:`MemoryError` and :exc:`datatable.exceptions.DtException`.

--- a/docs/api/exceptions/memoryerror.rst
+++ b/docs/api/exceptions/memoryerror.rst
@@ -1,0 +1,5 @@
+
+.. xexc:: datatable.exceptions.MemoryError
+    :src: --
+
+    Inherits from Python :py:exc:`MemoryError` and :exc:`datatable.exceptions.DtException`.

--- a/docs/api/exceptions/notimplementederror.rst
+++ b/docs/api/exceptions/notimplementederror.rst
@@ -1,0 +1,5 @@
+
+.. xexc:: datatable.exceptions.NotImplementedError
+    :src: --
+
+    Inherits from Python :py:exc:`NotImplementedError` and :exc:`datatable.exceptions.DtException`.

--- a/docs/api/exceptions/notimplementederror.rst
+++ b/docs/api/exceptions/notimplementederror.rst
@@ -2,4 +2,7 @@
 .. xexc:: datatable.exceptions.NotImplementedError
     :src: --
 
+    Raised whenever an operation with given parameter values or input types
+    is in theory valid, but hasn't been implemented yet.
+
     Inherits from Python :py:exc:`NotImplementedError` and :exc:`datatable.exceptions.DtException`.

--- a/docs/api/exceptions/overflowerror.rst
+++ b/docs/api/exceptions/overflowerror.rst
@@ -1,0 +1,5 @@
+
+.. xexc:: datatable.exceptions.OverflowError
+    :src: --
+
+    Inherits from Python :py:exc:`OverflowError` and :exc:`datatable.exceptions.DtException`.

--- a/docs/api/exceptions/overflowerror.rst
+++ b/docs/api/exceptions/overflowerror.rst
@@ -2,4 +2,7 @@
 .. xexc:: datatable.exceptions.OverflowError
     :src: --
 
+    Rare error that may occur if you pass a parameter that is too large to fit
+    into C++ `int64` type, or sometimes larger than a `double`.
+
     Inherits from Python :py:exc:`OverflowError` and :exc:`datatable.exceptions.DtException`.

--- a/docs/api/exceptions/typeerror.rst
+++ b/docs/api/exceptions/typeerror.rst
@@ -2,4 +2,9 @@
 .. xexc:: datatable.exceptions.TypeError
     :src: --
 
+    One of the most common exceptions raised by :mod:`datatable`, this occurs
+    when either a function receives an argument of unexpected type, or incorrect
+    number of arguments, or whenever an operation is requested on a column whose
+    type is not suitable for that operation.
+
     Inherits from Python :py:exc:`TypeError` and :exc:`datatable.exceptions.DtException`.

--- a/docs/api/exceptions/typeerror.rst
+++ b/docs/api/exceptions/typeerror.rst
@@ -1,0 +1,5 @@
+
+.. xexc:: datatable.exceptions.TypeError
+    :src: --
+
+    Inherits from Python :py:exc:`TypeError` and :exc:`datatable.exceptions.DtException`.

--- a/docs/api/exceptions/valueerror.rst
+++ b/docs/api/exceptions/valueerror.rst
@@ -2,4 +2,8 @@
 .. xexc:: datatable.exceptions.ValueError
     :src: --
 
+    Very common exception that occurs whenever an argument is passed to a
+    function and that argument has the correct type, yet the value is
+    not valid.
+
     Inherits from Python :py:exc:`ValueError` and :exc:`datatable.exceptions.DtException`.

--- a/docs/api/exceptions/valueerror.rst
+++ b/docs/api/exceptions/valueerror.rst
@@ -1,0 +1,5 @@
+
+.. xexc:: datatable.exceptions.ValueError
+    :src: --
+
+    Inherits from Python :py:exc:`ValueError` and :exc:`datatable.exceptions.DtException`.

--- a/docs/api/fexpr/__init__.rst
+++ b/docs/api/fexpr/__init__.rst
@@ -7,7 +7,7 @@
 
     Create a new :class:`dt.FExpr` object out of ``e``.
 
-    The ``FExpr`` is serve as a simple wrapper of the underlying object,
+    The ``FExpr`` serves as a simple wrapper of the underlying object,
     allowing it to be combined with othef ``FExpr``s.
 
     This constructor almost never needs to be run manually by the user.

--- a/docs/api/fexpr/__init__.rst
+++ b/docs/api/fexpr/__init__.rst
@@ -5,7 +5,7 @@
     __init__(self, e)
     --
 
-    Create a new :class:`dt.FExpr` object out of `e`.
+    Create a new :class:`dt.FExpr` object out of ``e``.
 
     The ``FExpr`` is serve as a simple wrapper of the underlying object,
     allowing it to be combined with othef ``FExpr``s.
@@ -18,5 +18,5 @@
     e: None | bool | int | str | float | slice | list |  tuple | dict | \
        type | stype | ltype | Generator | FExpr | Frame | range | \
        pd.DataFrame | pd.Series | np.array | np.ma.masked_array
-        The argument that will be converted into an `FExpr`.
+        The argument that will be converted into an ``FExpr``.
 

--- a/docs/api/frame/__getitem__.rst
+++ b/docs/api/frame/__getitem__.rst
@@ -247,11 +247,11 @@
             :widths: auto
             :class: api-table
 
-            * - :exc:`KeyError`
+            * - :exc:`KeyError <dt.exceptions.KeyError>`
               - raised if the column with the given name does not
                 exist in the frame.
 
-            * - :exc:`IndexError`
+            * - :exc:`IndexError <dt.exceptions.IndexError>`
               - raised if the column does not exist at the provided
                 index `j`.
 

--- a/docs/api/index-api.rst
+++ b/docs/api/index-api.rst
@@ -181,7 +181,7 @@ Other
     * - :data:`g`
       - Secondary namespace used during :meth:`DT[..., join()] <dt.Frame.__getitem__>` call.
 
-    * - :data:`options`
+    * - :class:`options`
       - ``datatable`` options.
 
 

--- a/docs/api/options.rst
+++ b/docs/api/options.rst
@@ -1,6 +1,6 @@
 
-.. xdata:: datatable.options
-    :src: src/datatable/__init__.py options
+.. xclass:: datatable.options
+    :src: src/datatable/options.py Config
 
     This namespace contains the following option groups:
 
@@ -8,19 +8,19 @@
         :widths: auto
         :class: api-table
 
-        * - :data:`.debug <datatable.options.debug>`
+        * - :class:`.debug <datatable.options.debug>`
           - Debug options.
 
-        * - :data:`.display <datatable.options.display>`
+        * - :class:`.display <datatable.options.display>`
           - Display options.
 
-        * - :data:`.frame <datatable.options.frame>`
-          - :class:`Frame` related options.
+        * - :class:`.frame <datatable.options.frame>`
+          - :class:`Frame <dt.Frame>`-related options.
 
-        * - :data:`.fread <datatable.options.fread>`
-          - :func:`fread()` related options.
+        * - :class:`.fread <datatable.options.fread>`
+          - :func:`fread() <dt.fread>`-related options.
 
-        * - :data:`.progress <datatable.options.progress>`
+        * - :class:`.progress <datatable.options.progress>`
           - Progress reporting options.
 
     It also contains the following individual options:

--- a/docs/api/options/debug.rst
+++ b/docs/api/options/debug.rst
@@ -1,5 +1,6 @@
 
-.. xdata:: datatable.options.debug
+.. xclass:: datatable.options.debug
+    :qual-type: class
     :src: --
 
     This namespace contains the following debug options:

--- a/docs/api/options/display.rst
+++ b/docs/api/options/display.rst
@@ -1,5 +1,6 @@
 
-.. xdata:: datatable.options.display
+.. xclass:: datatable.options.display
+    :qual-type: class
     :src: --
 
     This namespace contains the following display options:

--- a/docs/api/options/frame.rst
+++ b/docs/api/options/frame.rst
@@ -1,5 +1,6 @@
 
-.. xdata:: datatable.options.frame
+.. xclass:: datatable.options.frame
+    :qual-type: class
     :src: --
 
     This namespace contains the following :class:`Frame <dt.Frame>` options:

--- a/docs/api/options/fread.rst
+++ b/docs/api/options/fread.rst
@@ -1,5 +1,6 @@
 
-.. xdata:: datatable.options.fread
+.. xclass:: datatable.options.fread
+    :qual-type: class
     :src: --
 
     This namespace contains the following :func:`fread <dt.fread>` option groups:
@@ -8,7 +9,7 @@
         :widths: auto
         :class: api-table
 
-        * - :data:`.log <datatable.options.fread.log>`
+        * - :class:`.log <datatable.options.fread.log>`
           - Logging-related options.
 
 .. toctree::

--- a/docs/api/options/fread/log.rst
+++ b/docs/api/options/fread/log.rst
@@ -1,5 +1,6 @@
 
-.. xdata:: datatable.options.fread.log
+.. xclass:: datatable.options.fread.log
+    :qual-type: class
     :src: --
 
     This property controls the following logging options:

--- a/docs/api/options/progress.rst
+++ b/docs/api/options/progress.rst
@@ -1,5 +1,6 @@
 
-.. xdata:: datatable.options.progress
+.. xclass:: datatable.options.progress
+    :qual-type: class
     :src: --
 
     This namespace contains the following progress reporting options:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -185,7 +185,9 @@ def get_local_toc(document):
     html_text = "<div id='toc-local' class='list-group'>\n"
     html_text += " <b>Table of contents</b>\n"
     for title, node_id, level in titles:
-        html_text += f"  <a href='#{node_id}' class='list-group-item'>{title}</a>\n"
+        if level <= 1:
+            return document.reporter.error("More than one <h1> title on the page")
+        html_text += f"  <a href='#{node_id}' class='list-group-item level-{level-1}'>{title}</a>\n"
     html_text += "</div>\n"
     return html_text
 

--- a/docs/manual/comparison_with_pandas.rst
+++ b/docs/manual/comparison_with_pandas.rst
@@ -1,18 +1,17 @@
-.. py:currentmodule:: datatable
-
-
-.. raw:: html
-
-    <style>
-    .wy-nav-content { max-width: 100%; }
-    </style>
-
 
 Comparison with pandas
 ======================
-A lot of potential ``datatable`` users are likely to have some familiarity with `pandas <https://pandas.pydata.org/pandas-docs/stable/index.html>`__; as such, this page provides some examples of how various ``pandas`` operations can be performed within ``datatable``. ``datatable`` emphasizes speed and big data support (an area that ``pandas`` struggles with); it also has an expressive and concise syntax, which makes ``datatable`` also useful for small datasets.
+A lot of potential :mod:`datatable` users are likely to have some familiarity
+with `pandas`_; as such, this page provides some examples of how various
+pandas operations can be performed within datatable. The datatable module
+emphasizes speed and big data support (an area that pandas struggles with);
+it also has an expressive and concise syntax, which makes datatable also
+useful for small datasets.
 
-.. note:: In ``pandas``, there are two fundamental data structures, `Series <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.html#pandas.Series>`__ and `DataFrame <https://pandas.pydata.org/pandas-docs/stable/user_guide/dsintro.html#dataframe>`__. In ``datatable``, there is only one fundamental data structure - the `Frame <https://datatable.readthedocs.io/en/latest/api/frame.html#datatable-frame>`__. Most of the comparisons will be between ``pandas`` DataFrame and ``datatable`` Frame.
+Note: in pandas, there are two fundamental data structures: `Series`_ and
+`DataFrame`_. In datatable, there is only one fundamental data structure —
+the :class:`Frame`. Most of the comparisons will be between pandas ``DataFrame``
+and datatable ``Frame``.
 
 .. code-block:: python
 
@@ -111,42 +110,39 @@ Same as above, by position
 =================================================  ============================================
 
 
-In ``pandas`` every frame has a row index, and if a filtration is executed, the row number is returned:
+In pandas every frame has a row index, and if a filtration is executed,
+the row numbers are kept::
 
-.. code-block:: python
+    >>> # pandas
+    >>> df.loc[df['A'] > 3]
 
-    # pandas
-    df.loc[df['A']>3]
-
-        A   B   C   D
-    3   4   7   10  9
-    4   5   8   11     -1
-
-``datatable`` has no notion of a row index; the row numbers displayed are just for convenience:
-
-.. code-block:: python
-
-    >>> DT[f.A>3, :]
-
-        A   B   C   D
-    0   4   7   10  9
-    1   5   8   11     −1
+        A   B   C    D
+    3   4   7   10   9
+    4   5   8   11  -1
 
 
+Datatable has no notion of a row index; the row numbers displayed are just
+for convenience::
 
-In ``pandas``, the index can be numbers, or characters, or intervals, or even MultiIndexes; you can subset rows on these labels.
+    >>> DT[f.A > 3, :]
 
-.. code-block:: python
+        A   B   C    D
+    0   4   7   10   9
+    1   5   8   11  −1
 
-    # pandas
+
+In pandas, the index can be numbers, or characters, or intervals, or even
+``MultiIndex``es; you can subset rows on these labels::
+
+    >>> # pandas
     >>> df1 = df.set_index(pd.Index(['a','b','c','d','e']))
 
-        A   B   C   D
-    a   1   4   7   5
-    b   2   5   8   7
-    c   3   6   9   2
-    d   4   7   10  9
-    e   5   8   11     -1
+        A   B   C    D
+    a   1   4   7    5
+    b   2   5   8    7
+    c   3   6   9    2
+    d   4   7   10   9
+    e   5   8   11  -1
 
     >>> df1.loc["a":"c"]
 
@@ -155,9 +151,10 @@ In ``pandas``, the index can be numbers, or characters, or intervals, or even Mu
     b   2   5   8   7
     c   3   6   9   2
 
-``datatable`` has the `key <https://datatable.readthedocs.io/en/latest/api/frame/key.html#datatable-frame-key>`__ property, which is meant as an equivalent of pandas indices, but its purpose at the moment is for joins, not for subsetting data:
 
-.. code-block:: python
+Datatable has the :attr:`key <dt.Frame.key>` property, which is meant as
+an equivalent of pandas indices, but its purpose at the moment is for joins,
+not for subsetting data::
 
     >>> # datatable
     >>> data = {"A": [1, 2, 3, 4, 5],
@@ -180,9 +177,10 @@ In ``pandas``, the index can be numbers, or characters, or intervals, or even Mu
     >>> DT1["a":"c", :]
     TypeError: A string slice cannot be used as a row selector
 
-pandas' ``loc`` notation works on labels, while ``iloc`` works on actual position. This is noticeable during row selection.  ``datatable``, however, works only on position.
 
-.. code-block:: python
+Pandas' ``.loc`` notation works on labels, while ``.iloc`` works on actual
+positions. This is noticeable during row selection. Datatable, however, works
+only on positions::
 
     >>> # pandas
     >>> df1 = df.set_index('C')
@@ -195,34 +193,28 @@ pandas' ``loc`` notation works on labels, while ``iloc`` works on actual positio
     10  4   7   9
     11  5   8  -1
 
-Selecting with loc for the row with number 7 returns no error :
+Selecting with ``.loc`` for the row with number 7 returns no error::
 
-.. code-block:: python
-
-    # pandas
-    df1.loc[7]
+    >>> # pandas
+    >>> df1.loc[7]
 
     A    1
     B    4
     D    5
     Name: 7, dtype: int64
 
-However, selecting with ``iloc`` for the row with number 7 returns an error, because positionally, there is no row 7 :
+However, selecting with ``iloc`` for the row with number 7 returns an error,
+because positionally, there is no row 7::
 
-.. code-block:: python
-
-    # pandas
-    df.iloc[7]
-
-    ---------------------------------------------------------------------------
-    # Lots of code here related to the error message
-    .....
+    >>> # pandas
+    >>> df.iloc[7]
 
     IndexError: single positional indexer is out-of-bounds
 
-As stated earlier, ``datatable`` has the `key <https://datatable.readthedocs.io/en/latest/api/frame/key.html#datatable-frame-key>`__ property, which is used for joins, not row subsetting, and as such selection similar to ``loc`` with the row label is not possible.
 
-.. code-block:: python
+As stated earlier, datatable has the :attr:`dt.Frame.key` property, which is
+used for joins, not row subsetting, and as such selection similar to ``loc``
+with the row label is not possible::
 
     >>> # datatable
     >>> DT.key = 'C'
@@ -233,20 +225,16 @@ As stated earlier, ``datatable`` has the `key <https://datatable.readthedocs.io/
     8   2   5   7
     9   3   6   2
     10  4   7   9
-    11  5   8      −1
+    11  5   8  −1
 
     >>> # this will fail
     >>> DT[7, :]
 
-    ---------------------------------------------------------------------------
-    ValueError                                Traceback (most recent call last)
-    <ipython-input-107-e5be0baed765> in <module>
-    ----> 1 DT[7, :]
-
     ValueError: Row 7 is invalid for a frame with 5 rows
 
 
-Add New/Update Existing Columns
+
+Add new/update existing columns
 -------------------------------
 
 =======================================================  ===============================================================
@@ -277,10 +265,11 @@ Update multiple columns
 ``df.loc[:, "A":"C"] = np.arange(15).reshape(-1,3)``        ``DT[:, "A":"C"] = np.arange(15).reshape(-1,3)``
 =======================================================  ===============================================================
 
-.. note:: In ``datatable``, the :func:`update()` method is in-place; reassigment to the Frame ``DT`` is not required.
+.. note:: In datatable, the :func:`update()` method is in-place; reassigment to the Frame ``DT`` is not required.
 
 
-Rename Columns
+
+Rename columns
 --------------
 
 =======================================================  ===============================================================
@@ -293,19 +282,19 @@ Rename multiple columns
 ``df = df.rename(columns={"A":"col_A", "B":"col_B"})``      ``DT.names = {"A" : "col_A", "B": "col_B"}``
 =======================================================  ===============================================================
 
-In datatable, you can select and rename columns at the same time, by passing a dictionary of :ref:`f-expressions` into the ``j`` section :
-
-.. code-block:: python
+In datatable, you can select and rename columns at the same time, by passing
+a dictionary of :ref:`f-expressions` into the ``j`` section::
 
     >>> # datatable
     >>> DT[:, {"A": f.A, "box": f.B, "C": f.C, "D": f.D * 2}]
 
-    A   box C   D
+        A   box C   D
     0   1   4   7   10
     1   2   5   8   14
     2   3   6   9   4
     3   4   7   10  18
     4   5   8   11  −2
+
 
 
 Delete Columns
@@ -354,11 +343,13 @@ Sort by multiple columns - different sort directions
                                                               | ``DT[:, :, sort('A', 'C', reverse=[False, True])]``
 ===========================================================  ===============================================================
 
-.. note:: By default, ``pandas`` puts NAs last in the sorted data, while ``datatable`` puts them first.
+.. note:: By default, pandas puts NAs last in the sorted data, while datatable puts them first.
 
-.. note:: In ``pandas``, there is an option to sort with a Callable; this option is not supported in ``datatable``.
+.. note:: In pandas, there is an option to sort with a Callable; this option is not supported in datatable.
 
-.. note:: In ``pandas``, you can sort on the rows or columns; in ``datatable`` sorting is column-wise only.
+.. note:: In pandas, you can sort on the rows or columns; in datatable sorting is column-wise only.
+
+
 
 Grouping and Aggregation
 ------------------------
@@ -404,13 +395,11 @@ Get the last two rows per group
 ``df.groupby("a").tail(2)``                                     ``DT[-2:, :, by("a")]``
 ===========================================================  ===============================================================
 
-Transformations within groups in pandas is done using the `transform <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.core.groupby.DataFrameGroupBy.transform.html>`__ function:
+Transformations within groups in pandas is done using the `pd.transform`_ function::
 
-.. code-block:: python
-
-    # pandas
-    grouping = df.groupby("a")["b"].transform("min")
-    df.assign(min_b=grouping)
+    >>> # pandas
+    >>> grouping = df.groupby("a")["b"].transform("min")
+    >>> df.assign(min_b=grouping)
 
         a   b   c   min_b
     0   1   2   3   2
@@ -419,12 +408,10 @@ Transformations within groups in pandas is done using the `transform <https://pa
     3   1   2   33  2
     4   2   4   50  4
 
-In ``datatable``, transformations occur within the ``j`` section; in the presence of :func:`by()`, the computations within ``j`` are per group:
+In datatable, transformations occur within the ``j`` section; in the presence of :func:`by()`, the computations within ``j`` are per group::
 
-.. code-block:: python
-
-    # datatable
-    DT[:, f[:].extend({"min_b": dt.min(f.b)}), by("a")]
+    >>> # datatable
+    >>> DT[:, f[:].extend({"min_b": dt.min(f.b)}), by("a")]
 
         a   b   c   min_b
     0   1   2   3   2
@@ -433,16 +420,11 @@ In ``datatable``, transformations occur within the ``j`` section; in the presenc
     3   2   30  50  4
     4   2   4   50  4
 
-Note that the result above is sorted by the grouping column. If you want the data to maintain the same shape as the source data, then :func:`update()` is a better option (and usually faster):
+Note that the result above is sorted by the grouping column. If you want the data to maintain the same shape as the source data, then :func:`update()` is a better option (and usually faster)::
 
-
-.. code-block:: python
-
-    # datatable
-    DT[:, update(min_b = dt.min(f.b)), by("a")]
-
-    DT
-
+    >>> # datatable
+    >>> DT[:, update(min_b = dt.min(f.b)), by("a")]
+    >>> DT
         a   b   c   min_b
     0   1   2   3   2
     1   1   20  30  2
@@ -454,66 +436,56 @@ In pandas, some computations might require creating the column first before aggr
 
 .. code-block:: python
 
-    data = {'shop': ['A', 'B', 'A'],
-            'item_price': [123, 921, 28],
-            'item_sold': [1, 2, 4]}
-
-    df1 = pd.DataFrame(data) # pandas
-    DT1 = dt.Frame(data)  # datatable
-
-        shop    item_price  item_sold
+    >>> data = {'shop': ['A', 'B', 'A'],
+    ...         'item_price': [123, 921, 28],
+    ...         'item_sold': [1, 2, 4]}
+    >>> df1 = pd.DataFrame(data)  # pandas
+    >>> DT1 = dt.Frame(data)      # datatable
+        shop    item_price      item_sold
     0   A       123             1
     1   B       921             2
     2   A       28              4
 
-To get the total revenue, we first need to create a revenue column, then sum it in the groupby:
+To get the total revenue, we first need to create a revenue column, then sum it
+in the groupby::
 
-.. code-block:: python
+    >>> # pandas
+    >>> df1['revenue'] = df1['item_price'] * df1['item_sold']
+    >>> df1.groupby("shop")['revenue'].sum().reset_index()
+        shop    revenue
+    0   A       235
+    1   B       1842
 
-    # pandas
-    df1['revenue'] = df1['item_price'] * df1['item_sold']
-    df1.groupby("shop")['revenue'].sum().reset_index()
+In datatable, there is no need to create a temporary column; you can easily
+nest your computations in the ``j`` section; the computations will be
+executed per group::
+
+    >>> # datatable
+    >>> DT1[:, {"revenue": dt.sum(f.item_price * f.item_sold)}, by("shop")]
 
         shop    revenue
-    0   A   235
-    1   B   1842
+    0   A       235
+    1   B       1842
 
-In ``datatable``, there is no need to create a temporary column; you can easily nest your computations in the ``j`` section; the computations will be executed per group :
-
-.. code-block:: python
-
-    # datatable
-
-    DT1[:, {"revenue": dt.sum(f.item_price * f.item_sold)}, "shop"]
-
-        shop    revenue
-    0   A   235
-    1   B   1842
-
-You can learn more about the :func:`by()` function  at the `Grouping with by <https://datatable.readthedocs.io/en/latest/manual/groupby_examples.html>`__ documentation, as well as the API : :func:`by()`.
+You can learn more about the :func:`by()` function at the
+:ref:`Grouping with by` documentation.
 
 
-.. note:: pandas allows custom functions via the ``apply`` or ``pipe`` method. ``datatable`` does not yet support custom functions.
 
-.. note:: Also missing in ``datatable`` but available in pandas are cumulative functions (cumsum, cumprod, ...), some aggregate functions like `nunique`, `ngroup`, ..., as well as windows functions (rolling, expanding, ...)
-
-CONCATENATE
+Concatenate
 -----------
 
-In pandas you can combine multiple dataframes using the ``concatenate`` method; the concatenation is based on the indices :
-
-.. code-block:: python
+In pandas you can combine multiple dataframes using the ``concatenate()``
+method; the concatenation is based on the indices::
 
     # pandas
     df1 = pd.DataFrame({"A": ["a", "a", "a"], "B": range(3)})
 
     df2 = pd.DataFrame({"A": ["b", "b", "b"], "B": range(4, 7)})
 
-By default, pandas concatenates the rows, with one dataframe on top of the other:
+By default, pandas concatenates the rows, with one dataframe on top of the other::
 
-.. code-block:: python
-
-    pd.concat([df1, df2], axis = 0)
+    >>> pd.concat([df1, df2], axis = 0)
 
         A   B
     0   a   0
@@ -523,15 +495,13 @@ By default, pandas concatenates the rows, with one dataframe on top of the other
     1   b   5
     2   b   6
 
-The same functionality can be replicated in ``datatable`` using the `rbind <https://datatable.readthedocs.io/en/latest/api/frame/rbind.html#datatable-frame-rbind>`__ function:
+The same functionality can be replicated in datatable using the
+:meth:`dt.Frame.rbind` method::
 
-.. code-block:: python
-
-    # datatable
-    DT1 = dt.Frame(df1)
-    DT2 = dt.Frame(df2)
-
-    dt.rbind([DT1, DT2])
+    >>> # datatable
+    >>> DT1 = dt.Frame(df1)
+    >>> DT2 = dt.Frame(df2)
+    >>> dt.rbind([DT1, DT2])
 
         A   B
     0   a   0
@@ -541,64 +511,57 @@ The same functionality can be replicated in ``datatable`` using the `rbind <http
     4   b   5
     5   b   6
 
-Notice how in ``pandas`` the indices are preserved (you can get rid of the indices with the `ignore_index` argument), whereas in ``datatable`` the indices are not referenced.
+Notice how in pandas the indices are preserved (you can get rid of the indices
+with the ``ignore_index`` argument), whereas in datatable the indices are not
+referenced.
 
-To combine data across the columns, in ``pandas``, you set the axis argument to ``columns`` :
+To combine data across the columns, in pandas, you set the axis argument to
+``columns``::
 
-.. code-block:: python
-
-    # pandas
-    df1 = pd.DataFrame({"A": ["a", "a", "a"], "B": range(3)})
-
-    df2 = pd.DataFrame({"C": ["b", "b", "b"], "D": range(4, 7)})
-
-    df3 = pd.DataFrame({"E": ["c", "c", "c"], "F": range(7, 10)})
-
-    pd.concat([df1, df2, df3], axis = 1)
+    >>> # pandas
+    >>> df1 = pd.DataFrame({"A": ["a", "a", "a"], "B": range(3)})
+    >>> df2 = pd.DataFrame({"C": ["b", "b", "b"], "D": range(4, 7)})
+    >>> df3 = pd.DataFrame({"E": ["c", "c", "c"], "F": range(7, 10)})
+    >>> pd.concat([df1, df2, df3], axis = 1)
 
         A   B   C   D   E   F
     0   a   0   b   4   c   7
     1   a   1   b   5   c   8
     2   a   2   b   6   c   9
 
-In ``datatable``, you combine frames along the columns using the `cbind <https://datatable.readthedocs.io/en/latest/api/frame/cbind.html#datatable-frame-cbind>`__ function :
+In datatable, you combine frames along the columns using the
+:meth:`dt.Frame.cbind` method::
 
-.. code-block:: python
-
-    # datatable
-
-    DT1 = dt.Frame(df1)
-    DT2 = dt.Frame(df2)
-    DT3 = dt.Frame(df3)
-
-    dt.cbind([DT1, DT2, DT3])
+    >>> # datatable
+    >>> DT1 = dt.Frame(df1)
+    >>> DT2 = dt.Frame(df2)
+    >>> DT3 = dt.Frame(df3)
+    >>> dt.cbind([DT1, DT2, DT3])
 
         A   B   C   D   E   F
     0   a   0   b   4   c   7
     1   a   1   b   5   c   8
     2   a   2   b   6   c   9
 
-In ``pandas``, if you concatenate dataframes along the rows, and the columns do not match, a dataframe of all the columns is returned, with null values for the missing rows :
+In pandas, if you concatenate dataframes along the rows, and the columns do not
+match, a dataframe of all the columns is returned, with null values for the
+missing rows::
 
-.. code-block:: python
+    >>> # pandas
+    >>> pd.concat([df1, df2, df3], axis = 0)
 
-    # pandas
-    pd.concat([df1, df2, df3], axis = 0)
+        A    B    C    D    E    F
+    0   a    0.0  NaN  NaN  NaN  NaN
+    1   a    1.0  NaN  NaN  NaN  NaN
+    2   a    2.0  NaN  NaN  NaN  NaN
+    0   NaN  NaN  b    4.0  NaN  NaN
+    1   NaN  NaN  b    5.0  NaN  NaN
+    2   NaN  NaN  b    6.0  NaN  NaN
+    0   NaN  NaN  NaN  NaN  c    7.0
+    1   NaN  NaN  NaN  NaN  c    8.0
+    2   NaN  NaN  NaN  NaN  c    9.0
 
-        A   B   C   D   E   F
-    0   a   0.0 NaN NaN NaN NaN
-    1   a   1.0 NaN NaN NaN NaN
-    2   a   2.0 NaN NaN NaN NaN
-    0   NaN NaN b   4.0 NaN NaN
-    1   NaN NaN b   5.0 NaN NaN
-    2   NaN NaN b   6.0 NaN NaN
-    0   NaN NaN NaN NaN c   7.0
-    1   NaN NaN NaN NaN c   8.0
-    2   NaN NaN NaN NaN c   9.0
-
-In ``datatable``, if you concatenate along the rows and the columns in the frames do not match, you get an error message; you can however force the row combinations, by passing ``force=True`` :
-
-.. code-block:: python
+In datatable, if you concatenate along the rows and the columns in the frames do not match, you get an error message; you can however force the row combinations, by passing ``force=True``::
 
     # datatable
     dt.rbind([DT1, DT2, DT3], force=True)
@@ -617,47 +580,48 @@ In ``datatable``, if you concatenate along the rows and the columns in the frame
 .. note:: :func:`rbind()` and :func:`cbind()` methods exist for the frames, and operate in-place.
 
 
-JOIN/MERGE
+
+Join/merge
 ----------
 
-``pandas`` has a variety of options for joining dataframes, using the ``join`` or ``merge`` method; in ``datatable``, only the left join is possible, and there are certain limitations. You have to set keys on the dataframe to be joined, and for that, the keyed columns must be unique. The main function in ``datatable`` for joining dataframes based on column values is the :func:`join()` function. As such, our comparison will be limited to left-joins only.
+pandas has a variety of options for joining dataframes, using the ``join`` or ``merge`` method; in datatable, only the left join is possible, and there are certain limitations. You have to set keys on the dataframe to be joined, and for that, the keyed columns must be unique. The main function in datatable for joining dataframes based on column values is the :func:`join()` function. As such, our comparison will be limited to left-joins only.
 
 In pandas, you can join dataframes easily with the ``merge`` method :
 
 .. code-block:: python
 
-    df1 = pd.DataFrame({x : ["b"]*3 + ["a"]*3 + ["c"]*3,
-              y : [1, 3, 6] * 3,
-              v : range(1, 10)})
+    >>> df1 = pd.DataFrame({"x" : ["b"]*3 + ["a"]*3 + ["c"]*3,
+    ...                     "y" : [1, 3, 6] * 3,
+    ...                     "v" : range(1, 10)})
 
-    df2 = pd.DataFrame({"x":('c','b'),
-                  "v":(8,7),
-                  "foo":(4,2)})
+    >>> df2 = pd.DataFrame({"x": ('c','b'),
+    ...                     "v": (8,7),
+    ...                     "foo": (4,2)})
 
-    df1.merge(df2, on="x", how="left")
+    >>> df1.merge(df2, on="x", how="left")
 
-        x   y   v_x v_y foo
-    0   b   1   1   7.0 2.0
-    1   b   3   2   7.0 2.0
-    2   b   6   3   7.0 2.0
-    3   a   1   4   NaN NaN
-    4   a   3   5   NaN NaN
-    5   a   6   6   NaN NaN
-    6   c   1   7   8.0 4.0
-    7   c   3   8   8.0 4.0
-    8   c   6   9   8.0 4.0
+        x   y   v_x v_y  foo
+    0   b   1   1   7.0  2.0
+    1   b   3   2   7.0  2.0
+    2   b   6   3   7.0  2.0
+    3   a   1   4   NaN  NaN
+    4   a   3   5   NaN  NaN
+    5   a   6   6   NaN  NaN
+    6   c   1   7   8.0  4.0
+    7   c   3   8   8.0  4.0
+    8   c   6   9   8.0  4.0
 
 In datatable, there are limitations currently. First, the joining dataframe must be keyed. Second, the values in the column(s) used as the joining key(s) must be unique, otherwise the keying operation will fail. Third, the join columns must have the same name.
 
 .. code-block:: python
 
-    DT1 = dt.Frame(df1)
-    DT2 = dt.Frame(df2)
+    >>> DT1 = dt.Frame(df1)
+    >>> DT2 = dt.Frame(df2)
 
-    # set key on DT2
-    DT2.key = 'x'
+    >>> # set key on DT2
+    >>> DT2.key = 'x'
 
-    DT1[:, :, join(DT2)]
+    >>> DT1[:, :, join(DT2)]
 
         x   y   v   v.0 foo
     0   b   1   1   7   2
@@ -670,83 +634,85 @@ In datatable, there are limitations currently. First, the joining dataframe must
     7   c   3   8   8   4
     8   c   6   9   8   4
 
-More details about joins in ``datatable`` can be found at the :func:`join()` API and have a look at the `Tutorial on the join operator <https://datatable.readthedocs.io/en/latest/start/quick-start.html#join>`_
+More details about joins in datatable can be found at the :func:`join()` API
+and have a look at the :ref:`Tutorial on the join operator <join tutorial>`.
 
-MORE EXAMPLES
+
+
+More examples
 -------------
 
-This section shows how some solutions in ``pandas`` can be translated to ``datatable``; the examples used here, as well as the ``pandas`` solutions,  are from the `pandas cookbook <https://pandas.pydata.org/pandas-docs/stable/user_guide/cookbook.html>`__.
+This section shows how some solutions in pandas can be translated to datatable;
+the examples used here, as well as the pandas solutions, are from the
+`pandas cookbook`_.
 
 
-- if-then-else using numpy’s `where() <https://numpy.org/doc/stable/reference/generated/numpy.where.html>`__ :
+if-then-else
+~~~~~~~~~~~~
 
 .. code-block:: python
 
-    # pandas
-    df = pd.DataFrame({"AAA": [4, 5, 6, 7],
-                       "BBB": [10, 20, 30, 40],
-                       "CCC": [100, 50, -30, -50]})
-
-    df
-
+    >>> # Initial data frame:
+    >>> df = pd.DataFrame({"AAA": [4, 5, 6, 7],
+    ...                    "BBB": [10, 20, 30, 40],
+    ...                    "CCC": [100, 50, -30, -50]})
+    >>> df
         AAA BBB CCC
     0   4   10  100
     1   5   20  50
     2   6   30  -30
     3   7   40  -50
 
-Solution in ``pandas`` ::
+In pandas this can be achieved using numpy’s `where() <np.where_>`_::
 
-    df['logic'] = np.where(df['AAA'] > 5, 'high', 'low')
+    >>> df['logic'] = np.where(df['AAA'] > 5, 'high', 'low')
 
-        AAA  BBB  CCC logic
-    0    4   10  100   low
-    1    5   20   50   low
-    2    6   30  -30  high
-    3    7   40  -50  high
+        AAA  BBB  CCC  logic
+    0    4   10   100    low
+    1    5   20    50    low
+    2    6   30   -30   high
+    3    7   40   -50   high
 
-In ``datatable``, this can be solved using the :func:`ifelse()` function
-
-.. code-block:: python
+In datatable, this can be solved using the :func:`ifelse()` function::
 
     >>> # datatable
     >>> DT = dt.Frame(df)
-    >>> DT["logic"] = DT[:, ifelse(f.AAA > 5, "high", "low")]
+    >>> DT["logic"] = ifelse(f.AAA > 5, "high", "low")
     >>> DT
-       AAA  BBB CCC logic
-    0   4   10  100 low
-    1   5   20  50  low
-    2   6   30  −30 high
-    3   7   40  −50 high
+       AAA  BBB  CCC  logic
+    0   4   10   100    low
+    1   5   20    50    low
+    2   6   30   −30   high
+    3   7   40   −50   high
 
-- Select rows with data closest to certain value using argsort
+
+Select rows with data closest to certain value
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: python
 
-    # pandas
-    df = pd.DataFrame({"AAA": [4, 5, 6, 7],
-                       "BBB": [10, 20, 30, 40],
-                       "CCC": [100, 50, -30, -50]})
+    >>> # pandas
+    >>> df = pd.DataFrame({"AAA": [4, 5, 6, 7],
+    ...                    "BBB": [10, 20, 30, 40],
+    ...                    "CCC": [100, 50, -30, -50]})
+    >>> aValue = 43.0
 
-    aValue = 43.0
+Solution in pandas, using argsort::
 
-Solution in ``pandas`` ::
+    >>> df.loc[(df.CCC - aValue).abs().argsort()]
 
-    df.loc[(df.CCC - aValue).abs().argsort()]
+         AAA  BBB  CCC
+    1    5    20    50
+    0    4    10   100
+    2    6    30   -30
+    3    7    40   -50
 
-        AAA  BBB  CCC
-    1    5   20   50
-    0    4   10  100
-    2    6   30  -30
-    3    7   40  -50
+In datatable, the ``newsort`` function is roughly similar to `np.argsort`_
+or `pd.Series.argsort`_::
 
-In ``datatable``, the ``newsort`` function is roughly similar to `np.argsort <https://numpy.org/doc/stable/reference/generated/numpy.argsort.html>`__ or `pd.Series.argsort <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.argsort.html>`__ ::
-
-    DT = dt.Frame(df)
-
-    order = DT[:, dt.math.abs(f.CCC - aValue)].newsort()
-
-    order
+    >>> DT = dt.Frame(df)
+    >>> order = DT[:, dt.math.abs(f.CCC - aValue)].newsort()
+    >>> order
 
         order
     0   1
@@ -756,13 +722,13 @@ In ``datatable``, the ``newsort`` function is roughly similar to `np.argsort <ht
 
 Now, we can apply the ``order`` variable to the ``i`` section ::
 
-    DT[order, :]
+    >>> DT[order, :]
 
-       AAA  BBB CCC
-    0   5   20  50
-    1   4   10  100
-    2   6   30  −30
-    3   7   40  −50
+       AAA  BBB  CCC
+    0    5   20   50
+    1    4   10  100
+    2    6   30  −30
+    3    7   40  −50
 
 Of course, you can skip creating a temporary variable (at the expense of readability) ::
 
@@ -770,70 +736,65 @@ Of course, you can skip creating a temporary variable (at the expense of readabi
 
 
 
-- Efficiently and dynamically creating new columns using applymap
+Efficiently and dynamically creating new columns using applymap
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: python
 
-    # pandas
-    df = pd.DataFrame({"AAA": [1, 2, 1, 3],
-                       "BBB": [1, 1, 2, 2],
-                       "CCC": [2, 1, 3, 1]})
-
+    >>> # pandas
+    >>> df = pd.DataFrame({"AAA": [1, 2, 1, 3],
+    ...                    "BBB": [1, 1, 2, 2],
+    ...                    "CCC": [2, 1, 3, 1]})
        AAA  BBB CCC
     0   1   1   2
     1   2   1   1
     2   1   2   3
     3   3   2   1
 
-    source_cols = df.columns
+    >>> source_cols = df.columns
+    >>> new_cols = [str(x) + "_cat" for x in source_cols]
+    >>> categories = {1: 'Alpha', 2: 'Beta', 3: 'Charlie'}
+    >>> df[new_cols] = df[source_cols].applymap(categories.get)
+    >>> df
 
-    new_cols = [str(x) + "_cat" for x in source_cols]
+        AAA  BBB  CCC  AAA_cat  BBB_cat  CCC_cat
+    0    1    1    2   Alpha    Alpha    Beta
+    1    2    1    1   Beta     Alpha    Alpha
+    2    1    2    3   Alpha    Beta     Charlie
+    3    3    2    1   Charlie  Beta     Alpha
 
-    categories = {1: 'Alpha', 2: 'Beta', 3: 'Charlie'}
 
-    df[new_cols] = df[source_cols].applymap(categories.get)
+We can replicate the solution above in datatable::
 
-    df
+    >>> # datatable
+    >>> import itertools as it
 
-        AAA  BBB  CCC  AAA_cat BBB_cat  CCC_cat
-    0    1    1    2    Alpha   Alpha     Beta
-    1    2    1    1     Beta   Alpha    Alpha
-    2    1    2    3    Alpha    Beta  Charlie
-    3    3    2    1  Charlie    Beta    Alpha
+    >>> DT = dt.Frame(df)
 
-We can replicate the solution above in ``datatable`` :
+    >>> mixer = it.product(DT.names, categories)
 
-.. code-block:: python
+    >>> conditions = [(name, f[name] == value, categories[value])
+    ...               for name, value in mixer]
 
-    # datatable
+    >>> for name, cond, value in conditions:
+    ...    DT[cond, f"{name}_cat"] = value
 
-    import itertools as it
+        AAA BBB CCC AAA_cat  BBB_cat CCC_cat
+    0   1   1   2   Alpha    Alpha   Beta
+    1   2   1   1   Beta     Alpha   Alpha
+    2   1   2   3   Alpha    Beta    Charlie
+    3   3   2   1   Charlie  Beta    Alpha
 
-    DT = dt.Frame(df)
 
-    mixer = it.product(DT.names, categories)
-
-    conditions = [(name, f[name] == value, categories[value])
-                  for name, value in mixer]
-
-    for name, cond, value in conditions:
-        DT[cond, f"{name}_cat"] = value
-
-        AAA BBB CCC AAA_cat BBB_cat CCC_cat
-    0   1   1   2   Alpha   Alpha   Beta
-    1   2   1   1   Beta    Alpha   Alpha
-    2   1   2   3   Alpha   Beta    Charlie
-    3   3   2   1   Charlie Beta    Alpha
-
-- Keep other columns when using ``min()`` with groupby
+Keep other columns when using ``min()`` with groupby
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: python
 
-    # pandas
-    df = pd.DataFrame({'AAA': [1, 1, 1, 2, 2, 2, 3, 3],
-                       'BBB': [2, 1, 3, 4, 5, 1, 2, 3]})
-
-    df
+    >>> # pandas
+    >>> df = pd.DataFrame({'AAA': [1, 1, 1, 2, 2, 2, 3, 3],
+    ...                    'BBB': [2, 1, 3, 4, 5, 1, 2, 3]})
+    >>> df
 
         AAA  BBB
     0    1    2
@@ -845,42 +806,38 @@ We can replicate the solution above in ``datatable`` :
     6    3    2
     7    3    3
 
-Solution in ``pandas``::
+Solution in pandas::
 
-    df.loc[df.groupby("AAA")["BBB"].idxmin()]
+    >>> df.loc[df.groupby("AAA")["BBB"].idxmin()]
 
         AAA  BBB
     1    1    1
     5    2    1
     6    3    2
 
-In ``datatable``, you can :func:`sort()` within a group, to achieve the same result above :
+In datatable, you can :func:`sort()` within a group, to achieve the same result above::
 
-.. code-block:: python
-
-    # datatable
-
-    DT = dt.Frame(df)
-
-    DT[0, :, by("AAA"), sort(f.BBB)]
+    >>> # datatable
+    >>> DT = dt.Frame(df)
+    >>> DT[0, :, by("AAA"), sort(f.BBB)]
 
        AAA  BBB
     0   1   1
     1   2   1
     2   3   2
 
-- Apply to different items in a group
+
+Apply to different items in a group
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: python
 
-    # pandas
-
-    df = pd.DataFrame({'animal': 'cat dog cat fish dog cat cat'.split(),
-                       'size': list('SSMMMLL'),
-                       'weight': [8, 10, 11, 1, 20, 12, 12],
-                       'adult': [False] * 5 + [True] * 2})
-
-    df
+    >>> # pandas
+    >>> df = pd.DataFrame({'animal': 'cat dog cat fish dog cat cat'.split(),
+    ...                    'size': list('SSMMMLL'),
+    ...                    'weight': [8, 10, 11, 1, 20, 12, 12],
+    ...                    'adult': [False] * 5 + [True] * 2})
+    >>> df
 
       animal size  weight  adult
     0    cat    S       8  False
@@ -892,56 +849,57 @@ In ``datatable``, you can :func:`sort()` within a group, to achieve the same res
     6    cat    L      12   True
 
 
-Solution in ``pandas`` ::
+Solution in pandas::
 
-    def GrowUp(x):
-        avg_weight = sum(x[x['size'] == 'S'].weight * 1.5)
-        avg_weight += sum(x[x['size'] == 'M'].weight * 1.25)
-        avg_weight += sum(x[x['size'] == 'L'].weight)
-        avg_weight /= len(x)
-        return pd.Series(['L', avg_weight, True],
-                         index=['size', 'weight', 'adult'])
+    >>> def GrowUp(x):
+    ...     avg_weight = sum(x[x['size'] == 'S'].weight * 1.5)
+    ...     avg_weight += sum(x[x['size'] == 'M'].weight * 1.25)
+    ...     avg_weight += sum(x[x['size'] == 'L'].weight)
+    ...     avg_weight /= len(x)
+    ...     return pd.Series(['L', avg_weight, True],
+    ...                      index=['size', 'weight', 'adult'])
 
-    expected_df = gb.apply(GrowUp)
-
+    >>> expected_df = gb.apply(GrowUp)
             size   weight  adult
     animal
     cat       L  12.4375   True
     dog       L  20.0000   True
     fish      L   1.2500   True
 
-In ``datatable``, we can use the :func:`ifelse()` function to replicate the solution above, since it is based on a series of conditions::
+In datatable, we can use the :func:`ifelse()` function to replicate
+the solution above, since it is based on a series of conditions::
 
-    DT = dt.Frame(df)
+    >>> DT = dt.Frame(df)
 
-    conditions = ifelse(f.size == "S", f.weight * 1.5,
-                        f.size == "M", f.weight * 1.25,
-                        f.size == "L", f.weight,
-                        None)
+    >>> conditions = ifelse(f.size == "S", f.weight * 1.5,
+    ...                     f.size == "M", f.weight * 1.25,
+    ...                     f.size == "L", f.weight,
+    ...                     None)
 
-    DT[:, {"size": "L",
-           "avg_wt": dt.sum(conditions) / dt.count(),
-           "adult": True},
-       by("animal")]
+    >>> DT[:, {"size": "L",
+    ...        "avg_wt": dt.sum(conditions) / dt.count(),
+    ...        "adult": True},
+    ...    by("animal")]
 
-        animal  size    avg_wt  adult
-    0   cat L   12.4375 1
-    1   dog L   20  1
-    2   fish    L   1.25    1
+        animal  size  avg_wt   adult
+    0   cat     L     12.4375  1
+    1   dog     L     20       1
+    2   fish    L      1.25    1
 
 .. note:: :func:`ifelse()` can take multiple conditions, along with a default return value.
 
-.. note:: Custom functions are not supported in ``datatable`` yet.
+.. note:: Custom functions are not supported in datatable yet.
 
-- Sort groups by aggregated data
+
+Sort groups by aggregated data
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: python
 
-    # pandas
-
-    df = pd.DataFrame({'code': ['foo', 'bar', 'baz'] * 2,
-                       'data': [0.16, -0.21, 0.33, 0.45, -0.59, 0.62],
-                       'flag': [False, True] * 3})
+    >>> # pandas
+    >>> df = pd.DataFrame({'code': ['foo', 'bar', 'baz'] * 2,
+    ...                    'data': [0.16, -0.21, 0.33, 0.45, -0.59, 0.62],
+    ...                    'flag': [False, True] * 3})
 
         code    data    flag
     0    foo    0.16    False
@@ -951,96 +909,87 @@ In ``datatable``, we can use the :func:`ifelse()` function to replicate the solu
     4    bar   -0.59    False
     5    baz    0.62    True
 
-Solution in ``pandas`` ::
+Solution in pandas::
 
-    code_groups = df.groupby('code')
+    >>> code_groups = df.groupby('code')
+    >>> agg_n_sort_order = code_groups[['data']].transform(sum).sort_values(by='data')
+    >>> sorted_df = df.loc[agg_n_sort_order.index]
+    >>> sorted_df
+        code  data   flag
+    1   bar  -0.21   True
+    4   bar  -0.59  False
+    0   foo   0.16  False
+    3   foo   0.45   True
+    2   baz   0.33  False
+    5   baz   0.62   True
 
-    agg_n_sort_order = code_groups[['data']].transform(sum).sort_values(by='data')
+The solution above sorts the data based on the sum of the ``data`` column per
+group in the ``code`` column.
 
-    sorted_df = df.loc[agg_n_sort_order.index]
+We can replicate this in datatable::
 
-    sorted_df
+    >>> DT = dt.Frame(df)
+    >>> DT[:, update(sum_data = dt.sum(f.data)), by("code")]
+    >>> DT[:, :-1, sort(f.sum_data)]
+        code      data  flag
+    0   bar      −0.21     1
+    1   bar      −0.59     0
+    2   foo       0.16     0
+    3   foo       0.45     1
+    4   baz       0.33     0
+    5   baz       0.62     1
 
-        code  data  flag
-    1   bar -0.21   True
-    4   bar -0.59  False
-    0   foo  0.16  False
-    3   foo  0.45   True
-    2   baz  0.33  False
-    5   baz  0.62   True
 
-The solution above sorts the data based on the sum of the ``data`` column per group in the ``code`` column.
-
-We can replicate this in ``datatable`` ::
-
-    DT = dt.Frame(df)
-
-    DT[:, update(sum_data = dt.sum(f.data)), by("code")]
-
-    DT[:, :-1, sort(f.sum_data)]
-
-        code      data      flag
-    0   bar      −0.21       1
-    1   bar  −0.59       0
-    2   foo   0.16       0
-    3   foo   0.45       1
-    4   baz   0.33       0
-    5   baz   0.62       1
-
-- Create a value counts column and reassign back to the DataFrame
+Create a value counts column and reassign back to the DataFrame
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: python
 
-    # pandas
-    df = pd.DataFrame({'Color': 'Red Red Red Blue'.split(),
-                       'Value': [100, 150, 50, 50]})
+    >>> # pandas
+    >>> df = pd.DataFrame({'Color': 'Red Red Red Blue'.split(),
+    ...                    'Value': [100, 150, 50, 50]})
+    >>> df
+       Color  Value
+    0    Red    100
+    1    Red    150
+    2    Red     50
+    3   Blue     50
 
-    df
+Solution in pandas::
 
-      Color  Value
-    0   Red    100
-    1   Red    150
-    2   Red     50
-    3  Blue     50
-
-Solution in ``pandas`` ::
-
-    df['Counts'] = df.groupby(['Color']).transform(len)
-
-    df
-
+    >>> df['Counts'] = df.groupby(['Color']).transform(len)
+    >>> df
         Color  Value  Counts
-    0   Red    100       3
-    1   Red    150       3
-    2   Red     50       3
-    3  Blue     50       1
+    0   Red      100       3
+    1   Red      150       3
+    2   Red       50       3
+    3   Blue      50       1
 
-In ``datatable``, you can replicate the solution above with the :func:`count()` function ::
+In datatable, you can replicate the solution above with the :func:`count()`
+function::
 
-    DT = dt.Frame(df)
-
-    DT[:, update(Counts=dt.count()), by("Color")]
+    >>> DT = dt.Frame(df)
+    >>> DT[:, update(Counts=dt.count()), by("Color")]
 
         Color   Value   Counts
-    0   Red 100 3
-    1   Red 150 3
-    2   Red 50  3
-    3   Blue    50  1
+    0   Red       100        3
+    1   Red       150        3
+    2   Red        50        3
+    3   Blue       50        1
 
-- Shift groups of the values in a column based on the index
+
+Shift groups of the values in a column based on the index
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: python
 
-    # pandas
-
-    df = pd.DataFrame({'line_race': [10, 10, 8, 10, 10, 8],
-                       'beyer': [99, 102, 103, 103, 88, 100]},
-                       index=['Last Gunfighter', 'Last Gunfighter',
-                              'Last Gunfighter', 'Paynter', 'Paynter',
-                              'Paynter'])
-
-    df
-
+    >>> # pandas
+    >>> df = pd.DataFrame({'line_race': [10, 10, 8, 10, 10, 8],
+    ...                    'beyer': [99, 102, 103, 103, 88, 100]},
+    ...                    index=['Last Gunfighter', 'Last Gunfighter',
+    ...                           'Last Gunfighter', 'Paynter', 'Paynter',
+    ...                           'Paynter'])
+    >>> df
                         line_race  beyer
     Last Gunfighter         10     99
     Last Gunfighter         10    102
@@ -1050,12 +999,10 @@ In ``datatable``, you can replicate the solution above with the :func:`count()` 
     Paynter                  8    100
 
 
-Solution in ``pandas`` ::
+Solution in pandas::
 
-    df['beyer_shifted'] = df.groupby(level=0)['beyer'].shift(1)
-
-    df
-
+    >>>  df['beyer_shifted'] = df.groupby(level=0)['beyer'].shift(1)
+    >>> df
                         line_race  beyer  beyer_shifted
     Last Gunfighter         10     99            NaN
     Last Gunfighter         10    102           99.0
@@ -1064,64 +1011,61 @@ Solution in ``pandas`` ::
     Paynter                 10     88          103.0
     Paynter                  8    100           88.0
 
-``datatable`` has an equivalent :func:`shift()` function ::
+Datatable has an equivalent :func:`shift()` function::
 
-    DT = dt.Frame(df) # the index becomes part of the frame
+    >>> DT = dt.Frame(df) # the index becomes part of the frame
+    >>> DT[:, update(beyer_shifted = dt.shift(f.beyer)), by("index")]
+    >>> DT
+       line_race   beyer   index           beyer_shifted
+    0         10      99   Last Gunfighter            NA
+    1         10     102   Last Gunfighter            99
+    2          8     103   Last Gunfighter           102
+    3         10     103   Paynter                    NA
+    4         10      88   Paynter                   103
+    5          8     100   Paynter                    88
 
-    DT[:, update(beyer_shifted = dt.shift(f.beyer)), by("index")]
 
-    DT
-
-    line_race   beyer   index           beyer_shifted
-    0   10  99  Last Gunfighter     NA
-    1   10  102 Last Gunfighter     99
-    2   8   103 Last Gunfighter     102
-    3   10  103 Paynter             NA
-    4   10  88  Paynter             103
-    5   8   100 Paynter             88
-
-- Frequency table like `plyr <https://www.rdocumentation.org/packages/plyr/versions/1.8.6>`__ in R
+Frequency table like `plyr`_ in R
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: python
 
-    grades = [48, 99, 75, 80, 42, 80, 72, 68, 36, 78]
+    >>> grades = [48, 99, 75, 80, 42, 80, 72, 68, 36, 78]
+    >>> df = pd.DataFrame({'ID': ["x%d" % r for r in range(10)],
+    ...                    'Gender': ['F', 'M', 'F', 'M', 'F',
+    ...                               'M', 'F', 'M', 'M', 'M'],
+    ...                    'ExamYear': ['2007', '2007', '2007', '2008', '2008',
+    ...                                 '2008', '2008', '2009', '2009', '2009'],
+    ...                    'Class': ['algebra', 'stats', 'bio', 'algebra',
+    ...                              'algebra', 'stats', 'stats', 'algebra',
+    ...                              'bio', 'bio'],
+    ...                    'Participated': ['yes', 'yes', 'yes', 'yes', 'no',
+    ...                                     'yes', 'yes', 'yes', 'yes', 'yes'],
+    ...                    'Passed': ['yes' if x > 50 else 'no' for x in grades],
+    ...                    'Employed': [True, True, True, False,
+    ...                                 False, False, False, True, True, False],
+    ...                    'Grade': grades})
+    >>> df
 
-    df = pd.DataFrame({'ID': ["x%d" % r for r in range(10)],
-                       'Gender': ['F', 'M', 'F', 'M', 'F',
-                                  'M', 'F', 'M', 'M', 'M'],
-                       'ExamYear': ['2007', '2007', '2007', '2008', '2008',
-                                    '2008', '2008', '2009', '2009', '2009'],
-                       'Class': ['algebra', 'stats', 'bio', 'algebra',
-                                 'algebra', 'stats', 'stats', 'algebra',
-                                 'bio', 'bio'],
-                       'Participated': ['yes', 'yes', 'yes', 'yes', 'no',
-                                        'yes', 'yes', 'yes', 'yes', 'yes'],
-                       'Passed': ['yes' if x > 50 else 'no' for x in grades],
-                       'Employed': [True, True, True, False,
-                                    False, False, False, True, True, False],
-                       'Grade': grades})
-
-    df
-
-        ID  Gender  ExamYear    Class   Participated    Passed      Employed      Grade
-    0   x0  F   2007            algebra     yes         no      True            48
-    1   x1  M   2007            stats       yes         yes     True        99
-    2   x2  F   2007            bio     yes         yes     True        75
-    3   x3  M   2008            algebra     yes         yes     False       80
-    4   x4  F   2008            algebra     no          no      False       42
-    5   x5  M   2008            stats       yes         yes     False       80
-    6   x6  F   2008            stats       yes         yes     False       72
-    7   x7  M   2009            algebra     yes         yes     True        68
-    8   x8  M   2009            bio     yes         no      True        36
-    9   x9  M   2009            bio     yes         yes     False       78
+        ID  Gender  ExamYear    Class     Participated  Passed  Employed  Grade
+    0   x0  F           2007    algebra   yes           no      True         48
+    1   x1  M           2007    stats     yes           yes     True         99
+    2   x2  F           2007    bio       yes           yes     True         75
+    3   x3  M           2008    algebra   yes           yes     False        80
+    4   x4  F           2008    algebra   no            no      False        42
+    5   x5  M           2008    stats     yes           yes     False        80
+    6   x6  F           2008    stats     yes           yes     False        72
+    7   x7  M           2009    algebra   yes           yes     True         68
+    8   x8  M           2009    bio       yes           no      True         36
+    9   x9  M           2009    bio       yes           yes     False        78
 
 
-Solution in ``pandas`` ::
+Solution in pandas::
 
-    df.groupby('ExamYear').agg({'Participated': lambda x: x.value_counts()['yes'],
-                                'Passed': lambda x: sum(x == 'yes'),
-                                'Employed': lambda x: sum(x),
-                                'Grade': lambda x: sum(x) / len(x)})
+    >>> df.groupby('ExamYear').agg({'Participated': lambda x: x.value_counts()['yes'],
+    ...                             'Passed': lambda x: sum(x == 'yes'),
+    ...                             'Employed': lambda x: sum(x),
+    ...                             'Grade': lambda x: sum(x) / len(x)})
 
                 Participated  Passed  Employed      Grade
     ExamYear
@@ -1129,25 +1073,28 @@ Solution in ``pandas`` ::
     2008                 3       3         0        68.500000
     2009                 3       2         2        60.666667
 
-In ``datatable`` you can nest conditions within aggregations ::
 
-    DT = dt.Frame(df)
+In datatable you can nest conditions within aggregations::
 
-    DT[:, {"Participated": dt.sum(f.Participated == "yes"),
-           "Passed": dt.sum(f.Passed == "yes"),
-           "Employed": dt.sum(f.Employed),
-           "Grade": dt.mean(f.Grade)},
-       by("ExamYear")]
+    >>> DT = dt.Frame(df)
+
+    >>> DT[:, {"Participated": dt.sum(f.Participated == "yes"),
+    ...        "Passed": dt.sum(f.Passed == "yes"),
+    ...        "Employed": dt.sum(f.Employed),
+    ...        "Grade": dt.mean(f.Grade)},
+    ...    by("ExamYear")]
 
         ExamYear    Participated    Passed  Employed    Grade
     0   2007            3           2        3          74
     1   2008            3           3        0          68.5
     2   2009            3           2        2          60.6667
 
-Feel free to submit a pull request on `github <https://github.com/h2oai/datatable>`__ for examples you would like to share with the community.
+Feel free to submit a pull request on `github`_ for examples you would like to share with the community.
 
-MISSING FUNCTIONS
------------------
+
+
+Missing functionality
+---------------------
 
 Listed below are some functions in pandas that do not have an equivalent in datatable yet, and are likely to be implemented:
 
@@ -1176,7 +1123,21 @@ Listed below are some functions in pandas that do not have an equivalent in data
     - `string extract <https://pandas.pydata.org/pandas-docs/stable/generated/pandas.Series.str.extract.html>`__
     - `string replace <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.str.replace.html>`__
 
-- Custom function application, via `apply <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.apply.html>`__ and `pipe <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.pipe.html>`__.
+- Custom function application, via `pd.apply`_ and `pd.pipe`_.
 
-If there are any functions that you would like to see in ``datatable``, please head over to `github <https://github.com/h2oai/datatable/issues>`__ and raise a feature request.
+If there are any functions that you would like to see in datatable, please head over to `github`_ and raise a feature request.
 
+
+
+.. _`pandas`:            https://pandas.pydata.org/pandas-docs/stable/index.html
+.. _`pandas cookbook`:   https://pandas.pydata.org/pandas-docs/stable/user_guide/cookbook.html
+.. _`DataFrame`:         https://pandas.pydata.org/pandas-docs/stable/user_guide/dsintro.html#dataframe
+.. _`Series`:            https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.html#pandas.Series
+.. _`pd.Series.argsort`: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.argsort.html
+.. _`pd.transform`:      https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.core.groupby.DataFrameGroupBy.transform.html
+.. _`pd.apply`:          https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.apply.html
+.. _`pd.pipe`:           https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.pipe.html
+.. _`np.where`:          https://numpy.org/doc/stable/reference/generated/numpy.where.html
+.. _`np.argsort`:        https://numpy.org/doc/stable/reference/generated/numpy.argsort.html
+.. _`plyr`:              https://www.rdocumentation.org/packages/plyr/versions/1.8.6
+.. _`github`:            https://github.com/h2oai/datatable/issues

--- a/docs/manual/comparison_with_pandas.rst
+++ b/docs/manual/comparison_with_pandas.rst
@@ -118,19 +118,19 @@ In ``pandas`` every frame has a row index, and if a filtration is executed, the 
     # pandas
     df.loc[df['A']>3]
 
-    	A	B	C	D
-    3	4	7	10	9
-    4	5	8	11     -1
+        A   B   C   D
+    3   4   7   10  9
+    4   5   8   11     -1
 
 ``datatable`` has no notion of a row index; the row numbers displayed are just for convenience:
 
 .. code-block:: python
 
-    DT[f.A>3, :]
+    >>> DT[f.A>3, :]
 
-        A	B	C	D
-    0	4	7	10	9
-    1	5	8	11     −1
+        A   B   C   D
+    0   4   7   10  9
+    1   5   8   11     −1
 
 
 
@@ -139,71 +139,61 @@ In ``pandas``, the index can be numbers, or characters, or intervals, or even Mu
 .. code-block:: python
 
     # pandas
-    df1 = df.set_index(pd.Index(['a','b','c','d','e']))
+    >>> df1 = df.set_index(pd.Index(['a','b','c','d','e']))
 
-        A	B	C	D
-    a	1	4	7	5
-    b	2	5	8	7
-    c	3	6	9	2
-    d	4	7	10	9
-    e	5	8	11     -1
+        A   B   C   D
+    a   1   4   7   5
+    b   2   5   8   7
+    c   3   6   9   2
+    d   4   7   10  9
+    e   5   8   11     -1
 
-    df1.loc["a":"c"]
+    >>> df1.loc["a":"c"]
 
-
-        A	B	C	D
-    a	1	4	7	5
-    b	2	5	8	7
-    c	3	6	9	2
+        A   B   C   D
+    a   1   4   7   5
+    b   2   5   8   7
+    c   3   6   9   2
 
 ``datatable`` has the `key <https://datatable.readthedocs.io/en/latest/api/frame/key.html#datatable-frame-key>`__ property, which is meant as an equivalent of pandas indices, but its purpose at the moment is for joins, not for subsetting data:
 
 .. code-block:: python
 
-    # datatable
-    data = {"A": [1, 2, 3, 4, 5],
-            "B": [4, 5, 6, 7, 8],
-            "C": [7, 8, 9, 10, 11],
-            "D": [5, 7, 2, 9, -1],
-            "E": ['a','b','c','d','e']}
+    >>> # datatable
+    >>> data = {"A": [1, 2, 3, 4, 5],
+    ...         "B": [4, 5, 6, 7, 8],
+    ...         "C": [7, 8, 9, 10, 11],
+    ...         "D": [5, 7, 2, 9, -1],
+    ...         "E": ['a','b','c','d','e']}
+    >>> DT1 = dt.Frame(data)
+    >>> DT1.key = 'E'
+    >>> DT1
 
-    DT1 = dt.Frame(data)
+    E   A   B   C    D
+    a   1   4   7    5
+    b   2   5   8    7
+    c   3   6   9    2
+    d   4   7   10   9
+    e   5   8   11  −1
 
-    DT1.key = 'E'
-
-    DT1
-
-    E	A	B	C	D
-    a	1	4	7	5
-    b	2	5	8	7
-    c	3	6	9	2
-    d	4	7	10	9
-    e	5	8	11     −1
-
-    # this will fail
-    DT1["a":"c", :]
-
-    ---------------------------------------------------------------------------
-    TypeError                                 Traceback (most recent call last)
-    <ipython-input-98-73c453287f07> in <module>
-    ----> 1 DT["a":"c", :]
-
+    >>> # this will fail
+    >>> DT1["a":"c", :]
     TypeError: A string slice cannot be used as a row selector
 
 pandas' ``loc`` notation works on labels, while ``iloc`` works on actual position. This is noticeable during row selection.  ``datatable``, however, works only on position.
 
 .. code-block:: python
 
-    # pandas
-    df1 = df.set_index('C')
+    >>> # pandas
+    >>> df1 = df.set_index('C')
 
-        A	B	D
+        A   B   D
     C
-    7	1	4	5
-    8	2	5	7
-    9	3	6	2
-    10	4	7	9
-    11	5	8      -1
+    7   1   4   5
+    8   2   5   7
+    9   3   6   2
+    10  4   7   9
+    11  5   8  -1
 
 Selecting with loc for the row with number 7 returns no error :
 
@@ -225,8 +215,8 @@ However, selecting with ``iloc`` for the row with number 7 returns an error, bec
     df.iloc[7]
 
     ---------------------------------------------------------------------------
-   # Lots of code here related to the error message
-   .....
+    # Lots of code here related to the error message
+    .....
 
     IndexError: single positional indexer is out-of-bounds
 
@@ -234,21 +224,19 @@ As stated earlier, ``datatable`` has the `key <https://datatable.readthedocs.io/
 
 .. code-block:: python
 
-    # datatable
+    >>> # datatable
+    >>> DT.key = 'C'
+    >>> DT
 
-    DT.key = 'C'
+    C   A   B   D
+    7   1   4   5
+    8   2   5   7
+    9   3   6   2
+    10  4   7   9
+    11  5   8      −1
 
-    DT
-
-    C	A	B	D
-    7	1	4	5
-    8	2	5	7
-    9	3	6	2
-    10	4	7	9
-    11	5	8      −1
-
-    # this will fail
-    DT[7, :]
+    >>> # this will fail
+    >>> DT[7, :]
 
     ---------------------------------------------------------------------------
     ValueError                                Traceback (most recent call last)
@@ -309,15 +297,15 @@ In datatable, you can select and rename columns at the same time, by passing a d
 
 .. code-block:: python
 
-    # datatable
-    DT[:, {"A": f.A, "box": f.B, "C": f.C, "D": f.D * 2}]
+    >>> # datatable
+    >>> DT[:, {"A": f.A, "box": f.B, "C": f.C, "D": f.D * 2}]
 
-	A	box	C	D
-    0	1	4	7	10
-    1	2	5	8	14
-    2	3	6	9	4
-    3	4	7	10	18
-    4	5	8	11	−2
+    A   box C   D
+    0   1   4   7   10
+    1   2   5   8   14
+    2   3   6   9   4
+    3   4   7   10  18
+    4   5   8   11  −2
 
 
 Delete Columns
@@ -424,12 +412,12 @@ Transformations within groups in pandas is done using the `transform <https://pa
     grouping = df.groupby("a")["b"].transform("min")
     df.assign(min_b=grouping)
 
-        a	b	c	min_b
-    0	1	2	3	2
-    1	1	20	30	2
-    2	2	30	50	4
-    3	1	2	33	2
-    4	2	4	50	4
+        a   b   c   min_b
+    0   1   2   3   2
+    1   1   20  30  2
+    2   2   30  50  4
+    3   1   2   33  2
+    4   2   4   50  4
 
 In ``datatable``, transformations occur within the ``j`` section; in the presence of :func:`by()`, the computations within ``j`` are per group:
 
@@ -438,12 +426,12 @@ In ``datatable``, transformations occur within the ``j`` section; in the presenc
     # datatable
     DT[:, f[:].extend({"min_b": dt.min(f.b)}), by("a")]
 
-    	a	b	c	min_b
-    0	1	2	3	2
-    1	1	20	30	2
-    2	1	2	33	2
-    3	2	30	50	4
-    4	2	4	50	4
+        a   b   c   min_b
+    0   1   2   3   2
+    1   1   20  30  2
+    2   1   2   33  2
+    3   2   30  50  4
+    4   2   4   50  4
 
 Note that the result above is sorted by the grouping column. If you want the data to maintain the same shape as the source data, then :func:`update()` is a better option (and usually faster):
 
@@ -455,12 +443,12 @@ Note that the result above is sorted by the grouping column. If you want the dat
 
     DT
 
-        a	b	c	min_b
-    0	1	2	3	2
-    1	1	20	30	2
-    2	2	30	50	4
-    3	1	2	33	2
-    4	2	4	50	4
+        a   b   c   min_b
+    0   1   2   3   2
+    1   1   20  30  2
+    2   2   30  50  4
+    3   1   2   33  2
+    4   2   4   50  4
 
 In pandas, some computations might require creating the column first before aggregation within a groupby. Take the example below, where we need to calculate the revenue per group:
 
@@ -473,10 +461,10 @@ In pandas, some computations might require creating the column first before aggr
     df1 = pd.DataFrame(data) # pandas
     DT1 = dt.Frame(data)  # datatable
 
-    	shop	item_price	item_sold
-    0	A	    123	            1
-    1	B	    921	            2
-    2	A	    28	            4
+        shop    item_price  item_sold
+    0   A       123             1
+    1   B       921             2
+    2   A       28              4
 
 To get the total revenue, we first need to create a revenue column, then sum it in the groupby:
 
@@ -486,9 +474,9 @@ To get the total revenue, we first need to create a revenue column, then sum it 
     df1['revenue'] = df1['item_price'] * df1['item_sold']
     df1.groupby("shop")['revenue'].sum().reset_index()
 
-    	shop	revenue
-    0	A	235
-    1	B	1842
+        shop    revenue
+    0   A   235
+    1   B   1842
 
 In ``datatable``, there is no need to create a temporary column; you can easily nest your computations in the ``j`` section; the computations will be executed per group :
 
@@ -498,9 +486,9 @@ In ``datatable``, there is no need to create a temporary column; you can easily 
 
     DT1[:, {"revenue": dt.sum(f.item_price * f.item_sold)}, "shop"]
 
-        shop	revenue
-    0	A	235
-    1	B	1842
+        shop    revenue
+    0   A   235
+    1   B   1842
 
 You can learn more about the :func:`by()` function  at the `Grouping with by <https://datatable.readthedocs.io/en/latest/manual/groupby_examples.html>`__ documentation, as well as the API : :func:`by()`.
 
@@ -527,13 +515,13 @@ By default, pandas concatenates the rows, with one dataframe on top of the other
 
     pd.concat([df1, df2], axis = 0)
 
-        A	B
-    0	a	0
-    1	a	1
-    2	a	2
-    0	b	4
-    1	b	5
-    2	b	6
+        A   B
+    0   a   0
+    1   a   1
+    2   a   2
+    0   b   4
+    1   b   5
+    2   b   6
 
 The same functionality can be replicated in ``datatable`` using the `rbind <https://datatable.readthedocs.io/en/latest/api/frame/rbind.html#datatable-frame-rbind>`__ function:
 
@@ -545,13 +533,13 @@ The same functionality can be replicated in ``datatable`` using the `rbind <http
 
     dt.rbind([DT1, DT2])
 
-        A	B
-    0	a	0
-    1	a	1
-    2	a	2
-    3	b	4
-    4	b	5
-    5	b	6
+        A   B
+    0   a   0
+    1   a   1
+    2   a   2
+    3   b   4
+    4   b   5
+    5   b   6
 
 Notice how in ``pandas`` the indices are preserved (you can get rid of the indices with the `ignore_index` argument), whereas in ``datatable`` the indices are not referenced.
 
@@ -568,10 +556,10 @@ To combine data across the columns, in ``pandas``, you set the axis argument to 
 
     pd.concat([df1, df2, df3], axis = 1)
 
-    	A	B	C	D	E	F
-    0	a	0	b	4	c	7
-    1	a	1	b	5	c	8
-    2	a	2	b	6	c	9
+        A   B   C   D   E   F
+    0   a   0   b   4   c   7
+    1   a   1   b   5   c   8
+    2   a   2   b   6   c   9
 
 In ``datatable``, you combine frames along the columns using the `cbind <https://datatable.readthedocs.io/en/latest/api/frame/cbind.html#datatable-frame-cbind>`__ function :
 
@@ -585,10 +573,10 @@ In ``datatable``, you combine frames along the columns using the `cbind <https:/
 
     dt.cbind([DT1, DT2, DT3])
 
-        A	B	C	D	E	F
-    0	a	0	b	4	c	7
-    1	a	1	b	5	c	8
-    2	a	2	b	6	c	9
+        A   B   C   D   E   F
+    0   a   0   b   4   c   7
+    1   a   1   b   5   c   8
+    2   a   2   b   6   c   9
 
 In ``pandas``, if you concatenate dataframes along the rows, and the columns do not match, a dataframe of all the columns is returned, with null values for the missing rows :
 
@@ -597,16 +585,16 @@ In ``pandas``, if you concatenate dataframes along the rows, and the columns do 
     # pandas
     pd.concat([df1, df2, df3], axis = 0)
 
-        A	B	C	D	E	F
-    0	a	0.0	NaN	NaN	NaN	NaN
-    1	a	1.0	NaN	NaN	NaN	NaN
-    2	a	2.0	NaN	NaN	NaN	NaN
-    0	NaN	NaN	b	4.0	NaN	NaN
-    1	NaN	NaN	b	5.0	NaN	NaN
-    2	NaN	NaN	b	6.0	NaN	NaN
-    0	NaN	NaN	NaN	NaN	c	7.0
-    1	NaN	NaN	NaN	NaN	c	8.0
-    2	NaN	NaN	NaN	NaN	c	9.0
+        A   B   C   D   E   F
+    0   a   0.0 NaN NaN NaN NaN
+    1   a   1.0 NaN NaN NaN NaN
+    2   a   2.0 NaN NaN NaN NaN
+    0   NaN NaN b   4.0 NaN NaN
+    1   NaN NaN b   5.0 NaN NaN
+    2   NaN NaN b   6.0 NaN NaN
+    0   NaN NaN NaN NaN c   7.0
+    1   NaN NaN NaN NaN c   8.0
+    2   NaN NaN NaN NaN c   9.0
 
 In ``datatable``, if you concatenate along the rows and the columns in the frames do not match, you get an error message; you can however force the row combinations, by passing ``force=True`` :
 
@@ -615,16 +603,16 @@ In ``datatable``, if you concatenate along the rows and the columns in the frame
     # datatable
     dt.rbind([DT1, DT2, DT3], force=True)
 
-        A	B	C	D	E	F
-    0	a	0	NA	NA	NA	NA
-    1	a	1	NA	NA	NA	NA
-    2	a	2	NA	NA	NA	NA
-    3	NA	NA	b	4	NA	NA
-    4	NA	NA	b	5	NA	NA
-    5	NA	NA	b	6	NA	NA
-    6	NA	NA	NA	NA	c	7
-    7	NA	NA	NA	NA	c	8
-    8	NA	NA	NA	NA	c	9
+        A   B   C   D   E   F
+    0   a   0   NA  NA  NA  NA
+    1   a   1   NA  NA  NA  NA
+    2   a   2   NA  NA  NA  NA
+    3   NA  NA  b   4   NA  NA
+    4   NA  NA  b   5   NA  NA
+    5   NA  NA  b   6   NA  NA
+    6   NA  NA  NA  NA  c   7
+    7   NA  NA  NA  NA  c   8
+    8   NA  NA  NA  NA  c   9
 
 .. note:: :func:`rbind()` and :func:`cbind()` methods exist for the frames, and operate in-place.
 
@@ -648,16 +636,16 @@ In pandas, you can join dataframes easily with the ``merge`` method :
 
     df1.merge(df2, on="x", how="left")
 
-    	x	y	v_x	v_y	foo
-    0	b	1	1	7.0	2.0
-    1	b	3	2	7.0	2.0
-    2	b	6	3	7.0	2.0
-    3	a	1	4	NaN	NaN
-    4	a	3	5	NaN	NaN
-    5	a	6	6	NaN	NaN
-    6	c	1	7	8.0	4.0
-    7	c	3	8	8.0	4.0
-    8	c	6	9	8.0	4.0
+        x   y   v_x v_y foo
+    0   b   1   1   7.0 2.0
+    1   b   3   2   7.0 2.0
+    2   b   6   3   7.0 2.0
+    3   a   1   4   NaN NaN
+    4   a   3   5   NaN NaN
+    5   a   6   6   NaN NaN
+    6   c   1   7   8.0 4.0
+    7   c   3   8   8.0 4.0
+    8   c   6   9   8.0 4.0
 
 In datatable, there are limitations currently. First, the joining dataframe must be keyed. Second, the values in the column(s) used as the joining key(s) must be unique, otherwise the keying operation will fail. Third, the join columns must have the same name.
 
@@ -671,16 +659,16 @@ In datatable, there are limitations currently. First, the joining dataframe must
 
     DT1[:, :, join(DT2)]
 
-        x	y	v	v.0	foo
-    0	b	1	1	7	2
-    1	b	3	2	7	2
-    2	b	6	3	7	2
-    3	a	1	4	NA	NA
-    4	a	3	5	NA	NA
-    5	a	6	6	NA	NA
-    6	c	1	7	8	4
-    7	c	3	8	8	4
-    8	c	6	9	8	4
+        x   y   v   v.0 foo
+    0   b   1   1   7   2
+    1   b   3   2   7   2
+    2   b   6   3   7   2
+    3   a   1   4   NA  NA
+    4   a   3   5   NA  NA
+    5   a   6   6   NA  NA
+    6   c   1   7   8   4
+    7   c   3   8   8   4
+    8   c   6   9   8   4
 
 More details about joins in ``datatable`` can be found at the :func:`join()` API and have a look at the `Tutorial on the join operator <https://datatable.readthedocs.io/en/latest/start/quick-start.html#join>`_
 
@@ -701,11 +689,11 @@ This section shows how some solutions in ``pandas`` can be translated to ``datat
 
     df
 
-    	AAA	BBB	CCC
-    0	4	10	100
-    1	5	20	50
-    2	6	30	-30
-    3	7	40	-50
+        AAA BBB CCC
+    0   4   10  100
+    1   5   20  50
+    2   6   30  -30
+    3   7   40  -50
 
 Solution in ``pandas`` ::
 
@@ -721,17 +709,15 @@ In ``datatable``, this can be solved using the :func:`ifelse()` function
 
 .. code-block:: python
 
-    # datatable
-    DT = dt.Frame(df)
-
-    DT["logic"] = DT[:, ifelse(f.AAA > 5, "high", "low")]
-
-    DT
-       AAA	BBB	CCC	logic
-    0	4	10	100	low
-    1	5	20	50	low
-    2	6	30	−30	high
-    3	7	40	−50	high
+    >>> # datatable
+    >>> DT = dt.Frame(df)
+    >>> DT["logic"] = DT[:, ifelse(f.AAA > 5, "high", "low")]
+    >>> DT
+       AAA  BBB CCC logic
+    0   4   10  100 low
+    1   5   20  50  low
+    2   6   30  −30 high
+    3   7   40  −50 high
 
 - Select rows with data closest to certain value using argsort
 
@@ -762,21 +748,21 @@ In ``datatable``, the ``newsort`` function is roughly similar to `np.argsort <ht
 
     order
 
-    	order
-    0	1
-    1	0
-    2	2
-    3	3
+        order
+    0   1
+    1   0
+    2   2
+    3   3
 
 Now, we can apply the ``order`` variable to the ``i`` section ::
 
     DT[order, :]
 
-       AAA	BBB	CCC
-    0	5	20	50
-    1	4	10	100
-    2	6	30	−30
-    3	7	40	−50
+       AAA  BBB CCC
+    0   5   20  50
+    1   4   10  100
+    2   6   30  −30
+    3   7   40  −50
 
 Of course, you can skip creating a temporary variable (at the expense of readability) ::
 
@@ -793,11 +779,11 @@ Of course, you can skip creating a temporary variable (at the expense of readabi
                        "BBB": [1, 1, 2, 2],
                        "CCC": [2, 1, 3, 1]})
 
-       AAA	BBB	CCC
-    0	1	1	2
-    1	2	1	1
-    2	1	2	3
-    3	3	2	1
+       AAA  BBB CCC
+    0   1   1   2
+    1   2   1   1
+    2   1   2   3
+    3   3   2   1
 
     source_cols = df.columns
 
@@ -833,11 +819,11 @@ We can replicate the solution above in ``datatable`` :
     for name, cond, value in conditions:
         DT[cond, f"{name}_cat"] = value
 
-        AAA	BBB	CCC	AAA_cat	BBB_cat	CCC_cat
-    0	1	1	2	Alpha	Alpha	Beta
-    1	2	1	1	Beta	Alpha	Alpha
-    2	1	2	3	Alpha	Beta	Charlie
-    3	3	2	1	Charlie	Beta	Alpha
+        AAA BBB CCC AAA_cat BBB_cat CCC_cat
+    0   1   1   2   Alpha   Alpha   Beta
+    1   2   1   1   Beta    Alpha   Alpha
+    2   1   2   3   Alpha   Beta    Charlie
+    3   3   2   1   Charlie Beta    Alpha
 
 - Keep other columns when using ``min()`` with groupby
 
@@ -878,10 +864,10 @@ In ``datatable``, you can :func:`sort()` within a group, to achieve the same res
 
     DT[0, :, by("AAA"), sort(f.BBB)]
 
-       AAA	BBB
-    0	1	1
-    1	2	1
-    2	3	2
+       AAA  BBB
+    0   1   1
+    1   2   1
+    2   3   2
 
 - Apply to different items in a group
 
@@ -938,10 +924,10 @@ In ``datatable``, we can use the :func:`ifelse()` function to replicate the solu
            "adult": True},
        by("animal")]
 
-        animal	size	avg_wt	adult
-    0	cat	L	12.4375	1
-    1	dog	L	20	1
-    2	fish	L	1.25	1
+        animal  size    avg_wt  adult
+    0   cat L   12.4375 1
+    1   dog L   20  1
+    2   fish    L   1.25    1
 
 .. note:: :func:`ifelse()` can take multiple conditions, along with a default return value.
 
@@ -957,13 +943,13 @@ In ``datatable``, we can use the :func:`ifelse()` function to replicate the solu
                        'data': [0.16, -0.21, 0.33, 0.45, -0.59, 0.62],
                        'flag': [False, True] * 3})
 
-        code	data	flag
-    0	 foo 	0.16	False
-    1	 bar   -0.21	True
-    2	 baz 	0.33	False
-    3	 foo 	0.45	True
-    4	 bar   -0.59	False
-    5	 baz	0.62	True
+        code    data    flag
+    0    foo    0.16    False
+    1    bar   -0.21    True
+    2    baz    0.33    False
+    3    foo    0.45    True
+    4    bar   -0.59    False
+    5    baz    0.62    True
 
 Solution in ``pandas`` ::
 
@@ -993,13 +979,13 @@ We can replicate this in ``datatable`` ::
 
     DT[:, :-1, sort(f.sum_data)]
 
-        code      data	    flag
-    0	bar      −0.21	     1
-    1	bar	 −0.59	     0
-    2	foo	  0.16	     0
-    3	foo	  0.45	     1
-    4	baz	  0.33	     0
-    5	baz	  0.62	     1
+        code      data      flag
+    0   bar      −0.21       1
+    1   bar  −0.59       0
+    2   foo   0.16       0
+    3   foo   0.45       1
+    4   baz   0.33       0
+    5   baz   0.62       1
 
 - Create a value counts column and reassign back to the DataFrame
 
@@ -1035,11 +1021,11 @@ In ``datatable``, you can replicate the solution above with the :func:`count()` 
 
     DT[:, update(Counts=dt.count()), by("Color")]
 
-        Color	Value	Counts
-    0	Red	100	3
-    1	Red	150	3
-    2	Red	50	3
-    3	Blue	50	1
+        Color   Value   Counts
+    0   Red 100 3
+    1   Red 150 3
+    2   Red 50  3
+    3   Blue    50  1
 
 - Shift groups of the values in a column based on the index
 
@@ -1086,13 +1072,13 @@ Solution in ``pandas`` ::
 
     DT
 
-    line_race	beyer	index	        beyer_shifted
-    0	10	99	Last Gunfighter	    NA
-    1	10	102	Last Gunfighter	    99
-    2	8	103	Last Gunfighter	    102
-    3	10	103	Paynter	            NA
-    4	10	88	Paynter	            103
-    5	8	100	Paynter	            88
+    line_race   beyer   index           beyer_shifted
+    0   10  99  Last Gunfighter     NA
+    1   10  102 Last Gunfighter     99
+    2   8   103 Last Gunfighter     102
+    3   10  103 Paynter             NA
+    4   10  88  Paynter             103
+    5   8   100 Paynter             88
 
 - Frequency table like `plyr <https://www.rdocumentation.org/packages/plyr/versions/1.8.6>`__ in R
 
@@ -1117,17 +1103,17 @@ Solution in ``pandas`` ::
 
     df
 
-        ID	Gender	ExamYear	Class	Participated	Passed	    Employed	  Grade
-    0	x0	F	2007	        algebra	    yes	        no	    True            48
-    1	x1	M	2007	        stats	    yes	        yes	    True	    99
-    2	x2	F	2007	        bio	    yes	        yes	    True	    75
-    3	x3	M	2008	        algebra	    yes	        yes	    False	    80
-    4	x4	F	2008	        algebra	    no	        no	    False	    42
-    5	x5	M	2008	        stats	    yes	        yes	    False	    80
-    6	x6	F	2008	        stats	    yes	        yes	    False	    72
-    7	x7	M	2009	        algebra	    yes	        yes	    True	    68
-    8	x8	M	2009	        bio	    yes	        no	    True	    36
-    9	x9	M	2009	        bio	    yes	        yes	    False	    78
+        ID  Gender  ExamYear    Class   Participated    Passed      Employed      Grade
+    0   x0  F   2007            algebra     yes         no      True            48
+    1   x1  M   2007            stats       yes         yes     True        99
+    2   x2  F   2007            bio     yes         yes     True        75
+    3   x3  M   2008            algebra     yes         yes     False       80
+    4   x4  F   2008            algebra     no          no      False       42
+    5   x5  M   2008            stats       yes         yes     False       80
+    6   x6  F   2008            stats       yes         yes     False       72
+    7   x7  M   2009            algebra     yes         yes     True        68
+    8   x8  M   2009            bio     yes         no      True        36
+    9   x9  M   2009            bio     yes         yes     False       78
 
 
 Solution in ``pandas`` ::
@@ -1153,10 +1139,10 @@ In ``datatable`` you can nest conditions within aggregations ::
            "Grade": dt.mean(f.Grade)},
        by("ExamYear")]
 
-        ExamYear	Participated	Passed	Employed	Grade
-    0	2007	        3	        2	     3	        74
-    1	2008	        3	        3	     0	        68.5
-    2	2009	        3	        2	     2	        60.6667
+        ExamYear    Participated    Passed  Employed    Grade
+    0   2007            3           2        3          74
+    1   2008            3           3        0          68.5
+    2   2009            3           2        2          60.6667
 
 Feel free to submit a pull request on `github <https://github.com/h2oai/datatable>`__ for examples you would like to share with the community.
 

--- a/docs/manual/groupby_examples.rst
+++ b/docs/manual/groupby_examples.rst
@@ -1,4 +1,4 @@
-.. py:currentmodule:: datatable
+.. _`Grouping with by`:
 
 Grouping with ``by``
 ====================

--- a/docs/releases/v0.11.0.rst
+++ b/docs/releases/v0.11.0.rst
@@ -191,9 +191,9 @@
 
   -[new] datatable is now fully supported on Windows.
 
-  -[new] Added exception :exc:`InvalidOperationError`, which can be used to
-    signal when an operation is requested that would be illegal for the given
-    combination of parameters.
+  -[new] Added exception :exc:`dt.exceptions.InvalidOperationError`, which can
+    be used to signal when an operation is requested that would be illegal for
+    the given combination of parameters.
 
   -[new] New option ``dt.options.debug.enabled`` will report all calls to the
     internal C++ core functions, together with their timings. This may help

--- a/docs/start/quick-start.rst
+++ b/docs/start/quick-start.rst
@@ -246,6 +246,8 @@ This modifier controls the order of the rows in the result, much like SQL clause
 within each group.
 
 
+.. _`join tutorial`:
+
 join(...)
 ~~~~~~~~~
 

--- a/src/core/expr/py_join.cc
+++ b/src/core/expr/py_join.cc
@@ -62,7 +62,7 @@ except: ValueError
 
 See Also
 --------
-- `Tutorial on joins <../../start/quick-start.html#join>`_
+- :ref:`Tutorial on joins <join tutorial>`
 )";
 
 static PKArgs args___init__(

--- a/src/core/frame/names.cc
+++ b/src/core/frame/names.cc
@@ -164,13 +164,13 @@ except: KeyError | IndexError
         :widths: auto
         :class: api-table
 
-        * - :exc:`KeyError`
+        * - :exc:`dt.exceptions.KeyError`
           - raised if the `column` argument is a string, and the column with
             such name does not exist in the frame. When this exception is
             thrown, the error message may contain suggestions for up to 3
             similarly looking column names that actually exist in the Frame.
 
-        * - :exc:`IndexError`
+        * - :exc:`dt.exceptions.IndexError`
           - raised if the `column` argument is an integer that is either greater
             than or equal to :attr:`.ncols` or less than `-ncols`.
 
@@ -297,11 +297,11 @@ except: ValueError | KeyError
         :widths: auto
         :class: api-table
 
-        * - :exc:`ValueError`
+        * - :exc:`dt.exceptions.ValueError`
           - raised If the length of the list/tuple `new_names` does not match the
             number of columns in the frame.
 
-        * - :exc:`KeyError`
+        * - :exc:`dt.exceptions.KeyError`
           - raised If `new_names` is a dictionary containing entries that do not
             match any of the existing columns in the frame.
 

--- a/src/core/set_funcs.cc
+++ b/src/core/set_funcs.cc
@@ -243,10 +243,10 @@ except: ValueError | NotImplementedError
         :widths: auto
         :class: api-table
 
-        * - :exc:`ValueError`
+        * - :exc:`dt.exceptions.ValueError`
           - raised when one of the input frames has more than one column.
 
-        * - :exc:`NotImplementedError`
+        * - :exc:`dt.exceptions.NotImplementedError`
           - raised when one of the columns has stype `obj64`.
 
 See Also
@@ -366,10 +366,10 @@ except: ValueError | NotImplementedError
         :widths: auto
         :class: api-table
 
-        * - :exc:`ValueError`
+        * - :exc:`dt.exceptions.ValueError`
           - raised when one of the input frames has more than one column.
 
-        * - :exc:`NotImplementedError`
+        * - :exc:`dt.exceptions.NotImplementedError`
           - raised when one of the columns has stype `obj64`.
 
 See Also
@@ -465,11 +465,11 @@ except: ValueError | NotImplementedError
         :widths: auto
         :class: api-table
 
-        * - :exc:`ValueError`
+        * - :exc:`dt.exceptions.ValueError`
           - raised when one of the input frames, i.e. `frame0`
             or any one from the `frames`, has more than one column.
 
-        * - :exc:`NotImplementedError`
+        * - :exc:`dt.exceptions.NotImplementedError`
           - raised when one of the columns has stype `obj64`.
 
 
@@ -589,10 +589,10 @@ except: ValueError | NotImplementedError
         :widths: auto
         :class: api-table
 
-        * - :exc:`ValueError`
+        * - :exc:`dt.exceptions.ValueError`
           - raised when one of the input frames has more than one column.
 
-        * - :exc:`NotImplementedError`
+        * - :exc:`dt.exceptions.NotImplementedError`
           - raised when one of the columns has stype `obj64`.
 
 

--- a/src/core/str/py_str.cc
+++ b/src/core/str/py_str.cc
@@ -60,17 +60,13 @@ return: Frame
     The labels will also become the output column names.
 
 except: ValueError | TypeError
-    .. list-table::
-        :widths: auto
-        :class: api-table
+    :exc:`dt.exceptions.ValueError`
+        Raised if the input frame is missing or it has more
+        than one column. It is also raised if `sep` is not a single-character
+        string.
 
-        * - :exc:`ValueError`
-          - raised if the input frame is missing or it has more
-            than one column. It is also raised if `sep` is not a single-character
-            string.
-
-        * - :exc:`TypeError`
-          - raised if the single column of `frame` has non-string stype.
+    :exc:`dt.exceptions.TypeError`
+        Raised if the single column of `frame` has non-string stype.
 
 
 Examples

--- a/src/datatable/sphinxext/dtframe_directive.py
+++ b/src/datatable/sphinxext/dtframe_directive.py
@@ -501,7 +501,7 @@ def html_page_context(app, pagename, templatename, context, doctree):
         .datatable table.frame tr {
             border: none;
             max-width: none;
-            padding: 0.5em 0.5em;
+            padding: 2px 5px;
             text-align: right;
             vertical-align: middle;
         }

--- a/src/datatable/sphinxext/xfunction.py
+++ b/src/datatable/sphinxext/xfunction.py
@@ -226,6 +226,7 @@ class XobjectDirective(SphinxDirective):
         "settable": directives.unchanged,
         "deletable": directives.unchanged,
         "noindex": directives.unchanged,
+        "qual-type": directives.unchanged,
     }
 
     def __init__(self, *args):
@@ -241,7 +242,7 @@ class XobjectDirective(SphinxDirective):
         self.test_file = None
         self.tests_github_url = None
         self.qualifier = None
-        self.qualifier_reftype = "class" if self.name in ["xmethod", "xattr"] else "module"
+        self.qualifier_reftype = None
 
 
     def run(self):
@@ -256,6 +257,7 @@ class XobjectDirective(SphinxDirective):
         self._parse_option_tests()
         self._parse_option_settable()
         self._parse_option_deletable()
+        self._parse_option_qualtype()
         self._register_title_override()
 
         if self.src_fnname:
@@ -476,6 +478,12 @@ class XobjectDirective(SphinxDirective):
             raise self.error("Option :deletable: is not valid for a ..%s "
                              "directive" % self.name)
 
+
+    def _parse_option_qualtype(self):
+        reftype = self.options.get("qual-type", "").strip()
+        if not reftype:
+            reftype = "class" if self.name in ["xmethod", "xattr"] else "module"
+        self.qualifier_reftype = reftype
 
 
     #---------------------------------------------------------------------------

--- a/src/datatable/sphinxext/xfunction.py
+++ b/src/datatable/sphinxext/xfunction.py
@@ -279,7 +279,7 @@ class XobjectDirective(SphinxDirective):
             sources = []
         )
         xpy = self.env.get_domain("xpy")
-        if self.name == "xclass":
+        if self.name in ["xclass", "xexc"]:
             xpy.current_context = ("class", self.qualifier + self.obj_name)
         if self.name in ["xattr", "xmethod"]:
             assert self.qualifier[-1:] == '.'
@@ -304,7 +304,7 @@ class XobjectDirective(SphinxDirective):
         qualifier. This way the most important information will
         remain visible longer.
         """
-        if self.name in ["xclass", "xdata", "xfunction"]:
+        if self.name in ["xclass", "xexc", "xdata", "xfunction"]:
             title = self.obj_name
         elif self.name == "xattr":
             title = "." + self.obj_name
@@ -598,7 +598,7 @@ class XobjectDirective(SphinxDirective):
         that, defers parsing of each part to :meth:`_parse_parameters`
         and :meth:`_parse_body` respectively.
         """
-        if (self.name in ["xdata", "xattr", "xclass"] or
+        if (self.name in ["xdata", "xattr", "xclass", "xexc"] or
                 "--" not in self.doc_lines):
             self.parsed_params = []
             self._parse_body(self.doc_lines)
@@ -901,7 +901,7 @@ class XobjectDirective(SphinxDirective):
         targetname = self.qualifier + self.obj_name
         sig_node = xnodes.div(classes=["sig-container"], ids=[targetname])
         sig_nodeL = xnodes.div(classes=["sig-body"])
-        if self.name == "xclass":
+        if self.name in ["xclass", "xexc"]:
             sig_nodeL += self._generate_signature_class()
         else:
             self._generate_sigbody(sig_nodeL, "normal")
@@ -951,7 +951,7 @@ class XobjectDirective(SphinxDirective):
 
 
     def _generate_signature_class(self):
-        assert self.name == "xclass"
+        assert self.name == "xclass" or self.name == "xexc"
         body = xnodes.div(classes=["sig-main"])
         body += xnodes.div(nodes.Text("class "), classes=["keyword"])
         body += self._generate_qualifier()
@@ -1472,7 +1472,8 @@ def on_env_merge_info(app, env, docnames, other):
 def on_source_read(app, docname, source):
     assert isinstance(source, list) and len(source) == 1
     txt = source[0]
-    mm = re.match(r"\s*\.\. (xfunction|xmethod|xclass|xdata|xattr):: (.*)", txt)
+    mm = re.match(r"\s*\.\. (xfunction|xmethod|xclass|xexc|xdata|xattr):: (.*)",
+                  txt)
     if mm:
         kind = mm.group(1)
         name = mm.group(2)
@@ -1507,6 +1508,7 @@ def setup(app):
     app.add_directive("xfunction", XobjectDirective)
     app.add_directive("xmethod", XobjectDirective)
     app.add_directive("xclass", XobjectDirective)
+    app.add_directive("xexc", XobjectDirective)
     app.add_directive("xattr", XobjectDirective)
     app.add_directive("xparam", XparamDirective)
     app.add_directive("xversionadded", XversionaddedDirective)

--- a/src/datatable/sphinxext/xfunction.py
+++ b/src/datatable/sphinxext/xfunction.py
@@ -241,6 +241,7 @@ class XobjectDirective(SphinxDirective):
         self.test_file = None
         self.tests_github_url = None
         self.qualifier = None
+        self.qualifier_reftype = "class" if self.name in ["xmethod", "xattr"] else "module"
 
 
     def run(self):
@@ -975,6 +976,7 @@ class XobjectDirective(SphinxDirective):
             assert qual_parts[-1] == ""
             self.obj_name = qual_parts[-2]
             self.qualifier = ".".join(qual_parts[:-2]) + "."
+            self.qualifier_reftype = "module"
             assert self.parsed_params[0] == "self"
             del self.parsed_params[0]
 
@@ -985,11 +987,10 @@ class XobjectDirective(SphinxDirective):
 
 
     def _generate_qualifier(self):
-        reftype = "class" if self.name in ["xmethod", "xattr"] else "module"
         node = xnodes.div(classes=["sig-qualifier"])
         ref = addnodes.pending_xref("", nodes.Text(self.qualifier),
                                     reftarget=self.qualifier[:-1],
-                                    reftype=reftype, refdomain="xpy")
+                                    reftype=self.qualifier_reftype, refdomain="xpy")
         # Note: `ref` cannot be added directly: docutils requires that
         # <reference> nodes were nested inside <TextElement> nodes.
         node += nodes.generated("", "", ref)

--- a/src/datatable/sphinxext/xpython.py
+++ b/src/datatable/sphinxext/xpython.py
@@ -419,9 +419,12 @@ class XPythonDomain(sphinx.domains.Domain):
         print("\x1B[93mWarning\x1B[33m: " + msg + "\x1B[m")
 
     def error(self, msg, node=None):
+        doc = None
+        line = None
         if node:
             doc = node.get("refdoc")
             line = node.get("refline")
+        if doc:
             msg += f" -- at {doc}:{line}"
         else:
             msg += f" -- at {self.env.docname}"


### PR DESCRIPTION
- Added a doc page for each exception class;
- Fix invalid links in multiple files;
- Added option `:qual-type:` in `xobject` directive to override the default type of the qualifier link (only needed for datatable options);
- Fix several errors where pygments was unable to lex a code block;
- Proofread the "comparison with pandas" page: large examples converted into subsections; code samples use console notation whenever input is mixed with the output; canonicalize all internal links; general formatting.
- Table of Contents on the rhs now supports headers of levels 2 and 3;
- Few minor CSS style adjustments.

After this PR, there should no longer be any errors/warnings when building the documentation.

Closes  #2720
Closes #2678