### PR TITLE
Automatically build documentation on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ jobs:
         - LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so
         - SEGFAULT_SIGNALS=all
         - DT_HARNESS=Travis
+        - DT_BUILD_DOCS=1
         - CXX=$LLVM7/bin/clang-7
 
     - name: "Python 3.7 on Linux with LLVM10"
@@ -56,6 +57,7 @@ script:
   - python ci/ext.py wheel
   - pip install --upgrade dist/*.whl
   - pip install -r requirements_tests.txt
+  - pip install -r requirements_docs.txt
   - pip install -r requirements_extra.txt
   - python -m pytest -ra --showlocals -Werror tests
 

--- a/docs/api/frame.rst
+++ b/docs/api/frame.rst
@@ -239,6 +239,7 @@
     .keys()          <frame/keys>
     .ltypes          <frame/ltypes>
     .materialize()   <frame/materialize>
+    .meta            <frame/meta>
     .names           <frame/names>
     .ncols           <frame/ncols>
     .nrows           <frame/nrows>


### PR DESCRIPTION
This PR creates a test that would  build the documentation with Sphinx and  check that there are no warnings/errors. Since  this test is time-consuming, it needs to be enabled via an environment variable `DT_BUILD_DOCS`. At the moment I've enabled this test on Travis for python 3.6 (it appears that sphinx is much slower under python 3.8).

Closes #2744