### PR TITLE
Show types for a frame in  python console

### DIFF
--- a/docs/releases/v1.0.0.rst
+++ b/docs/releases/v1.0.0.rst
@@ -21,6 +21,10 @@
       can now be an unsorted list. The list can also contain duplicate
       values.
 
+    -[enh] When a Frame is shown in a python console, it will now display
+      the stype of each column, as a second line under the column names.
+      [#2810]
+
     -[fix] A Frame can now be created properly from a list of numpy bool
       objects. [#2762]
 

--- a/src/core/cstring.cc
+++ b/src/core/cstring.cc
@@ -20,7 +20,7 @@
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #include <algorithm>         // std::min
-#include <cstring>           // std::strncmp
+#include <cstring>           // std::strncmp, std::strlen
 #include <string>            // std::string
 #include "buffer.h"
 #include "cstring.h"
@@ -46,6 +46,10 @@ CString::CString(const char* ptr, size_t sz)
 
 CString::CString(const std::string& str)
   : ptr_(str.data()), size_(str.size()) {}
+
+CString CString::from_null_terminated_string(const char* cstr) {
+  return CString(cstr, std::strlen(cstr));
+}
 
 
 CString& CString::operator=(CString&& other) {

--- a/src/core/cstring.h
+++ b/src/core/cstring.h
@@ -63,6 +63,7 @@ class CString
     CString& operator=(const std::string& str);
     CString& operator=(const CString&) = delete;
     CString& operator=(std::string&& str) = delete;
+    static CString from_null_terminated_string(const char* cstr);
 
     bool operator==(const CString&) const noexcept;
     bool operator<(const CString&)  const noexcept;

--- a/src/core/frame/repr/terminal_widget.h
+++ b/src/core/frame/repr/terminal_widget.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019 H2O.ai
+// Copyright 2019-2020 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -59,6 +59,7 @@ class TerminalWidget : public Widget {
     std::vector<size_t> _order_colindices() const;
 
     void _render_column_names();
+    void _render_column_types();
     void _render_header_separator();
     void _render_data();
     void _render_footer();

--- a/src/core/frame/repr/text_column.cc
+++ b/src/core/frame/repr/text_column.cc
@@ -88,7 +88,8 @@ Data_TextColumn::Data_TextColumn(const std::string& name,
   // -2 takes into account column's margins
   max_width_ = std::min(max_width - 2, display_max_column_width);
   name_ = _escape_string(CString(name));
-  width_ = std::max(width_, name_.size());
+  type_ = stype_name(col.stype());
+  width_ = std::max(std::max(width_, name_.size()), type_.size());
   LType ltype = col.ltype();
   align_right_ = (ltype == LType::MU) ||
                  (ltype == LType::BOOL) ||
@@ -102,6 +103,15 @@ Data_TextColumn::Data_TextColumn(const std::string& name,
 
 void Data_TextColumn::print_name(TerminalStream& out) const {
   _print_aligned_value(out, name_);
+}
+
+
+void Data_TextColumn::print_type(TerminalStream& out) const {
+  if (name_.empty()) {
+    out << std::string(margin_left_ + margin_right_ + width_, ' ');
+  } else {
+    _print_aligned_value(out, tstring(type_));
+  }
 }
 
 
@@ -374,6 +384,10 @@ void VSep_TextColumn::print_name(TerminalStream& out) const {
   out << tstring("|", style::nobold|style::grey);
 }
 
+void VSep_TextColumn::print_type(TerminalStream& out) const {
+  out << tstring("|", style::nobold|style::nodim|style::noitalic|style::grey);
+}
+
 void VSep_TextColumn::print_separator(TerminalStream& out) const {
   out << '+';
 }
@@ -402,6 +416,12 @@ void Ellipsis_TextColumn::print_name(TerminalStream& out) const {
   out << ell_;
   out << std::string(margin_right_, ' ');
 }
+
+
+void Ellipsis_TextColumn::print_type(TerminalStream& out) const {
+  out << std::string(margin_left_ + margin_right_ + width_, ' ');
+}
+
 
 void Ellipsis_TextColumn::print_separator(TerminalStream& out) const {
   out << std::string(margin_left_, ' ');

--- a/src/core/frame/repr/text_column.cc
+++ b/src/core/frame/repr/text_column.cc
@@ -88,8 +88,10 @@ Data_TextColumn::Data_TextColumn(const std::string& name,
   // -2 takes into account column's margins
   max_width_ = std::min(max_width - 2, display_max_column_width);
   name_ = _escape_string(CString(name));
-  type_ = stype_name(col.stype());
-  width_ = std::max(std::max(width_, name_.size()), type_.size());
+  type_ = _escape_string(CString::from_null_terminated_string(
+                            stype_name(col.stype())));
+  width_ = std::max(std::max(width_, name_.size()),
+                    name_.empty()? 0 : type_.size());
   LType ltype = col.ltype();
   align_right_ = (ltype == LType::MU) ||
                  (ltype == LType::BOOL) ||
@@ -110,7 +112,7 @@ void Data_TextColumn::print_type(TerminalStream& out) const {
   if (name_.empty()) {
     out << std::string(margin_left_ + margin_right_ + width_, ' ');
   } else {
-    _print_aligned_value(out, tstring(type_));
+    _print_aligned_value(out, type_);
   }
 }
 

--- a/src/core/frame/repr/text_column.h
+++ b/src/core/frame/repr/text_column.h
@@ -85,7 +85,7 @@ class Data_TextColumn : public TextColumn {
   private:
     sstrvec data_;
     tstring name_;
-    std::string type_;
+    tstring type_;
     int max_width_;
     int : 32;
 

--- a/src/core/frame/repr/text_column.h
+++ b/src/core/frame/repr/text_column.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019 H2O.ai
+// Copyright 2019-2020 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -74,6 +74,7 @@ class TextColumn {
     int get_width() const;
 
     virtual void print_name(TerminalStream&) const = 0;
+    virtual void print_type(TerminalStream&) const = 0;
     virtual void print_separator(TerminalStream&) const = 0;
     virtual void print_value(TerminalStream&, size_t i) const = 0;
 };
@@ -84,6 +85,7 @@ class Data_TextColumn : public TextColumn {
   private:
     sstrvec data_;
     tstring name_;
+    std::string type_;
     int max_width_;
     int : 32;
 
@@ -96,6 +98,7 @@ class Data_TextColumn : public TextColumn {
     Data_TextColumn(Data_TextColumn&&) noexcept = default;
 
     void print_name(TerminalStream&) const override;
+    void print_type(TerminalStream&) const override;
     void print_separator(TerminalStream&) const override;
     void print_value(TerminalStream&, size_t i) const override;
 
@@ -125,6 +128,7 @@ class VSep_TextColumn : public TextColumn {
     VSep_TextColumn(VSep_TextColumn&&) noexcept = default;
 
     void print_name(TerminalStream&) const override;
+    void print_type(TerminalStream&) const override;
     void print_separator(TerminalStream&) const override;
     void print_value(TerminalStream&, size_t i) const override;
 };
@@ -141,6 +145,7 @@ class Ellipsis_TextColumn : public TextColumn {
     Ellipsis_TextColumn(Ellipsis_TextColumn&&) noexcept = default;
 
     void print_name(TerminalStream&) const override;
+    void print_type(TerminalStream&) const override;
     void print_separator(TerminalStream&) const override;
     void print_value(TerminalStream&, size_t i) const override;
 };


### PR DESCRIPTION
Each column's type is displayed under that column's name. In jupyter output the type of each column is already displayed.

For example:
```
       |  year  month    day  dep_delay  arr_delay  carrier  origin  dest   air_time  distance   hour
       | int32  int32  int32      int32      int32  str32    str32   str32     int32     int32  int32
------ + -----  -----  -----  ---------  ---------  -------  ------  -----  --------  --------  -----
     0 |  2014      1      1         14         13  AA       JFK     LAX         359      2475      9
     1 |  2014      1      1         -3         13  AA       JFK     LAX         363      2475     11
     2 |  2014      1      1          2          9  AA       JFK     LAX         351      2475     19
     3 |  2014      1      1         -8        -26  AA       LGA     PBI         157      1035      7
     4 |  2014      1      1          2          1  AA       JFK     LAX         350      2475     13
```
Closes #2810