### PR TITLE
Directives x-version-changed and x-version-deprecated

### DIFF
--- a/docs/_ext/xfunction.py
+++ b/docs/_ext/xfunction.py
@@ -1371,11 +1371,14 @@ class XparamDirective(SphinxDirective):
 
 
 #-------------------------------------------------------------------------------
-# XversionaddedDirective
+# XversionActionDirective
 #-------------------------------------------------------------------------------
 
-class XversionaddedDirective(SphinxDirective):
-    has_content = False
+class XversionActionDirective(SphinxDirective):
+    #
+    #  TODO: add this to 'xversion' domain
+    #
+    has_content = True
     required_arguments = 1
     optional_arguments = 0
     final_argument_whitespace = False
@@ -1389,12 +1392,17 @@ class XversionaddedDirective(SphinxDirective):
         if len(version.split('.')) <= 2:
             target += ".0"
 
-        node = xnodes.div(classes=["x-version-added"])
-        node += nodes.Text("New in version ")
+        assert self.name.startswith("x-version-")
+        action = self.name[10:]
+        node = xnodes.div()
+        node += nodes.Text(action.title() + " in version ")
         node += nodes.inline("", "",
             addnodes.pending_xref("", nodes.Text(version),
                 refdomain="std", reftype="doc", refexplicit=True,
                 reftarget=target))
+        node = xnodes.div(node, classes=["x-version", action])
+
+        self.state.nested_parse(self.content, self.content_offset, node)
         return [node]
 
 
@@ -1512,6 +1520,7 @@ def setup(app):
     app.add_config_value("xf_permalink_url0", "", "env")
     app.add_config_value("xf_permalink_url2", "", "env")
     app.add_css_file("xfunction.css")
+    app.add_css_file("xversion.css")
     app.add_js_file("https://use.fontawesome.com/0f455d5fb2.js")
     app.add_directive("xdata", XobjectDirective)
     app.add_directive("xfunction", XobjectDirective)
@@ -1520,7 +1529,9 @@ def setup(app):
     app.add_directive("xexc", XobjectDirective)
     app.add_directive("xattr", XobjectDirective)
     app.add_directive("xparam", XparamDirective)
-    app.add_directive("xversionadded", XversionaddedDirective)
+    app.add_directive("x-version-added", XversionActionDirective)
+    app.add_directive("x-version-changed", XversionActionDirective)
+    app.add_directive("x-version-deprecated", XversionActionDirective)
 
     app.connect("env-get-outdated", on_env_get_outdated)
     app.connect("env-purge-doc", on_env_purge_doc)

--- a/docs/_static/xfunction.css
+++ b/docs/_static/xfunction.css
@@ -144,17 +144,6 @@
     font-weight: normal;
 }
 
-.x-function .x-version-added {
-    font-style: italic;
-    font-size: 90%;
-    text-align: right;
-    position: relative;
-    top: -6pt;
-}
-
-.x-function .xparam-body .x-version-added {
-    top: 0;
-}
 
 
 /*------------------------------------------------------------------------------

--- a/docs/_static/xversion.css
+++ b/docs/_static/xversion.css
@@ -1,0 +1,84 @@
+
+/*------------------------------------------------------------------------------
+ * x-version (common)
+ *-----------------------------------------------------------------------------*/
+
+.x-version > div:first-child {
+    display: inline-block;
+    padding: 3px 8px;
+    font-style: italic;
+    font-size: 90%;
+}
+
+.x-version > div:first-child:before {
+    font-family: 'FontAwesome';
+    font-style: normal;
+    padding-right: 8px;
+}
+
+
+
+/*------------------------------------------------------------------------------
+ * x-version-added
+ *-----------------------------------------------------------------------------*/
+
+.x-version.added {
+    margin: -7px 0 8px 32px;
+    text-align: right;
+}
+
+.x-version.added > div {
+    background: #e0f8e0;
+    color: #007700;
+}
+
+.x-version.added > div:first-child:before {
+    content: "\f055";
+}
+
+
+/*------------------------------------------------------------------------------
+ * x-version-deprecated
+ *-----------------------------------------------------------------------------*/
+
+.x-version.deprecated {
+    margin: -7px 0 8px 32px;
+    text-align: right;
+}
+
+.x-version.deprecated > div {
+    background: #fcf2e4;
+    color: #ff7700;
+}
+
+.x-version.deprecated > div:first-child:before {
+    content: "\f071";
+}
+
+
+/*------------------------------------------------------------------------------
+ * x-version-changed
+ *-----------------------------------------------------------------------------*/
+
+.x-version.changed {
+    border: 1px solid #82dbef;
+    padding: 4px 8px 4px 30px;
+    background: #f3f9ff;
+}
+
+.x-version.changed > div:first-child {
+    color: #1c6c79;
+    margin-bottom: .5rem;
+    padding: 0;
+    position: relative;
+}
+
+.x-version.changed > div:first-child:before {
+    content: "\f0aa";
+    position: absolute;
+    left: -18px;
+}
+
+.x-version.changed > p:last-child {
+    margin-bottom: 0;
+}

--- a/docs/_static/xversion.css
+++ b/docs/_static/xversion.css
@@ -36,6 +36,12 @@
     content: "\f055";
 }
 
+.x-version.added > div:first-child a {
+    color: #0a6d0a;
+    font-weight: bold;
+}
+
+
 
 /*------------------------------------------------------------------------------
  * x-version-deprecated
@@ -54,6 +60,12 @@
 .x-version.deprecated > div:first-child:before {
     content: "\f071";
 }
+
+div.x-version.deprecated > div:first-child a {
+    color: #d07617;
+    font-weight: bold;
+}
+
 
 
 /*------------------------------------------------------------------------------
@@ -77,6 +89,11 @@
     content: "\f0aa";
     position: absolute;
     left: -18px;
+}
+
+.x-version.changed > div:first-child a {
+    font-weight: bold;
+    color: #155d69;
 }
 
 .x-version.changed > p:last-child {

--- a/docs/api/dt/build_info.rst
+++ b/docs/api/dt/build_info.rst
@@ -50,14 +50,14 @@
 
     .. xparam:: .git_date: str
 
-        .. xversionadded:: 0.11
+        .. x-version-added:: 0.11
 
         Timestamp of the git commit from which the build was made.
 
 
     .. xparam:: .git_diff: str
 
-        .. xversionadded:: 0.11
+        .. x-version-added:: 0.11
 
         If the source tree contains any uncommitted changes (compared
         to the checked out git revision), then the summary of these

--- a/docs/api/fexpr/len.rst
+++ b/docs/api/fexpr/len.rst
@@ -5,7 +5,7 @@
     len(self)
     --
 
-    .. deprecated:: 0.11
+    .. x-version-deprecated:: 0.11
 
     Return the string length for a string column. This method can only
     be applied to string columns, and it returns an integer column as a

--- a/docs/develop/documentation.rst
+++ b/docs/develop/documentation.rst
@@ -260,9 +260,11 @@ version, use:
 
 .. code-block:: rst
 
-    .. xversionadded:: 0.10.0
+    .. x-version-added:: 0.10.0
 
-    .. versionchanged:: 0.11.0
+    .. x-version-changed:: 0.11.0
+
+    .. x-version-deprecated:: 1.0.0
 
 
 The ``.. seealso::`` directive adds a Wikipedia-style "see also:" entry at the

--- a/docs/develop/documentation.rst
+++ b/docs/develop/documentation.rst
@@ -262,10 +262,11 @@ version, use:
 
     .. x-version-added:: 0.10.0
 
-    .. x-version-changed:: 0.11.0
-
     .. x-version-deprecated:: 1.0.0
 
+    .. x-version-changed:: 0.11.0
+
+        Here's what changed: blah-blah-blah
 
 The ``.. seealso::`` directive adds a Wikipedia-style "see also:" entry at the
 beginning of a section. The argument of this directive should contain a link

--- a/docs/develop/test.rst
+++ b/docs/develop/test.rst
@@ -523,4 +523,30 @@ spaced from the admonition.
     - Fourth is the last one (or is it?)
 
 
+
+X-versions
+----------
+
+.. x-version-added:: 0.8.0
+
+The ``..x-version-added`` directive usually comes as a first item after a
+header, so it has reduced margins from the top, and has to have adequate
+margins on the bottom to compensate.
+
+.. x-version-deprecated:: 0.10.0
+
+The ``..x-version-changed`` directive is a paragraph-level, and it usually has
+some additional content describing what exactly has changed.
+
+.. x-version-changed:: 0.9.0
+
+    Nobody knows what exactly changed, but most observers agree that
+    *something* did.
+
+    While we're trying to figure out what it was, please visit the release
+    notes (linked above) and see if it makes sense to you.
+
+
+
+
 .. _`example website`: https://www.example.com/

--- a/docs/manual/f-expressions.rst
+++ b/docs/manual/f-expressions.rst
@@ -141,7 +141,7 @@ such as:
     >>> sum(f[:])       # equivalent to [sum(f[i]) for i in range(DT.ncols)]
     >>> f[:3] + f[-3:]  # same as [f[0]+f[-3], f[1]+f[-2], f[2]+f[-1]]
 
-.. xversionadded:: 0.10.0
+.. x-version-added:: 0.10.0
 
 
 Modifying a columnset
@@ -200,5 +200,5 @@ will be thrown if the argument of ``.remove()`` contains any transformed
 columns.
 
 
-.. xversionadded:: 0.10.0
+.. x-version-added:: 0.10.0
 

--- a/src/core/datatablemodule.cc
+++ b/src/core/datatablemodule.cc
@@ -125,7 +125,7 @@ return: List[bool]
 
 Notes
 -----
-.. deprecated:: 0.11.0
+.. x-version-deprecated:: 0.11.0
 
 This function will be expanded and moved into the main :class:`dt.Frame` class.
 )";
@@ -217,7 +217,7 @@ static const char* doc_in_debug_mode =
 R"(
 Return `True` if :mod:`datatable` was compiled in debug mode.
 
-.. deprecated:: 0.11.0
+.. x-version-deprecated:: 0.11.0
 )";
 
 static py::PKArgs args_in_debug_mode(
@@ -301,7 +301,7 @@ static const char* doc_compiler_version =
 R"(
 Return the version of the C++ compiler used to compile this module.
 
-.. deprecated:: 0.11.0
+.. x-version-deprecated:: 0.11.0
 )";
 
 static py::PKArgs args_compiler_version(
@@ -339,7 +339,7 @@ static const char* doc_regex_supported =
 R"(
 Was the datatable built with regular expression support?
 
-.. deprecated:: 0.11.0
+.. x-version-deprecated:: 0.11.0
 )";
 
 static py::PKArgs args_regex_supported(

--- a/src/core/expr/fexpr.cc
+++ b/src/core/expr/fexpr.cc
@@ -285,7 +285,7 @@ static const char* doc_re_match =
 R"(re_match(self, pattern, flags=None)
 --
 
-.. deprecated:: 0.11
+.. x-version-deprecated:: 0.11
 
 Test whether values in a string column match a regular expression.
 

--- a/src/core/expr/fexpr_astype.cc
+++ b/src/core/expr/fexpr_astype.cc
@@ -71,7 +71,7 @@ class FExpr_AsType : public FExpr_FuncUnary {
 static const char* doc_astype =
 R"(as_type(cols, new_type)
 --
-.. xversionadded:: 1.0
+.. x-version-added:: 1.0
 
 Convert columns `cols` into the prescribed stype.
 

--- a/src/core/expr/fexpr_cut.cc
+++ b/src/core/expr/fexpr_cut.cc
@@ -133,7 +133,7 @@ class FExpr_Cut : public FExpr_Func {
 static const char* doc_cut =
 R"(cut(cols, nbins=10, right_closed=True)
 --
-.. xversionadded:: 0.11
+.. x-version-added:: 0.11
 
 Cut all the columns from `cols` by binning their values into
 equal-width discrete intervals.

--- a/src/core/expr/fexpr_ifelse.cc
+++ b/src/core/expr/fexpr_ifelse.cc
@@ -144,7 +144,7 @@ std::string FExpr_IfElse::repr() const {
 static const char* doc_ifelse =
 R"(ifelse(condition1, value1, condition2, value2, ..., default)
 --
-.. xversionadded:: 0.11.0
+.. x-version-added:: 0.11.0
 
 An expression that chooses its value based on one or more
 conditions.
@@ -187,7 +187,7 @@ return: FExpr
 
 Notes
 -----
-.. versionchanged:: 1.0.0
+.. x-version-changed:: 1.0.0
 
     Earlier this function accepted a single condition only.
 
@@ -203,7 +203,7 @@ Examples
 
     df = dt.Frame("""Type       Set
                       A          Z
-                      B          Z           
+                      B          Z
                       B          X
                       C          Y""")
 

--- a/src/core/expr/fexpr_qcut.cc
+++ b/src/core/expr/fexpr_qcut.cc
@@ -139,7 +139,7 @@ class FExpr_Qcut : public FExpr_Func {
 static const char* doc_qcut =
 R"(qcut(cols, nquantiles=10)
 --
-.. xversionadded:: 0.11
+.. x-version-added:: 0.11
 
 Bin all the columns from `cols` into intervals with approximately
 equal populations. Thus, the intervals are chosen according to

--- a/src/core/expr/fexpr_round.cc
+++ b/src/core/expr/fexpr_round.cc
@@ -302,7 +302,7 @@ class FExpr_Round : public FExpr_FuncUnary {
 static const char* doc_round =
 R"(round(cols, ndigits=None)
 --
-.. xversionadded:: 0.11
+.. x-version-added:: 0.11
 
 Round the values in `cols` up to the specified number of the digits
 of precision `ndigits`. If the number of digits is omitted, rounds

--- a/src/core/frame/py_frame.cc
+++ b/src/core/frame/py_frame.cc
@@ -284,7 +284,7 @@ size_t Frame::m__len__() const {
 static const char* doc_export_names =
 R"(export_names(self)
 --
-.. xversionadded:: 0.10
+.. x-version-added:: 0.10
 
 Return a tuple of :ref:`f-expressions` for all columns of the frame.
 
@@ -452,7 +452,7 @@ void Frame::materialize(const PKArgs& args) {
 
 static const char* doc_meta =
 R"(
-.. xversionadded:: 1.0
+.. x-version-added:: 1.0
 
 Frame's meta information.
 
@@ -620,7 +620,7 @@ oobj Frame::get_ndims() const {
 
 static const char* doc_source =
 R"(
-.. xversionadded:: 0.11
+.. x-version-added:: 0.11
 
 The name of the file where this frame was loaded from.
 
@@ -701,7 +701,7 @@ oobj Frame::get_stypes() const {
 
 static const char* doc_stype =
 R"(
-.. xversionadded:: v0.10.0
+.. x-version-added:: v0.10.0
 
 The common :class:`dt.stype` for all columns.
 

--- a/src/core/read/py_fread.cc
+++ b/src/core/read/py_fread.cc
@@ -214,7 +214,8 @@ memory_limit: int
 return: Frame
     A single :class:`Frame` object is always returned.
 
-    .. versionchanged:: 0.11.0
+    .. x-version-changed:: 0.11.0
+
         Previously, a ``dict`` of Frames was returned when multiple
         input sources were provided.
 

--- a/src/datatable/__init__.py
+++ b/src/datatable/__init__.py
@@ -155,7 +155,7 @@ dt.lib._datatable.initialize_final()
 
 def open(path):
     """
-    .. deprecated:: 0.10.0
+    .. x-version-deprecated:: 0.10.0
         Use :func:`fread` instead.
     """
     import warnings


### PR DESCRIPTION
The primary difference from Sphinx standard `..versionchanged` and `..deprecated` directives is that the version number is a link and leads to the corresponding Release Notes page. 