### PR TITLE
[ENH] f-expression with list/tuple accepted in `j` selector

### DIFF
--- a/docs/api/namespace/__getitem__.rst
+++ b/docs/api/namespace/__getitem__.rst
@@ -2,14 +2,10 @@
 .. xmethod:: datatable.Namespace.__getitem__
     :src: src/core/expr/namespace.cc Namespace::m__getitem__
 
-    __getitem__(self, item)
+    __getitem__(self, *items)
     --
 
     Retrieve column(s) by their indices/names/types.
-
-    Also retrieve column(s) via :ref:`f-expressions`
-    containing a list/tuple of
-    column names/column positions/column types.
 
     By "retrieve" we actually mean that an expression is created
     such that when that expression is used within the
@@ -19,12 +15,12 @@
 
     Parameters
     ----------
-    item: int | str | slice | None | type | stype | ltype | Expr
+    items: int | str | slice | None | type | stype | ltype | list | tuple
         The column selector:
 
         ``int``
             Retrieve the column at the specified index. For example,
-            ``f[0]`` denotes the first column, whlie ``f[-1]`` is the
+            ``f[0]`` denotes the first column, while ``f[-1]`` is the
             last.
 
         ``str``
@@ -34,16 +30,22 @@
             Retrieve a slice of columns from the namespace. Both integer
             and string slices are supported.
 
+            Note that for string slicing, both the *start* and *stop* column
+            names are included, unlike integer slicing, where the *stop* value
+            is not included. Have a look at the examples below for more clarity.
+
         ``None``
             Retrieve no columns (an empty columnset).
 
         ``type`` | ``stype`` | ``ltype``
             Retrieve columns matching the specified type.
 
-        ``Expr``
+        ``list/tuple``
             Retrieve columns matching the column names/column positions/column types
-            within the list/tuple.  For example, ``f[0, -1]`` will return the first and
-            last columns.
+            within the list/tuple.
+
+            For example, ``f[0, -1]`` will return the first and last columns.
+            Have a look at the examples below for more clarity.
 
     return: FExpr
         An expression that selects the specified column from a frame.
@@ -60,3 +62,170 @@
         :ref:`f-expressions` containing a list/tuple of
         column names/column positions/column types are
         accepted within the `j` selector.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> from datatable import dt, f, by
+        >>>
+        >>> df = dt.Frame({'A': [1, 2, 3, 4],
+        ...                'B': ["tolu", "sammy", "ogor", "boondocks"],
+        ...                'C': [9.0, 10.0, 11.0, 12.0]})
+        >>>
+        >>> df
+           |     A  B                C
+           | int32  str32      float64
+        -- + -----  ---------  -------
+         0 |     1  tolu             9
+         1 |     2  sammy           10
+         2 |     3  ogor            11
+         3 |     4  boondocks       12
+        [4 rows x 3 columns]
+
+
+    Select by column position::
+
+        >>> df[:, f[0]]
+           |     A
+           | int32
+        -- + -----
+         0 |     1
+         1 |     2
+         2 |     3
+         3 |     4
+        [4 rows x 1 column]
+
+
+    Select by column name::
+
+        >>> df[:, f["A"]]
+           |     A
+           | int32
+        -- + -----
+         0 |     1
+         1 |     2
+         2 |     3
+         3 |     4
+        [4 rows x 1 column]
+
+
+    Select a slice::
+
+        >>> df[:, f[0 : 2]]
+           |     A  B
+           | int32  str32
+        -- + -----  ---------
+         0 |     1  tolu
+         1 |     2  sammy
+         2 |     3  ogor
+         3 |     4  boondocks
+        [4 rows x 2 columns]
+
+
+    Slicing with column names::
+
+        >>> df[:, f["A" : "C"]]
+           |     A  B                C
+           | int32  str32      float64
+        -- + -----  ---------  -------
+         0 |     1  tolu             9
+         1 |     2  sammy           10
+         2 |     3  ogor            11
+         3 |     4  boondocks       12
+        [4 rows x 3 columns]
+
+    .. note:: For string slicing, **both** the start and stop are included; for integer slicing the stop is **not** included.
+
+    Select by data type::
+
+        >>> df[:, f[dt.str32]]
+           | B
+           | str32
+        -- + ---------
+         0 | tolu
+         1 | sammy
+         2 | ogor
+         3 | boondocks
+        [4 rows x 1 column]
+
+        >>> df[:, f[float]]
+           |       C
+           | float64
+        -- + -------
+         0 |       9
+         1 |      10
+         2 |      11
+         3 |      12
+        [4 rows x 1 column]
+
+    Select a list/tuple of columns by position::
+
+        >>> df[:, f[0, 1]]
+
+           |     A  B
+           | int32  str32
+        -- + -----  ---------
+         0 |     1  tolu
+         1 |     2  sammy
+         2 |     3  ogor
+         3 |     4  boondocks
+        [4 rows x 2 columns]
+
+    Or by column names::
+
+        >>> df[:, f[("A", "B")]]
+           |     A  B
+           | int32  str32
+        -- + -----  ---------
+         0 |     1  tolu
+         1 |     2  sammy
+         2 |     3  ogor
+         3 |     4  boondocks
+        [4 rows x 2 columns]
+
+
+    Note that in the code above, the parentheses are unnecessary, since tuples in python are defined
+    by the presence of a comma. So the below code works as well::
+
+        >>> df[:, f["A", "B"]]
+           |     A  B
+           | int32  str32
+        -- + -----  ---------
+         0 |     1  tolu
+         1 |     2  sammy
+         2 |     3  ogor
+         3 |     4  boondocks
+        [4 rows x 2 columns]
+
+
+    Select a list/tuple of data types::
+
+        >>> df[:, f[int, float]]
+           |     A        C
+           | int32  float64
+        -- + -----  -------
+         0 |     1        9
+         1 |     2       10
+         2 |     3       11
+         3 |     4       12
+        [4 rows x 2 columns]
+
+    Passing ``None`` within an :ref:`f-expressions` returns an empty columnset::
+
+        >>> df[:, f[None]]
+           |
+           |
+        -- +
+         0 |
+         1 |
+         2 |
+         3 |
+        [4 rows x 0 columns]
+
+
+
+
+
+
+

--- a/docs/api/namespace/__getitem__.rst
+++ b/docs/api/namespace/__getitem__.rst
@@ -43,3 +43,11 @@
     See also
     --------
     - :ref:`f-expressions` -- user guide on using f-expressions.
+
+    Notes
+    -----
+    .. x-version-changed:: 1.0.0
+
+        :ref:`f-expressions` containing a list/tuple of
+        column names/column positions/column types are
+        accepted within the `j` selector.

--- a/docs/api/namespace/__getitem__.rst
+++ b/docs/api/namespace/__getitem__.rst
@@ -7,6 +7,10 @@
 
     Retrieve column(s) by their indices/names/types.
 
+    Also retrieve column(s) via :ref:`f-expressions`
+    containing a list/tuple of
+    column names/column positions/column types.
+
     By "retrieve" we actually mean that an expression is created
     such that when that expression is used within the
     :meth:`DT[i,j] <dt.Frame.__getitem__>` call, it would locate and
@@ -15,7 +19,7 @@
 
     Parameters
     ----------
-    item: int | str | slice | None | type | stype | ltype
+    item: int | str | slice | None | type | stype | ltype | Expr
         The column selector:
 
         ``int``
@@ -35,6 +39,11 @@
 
         ``type`` | ``stype`` | ``ltype``
             Retrieve columns matching the specified type.
+
+        ``Expr``
+            Retrieve columns matching the column names/column positions/column types
+            within the list/tuple.  For example, ``f[0, -1]`` will return the first and
+            last columns.
 
     return: FExpr
         An expression that selects the specified column from a frame.

--- a/docs/releases/v1.0.0.rst
+++ b/docs/releases/v1.0.0.rst
@@ -53,7 +53,7 @@
       columns of type ArrayView64. [#2802]
 
     -[enh] :ref:`f-expressions` now accepts a list/tuple of
-      column names/column positions/column types in the ``j`` section.
+      column names/column positions/column types in the ``j`` section. [#2797]
 
 
     fread

--- a/docs/releases/v1.0.0.rst
+++ b/docs/releases/v1.0.0.rst
@@ -52,6 +52,9 @@
     -[fix] Fix a crash that occurred when using `median()` on virtual
       columns of type ArrayView64. [#2802]
 
+    -[enh] :ref:`f-expressions` now accepts a list/tuple of
+      column names/column positions/column types in the ``j`` section.
+
 
     fread
     -----

--- a/src/core/expr/fexpr_list.cc
+++ b/src/core/expr/fexpr_list.cc
@@ -98,9 +98,12 @@ Workframe FExpr_List::evaluate_r(
 
 
 
-Workframe FExpr_List::evaluate_f(EvalContext&, size_t) const {
-  throw TypeError()
-      << "A list or a sequence cannot be used inside an f-selector";
+Workframe FExpr_List::evaluate_f(EvalContext& ctx, size_t i) const {
+  Workframe outputs(ctx);
+  for (const auto& arg : args_) {
+    outputs.cbind( arg->evaluate_f(ctx, i) );
+  }
+  return outputs;
 }
 
 

--- a/src/core/expr/namespace.cc
+++ b/src/core/expr/namespace.cc
@@ -95,11 +95,12 @@ oobj Namespace::m__getattr__(robj attr) {
 //------------------------------------------------------------------------------
 
 oobj Namespace::m__getitem__(robj item) {
-  if (!(item.is_int() || item.is_string() || item.is_slice() ||
-        item.is_none() || item.is_type() || item.is_stype() || item.is_ltype()))
+  if (!(item.is_int() || item.is_string() ||item.is_slice() ||
+        item.is_none() || item.is_type() || item.is_stype() ||
+        item.is_ltype() || item.is_list_or_tuple()))
   {
     throw TypeError() << "Column selector should be an integer, string, "
-                         "or slice, not " << item.typeobj();
+                         "or slice, or list/tuple, not " << item.typeobj();
   }
   return dt::expr::PyFExpr::make(
               new dt::expr::FExpr_ColumnAsArg(index_, item));

--- a/tests/munging/test-dt-cols.py
+++ b/tests/munging/test-dt-cols.py
@@ -107,7 +107,19 @@ def test_j_function(dt0):
         dt0, lambda r: r.A,
         "An object of type <class 'function'> cannot be used in an FExpr")
 
+def test_j_f_sequence():
+    frame = dt.Frame(
+    {
+        "id": ["a", "a", "a", "b", "b"],
+        "type": ["in_scope", "in_scope", "exclude", "in_scope", "exclude"],
+        "value": [5, 5, 99, 20, 99],
+    }
+)
 
+    # multiple column selection by label
+    assert frame[:, f['value', 'id']].to_list()[0] == frame[:, ['value', 'id']].to_list()[0]
+    # multiple column selection by position
+    assert frame[:, f[-1, 0]].to_list()[0] == frame[:, ['value', 'id']].to_list()[0]
 
 #-------------------------------------------------------------------------------
 # Integer-valued `j`

--- a/tests/munging/test-dt-cols.py
+++ b/tests/munging/test-dt-cols.py
@@ -117,9 +117,9 @@ def test_j_f_sequence():
 )
 
     # multiple column selection by label
-    assert frame[:, f['value', 'id']].to_list()[0] == frame[:, ['value', 'id']].to_list()[0]
+    assert_equals(frame[:, f['value', 'id']], frame[:, ['value', 'id']])
     # multiple column selection by position
-    assert frame[:, f[-1, 0]].to_list()[0] == frame[:, ['value', 'id']].to_list()[0]
+    assert_equals(frame[:, f[-1, 0]], frame[:, ['value', 'id']])
 
 #-------------------------------------------------------------------------------
 # Integer-valued `j`

--- a/tests/test-dt-expr.py
+++ b/tests/test-dt-expr.py
@@ -137,8 +137,10 @@ def test_equal_columnset():
     DT = dt.Frame([[1, 2, 3], [5, 4, 1]], names=["A", "B"])
     DT2 = DT[:, f[:] == 1]
     DT3 = DT[:, 2 < f[:]]
+    DT4 = DT[:, 2<f["A", "B"]] # test f-expressions with sequence
     assert_equals(DT2, dt.Frame([[True, False, False], [False, False, True]]))
     assert_equals(DT3, dt.Frame([[False, False, True], [True, True, False]]))
+    assert_equals(DT4, dt.Frame([[False, False, True], [True, True, False]]))
 
 
 

--- a/tests/test-f.py
+++ b/tests/test-f.py
@@ -89,14 +89,14 @@ def test_f_col_selector_invalid():
     with pytest.raises(TypeError) as e:
         noop(f[2.5])
     assert str(e.value) == ("Column selector should be an integer, string, or "
-                            "slice, not <class 'float'>")
+                            "slice, or list/tuple, not <class 'float'>")
     # Note: at some point we may start supporting all the expressions below:
     with pytest.raises(TypeError):
-        noop(f[[7, 4]])
-    with pytest.raises(TypeError):
-        noop(f[("A", "B", "C")])
-    with pytest.raises(TypeError):
         noop(f[lambda: 1])
+
+def test_f_col_selector_list_tuple():
+    assert str(f[[7, 4]]) == "FExpr<f[[7, 4]]>"
+    assert str(f[("A", "B", "C")]) == "FExpr<f[['A', 'B', 'C']]>"
 
 
 def test_f_expressions():
@@ -120,6 +120,9 @@ def test_f_columnset_str():
     assert str(f[dt.int32]) == "FExpr<f[stype.int32]>"
     assert str(f[dt.float64]) == "FExpr<f[stype.float64]>"
     assert str(f[dt.ltype.int]) == "FExpr<f[ltype.int]>"
+    assert str(f[int, float]) == "FExpr<f[[int, float]]>"
+    assert str(f[dt.int32, dt.float64, dt.str32]) == \
+        "FExpr<f[[stype.int32, stype.float64, stype.str32]]>"
 
 
 def test_f_columnset_extend():
@@ -127,11 +130,15 @@ def test_f_columnset_extend():
         "Expr:setplus(FExpr<f[:]>, FExpr<f.A>; )"
     assert str(f[int].extend(f[str])) == \
         "Expr:setplus(FExpr<f[int]>, FExpr<f[str]>; )"
+    assert str(f.A.extend(f['B','C'])) == \
+        "Expr:setplus(FExpr<f.A>, FExpr<f[['B', 'C']]>; )"
 
 
 def test_f_columnset_remove():
     assert str(f[:].remove(f.A)) == "Expr:setminus(FExpr<f[:]>, FExpr<f.A>; )"
     assert str(f[int].remove(f[0])) == "Expr:setminus(FExpr<f[int]>, FExpr<f[0]>; )"
+    assert str(f.A.remove(f['B','C'])) == \
+        "Expr:setminus(FExpr<f.A>, FExpr<f[['B', 'C']]>; )"
 
 
 
@@ -199,6 +206,7 @@ def test_f_columnset_ltypes(DT):
 def test_columnset_sum(DT):
     assert_equals(DT[:, f[int].extend(f[float])], DT[:, [int, float]])
     assert_equals(DT[:, f[:3].extend(f[-3:])], DT[:, [0, 1, 2, -3, -2, -1]])
+    assert_equals( DT[:, f['A','B','C'].extend(f['E','F', 'G'])], DT[:, [0, 1, 2, -3, -2, -1]])
     assert_equals(DT[:, f.A.extend(f.B)], DT[:, ['A', 'B']])
     assert_equals(DT[:, f[:].extend({"extra": f.A + f.C})],
                   dt.cbind(DT, DT[:, {"extra": f.A + f.C}]))


### PR DESCRIPTION
- resolves #2797 
- Allows lists/tuples of f-expression in the `j` selector