### PR TITLE
Optimize i-selector of frame type

### DIFF
--- a/src/core/rowindex_array.cc
+++ b/src/core/rowindex_array.cc
@@ -140,13 +140,15 @@ void ArrayRowIndexImpl::init_from_boolean_column(const Column& col) {
     return;
   }
   int8_t value;
+  Column colcopy = col;
+  colcopy.materialize();
   if (length <= INT32_MAX && col.nrows() <= INT32_MAX) {
     type = RowIndexType::ARR32;
     _resize_data();
     auto ind32 = static_cast<int32_t*>(buf_.xptr());
     size_t k = 0;
     for (size_t i = 0; i < col.nrows(); ++i) {
-      bool isvalid = col.get_element(i, &value);
+      bool isvalid = colcopy.get_element(i, &value);
       if (value && isvalid) {
         ind32[k++] = static_cast<int32_t>(i);
       }
@@ -157,7 +159,7 @@ void ArrayRowIndexImpl::init_from_boolean_column(const Column& col) {
     auto ind64 = static_cast<int64_t*>(buf_.xptr());
     size_t k = 0;
     for (size_t i = 0; i < col.nrows(); ++i) {
-      bool isvalid = col.get_element(i, &value);
+      bool isvalid = colcopy.get_element(i, &value);
       if (value && isvalid) {
         ind64[k++] = static_cast<int64_t>(i);
       }


### PR DESCRIPTION
Under these circumstances:
`df[condition, :]` that condition is a frame
If the condition frame contains a more complex virtual column, because the function `ArrayRowIndexImpl::init_from_boolean_column` does not have the parallelized `get_element` function, serialization is slower. **Call the parallelized `materialize` function in advance to optimize performance**.**On the other hand, `materialize` function in advance can also use data locality to improve performance**

Take the data of kaggle competition as an example，can be accelerated **3x** times in my machine.
https://www.kaggle.com/benhamner/sf-bay-area-bike-share/data

![image](https://user-images.githubusercontent.com/19861628/104680197-4b63b280-572a-11eb-82e0-1b557c889e39.png)

Machine hardware：
_Intel(R) Core(TM) i9-9820X CPU @ 3.30GHz
20 cores_