### PR TITLE
Prevent overflow in FTRL predictions

### DIFF
--- a/src/core/models/dt_ftrl.cc
+++ b/src/core/models/dt_ftrl.cc
@@ -875,7 +875,7 @@ dtptr Ftrl<T>::predict(const DataTable* dt_X) {
  *  Normalize predictions, so that their values sum up to `1` row-wise.
  *  To prevent overflow when calculating the softmax function,
  *  we multiply its numerator and denominator by `std::exp(-max)`,
- *  where `max` is the maximum value of prediction for a given row.
+ *  where `max` is the maximum value of predictions for a given row.
  */
 template <typename T>
 void Ftrl<T>::softmax_rows(std::vector<T*>& data_p, const size_t nrows) {

--- a/src/core/models/dt_ftrl.h
+++ b/src/core/models/dt_ftrl.h
@@ -132,7 +132,7 @@ class Ftrl : public dt::FtrlBase {
     void create_fi();
     void init_fi();
     void define_features();
-    void normalize_rows(dtptr&);
+    void softmax_rows(std::vector<T*>&, const size_t);
 
     // Parameter helper methods.
     void init_helper_params();


### PR DESCRIPTION
For multinomial classification problems FTRL does `softmax` normalization of the computed predictions. Since it involves computation of exponential functions, it may occasionally overflow on some data. In this PR we fix this issue by trying to avoid calculations of exponential function on large arguments.

WIP for https://github.com/h2oai/h2oai/issues/20286