### PR TITLE
New Type class

### DIFF
--- a/docs/_ext/xfunction.py
+++ b/docs/_ext/xfunction.py
@@ -1140,7 +1140,7 @@ def locate_cxx_function(name, kind, lines):
         rx_start = re.compile(r"(\s*)"
                               r"(?:static\s+|inline\s+)*"
                               r"(?:[\w:*&<> ]+)\s+" +
-                              name +
+                              r"(?:\w+::)*" + name +
                               r"\s*\(.*\)\s*" +
                               r"(?:const\s*|noexcept\s*|override\s*)*" +
                               r"\{\s*")

--- a/docs/api/frame.rst
+++ b/docs/api/frame.rst
@@ -122,6 +122,9 @@
         * - :attr:`.stypes`
           - Storage types (:class:`dt.stype`s) of all columns.
 
+        * - :attr:`.types`
+          - types (:class:`dt.Type`s) of all columns.
+
 
     Other methods
     -------------
@@ -262,4 +265,5 @@
     .to_numpy()      <frame/to_numpy>
     .to_pandas()     <frame/to_pandas>
     .to_tuples()     <frame/to_tuples>
+    .types           <frame/types>
     .view()          <frame/view>

--- a/docs/api/frame/types.rst
+++ b/docs/api/frame/types.rst
@@ -1,0 +1,4 @@
+
+.. xattr:: datatable.Frame.types
+    :src: src/core/frame/py_frame.cc Frame::get_types
+    :doc: src/core/frame/py_frame.cc doc_types

--- a/docs/api/index-api.rst
+++ b/docs/api/index-api.rst
@@ -201,7 +201,7 @@ Other
     ltype             <ltype>
     Namespace         <namespace>
     stype             <stype>
-    Type             <type>
+    Type              <type>
     as_type()         <dt/as_type>
     build_info        <dt/build_info>
     by()              <dt/by>

--- a/docs/api/index-api.rst
+++ b/docs/api/index-api.rst
@@ -48,12 +48,14 @@ Classes
     * - :class:`Namespace`
       - Helper class for addressing columns in a frame.
 
+    * - :class:`Type`
+      - Column's type, similar to numpy's ``dtype``.
+
     * - :class:`stype`
-      - Enum of column "storage" types, analogous to numpy's ``dtype``.
+      - [DEPRECATED] Enum of column "storage" types.
 
     * - :class:`ltype`
-      - Enum of column "logical" types, similar to standard Python notion
-        of a ``type``.
+      - [DEPRECATED] Enum of column "logical" types.
 
 
 Functions
@@ -199,6 +201,7 @@ Other
     ltype             <ltype>
     Namespace         <namespace>
     stype             <stype>
+    Type             <type>
     as_type()         <dt/as_type>
     build_info        <dt/build_info>
     by()              <dt/by>

--- a/docs/api/type.rst
+++ b/docs/api/type.rst
@@ -6,14 +6,15 @@
     .. toctree::
         :hidden:
 
-        void     <type/void>
         bool8    <type/bool8>
-        int8     <type/int8>
+        float32  <type/float32>
+        float64  <type/float64>
         int16    <type/int16>
         int32    <type/int32>
         int64    <type/int64>
-        float32  <type/float32>
-        float64  <type/float64>
+        int8     <type/int8>
+        name     <type/name>
+        obj64    <type/obj64>
         str32    <type/str32>
         str64    <type/str64>
-        obj64    <type/obj64>
+        void     <type/void>

--- a/docs/api/type.rst
+++ b/docs/api/type.rst
@@ -1,0 +1,19 @@
+
+.. xclass:: datatable.Type
+    :src: src/core/types/py_type.h PyType
+    :doc: src/core/types/py_type.cc doc_Type
+
+    .. toctree::
+        :hidden:
+
+        void     <type/void>
+        bool8    <type/bool8>
+        int8     <type/int8>
+        int16    <type/int16>
+        int32    <type/int32>
+        int64    <type/int64>
+        float32  <type/float32>
+        float64  <type/float64>
+        str32    <type/str32>
+        str64    <type/str64>
+        obj64    <type/obj64>

--- a/docs/api/type/bool8.rst
+++ b/docs/api/type/bool8.rst
@@ -1,0 +1,17 @@
+
+.. xattr:: datatable.Type.bool8
+    :src: --
+
+    The type of a column with boolean data.
+
+    In a column of this type each data element is stored as 1 byte. NA values
+    are also supported.
+
+    The boolean type is considered numeric, where ``True`` is 1 and ``False``
+    is 0.
+
+
+    Examples
+    --------
+    >>> dt.Frame([True, False, None]).types
+    [Type.bool8]

--- a/docs/api/type/float32.rst
+++ b/docs/api/type/float32.rst
@@ -3,4 +3,4 @@
     :src: --
 
     Single-precision floating point type. This corresponds to C type ``float``.
-    Each element of this type is 4 bytes.
+    Each element of this type is 4 bytes long.

--- a/docs/api/type/float32.rst
+++ b/docs/api/type/float32.rst
@@ -1,0 +1,6 @@
+
+.. xattr:: datatable.Type.float32
+    :src: --
+
+    Single-precision floating point type. This corresponds to C type ``float``.
+    Each element of this type is 4 bytes.

--- a/docs/api/type/float64.rst
+++ b/docs/api/type/float64.rst
@@ -3,4 +3,4 @@
     :src: --
 
     Double-precision IEEE-754 floating point type. This corresponds to C type
-    ``double``. Each element of this type is 8 bytes.
+    ``double``. Each element of this type is 8 bytes long.

--- a/docs/api/type/float64.rst
+++ b/docs/api/type/float64.rst
@@ -1,0 +1,6 @@
+
+.. xattr:: datatable.Type.float64
+    :src: --
+
+    Double-precision IEEE-754 floating point type. This corresponds to C type
+    ``double``. Each element of this type is 8 bytes.

--- a/docs/api/type/int16.rst
+++ b/docs/api/type/int16.rst
@@ -1,0 +1,9 @@
+
+.. xattr:: datatable.Type.int16
+    :src: --
+
+    Integer type, corresponding to ``int16_t`` in C. This type uses 2 bytes per
+    data element, and can store values in the range ``-32767 .. 32767``.
+
+    Most arithmetic operations involving this type will produce a result of
+    type ``int32``, which follows the convention of the C language.

--- a/docs/api/type/int32.rst
+++ b/docs/api/type/int32.rst
@@ -1,0 +1,11 @@
+
+.. xattr:: datatable.Type.int32
+    :src: --
+
+    Integer type, corresponding to ``int32_t`` in C. This type uses 4 bytes per
+    data element, and can store values in the range ``-2,147,483,647 ..
+    2,147,483,647``.
+
+    This is the most common type for handling integer data. When a python list
+    of integers is converted into a Frame, a column of this type will usually
+    be created.

--- a/docs/api/type/int64.rst
+++ b/docs/api/type/int64.rst
@@ -3,4 +3,4 @@
     :src: --
 
     Integer type which corresponds to ``int64_t`` in C. This type uses 8 bytes per
-    data element,, and can store values in the range ``-(2**63-1) .. (2**63-1)``.
+    data element, and can store values in the range ``-(2**63-1) .. (2**63-1)``.

--- a/docs/api/type/int64.rst
+++ b/docs/api/type/int64.rst
@@ -1,0 +1,6 @@
+
+.. xattr:: datatable.Type.int64
+    :src: --
+
+    Integer type which corresponds to ``int64_t`` in C. This type uses 8 bytes per
+    data element,, and can store values in the range ``-(2**63-1) .. (2**63-1)``.

--- a/docs/api/type/int8.rst
+++ b/docs/api/type/int8.rst
@@ -1,0 +1,10 @@
+
+.. xattr:: datatable.Type.int8
+    :src: --
+
+    Integer type, corresponding to ``int8_t`` in C. This type uses 1 byte per
+    data element, and can store values in the range ``-127 .. 127``.
+
+    Most arithmetic operations involving this type will produce a result of
+    type ``int32``, which follows the convention of the C language.
+

--- a/docs/api/type/name.rst
+++ b/docs/api/type/name.rst
@@ -1,0 +1,4 @@
+
+.. xattr:: datatable.Type.name
+    :src: src/core/types/py_type.cc get_name
+    :doc: src/core/types/py_type.cc doc_name

--- a/docs/api/type/obj64.rst
+++ b/docs/api/type/obj64.rst
@@ -1,0 +1,5 @@
+
+.. xattr:: datatable.Type.obj64
+    :src: --
+
+    This type can be used to store arbitrary Python objects.

--- a/docs/api/type/str32.rst
+++ b/docs/api/type/str32.rst
@@ -1,0 +1,5 @@
+
+.. xattr:: datatable.Type.str32
+    :src: --
+
+    String type, where the offsets buffer uses 32-bit integers.

--- a/docs/api/type/str64.rst
+++ b/docs/api/type/str64.rst
@@ -1,0 +1,5 @@
+
+.. xattr:: datatable.Type.str64
+    :src: --
+
+    String type, where the offsets buffer uses 64-bit integers.

--- a/docs/api/type/void.rst
+++ b/docs/api/type/void.rst
@@ -1,0 +1,16 @@
+
+.. xattr:: datatable.Type.void
+    :src: --
+
+    The type of a column where all values are NAs.
+
+    In ``datatable``, any column can have NA values in it. There is, however,
+    a special type that can be assigned for a column where *all* values are
+    NAs: ``void``. This type's special property is that it can be used in
+    place where any other type could be expected.
+
+
+    Examples
+    --------
+    >>> dt.Frame([None, None, None]).types
+    [Type.void]

--- a/docs/develop/create-fexpr.rst
+++ b/docs/develop/create-fexpr.rst
@@ -166,7 +166,7 @@ inside the current file `expr/fexpr_gcd.cc`.
         {
           xassert(acol_.nrows() == bcol_.nrows());
           xassert(acol_.stype() == bcol_.stype());
-          xassert(compatible_type<T>(acol_.stype()));
+          xassert(acol_.type().can_be_read_as<T>());
         }
 
         ColumnImpl* clone() const override {

--- a/docs/releases/v1.0.0.rst
+++ b/docs/releases/v1.0.0.rst
@@ -5,6 +5,10 @@
     -----
     .. current-class:: datatable.Frame
 
+    -[new] Property :attr:`.types` returns the list of :class:`dt.Type`
+      objects for each column of the frame. These types are a generalization
+      of previous stypes, and will eventually replace them.
+
     -[new] A Frame can now be constructed from an Arrow
       table::
 
@@ -32,6 +36,10 @@
 
     -[fix] A Frame can now be created properly from a list of numpy bool
       objects. [#2762]
+
+    -[api] Properties :attr:`.stypes` and :attr:`.ltypes` are not considered
+      deprecated and will be removed in a future version. Currently they
+      continue to work as before, however.
 
 
     FExpr

--- a/docs/releases/v1.0.0.rst
+++ b/docs/releases/v1.0.0.rst
@@ -37,7 +37,7 @@
     -[fix] A Frame can now be created properly from a list of numpy bool
       objects. [#2762]
 
-    -[api] Properties :attr:`.stypes` and :attr:`.ltypes` are not considered
+    -[api] Properties :attr:`.stypes` and :attr:`.ltypes` are now considered
       deprecated and will be removed in a future version. Currently they
       continue to work as before, however.
 

--- a/src/core/_dt.h
+++ b/src/core/_dt.h
@@ -51,6 +51,7 @@ namespace dt {
   struct ArrowSchema;
   class OArrowArray;
   class OArrowSchema;
+  class Type;
 }
 
 

--- a/src/core/api.cc
+++ b/src/core/api.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2020 H2O.ai
+// Copyright 2018-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -53,8 +53,7 @@ size_t DtABIVersion() {
 
 int DtFrame_Check(PyObject* ob) {
   if (ob == nullptr) return 0;
-  auto typeptr = reinterpret_cast<PyObject*>(&py::Frame::type);
-  int ret = PyObject_IsInstance(ob, typeptr);
+  int ret = PyObject_IsInstance(ob, py::Frame::typePtr);
   if (ret == -1) {
     PyErr_Clear();
     ret = 0;

--- a/src/core/column.cc
+++ b/src/core/column.cc
@@ -159,6 +159,10 @@ size_t Column::na_count() const {
   return stats()->nacount();
 }
 
+const dt::Type& Column::type() const noexcept {
+  return impl_->type_;
+}
+
 dt::SType Column::stype() const noexcept {
   return impl_->type_.stype();
 }

--- a/src/core/column.cc
+++ b/src/core/column.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2020 H2O.ai
+// Copyright 2018-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -152,7 +152,7 @@ bool Column::operator==(const Column& other) const noexcept {
 //------------------------------------------------------------------------------
 
 size_t Column::nrows() const noexcept {
-  return impl_->nrows_;
+  return impl_->nrows();
 }
 
 size_t Column::na_count() const {
@@ -160,15 +160,15 @@ size_t Column::na_count() const {
 }
 
 dt::SType Column::stype() const noexcept {
-  return impl_->stype_;
+  return impl_->type_.stype();
 }
 
 dt::LType Column::ltype() const noexcept {
-  return dt::stype_to_ltype(impl_->stype_);
+  return dt::stype_to_ltype(impl_->stype());
 }
 
 bool Column::is_fixedwidth() const noexcept {
-  return !stype_is_variable_width(impl_->stype_);
+  return !stype_is_variable_width(impl_->stype());
 }
 
 bool Column::is_virtual() const noexcept {
@@ -184,7 +184,7 @@ bool Column::is_constant() const noexcept {
 }
 
 size_t Column::elemsize() const noexcept {
-  return stype_elemsize(impl_->stype_);
+  return stype_elemsize(impl_->stype());
 }
 
 Column::operator bool() const noexcept {

--- a/src/core/column.h
+++ b/src/core/column.h
@@ -116,6 +116,7 @@ class Column
   public:
     size_t nrows() const noexcept;
     size_t na_count() const;
+    const dt::Type& type() const noexcept;
     dt::SType stype() const noexcept;
     dt::LType ltype() const noexcept;
     size_t elemsize() const noexcept;

--- a/src/core/column/arrow_fw.cc
+++ b/src/core/column/arrow_fw.cc
@@ -62,7 +62,7 @@ const void* ArrowFw_ColumnImpl::get_buffer(size_t i) const {
 template <typename T>
 inline bool ArrowFw_ColumnImpl::_get(size_t  i, T* out) const {
   xassert(i < nrows_);
-  xassert(compatible_type<T>(stype()));
+  xassert(type().can_be_read_as<T>());
   auto validity_data = static_cast<const uint8_t*>(validity_.rptr());
   bool valid = !validity_data || (validity_data[i / 8] & (1 << (i & 7)));
   if (valid) {

--- a/src/core/column/arrow_fw.cc
+++ b/src/core/column/arrow_fw.cc
@@ -39,7 +39,7 @@ ArrowFw_ColumnImpl::ArrowFw_ColumnImpl(size_t nrows, SType stype,
 
 ColumnImpl* ArrowFw_ColumnImpl::clone() const {
   return new ArrowFw_ColumnImpl(
-                nrows_, stype_, Buffer(validity_), Buffer(data_));
+                nrows(), stype(), Buffer(validity_), Buffer(data_));
 }
 
 
@@ -62,7 +62,7 @@ const void* ArrowFw_ColumnImpl::get_buffer(size_t i) const {
 template <typename T>
 inline bool ArrowFw_ColumnImpl::_get(size_t  i, T* out) const {
   xassert(i < nrows_);
-  xassert(compatible_type<T>(stype_));
+  xassert(compatible_type<T>(stype()));
   auto validity_data = static_cast<const uint8_t*>(validity_.rptr());
   bool valid = !validity_data || (validity_data[i / 8] & (1 << (i & 7)));
   if (valid) {

--- a/src/core/column/arrow_str.cc
+++ b/src/core/column/arrow_str.cc
@@ -37,14 +37,14 @@ ArrowStr_ColumnImpl<T>::ArrowStr_ColumnImpl(
 {
   xassert(!validity_ || validity_.size() >= (nrows + 7) / 8);
   xassert(offsets_.size() >= stype_elemsize(stype) * (nrows + 1));
-  xassert(stype_elemsize(stype_) == sizeof(T));
+  xassert(stype_elemsize(stype) == sizeof(T));
 }
 
 
 template <typename T>
 ColumnImpl* ArrowStr_ColumnImpl<T>::clone() const {
   return new ArrowStr_ColumnImpl(
-      nrows_, stype_, Buffer(validity_), Buffer(offsets_), Buffer(strdata_));
+      nrows(), stype(), Buffer(validity_), Buffer(offsets_), Buffer(strdata_));
 }
 
 template <typename T>

--- a/src/core/column/cast_bool.cc
+++ b/src/core/column/cast_bool.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2020 H2O.ai
+// Copyright 2020-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -24,7 +24,7 @@ namespace dt {
 
 
 ColumnImpl* CastBool_ColumnImpl::clone() const {
-  return new CastBool_ColumnImpl(stype_, Column(arg_));
+  return new CastBool_ColumnImpl(stype(), Column(arg_));
 }
 
 

--- a/src/core/column/cast_numeric.cc
+++ b/src/core/column/cast_numeric.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2020 H2O.ai
+// Copyright 2020-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -30,7 +30,7 @@ namespace dt {
 
 template <typename T>
 ColumnImpl* CastNumeric_ColumnImpl<T>::clone() const {
-  return new CastNumeric_ColumnImpl<T>(stype_, Column(arg_));
+  return new CastNumeric_ColumnImpl<T>(stype(), Column(arg_));
 }
 
 

--- a/src/core/column/cast_object.cc
+++ b/src/core/column/cast_object.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2020 H2O.ai
+// Copyright 2020-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -27,7 +27,7 @@ namespace dt {
 
 
 ColumnImpl* CastObject_ColumnImpl::clone() const {
-  return new CastObject_ColumnImpl(stype_, Column(arg_));
+  return new CastObject_ColumnImpl(stype(), Column(arg_));
 }
 
 bool CastObject_ColumnImpl::allow_parallel_access() const {

--- a/src/core/column/cast_string.cc
+++ b/src/core/column/cast_string.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2020 H2O.ai
+// Copyright 2020-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -29,7 +29,7 @@ namespace dt {
 
 
 ColumnImpl* CastString_ColumnImpl::clone() const {
-  return new CastString_ColumnImpl(stype_, Column(arg_));
+  return new CastString_ColumnImpl(stype(), Column(arg_));
 }
 
 

--- a/src/core/column/cast_to_bool.cc
+++ b/src/core/column/cast_to_bool.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2020 H2O.ai
+// Copyright 2020-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -65,7 +65,7 @@ template class CastNumericToBool_ColumnImpl<double>;
 
 CastStringToBool_ColumnImpl::CastStringToBool_ColumnImpl(Column&& arg)
   : Cast_ColumnImpl(SType::BOOL, std::move(arg))
-{ xassert(compatible_type<CString>(arg_.stype())); }
+{ xassert(arg_.type().can_be_read_as<CString>()); }
 
 
 ColumnImpl* CastStringToBool_ColumnImpl::clone() const {

--- a/src/core/column/column_impl.cc
+++ b/src/core/column/column_impl.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2020 H2O.ai
+// Copyright 2018-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -36,8 +36,8 @@ namespace dt {
 //------------------------------------------------------------------------------
 
 ColumnImpl::ColumnImpl(size_t nrows, SType stype)
-  : nrows_(nrows),
-    stype_(stype),
+  : type_(Type::from_stype(stype)),
+    nrows_(nrows),
     refcount_(1) {}
 
 
@@ -53,14 +53,14 @@ ColumnImpl::ColumnImpl(size_t nrows, SType stype)
       << " values from a column of type " << col_stype;
 }
 
-bool ColumnImpl::get_element(size_t, int8_t*)  const { err(stype_, "int8"); }
-bool ColumnImpl::get_element(size_t, int16_t*) const { err(stype_, "int16"); }
-bool ColumnImpl::get_element(size_t, int32_t*) const { err(stype_, "int32"); }
-bool ColumnImpl::get_element(size_t, int64_t*) const { err(stype_, "int64"); }
-bool ColumnImpl::get_element(size_t, float*)   const { err(stype_, "float32"); }
-bool ColumnImpl::get_element(size_t, double*)  const { err(stype_, "float64"); }
-bool ColumnImpl::get_element(size_t, CString*) const { err(stype_, "string"); }
-bool ColumnImpl::get_element(size_t, py::oobj*)const { err(stype_, "object"); }
+bool ColumnImpl::get_element(size_t, int8_t*)  const { err(stype(), "int8"); }
+bool ColumnImpl::get_element(size_t, int16_t*) const { err(stype(), "int16"); }
+bool ColumnImpl::get_element(size_t, int32_t*) const { err(stype(), "int32"); }
+bool ColumnImpl::get_element(size_t, int64_t*) const { err(stype(), "int64"); }
+bool ColumnImpl::get_element(size_t, float*)   const { err(stype(), "float32"); }
+bool ColumnImpl::get_element(size_t, double*)  const { err(stype(), "float64"); }
+bool ColumnImpl::get_element(size_t, CString*) const { err(stype(), "string"); }
+bool ColumnImpl::get_element(size_t, py::oobj*)const { err(stype(), "object"); }
 
 
 
@@ -71,8 +71,8 @@ bool ColumnImpl::get_element(size_t, py::oobj*)const { err(stype_, "object"); }
 
 template <typename T>
 void ColumnImpl::_materialize_fw(Column& out) {
-  xassert(compatible_type<T>(stype_));
-  auto out_column = Sentinel_ColumnImpl::make_column(nrows_, stype_);
+  xassert(compatible_type<T>(stype()));
+  auto out_column = Sentinel_ColumnImpl::make_column(nrows_, stype());
   auto out_data = static_cast<T*>(out_column.get_data_editable(0));
   auto nthreads = NThreads(this->allow_parallel_access());
 
@@ -97,8 +97,8 @@ void ColumnImpl::_materialize_fw(Column& out) {
 
 
 void ColumnImpl::_materialize_obj(Column& out) {
-  xassert(stype_ == SType::OBJ);
-  auto out_column = Sentinel_ColumnImpl::make_column(nrows_, stype_);
+  xassert(stype() == SType::OBJ);
+  auto out_column = Sentinel_ColumnImpl::make_column(nrows_, stype());
   auto out_data = static_cast<py::oobj*>(out_column.get_data_editable(0));
 
   // Treating output array as `py::oobj[]` will ensure that the elements
@@ -123,8 +123,8 @@ void ColumnImpl::_materialize_str(Column& out) {
 void ColumnImpl::materialize(Column& out, bool to_memory) {
   (void) to_memory;  // default materialization is always to memory
   this->pre_materialize_hook();
-  switch (stype_) {
-    case SType::VOID:    stype_ = dt::SType::BOOL; FALLTHROUGH;
+  switch (stype()) {
+    case SType::VOID:    return; //stype() = dt::SType::BOOL; FALLTHROUGH;
     case SType::BOOL:
     case SType::INT8:    return _materialize_fw<int8_t> (out);
     case SType::INT16:   return _materialize_fw<int16_t>(out);
@@ -137,7 +137,7 @@ void ColumnImpl::materialize(Column& out, bool to_memory) {
     case SType::OBJ:     return _materialize_obj(out);
     default:
       throw NotImplError() << "Cannot materialize column of stype `"
-                           << stype_ << "`";
+                           << stype() << "`";
   }
 }
 
@@ -169,7 +169,7 @@ void ColumnImpl::fill_npmask(bool* outmask, size_t row0, size_t row1) const {
     std::fill(outmask + row0, outmask + row1, false);
     return;
   }
-  switch (stype_) {
+  switch (stype()) {
     case SType::VOID: {
       std::fill(outmask + row0, outmask + row1, true);
       break;
@@ -186,7 +186,7 @@ void ColumnImpl::fill_npmask(bool* outmask, size_t row0, size_t row1) const {
     case SType::OBJ:     _fill_npmask<py::oobj>(outmask, row0, row1); break;
     default:
       throw NotImplError() << "Cannot fill_npmask() on column of stype `"
-                           << stype_ << "`";
+                           << stype() << "`";
   }
 }
 

--- a/src/core/column/column_impl.cc
+++ b/src/core/column/column_impl.cc
@@ -71,7 +71,7 @@ bool ColumnImpl::get_element(size_t, py::oobj*)const { err(stype(), "object"); }
 
 template <typename T>
 void ColumnImpl::_materialize_fw(Column& out) {
-  xassert(compatible_type<T>(stype()));
+  xassert(type().can_be_read_as<T>());
   auto out_column = Sentinel_ColumnImpl::make_column(nrows_, stype());
   auto out_data = static_cast<T*>(out_column.get_data_editable(0));
   auto nthreads = NThreads(this->allow_parallel_access());

--- a/src/core/column/column_impl.h
+++ b/src/core/column/column_impl.h
@@ -52,10 +52,9 @@ namespace dt {
 class ColumnImpl
 {
   protected:
+    Type   type_;
     size_t nrows_;
-    SType  stype_;
-    size_t : 24;
-    mutable uint32_t refcount_;
+    mutable size_t refcount_;
     mutable std::unique_ptr<Stats> stats_;
 
   //------------------------------------
@@ -92,7 +91,7 @@ class ColumnImpl
   //------------------------------------
   public:
     size_t nrows() const noexcept { return nrows_; }
-    SType  stype() const noexcept { return stype_; }
+    SType  stype() const { return type_.stype(); }
     virtual bool is_virtual() const noexcept = 0;
     virtual bool computationally_expensive() const { return false; }
     virtual size_t memory_footprint() const noexcept = 0;

--- a/src/core/column/column_impl.h
+++ b/src/core/column/column_impl.h
@@ -27,6 +27,7 @@
 #include "groupby.h"     // Groupby
 #include "buffer.h"      // Buffer
 #include "stats.h"       // Stats
+#include "types/type.h"
 namespace dt {
 
 

--- a/src/core/column/column_impl.h
+++ b/src/core/column/column_impl.h
@@ -92,6 +92,7 @@ class ColumnImpl
   public:
     size_t nrows() const noexcept { return nrows_; }
     SType  stype() const { return type_.stype(); }
+    const Type& type() const { return type_; }
     virtual bool is_virtual() const noexcept = 0;
     virtual bool computationally_expensive() const { return false; }
     virtual size_t memory_footprint() const noexcept = 0;

--- a/src/core/column/const.cc
+++ b/src/core/column/const.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019-2020 H2O.ai
+// Copyright 2019-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -46,7 +46,7 @@ class ConstFloat_ColumnImpl : public Const_ColumnImpl {
         value(x) {}
 
     ColumnImpl* clone() const override {
-      return new ConstFloat_ColumnImpl(nrows_, value, stype_);
+      return new ConstFloat_ColumnImpl(nrows_, value, stype());
     }
 
     bool get_element(size_t, float* out) const override {
@@ -107,7 +107,7 @@ class ConstString_ColumnImpl : public Const_ColumnImpl {
         value(std::move(x)) {}
 
     ColumnImpl* clone() const override {
-      return new ConstString_ColumnImpl(nrows_, CString(value), stype_);
+      return new ConstString_ColumnImpl(nrows_, CString(value), stype());
     }
 
     bool get_element(size_t, CString* out) const override {

--- a/src/core/column/const.h
+++ b/src/core/column/const.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019-2020 H2O.ai
+// Copyright 2019-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -94,7 +94,7 @@ class ConstInt_ColumnImpl : public Const_ColumnImpl {
         value(x) {}
 
     ColumnImpl* clone() const override {
-      return new ConstInt_ColumnImpl(nrows_, value, stype_);
+      return new ConstInt_ColumnImpl(nrows_, value, stype());
     }
 
     bool get_element(size_t, int8_t* out) const override {

--- a/src/core/column/const_na.cc
+++ b/src/core/column/const_na.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019 H2O.ai
+// Copyright 2019-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -44,7 +44,7 @@ bool ConstNa_ColumnImpl::get_element(size_t, py::oobj*) const { return false; }
 
 
 ColumnImpl* ConstNa_ColumnImpl::clone() const {
-  return new ConstNa_ColumnImpl(nrows_, stype_);
+  return new ConstNa_ColumnImpl(nrows_, stype());
 }
 
 
@@ -59,7 +59,24 @@ void ConstNa_ColumnImpl::na_pad(size_t nrows, Column&) {
 //------------------------------------------------------------------------------
 
 template <typename T, typename ColClass>
-static Column _fw_col(size_t nrows) {
+static Column _fw_col(size_t nrows, SType stype) {
+  Buffer buf = Buffer::mem(nrows * sizeof(T));
+  T* data = static_cast<T*>(buf.xptr());
+
+  parallel_for_static(nrows,
+    [=](size_t i) {
+      data[i] = GETNA<T>();
+    });
+
+  if (std::is_same<T, PyObject*>::value) {
+    Py_None->ob_refcnt += nrows;
+    buf.set_pyobjects(/* clear_data= */ false);
+  }
+  return Column(new ColClass(nrows, stype, std::move(buf)));
+}
+
+template <typename T, typename ColClass>
+static Column _special_col(size_t nrows) {
   Buffer buf = Buffer::mem(nrows * sizeof(T));
   T* data = static_cast<T*>(buf.xptr());
 
@@ -90,20 +107,21 @@ static Column _str_col(size_t nrows) {
 
 
 void ConstNa_ColumnImpl::materialize(Column& out, bool) {
-  switch (stype_) {
+  auto st = stype();
+  switch (st) {
     case SType::VOID:    // TODO: make void column "material"
-    case SType::BOOL:    out = _fw_col<int8_t,  SentinelBool_ColumnImpl>(nrows_); break;
-    case SType::INT8:    out = _fw_col<int8_t,  SentinelFw_ColumnImpl<int8_t>>(nrows_); break;
-    case SType::INT16:   out = _fw_col<int16_t, SentinelFw_ColumnImpl<int16_t>>(nrows_); break;
-    case SType::INT32:   out = _fw_col<int32_t, SentinelFw_ColumnImpl<int32_t>>(nrows_); break;
-    case SType::INT64:   out = _fw_col<int64_t, SentinelFw_ColumnImpl<int64_t>>(nrows_); break;
-    case SType::FLOAT32: out = _fw_col<float,   SentinelFw_ColumnImpl<float>>(nrows_); break;
-    case SType::FLOAT64: out = _fw_col<double,  SentinelFw_ColumnImpl<double>>(nrows_); break;
-    case SType::OBJ:     out = _fw_col<PyObject*, SentinelObj_ColumnImpl>(nrows_); break;
+    case SType::BOOL:    out = _special_col<int8_t,  SentinelBool_ColumnImpl>(nrows_); break;
+    case SType::INT8:    out = _fw_col<int8_t,  SentinelFw_ColumnImpl<int8_t>>(nrows_, st); break;
+    case SType::INT16:   out = _fw_col<int16_t, SentinelFw_ColumnImpl<int16_t>>(nrows_, st); break;
+    case SType::INT32:   out = _fw_col<int32_t, SentinelFw_ColumnImpl<int32_t>>(nrows_, st); break;
+    case SType::INT64:   out = _fw_col<int64_t, SentinelFw_ColumnImpl<int64_t>>(nrows_, st); break;
+    case SType::FLOAT32: out = _fw_col<float,   SentinelFw_ColumnImpl<float>>(nrows_, st); break;
+    case SType::FLOAT64: out = _fw_col<double,  SentinelFw_ColumnImpl<double>>(nrows_, st); break;
+    case SType::OBJ:     out = _special_col<PyObject*, SentinelObj_ColumnImpl>(nrows_); break;
     case SType::STR32:   out = _str_col<uint32_t>(nrows_); break;
     case SType::STR64:   out = _str_col<uint64_t>(nrows_); break;
     default:
-      throw NotImplError() << "Cannot materialize NaColumn of type " << stype_;
+      throw NotImplError() << "Cannot materialize NaColumn of type " << stype();
   }
 }
 

--- a/src/core/column/func_binary.h
+++ b/src/core/column/func_binary.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019-2020 H2O.ai
+// Copyright 2019-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -118,7 +118,7 @@ FuncBinary1_ColumnImpl<T1, T2, TO>::FuncBinary1_ColumnImpl(
 template <typename T1, typename T2, typename TO>
 ColumnImpl* FuncBinary1_ColumnImpl<T1, T2, TO>::clone() const {
   return new FuncBinary1_ColumnImpl<T1, T2, TO>(
-                Column(arg1_), Column(arg2_), func_, nrows_, stype_);
+                Column(arg1_), Column(arg2_), func_, nrows_, stype());
 }
 
 
@@ -137,7 +137,7 @@ template <typename T1, typename T2, typename TO>
 void FuncBinary1_ColumnImpl<T1, T2, TO>::verify_integrity() const {
   arg1_.verify_integrity();
   arg2_.verify_integrity();
-  xassert(compatible_type<TO>(stype_));
+  xassert(compatible_type<TO>(stype()));
   xassert(compatible_type<T1>(arg1_.stype()));
   xassert(compatible_type<T2>(arg2_.stype()));
   XAssert(nrows_ <= arg2_.nrows());
@@ -182,7 +182,7 @@ FuncBinary2_ColumnImpl<T1, T2, TO>::FuncBinary2_ColumnImpl(
 template <typename T1, typename T2, typename TO>
 ColumnImpl* FuncBinary2_ColumnImpl<T1, T2, TO>::clone() const {
   return new FuncBinary2_ColumnImpl<T1, T2, TO>(
-                Column(arg1_), Column(arg2_), func_, nrows_, stype_);
+                Column(arg1_), Column(arg2_), func_, nrows_, stype());
 }
 
 template <typename T1, typename T2, typename TO>
@@ -197,7 +197,7 @@ template <typename T1, typename T2, typename TO>
 void FuncBinary2_ColumnImpl<T1, T2, TO>::verify_integrity() const {
   arg1_.verify_integrity();
   arg2_.verify_integrity();
-  xassert(compatible_type<TO>(stype_));
+  xassert(compatible_type<TO>(stype()));
   xassert(compatible_type<T1>(arg1_.stype()));
   xassert(compatible_type<T2>(arg2_.stype()));
   XAssert(nrows_ <= arg2_.nrows());

--- a/src/core/column/func_binary.h
+++ b/src/core/column/func_binary.h
@@ -197,9 +197,9 @@ template <typename T1, typename T2, typename TO>
 void FuncBinary2_ColumnImpl<T1, T2, TO>::verify_integrity() const {
   arg1_.verify_integrity();
   arg2_.verify_integrity();
-  xassert(compatible_type<TO>(stype()));
-  xassert(compatible_type<T1>(arg1_.stype()));
-  xassert(compatible_type<T2>(arg2_.stype()));
+  xassert(type_.can_be_read_as<TO>());
+  xassert(arg1_.type().can_be_read_as<T1>());
+  xassert(arg2_.type().can_be_read_as<T2>());
   XAssert(nrows_ <= arg2_.nrows());
   XAssert(nrows_ <= arg1_.nrows());
   XAssert(func_ != nullptr);

--- a/src/core/column/func_nary.h
+++ b/src/core/column/func_nary.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019-2020 H2O.ai
+// Copyright 2019-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -72,7 +72,7 @@ FuncNary_ColumnImpl<T>::FuncNary_ColumnImpl(
 template <typename T>
 ColumnImpl* FuncNary_ColumnImpl<T>::clone() const {
   return new FuncNary_ColumnImpl<T>(
-                colvec(columns_), evaluator_, nrows_, stype_);
+                colvec(columns_), evaluator_, nrows_, stype());
 }
 
 

--- a/src/core/column/func_unary.h
+++ b/src/core/column/func_unary.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019-2020 H2O.ai
+// Copyright 2019-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -109,7 +109,7 @@ FuncUnary1_ColumnImpl<TI, TO>::FuncUnary1_ColumnImpl(
 template <typename TI, typename TO>
 ColumnImpl* FuncUnary1_ColumnImpl<TI, TO>::clone() const {
   return new FuncUnary1_ColumnImpl<TI, TO>(
-                Column(arg_), func_, nrows_, stype_);
+                Column(arg_), func_, nrows_, stype());
 }
 
 
@@ -127,7 +127,7 @@ bool FuncUnary1_ColumnImpl<TI, TO>::get_element(size_t i, TO* out) const {
 template <typename TI, typename TO>
 void FuncUnary1_ColumnImpl<TI, TO>::verify_integrity() const {
   arg_.verify_integrity();
-  xassert(compatible_type<TO>(stype_));
+  xassert(compatible_type<TO>(stype()));
   xassert(compatible_type<TI>(arg_.stype()));
   XAssert(nrows_ <= arg_.nrows());
   XAssert(func_ != nullptr);
@@ -168,7 +168,7 @@ FuncUnary2_ColumnImpl<TI, TO>::FuncUnary2_ColumnImpl(
 template <typename TI, typename TO>
 ColumnImpl* FuncUnary2_ColumnImpl<TI, TO>::clone() const {
   return new FuncUnary2_ColumnImpl<TI, TO>(
-                Column(arg_), func_, nrows_, stype_);
+                Column(arg_), func_, nrows_, stype());
 }
 
 template <typename TI, typename TO>
@@ -182,7 +182,7 @@ bool FuncUnary2_ColumnImpl<TI, TO>::get_element(size_t i, TO* out) const {
 template <typename TI, typename TO>
 void FuncUnary2_ColumnImpl<TI, TO>::verify_integrity() const {
   arg_.verify_integrity();
-  xassert(compatible_type<TO>(stype_));
+  xassert(compatible_type<TO>(stype()));
   xassert(compatible_type<TI>(arg_.stype()));
   XAssert(nrows_ <= arg_.nrows());
   XAssert(func_ != nullptr);

--- a/src/core/column/ifelsen.cc
+++ b/src/core/column/ifelsen.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2020 H2O.ai
+// Copyright 2020-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -35,8 +35,8 @@ IfElseN_ColumnImpl::IfElseN_ColumnImpl(colvec&& cond, colvec&& vals)
     xassert(cnd.nrows() == nrows_);
   }
   for (const Column& val : values_) {
-    xassert(val.stype() == stype_);
-    xassert(val.nrows() == nrows_);
+    xassert(val.stype() == stype());
+    xassert(val.nrows() == nrows());
   }
 }
 

--- a/src/core/column/isclose.h
+++ b/src/core/column/isclose.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019-2020 H2O.ai
+// Copyright 2019-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -48,8 +48,8 @@ class IsClose_ColumnImpl : public Virtual_ColumnImpl {
         rtol_(rtol),
         atol_(atol)
     {
-      xassert(compatible_type<T>(argx_.stype()));
-      xassert(compatible_type<T>(argy_.stype()));
+      xassert(argx_.type().can_be_read_as<T>());
+      xassert(argy_.type().can_be_read_as<T>());
     }
 
     ColumnImpl* clone() const override {

--- a/src/core/column/isna.h
+++ b/src/core/column/isna.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019-2020 H2O.ai
+// Copyright 2019-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -36,7 +36,7 @@ class Isna_ColumnImpl : public Virtual_ColumnImpl {
       : Virtual_ColumnImpl(col.nrows(), SType::BOOL),
         arg_(std::move(col))
     {
-      xassert(compatible_type<T>(arg_.stype()));
+      xassert(arg_.type().can_be_read_as<T>());
     }
 
 

--- a/src/core/column/npmasked.cc
+++ b/src/core/column/npmasked.cc
@@ -45,7 +45,7 @@ ColumnImpl* NpMasked_ColumnImpl::clone() const {
 
 template <typename T>
 void NpMasked_ColumnImpl::_apply_mask(Column& out) {
-  xassert(compatible_type<T>(arg_.stype()));
+  xassert(arg_.type().can_be_read_as<T>());
   auto mask_data = static_cast<const bool*>(mask_.rptr());
   auto col_data = static_cast<T*>(arg_.get_data_editable());
 

--- a/src/core/column/npmasked.cc
+++ b/src/core/column/npmasked.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019-2020 H2O.ai
+// Copyright 2019-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -61,7 +61,7 @@ void NpMasked_ColumnImpl::materialize(Column& out, bool to_memory) {
       arg_.is_fixedwidth() &&
       arg_.is_data_editable())
   {
-    switch (stype_) {
+    switch (stype()) {
       case SType::BOOL:
       case SType::INT8:    return _apply_mask<int8_t>(out);
       case SType::INT16:   return _apply_mask<int16_t>(out);

--- a/src/core/column/range.cc
+++ b/src/core/column/range.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019-2020 H2O.ai
+// Copyright 2019-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -72,7 +72,7 @@ Range_ColumnImpl::Range_ColumnImpl(size_t nrows, SType stype, int64_t start,
 
 
 ColumnImpl* Range_ColumnImpl::clone() const {
-  return new Range_ColumnImpl(nrows_, stype_, start_, step_);
+  return new Range_ColumnImpl(nrows_, stype(), start_, step_);
 }
 
 
@@ -104,7 +104,7 @@ bool Range_ColumnImpl::get_element(size_t i, double* out)  const { return _get(i
 
 template <typename T>
 void Range_ColumnImpl::_materialize(Column& out) const {
-  Column newcol = Column::new_data_column(nrows_, stype_);
+  Column newcol = Column::new_data_column(nrows_, stype());
   T* data = static_cast<T*>(newcol.get_data_editable(0));
   parallel_for_static(nrows_,
     [&](size_t i) {
@@ -114,7 +114,7 @@ void Range_ColumnImpl::_materialize(Column& out) const {
 }
 
 void Range_ColumnImpl::materialize(Column& out, bool) {
-  switch (stype_) {
+  switch (stype()) {
     case SType::INT8:    return _materialize<int8_t>(out);
     case SType::INT16:   return _materialize<int16_t>(out);
     case SType::INT32:   return _materialize<int32_t>(out);
@@ -134,7 +134,7 @@ void Range_ColumnImpl::materialize(Column& out, bool) {
 
 void Range_ColumnImpl::verify_integrity() const {
   Virtual_ColumnImpl::verify_integrity();
-  auto ltype = stype_to_ltype(stype_);
+  auto ltype = stype_to_ltype(stype());
   XAssert(ltype == LType::INT || ltype == LType::REAL);
 }
 

--- a/src/core/column/rbound.cc
+++ b/src/core/column/rbound.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019-2020 H2O.ai
+// Copyright 2019-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -53,10 +53,10 @@ Rbound_ColumnImpl::Rbound_ColumnImpl(const colvec& columns)
 {
   xassert(!chunks_.empty());
   for (auto& col : chunks_) {
-    col.cast_inplace(stype_);  // noop if stypes are the same
+    col.cast_inplace(stype());  // noop if stypes are the same
   }
   calculate_nacount();
-  switch (stype_to_ltype(stype_)) {
+  switch (stype_to_ltype(stype())) {
     case LType::BOOL: calculate_boolean_stats(); break;
     case LType::INT:  calculate_integer_stats(); break;
     default: break;
@@ -84,7 +84,7 @@ void Rbound_ColumnImpl::calculate_nacount() {
 
 
 void Rbound_ColumnImpl::calculate_boolean_stats() {
-  xassert(stype_ == SType::BOOL);
+  xassert(stype() == SType::BOOL);
   bool is_valid = true;
   size_t count1 = 0;
   for (const auto& col : chunks_) {
@@ -103,8 +103,8 @@ void Rbound_ColumnImpl::calculate_boolean_stats() {
 
 
 void Rbound_ColumnImpl::calculate_integer_stats() {
-  xassert(stype_ == SType::INT8 || stype_ == SType::INT16 ||
-          stype_ == SType::INT32 || stype_ == SType::INT64);
+  xassert(stype() == SType::INT8 || stype() == SType::INT16 ||
+          stype() == SType::INT32 || stype() == SType::INT64);
   int64_t min = std::numeric_limits<int64_t>::max();
   int64_t max = -std::numeric_limits<int64_t>::max();
   bool valid = false;
@@ -126,7 +126,7 @@ void Rbound_ColumnImpl::calculate_integer_stats() {
 
 
 void Rbound_ColumnImpl::calculate_float_stats() {
-  xassert(stype_ == SType::FLOAT32 || stype_ == SType::FLOAT64);
+  xassert(stype() == SType::FLOAT32 || stype() == SType::FLOAT64);
   double min = std::numeric_limits<double>::infinity();
   double max = -std::numeric_limits<double>::infinity();
   bool valid = false;

--- a/src/core/column/sentinel.cc
+++ b/src/core/column/sentinel.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019-2020 H2O.ai
+// Copyright 2019-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -30,12 +30,12 @@ namespace dt {
 Column Sentinel_ColumnImpl::make_column(size_t nrows, SType stype) {
   switch (stype) {
     case SType::BOOL:    return Column(new SentinelBool_ColumnImpl(nrows));
-    case SType::INT8:    return Column(new SentinelFw_ColumnImpl<int8_t>(nrows));
-    case SType::INT16:   return Column(new SentinelFw_ColumnImpl<int16_t>(nrows));
-    case SType::INT32:   return Column(new SentinelFw_ColumnImpl<int32_t>(nrows));
-    case SType::INT64:   return Column(new SentinelFw_ColumnImpl<int64_t>(nrows));
-    case SType::FLOAT32: return Column(new SentinelFw_ColumnImpl<float>(nrows));
-    case SType::FLOAT64: return Column(new SentinelFw_ColumnImpl<double>(nrows));
+    case SType::INT8:    return Column(new SentinelFw_ColumnImpl<int8_t>(nrows, stype));
+    case SType::INT16:   return Column(new SentinelFw_ColumnImpl<int16_t>(nrows, stype));
+    case SType::INT32:   return Column(new SentinelFw_ColumnImpl<int32_t>(nrows, stype));
+    case SType::INT64:   return Column(new SentinelFw_ColumnImpl<int64_t>(nrows, stype));
+    case SType::FLOAT32: return Column(new SentinelFw_ColumnImpl<float>(nrows, stype));
+    case SType::FLOAT64: return Column(new SentinelFw_ColumnImpl<double>(nrows, stype));
     case SType::STR32:   return Column(new SentinelStr_ColumnImpl<uint32_t>(nrows));
     case SType::STR64:   return Column(new SentinelStr_ColumnImpl<uint64_t>(nrows));
     case SType::OBJ:     return Column(new SentinelObj_ColumnImpl(nrows));
@@ -52,12 +52,12 @@ Column Sentinel_ColumnImpl::make_fw_column(
   xassert(buf.size() >= nrows * stype_elemsize(stype));
   switch (stype) {
     case SType::BOOL:    return Column(new SentinelBool_ColumnImpl(nrows, std::move(buf)));
-    case SType::INT8:    return Column(new SentinelFw_ColumnImpl<int8_t>(nrows, std::move(buf)));
-    case SType::INT16:   return Column(new SentinelFw_ColumnImpl<int16_t>(nrows, std::move(buf)));
-    case SType::INT32:   return Column(new SentinelFw_ColumnImpl<int32_t>(nrows, std::move(buf)));
-    case SType::INT64:   return Column(new SentinelFw_ColumnImpl<int64_t>(nrows, std::move(buf)));
-    case SType::FLOAT32: return Column(new SentinelFw_ColumnImpl<float>(nrows, std::move(buf)));
-    case SType::FLOAT64: return Column(new SentinelFw_ColumnImpl<double>(nrows, std::move(buf)));
+    case SType::INT8:    return Column(new SentinelFw_ColumnImpl<int8_t>(nrows, stype, std::move(buf)));
+    case SType::INT16:   return Column(new SentinelFw_ColumnImpl<int16_t>(nrows, stype, std::move(buf)));
+    case SType::INT32:   return Column(new SentinelFw_ColumnImpl<int32_t>(nrows, stype, std::move(buf)));
+    case SType::INT64:   return Column(new SentinelFw_ColumnImpl<int64_t>(nrows, stype, std::move(buf)));
+    case SType::FLOAT32: return Column(new SentinelFw_ColumnImpl<float>(nrows, stype, std::move(buf)));
+    case SType::FLOAT64: return Column(new SentinelFw_ColumnImpl<double>(nrows, stype, std::move(buf)));
     case SType::OBJ:     return Column(new SentinelObj_ColumnImpl(nrows, std::move(buf)));
     default:
       throw ValueError()
@@ -115,7 +115,7 @@ Sentinel_ColumnImpl::Sentinel_ColumnImpl(size_t nrows, SType stype)
 
 
 bool Sentinel_ColumnImpl::allow_parallel_access() const {
-  return (stype_ != SType::OBJ);
+  return !(stype() == SType::OBJ);
 }
 
 bool Sentinel_ColumnImpl::is_virtual() const noexcept {

--- a/src/core/column/sentinel_fw.cc
+++ b/src/core/column/sentinel_fw.cc
@@ -38,7 +38,7 @@ template <typename T>
 SentinelFw_ColumnImpl<T>::SentinelFw_ColumnImpl(ColumnImpl*&& other)
   : Sentinel_ColumnImpl(other->nrows(), other->stype())
 {
-  xassert(compatible_type<T>(other->stype()));
+  xassert(other->type().can_be_read_as<T>());
   auto fwother = dynamic_cast<SentinelFw_ColumnImpl<T>*>(other);
   xassert(fwother != nullptr);
   mbuf_ = std::move(fwother->mbuf_);

--- a/src/core/column/sentinel_fw.h
+++ b/src/core/column/sentinel_fw.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019 H2O.ai
+// Copyright 2019-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -37,8 +37,8 @@ class SentinelFw_ColumnImpl : public Sentinel_ColumnImpl
     Buffer mbuf_;
 
   public:
-    SentinelFw_ColumnImpl(size_t nrows);
-    SentinelFw_ColumnImpl(size_t nrows, Buffer&&);
+    SentinelFw_ColumnImpl(size_t nrows, SType stype);
+    SentinelFw_ColumnImpl(size_t nrows, SType stype, Buffer&&);
     SentinelFw_ColumnImpl(ColumnImpl*&&);
 
     virtual ColumnImpl* clone() const override;

--- a/src/core/column/sentinel_str.cc
+++ b/src/core/column/sentinel_str.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2020 H2O.ai
+// Copyright 2018-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -170,7 +170,7 @@ void SentinelStr_ColumnImpl<T>::replace_values(
   Column with;
   if (replace_with) {
     with = replace_with;  // copy
-    if (with.stype() != stype_) with = with.cast(stype_);
+    if (with.stype() != stype()) with = with.cast(stype());
   }
 
   if (!with || with.nrows() == 1) {

--- a/src/core/datatablemodule.cc
+++ b/src/core/datatablemodule.cc
@@ -491,6 +491,7 @@ extern "C" {
       py::ReadIterator::init_type(m);
       py::Namespace::init_type(m);
       dt::expr::PyFExpr::init_type(m);
+      dt::PyTypeMeta::init_type(m);
       dt::PyType::init_type(m);
 
       dt::init_config_option(m);

--- a/src/core/datatablemodule.cc
+++ b/src/core/datatablemodule.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2020 H2O.ai
+// Copyright 2018-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -53,6 +53,7 @@
 #include "python/xargs.h"
 #include "read/py_read_iterator.h"
 #include "sort.h"
+#include "types/py_type.h"
 #include "utils/assert.h"
 #include "utils/exceptions.h"
 #include "utils/macros.h"
@@ -490,6 +491,7 @@ extern "C" {
       py::ReadIterator::init_type(m);
       py::Namespace::init_type(m);
       dt::expr::PyFExpr::init_type(m);
+      dt::PyType::init_type(m);
 
       dt::init_config_option(m);
       py::oby::init(m);

--- a/src/core/datatablemodule.cc
+++ b/src/core/datatablemodule.cc
@@ -413,12 +413,16 @@ static void initialize_options(const py::PKArgs& args) {
 }
 
 
-static py::PKArgs args_initialize_final(
-  0, 0, 0, false, false, {}, "initialize_final", "");
-
-static void initialize_final(const py::PKArgs&) {
+static py::oobj initialize_final(const py::XArgs&) {
   init_exceptions();
+  dt::PyType::init();
+  return py::None();
 }
+DECLARE_PYFN(&initialize_final)
+    ->name("initialize_final")
+    ->docs("Called once at the end of initialization of the python datatable "
+           "module. This function will import some of the objects defined "
+           "in the python module into the extension.");
 
 
 
@@ -435,7 +439,6 @@ void py::DatatableModule::init_methods() {
   ADD_FN(&frame_integrity_check, args_frame_integrity_check);
   ADD_FN(&get_thread_ids, args_get_thread_ids);
   ADD_FN(&initialize_options, args_initialize_options);
-  ADD_FN(&initialize_final, args_initialize_final);
   ADD_FN(&compiler_version, args_compiler_version);
   ADD_FN(&regex_supported, args_regex_supported);
   ADD_FN(&apply_color, args_apply_color);
@@ -491,8 +494,6 @@ extern "C" {
       py::ReadIterator::init_type(m);
       py::Namespace::init_type(m);
       dt::expr::PyFExpr::init_type(m);
-      dt::PyTypeMeta::init_type(m);
-      dt::PyType::init_type(m);
 
       dt::init_config_option(m);
       py::oby::init(m);

--- a/src/core/datatablemodule.cc
+++ b/src/core/datatablemodule.cc
@@ -415,7 +415,6 @@ static void initialize_options(const py::PKArgs& args) {
 
 static py::oobj initialize_final(const py::XArgs&) {
   init_exceptions();
-  dt::PyType::init();
   return py::None();
 }
 DECLARE_PYFN(&initialize_final)
@@ -494,6 +493,7 @@ extern "C" {
       py::ReadIterator::init_type(m);
       py::Namespace::init_type(m);
       dt::expr::PyFExpr::init_type(m);
+      dt::PyType::init_type(m);
 
       dt::init_config_option(m);
       py::oby::init(m);

--- a/src/core/expr/fbinary/fexpr__truediv__.cc
+++ b/src/core/expr/fbinary/fexpr__truediv__.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2020 H2O.ai
+// Copyright 20202-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -62,10 +62,10 @@ class FExpr__truediv__ : public FExpr_BinaryOp {
   private:
     template <typename T>
     static Column make(Column&& a, Column&& b, SType stype) {
-      xassert(compatible_type<T>(stype));
       size_t nrows = a.nrows();
       a.cast_inplace(stype);
       b.cast_inplace(stype);
+      xassert(a.type().can_be_read_as<T>());
       return Column(new FuncBinary1_ColumnImpl<T, T, T>(
         std::move(a), std::move(b),
         [](T x, T y){

--- a/src/core/expr/fexpr.cc
+++ b/src/core/expr/fexpr.cc
@@ -108,7 +108,8 @@ using namespace py;
 
 // static "constructor"
 oobj PyFExpr::make(FExpr* expr) {
-  oobj res = robj(reinterpret_cast<PyObject*>(FExpr_Type)).call();
+  xassert(FExpr_Type);
+  oobj res = robj(FExpr_Type).call();
   auto fexpr = reinterpret_cast<PyFExpr*>(res.to_borrowed_ref());
   fexpr->expr_ = ptrExpr(expr);
   return res;
@@ -391,7 +392,7 @@ void PyFExpr::impl_init_type(XTypeMaker& xt) {
   xt.add(METHOD__POS__(&PyFExpr::nb__pos__));
   xt.add(METHOD__CMP__(&PyFExpr::m__compare__));
 
-  FExpr_Type = &type;
+  FExpr_Type = xt.get_type_object();
 }
 
 

--- a/src/core/expr/fexpr_literal_type.cc
+++ b/src/core/expr/fexpr_literal_type.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019-2020 H2O.ai
+// Copyright 2019-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -101,7 +101,7 @@ Workframe FExpr_Literal_Type::evaluate_n(EvalContext&) const {
 
 
 Workframe FExpr_Literal_Type::evaluate_f(EvalContext& ctx, size_t fid) const {
-  if (value_.is_type()) {
+  if (value_.is_pytype()) {
     auto et = reinterpret_cast<PyTypeObject*>(value_.to_borrowed_ref());
     if (et == &PyLong_Type)       return _select_types(ctx, fid, stINT);
     if (et == &PyFloat_Type)      return _select_types(ctx, fid, stFLOAT);
@@ -148,7 +148,7 @@ static void _resolve_stype(py::robj value_, SType* out_stype, LType* out_ltype)
 {
   *out_stype = SType::AUTO;
   *out_ltype = LType::MU;
-  if (value_.is_type()) {
+  if (value_.is_pytype()) {
     auto et = reinterpret_cast<PyTypeObject*>(value_.to_borrowed_ref());
     *out_ltype = (et == &PyLong_Type)?       LType::INT :
                  (et == &PyFloat_Type)?      LType::REAL :
@@ -230,7 +230,7 @@ int FExpr_Literal_Type::precedence() const noexcept {
 
 
 std::string FExpr_Literal_Type::repr() const {
-  if (value_.is_type()) {
+  if (value_.is_pytype()) {
     auto et = reinterpret_cast<PyTypeObject*>(value_.to_borrowed_ref());
     if (et == &PyLong_Type)       return "int";
     if (et == &PyFloat_Type)      return "float";

--- a/src/core/expr/fexpr_round.cc
+++ b/src/core/expr/fexpr_round.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2020 H2O.ai
+// Copyright 2020-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -175,7 +175,7 @@ class Round_ColumnImpl : public Virtual_ColumnImpl {
     }
 
     ColumnImpl* clone() const override {
-      return new Round_ColumnImpl(Column(arg_), stype_);
+      return new Round_ColumnImpl(Column(arg_), stype());
     }
 
     size_t n_children() const noexcept override { return 1; }

--- a/src/core/expr/fexpr_round.cc
+++ b/src/core/expr/fexpr_round.cc
@@ -69,7 +69,7 @@ class RoundNeg_ColumnImpl : public Virtual_ColumnImpl {
         arg_(std::move(arg)),
         scale_(scale)
     {
-      xassert(compatible_type<T>(arg_.stype()));
+      xassert(arg_.type().can_be_read_as<T>());
     }
 
     ColumnImpl* clone() const override {

--- a/src/core/expr/head_reduce_binary.cc
+++ b/src/core/expr/head_reduce_binary.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019-2020 H2O.ai
+// Copyright 2019-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -79,7 +79,7 @@ class BinaryReduced_ColumnImpl : public Virtual_ColumnImpl {
 
     ColumnImpl* clone() const override {
       return new BinaryReduced_ColumnImpl<T>(
-                  stype_, Column(arg1), Column(arg2), groupby, reducer);
+                  stype(), Column(arg1), Column(arg2), groupby, reducer);
     }
 
     bool get_element(size_t i, T* out) const override {

--- a/src/core/expr/head_reduce_unary.cc
+++ b/src/core/expr/head_reduce_unary.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019-2020 H2O.ai
+// Copyright 2019-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -79,7 +79,7 @@ class Reduced_ColumnImpl : public Virtual_ColumnImpl {
     }
 
     ColumnImpl* clone() const override {
-      return new Reduced_ColumnImpl<T, U>(stype_, Column(arg), groupby,
+      return new Reduced_ColumnImpl<T, U>(stype(), Column(arg), groupby,
                                           reducer);
     }
 
@@ -864,7 +864,7 @@ class SdGrouped_ColumnImpl : public Virtual_ColumnImpl {
         groupby(grpby) {}
 
     ColumnImpl* clone() const override {
-      return new SdGrouped_ColumnImpl(stype_, Column(arg), groupby);
+      return new SdGrouped_ColumnImpl(stype(), Column(arg), groupby);
     }
 
     bool get_element(size_t i, float* out) const override {

--- a/src/core/expr/namespace.cc
+++ b/src/core/expr/namespace.cc
@@ -66,18 +66,11 @@ oobj Namespace::m__repr__() const {
 // __getattr__()
 //------------------------------------------------------------------------------
 
-static bool is_system_attr(robj attr) {
-  auto a = attr.to_cstring();
-  auto n = a.size();
-  return (n > 4 && a[0] == '_' && a[1] == '_' &&
-                   a[n-1] == '_' && a[n-2] == '_');
-}
-
 oobj Namespace::m__getattr__(robj attr) {
   // For system attributes such as `__module__`, `__class__`,
   // `__doc__`, etc, use the standard object.__getattribute__()
   // method.
-  if (is_system_attr(attr)) {
+  if (is_python_system_attr(attr)) {
     return oobj::from_new_reference(
         PyObject_GenericGetAttr(
           reinterpret_cast<PyObject*>(this),

--- a/src/core/expr/namespace.cc
+++ b/src/core/expr/namespace.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2020 H2O.ai
+// Copyright 2020-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -96,7 +96,7 @@ oobj Namespace::m__getattr__(robj attr) {
 
 oobj Namespace::m__getitem__(robj item) {
   if (!(item.is_int() || item.is_string() || item.is_slice() ||
-        item.is_none() || item.is_type() || item.is_stype() || item.is_ltype()))
+        item.is_none() || item.is_pytype() || item.is_stype() || item.is_ltype()))
   {
     throw TypeError() << "Column selector should be an integer, string, "
                          "or slice, not " << item.typeobj();

--- a/src/core/expr/py_sort.cc
+++ b/src/core/expr/py_sort.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2019 H2O.ai
+// Copyright 2018-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -170,8 +170,8 @@ osort::osort(const robj& src) : oobj(src) {}
 osort::osort(const oobj& src) : oobj(src) {}
 
 osort::osort(const otuple& cols) {
-  PyObject* cls = reinterpret_cast<PyObject*>(&osort::osort_pyobject::type);
-  v = PyObject_CallObject(cls, cols.to_borrowed_ref());
+  v = PyObject_CallObject(osort::osort_pyobject::typePtr,
+                          cols.to_borrowed_ref());
   if (!v) throw PyError();
 }
 

--- a/src/core/frame/integrity_check.cc
+++ b/src/core/frame/integrity_check.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2020 H2O.ai
+// Copyright 2018-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -153,8 +153,8 @@ namespace dt {
 //------------------------------------------------------------------------------
 
 void ColumnImpl::verify_integrity() const {
-  XAssert(static_cast<int64_t>(nrows_) >= 0);
-  XAssert(static_cast<size_t>(stype_) < dt::STYPES_COUNT);
+  XAssert(static_cast<int64_t>(nrows()) >= 0);
+  XAssert(static_cast<size_t>(stype()) < dt::STYPES_COUNT);
   XAssert(refcount_ > 0 && refcount_ < uint32_t(-100));
   if (stats_) { // Stats are allowed to be null
     stats_->verify_integrity(this);
@@ -171,7 +171,7 @@ void ColumnImpl::verify_integrity() const {
 template <typename T>
 void SentinelFw_ColumnImpl<T>::verify_integrity() const {
   ColumnImpl::verify_integrity();
-  xassert(compatible_type<T>(stype_));
+  xassert(compatible_type<T>(stype()));
   XAssert(mbuf_.size() >= sizeof(T) * nrows_);
   mbuf_.verify_integrity();
 }
@@ -185,7 +185,7 @@ void SentinelFw_ColumnImpl<T>::verify_integrity() const {
 
 void SentinelBool_ColumnImpl::verify_integrity() const {
   SentinelFw_ColumnImpl<int8_t>::verify_integrity();
-  XAssert(stype_ == dt::SType::BOOL);
+  XAssert(stype() == dt::SType::BOOL);
 
   // Check that all elements in column are either 0, 1, or NA_I1
   size_t mbuf_nrows = mbuf_.size();

--- a/src/core/frame/integrity_check.cc
+++ b/src/core/frame/integrity_check.cc
@@ -171,7 +171,7 @@ void ColumnImpl::verify_integrity() const {
 template <typename T>
 void SentinelFw_ColumnImpl<T>::verify_integrity() const {
   ColumnImpl::verify_integrity();
-  xassert(compatible_type<T>(stype()));
+  xassert(type_.can_be_read_as<T>());
   XAssert(mbuf_.size() >= sizeof(T) * nrows_);
   mbuf_.verify_integrity();
 }

--- a/src/core/frame/join.cc
+++ b/src/core/frame/join.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2020 H2O.ai
+// Copyright 2018-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -187,8 +187,8 @@ template <typename TX, typename TJ>
 FwCmp<TX, TJ>::FwCmp(const Column& xcol, const Column& jcol)
   : colX(xcol), colJ(jcol)
 {
-  xassert(dt::compatible_type<TX>(xcol.stype()));
-  xassert(dt::compatible_type<TJ>(jcol.stype()));
+  xassert(xcol.type().can_be_read_as<TX>());
+  xassert(jcol.type().can_be_read_as<TJ>());
 }
 
 template <typename TX, typename TJ>

--- a/src/core/frame/py_frame.cc
+++ b/src/core/frame/py_frame.cc
@@ -369,6 +369,7 @@ bool Frame::internal_construction = false;
 
 
 oobj Frame::oframe(DataTable* dt) {
+  xassert(Frame_Type);
   Frame::internal_construction = true;
   PyObject* res = PyObject_CallObject(Frame_Type, nullptr);
   Frame::internal_construction = false;
@@ -1166,7 +1167,7 @@ void Frame::impl_init_type(XTypeMaker& xt) {
   xt.add(METHOD__GETITEM__(&Frame::m__getitem__));
   xt.add(METHOD__SETITEM__(&Frame::m__setitem__));
   xt.add(BUFFERS(&Frame::m__getbuffer__, &Frame::m__releasebuffer__));
-  Frame_Type = reinterpret_cast<PyObject*>(&Frame::type);
+  Frame_Type = xt.get_type_object();
 
   _init_cbind(xt);
   _init_key(xt);

--- a/src/core/frame/py_frame.cc
+++ b/src/core/frame/py_frame.cc
@@ -26,6 +26,7 @@
 #include "python/_all.h"
 #include "python/string.h"
 #include "stype.h"
+#include "types/py_type.h"
 namespace py {
 
 PyObject* Frame_Type = nullptr;
@@ -674,6 +675,37 @@ void Frame::set_source(const std::string& src) {
 
 
 //------------------------------------------------------------------------------
+// .types
+//------------------------------------------------------------------------------
+
+static const char* doc_types =
+R"(
+The list of `Type`s for each column of the frame.
+
+Parameters
+----------
+return: List[Type]
+    The length of the list is the same as the number of columns in the frame.
+
+
+See also
+--------
+- :attr:`.stypes` -- old interface for column types
+)";
+
+static GSArgs args_types("types", doc_types);
+
+oobj Frame::get_types() const {
+  py::olist result(dt->ncols());
+  for (size_t i = 0; i < dt->ncols(); i++) {
+    result.set(i, dt::PyType::make(dt->get_column(i).type()));
+  }
+  return std::move(result);
+}
+
+
+
+//------------------------------------------------------------------------------
 // .stypes
 //------------------------------------------------------------------------------
 
@@ -1163,6 +1195,7 @@ void Frame::impl_init_type(XTypeMaker& xt) {
   xt.add(GETTER(&Frame::get_source, args_source));
   xt.add(GETTER(&Frame::get_stype,  args_stype));
   xt.add(GETTER(&Frame::get_stypes, args_stypes));
+  xt.add(GETTER(&Frame::get_types, args_types));
 
   xt.add(METHOD(&Frame::head, args_head));
   xt.add(METHOD(&Frame::tail, args_tail));

--- a/src/core/frame/py_frame.h
+++ b/src/core/frame/py_frame.h
@@ -108,6 +108,7 @@ class Frame : public XObject<Frame> {
     oobj get_source() const;
     oobj get_stype() const;
     oobj get_stypes() const;
+    oobj get_types() const;
     void set_key(const Arg&);
     void set_meta(const Arg&);
     void set_names(const Arg&);

--- a/src/core/frame/rbind.cc
+++ b/src/core/frame/rbind.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2020 H2O.ai
+// Copyright 2018-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -500,7 +500,7 @@ void dt::SentinelStr_ColumnImpl<T>::rbind_impl(
     Column& col = columns[i];
     if (col.stype() == dt::SType::VOID) continue;
     if (col.ltype() != LType::STRING) {
-      col.cast_inplace(stype_);
+      col.cast_inplace(stype());
       col.materialize();
     }
     new_strbuf_size += col.get_data_size(1);
@@ -611,8 +611,8 @@ void dt::SentinelFw_ColumnImpl<T>::rbind_impl(
         resptr += rows_to_fill * sizeof(T);
         rows_to_fill = 0;
       }
-      if (col.stype() != stype_) {
-        col.cast_inplace(stype_);
+      if (col.stype() != stype()) {
+        col.cast_inplace(stype());
         col.materialize();
       }
       size_t col_data_size = sizeof(T) * col.nrows();

--- a/src/core/frame/to_arrow.cc
+++ b/src/core/frame/to_arrow.cc
@@ -184,7 +184,7 @@ static void _clear_validity_buffer(size_t n, size_t* data) {
 
 
 Column dt::ColumnImpl::_as_arrow_void() const {
-  xassert(stype_ == SType::VOID);
+  xassert(stype() == SType::VOID);
   size_t bufsize = (nrows_ + 63)/64 * 8;
   Buffer validity_buffer = Buffer::mem(bufsize);
   auto validity_data = static_cast<size_t*>(validity_buffer.xptr());
@@ -194,7 +194,7 @@ Column dt::ColumnImpl::_as_arrow_void() const {
 
 
 Column dt::ColumnImpl::_as_arrow_bool() const {
-  xassert(stype_ == SType::BOOL);
+  xassert(stype() == SType::BOOL);
   // The buffers must be aligned at 8-bytes boundary
   size_t bufsize = (nrows_ + 63)/64 * 8;
   Buffer validity_buffer = Buffer::mem(bufsize);
@@ -242,7 +242,7 @@ Column dt::ColumnImpl::_as_arrow_fw() const {
     });
 
   return Column(new ArrowFw_ColumnImpl(
-      nrows_, stype_, std::move(validity_buffer), std::move(data_buffer))
+      nrows_, stype(), std::move(validity_buffer), std::move(data_buffer))
   );
 }
 
@@ -325,7 +325,7 @@ Column dt::ColumnImpl::_as_arrow_str() const {
   );
 
   return Column(new dt::ArrowStr_ColumnImpl<T>(
-      nrows_, stype_, std::move(validity_buffer),
+      nrows(), stype(), std::move(validity_buffer),
       std::move(offsets_buffer), std::move(strdata_buffer))
   );
 }
@@ -336,7 +336,7 @@ Column dt::ColumnImpl::_as_arrow_str() const {
   * Arrow_ColumnImpl.
   */
 Column dt::ColumnImpl::as_arrow() const {
-  switch (stype_) {
+  switch (stype()) {
     case SType::VOID: return _as_arrow_void();
     case SType::BOOL: return _as_arrow_bool();
     case SType::INT8: return _as_arrow_fw<int8_t>();
@@ -349,5 +349,5 @@ Column dt::ColumnImpl::as_arrow() const {
     case SType::STR64: return _as_arrow_str<uint64_t>();
     default: break;
   }
-  throw NotImplError() << "Cannot convert column of type " << stype_ << " into arrow";
+  throw NotImplError() << "Cannot convert column of type " << stype() << " into arrow";
 }

--- a/src/core/options.cc
+++ b/src/core/options.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2020 H2O.ai
+// Copyright 2018-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -119,8 +119,7 @@ void register_option(const char* name,
                      const char* docstring)
 {
   xassert(dt_options);
-  auto pytype = reinterpret_cast<PyObject*>(&py::config_option::type);
-  auto v = PyObject_CallObject(pytype, nullptr);
+  auto v = PyObject_CallObject(py::config_option::typePtr, nullptr);
   if (!v) throw PyError();
   py::oobj opt = py::oobj::from_new_reference(v);
   auto p = static_cast<py::config_option*>(v);

--- a/src/core/py_buffers.cc
+++ b/src/core/py_buffers.cc
@@ -429,7 +429,7 @@ static void _install_buffer_hooks(const py::PKArgs& args)
 {
   PyObject* obj = args[0].to_borrowed_ref();
   if (obj) {
-    auto frame_type = reinterpret_cast<PyObject*>(&py::Frame::type);
+    auto frame_type = py::Frame::typePtr;
     int ret = PyObject_IsSubclass(obj, frame_type);
     if (ret == -1) throw PyError();
     if (ret == 0) {
@@ -437,7 +437,8 @@ static void _install_buffer_hooks(const py::PKArgs& args)
           "applied to subclasses of core.Frame";
     }
     auto type = reinterpret_cast<PyTypeObject*>(obj);
-    type->tp_as_buffer = py::Frame::type.tp_as_buffer;
+    type->tp_as_buffer =
+        reinterpret_cast<PyTypeObject*>(frame_type)->tp_as_buffer;
   }
 }
 

--- a/src/core/py_buffers.cc
+++ b/src/core/py_buffers.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2020 H2O.ai
+// Copyright 2018-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -471,7 +471,7 @@ static const char* format_from_stype(dt::SType stype)
 
 template <typename T>
 static void _copy_column_fw(const Column& col, Buffer& buf) {
-  xassert(dt::compatible_type<T>(col.stype()));
+  xassert(col.type().can_be_read_as<T>());
   xassert(buf.size() == col.nrows() * sizeof(T));
   auto nthreads = dt::NThreads(col.allow_parallel_access());
   auto out_data = static_cast<T*>(buf.wptr());
@@ -485,7 +485,7 @@ static void _copy_column_fw(const Column& col, Buffer& buf) {
 }
 
 static void _copy_column_obj(const Column& col, Buffer& buf) {
-  xassert(dt::compatible_type<py::oobj>(col.stype()));
+  xassert(col.type().can_be_read_as<py::oobj>());
   xassert(buf.size() == col.nrows() * sizeof(py::oobj));
   xassert(!buf.is_pyobjects());
   auto out_data = reinterpret_cast<PyObject**>(buf.wptr());

--- a/src/core/python/dict.cc
+++ b/src/core/python/dict.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2020 H2O.ai
+// Copyright 2018-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -55,6 +55,10 @@ odict::odict(std::initializer_list<oobj> args)
 
 rdict rdict::unchecked(const robj& src) {
   return rdict(src);
+}
+
+rdict rdict::unchecked(PyObject* src) {
+  return rdict(robj(src));
 }
 
 odict odict::copy() const {
@@ -122,6 +126,11 @@ robj rdict::get_or_none(_obj key) const {
 
 void odict::set(_obj key, _obj val) {
   // PyDict_SetItem INCREFs both key and value internally
+  int r = PyDict_SetItem(v, key.v, val.v);
+  if (r) throw PyError();
+}
+
+void rdict::set(_obj key, _obj val) {
   int r = PyDict_SetItem(v, key.v, val.v);
   if (r) throw PyError();
 }

--- a/src/core/python/dict.h
+++ b/src/core/python/dict.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2020 H2O.ai
+// Copyright 2018-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -113,12 +113,14 @@ class rdict : public robj {
     using robj::robj;
 
     static rdict unchecked(const robj&);
+    static rdict unchecked(PyObject*);
 
     size_t size() const;
     bool empty() const;
     bool has(_obj key) const;
     robj get(_obj key) const;
     robj get_or_none(_obj key) const;
+    void set(_obj key, _obj val);
 
     dict_iterator begin() const;
     dict_iterator end() const;

--- a/src/core/python/obj.cc
+++ b/src/core/python/obj.cc
@@ -114,9 +114,18 @@ oobj::oobj() {
   v = nullptr;
 }
 
+oobj::oobj(std::nullptr_t) {
+  v = nullptr;
+}
+
 oobj::oobj(PyObject* p) {
   v = p;
-  if (p) Py_INCREF(p);
+  Py_XINCREF(v);
+}
+
+oobj::oobj(PyTypeObject* p) {
+  v = reinterpret_cast<PyObject*>(p);
+  Py_XINCREF(v);
 }
 
 oobj::oobj(const oobj& other) : oobj(other.v) {}

--- a/src/core/python/obj.cc
+++ b/src/core/python/obj.cc
@@ -1088,6 +1088,17 @@ PyObject* oobj::release() && {
 }
 
 
+bool is_python_system_attr(py::robj attr) {
+  return is_python_system_attr(attr.to_cstring());
+}
+bool is_python_system_attr(const dt::CString& attr) {
+  auto a = attr.data();
+  auto n = attr.size();
+  return (n > 4 && a[0] == '_' && a[1] == '_' &&
+                   a[n-1] == '_' && a[n-2] == '_');
+}
+
+
 oobj get_module(const char* modname) {
   py::ostring pyname(modname);
   #if PY_VERSION_HEX >= 0x03070000

--- a/src/core/python/obj.cc
+++ b/src/core/python/obj.cc
@@ -212,10 +212,10 @@ bool _obj::is_int()           const noexcept { return v && PyLong_Check(v) && !i
 bool _obj::is_float()         const noexcept { return v && PyFloat_Check(v); }
 bool _obj::is_string()        const noexcept { return v && PyUnicode_Check(v); }
 bool _obj::is_bytes()         const noexcept { return v && PyBytes_Check(v); }
-bool _obj::is_type()          const noexcept { return v && PyType_Check(v); }
+bool _obj::is_pytype()        const noexcept { return v && PyType_Check(v); }
 bool _obj::is_ltype()         const noexcept { return v && dt::is_ltype_object(v); }
 bool _obj::is_stype()         const noexcept { return v && dt::is_stype_object(v); }
-bool _obj::is_anytype()       const noexcept { return is_type() || is_stype() || is_ltype(); }
+bool _obj::is_anytype()       const noexcept { return is_pytype() || is_stype() || is_ltype(); }
 bool _obj::is_list()          const noexcept { return v && PyList_Check(v); }
 bool _obj::is_tuple()         const noexcept { return v && PyTuple_Check(v); }
 bool _obj::is_dict()          const noexcept { return v && PyDict_Check(v); }

--- a/src/core/python/obj.cc
+++ b/src/core/python/obj.cc
@@ -60,7 +60,7 @@ static void init_numpy();
 PyObject* Expr_Type = nullptr;
 
 // Set from expr/fexpr.cc
-PyTypeObject* FExpr_Type = nullptr;
+PyObject* FExpr_Type = nullptr;
 
 // `_Py_static_string_init` invoked by the `_Py_IDENTIFIER` uses
 // a designated initializer, that is not supported by the C++14 standard.
@@ -327,7 +327,7 @@ bool _obj::is_dtexpr() const noexcept {
 }
 
 bool _obj::is_fexpr() const noexcept {
-  return v && Py_TYPE(v) == FExpr_Type;
+  return v && reinterpret_cast<PyObject*>(Py_TYPE(v)) == FExpr_Type;
 }
 
 

--- a/src/core/python/obj.h
+++ b/src/core/python/obj.h
@@ -386,6 +386,9 @@ robj rnone();
 void write_to_stdout(const std::string& str);
 
 
+bool is_python_system_attr(py::robj attr);
+bool is_python_system_attr(const dt::CString& attr);
+
 oobj get_module(const char* name);
 
 

--- a/src/core/python/obj.h
+++ b/src/core/python/obj.h
@@ -186,6 +186,7 @@ class _obj {
     bool is_pandas_categorical() const noexcept;
     bool is_pandas_frame()  const noexcept;
     bool is_pandas_series() const noexcept;
+    bool is_pytype()        const noexcept;
     bool is_range()         const noexcept;
     bool is_slice()         const noexcept;
     bool is_sort_node()     const noexcept;
@@ -193,7 +194,7 @@ class _obj {
     bool is_stype()         const noexcept;
     bool is_true()          const noexcept;
     bool is_tuple()         const noexcept;
-    bool is_pytype()        const noexcept;
+    bool is_type()          const noexcept;
     bool is_undefined()     const noexcept;
     bool is_update_node()   const noexcept;
 
@@ -259,6 +260,7 @@ class _obj {
     DataTable*  to_datatable      (const error_manager& = _em0) const;
     py::Frame*  to_pyframe        (const error_manager& = _em0) const;
     dt::SType   to_stype          (const error_manager& = _em0) const;
+    dt::Type    to_type           (const error_manager& = _em0) const;
     py::ojoin   to_ojoin_lax      () const;
     py::oby     to_oby_lax        () const;
     py::osort   to_osort_lax      () const;
@@ -290,6 +292,7 @@ class _obj {
       virtual Error error_not_range          (PyObject*) const;
       virtual Error error_not_slice          (PyObject*) const;
       virtual Error error_not_stype          (PyObject*) const;
+      virtual Error error_not_type           (PyObject*) const;
       virtual Error error_not_iterable       (PyObject*) const;
       virtual Error error_int32_overflow     (PyObject*) const;
       virtual Error error_int64_overflow     (PyObject*) const;

--- a/src/core/python/obj.h
+++ b/src/core/python/obj.h
@@ -395,7 +395,7 @@ oobj get_module(const char* name);
 
 
 extern PyObject* Expr_Type;
-extern PyTypeObject* FExpr_Type;
+extern PyObject* FExpr_Type;
 
 
 }  // namespace py

--- a/src/core/python/obj.h
+++ b/src/core/python/obj.h
@@ -334,7 +334,9 @@ class robj : public _obj {
 class oobj : public _obj {
   public:
     oobj();
+    oobj(std::nullptr_t);
     oobj(PyObject* p);
+    oobj(PyTypeObject* p);
     oobj(const oobj&);
     oobj(const robj&);
     oobj(oobj&&);

--- a/src/core/python/obj.h
+++ b/src/core/python/obj.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2020 H2O.ai
+// Copyright 2018-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -193,7 +193,7 @@ class _obj {
     bool is_stype()         const noexcept;
     bool is_true()          const noexcept;
     bool is_tuple()         const noexcept;
-    bool is_type()          const noexcept;
+    bool is_pytype()        const noexcept;
     bool is_undefined()     const noexcept;
     bool is_update_node()   const noexcept;
 

--- a/src/core/python/xobject.cc
+++ b/src/core/python/xobject.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019-2020 H2O.ai
+// Copyright 2019-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -62,6 +62,7 @@ XTypeMaker::NbTrueDivideTag  XTypeMaker::nb_truedivide_tag;
 
 
 XTypeMaker::XTypeMaker(PyTypeObject* t, size_t objsize) : type(t) {
+  if (objsize == 0) return;
   std::memset(type, 0, sizeof(PyTypeObject));
   Py_INCREF(type);
   type->tp_basicsize = static_cast<Py_ssize_t>(objsize);
@@ -113,6 +114,7 @@ void XTypeMaker::set_base_class(PyTypeObject* base_type) {
 }
 
 
+// It's unclear whether this could actually work
 void XTypeMaker::set_meta_class(PyTypeObject* meta_type) {
   xassert(meta_type->tp_base == &PyType_Type);
   type->ob_base.ob_base.ob_type = meta_type;

--- a/src/core/python/xobject.cc
+++ b/src/core/python/xobject.cc
@@ -113,6 +113,12 @@ void XTypeMaker::set_base_class(PyTypeObject* base_type) {
 }
 
 
+void XTypeMaker::set_meta_class(PyTypeObject* meta_type) {
+  xassert(meta_type->tp_base == &PyType_Type);
+  type->ob_base.ob_base.ob_type = meta_type;
+}
+
+
 void XTypeMaker::set_subclassable(bool flag /* = true */) {
   if (flag) {
     type->tp_flags |= Py_TPFLAGS_BASETYPE;

--- a/src/core/python/xobject.h
+++ b/src/core/python/xobject.h
@@ -91,6 +91,7 @@ class XTypeMaker {
     void set_class_name(const char* name);
     void set_class_doc(const char* doc);
     void set_base_class(PyTypeObject* base_type);
+    void set_meta_class(PyTypeObject* meta_type);
     void set_subclassable(bool flag = true);
 
     // initproc = int(*)(PyObject*, PyObject*, PyObject*)

--- a/src/core/python/xobject.h
+++ b/src/core/python/xobject.h
@@ -19,7 +19,6 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
-#include <iostream>
 #ifndef dt_PYTHON_XOBJECT_h
 #define dt_PYTHON_XOBJECT_h
 #include <cstring>    // std::memcpy, std::memset, std::strrchr

--- a/src/core/python/xobject.h
+++ b/src/core/python/xobject.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2020 H2O.ai
+// Copyright 2018-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -595,7 +595,7 @@ RESTORE_CLANG_WARNING("-Wunused-template")
 
 // FIXME: this does not report function's name to the CallLogger
 #define METHOD0(METH, NAME)                                                    \
-    _safe_repr<CLASS_OF(METH), METH>, NAME, py::XTypeMaker::method0_tag
+    py::_safe_repr<CLASS_OF(METH), METH>, NAME, py::XTypeMaker::method0_tag
 
 
 #define BUFFERS(GETMETH, DELMETH)                                              \
@@ -605,31 +605,31 @@ RESTORE_CLANG_WARNING("-Wunused-template")
 
 
 #define METHOD__REPR__(METH)                                                   \
-    _safe_repr<CLASS_OF(METH), METH>, py::XTypeMaker::repr_tag
+    py::_safe_repr<CLASS_OF(METH), METH>, py::XTypeMaker::repr_tag
 
 
 #define METHOD__STR__(METH)                                                    \
-    _safe_repr<CLASS_OF(METH), METH>, py::XTypeMaker::str_tag
+    py::_safe_repr<CLASS_OF(METH), METH>, py::XTypeMaker::str_tag
 
 
 #define METHOD__LEN__(METH)                                                    \
-    _safe_len<CLASS_OF(METH), METH>, py::XTypeMaker::length_tag
+    py::_safe_len<CLASS_OF(METH), METH>, py::XTypeMaker::length_tag
 
 
 #define METHOD__GETATTR__(METH)                                                \
-    _safe_getattr<CLASS_OF(METH), METH>, py::XTypeMaker::getattr_tag
+    py::_safe_getattr<CLASS_OF(METH), METH>, py::XTypeMaker::getattr_tag
 
 
 #define METHOD__GETITEM__(METH)                                                \
-    _safe_getitem<CLASS_OF(METH), METH>, py::XTypeMaker::getitem_tag
+    py::_safe_getitem<CLASS_OF(METH), METH>, py::XTypeMaker::getitem_tag
 
 
 #define METHOD__SETITEM__(METH)                                                \
-    _safe_setitem<CLASS_OF(METH), METH>, py::XTypeMaker::setitem_tag
+    py::_safe_setitem<CLASS_OF(METH), METH>, py::XTypeMaker::setitem_tag
 
 
 #define METHOD__ITER__(METH)                                                   \
-    _safe_unary<CLASS_OF(METH), METH, dt::CallLogger::Op::__iter__>,           \
+    py::_safe_unary<CLASS_OF(METH), METH, dt::CallLogger::Op::__iter__>,       \
     py::XTypeMaker::iter_tag
 
 
@@ -638,7 +638,7 @@ RESTORE_CLANG_WARNING("-Wunused-template")
 
 
 #define METHOD__NEXT__(METH)                                                   \
-    _safe_unary<CLASS_OF(METH), METH, dt::CallLogger::Op::__next__>,           \
+    py::_safe_unary<CLASS_OF(METH), METH, dt::CallLogger::Op::__next__>,       \
     py::XTypeMaker::next_tag
 
 
@@ -653,7 +653,7 @@ RESTORE_CLANG_WARNING("-Wunused-template")
 
 
 #define METHOD__CMP__(METH)                                                    \
-    _safe_cmp<METH>, py::XTypeMaker::rich_compare_tag
+    py::_safe_cmp<METH>, py::XTypeMaker::rich_compare_tag
 
 
 /**
@@ -666,27 +666,27 @@ RESTORE_CLANG_WARNING("-Wunused-template")
   */
 
 #define METHOD__ADD__(METH)                                                    \
-    _safe_binary<METH, dt::CallLogger::Op::__add__>,                           \
+    py::_safe_binary<METH, dt::CallLogger::Op::__add__>,                       \
     py::XTypeMaker::nb_add_tag
 
 
 #define METHOD__SUB__(METH)                                                    \
-    _safe_binary<METH, dt::CallLogger::Op::__sub__>,                           \
+    py::_safe_binary<METH, dt::CallLogger::Op::__sub__>,                       \
     py::XTypeMaker::nb_subtract_tag
 
 
 #define METHOD__MUL__(METH)                                                    \
-    _safe_binary<METH, dt::CallLogger::Op::__mul__>,                           \
+    py::_safe_binary<METH, dt::CallLogger::Op::__mul__>,                       \
     py::XTypeMaker::nb_multiply_tag
 
 
 #define METHOD__MOD__(METH)                                                    \
-    _safe_binary<METH, dt::CallLogger::Op::__mod__>,                           \
+    py::_safe_binary<METH, dt::CallLogger::Op::__mod__>,                       \
     py::XTypeMaker::nb_remainder_tag
 
 
 #define METHOD__DIVMOD__(METH)                                                 \
-    _safe_binary<METH, dt::CallLogger::Op::__divmod__>,                        \
+    py::_safe_binary<METH, dt::CallLogger::Op::__divmod__>,                    \
     py::XTypeMaker::nb_divmod_tag
 
 
@@ -696,37 +696,37 @@ RESTORE_CLANG_WARNING("-Wunused-template")
 
 
 #define METHOD__LSHIFT__(METH)                                                 \
-    _safe_binary<METH, dt::CallLogger::Op::__lshift__>,                        \
+    py::_safe_binary<METH, dt::CallLogger::Op::__lshift__>,                    \
     py::XTypeMaker::nb_lshift_tag
 
 
 #define METHOD__RSHIFT__(METH)                                                 \
-    _safe_binary<METH, dt::CallLogger::Op::__rshift__>,                        \
+    py::_safe_binary<METH, dt::CallLogger::Op::__rshift__>,                    \
     py::XTypeMaker::nb_rshift_tag
 
 
 #define METHOD__AND__(METH)                                                    \
-    _safe_binary<METH, dt::CallLogger::Op::__and__>,                           \
+    py::_safe_binary<METH, dt::CallLogger::Op::__and__>,                       \
     py::XTypeMaker::nb_and_tag
 
 
 #define METHOD__XOR__(METH)                                                    \
-    _safe_binary<METH, dt::CallLogger::Op::__xor__>,                           \
+    py::_safe_binary<METH, dt::CallLogger::Op::__xor__>,                       \
     py::XTypeMaker::nb_xor_tag
 
 
 #define METHOD__OR__(METH)                                                     \
-    _safe_binary<METH, dt::CallLogger::Op::__or__>,                            \
+    py::_safe_binary<METH, dt::CallLogger::Op::__or__>,                        \
     py::XTypeMaker::nb_or_tag
 
 
 #define METHOD__FLOORDIV__(METH)                                               \
-    _safe_binary<METH, dt::CallLogger::Op::__floordiv__>,                      \
+    py::_safe_binary<METH, dt::CallLogger::Op::__floordiv__>,                  \
     py::XTypeMaker::nb_floordivide_tag
 
 
 #define METHOD__TRUEDIV__(METH)                                                \
-    _safe_binary<METH, dt::CallLogger::Op::__truediv__>,                       \
+    py::_safe_binary<METH, dt::CallLogger::Op::__truediv__>,                   \
     py::XTypeMaker::nb_truedivide_tag
 
 
@@ -735,36 +735,36 @@ RESTORE_CLANG_WARNING("-Wunused-template")
   */
 
 #define METHOD__NEG__(METH)                                                    \
-    _safe_unary<CLASS_OF(METH), METH, dt::CallLogger::Op::__neg__>,            \
+    py::_safe_unary<CLASS_OF(METH), METH, dt::CallLogger::Op::__neg__>,        \
     py::XTypeMaker::nb_negative_tag
 
 
 #define METHOD__POS__(METH)                                                    \
-    _safe_unary<CLASS_OF(METH), METH, dt::CallLogger::Op::__pos__>,            \
+    py::_safe_unary<CLASS_OF(METH), METH, dt::CallLogger::Op::__pos__>,        \
     py::XTypeMaker::nb_positive_tag
 
 
 #define METHOD__ABS__(METH)                                                    \
-    _safe_unary<CLASS_OF(METH), METH, dt::CallLogger::Op::__abs__>,            \
+    py::_safe_unary<CLASS_OF(METH), METH, dt::CallLogger::Op::__abs__>,        \
     py::XTypeMaker::nb_absolute_tag
 
 
 #define METHOD__INVERT__(METH)                                                 \
-    _safe_unary<CLASS_OF(METH), METH, dt::CallLogger::Op::__invert__>,         \
+    py::_safe_unary<CLASS_OF(METH), METH, dt::CallLogger::Op::__invert__>,     \
     py::XTypeMaker::nb_invert_tag
 
 
 #define METHOD__BOOL__(METH)                                                   \
-    _safe_bool<CLASS_OF(METH), METH>, py::XTypeMaker::nb_bool_tag
+    py::_safe_bool<CLASS_OF(METH), METH>, py::XTypeMaker::nb_bool_tag
 
 
 #define METHOD__INT__(METH)                                                    \
-    _safe_unary<CLASS_OF(METH), METH, dt::CallLogger::Op::__int__>,            \
+    py::_safe_unary<CLASS_OF(METH), METH, dt::CallLogger::Op::__int__>,        \
     py::XTypeMaker::nb_int_tag
 
 
 #define METHOD__FLOAT__(METH)                                                  \
-    _safe_unary<CLASS_OF(METH), METH, dt::CallLogger::Op::__float__>,          \
+    py::_safe_unary<CLASS_OF(METH), METH, dt::CallLogger::Op::__float__>,      \
     py::XTypeMaker::nb_float_tag
 
 

--- a/src/core/read/py_read_iterator.cc
+++ b/src/core/read/py_read_iterator.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019-2020 H2O.ai
+// Copyright 2019-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -36,10 +36,8 @@ oobj ReadIterator::m__next__() {
 }
 
 
-oobj ReadIterator::make(std::unique_ptr<dt::read::MultiSource>&& multisource)
-{
-  robj rtype(reinterpret_cast<PyObject*>(&ReadIterator::type));
-  oobj resobj = rtype.call();
+oobj ReadIterator::make(std::unique_ptr<dt::read::MultiSource>&& multisource) {
+  oobj resobj = robj(ReadIterator::typePtr).call();
   ReadIterator* iterator = ReadIterator::cast_from(resobj);
   iterator->multisource_ = std::move(multisource);
   return resobj;

--- a/src/core/read/source.cc
+++ b/src/core/read/source.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2020 H2O.ai
+// Copyright 2020-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),

--- a/src/core/rowindex_array.cc
+++ b/src/core/rowindex_array.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2020 H2O.ai
+// Copyright 2018-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -213,9 +213,9 @@ const int64_t* ArrayRowIndexImpl::indices64() const noexcept {
 
 Column ArrayRowIndexImpl::as_column() const {
   if (type == RowIndexType::ARR32) {
-    return Column(new dt::SentinelFw_ColumnImpl<int32_t>(length, Buffer(buf_)));
+    return Column(new dt::SentinelFw_ColumnImpl<int32_t>(length, dt::SType::INT32, Buffer(buf_)));
   } else {
-    return Column(new dt::SentinelFw_ColumnImpl<int64_t>(length, Buffer(buf_)));
+    return Column(new dt::SentinelFw_ColumnImpl<int64_t>(length, dt::SType::INT64, Buffer(buf_)));
   }
 }
 

--- a/src/core/sort/sorter_float.h
+++ b/src/core/sort/sorter_float.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2020 H2O.ai
+// Copyright 2020-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -81,7 +81,7 @@ class Sorter_Float : public SSorter<T>
     Sorter_Float(const Column& col)
       : column_(col)
     {
-      xassert(compatible_type<TE>(col.stype()));
+      xassert(col.type().can_be_read_as<TE>());
     }
 
 

--- a/src/core/sort/sorter_int.h
+++ b/src/core/sort/sorter_int.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2020 H2O.ai
+// Copyright 2020-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -60,7 +60,7 @@ class Sorter_Int : public SSorter<T>
     Sorter_Int(const Column& col)
       : column_(col)
     {
-      xassert(compatible_type<TI>(col.stype()));
+      xassert(col.type().can_be_read_as<TI>());
     }
 
 

--- a/src/core/stats.cc
+++ b/src/core/stats.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2020 H2O.ai
+// Copyright 2018-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -503,7 +503,7 @@ void StringStats::set_mode(const dt::CString& value, bool isvalid) {
 
 template <typename T>
 static size_t _compute_nacount(const dt::ColumnImpl* col) {
-  xassert(dt::compatible_type<T>(col->stype()));
+  xassert(col->type().can_be_read_as<T>());
   std::atomic<size_t> total_countna { 0 };
   dt::parallel_region(
     dt::NThreads(col->allow_parallel_access()),
@@ -564,7 +564,7 @@ void BooleanStats::compute_minmax() {
 
 template <typename T>
 void NumericStats<T>::compute_minmax() {
-  xassert(dt::compatible_type<T>(column->stype()));
+  xassert(column->type().can_be_read_as<T>());
   size_t nrows = column->nrows();
   size_t count_valid = 0;
   T min = infinity<T>();

--- a/src/core/stype.h
+++ b/src/core/stype.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2020 H2O.ai
+// Copyright 2018-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -27,6 +27,7 @@
 #include "cstring.h"
 #include "python/obj.h"
 #include "python/python.h"
+#include "types/type.h"
 namespace dt {
 
 
@@ -292,15 +293,9 @@ using ref_t = typename _ref<T>::t;
   * reading values from a column of the given stype.
   */
 template<typename T>
-inline bool compatible_type(SType) { return false; }
-template<> inline bool compatible_type<int8_t>(SType s)   { return (s == SType::VOID || s == SType::INT8 || s == SType::BOOL); }
-template<> inline bool compatible_type<int16_t>(SType s)  { return (s == SType::INT16); }
-template<> inline bool compatible_type<int32_t>(SType s)  { return (s == SType::INT32); }
-template<> inline bool compatible_type<int64_t>(SType s)  { return (s == SType::INT64); }
-template<> inline bool compatible_type<float>(SType s)    { return (s == SType::FLOAT32); }
-template<> inline bool compatible_type<double>(SType s)   { return (s == SType::FLOAT64); }
-template<> inline bool compatible_type<CString>(SType s)  { return (s == SType::STR32 || s == SType::STR64); }
-template<> inline bool compatible_type<py::oobj>(SType s) { return (s == SType::OBJ); }
+inline bool compatible_type(SType stype) {
+  return Type::from_stype(stype).can_be_read_as<T>();
+}
 
 
 

--- a/src/core/types/py_type.cc
+++ b/src/core/types/py_type.cc
@@ -24,19 +24,34 @@
 #include "python/_all.h"
 namespace dt {
 
+static PyTypeObject* pythonType = nullptr;
 
 py::oobj PyType::make(Type type) {
-  py::oobj res = py::robj(reinterpret_cast<PyObject*>(&PyType::type)).call();
+  xassert(pythonType);
+  py::oobj res = py::robj(reinterpret_cast<PyObject*>(pythonType)).call();
   PyType* typed = reinterpret_cast<PyType*>(res.to_borrowed_ref());
   typed->type_ = std::move(type);
   return res;
 }
 
+bool PyType::check(PyObject* v) {
+  if (!v) return false;
+  auto typeptr = reinterpret_cast<PyObject*>(pythonType);
+  int ret = PyObject_IsInstance(v, typeptr);
+  if (ret == -1) PyErr_Clear();
+  return (ret == 1);
+}
+
+PyType* PyType::cast_from(py::robj obj) {
+  PyObject* v = obj.to_borrowed_ref();
+  return PyType::check(v)? reinterpret_cast<PyType*>(v) : nullptr;
+}
+
 
 static py::PKArgs args___init__(0, 0, 0, false, false, {}, "__init__", nullptr);
 
-
-void PyType::m__init__(const py::PKArgs&) {}
+void PyType::m__init__(const py::PKArgs&) {
+}
 
 
 void PyType::m__dealloc__() {
@@ -51,8 +66,8 @@ py::oobj PyType::m__repr__() const {
 
 py::oobj PyType::m__compare__(py::robj x, py::robj y, int op) {
   if (x.is_type() && y.is_type()) {
-    dt::Type xtype = x.to_type();
-    dt::Type ytype = y.to_type();
+    dt::Type xtype = reinterpret_cast<PyType*>(x.to_borrowed_ref())->type_;
+    dt::Type ytype = reinterpret_cast<PyType*>(y.to_borrowed_ref())->type_;
     if (op == Py_EQ) return py::obool(xtype == ytype);
     if (op == Py_NE) return py::obool(!(xtype == ytype));
   }
@@ -60,88 +75,37 @@ py::oobj PyType::m__compare__(py::robj x, py::robj y, int op) {
 }
 
 
-
 static const char* doc_Type =
 R"(
 Type of data in a column.
 )";
 
-void PyType::impl_init_type(py::XTypeMaker& xt) {
-  xt.set_class_name("datatable.Type");
-  xt.set_class_doc(doc_Type);
-  xt.set_subclassable(false);
-  xt.set_meta_class(&PyTypeMeta::type);
+void PyType::init() {
+  py::oobj pydtType = py::oobj::import("datatable", "Type");
+  pythonType = reinterpret_cast<PyTypeObject*>(pydtType.to_borrowed_ref());
+  xassert(pythonType->tp_basicsize == sizeof(PyType) - sizeof(dt::Type));
+  pythonType->tp_basicsize = sizeof(PyType);
+
+  py::XTypeMaker xt(pythonType, 0);
   xt.add(CONSTRUCTOR(&PyType::m__init__, args___init__));
   xt.add(DESTRUCTOR(&PyType::m__dealloc__));
   xt.add(METHOD__REPR__(&PyType::m__repr__));
   xt.add(METHOD__CMP__(&PyType::m__compare__));
-}
 
+  pydtType.set_attr("void",    PyType::make(Type::void0()));
+  pydtType.set_attr("bool8",   PyType::make(Type::bool8()));
+  pydtType.set_attr("int8",    PyType::make(Type::int8()));
+  pydtType.set_attr("int16",   PyType::make(Type::int16()));
+  pydtType.set_attr("int32",   PyType::make(Type::int32()));
+  pydtType.set_attr("int64",   PyType::make(Type::int64()));
+  pydtType.set_attr("float32", PyType::make(Type::float32()));
+  pydtType.set_attr("float64", PyType::make(Type::float64()));
+  pydtType.set_attr("str32",   PyType::make(Type::str32()));
+  pydtType.set_attr("str64",   PyType::make(Type::str64()));
+  pydtType.set_attr("obj64",   PyType::make(Type::obj64()));
 
-
-//------------------------------------------------------------------------------
-// PyTypeMeta
-//------------------------------------------------------------------------------
-
-static const char* doc_TypeMeta = "Metaclass for dt.Type";
-
-static py::PKArgs args_meta___init__(0, 0, 0, false, false, {}, "__init__", nullptr);
-
-void PyTypeMeta::m__init__(const py::PKArgs&) {}
-void PyTypeMeta::m__dealloc__() {}
-
-
-// `typeMetaDict` cannot be simple `py::odict`, because otherwise it will
-// get GCd after python shutdown, which will cause a segfault.
-static py::odict* typeMetaDict = nullptr;
-static void init_typemeta_dict() {
-  typeMetaDict = new py::odict();
-  typeMetaDict->set(py::ostring("void"),    PyType::make(Type::void0()));
-  typeMetaDict->set(py::ostring("bool8"),   PyType::make(Type::bool8()));
-  typeMetaDict->set(py::ostring("int8"),    PyType::make(Type::int8()));
-  typeMetaDict->set(py::ostring("int16"),   PyType::make(Type::int16()));
-  typeMetaDict->set(py::ostring("int32"),   PyType::make(Type::int32()));
-  typeMetaDict->set(py::ostring("int64"),   PyType::make(Type::int64()));
-  typeMetaDict->set(py::ostring("float32"), PyType::make(Type::float32()));
-  typeMetaDict->set(py::ostring("float64"), PyType::make(Type::float64()));
-  typeMetaDict->set(py::ostring("str32"),   PyType::make(Type::str32()));
-  typeMetaDict->set(py::ostring("str64"),   PyType::make(Type::str64()));
-  typeMetaDict->set(py::ostring("obj64"),   PyType::make(Type::obj64()));
-}
-
-py::oobj PyTypeMeta::m__getattr__(py::robj attr) {
-  if (!typeMetaDict) init_typemeta_dict();
-  auto res = typeMetaDict->get(attr);
-  if (res) return res;
-
-  std::string attr_str = attr.to_string();
-  if (attr_str == "__dict__") {
-    return *typeMetaDict;
-  }
-  if (py::is_python_system_attr(CString(attr_str))) {
-    return py::oobj::from_new_reference(
-        PyObject_GenericGetAttr(
-          reinterpret_cast<PyObject*>(this),
-          attr.to_borrowed_ref()
-        ));
-  }
-  throw AttributeError() << "Type `" << attr_str << "` does not exist";
-}
-
-
-py::oobj PyTypeMeta::m__repr__() const {
-  return py::ostring("<class 'datatable._TypeMeta'>");
-}
-
-void PyTypeMeta::impl_init_type(py::XTypeMaker& xt) {
-  xt.set_class_name("datatable._TypeMeta");
-  xt.set_base_class(&PyType_Type);
-  xt.set_class_doc(doc_TypeMeta);
-  xt.set_subclassable(false);
-  xt.add(CONSTRUCTOR(&PyTypeMeta::m__init__, args_meta___init__));
-  xt.add(DESTRUCTOR(&PyTypeMeta::m__dealloc__));
-  xt.add(METHOD__REPR__(&PyTypeMeta::m__repr__));
-  xt.add(METHOD__GETATTR__(&PyTypeMeta::m__getattr__));
+  // Python ignores tp_doc on heap-allocated types
+  pydtType.set_attr("__doc__", py::ostring(doc_Type));
 }
 
 

--- a/src/core/types/py_type.cc
+++ b/src/core/types/py_type.cc
@@ -19,6 +19,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
+#include <iostream>
 #include "types/py_type.h"
 #include "python/_all.h"
 namespace dt {
@@ -69,10 +70,78 @@ void PyType::impl_init_type(py::XTypeMaker& xt) {
   xt.set_class_name("datatable.Type");
   xt.set_class_doc(doc_Type);
   xt.set_subclassable(false);
+  xt.set_meta_class(&PyTypeMeta::type);
   xt.add(CONSTRUCTOR(&PyType::m__init__, args___init__));
   xt.add(DESTRUCTOR(&PyType::m__dealloc__));
   xt.add(METHOD__REPR__(&PyType::m__repr__));
   xt.add(METHOD__CMP__(&PyType::m__compare__));
+}
+
+
+
+//------------------------------------------------------------------------------
+// PyTypeMeta
+//------------------------------------------------------------------------------
+
+static const char* doc_TypeMeta = "Metaclass for dt.Type";
+
+static py::PKArgs args_meta___init__(0, 0, 0, false, false, {}, "__init__", nullptr);
+
+void PyTypeMeta::m__init__(const py::PKArgs&) {}
+void PyTypeMeta::m__dealloc__() {}
+
+
+// `typeMetaDict` cannot be simple `py::odict`, because otherwise it will
+// get GCd after python shutdown, which will cause a segfault.
+static py::odict* typeMetaDict = nullptr;
+static void init_typemeta_dict() {
+  typeMetaDict = new py::odict();
+  typeMetaDict->set(py::ostring("void"),    PyType::make(Type::void0()));
+  typeMetaDict->set(py::ostring("bool8"),   PyType::make(Type::bool8()));
+  typeMetaDict->set(py::ostring("int8"),    PyType::make(Type::int8()));
+  typeMetaDict->set(py::ostring("int16"),   PyType::make(Type::int16()));
+  typeMetaDict->set(py::ostring("int32"),   PyType::make(Type::int32()));
+  typeMetaDict->set(py::ostring("int64"),   PyType::make(Type::int64()));
+  typeMetaDict->set(py::ostring("float32"), PyType::make(Type::float32()));
+  typeMetaDict->set(py::ostring("float64"), PyType::make(Type::float64()));
+  typeMetaDict->set(py::ostring("str32"),   PyType::make(Type::str32()));
+  typeMetaDict->set(py::ostring("str64"),   PyType::make(Type::str64()));
+  typeMetaDict->set(py::ostring("obj64"),   PyType::make(Type::obj64()));
+}
+
+py::oobj PyTypeMeta::m__getattr__(py::robj attr) {
+  if (!typeMetaDict) init_typemeta_dict();
+  auto res = typeMetaDict->get(attr);
+  if (res) return res;
+
+  std::string attr_str = attr.to_string();
+  if (attr_str == "__dict__") {
+    return *typeMetaDict;
+  }
+  if (py::is_python_system_attr(CString(attr_str))) {
+    return py::oobj::from_new_reference(
+        PyObject_GenericGetAttr(
+          reinterpret_cast<PyObject*>(this),
+          attr.to_borrowed_ref()
+        ));
+  }
+  throw AttributeError() << "Type `" << attr_str << "` does not exist";
+}
+
+
+py::oobj PyTypeMeta::m__repr__() const {
+  return py::ostring("<class 'datatable._TypeMeta'>");
+}
+
+void PyTypeMeta::impl_init_type(py::XTypeMaker& xt) {
+  xt.set_class_name("datatable._TypeMeta");
+  xt.set_base_class(&PyType_Type);
+  xt.set_class_doc(doc_TypeMeta);
+  xt.set_subclassable(false);
+  xt.add(CONSTRUCTOR(&PyTypeMeta::m__init__, args_meta___init__));
+  xt.add(DESTRUCTOR(&PyTypeMeta::m__dealloc__));
+  xt.add(METHOD__REPR__(&PyTypeMeta::m__repr__));
+  xt.add(METHOD__GETATTR__(&PyTypeMeta::m__getattr__));
 }
 
 

--- a/src/core/types/py_type.cc
+++ b/src/core/types/py_type.cc
@@ -220,7 +220,19 @@ py::oobj PyType::m__compare__(py::robj x, py::robj y, int op) {
 }
 
 
-static py::GSArgs args_get_name("name", "The name of the type");
+static const char* doc_name =
+R"(
+Return the canonical name of this type, as a string.
+
+Examples
+--------
+>>> dt.Type.int64.name
+'int64'
+>>> dt.Type(np.bool_).name
+'bool8'
+)";
+
+static py::GSArgs args_get_name("name", doc_name);
 
 py::oobj PyType::get_name() const {
   return py::ostring(type_.to_string());

--- a/src/core/types/py_type.cc
+++ b/src/core/types/py_type.cc
@@ -248,7 +248,7 @@ void PyType::impl_init_type(py::XTypeMaker& xt) {
   xt.add(DESTRUCTOR(&PyType::m__dealloc__));
   xt.add(METHOD__REPR__(&PyType::m__repr__));
   xt.add(METHOD__CMP__(&PyType::m__compare__));
-  // xt.add(GETTER(&PyType::get_name, args_get_name));
+  xt.add(GETTER(&PyType::get_name, args_get_name));
   pythonType = xt.get_type_object();
 
   xt.add_attr("void",    PyType::make(Type::void0()));

--- a/src/core/types/py_type.cc
+++ b/src/core/types/py_type.cc
@@ -216,7 +216,18 @@ py::oobj PyType::m__compare__(py::robj x, py::robj y, int op) {
 
 static const char* doc_Type =
 R"(
-Type of data in a column.
+.. x-version-added:: 1.0.0
+
+Type of data stored in a single column of a Frame.
+
+The type describes both the logical meaning of the data (i.e. an integer,
+a floating point number, a string, etc.), as well as storage requirement
+of that data (the number of bits per element). Some types may carry
+additional properties, such as a timezone  or precision.
+
+.. note::
+
+    This property replaces previous :class:`dt.stype` and :class:`dt.ltype`.
 )";
 
 // This can only be called after python datatable module has been initialized

--- a/src/core/types/py_type.cc
+++ b/src/core/types/py_type.cc
@@ -24,6 +24,14 @@
 namespace dt {
 
 
+py::oobj PyType::make(Type type) {
+  py::oobj res = py::robj(reinterpret_cast<PyObject*>(&PyType::type)).call();
+  PyType* typed = reinterpret_cast<PyType*>(res.to_borrowed_ref());
+  typed->type_ = std::move(type);
+  return res;
+}
+
+
 static py::PKArgs args___init__(0, 0, 0, false, false, {}, "__init__", nullptr);
 
 
@@ -36,14 +44,16 @@ void PyType::m__dealloc__() {
 
 
 py::oobj PyType::m__repr__() const {
-  return py::ostring("Type.");
+  return py::ostring("Type." + type_.to_string());
 }
 
 
 py::oobj PyType::m__compare__(py::robj x, py::robj y, int op) {
-
-  if (op == Py_EQ) {
-    return py::obool();
+  if (x.is_type() && y.is_type()) {
+    dt::Type xtype = x.to_type();
+    dt::Type ytype = y.to_type();
+    if (op == Py_EQ) return py::obool(xtype == ytype);
+    if (op == Py_NE) return py::obool(!(xtype == ytype));
   }
   return py::False();
 }

--- a/src/core/types/py_type.cc
+++ b/src/core/types/py_type.cc
@@ -24,6 +24,7 @@
 #include "python/_all.h"
 namespace dt {
 
+// Pointer to the `class Type` that was created from python.
 static PyTypeObject* pythonType = nullptr;
 
 py::oobj PyType::make(Type type) {
@@ -104,7 +105,7 @@ static bool stypes_imported = false;
 static void init_src_store_from_stypes() {
   if (stypes_imported) return;
   stypes_imported = true;
-  auto stype = oobj::import("datatable", "stype");
+  auto stype = py::oobj::import("datatable", "stype");
 
   src_store->set(stype.get_attr("void"), PyType::make(Type::void0()));
   src_store->set(stype.get_attr("bool8"), PyType::make(Type::bool8()));

--- a/src/core/types/py_type.cc
+++ b/src/core/types/py_type.cc
@@ -48,9 +48,148 @@ PyType* PyType::cast_from(py::robj obj) {
 }
 
 
-static py::PKArgs args___init__(0, 0, 0, false, false, {}, "__init__", nullptr);
+static py::odict* src_store = nullptr;
+static void init_src_store_basic() {
+  if (src_store) return;
+  src_store = new py::odict();
 
-void PyType::m__init__(const py::PKArgs&) {
+  auto tVoid = PyType::make(Type::void0());
+  src_store->set(py::ostring("void"), tVoid);
+  src_store->set(py::ostring("V"), tVoid);
+  src_store->set(py::None(), tVoid);
+
+  auto tBool = PyType::make(Type::bool8());
+  src_store->set(py::ostring("bool8"), tBool);
+  src_store->set(py::ostring("boolean"), tBool);
+  src_store->set(py::ostring("bool"), tBool);
+  src_store->set(py::oobj(&PyBool_Type), tBool);
+
+  src_store->set(py::ostring("int8"),  PyType::make(Type::int8()));
+  src_store->set(py::ostring("int16"), PyType::make(Type::int16()));
+  src_store->set(py::ostring("int32"), PyType::make(Type::int32()));
+
+  auto tInt64 = PyType::make(Type::int64());
+  src_store->set(py::ostring("int64"), tInt64);
+  src_store->set(py::ostring("integer"), tInt64);
+  src_store->set(py::ostring("int"), tInt64);
+  src_store->set(py::oobj(&PyLong_Type), tInt64);
+
+  auto tFloat32 = PyType::make(Type::float32());
+  src_store->set(py::ostring("float32"), tFloat32);
+  src_store->set(py::ostring("float"), tFloat32);
+
+  auto tFloat64 = PyType::make(Type::float64());
+  src_store->set(py::ostring("float64"), tFloat64);
+  src_store->set(py::ostring("double"), tFloat64);
+  src_store->set(py::oobj(&PyFloat_Type), tFloat64);
+
+  auto tStr32 = PyType::make(Type::str32());
+  src_store->set(py::ostring("str32"), tStr32);
+  src_store->set(py::ostring("<U"), tStr32);
+  src_store->set(py::ostring("str"), tStr32);
+  src_store->set(py::ostring("string"), tStr32);
+  src_store->set(py::oobj(&PyUnicode_Type), tStr32);
+
+  src_store->set(py::ostring("str64"), PyType::make(Type::str64()));
+
+  auto tObj64 = PyType::make(Type::obj64());
+  src_store->set(py::ostring("obj64"), tObj64);
+  src_store->set(py::ostring("obj"), tObj64);
+  src_store->set(py::ostring("object"), tObj64);
+  src_store->set(py::oobj(&PyBaseObject_Type), tObj64);
+}
+
+
+static bool stypes_imported = false;
+static void init_src_store_from_stypes() {
+  if (stypes_imported) return;
+  stypes_imported = true;
+  auto stype = oobj::import("datatable", "stype");
+
+  src_store->set(stype.get_attr("void"), PyType::make(Type::void0()));
+  src_store->set(stype.get_attr("bool8"), PyType::make(Type::bool8()));
+  src_store->set(stype.get_attr("int8"), PyType::make(Type::int8()));
+  src_store->set(stype.get_attr("int16"), PyType::make(Type::int16()));
+  src_store->set(stype.get_attr("int32"), PyType::make(Type::int32()));
+  src_store->set(stype.get_attr("int64"), PyType::make(Type::int64()));
+  src_store->set(stype.get_attr("float32"), PyType::make(Type::float32()));
+  src_store->set(stype.get_attr("float64"), PyType::make(Type::float64()));
+  src_store->set(stype.get_attr("str32"), PyType::make(Type::str32()));
+  src_store->set(stype.get_attr("str64"), PyType::make(Type::str64()));
+  src_store->set(stype.get_attr("obj64"), PyType::make(Type::obj64()));
+}
+
+
+static bool numpy_types_imported = false;
+static void init_src_store_from_numpy() {
+  if (numpy_types_imported) return;
+  auto np = py::get_module("numpy");
+  if (!np) return;
+  numpy_types_imported = true;
+  auto dtype = np.get_attr("dtype");
+
+  auto tVoid = PyType::make(Type::void0());
+  src_store->set(np.get_attr("void"), tVoid);
+  src_store->set(dtype.call({py::ostring("void")}), tVoid);
+
+  auto tBool = PyType::make(Type::bool8());
+  src_store->set(np.get_attr("bool_"), tBool);
+  src_store->set(dtype.call({py::ostring("bool")}), tBool);
+
+  auto tInt8 = PyType::make(Type::int8());
+  src_store->set(np.get_attr("int8"), tInt8);
+  src_store->set(dtype.call({py::ostring("int8")}), tInt8);
+
+  auto tInt16 = PyType::make(Type::int16());
+  src_store->set(np.get_attr("int16"), tInt16);
+  src_store->set(dtype.call({py::ostring("int16")}), tInt16);
+
+  auto tInt32 = PyType::make(Type::int32());
+  src_store->set(np.get_attr("int32"), tInt32);
+  src_store->set(dtype.call({py::ostring("int32")}), tInt32);
+
+  auto tInt64 = PyType::make(Type::int64());
+  src_store->set(np.get_attr("int64"), tInt64);
+  src_store->set(dtype.call({py::ostring("int64")}), tInt64);
+
+  auto tFloat32 = PyType::make(Type::float32());
+  src_store->set(np.get_attr("float16"), tFloat32);
+  src_store->set(np.get_attr("float32"), tFloat32);
+  src_store->set(dtype.call({py::ostring("float16")}), tFloat32);
+  src_store->set(dtype.call({py::ostring("float32")}), tFloat32);
+
+  auto tFloat64 = PyType::make(Type::float64());
+  src_store->set(np.get_attr("float64"), tFloat64);
+  src_store->set(dtype.call({py::ostring("float64")}), tFloat64);
+
+  auto tStr32 = PyType::make(Type::str32());
+  src_store->set(np.get_attr("str_"), tStr32);
+  src_store->set(dtype.call({py::ostring("str")}), tStr32);
+}
+
+
+static py::PKArgs args___init__(
+    1, 0, 0, false, false, {"src"}, "__init__", nullptr);
+
+void PyType::m__init__(const py::PKArgs& args) {
+  auto src = args[0].to_oobj();
+  if (!src) return;
+  for (int i = 0; i < 3; i++) {
+    if (i == 0) init_src_store_basic();
+    if (i == 1) init_src_store_from_stypes();
+    if (i == 2) init_src_store_from_numpy();
+    auto stored_type = src_store->get(src);
+    if (stored_type) {
+      type_ = reinterpret_cast<PyType*>(stored_type.to_borrowed_ref())->type_;
+      return;
+    }
+  }
+  if (src.is_type()) {   // make Type objects from other Type objects
+    type_ = reinterpret_cast<PyType*>(src.to_borrowed_ref())->type_;
+    return;
+  }
+  throw ValueError() << "Cannot create Type object from "
+                     << src.safe_repr().to_string();
 }
 
 
@@ -80,6 +219,7 @@ R"(
 Type of data in a column.
 )";
 
+// This can only be called after python datatable module has been initialized
 void PyType::init() {
   py::oobj pydtType = py::oobj::import("datatable", "Type");
   pythonType = reinterpret_cast<PyTypeObject*>(pydtType.to_borrowed_ref());

--- a/src/core/types/py_type.h
+++ b/src/core/types/py_type.h
@@ -30,13 +30,11 @@ namespace dt {
   * This class corresponds is python-visible `dt.Type`: it describes
   * a type of a single column.
   *
-  * This class uses non-standard initialization mechanism: originally
-  * it is defined in python (see "__init__.py"), and then we patch
-  * that python class so that its definition would match that of
-  * PyType. This approach is used in order to allow the class to
-  * carry class attributes `.int32`, `.float64`, etc. Regular
-  * extension classes do not support class attributes, nor proper
-  * metatypes.
+  * This class uses "dynamic" initialization mechanism: the class
+  * object is defined via a call to python `type(name, (), {})`, and
+  * then the resulting object is modified to add new methods. This
+  * mechanism is used because the "standard" extension types do not
+  * allow to define class properties (which we need).
   *
   * Because of this mechanism, the XObject's field `.type` is not
   * used: instead we use a static variable defined in "py_type.cc".

--- a/src/core/types/py_type.h
+++ b/src/core/types/py_type.h
@@ -27,7 +27,7 @@ namespace dt {
 
 
 /**
-  * This class corresponds is python-visible `dt.Type`: it describes
+  * This class corresponds to python-visible `dt.Type`: it describes
   * a type of a single column.
   *
   * This class uses "dynamic" initialization mechanism: the class

--- a/src/core/types/py_type.h
+++ b/src/core/types/py_type.h
@@ -26,8 +26,27 @@
 namespace dt {
 
 
+/**
+  * This class corresponds is python-visible `dt.Type`: it describes
+  * a type of a single column.
+  *
+  * This class uses non-standard initialization mechanism: originally
+  * it is defined in python (see "__init__.py"), and then we patch
+  * that python class so that its definition would match that of
+  * PyType. This approach is used in order to allow the class to
+  * carry class attributes `.int32`, `.float64`, etc. Regular
+  * extension classes do not support class attributes, nor proper
+  * metatypes.
+  *
+  * Because of this mechanism, the XObject's field `.type` is not
+  * used: instead we use a static variable defined in "py_type.cc".
+  * This is why methods `init()`, `check()` and `cast_from()` has to
+  * be redefined.
+  */
 class PyType : public py::XObject<PyType> {
   private:
+    size_t : 64;  // __dict__
+    size_t : 64;  // __weakref__
     Type type_;
 
   public:
@@ -40,19 +59,12 @@ class PyType : public py::XObject<PyType> {
 
     static py::oobj m__compare__(py::robj, py::robj, int op);
 
-    static void impl_init_type(py::XTypeMaker& xt);
+    // Redefine these methods from py::XObject, because this type
+    // does not undergo "normal" initialization process.
+    static void init();
+    static bool check(PyObject*);
+    static PyType* cast_from(py::robj obj);
 };
-
-
-class PyTypeMeta : public py::XObject<PyTypeMeta> {
-  public:
-    void m__init__(const py::PKArgs&);
-    void m__dealloc__();
-    py::oobj m__repr__() const;
-    py::oobj m__getattr__(py::robj attr);
-    static void impl_init_type(py::XTypeMaker& xt);
-};
-
 
 
 

--- a/src/core/types/py_type.h
+++ b/src/core/types/py_type.h
@@ -19,51 +19,28 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
-#include "types/type_impl.h"
+#ifndef dt_TYPES_PY_TYPE_h
+#define dt_TYPES_PY_TYPE_h
+#include "types/type.h"
+#include "python/xobject.h"
 namespace dt {
 
 
-TypeImpl::TypeImpl(SType stype)
-  : stype_(stype),
-    refcount_(1) {}
+class PyType : public py::XObject<PyType> {
+  private:
+    Type type_;
 
-TypeImpl::~TypeImpl() {}
+  public:
+    void m__init__(const py::PKArgs&);
+    void m__dealloc__();
+    py::oobj m__repr__() const;
+
+    static py::oobj m__compare__(py::robj, py::robj, int op);
+
+    static void impl_init_type(py::XTypeMaker& xt);
+};
 
 
 
-void TypeImpl::acquire() noexcept {
-  refcount_++;
 }
-
-void TypeImpl::release() noexcept {
-  refcount_--;
-  if (refcount_ == 0) delete this;
-}
-
-
-bool TypeImpl::is_boolean() const { return false; }
-bool TypeImpl::is_integer() const { return false; }
-bool TypeImpl::is_float()   const { return false; }
-bool TypeImpl::is_numeric() const { return false; }
-bool TypeImpl::is_string()  const { return false; }
-bool TypeImpl::is_time()    const { return false; }
-bool TypeImpl::is_object()  const { return false; }
-
-
-bool TypeImpl::can_be_read_as_int8()     const { return false; }
-bool TypeImpl::can_be_read_as_int16()    const { return false; }
-bool TypeImpl::can_be_read_as_int32()    const { return false; }
-bool TypeImpl::can_be_read_as_int64()    const { return false; }
-bool TypeImpl::can_be_read_as_float32()  const { return false; }
-bool TypeImpl::can_be_read_as_float64()  const { return false; }
-bool TypeImpl::can_be_read_as_cstring()  const { return false; }
-bool TypeImpl::can_be_read_as_pyobject() const { return false; }
-
-bool TypeImpl::equals(const TypeImpl* other) const {
-  return stype_ == other->stype_;
-}
-
-
-
-
-}  // namespace dt
+#endif

--- a/src/core/types/py_type.h
+++ b/src/core/types/py_type.h
@@ -43,27 +43,23 @@ namespace dt {
   * This is why methods `init()`, `check()` and `cast_from()` has to
   * be redefined.
   */
-class PyType : public py::XObject<PyType> {
+class PyType : public py::XObject<PyType, true> {
   private:
-    size_t : 64;  // __dict__
-    size_t : 64;  // __weakref__
     Type type_;
 
   public:
     static py::oobj make(Type);
+    static py::oobj m__compare__(py::robj, py::robj, int op);
 
     void m__init__(const py::PKArgs&);
     void m__dealloc__();
     py::oobj m__repr__() const;
+
+    py::oobj get_name() const;
+
     Type get_type() const { return type_; }
 
-    static py::oobj m__compare__(py::robj, py::robj, int op);
-
-    // Redefine these methods from py::XObject, because this type
-    // does not undergo "normal" initialization process.
-    static void init();
-    static bool check(PyObject*);
-    static PyType* cast_from(py::robj obj);
+    static void impl_init_type(py::XTypeMaker& xt);
 };
 
 

--- a/src/core/types/py_type.h
+++ b/src/core/types/py_type.h
@@ -44,6 +44,17 @@ class PyType : public py::XObject<PyType> {
 };
 
 
+class PyTypeMeta : public py::XObject<PyTypeMeta> {
+  public:
+    void m__init__(const py::PKArgs&);
+    void m__dealloc__();
+    py::oobj m__repr__() const;
+    py::oobj m__getattr__(py::robj attr);
+    static void impl_init_type(py::XTypeMaker& xt);
+};
+
+
+
 
 }
 #endif

--- a/src/core/types/py_type.h
+++ b/src/core/types/py_type.h
@@ -31,9 +31,12 @@ class PyType : public py::XObject<PyType> {
     Type type_;
 
   public:
+    static py::oobj make(Type);
+
     void m__init__(const py::PKArgs&);
     void m__dealloc__();
     py::oobj m__repr__() const;
+    Type get_type() const { return type_; }
 
     static py::oobj m__compare__(py::robj, py::robj, int op);
 

--- a/src/core/types/type.cc
+++ b/src/core/types/type.cc
@@ -121,5 +121,11 @@ template<> bool Type::can_be_read_as<CString>()  const { return impl_->can_be_re
 template<> bool Type::can_be_read_as<py::oobj>() const { return impl_->can_be_read_as_pyobject(); }
 
 
+bool Type::operator==(const Type& other) const {
+  return (impl_ == other.impl_) || (impl_->equals(other.impl_));
+}
+
+
+
 
 }  // namespace dt

--- a/src/core/types/type.cc
+++ b/src/core/types/type.cc
@@ -19,6 +19,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
+#include "python/obj.h"
 #include "stype.h"
 #include "types/type.h"
 #include "types/type_bool.h"
@@ -74,8 +75,8 @@ Type Type::int8()    { return Type(new Type_Int(SType::INT8)); }
 Type Type::int16()   { return Type(new Type_Int(SType::INT16)); }
 Type Type::int32()   { return Type(new Type_Int(SType::INT32)); }
 Type Type::int64()   { return Type(new Type_Int(SType::INT64)); }
-Type Type::float32() { return Type(new Type_Float(SType::FLOAT32)); }
-Type Type::float64() { return Type(new Type_Float(SType::FLOAT64)); }
+Type Type::float32() { return Type(new Type_Float32()); }
+Type Type::float64() { return Type(new Type_Float64()); }
 Type Type::str32()   { return Type(new Type_String(SType::STR32)); }
 Type Type::str64()   { return Type(new Type_String(SType::STR64)); }
 Type Type::obj64()   { return Type(new Type_Object()); }
@@ -108,6 +109,16 @@ bool Type::is_numeric() const { return impl_->is_numeric(); }
 bool Type::is_string()  const { return impl_->is_string(); }
 bool Type::is_object()  const { return impl_->is_object(); }
 
+
+template<typename T> bool Type::can_be_read_as() const { return false; }
+template<> bool Type::can_be_read_as<int8_t>()   const { return impl_->can_be_read_as_int8(); }
+template<> bool Type::can_be_read_as<int16_t>()  const { return impl_->can_be_read_as_int16(); }
+template<> bool Type::can_be_read_as<int32_t>()  const { return impl_->can_be_read_as_int32(); }
+template<> bool Type::can_be_read_as<int64_t>()  const { return impl_->can_be_read_as_int64(); }
+template<> bool Type::can_be_read_as<float>()    const { return impl_->can_be_read_as_float32(); }
+template<> bool Type::can_be_read_as<double>()   const { return impl_->can_be_read_as_float64(); }
+template<> bool Type::can_be_read_as<CString>()  const { return impl_->can_be_read_as_cstring(); }
+template<> bool Type::can_be_read_as<py::oobj>() const { return impl_->can_be_read_as_pyobject(); }
 
 
 

--- a/src/core/types/type.cc
+++ b/src/core/types/type.cc
@@ -99,6 +99,7 @@ Type Type::from_stype(SType stype) {
 }
 
 
+SType Type::stype() const { return impl_->stype_; }
 
 bool Type::is_boolean() const { return impl_->is_boolean(); }
 bool Type::is_integer() const { return impl_->is_integer(); }

--- a/src/core/types/type.cc
+++ b/src/core/types/type.cc
@@ -126,6 +126,7 @@ bool Type::operator==(const Type& other) const {
 }
 
 std::string Type::to_string() const {
+  if (!impl_) return "Type()";
   return impl_->to_string();
 }
 

--- a/src/core/types/type.cc
+++ b/src/core/types/type.cc
@@ -125,6 +125,9 @@ bool Type::operator==(const Type& other) const {
   return (impl_ == other.impl_) || (impl_->equals(other.impl_));
 }
 
+std::string Type::to_string() const {
+  return impl_->to_string();
+}
 
 
 

--- a/src/core/types/type.cc
+++ b/src/core/types/type.cc
@@ -1,0 +1,113 @@
+//------------------------------------------------------------------------------
+// Copyright 2021 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#include "stype.h"
+#include "types/type.h"
+#include "types/type_bool.h"
+#include "types/type_float.h"
+#include "types/type_impl.h"
+#include "types/type_int.h"
+#include "types/type_object.h"
+#include "types/type_string.h"
+#include "types/type_void.h"
+namespace dt {
+
+
+Type::Type(TypeImpl*&& impl) noexcept  // private
+  : impl_(impl) {}
+
+Type::Type() noexcept
+  : impl_(nullptr) {}
+
+Type::Type(const Type& other) noexcept {
+  impl_ = other.impl_;
+  if (impl_) impl_->acquire();
+}
+
+Type::Type(Type&& other) noexcept {
+  impl_ = other.impl_;
+  other.impl_ = nullptr;
+}
+
+Type& Type::operator=(const Type& other) {
+  auto old_impl = impl_;
+  impl_ = other.impl_;
+  if (old_impl) impl_->release();
+  if (impl_) impl_->acquire();
+  return *this;
+}
+
+Type& Type::operator=(Type&& other) {
+  auto old_impl = impl_;
+  impl_ = other.impl_;
+  other.impl_ = old_impl;
+  return *this;
+}
+
+Type::~Type() {
+  if (impl_) impl_->release();
+}
+
+
+
+Type Type::void0()   { return Type(new Type_Void()); }
+Type Type::bool8()   { return Type(new Type_Bool8()); }
+Type Type::int8()    { return Type(new Type_Int(SType::INT8)); }
+Type Type::int16()   { return Type(new Type_Int(SType::INT16)); }
+Type Type::int32()   { return Type(new Type_Int(SType::INT32)); }
+Type Type::int64()   { return Type(new Type_Int(SType::INT64)); }
+Type Type::float32() { return Type(new Type_Float(SType::FLOAT32)); }
+Type Type::float64() { return Type(new Type_Float(SType::FLOAT64)); }
+Type Type::str32()   { return Type(new Type_String(SType::STR32)); }
+Type Type::str64()   { return Type(new Type_String(SType::STR64)); }
+Type Type::obj64()   { return Type(new Type_Object()); }
+
+Type Type::from_stype(SType stype) {
+  switch (stype) {
+    case SType::VOID:    return void0();
+    case SType::BOOL:    return bool8();
+    case SType::INT8:    return int8();
+    case SType::INT16:   return int16();
+    case SType::INT32:   return int32();
+    case SType::INT64:   return int64();
+    case SType::FLOAT32: return float32();
+    case SType::FLOAT64: return float64();
+    case SType::STR32:   return str32();
+    case SType::STR64:   return str64();
+    case SType::OBJ:     return obj64();
+    default: break;
+  }
+  throw NotImplError() << "Cannot instantiate Type from " << stype;
+}
+
+
+
+bool Type::is_boolean() const { return impl_->is_boolean(); }
+bool Type::is_integer() const { return impl_->is_integer(); }
+bool Type::is_float()   const { return impl_->is_float(); }
+bool Type::is_numeric() const { return impl_->is_numeric(); }
+bool Type::is_string()  const { return impl_->is_string(); }
+bool Type::is_object()  const { return impl_->is_object(); }
+
+
+
+
+}  // namespace dt

--- a/src/core/types/type.cc
+++ b/src/core/types/type.cc
@@ -69,17 +69,17 @@ Type::~Type() {
 
 
 
-Type Type::void0()   { return Type(new Type_Void()); }
-Type Type::bool8()   { return Type(new Type_Bool8()); }
-Type Type::int8()    { return Type(new Type_Int(SType::INT8)); }
-Type Type::int16()   { return Type(new Type_Int(SType::INT16)); }
-Type Type::int32()   { return Type(new Type_Int(SType::INT32)); }
-Type Type::int64()   { return Type(new Type_Int(SType::INT64)); }
-Type Type::float32() { return Type(new Type_Float32()); }
-Type Type::float64() { return Type(new Type_Float64()); }
-Type Type::str32()   { return Type(new Type_String(SType::STR32)); }
-Type Type::str64()   { return Type(new Type_String(SType::STR64)); }
-Type Type::obj64()   { return Type(new Type_Object()); }
+Type Type::void0()   { return Type(new Type_Void); }
+Type Type::bool8()   { return Type(new Type_Bool8); }
+Type Type::int8()    { return Type(new Type_Int8); }
+Type Type::int16()   { return Type(new Type_Int16); }
+Type Type::int32()   { return Type(new Type_Int32); }
+Type Type::int64()   { return Type(new Type_Int64); }
+Type Type::float32() { return Type(new Type_Float32); }
+Type Type::float64() { return Type(new Type_Float64); }
+Type Type::str32()   { return Type(new Type_String32); }
+Type Type::str64()   { return Type(new Type_String64); }
+Type Type::obj64()   { return Type(new Type_Object); }
 
 Type Type::from_stype(SType stype) {
   switch (stype) {

--- a/src/core/types/type.h
+++ b/src/core/types/type.h
@@ -21,7 +21,7 @@
 //------------------------------------------------------------------------------
 #ifndef dt_TYPES_TYPE_h
 #define dt_TYPES_TYPE_h
-#include "stype.h"
+#include "_dt.h"
 namespace dt {
 
 class TypeImpl;
@@ -45,6 +45,9 @@ class Type {
     TypeImpl* impl_;   // owned
 
   public:
+    //--------------------------------------------------------------------------
+    // Constructors
+    //--------------------------------------------------------------------------
     Type() noexcept;
     Type(const Type& other) noexcept;
     Type(Type&& other) noexcept;
@@ -65,6 +68,10 @@ class Type {
     static Type obj64();
     static Type from_stype(SType);
 
+
+    //--------------------------------------------------------------------------
+    // Properties
+    //--------------------------------------------------------------------------
     SType stype() const;
     bool is_boolean() const;
     bool is_integer() const;
@@ -73,11 +80,23 @@ class Type {
     bool is_string() const;
     bool is_object() const;
 
+    template<typename T>
+    bool can_be_read_as() const;
+
+
   private:
     Type(TypeImpl*&&) noexcept;
 };
 
 
+template<> bool Type::can_be_read_as<int8_t>() const;
+template<> bool Type::can_be_read_as<int16_t>() const;
+template<> bool Type::can_be_read_as<int32_t>() const;
+template<> bool Type::can_be_read_as<int64_t>() const;
+template<> bool Type::can_be_read_as<float>() const;
+template<> bool Type::can_be_read_as<double>() const;
+template<> bool Type::can_be_read_as<CString>() const;
+template<> bool Type::can_be_read_as<py::oobj>() const;
 
 
 

--- a/src/core/types/type.h
+++ b/src/core/types/type.h
@@ -84,6 +84,7 @@ class Type {
     bool can_be_read_as() const;
 
     bool operator==(const Type& other) const;
+    std::string to_string() const;
 
   private:
     Type(TypeImpl*&&) noexcept;

--- a/src/core/types/type.h
+++ b/src/core/types/type.h
@@ -1,0 +1,85 @@
+//------------------------------------------------------------------------------
+// Copyright 2021 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#ifndef dt_TYPES_TYPE_h
+#define dt_TYPES_TYPE_h
+#include "stype.h"
+namespace dt {
+
+class TypeImpl;
+
+
+/**
+  * This class encompasses the type of a single column. It has a
+  * "shared pointer" semantics so that it is easy to copy and pass
+  * it around.
+  *
+  * Originally, the type of a column was governed by a simple enum
+  * SType. However, eventually we came to the point where this is no
+  * longer sufficient: certain types must carry additional
+  * information that cannot be enumerated.
+  *
+  * The SType enum currently remains as a fallback; it may be
+  * eliminated in the future.
+  */
+class Type {
+  private:
+    TypeImpl* impl_;   // owned
+
+  public:
+    Type() noexcept;
+    Type(const Type& other) noexcept;
+    Type(Type&& other) noexcept;
+    Type& operator=(const Type& other);
+    Type& operator=(Type&& other);
+    ~Type();
+
+    static Type void0();
+    static Type bool8();
+    static Type int8();
+    static Type int16();
+    static Type int32();
+    static Type int64();
+    static Type float32();
+    static Type float64();
+    static Type str32();
+    static Type str64();
+    static Type obj64();
+    static Type from_stype(SType);
+
+    SType stype() const;
+    bool is_boolean() const;
+    bool is_integer() const;
+    bool is_float() const;
+    bool is_numeric() const;
+    bool is_string() const;
+    bool is_object() const;
+
+  private:
+    Type(TypeImpl*&&) noexcept;
+};
+
+
+
+
+
+}  // namespace dt
+#endif

--- a/src/core/types/type.h
+++ b/src/core/types/type.h
@@ -83,6 +83,7 @@ class Type {
     template<typename T>
     bool can_be_read_as() const;
 
+    bool operator==(const Type& other) const;
 
   private:
     Type(TypeImpl*&&) noexcept;

--- a/src/core/types/type_bool.h
+++ b/src/core/types/type_bool.h
@@ -1,0 +1,40 @@
+//------------------------------------------------------------------------------
+// Copyright 2021 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#ifndef dt_TYPES_TYPE_BOOL_h
+#define dt_TYPES_TYPE_BOOL_h
+#include "types/type_impl.h"
+namespace dt {
+
+
+
+class Type_Bool8 : public TypeImpl {
+  public:
+    Type_Bool8() : TypeImpl(SType::BOOL) {}
+
+    bool is_boolean() const override { return true; }
+    bool is_numeric() const override { return true; }
+};
+
+
+
+}  // namespace dt
+#endif

--- a/src/core/types/type_bool.h
+++ b/src/core/types/type_bool.h
@@ -33,6 +33,8 @@ class Type_Bool8 : public TypeImpl {
     bool is_boolean() const override { return true; }
     bool is_numeric() const override { return true; }
     bool can_be_read_as_int8() const override { return true; }
+
+    std::string to_string() const override { return "bool8"; }
 };
 
 

--- a/src/core/types/type_bool.h
+++ b/src/core/types/type_bool.h
@@ -32,6 +32,7 @@ class Type_Bool8 : public TypeImpl {
 
     bool is_boolean() const override { return true; }
     bool is_numeric() const override { return true; }
+    bool can_be_read_as_int8() const override { return true; }
 };
 
 

--- a/src/core/types/type_float.h
+++ b/src/core/types/type_float.h
@@ -42,6 +42,7 @@ class Type_Float32 : public Type_Float {
   public:
     Type_Float32() : Type_Float(SType::FLOAT32) {}
     bool can_be_read_as_float32() const override { return true; }
+    std::string to_string() const override { return "float32"; }
 };
 
 
@@ -49,6 +50,7 @@ class Type_Float64 : public Type_Float {
   public:
     Type_Float64() : Type_Float(SType::FLOAT64) {}
     bool can_be_read_as_float64() const override { return true; }
+    std::string to_string() const override { return "float64"; }
 };
 
 

--- a/src/core/types/type_float.h
+++ b/src/core/types/type_float.h
@@ -1,0 +1,43 @@
+//------------------------------------------------------------------------------
+// Copyright 2021 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#ifndef dt_TYPES_TYPE_FLOAT_h
+#define dt_TYPES_TYPE_FLOAT_h
+#include "types/type_impl.h"
+#include "utils/assert.h"
+namespace dt {
+
+
+
+class Type_Float : public TypeImpl {
+  public:
+    Type_Float(SType stype) : TypeImpl(stype) {
+      xassert(stype == SType::FLOAT32 || stype == SType::FLOAT64);
+    }
+
+    bool is_float()   const override { return true; }
+    bool is_numeric() const override { return true; }
+};
+
+
+
+}  // namespace dt
+#endif

--- a/src/core/types/type_float.h
+++ b/src/core/types/type_float.h
@@ -28,14 +28,29 @@ namespace dt {
 
 
 class Type_Float : public TypeImpl {
-  public:
-    Type_Float(SType stype) : TypeImpl(stype) {
-      xassert(stype == SType::FLOAT32 || stype == SType::FLOAT64);
-    }
+  protected:
+    using TypeImpl::TypeImpl;
 
+  public:
     bool is_float()   const override { return true; }
     bool is_numeric() const override { return true; }
 };
+
+
+
+class Type_Float32 : public Type_Float {
+  public:
+    Type_Float32() : Type_Float(SType::FLOAT32) {}
+    bool can_be_read_as_float32() const override { return true; }
+};
+
+
+class Type_Float64 : public Type_Float {
+  public:
+    Type_Float64() : Type_Float(SType::FLOAT64) {}
+    bool can_be_read_as_float64() const override { return true; }
+};
+
 
 
 

--- a/src/core/types/type_impl.cc
+++ b/src/core/types/type_impl.cc
@@ -50,6 +50,15 @@ bool TypeImpl::is_time()    const { return false; }
 bool TypeImpl::is_object()  const { return false; }
 
 
+bool TypeImpl::can_be_read_as_int8()     const { return false; }
+bool TypeImpl::can_be_read_as_int16()    const { return false; }
+bool TypeImpl::can_be_read_as_int32()    const { return false; }
+bool TypeImpl::can_be_read_as_int64()    const { return false; }
+bool TypeImpl::can_be_read_as_float32()  const { return false; }
+bool TypeImpl::can_be_read_as_float64()  const { return false; }
+bool TypeImpl::can_be_read_as_cstring()  const { return false; }
+bool TypeImpl::can_be_read_as_pyobject() const { return false; }
+
 
 
 }  // namespace dt

--- a/src/core/types/type_impl.cc
+++ b/src/core/types/type_impl.cc
@@ -1,0 +1,55 @@
+//------------------------------------------------------------------------------
+// Copyright 2021 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#include "types/type_impl.h"
+namespace dt {
+
+
+TypeImpl::TypeImpl(SType stype)
+  : stype_(stype),
+    refcount_(1) {}
+
+TypeImpl::~TypeImpl() {}
+
+
+
+void TypeImpl::acquire() noexcept {
+  refcount_++;
+}
+
+void TypeImpl::release() noexcept {
+  refcount_--;
+  if (refcount_ == 0) delete this;
+}
+
+
+bool TypeImpl::is_boolean() const { return false; }
+bool TypeImpl::is_integer() const { return false; }
+bool TypeImpl::is_float()   const { return false; }
+bool TypeImpl::is_numeric() const { return false; }
+bool TypeImpl::is_string()  const { return false; }
+bool TypeImpl::is_time()    const { return false; }
+bool TypeImpl::is_object()  const { return false; }
+
+
+
+
+}  // namespace dt

--- a/src/core/types/type_impl.h
+++ b/src/core/types/type_impl.h
@@ -39,6 +39,8 @@ class TypeImpl {
     TypeImpl();
     virtual ~TypeImpl();
 
+    SType stype() const { return stype_; }
+
     virtual bool is_boolean() const;
     virtual bool is_integer() const;
     virtual bool is_float() const;
@@ -46,6 +48,16 @@ class TypeImpl {
     virtual bool is_string() const;
     virtual bool is_time() const;
     virtual bool is_object() const;
+
+    virtual bool can_be_read_as_int8() const;
+    virtual bool can_be_read_as_int16() const;
+    virtual bool can_be_read_as_int32() const;
+    virtual bool can_be_read_as_int64() const;
+    virtual bool can_be_read_as_float32() const;
+    virtual bool can_be_read_as_float64() const;
+    virtual bool can_be_read_as_cstring() const;
+    virtual bool can_be_read_as_pyobject() const;
+
 
   protected:
     TypeImpl(SType stype);

--- a/src/core/types/type_impl.h
+++ b/src/core/types/type_impl.h
@@ -62,6 +62,9 @@ class TypeImpl {
     // Override if your TypeImpl contains more information.
     virtual bool equals(const TypeImpl* other) const;
 
+    // This method must be implemented by each subclass
+    virtual std::string to_string() const = 0;
+
   protected:
     TypeImpl(SType stype);
 };

--- a/src/core/types/type_impl.h
+++ b/src/core/types/type_impl.h
@@ -1,0 +1,58 @@
+//------------------------------------------------------------------------------
+// Copyright 2021 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#ifndef dt_TYPES_TYPE_IMPL_h
+#define dt_TYPES_TYPE_IMPL_h
+#include "types/type.h"
+namespace dt {
+
+
+class TypeImpl {
+  private:
+    SType stype_;
+    int : 24;
+    int32_t refcount_;
+    friend class Type;
+
+    void acquire() noexcept;
+    void release() noexcept;
+
+  public:
+    TypeImpl();
+    virtual ~TypeImpl();
+
+    virtual bool is_boolean() const;
+    virtual bool is_integer() const;
+    virtual bool is_float() const;
+    virtual bool is_numeric() const;
+    virtual bool is_string() const;
+    virtual bool is_time() const;
+    virtual bool is_object() const;
+
+  protected:
+    TypeImpl(SType stype);
+};
+
+
+
+
+}  // namespace dt
+#endif

--- a/src/core/types/type_impl.h
+++ b/src/core/types/type_impl.h
@@ -58,6 +58,9 @@ class TypeImpl {
     virtual bool can_be_read_as_cstring() const;
     virtual bool can_be_read_as_pyobject() const;
 
+    // Default implementation only checks the equality of stypes.
+    // Override if your TypeImpl contains more information.
+    virtual bool equals(const TypeImpl* other) const;
 
   protected:
     TypeImpl(SType stype);

--- a/src/core/types/type_int.h
+++ b/src/core/types/type_int.h
@@ -36,6 +36,11 @@ class Type_Int : public TypeImpl {
 
     bool is_integer() const override { return true; }
     bool is_numeric() const override { return true; }
+
+    bool can_be_read_as_int8()  const override { return stype() == SType::INT8; }
+    bool can_be_read_as_int16() const override { return stype() == SType::INT16; }
+    bool can_be_read_as_int32() const override { return stype() == SType::INT32; }
+    bool can_be_read_as_int64() const override { return stype() == SType::INT64; }
 };
 
 

--- a/src/core/types/type_int.h
+++ b/src/core/types/type_int.h
@@ -1,0 +1,44 @@
+//------------------------------------------------------------------------------
+// Copyright 2021 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#ifndef dt_TYPES_TYPE_INT_h
+#define dt_TYPES_TYPE_INT_h
+#include "types/type_impl.h"
+#include "utils/assert.h"
+namespace dt {
+
+
+
+class Type_Int : public TypeImpl {
+  public:
+    Type_Int(SType stype) : TypeImpl(stype) {
+      xassert(stype == SType::INT8 || stype == SType::INT16 ||
+              stype == SType::INT32 || stype == SType::INT64);
+    }
+
+    bool is_integer() const override { return true; }
+    bool is_numeric() const override { return true; }
+};
+
+
+
+}  // namespace dt
+#endif

--- a/src/core/types/type_int.h
+++ b/src/core/types/type_int.h
@@ -41,6 +41,7 @@ class Type_Int8 : public Type_Int {
   public:
     Type_Int8() : Type_Int(SType::INT8) {}
     bool can_be_read_as_int8()  const override { return true; }
+    std::string to_string() const override { return "int8"; }
 };
 
 
@@ -48,6 +49,7 @@ class Type_Int16 : public Type_Int {
   public:
     Type_Int16() : Type_Int(SType::INT16) {}
     bool can_be_read_as_int16()  const override { return true; }
+    std::string to_string() const override { return "int16"; }
 };
 
 
@@ -55,6 +57,7 @@ class Type_Int32 : public Type_Int {
   public:
     Type_Int32() : Type_Int(SType::INT32) {}
     bool can_be_read_as_int32()  const override { return true; }
+    std::string to_string() const override { return "int32"; }
 };
 
 
@@ -62,6 +65,7 @@ class Type_Int64 : public Type_Int {
   public:
     Type_Int64() : Type_Int(SType::INT64) {}
     bool can_be_read_as_int64()  const override { return true; }
+    std::string to_string() const override { return "int64"; }
 };
 
 

--- a/src/core/types/type_int.h
+++ b/src/core/types/type_int.h
@@ -28,20 +28,42 @@ namespace dt {
 
 
 class Type_Int : public TypeImpl {
-  public:
-    Type_Int(SType stype) : TypeImpl(stype) {
-      xassert(stype == SType::INT8 || stype == SType::INT16 ||
-              stype == SType::INT32 || stype == SType::INT64);
-    }
+  protected:
+    using TypeImpl::TypeImpl;
 
+  public:
     bool is_integer() const override { return true; }
     bool is_numeric() const override { return true; }
-
-    bool can_be_read_as_int8()  const override { return stype() == SType::INT8; }
-    bool can_be_read_as_int16() const override { return stype() == SType::INT16; }
-    bool can_be_read_as_int32() const override { return stype() == SType::INT32; }
-    bool can_be_read_as_int64() const override { return stype() == SType::INT64; }
 };
+
+
+class Type_Int8 : public Type_Int {
+  public:
+    Type_Int8() : Type_Int(SType::INT8) {}
+    bool can_be_read_as_int8()  const override { return true; }
+};
+
+
+class Type_Int16 : public Type_Int {
+  public:
+    Type_Int16() : Type_Int(SType::INT16) {}
+    bool can_be_read_as_int16()  const override { return true; }
+};
+
+
+class Type_Int32 : public Type_Int {
+  public:
+    Type_Int32() : Type_Int(SType::INT32) {}
+    bool can_be_read_as_int32()  const override { return true; }
+};
+
+
+class Type_Int64 : public Type_Int {
+  public:
+    Type_Int64() : Type_Int(SType::INT64) {}
+    bool can_be_read_as_int64()  const override { return true; }
+};
+
 
 
 

--- a/src/core/types/type_object.h
+++ b/src/core/types/type_object.h
@@ -31,6 +31,7 @@ class Type_Object : public TypeImpl {
     Type_Object() : TypeImpl(SType::OBJ) {}
 
     bool is_object() const override { return true; }
+    bool can_be_read_as_pyobject() const override { return true; }
 };
 
 

--- a/src/core/types/type_object.h
+++ b/src/core/types/type_object.h
@@ -1,0 +1,39 @@
+//------------------------------------------------------------------------------
+// Copyright 2021 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#ifndef dt_TYPES_TYPE_OBJECT_h
+#define dt_TYPES_TYPE_OBJECT_h
+#include "types/type_impl.h"
+namespace dt {
+
+
+
+class Type_Object : public TypeImpl {
+  public:
+    Type_Object() : TypeImpl(SType::OBJ) {}
+
+    bool is_object() const override { return true; }
+};
+
+
+
+}  // namespace dt
+#endif

--- a/src/core/types/type_object.h
+++ b/src/core/types/type_object.h
@@ -32,6 +32,7 @@ class Type_Object : public TypeImpl {
 
     bool is_object() const override { return true; }
     bool can_be_read_as_pyobject() const override { return true; }
+    std::string to_string() const override { return "obj64"; }
 };
 
 

--- a/src/core/types/type_string.h
+++ b/src/core/types/type_string.h
@@ -1,0 +1,42 @@
+//------------------------------------------------------------------------------
+// Copyright 2021 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#ifndef dt_TYPES_TYPE_STRING_h
+#define dt_TYPES_TYPE_STRING_h
+#include "types/type_impl.h"
+#include "utils/assert.h"
+namespace dt {
+
+
+
+class Type_String : public TypeImpl {
+  public:
+    Type_String(SType stype) : TypeImpl(stype) {
+      xassert(stype == SType::STR32 || stype == SType::STR64);
+    }
+
+    bool is_string() const override { return true; }
+};
+
+
+
+}  // namespace dt
+#endif

--- a/src/core/types/type_string.h
+++ b/src/core/types/type_string.h
@@ -28,14 +28,26 @@ namespace dt {
 
 
 class Type_String : public TypeImpl {
-  public:
-    Type_String(SType stype) : TypeImpl(stype) {
-      xassert(stype == SType::STR32 || stype == SType::STR64);
-    }
+  protected:
+    using TypeImpl::TypeImpl;
 
+  public:
     bool is_string() const override { return true; }
     bool can_be_read_as_cstring() const override { return true; }
 };
+
+
+class Type_String32 : public Type_String {
+  public:
+    Type_String32() : Type_String(SType::STR32) {}
+};
+
+
+class Type_String64 : public Type_String {
+  public:
+    Type_String64() : Type_String(SType::STR64) {}
+};
+
 
 
 

--- a/src/core/types/type_string.h
+++ b/src/core/types/type_string.h
@@ -34,6 +34,7 @@ class Type_String : public TypeImpl {
     }
 
     bool is_string() const override { return true; }
+    bool can_be_read_as_cstring() const override { return true; }
 };
 
 

--- a/src/core/types/type_string.h
+++ b/src/core/types/type_string.h
@@ -40,12 +40,14 @@ class Type_String : public TypeImpl {
 class Type_String32 : public Type_String {
   public:
     Type_String32() : Type_String(SType::STR32) {}
+    std::string to_string() const override { return "str32"; }
 };
 
 
 class Type_String64 : public Type_String {
   public:
     Type_String64() : Type_String(SType::STR64) {}
+    std::string to_string() const override { return "str64"; }
 };
 
 

--- a/src/core/types/type_void.h
+++ b/src/core/types/type_void.h
@@ -34,6 +34,9 @@ class Type_Void : public TypeImpl {
     bool is_integer() const override { return true; }
     bool is_float()   const override { return true; }
     bool is_numeric() const override { return true; }
+
+    // [FIXME]
+    bool can_be_read_as_int8() const override { return true; }
 };
 
 

--- a/src/core/types/type_void.h
+++ b/src/core/types/type_void.h
@@ -1,0 +1,42 @@
+//------------------------------------------------------------------------------
+// Copyright 2021 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#ifndef dt_TYPES_TYPE_VOID_h
+#define dt_TYPES_TYPE_VOID_h
+#include "types/type_impl.h"
+namespace dt {
+
+
+
+class Type_Void : public TypeImpl {
+  public:
+    Type_Void() : TypeImpl(SType::VOID) {}
+
+    bool is_boolean() const override { return true; }
+    bool is_integer() const override { return true; }
+    bool is_float()   const override { return true; }
+    bool is_numeric() const override { return true; }
+};
+
+
+
+}  // namespace dt
+#endif

--- a/src/core/types/type_void.h
+++ b/src/core/types/type_void.h
@@ -37,6 +37,8 @@ class Type_Void : public TypeImpl {
 
     // [FIXME]
     bool can_be_read_as_int8() const override { return true; }
+
+    std::string to_string() const override { return "void"; }
 };
 
 

--- a/src/core/utils/exceptions.cc
+++ b/src/core/utils/exceptions.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2020 H2O.ai
+// Copyright 2018-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -352,6 +352,7 @@ void Error::emit_warning() const {
 //==============================================================================
 
 Error AssertionError()        { return Error(PyExc_AssertionError); }
+Error AttributeError()        { return Error(PyExc_AttributeError); }
 Error RuntimeError()          { return Error(PyExc_RuntimeError); }
 Error ImportError()           { return Error(DtExc_ImportError); }
 Error IndexError()            { return Error(DtExc_IndexError); }

--- a/src/core/utils/exceptions.h
+++ b/src/core/utils/exceptions.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2020 H2O.ai
+// Copyright 2018-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -100,6 +100,7 @@ template <> Error& Error::operator<<(const char&);
 //------------------------------------------------------------------------------
 
 Error AssertionError();
+Error AttributeError();
 Error ImportError();
 Error IndexError();
 Error InvalidOperationError();

--- a/src/core/utils/logger.cc
+++ b/src/core/utils/logger.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2020 H2O.ai
+// Copyright 2020-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -68,8 +68,7 @@ class DefaultLogger : public XObject<DefaultLogger>
 
   public:
     static oobj make(const dt::log::Logger& logger) {
-      robj rtype(reinterpret_cast<PyObject*>(&DefaultLogger::type));
-      oobj resobj = rtype.call();
+      oobj resobj = robj(DefaultLogger::typePtr).call();
       DefaultLogger* dlogger = DefaultLogger::cast_from(resobj);
       dlogger->prefix_ = std::make_unique<std::string>(logger.prefix_);
       dlogger->use_colors_ = logger.use_colors_;

--- a/src/datatable/__init__.py
+++ b/src/datatable/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #-------------------------------------------------------------------------------
-# Copyright 2018-2020 H2O.ai
+# Copyright 2018-2021 H2O.ai
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -53,7 +53,6 @@ from .lib._datatable import (
     shift,
     sort,
     symdiff,
-    Type,
     union,
     unique,
     update,
@@ -134,6 +133,9 @@ __all__ = (
     "union",
     "unique",
 )
+
+class Type:
+    pass
 
 bool8 = stype.bool8
 int8 = stype.int8

--- a/src/datatable/__init__.py
+++ b/src/datatable/__init__.py
@@ -53,6 +53,7 @@ from .lib._datatable import (
     shift,
     sort,
     symdiff,
+    Type,
     union,
     unique,
     update,
@@ -133,9 +134,6 @@ __all__ = (
     "union",
     "unique",
 )
-
-class Type:
-    pass
 
 bool8 = stype.bool8
 int8 = stype.int8

--- a/src/datatable/__init__.py
+++ b/src/datatable/__init__.py
@@ -53,6 +53,7 @@ from .lib._datatable import (
     shift,
     sort,
     symdiff,
+    Type,
     union,
     unique,
     update,
@@ -129,6 +130,7 @@ __all__ = (
     "str64",
     "stype",
     "symdiff",
+    "Type",
     "union",
     "unique",
 )

--- a/tests/test-dt.py
+++ b/tests/test-dt.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #-------------------------------------------------------------------------------
-# Copyright 2018-2020 H2O.ai
+# Copyright 2018-2021 H2O.ai
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -371,6 +371,33 @@ def test_random_attack():
     out, err = proc.communicate(timeout=100)
     assert "FAIL" not in out.decode()
     assert not err
+
+
+
+#-------------------------------------------------------------------------------
+# Types
+#-------------------------------------------------------------------------------
+
+def test_dt0_types(dt0):
+    T = dt.Type
+    assert dt0.types == \
+        [T.int32, T.bool8, T.int8, T.float64, T.void, T.int8, T.str32]
+
+
+def test_empty_frame_types():
+    DT = dt.Frame([])
+    assert DT.types == []
+    DT.nrows = 11
+    assert DT.types == []
+
+
+def test_modify_types_list():
+    DT = dt.Frame(A=[1, 4], B=['g', 'r'])
+    assert DT.types == [dt.Type.int32, dt.Type.str32]
+    types = DT.types
+    types[0] = 42
+    assert DT.types == [dt.Type.int32, dt.Type.str32]
+
 
 
 

--- a/tests/test-types.py
+++ b/tests/test-types.py
@@ -59,7 +59,6 @@ def test_type_repr():
 
 
 def test_type_names():
-    return
     assert Type.void.name == "void"
     assert Type.bool8.name == "bool8"
     assert Type.int8.name == "int8"

--- a/tests/test-types.py
+++ b/tests/test-types.py
@@ -146,6 +146,32 @@ def test_type_create_from_python_types():
     assert Type(object) == Type.obj64
 
 
+def test_type_create_from_numpy_classes(np):
+    assert Type(np.void) == Type.void
+    assert Type(np.bool_) == Type.bool8
+    assert Type(np.int8) == Type.int8
+    assert Type(np.int16) == Type.int16
+    assert Type(np.int32) == Type.int32
+    assert Type(np.int64) == Type.int64
+    assert Type(np.float16) == Type.float32
+    assert Type(np.float32) == Type.float32
+    assert Type(np.float64) == Type.float64
+    assert Type(np.str_) == Type.str32
+
+
+def test_type_create_from_numpy_dtypes(np):
+    assert Type(np.dtype("void")) == Type.void
+    assert Type(np.dtype("bool")) == Type.bool8
+    assert Type(np.dtype("int8")) == Type.int8
+    assert Type(np.dtype("int16")) == Type.int16
+    assert Type(np.dtype("int32")) == Type.int32
+    assert Type(np.dtype("int64")) == Type.int64
+    assert Type(np.dtype("float16")) == Type.float32
+    assert Type(np.dtype("float32")) == Type.float32
+    assert Type(np.dtype("float64")) == Type.float64
+    assert Type(np.dtype("str")) == Type.str32
+
+
 def test_type_create_invalid():
     msg = "Cannot create Type object from"
     with pytest.raises(ValueError, match=msg):

--- a/tests/test-types.py
+++ b/tests/test-types.py
@@ -1,12 +1,76 @@
 #!/usr/bin/env python
-# © H2O.ai 2018; -*- encoding: utf-8 -*-
-#   This Source Code Form is subject to the terms of the Mozilla Public
-#   License, v. 2.0. If a copy of the MPL was not distributed with this
-#   file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -*- coding: utf-8 -*-
+#-------------------------------------------------------------------------------
+# Copyright 2018-2021 H2O.ai
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
 #-------------------------------------------------------------------------------
 import pytest
 import datatable as dt
+from datatable import Type
 
+
+#-------------------------------------------------------------------------------
+# Test Type class
+#-------------------------------------------------------------------------------
+
+def test_type_singletons():
+    assert Type.void
+    assert Type.bool8
+    assert Type.int8
+    assert Type.int16
+    assert Type.int32
+    assert Type.int64
+    assert Type.float32
+    assert Type.float64
+    assert Type.str32
+    assert Type.str64
+    assert Type.obj64
+
+
+def test_type_repr():
+    assert repr(Type.void) == "Type.void"
+    assert repr(Type.bool8) == "Type.bool8"
+    assert repr(Type.int8) == "Type.int8"
+    assert repr(Type.int16) == "Type.int16"
+    assert repr(Type.int32) == "Type.int32"
+    assert repr(Type.int64) == "Type.int64"
+    assert repr(Type.float32) == "Type.float32"
+    assert repr(Type.float64) == "Type.float64"
+    assert repr(Type.str32) == "Type.str32"
+    assert repr(Type.str64) == "Type.str64"
+    assert repr(Type.obj64) == "Type.obj64"
+
+
+def test_type_names():
+    return
+    assert Type.void.name == "void"
+    assert Type.bool8.name == "bool8"
+    assert Type.int8.name == "int8"
+    assert Type.int16.name == "int16"
+    assert Type.int32.name == "int32"
+    assert Type.int64.name == "int64"
+    assert Type.float32.name == "float32"
+    assert Type.float64.name == "float64"
+    assert Type.str32.name == "str32"
+    assert Type.str64.name == "str64"
+    assert Type.obj64.name == "obj64"
 
 
 

--- a/tests/test-types.py
+++ b/tests/test-types.py
@@ -72,6 +72,94 @@ def test_type_names():
     assert Type.obj64.name == "obj64"
 
 
+def test_type_cmp():
+    assert Type.int8 == Type.int8
+    assert Type.int8 != Type.int32
+    assert not(Type.int8 == Type.int32)
+    assert not(Type.int32 == Type.float32)
+    assert not(Type.void == Type.obj64)
+
+
+def test_type_create_from_strings():
+    assert Type("V") == Type.void
+    assert Type("bool") == Type.bool8
+    assert Type("boolean") == Type.bool8
+    assert Type("int") == Type.int64
+    assert Type("integer") == Type.int64
+    assert Type("float") == Type.float32
+    assert Type("double") == Type.float64
+    assert Type("<U") == Type.str32
+    assert Type("str") == Type.str32
+    assert Type("string") == Type.str32
+    assert Type("obj") == Type.obj64
+    assert Type("object") == Type.obj64
+
+
+def test_type_create_from_names():
+    assert Type("void") == Type.void
+    assert Type("bool8") == Type.bool8
+    assert Type("int8") == Type.int8
+    assert Type("int16") == Type.int16
+    assert Type("int32") == Type.int32
+    assert Type("int64") == Type.int64
+    assert Type("float32") == Type.float32
+    assert Type("float64") == Type.float64
+    assert Type("str32") == Type.str32
+    assert Type("str64") == Type.str64
+    assert Type("obj64") == Type.obj64
+
+
+def test_type_create_from_stypes():
+    assert Type(dt.stype.void) == Type.void
+    assert Type(dt.stype.bool8) == Type.bool8
+    assert Type(dt.stype.int8) == Type.int8
+    assert Type(dt.stype.int16) == Type.int16
+    assert Type(dt.stype.int32) == Type.int32
+    assert Type(dt.stype.int64) == Type.int64
+    assert Type(dt.stype.float32) == Type.float32
+    assert Type(dt.stype.float64) == Type.float64
+    assert Type(dt.stype.str32) == Type.str32
+    assert Type(dt.stype.str64) == Type.str64
+    assert Type(dt.stype.obj64) == Type.obj64
+
+
+def test_type_create_from_types():
+    assert Type(Type.void) == Type.void
+    assert Type(Type.bool8) == Type.bool8
+    assert Type(Type.int8) == Type.int8
+    assert Type(Type.int16) == Type.int16
+    assert Type(Type.int32) == Type.int32
+    assert Type(Type.int64) == Type.int64
+    assert Type(Type.float32) == Type.float32
+    assert Type(Type.float64) == Type.float64
+    assert Type(Type.str32) == Type.str32
+    assert Type(Type.str64) == Type.str64
+    assert Type(Type.obj64) == Type.obj64
+
+
+def test_type_create_from_python_types():
+    assert Type(None) == Type.void
+    assert Type(bool) == Type.bool8
+    assert Type(int) == Type.int64
+    assert Type(float) == Type.float64
+    assert Type(str) == Type.str32
+    assert Type(object) == Type.obj64
+
+
+def test_type_create_invalid():
+    msg = "Cannot create Type object from"
+    with pytest.raises(ValueError, match=msg):
+        Type(0)
+    with pytest.raises(ValueError, match=msg):
+        Type(0.5)
+    with pytest.raises(ValueError, match=msg):
+        Type("nothing")
+    with pytest.raises(ValueError, match=msg):
+        Type(type)
+    with pytest.raises(TypeError):
+        Type()
+
+
 
 #-------------------------------------------------------------------------------
 # Test stype enum


### PR DESCRIPTION
The class Type is intended as a replacement for stype/ltype enums.
The main difference from `stype` is that the new class is not an enum, and supports arbitrary type descriptors.

This new class is necessary in order to implement datetime types with various precision / timezone parameters. In the future this class will also be able to accommodate columns of "list" types, compound (struct) columns, union columns, etc.

In the future we want to gradually replace all uses of `stype` with the equivalent code that uses `Type`s.