### PR TITLE
Change required version of xlrd package

### DIFF
--- a/requirements_extra.txt
+++ b/requirements_extra.txt
@@ -1,4 +1,4 @@
 numpy
 pandas
 pyarrow
-xlrd
+xlrd<=1.2.0


### PR DESCRIPTION
Changed the required version of `xlrd` package to "<=1.2.0", due to the fact that the latest version 2.0.0 removed support for xlsx files. Note that we are only changing the "extra" requirements: these are not forced on the user, rather they are what our package recommends to have.

It might be desirable at this point to either switch to `openpyxl` library for reading xlsx files, or to implement the necessary logic from scratch -- but both of these options require considerable time. 

This change, on the other hand, can be done quickly, and it solves the immediate problem that some of our tests that use xlsx files are now failing.

Closes #2823