### PR TITLE
Add type date32

### DIFF
--- a/docs/api/type.rst
+++ b/docs/api/type.rst
@@ -7,6 +7,7 @@
         :hidden:
 
         bool8    <type/bool8>
+        date32   <type/date32>
         float32  <type/float32>
         float64  <type/float64>
         int16    <type/int16>

--- a/docs/api/type/date32.rst
+++ b/docs/api/type/date32.rst
@@ -1,0 +1,23 @@
+
+.. xattr:: datatable.Type.date32
+    :src: --
+
+    .. x-version-added:: 1.0.0
+
+    The ``date32`` type is used to represent a particular calendar date without
+    a time component. Internally, this type is stored as a 32-bit integer
+    containing the number of days since the epoch (Jan 1, 1970). Thus, this
+    type accommodates dates within the range of approximately ±5.8 million
+    years.
+
+    The calendar used for this type is `proleptic Gregorian`_, meaning that it
+    extends the modern-day Gregorian calendar into the past before this calendar
+    was first adopted.
+
+    This type corresponds to ``datetime.date`` in Python, ``pa.date32()`` in
+    pyarrow, and ``np.dtype('<M8[D]')`` in numpy.
+
+
+    .. _`proleptic gregorian`: https://en.wikipedia.org/wiki/Proleptic_Gregorian_calendar
+
+

--- a/docs/api/type/date32.rst
+++ b/docs/api/type/date32.rst
@@ -4,9 +4,9 @@
 
     .. x-version-added:: 1.0.0
 
-    The ``date32`` type is used to represent a particular calendar date without
-    a time component. Internally, this type is stored as a 32-bit integer
-    containing the number of days since the epoch (Jan 1, 1970). Thus, this
+    The ``date32`` type represents a particular calendar date without a time
+    component. Internally, this type is stored as a 32-bit signed integer
+    counting the number of days since 1970-01-01 ("the epoch"). Thus, this
     type accommodates dates within the range of approximately ±5.8 million
     years.
 

--- a/docs/api/type/int8.rst
+++ b/docs/api/type/int8.rst
@@ -2,9 +2,21 @@
 .. xattr:: datatable.Type.int8
     :src: --
 
-    Integer type, corresponding to ``int8_t`` in C. This type uses 1 byte per
-    data element, and can store values in the range ``-127 .. 127``.
+    Integer type that uses 1 byte per data element and can store values in the
+    range ``-127 .. 127``.
+
+    This type corresponds to ``int8_t`` in C/C++, ``int`` in python,
+    ``np.dtype('int8')`` in numpy, and ``pa.int8()`` in pyarrow.
 
     Most arithmetic operations involving this type will produce a result of
     type ``int32``, which follows the convention of the C language.
 
+
+    Examples
+    --------
+    >>> dt.Type.int8
+    Type.int8
+    >>> dt.Type('int8')
+    Type.int8
+    >>> dt.Frame([1, 0, 1, 1, 0]).types
+    [Type.int8]

--- a/docs/manual/datetime.rst
+++ b/docs/manual/datetime.rst
@@ -1,0 +1,45 @@
+
+Dates and time
+--------------
+.. x-version-added:: 1.0.0
+
+``datatable`` has several builtin types to support working with date/time
+variables.
+
+
+date32
+======
+The ``date32`` type is used to represent a particular calendar date without a
+time component. Internally, this type is stored as a 32-bit integer containing
+the number of days since the epoch (Jan 1, 1970). Thus, this type accommodates
+dates within the range of approximately ±5.8 million years.
+
+The calendar used for this type is `proleptic Gregorian`_, meaning that it
+extends the modern-day Gregorian calendar into the past before this calendar
+was first adopted.
+
+
+time64
+======
+The ``time64`` type is used to represent a specific moment in time. This
+corresponds to ``datetime`` in Python, or ``timestamp`` in Arrow or pandas.
+Internally, this type is stored as a 64-bit integer containing the number of
+milliseconds since the epoch (Jan 1, 1970) in UTC.
+
+This type is not `leap-seconds`_ aware, meaning that it assumes that each day
+has exactly 24×3600 seconds. In practice it means that calculating time
+difference between two ``time64`` moments may be off by the number of leap
+seconds that have occurred between them.
+
+A ``time64`` column may also carry a time zone as meta information. This time
+zone is used to convert the timestamp from the absolute UTC time to the local
+calendar. For example, suppose you have two ``time64`` columns: one is in UTC
+while the other is in *America/Los\_Angeles* time zone. Assume both columns
+store the same value ``1577836800000``. Then these two columns represent the
+same moment in time, however their calendar representations are different:
+``2020-01-01T00:00:00Z`` and ``2019-12-31T16:00:00-0800`` respectively.
+
+
+
+.. _`proleptic gregorian`: https://en.wikipedia.org/wiki/Proleptic_Gregorian_calendar
+.. _`leap-seconds`: https://en.wikipedia.org/wiki/Leap_second

--- a/docs/manual/index-manual.rst
+++ b/docs/manual/index-manual.rst
@@ -12,4 +12,5 @@ User Guide
     comparison_with_pandas
     comparison_with_rdatatable
     comparison_with_sql
+    datetime
     ftrl

--- a/docs/releases/v1.0.0.rst
+++ b/docs/releases/v1.0.0.rst
@@ -9,6 +9,12 @@
       objects for each column of the frame. These types are a generalization
       of previous stypes, and will eventually replace them.
 
+    -[new] New column type :attr:`dt.Type.date32` added, which can store a
+      calendar date [#1646]::
+
+          >>> import datetime
+          >>> DT = dt.Frame([datetime.date(2021, 2, 17)])
+
     -[new] A Frame can now be constructed from an Arrow
       table::
 

--- a/src/core/_dt.h
+++ b/src/core/_dt.h
@@ -74,6 +74,7 @@ namespace py {
   class buffer;  // in pybuffer.h
   class obool;
   class oby;
+  class odate;
   class odict;
   class ofloat;
   class oint;

--- a/src/core/column.cc
+++ b/src/core/column.cc
@@ -270,6 +270,11 @@ py::oobj Column::get_element_as_pyobject(size_t i) const {
     case dt::SType::FLOAT64: return getelem<double>(*this, i);
     case dt::SType::STR32:
     case dt::SType::STR64:   return getelem<dt::CString>(*this, i);
+    case dt::SType::DATE32: {
+      int32_t x;
+      bool isvalid = get_element(i, &x);
+      return isvalid? py::odate(x) : py::None();
+    }
     case dt::SType::OBJ: {
       py::oobj x;
       bool isvalid = get_element(i, &x);
@@ -293,6 +298,7 @@ bool Column::get_element_isvalid(size_t i) const {
       int16_t x;
       return get_element(i, &x);
     }
+    case dt::SType::DATE32:
     case dt::SType::INT32: {
       int32_t x;
       return get_element(i, &x);

--- a/src/core/column/sentinel.cc
+++ b/src/core/column/sentinel.cc
@@ -36,6 +36,7 @@ Column Sentinel_ColumnImpl::make_column(size_t nrows, SType stype) {
     case SType::INT64:   return Column(new SentinelFw_ColumnImpl<int64_t>(nrows, stype));
     case SType::FLOAT32: return Column(new SentinelFw_ColumnImpl<float>(nrows, stype));
     case SType::FLOAT64: return Column(new SentinelFw_ColumnImpl<double>(nrows, stype));
+    case SType::DATE32:  return Column(new SentinelFw_ColumnImpl<int32_t>(nrows, stype));
     case SType::STR32:   return Column(new SentinelStr_ColumnImpl<uint32_t>(nrows));
     case SType::STR64:   return Column(new SentinelStr_ColumnImpl<uint64_t>(nrows));
     case SType::OBJ:     return Column(new SentinelObj_ColumnImpl(nrows));
@@ -58,6 +59,7 @@ Column Sentinel_ColumnImpl::make_fw_column(
     case SType::INT64:   return Column(new SentinelFw_ColumnImpl<int64_t>(nrows, stype, std::move(buf)));
     case SType::FLOAT32: return Column(new SentinelFw_ColumnImpl<float>(nrows, stype, std::move(buf)));
     case SType::FLOAT64: return Column(new SentinelFw_ColumnImpl<double>(nrows, stype, std::move(buf)));
+    case SType::DATE32:  return Column(new SentinelFw_ColumnImpl<int32_t>(nrows, stype, std::move(buf)));
     case SType::OBJ:     return Column(new SentinelObj_ColumnImpl(nrows, std::move(buf)));
     default:
       throw ValueError()

--- a/src/core/column_from_python.cc
+++ b/src/core/column_from_python.cc
@@ -285,6 +285,33 @@ static size_t parse_as_date32(const Column& inputcol, Buffer& mbuf, size_t i0) {
 }
 
 
+static Column force_as_date32(const Column& inputcol) {
+  size_t nrows = inputcol.nrows();
+  Buffer databuf = Buffer::mem(nrows * sizeof(int32_t));
+  auto outdata = static_cast<int32_t*>(databuf.xptr());
+
+  int overflow = 0;
+  py::oobj item;
+  for (size_t i = 0; i < nrows; ++i) {
+    inputcol.get_element(i, &item);
+    if (item.is_date()) {
+      outdata[i] = item.to_odate().get_days();
+    }
+    else if (item.is_int()) {
+      outdata[i] = item.to_pyint().ovalue<int32_t>(&overflow);
+    }
+    else if (item.is_float()) {
+      outdata[i] = static_cast<int32_t>(item.to_double());
+    }
+    else {
+      outdata[i] = dt::GETNA<int32_t>();
+    }
+  }
+  PyErr_Clear();  // in case an overflow occurred
+  return Column::new_mbuf_column(nrows, dt::SType::DATE32, std::move(databuf));
+}
+
+
 
 
 //------------------------------------------------------------------------------
@@ -574,6 +601,7 @@ static Column parse_column_fixed_stype(const Column& inputcol, dt::SType stype) 
     case dt::SType::FLOAT64: return force_as_real<double>(inputcol);
     case dt::SType::STR32:   return force_as_str<uint32_t>(inputcol);
     case dt::SType::STR64:   return force_as_str<uint64_t>(inputcol);
+    case dt::SType::DATE32:  return force_as_date32(inputcol);
     case dt::SType::OBJ:     return force_as_pyobj(inputcol);
     default:
       throw ValueError() << "Unable to create Column of type `"

--- a/src/core/column_from_python.cc
+++ b/src/core/column_from_python.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2020 H2O.ai
+// Copyright 2018-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -273,6 +273,21 @@ static Column force_as_real(const Column& inputcol)
 
 
 //------------------------------------------------------------------------------
+// Date32
+//------------------------------------------------------------------------------
+
+static size_t parse_as_date32(const Column& inputcol, Buffer& mbuf, size_t i0) {
+  return parse_as_X<int32_t>(inputcol, mbuf, i0,
+            [](const py::oobj& item, int32_t* out) {
+              return item.parse_date(out) ||
+                     item.parse_none(out);
+            });
+}
+
+
+
+
+//------------------------------------------------------------------------------
 // String
 //------------------------------------------------------------------------------
 
@@ -452,7 +467,7 @@ static const std::vector<dt::SType>& successors(dt::SType stype) {
   static styvec s_void = {
     dt::SType::BOOL, dt::SType::INT8, dt::SType::INT16, dt::SType::INT32,
     dt::SType::INT64, dt::SType::FLOAT32, dt::SType::FLOAT64, dt::SType::STR32,
-    dt::SType::OBJ
+    dt::SType::DATE32, dt::SType::OBJ
   };
   static styvec s_bool8 = {dt::SType::INT8, dt::SType::INT16, dt::SType::INT32, dt::SType::INT64, dt::SType::FLOAT64, dt::SType::STR32, dt::SType::OBJ};
   static styvec s_int8  = {dt::SType::INT16, dt::SType::INT32, dt::SType::INT64, dt::SType::FLOAT64, dt::SType::STR32, dt::SType::OBJ};
@@ -463,6 +478,7 @@ static const std::vector<dt::SType>& successors(dt::SType stype) {
   static styvec s_float64 = {dt::SType::STR32, dt::SType::OBJ};
   static styvec s_str32 = {dt::SType::STR64, dt::SType::OBJ};
   static styvec s_str64 = {dt::SType::OBJ};
+  static styvec s_date32 = {};
 
   switch (stype) {
     case dt::SType::VOID:    return s_void;
@@ -475,6 +491,7 @@ static const std::vector<dt::SType>& successors(dt::SType stype) {
     case dt::SType::FLOAT64: return s_float64;
     case dt::SType::STR32:   return s_str32;
     case dt::SType::STR64:   return s_str64;
+    case dt::SType::DATE32:  return s_date32;
     default:
       throw RuntimeError() << "Unknown successors of stype " << stype;  // LCOV_EXCL_LINE
   }
@@ -506,6 +523,7 @@ static Column parse_column_auto_stype(const Column& inputcol) {
         case dt::SType::FLOAT64: j = parse_as_float64(inputcol, databuf, i); break;
         case dt::SType::STR32:   j = parse_as_str<uint32_t>(inputcol, databuf, strbuf); break;
         case dt::SType::STR64:   j = parse_as_str<uint64_t>(inputcol, databuf, strbuf); break;
+        case dt::SType::DATE32:  j = parse_as_date32(inputcol, databuf, i); break;
         case dt::SType::OBJ:     return force_as_pyobj(inputcol);
         default: continue;  // try another stype
       }

--- a/src/core/datatablemodule.cc
+++ b/src/core/datatablemodule.cc
@@ -19,6 +19,8 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
+#include <Python.h>
+#include <datetime.h>      // from Python
 #include <exception>       // std::exception
 #include <iostream>        // std::cerr
 #include <mutex>           // std::mutex, std::lock_guard
@@ -505,6 +507,11 @@ extern "C" {
       exception_to_python(e);
       m = nullptr;
     }
+
+    // In order to be able to use python API to access datetime objects,
+    // we need to "import" it via a special macro.
+    // See https://docs.python.org/3/c-api/datetime.html
+    PyDateTime_IMPORT;
 
     return m;
   }

--- a/src/core/datatablemodule.cc
+++ b/src/core/datatablemodule.cc
@@ -19,8 +19,6 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
-#include <Python.h>
-#include <datetime.h>      // from Python
 #include <exception>       // std::exception
 #include <iostream>        // std::cerr
 #include <mutex>           // std::mutex, std::lock_guard
@@ -502,16 +500,12 @@ extern "C" {
       py::ojoin::init(m);
       py::osort::init(m);
       py::oupdate::init(m);
+      py::odate::init();
 
     } catch (const std::exception& e) {
       exception_to_python(e);
       m = nullptr;
     }
-
-    // In order to be able to use python API to access datetime objects,
-    // we need to "import" it via a special macro.
-    // See https://docs.python.org/3/c-api/datetime.html
-    PyDateTime_IMPORT;
 
     return m;
   }

--- a/src/core/frame/repr/text_column.cc
+++ b/src/core/frame/repr/text_column.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019-2020 H2O.ai
+// Copyright 2019-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -20,8 +20,10 @@
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #include <algorithm>                  // std::min, std::max
+#include <iomanip>                    // std::setfill, std::setw
 #include "frame/repr/repr_options.h"
 #include "frame/repr/text_column.h"
+#include "lib/hh/date.h"
 #include "ltype.h"
 #include "utils/assert.h"
 #include "encodings.h"
@@ -176,6 +178,19 @@ tstring Data_TextColumn::_render_value_float(const Column& col, size_t i) const
   return tstring(out.str());
 }
 
+tstring Data_TextColumn::_render_value_date(const Column& col, size_t i) const {
+  int32_t value;
+  bool isvalid = col.get_element(i, &value);
+  hh::ymd parsed = hh::civil_from_days(value);
+  if (!isvalid) return na_value_;
+  std::ostringstream out;
+  out << std::setfill('0');
+  out << std::setw(4) << parsed.year << '-'
+      << std::setw(2) << parsed.month << '-'
+      << std::setw(2) << parsed.day;
+  return tstring(out.str());
+}
+
 
 bool Data_TextColumn::_needs_escaping(const CString& str) const {
   size_t n = str.size();
@@ -313,6 +328,7 @@ tstring Data_TextColumn::_render_value(const Column& col, size_t i) const {
     case SType::FLOAT64: return _render_value_float<double>(col, i);
     case SType::STR32:
     case SType::STR64:   return _render_value_string(col, i);
+    case SType::DATE32:  return _render_value_date(col, i);
     default: return tstring("");
   }
 }

--- a/src/core/frame/repr/text_column.h
+++ b/src/core/frame/repr/text_column.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019-2020 H2O.ai
+// Copyright 2019-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -114,6 +114,7 @@ class Data_TextColumn : public TextColumn {
     tstring _render_value_int(const Column&, size_t i) const;
     tstring _render_value_bool(const Column&, size_t i) const;
     tstring _render_value_string(const Column&, size_t i) const;
+    tstring _render_value_date(const Column&, size_t i) const;
 
     bool _needs_escaping(const CString&) const;
     tstring _escape_string(const CString&) const;

--- a/src/core/lib/hh/date.cc
+++ b/src/core/lib/hh/date.cc
@@ -41,7 +41,7 @@ namespace hh {
 //     [civil_from_days(numeric_limits<int>::min()),
 //      civil_from_days(numeric_limits<int>::max()-719468)]
 //
-constexpr int days_from_civil(int y, int m, int d) noexcept {
+int days_from_civil(int y, int m, int d) noexcept {
   y -= (m <= 2);
   const int era = (y >= 0 ? y : y-399) / 400;
   const int yoe = y - era * 400;                             // [0, 399]
@@ -56,7 +56,7 @@ constexpr int days_from_civil(int y, int m, int d) noexcept {
 //   z is number of days since 1970-01-01 and is in the range:
 //   [numeric_limits<int>::min(), numeric_limits<int>::max()-719468].
 //
-constexpr ymd civil_from_days(int z) noexcept {
+ymd civil_from_days(int z) noexcept {
   z += 719468;
   const int era = (z >= 0 ? z : z - 146096) / 146097;
   const int doe = z - era * 146097;                                 // [0, 146096]
@@ -70,7 +70,7 @@ constexpr ymd civil_from_days(int z) noexcept {
 }
 
 
-constexpr bool is_leap(int y) noexcept {
+bool is_leap(int y) noexcept {
   return (y % 4 == 0) && (y % 100 != 0 || y % 400 == 0);
 }
 
@@ -79,7 +79,7 @@ constexpr bool is_leap(int y) noexcept {
 // Returns: The number of days in the month m of common year
 // The result is always in the range [28, 31].
 //
-constexpr int last_day_of_month_common_year(int m) noexcept {
+int last_day_of_month_common_year(int m) noexcept {
   constexpr char a[] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
   return static_cast<int>(a[m - 1]);
 }
@@ -89,7 +89,7 @@ constexpr int last_day_of_month_common_year(int m) noexcept {
 // Returns: The number of days in the month m of leap year
 // The result is always in the range [29, 31].
 //
-constexpr int last_day_of_month_leap_year(int m) noexcept {
+int last_day_of_month_leap_year(int m) noexcept {
   constexpr char a[] = {31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
   return static_cast<int>(a[m - 1]);
 }
@@ -99,7 +99,7 @@ constexpr int last_day_of_month_leap_year(int m) noexcept {
 // Returns: The number of days in the month m of year y
 // The result is always in the range [28, 31].
 //
-constexpr int last_day_of_month(int y, int m) noexcept {
+int last_day_of_month(int y, int m) noexcept {
   return (m != 2 || !is_leap(y)) ? last_day_of_month_common_year(m) : 29;
 }
 
@@ -108,7 +108,7 @@ constexpr int last_day_of_month(int y, int m) noexcept {
 // Preconditions:
 //   z is number of days since 1970-01-01 and is in the range:
 //   [numeric_limits<int>::min(), numeric_limits<int>::max()-4].
-constexpr int weekday_from_days(int z) noexcept {
+int weekday_from_days(int z) noexcept {
   return (z >= -4) ? (z+4) % 7 : (z+5) % 7 + 6;
 }
 

--- a/src/core/lib/hh/date.cc
+++ b/src/core/lib/hh/date.cc
@@ -1,0 +1,118 @@
+//------------------------------------------------------------------------------
+// Copyright 2021 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+//
+// The algorithms listed here are borrowed from Howard Hinnant's
+// http://howardhinnant.github.io/date_algorithms.html
+//
+//------------------------------------------------------------------------------
+#include "lib/hh/date.h"
+namespace hh {
+
+
+// Returns number of days since epoch 1970-01-01. Negative values indicate
+// days prior to 1970-01-01.
+//
+// Preconditions:
+//   y-m-d represents a date in the proleptic Gregorian calendar
+//   m is in [1, 12]
+//   d is in [1, last_day_of_month(y, m)]
+//   y is "approximately" in
+//     [numeric_limits<int>::min()/366, numeric_limits<int>::max()/366]
+//   Exact range of validity is:
+//     [civil_from_days(numeric_limits<int>::min()),
+//      civil_from_days(numeric_limits<int>::max()-719468)]
+//
+constexpr int days_from_civil(int y, int m, int d) noexcept {
+  y -= (m <= 2);
+  const int era = (y >= 0 ? y : y-399) / 400;
+  const int yoe = y - era * 400;                             // [0, 399]
+  const int doy = (153*(m + (m > 2 ? -3 : 9)) + 2)/5 + d-1;  // [0, 365]
+  const int doe = yoe * 365 + yoe/4 - yoe/100 + doy;         // [0, 146096]
+  return era * 146097 + doe - 719468;
+}
+
+
+// Returns year/month/day triple in Gregorian calendar
+// Preconditions:
+//   z is number of days since 1970-01-01 and is in the range:
+//   [numeric_limits<int>::min(), numeric_limits<int>::max()-719468].
+//
+constexpr ymd civil_from_days(int z) noexcept {
+  z += 719468;
+  const int era = (z >= 0 ? z : z - 146096) / 146097;
+  const int doe = z - era * 146097;                                 // [0, 146096]
+  const int yoe = (doe - doe/1460 + doe/36524 - doe/146096) / 365;  // [0, 399]
+  const int y = yoe + era * 400;
+  const int doy = doe - (365*yoe + yoe/4 - yoe/100);                // [0, 365]
+  const int mp = (5*doy + 2)/153;                                   // [0, 11]
+  const int d = doy - (153*mp+2)/5 + 1;                             // [1, 31]
+  const int m = mp + (mp < 10 ? 3 : -9);                            // [1, 12]
+  return ymd(y + (m <= 2), m, d);
+}
+
+
+constexpr bool is_leap(int y) noexcept {
+  return (y % 4 == 0) && (y % 100 != 0 || y % 400 == 0);
+}
+
+
+// Preconditions: m is in [1, 12]
+// Returns: The number of days in the month m of common year
+// The result is always in the range [28, 31].
+//
+constexpr int last_day_of_month_common_year(int m) noexcept {
+  constexpr char a[] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+  return static_cast<int>(a[m - 1]);
+}
+
+
+// Preconditions: m is in [1, 12]
+// Returns: The number of days in the month m of leap year
+// The result is always in the range [29, 31].
+//
+constexpr int last_day_of_month_leap_year(int m) noexcept {
+  constexpr char a[] = {31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+  return static_cast<int>(a[m - 1]);
+}
+
+
+// Preconditions: m is in [1, 12]
+// Returns: The number of days in the month m of year y
+// The result is always in the range [28, 31].
+//
+constexpr int last_day_of_month(int y, int m) noexcept {
+  return (m != 2 || !is_leap(y)) ? last_day_of_month_common_year(m) : 29;
+}
+
+
+// Returns day of week in civil calendar [0, 6] -> [Sun, Sat]
+// Preconditions:
+//   z is number of days since 1970-01-01 and is in the range:
+//   [numeric_limits<int>::min(), numeric_limits<int>::max()-4].
+constexpr int weekday_from_days(int z) noexcept {
+  return (z >= -4) ? (z+4) % 7 : (z+5) % 7 + 6;
+}
+
+
+
+
+}  // namespace hh

--- a/src/core/lib/hh/date.h
+++ b/src/core/lib/hh/date.h
@@ -1,0 +1,48 @@
+//------------------------------------------------------------------------------
+// Copyright 2021 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#ifndef hh_DATE_h
+#define hh_DATE_h
+namespace hh {
+
+
+struct ymd {
+  int year;
+  int month;
+  int day;
+  int : 32;
+
+  constexpr ymd(int y, int m, int d) : year(y), month(m), day(d) {}
+};
+
+
+constexpr int days_from_civil(int y, int m, int d) noexcept;
+constexpr ymd civil_from_days(int z) noexcept;
+constexpr bool is_leap(int y) noexcept;
+constexpr int last_day_of_month_common_year(int m) noexcept;
+constexpr int last_day_of_month_leap_year(int m) noexcept;
+constexpr int last_day_of_month(int y, int m) noexcept;
+constexpr int weekday_from_days(int z) noexcept;
+
+
+
+}  // namespace hh
+#endif

--- a/src/core/lib/hh/date.h
+++ b/src/core/lib/hh/date.h
@@ -34,13 +34,13 @@ struct ymd {
 };
 
 
-constexpr int days_from_civil(int y, int m, int d) noexcept;
-constexpr ymd civil_from_days(int z) noexcept;
-constexpr bool is_leap(int y) noexcept;
-constexpr int last_day_of_month_common_year(int m) noexcept;
-constexpr int last_day_of_month_leap_year(int m) noexcept;
-constexpr int last_day_of_month(int y, int m) noexcept;
-constexpr int weekday_from_days(int z) noexcept;
+int days_from_civil(int y, int m, int d) noexcept;
+ymd civil_from_days(int z) noexcept;
+bool is_leap(int y) noexcept;
+int last_day_of_month_common_year(int m) noexcept;
+int last_day_of_month_leap_year(int m) noexcept;
+int last_day_of_month(int y, int m) noexcept;
+int weekday_from_days(int z) noexcept;
 
 
 

--- a/src/core/python/date.cc
+++ b/src/core/python/date.cc
@@ -71,4 +71,6 @@ void odate::init() {
 }
 
 
+
+
 }  // namespace py

--- a/src/core/python/date.cc
+++ b/src/core/python/date.cc
@@ -20,7 +20,7 @@
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #include <Python.h>
-#include <datetime.h>      // from Python
+#include <datetime.h>     // Python "datetime" module, not included in Python.h
 #include "python/date.h"
 #include "lib/hh/date.h"
 namespace py {
@@ -45,6 +45,27 @@ bool odate::check(robj obj) {
 }
 
 
+int odate::get_days() const {
+  return hh::days_from_civil(
+      PyDateTime_GET_YEAR(v),
+      PyDateTime_GET_MONTH(v),
+      PyDateTime_GET_DAY(v)
+  );
+}
+
+
+void odate::init() {
+  // In order to be able to use python API to access datetime objects,
+  // we need to "import" it via a special macro. This macro loads the
+  // datetime module as a capsule and stores it in PyDateTimeAPI variable.
+  //
+  // Note that the PyDateTimeAPI variable will be local to this file,
+  // which means that no PyDateTime* macros will work outside of this
+  // translation unit.
+  //
+  // See https://docs.python.org/3/c-api/datetime.html
+  PyDateTime_IMPORT;
+}
 
 
 }  // namespace py

--- a/src/core/python/date.cc
+++ b/src/core/python/date.cc
@@ -38,6 +38,9 @@ odate::odate(hh::ymd date) {
   if (!v) throw PyError();
 }
 
+odate::odate(int32_t days)
+  : odate(hh::civil_from_days(days)) {}
+
 
 
 bool odate::check(robj obj) {

--- a/src/core/python/date.cc
+++ b/src/core/python/date.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2020 H2O.ai
+// Copyright 2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -19,20 +19,32 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
-#include "python/python.h"
-
-#include "python/bool.h"
+#include <Python.h>
+#include <datetime.h>      // from Python
 #include "python/date.h"
-#include "python/dict.h"
-#include "python/float.h"
-#include "python/int.h"
-#include "python/iter.h"
-#include "python/list.h"
-#include "python/namedtuple.h"
-#include "python/obj.h"
-#include "python/pybuffer.h"
-#include "python/range.h"
-#include "python/set.h"
-#include "python/slice.h"
-#include "python/string.h"
-#include "python/tuple.h"
+#include "lib/hh/date.h"
+namespace py {
+
+
+odate::odate(PyObject* obj) : oobj(obj) {}  // private
+
+odate odate::unchecked(PyObject* obj) {
+  return odate(obj);
+}
+
+
+odate::odate(hh::ymd date) {
+  v = PyDate_FromDate(date.year, date.month, date.day);
+  if (!v) throw PyError();
+}
+
+
+
+bool odate::check(robj obj) {
+  return PyDate_Check(obj.to_borrowed_ref());
+}
+
+
+
+
+}  // namespace py

--- a/src/core/python/date.h
+++ b/src/core/python/date.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2020 H2O.ai
+// Copyright 2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -19,20 +19,31 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
-#include "python/python.h"
-
-#include "python/bool.h"
-#include "python/date.h"
-#include "python/dict.h"
-#include "python/float.h"
-#include "python/int.h"
-#include "python/iter.h"
-#include "python/list.h"
-#include "python/namedtuple.h"
+#ifndef dt_PYTHON_DATE_h
+#define dt_PYTHON_DATE_h
 #include "python/obj.h"
-#include "python/pybuffer.h"
-#include "python/range.h"
-#include "python/set.h"
-#include "python/slice.h"
-#include "python/string.h"
-#include "python/tuple.h"
+#include "lib/hh/date.h"
+namespace py {
+
+
+class odate : public oobj {
+  public:
+    odate() = default;
+    odate(const odate&) = default;
+    odate(odate&&) = default;
+    odate& operator=(const odate&) = default;
+    odate& operator=(odate&&) = default;
+
+    static odate unchecked(PyObject*);
+    explicit odate(hh::ymd date);
+
+    static bool check(py::robj obj);
+
+  private:
+    explicit odate(PyObject*);
+};
+
+
+
+}  // namespace py
+#endif

--- a/src/core/python/date.h
+++ b/src/core/python/date.h
@@ -37,7 +37,10 @@ class odate : public oobj {
     static odate unchecked(PyObject*);
     explicit odate(hh::ymd date);
 
+    static void init();
     static bool check(py::robj obj);
+
+    int get_days() const;
 
   private:
     explicit odate(PyObject*);

--- a/src/core/python/date.h
+++ b/src/core/python/date.h
@@ -35,6 +35,7 @@ class odate : public oobj {
     odate& operator=(odate&&) = default;
 
     static odate unchecked(PyObject*);
+    explicit odate(int32_t days);
     explicit odate(hh::ymd date);
 
     static void init();

--- a/src/core/python/obj.cc
+++ b/src/core/python/obj.cc
@@ -222,6 +222,7 @@ bool _obj::is_int()           const noexcept { return v && PyLong_Check(v) && !i
 bool _obj::is_float()         const noexcept { return v && PyFloat_Check(v); }
 bool _obj::is_string()        const noexcept { return v && PyUnicode_Check(v); }
 bool _obj::is_bytes()         const noexcept { return v && PyBytes_Check(v); }
+bool _obj::is_date()          const noexcept { return v && odate::check(robj(v)); }
 bool _obj::is_pytype()        const noexcept { return v && PyType_Check(v); }
 bool _obj::is_ltype()         const noexcept { return v && dt::is_ltype_object(v); }
 bool _obj::is_stype()         const noexcept { return v && dt::is_stype_object(v); }
@@ -827,6 +828,13 @@ strvec _obj::to_stringlist(const error_manager&) const {
 }
 
 
+odate _obj::to_odate(const error_manager& em) const {
+  if (is_date()) {
+    return odate::unchecked(v);
+  }
+  throw em.error_not_date(v);
+}
+
 
 //------------------------------------------------------------------------------
 // Object conversions
@@ -1248,6 +1256,10 @@ Error _obj::error_manager::error_not_integer(PyObject* o) const {
 
 Error _obj::error_manager::error_not_double(PyObject* o) const {
   return TypeError() << "Expected a float, instead got " << Py_TYPE(o);
+}
+
+Error _obj::error_manager::error_not_date(PyObject* o) const {
+  return TypeError() << "Expected a date, instead got " << Py_TYPE(o);
 }
 
 Error _obj::error_manager::error_not_string(PyObject* o) const {

--- a/src/core/python/obj.cc
+++ b/src/core/python/obj.cc
@@ -507,6 +507,15 @@ bool _obj::parse_double(double* out) const {
 }
 
 
+bool _obj::parse_date(int32_t* out) const {
+  if (py::odate::check(v)) {
+    *out = py::odate::unchecked(v).get_days();
+    return true;
+  }
+  return false;
+}
+
+
 
 
 //------------------------------------------------------------------------------

--- a/src/core/python/obj.h
+++ b/src/core/python/obj.h
@@ -225,6 +225,7 @@ class _obj {
     bool parse_numpy_float(float*) const;
     bool parse_numpy_float(double*) const;
     bool parse_double(double*) const;
+    bool parse_date(int32_t*) const;
 
     struct error_manager;  // see below
     int8_t      to_bool           (const error_manager& = _em0) const;

--- a/src/core/python/obj.h
+++ b/src/core/python/obj.h
@@ -162,6 +162,7 @@ class _obj {
     bool is_by_node()       const noexcept;
     bool is_bytes()         const noexcept;
     bool is_callable()      const noexcept;
+    bool is_date()          const noexcept;
     bool is_dict()          const noexcept;
     bool is_dtexpr()        const noexcept;
     bool is_ellipsis()      const noexcept;
@@ -253,6 +254,7 @@ class _obj {
     py::orange  to_orange         (const error_manager& = _em0) const;
     py::oiter   to_oiter          (const error_manager& = _em0) const;
     py::oslice  to_oslice         (const error_manager& = _em0) const;
+    py::odate   to_odate          (const error_manager& = _em0) const;
 
     py::otuple  to_otuple         (const error_manager& = _em0) const;
     py::rtuple  to_rtuple_lax     () const;
@@ -287,6 +289,7 @@ class _obj {
       virtual Error error_not_rowindex       (PyObject*) const;
       virtual Error error_not_frame          (PyObject*) const;
       virtual Error error_not_column         (PyObject*) const;
+      virtual Error error_not_date           (PyObject*) const;
       virtual Error error_not_list           (PyObject*) const;
       virtual Error error_not_dict           (PyObject*) const;
       virtual Error error_not_range          (PyObject*) const;

--- a/src/core/stype.cc
+++ b/src/core/stype.cc
@@ -56,10 +56,8 @@ LType stype_to_ltype(SType stype) {
     case SType::FLOAT64: return LType::REAL;
     case SType::STR32  : return LType::STRING;
     case SType::STR64  : return LType::STRING;
-    case SType::DATE64 : return LType::DATETIME;
-    case SType::TIME32 : return LType::DATETIME;
+    case SType::TIME64 : return LType::DATETIME;
     case SType::DATE32 : return LType::DATETIME;
-    case SType::DATE16 : return LType::DATETIME;
     case SType::OBJ    : return LType::OBJECT;
     default            : return LType::INVALID;
   }
@@ -78,10 +76,8 @@ const char* stype_name(SType stype) {
     case SType::FLOAT64: return "float64";
     case SType::STR32  : return "str32";
     case SType::STR64  : return "str64";
-    case SType::DATE64 : return "date64";
-    case SType::TIME32 : return "time32";
+    case SType::TIME64 : return "time64";
     case SType::DATE32 : return "date32";
-    case SType::DATE16 : return "date16";
     case SType::OBJ    : return "obj64";
     case SType::AUTO   : return "auto";
     default            : return "unknown";
@@ -101,10 +97,8 @@ size_t stype_elemsize(SType stype) {
     case SType::FLOAT64: return sizeof(element_t<SType::FLOAT64>);
     case SType::STR32  : return sizeof(element_t<SType::STR32>);
     case SType::STR64  : return sizeof(element_t<SType::STR64>);
-    case SType::DATE64 : return sizeof(element_t<SType::DATE64>);
-    case SType::TIME32 : return sizeof(element_t<SType::TIME32>);
+    case SType::TIME64 : return sizeof(element_t<SType::TIME64>);
     case SType::DATE32 : return sizeof(element_t<SType::DATE32>);
-    case SType::DATE16 : return sizeof(element_t<SType::DATE16>);
     case SType::OBJ    : return sizeof(element_t<SType::OBJ>);
     default            : return 0;
   }
@@ -153,10 +147,8 @@ void init_py_stype_objs(PyObject* stype_enum) {
   _init_py_stype(SType::FLOAT64);
   _init_py_stype(SType::STR32);
   _init_py_stype(SType::STR64);
-  // _init_py_stype(SType::DATE64);
-  // _init_py_stype(SType::TIME32);
-  // _init_py_stype(SType::DATE32);
-  // _init_py_stype(SType::DATE16);
+  _init_py_stype(SType::TIME64);
+  _init_py_stype(SType::DATE32);
   _init_py_stype(SType::OBJ);
 }
 

--- a/src/core/stype.h
+++ b/src/core/stype.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2020 H2O.ai
+// Copyright 2018-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -31,140 +31,12 @@ namespace dt {
 
 
 /**
- * "Storage" type of a data column.
- *
- * These storage types are in 1-to-many correspondence with the
- * logical types. That is, a single logical type may have multiple
- * storage types, but not the other way around.
- *
- * -------------------------------------------------------------------
- *
- * SType::VOID
- *     This type is used for a column containing only NA values. As
- *     such, it has no element types, and cannot be materialized. It
- *     is also the most flexible of all types, as it can mimic any
- *     other stype.
- *
- * SType::BOOL
- *     elem: int8_t (1 byte)
- *     NA:   -128
- *     A boolean with True = 1, False = 0. All other values are
- *     invalid.
- *
- * -------------------------------------------------------------------
- *
- * SType::INT8
- *     elem: int8_t (1 byte)
- *     NA:   -2**7 = -128
- *     An integer in the range -127 .. 127.
- *
- * SType::INT16
- *     elem: int16_t (2 bytes)
- *     NA:   -2**15 = -32768
- *     An integer in the range -32767 .. 32767.
- *
- * SType::INT32
- *     elem: int32_t (4 bytes)
- *     NA:   -2**31 = -2147483648
- *     An integer in the range -2147483647 .. 2147483647.
- *
- * SType::INT64
- *     elem: int64_t (8 bytes)
- *     NA:   -2**63 = -9223372036854775808
- *     An integer in the range [-M; M], where M = 9223372036854775807.
- *
- * -------------------------------------------------------------------
- *
- * SType::FLOAT32
- *     elem: float (4 bytes)
- *     NA:   nan
- *     Floating-point real number, corresponding to C `float` type
- *     (IEEE 754). We consider any float NaN value to ba an NA.
- *
- * SType::FLOAT64
- *     elem: double (8 bytes)
- *     NA:   nan
- *     Floating-point real number, corresponding to C `double` type
- *     (IEEE 754). Any double NaN value is considered an NA.
- *
- * -------------------------------------------------------------------
- *
- * SType::STR32
- *     elem: uint32_t (4 bytes) + unsigned char[]
- *     NA:   (1 << 31) mask
- *     Variable-width strings. The data consists of 2 buffers:
- *       1) string data. All non-NA strings are UTF-8 encoded and
- *          placed end-to-end.
- *       2) offsets. This is an array of uint32_t's representing
- *          offsets of each string in buffer 1). This array has
- *          nrows + 1 elements, with first element being 0, second
- *          element containing the end offset of the first string,
- *          ..., until the last element which stores the end offset
- *          of the last string. NA strings are encoded as the
- *          previous offset + NA mask (which is 1<<31).
- *     Thus, i-th string is NA if its highest bit is set, or
- *     otherwise it's a valid string whose starting offset is
- *     `start(i) = off(i-1) & ~(1<<31)`, ending offset is
- *     `end(i) = off(i)`, and `len(i) = end(i) - start(i)`.
- *
- *     For example, a column with 4 values `[NA, "hello", "", NA]`
- *     will be encoded as a string buffer of size 5 = (0 + 5 + 0 + 0)
- *     and offsets buffer containing 5 uint32_t's:
- *         strbuf  = [h e l l o]
- *         offsets = [0, 1<<31, 5, 5, 5|(1<<31)]
- *
- * SType::STR64
- *     elem: uint64_t (8 bytes) + unsigned char[]
- *     NA:   (1 << 63) mask
- *     Variable-width strings: same as SType::STR32 but use 64-bit
- *     offsets.
- *
- * -------------------------------------------------------------------
- *
- * SType::DATE64
- *     elem: int64_t (8 bytes)
- *     NA:   -2**63
- *     Timestamp, stored as the number of microseconds since
- *     0000-03-01. The allowed time range is ≈290,000 years around
- *     the epoch. The time is assumed to be in UTC, and does not
- *     allow specifying a time zone.
- *
- * SType::DATE32
- *     elem: int32_t (4 bytes)
- *     NA:   -2**31
- *     Date only: the number of days since 0000-03-01. The allowed
- *     time range is ≈245,000 years.
- *
- * SType::DATE16
- *     elem: int16_t (2 bytes)
- *     NA:   -2**15
- *     Year+month only: the number of months since 0000-03-01. The
- *     allowed time range is up to year 2730.
- *     This type is specifically designed for business applications.
- *     It allows adding/subtraction in monthly/yearly intervals (other
- *     datetime types do not allow that since months/years have uneven
- *     lengths).
- *
- * SType::TIME32
- *     elem: int32_t (4 bytes)
- *     NA:   -2**31
- *     Time only: the number of milliseconds since midnight. The
- *     allowed time range is ≈24 days.
- *
- *
- * -------------------------------------------------------------------
- *
- * SType::OBJ
- *     elem: PyObject*
- *     NA:   Py_None
- *
- * -------------------------------------------------------------------
- *
- * SType::AUTO
- *     Special stype that indicates a type that must be automatically
- *     detected. A column with this stype cannot be created.
- *
- */
+  * "Storage" type of a data column.
+  *
+  * These storage types are in 1-to-many correspondence with the
+  * logical types. That is, a single logical type may have multiple
+  * storage types, but not the other way around.
+  */
 enum class SType : uint8_t {
   VOID    = 0,
   BOOL    = 1,
@@ -176,10 +48,8 @@ enum class SType : uint8_t {
   FLOAT64 = 7,
   STR32   = 11,
   STR64   = 12,
-  DATE64  = 17,
-  TIME32  = 18,
-  DATE32  = 19,
-  DATE16  = 20,
+  DATE32  = 17,
+  TIME64  = 18,
   OBJ     = 21,
 
   AUTO    = 22,
@@ -192,6 +62,10 @@ constexpr size_t STYPES_COUNT = static_cast<size_t>(SType::INVALID);
 // XXX: which functionality relies on this assumption?
 static_assert(STYPES_COUNT <= 64, "Too many stypes");
 
+
+using utc_timestamp_t = int64_t;
+using local_time_t = int64_t;
+using local_date_t = int64_t;
 
 
 //------------------------------------------------------------------------------
@@ -218,10 +92,8 @@ template <> struct _elt<SType::INT32>   { using t = int32_t; };
 template <> struct _elt<SType::INT64>   { using t = int64_t; };
 template <> struct _elt<SType::FLOAT32> { using t = float; };
 template <> struct _elt<SType::FLOAT64> { using t = double; };
-template <> struct _elt<SType::DATE64>  { using t = int64_t; };
 template <> struct _elt<SType::DATE32>  { using t = int32_t; };
-template <> struct _elt<SType::DATE16>  { using t = int16_t; };
-template <> struct _elt<SType::TIME32>  { using t = int32_t; };
+template <> struct _elt<SType::TIME64>  { using t = int64_t; };
 template <> struct _elt<SType::STR32>   { using t = uint32_t; };
 template <> struct _elt<SType::STR64>   { using t = uint64_t; };
 template <> struct _elt<SType::OBJ>     { using t = PyObject*; };

--- a/src/core/types/py_type.cc
+++ b/src/core/types/py_type.cc
@@ -127,7 +127,7 @@ static void init_src_store_from_stypes() {
 static bool numpy_types_imported = false;
 static void init_src_store_from_numpy() {
   if (numpy_types_imported) return;
-  auto np = py::get_module("numpy");
+  auto np = py::get_module("numpy"); // only returns if numpy already loaded
   if (!np) return;
   numpy_types_imported = true;
   auto dtype = np.get_attr("dtype");
@@ -175,19 +175,58 @@ static void init_src_store_from_numpy() {
 }
 
 
+static bool pyarrow_types_imported = false;
+static void init_src_store_from_pyarrow() {
+  if (pyarrow_types_imported) return;
+  auto pa = py::get_module("pyarrow");
+  if (!pa) return;
+  pyarrow_types_imported = true;
+  src_store->set(pa.invoke("void"), PyType::make(Type::void()));
+  src_store->set(pa.invoke("bool_"), PyType::make(Type::bool8()));
+  src_store->set(pa.invoke("int8"), PyType::make(Type::int8()));
+  src_store->set(pa.invoke("int16"), PyType::make(Type::int16()));
+  src_store->set(pa.invoke("int32"), PyType::make(Type::int32()));
+  src_store->set(pa.invoke("int64"), PyType::make(Type::int64()));
+  src_store->set(pa.invoke("float32"), PyType::make(Type::float32()));
+  src_store->set(pa.invoke("float64"), PyType::make(Type::float64()));
+  src_store->set(pa.invoke("string"), PyType::make(Type::str32()));
+  src_store->set(pa.invoke("long_string"), PyType::make(Type::str64()));
+  src_store->set(pa.invoke("date32"), PyType::make(Type::date32()));
+}
+
+
 static py::PKArgs args___init__(
     1, 0, 0, false, false, {"src"}, "__init__", nullptr);
 
+
+// This constructor implements ``dt.Type(src)``. There are 2 modes of invoking
+// this: the "internal" mode (invoked without arguments) is called only by
+// PyType::make(). This mode is indicated by temporary setting global variable
+// ``internal_initialization = true``.
+//
+// The "normal" calling mode requires a single argument (possibly with
+// additional keywords for more advanced types).
+//
+// Creating PyTypes requires a lookup in the ``src_store`` dictionary, and
+// that dictionary is populated with various known sources in multiple steps.
+// Notably, numpy/pyarrow dtypes are among the sources, and we need to import
+// those libraries in order to fully populate ``src_store``. However, we are
+// doing a lazy import: the ``py::get_module()`` function that we use returns
+// the library instance if and only if that library was already loaded. Thus,
+// when we call ``init_src_store_from_numpy()``, and the user hasn't imported
+// numpy yet, then we skip putting numpy sources into the ``src_store``.
+//
 void PyType::m__init__(const py::PKArgs& args) {
   if (internal_initialization) return;
   auto src = args[0].to_oobj();
   if (!src) {
     throw TypeError() << "Missing required argument `src` in Type constructor";
   }
-  for (int i = 0; i < 3; i++) {
+  for (int i = 0; i < 4; i++) {
     if (i == 0) init_src_store_basic();
     if (i == 1) init_src_store_from_stypes();
     if (i == 2) init_src_store_from_numpy();
+    if (i == 3) init_src_store_from_pyarrow();
     auto stored_type = src_store->get(src);
     if (stored_type) {
       type_ = reinterpret_cast<PyType*>(stored_type.to_borrowed_ref())->type_;

--- a/src/core/types/py_type.cc
+++ b/src/core/types/py_type.cc
@@ -81,6 +81,11 @@ static void init_src_store_basic() {
   src_store->set(py::ostring("double"), tFloat64);
   src_store->set(py::oobj(&PyFloat_Type), tFloat64);
 
+  auto tDate32 = PyType::make(Type::date32());
+  src_store->set(py::ostring("date"), tDate32);
+  src_store->set(py::ostring("date32"), tDate32);
+  src_store->set(py::oobj::import("datetime", "date"), tDate32);
+
   auto tStr32 = PyType::make(Type::str32());
   src_store->set(py::ostring("str32"), tStr32);
   src_store->set(py::ostring("<U"), tStr32);
@@ -112,6 +117,7 @@ static void init_src_store_from_stypes() {
   src_store->set(stype.get_attr("int64"), PyType::make(Type::int64()));
   src_store->set(stype.get_attr("float32"), PyType::make(Type::float32()));
   src_store->set(stype.get_attr("float64"), PyType::make(Type::float64()));
+  src_store->set(stype.get_attr("date32"), PyType::make(Type::date32()));
   src_store->set(stype.get_attr("str32"), PyType::make(Type::str32()));
   src_store->set(stype.get_attr("str64"), PyType::make(Type::str64()));
   src_store->set(stype.get_attr("obj64"), PyType::make(Type::obj64()));
@@ -155,6 +161,9 @@ static void init_src_store_from_numpy() {
   src_store->set(np.get_attr("float32"), tFloat32);
   src_store->set(dtype.call({py::ostring("float16")}), tFloat32);
   src_store->set(dtype.call({py::ostring("float32")}), tFloat32);
+
+  auto tDate32 = PyType::make(Type::date32());
+  src_store->set(dtype.call({py::ostring("<M8[D]")}), tDate32);
 
   auto tFloat64 = PyType::make(Type::float64());
   src_store->set(np.get_attr("float64"), tFloat64);
@@ -279,6 +288,7 @@ void PyType::impl_init_type(py::XTypeMaker& xt) {
   xt.add_attr("int64",   PyType::make(Type::int64()));
   xt.add_attr("float32", PyType::make(Type::float32()));
   xt.add_attr("float64", PyType::make(Type::float64()));
+  xt.add_attr("date32",  PyType::make(Type::date32()));
   xt.add_attr("str32",   PyType::make(Type::str32()));
   xt.add_attr("str64",   PyType::make(Type::str64()));
   xt.add_attr("obj64",   PyType::make(Type::obj64()));

--- a/src/core/types/py_type.cc
+++ b/src/core/types/py_type.cc
@@ -181,7 +181,7 @@ static void init_src_store_from_pyarrow() {
   auto pa = py::get_module("pyarrow");
   if (!pa) return;
   pyarrow_types_imported = true;
-  src_store->set(pa.invoke("void"), PyType::make(Type::void()));
+  src_store->set(pa.invoke("null"), PyType::make(Type::void0()));
   src_store->set(pa.invoke("bool_"), PyType::make(Type::bool8()));
   src_store->set(pa.invoke("int8"), PyType::make(Type::int8()));
   src_store->set(pa.invoke("int16"), PyType::make(Type::int16()));
@@ -190,7 +190,7 @@ static void init_src_store_from_pyarrow() {
   src_store->set(pa.invoke("float32"), PyType::make(Type::float32()));
   src_store->set(pa.invoke("float64"), PyType::make(Type::float64()));
   src_store->set(pa.invoke("string"), PyType::make(Type::str32()));
-  src_store->set(pa.invoke("long_string"), PyType::make(Type::str64()));
+  src_store->set(pa.invoke("large_string"), PyType::make(Type::str64()));
   src_store->set(pa.invoke("date32"), PyType::make(Type::date32()));
 }
 

--- a/src/core/types/type.cc
+++ b/src/core/types/type.cc
@@ -23,6 +23,7 @@
 #include "stype.h"
 #include "types/type.h"
 #include "types/type_bool.h"
+#include "types/type_date.h"
 #include "types/type_float.h"
 #include "types/type_impl.h"
 #include "types/type_int.h"
@@ -71,6 +72,7 @@ Type::~Type() {
 
 Type Type::void0()   { return Type(new Type_Void); }
 Type Type::bool8()   { return Type(new Type_Bool8); }
+Type Type::date32()  { return Type(new Type_Date32); }
 Type Type::int8()    { return Type(new Type_Int8); }
 Type Type::int16()   { return Type(new Type_Int16); }
 Type Type::int32()   { return Type(new Type_Int32); }
@@ -93,6 +95,7 @@ Type Type::from_stype(SType stype) {
     case SType::FLOAT64: return float64();
     case SType::STR32:   return str32();
     case SType::STR64:   return str64();
+    case SType::DATE32:  return date32();
     case SType::OBJ:     return obj64();
     default: break;
   }

--- a/src/core/types/type.h
+++ b/src/core/types/type.h
@@ -55,17 +55,19 @@ class Type {
     Type& operator=(Type&& other);
     ~Type();
 
-    static Type void0();
     static Type bool8();
+    static Type date32();
+    static Type float32();
+    static Type float64();
     static Type int8();
     static Type int16();
     static Type int32();
     static Type int64();
-    static Type float32();
-    static Type float64();
+    static Type obj64();
     static Type str32();
     static Type str64();
-    static Type obj64();
+    static Type void0();
+
     static Type from_stype(SType);
 
 

--- a/src/core/types/type_date.h
+++ b/src/core/types/type_date.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2020 H2O.ai
+// Copyright 2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -19,20 +19,22 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
-#include "python/python.h"
+#ifndef dt_TYPES_TYPE_DATE_h
+#define dt_TYPES_TYPE_DATE_h
+#include "types/type_impl.h"
+namespace dt {
 
-#include "python/bool.h"
-#include "python/date.h"
-#include "python/dict.h"
-#include "python/float.h"
-#include "python/int.h"
-#include "python/iter.h"
-#include "python/list.h"
-#include "python/namedtuple.h"
-#include "python/obj.h"
-#include "python/pybuffer.h"
-#include "python/range.h"
-#include "python/set.h"
-#include "python/slice.h"
-#include "python/string.h"
-#include "python/tuple.h"
+
+
+class Type_Date32 : public TypeImpl {
+  public:
+    Type_Date32() : TypeImpl(SType::DATE32) {}
+
+    bool can_be_read_as_int32() const override { return true; }
+    std::string to_string() const override { return "date32"; }
+};
+
+
+
+}  // namespace dt
+#endif

--- a/src/core/types/type_impl.cc
+++ b/src/core/types/type_impl.cc
@@ -56,6 +56,7 @@ bool TypeImpl::can_be_read_as_int32()    const { return false; }
 bool TypeImpl::can_be_read_as_int64()    const { return false; }
 bool TypeImpl::can_be_read_as_float32()  const { return false; }
 bool TypeImpl::can_be_read_as_float64()  const { return false; }
+bool TypeImpl::can_be_read_as_date()     const { return false; }
 bool TypeImpl::can_be_read_as_cstring()  const { return false; }
 bool TypeImpl::can_be_read_as_pyobject() const { return false; }
 

--- a/src/core/types/type_impl.h
+++ b/src/core/types/type_impl.h
@@ -55,6 +55,7 @@ class TypeImpl {
     virtual bool can_be_read_as_int64() const;
     virtual bool can_be_read_as_float32() const;
     virtual bool can_be_read_as_float64() const;
+    virtual bool can_be_read_as_date() const;
     virtual bool can_be_read_as_cstring() const;
     virtual bool can_be_read_as_pyobject() const;
 

--- a/src/datatable/types.py
+++ b/src/datatable/types.py
@@ -226,6 +226,8 @@ _stype_2_ltype = {
     stype.float64: ltype.real,
     stype.str32: ltype.str,
     stype.str64: ltype.str,
+    stype.date32: ltype.time,
+    stype.time64: ltype.time,
     stype.obj64: ltype.obj,
 }
 

--- a/src/datatable/types.py
+++ b/src/datatable/types.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #-------------------------------------------------------------------------------
-# Copyright 2018-2020 H2O.ai
+# Copyright 2018-2021 H2O.ai
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -212,6 +212,8 @@ _stype_2_short = {
     stype.float64: "r8",
     stype.str32: "s4",
     stype.str64: "s8",
+    stype.time64: "t8",
+    stype.date32: "d4",
     stype.obj64: "o8",
 }
 

--- a/src/datatable/types.py
+++ b/src/datatable/types.py
@@ -56,6 +56,8 @@ class stype(enum.Enum):
     float64 = 7
     str32 = 11
     str64 = 12
+    date32 = 17
+    time64 = 18
     obj64 = 21
 
     def __repr__(self):

--- a/tests/test-dt.py
+++ b/tests/test-dt.py
@@ -830,15 +830,20 @@ def test_single_element_extraction_from_view(dt0):
 
 @pytest.mark.parametrize('st', list(dt.stype))
 def test_single_element_all_stypes(st):
+    from datetime import date as dd
+    if st == dt.stype.time64:
+        return
     pt = (bool if st == dt.stype.bool8 else
           int if st.ltype == dt.ltype.int else
           float if st.ltype == dt.ltype.real else
           str if st.ltype == dt.ltype.str else
+          dd if st == dt.stype.date32 else
           object)
     src = [True, False, True, None] if pt is bool else \
           [1, 7, -99, 214, None, 3333] if pt is int else \
           [2.5, 3.4e15, -7.909, None] if pt is float else \
           ['Oh', 'gobbly', None, 'sproo'] if pt is str else \
+          [dd(2000, 5, 5), dd(2012, 12, 12), None] if pt is dd else \
           [dt, st, list, None, {3, 2, 1}]
     df = dt.Frame(A=src, stype=st)
     frame_integrity_check(df)

--- a/tests/test-types.py
+++ b/tests/test-types.py
@@ -203,9 +203,11 @@ def test_stype():
     assert stype.float64
     assert stype.str32
     assert stype.str64
+    assert stype.date32
+    assert stype.time64
     assert stype.obj64
     # When new stypes are added, don't forget to update this test suite
-    assert len(stype) == 11
+    assert len(stype) == 13
 
 
 def test_stype_names():
@@ -220,6 +222,8 @@ def test_stype_names():
     assert stype.float64.name == "float64"
     assert stype.str32.name == "str32"
     assert stype.str64.name == "str64"
+    assert stype.date32.name == "date32"
+    assert stype.time64.name == "time64"
     assert stype.obj64.name == "obj64"
 
 
@@ -337,7 +341,8 @@ def test_stype_instantiate_bad():
 @pytest.mark.parametrize("st", list(dt.stype))
 def test_stype_minmax(st):
     from datatable import stype, ltype
-    if st in (stype.void, stype.str32, stype.str64, stype.obj64):
+    if st in (stype.void, stype.str32, stype.str64, stype.obj64, stype.time64,
+              stype.date32):
         assert st.min is None
         assert st.max is None
     else:
@@ -409,5 +414,5 @@ def test_ltype_stypes():
                                      stype.int64}
     assert set(ltype.real.stypes) == {stype.float32, stype.float64}
     assert set(ltype.str.stypes) == {stype.str32, stype.str64}
-    assert set(ltype.time.stypes) == set()
+    assert set(ltype.time.stypes) == {stype.time64, stype.date32}
     assert set(ltype.obj.stypes) == {stype.obj64}

--- a/tests/types/test-date32.py
+++ b/tests/types/test-date32.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#-------------------------------------------------------------------------------
+# Copyright 2021 H2O.ai
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#-------------------------------------------------------------------------------
+import datetime
+import datatable as dt
+
+
+
+def test_date32_type():
+    date32 = dt.Type.date32
+    assert dt.Type("date") == date32
+    assert dt.Type("date32") == date32
+    assert dt.Type(datetime.date) == date32
+
+    assert repr(date32) == "Type.date32"
+    assert date32.name == "date32"
+
+
+def test_date32_type_from_numpy(np):
+    assert dt.Type(np.dtype("datetime64[D]")) == dt.Type.date32
+
+
+def test_date32_type_from_pyarrow(pa):
+    assert dt.Type(pa.date32()) == dt.Type.date32
+
+
+# def test_date32_create_from

--- a/tests/types/test-date32.py
+++ b/tests/types/test-date32.py
@@ -26,14 +26,15 @@ import datatable as dt
 
 
 
-def test_date32_type():
-    date32 = dt.Type.date32
-    assert dt.Type("date") == date32
-    assert dt.Type("date32") == date32
-    assert dt.Type(datetime.date) == date32
+def test_date32_name():
+    assert repr(dt.Type.date32) == "Type.date32"
+    assert dt.Type.date32.name == "date32"
 
-    assert repr(date32) == "Type.date32"
-    assert date32.name == "date32"
+
+def test_date32_type_from_basic():
+    assert dt.Type("date") == dt.Type.date32
+    assert dt.Type("date32") == dt.Type.date32
+    assert dt.Type(datetime.date) == dt.Type.date32
 
 
 def test_date32_type_from_numpy(np):
@@ -44,4 +45,25 @@ def test_date32_type_from_pyarrow(pa):
     assert dt.Type(pa.date32()) == dt.Type.date32
 
 
-# def test_date32_create_from
+
+def test_date32_create_from_python():
+    d = datetime.date
+    src = [d(2000, 1, 5), d(2010, 11, 23), d(2020, 2, 29), None]
+    DT = dt.Frame(src)
+    assert DT.types == [dt.Type.date32]
+    assert DT.to_list() == [src]
+
+
+def test_date32_repr():
+    d = datetime.date
+    src = [d(1, 1, 1), d(2001, 12, 13), d(5756, 5, 9)]
+    DT = dt.Frame(src)
+    assert str(DT) == (
+        "   | C0        \n"
+        "   | date32    \n"
+        "-- + ----------\n"
+        " 0 | 0001-01-01\n"
+        " 1 | 2001-12-13\n"
+        " 2 | 5756-05-09\n"
+        "[3 rows x 1 column]\n"
+    )

--- a/tests/types/test-date32.py
+++ b/tests/types/test-date32.py
@@ -54,6 +54,16 @@ def test_date32_create_from_python():
     assert DT.to_list() == [src]
 
 
+def test_date32_create_from_python_force():
+    d = datetime.date
+    DT = dt.Frame([18675, -100000, None, 0.75, 'hello'], stype='date32')
+    assert DT.types == [dt.Type.date32]
+    assert DT.to_list() == [
+        [d(2021, 2, 17), d(1696, 3, 17), None, d(1970, 1, 1), None]
+    ]
+
+
+
 def test_date32_repr():
     d = datetime.date
     src = [d(1, 1, 1), d(2001, 12, 13), d(5756, 5, 9)]


### PR DESCRIPTION
Created column type `date32` for storing calendar dates. Currently only the following operations are supported:
- creation from python `datetime.date` objects;
- converting into python;
- `repr()`, i.e. the  column can be viewed in a console.

WIP for #1646
