### PR TITLE
Create properties min/max for Type

### DIFF
--- a/docs/api/type.rst
+++ b/docs/api/type.rst
@@ -3,18 +3,37 @@
     :src: src/core/types/py_type.h PyType
     :doc: src/core/types/py_type.cc doc_Type
 
-    .. toctree::
-        :hidden:
 
-        bool8    <type/bool8>
-        float32  <type/float32>
-        float64  <type/float64>
-        int16    <type/int16>
-        int32    <type/int32>
-        int64    <type/int64>
-        int8     <type/int8>
-        name     <type/name>
-        obj64    <type/obj64>
-        str32    <type/str32>
-        str64    <type/str64>
-        void     <type/void>
+    Properties
+    ----------
+    .. list-table::
+        :widths: auto
+        :class: api-table
+
+        * - :attr:`.max`
+          - The maximum value for this type
+
+        * - :attr:`.min`
+          - The minimum value for this type
+
+        * - :attr:`.name`
+          - The name of this type
+
+
+.. toctree::
+    :hidden:
+
+    bool8    <type/bool8>
+    float32  <type/float32>
+    float64  <type/float64>
+    int16    <type/int16>
+    int32    <type/int32>
+    int64    <type/int64>
+    int8     <type/int8>
+    min      <type/min>
+    max      <type/max>
+    name     <type/name>
+    obj64    <type/obj64>
+    str32    <type/str32>
+    str64    <type/str64>
+    void     <type/void>

--- a/docs/api/type.rst
+++ b/docs/api/type.rst
@@ -3,6 +3,25 @@
     :src: src/core/types/py_type.h PyType
     :doc: src/core/types/py_type.cc doc_Type
 
+
+    Values
+    ------
+    The following types are currently available:
+
+    - :attr:`dt.Type.bool8`
+    - :attr:`dt.Type.date32`
+    - :attr:`dt.Type.float32`
+    - :attr:`dt.Type.float64`
+    - :attr:`dt.Type.int16`
+    - :attr:`dt.Type.int32`
+    - :attr:`dt.Type.int64`
+    - :attr:`dt.Type.int8`
+    - :attr:`dt.Type.obj64`
+    - :attr:`dt.Type.str32`
+    - :attr:`dt.Type.str64`
+    - :attr:`dt.Type.void`
+
+
     Properties
     ----------
     .. list-table::

--- a/docs/api/type/date32.rst
+++ b/docs/api/type/date32.rst
@@ -17,6 +17,15 @@
     This type corresponds to ``datetime.date`` in Python, ``pa.date32()`` in
     pyarrow, and ``np.dtype('<M8[D]')`` in numpy.
 
+    .. note::
+
+        Python's ``datetime.date`` object can accommodate dates from year 1 to
+        year 9999, which is much smaller than what ``date32`` type allows.
+        As a consequence, certain date values will overflow if converted to
+        python objects.
+
+        For the same reason the :attr:`.min` and :attr:`.max` properties of this
+        type return 1x1 frames instead of ``datetime.date`` objects.
 
     .. _`proleptic gregorian`: https://en.wikipedia.org/wiki/Proleptic_Gregorian_calendar
 

--- a/docs/api/type/max.rst
+++ b/docs/api/type/max.rst
@@ -1,0 +1,4 @@
+
+.. xattr:: datatable.Type.max
+    :src: src/core/types/py_type.cc get_max
+    :doc: src/core/types/py_type.cc doc_max

--- a/docs/api/type/min.rst
+++ b/docs/api/type/min.rst
@@ -1,0 +1,4 @@
+
+.. xattr:: datatable.Type.min
+    :src: src/core/types/py_type.cc get_min
+    :doc: src/core/types/py_type.cc doc_min

--- a/src/core/types/py_type.cc
+++ b/src/core/types/py_type.cc
@@ -225,6 +225,11 @@ py::oobj PyType::m__compare__(py::robj x, py::robj y, int op) {
 }
 
 
+
+//------------------------------------------------------------------------------
+// .name
+//------------------------------------------------------------------------------
+
 static const char* doc_name =
 R"(
 Return the canonical name of this type, as a string.
@@ -243,6 +248,72 @@ py::oobj PyType::get_name() const {
   return py::ostring(type_.to_string());
 }
 
+
+
+//------------------------------------------------------------------------------
+// .min / .max
+//------------------------------------------------------------------------------
+
+static const char* doc_min =
+R"(
+The smallest value that this type can hold, if applicable.
+
+Parameters
+----------
+return: Any
+    The type of the returned value corresponds to the Type object: an int
+    for integer types, a float for floating-point types, etc. If the type
+    has no well-defined min value then `None` is returned.
+
+
+Examples
+--------
+>>> dt.Type.int8.min
+-127
+>>> dt.Type.float32.min
+-3.4028234663852886e+38
+
+See also
+--------
+:attr:`.max` -- the largest value for the type.
+)";
+
+static const char* doc_max =
+R"(
+The largest value that this type can hold, if applicable.
+
+Parameters
+----------
+return: Any
+    The type of the returned value corresponds to the Type object: an int
+    for integer types, a float for floating-point types, etc. If the type
+    has no well-defined max value then `None` is returned.
+
+
+Examples
+--------
+>>> dt.Type.int32.max
+2147483647
+>>> dt.Type.float64.max
+1.7976931348623157e+308
+
+
+See also
+--------
+:attr:`.min` -- the smallest value for the type.
+)";
+
+static py::GSArgs args_get_min("min", doc_min);
+static py::GSArgs args_get_max("max", doc_max);
+
+
+py::oobj PyType::get_min() const {
+  return type_.min();
+}
+
+py::oobj PyType::get_max() const {
+  return type_.max();
+}
 
 
 
@@ -275,6 +346,8 @@ void PyType::impl_init_type(py::XTypeMaker& xt) {
   xt.add(METHOD__CMP__(&PyType::m__compare__));
   xt.add(METHOD__HASH__(&PyType::m__hash__));
   xt.add(GETTER(&PyType::get_name, args_get_name));
+  xt.add(GETTER(&PyType::get_min, args_get_min));
+  xt.add(GETTER(&PyType::get_max, args_get_max));
   pythonType = xt.get_type_object();
 
   xt.add_attr("void",    PyType::make(Type::void0()));

--- a/src/core/types/py_type.cc
+++ b/src/core/types/py_type.cc
@@ -320,6 +320,13 @@ Examples
 -127
 >>> dt.Type.float32.min
 -3.4028234663852886e+38
+>>> dt.Type.date32.min
+   | min
+   | date32
+-- + --------------
+ 0 | -5877641-06-24
+[1 row x 1 column]
+
 
 See also
 --------
@@ -344,7 +351,12 @@ Examples
 2147483647
 >>> dt.Type.float64.max
 1.7976931348623157e+308
-
+>>> dt.Type.date32.max
+   | max
+   | date32
+-- + -------------
+ 0 | 5879610-09-09
+[1 row x 1 column]
 
 See also
 --------

--- a/src/core/types/py_type.cc
+++ b/src/core/types/py_type.cc
@@ -256,7 +256,7 @@ py::oobj PyType::get_name() const {
 
 static const char* doc_min =
 R"(
-The smallest value that this type can hold, if applicable.
+The smallest finite value that this type can represent, if applicable.
 
 Parameters
 ----------
@@ -280,7 +280,7 @@ See also
 
 static const char* doc_max =
 R"(
-The largest value that this type can hold, if applicable.
+The largest finite value that this type can represent, if applicable.
 
 Parameters
 ----------

--- a/src/core/types/py_type.h
+++ b/src/core/types/py_type.h
@@ -55,6 +55,8 @@ class PyType : public py::XObject<PyType, true> {
     size_t m__hash__() const;
 
     py::oobj get_name() const;
+    py::oobj get_min() const;
+    py::oobj get_max() const;
 
     Type get_type() const { return type_; }
 

--- a/src/core/types/type.cc
+++ b/src/core/types/type.cc
@@ -100,6 +100,8 @@ Type Type::from_stype(SType stype) {
 }
 
 size_t Type::hash() const { return impl_->hash(); }
+py::oobj Type::min() const { return impl_->min(); }
+py::oobj Type::max() const { return impl_->max(); }
 SType Type::stype() const { return impl_->stype_; }
 
 bool Type::is_boolean() const { return impl_->is_boolean(); }

--- a/src/core/types/type.h
+++ b/src/core/types/type.h
@@ -73,6 +73,9 @@ class Type {
     // Properties
     //--------------------------------------------------------------------------
     size_t hash() const;
+    py::oobj min() const;
+    py::oobj max() const;
+
     SType stype() const;
     bool is_boolean() const;
     bool is_integer() const;

--- a/src/core/types/type_bool.h
+++ b/src/core/types/type_bool.h
@@ -21,6 +21,7 @@
 //------------------------------------------------------------------------------
 #ifndef dt_TYPES_TYPE_BOOL_h
 #define dt_TYPES_TYPE_BOOL_h
+#include "python/_all.h"
 #include "types/type_impl.h"
 namespace dt {
 
@@ -34,7 +35,17 @@ class Type_Bool8 : public TypeImpl {
     bool is_numeric() const override { return true; }
     bool can_be_read_as_int8() const override { return true; }
 
-    std::string to_string() const override { return "bool8"; }
+    std::string to_string() const override {
+      return "bool8";
+    }
+
+    virtual py::oobj min() const override {
+      return py::False();
+    }
+
+    virtual py::oobj max() const override {
+      return py::True();
+    }
 };
 
 

--- a/src/core/types/type_date.h
+++ b/src/core/types/type_date.h
@@ -21,6 +21,8 @@
 //------------------------------------------------------------------------------
 #ifndef dt_TYPES_TYPE_DATE_h
 #define dt_TYPES_TYPE_DATE_h
+#include "frame/py_frame.h"
+#include "stype.h"
 #include "types/type_impl.h"
 namespace dt {
 
@@ -32,6 +34,26 @@ class Type_Date32 : public TypeImpl {
 
     bool can_be_read_as_int32() const override { return true; }
     std::string to_string() const override { return "date32"; }
+
+    py::oobj min() const override {
+      return _wrap_value(-std::numeric_limits<int>::max(), "min");
+    }
+    py::oobj max() const override {
+      return _wrap_value(std::numeric_limits<int>::max() - 719468, "max");
+    }
+
+  private:
+    // The min/max value is returned as a 1x1 frame instead of a python
+    // datetime.date object because the latter can only accommodate year
+    // range 1 .. 9999
+    //
+    py::oobj _wrap_value(int32_t value, const char* name) const {
+      Column col = Column::new_data_column(1, SType::DATE32);
+      static_cast<int32_t*>(col.get_data_editable())[0] = value;
+      return py::Frame::oframe(new DataTable(
+        {std::move(col)}, {name}
+      ));
+    }
 };
 
 

--- a/src/core/types/type_float.h
+++ b/src/core/types/type_float.h
@@ -21,6 +21,7 @@
 //------------------------------------------------------------------------------
 #ifndef dt_TYPES_TYPE_FLOAT_h
 #define dt_TYPES_TYPE_FLOAT_h
+#include "python/float.h"
 #include "types/type_impl.h"
 #include "utils/assert.h"
 namespace dt {
@@ -43,6 +44,13 @@ class Type_Float32 : public Type_Float {
     Type_Float32() : Type_Float(SType::FLOAT32) {}
     bool can_be_read_as_float32() const override { return true; }
     std::string to_string() const override { return "float32"; }
+
+    py::oobj min() const override {
+      return py::ofloat(-std::numeric_limits<float>::max());
+    }
+    py::oobj max() const override {
+      return py::ofloat(std::numeric_limits<float>::max());
+    }
 };
 
 
@@ -51,6 +59,13 @@ class Type_Float64 : public Type_Float {
     Type_Float64() : Type_Float(SType::FLOAT64) {}
     bool can_be_read_as_float64() const override { return true; }
     std::string to_string() const override { return "float64"; }
+
+    py::oobj min() const override {
+      return py::ofloat(-std::numeric_limits<double>::max());
+    }
+    py::oobj max() const override {
+      return py::ofloat(std::numeric_limits<double>::max());
+    }
 };
 
 

--- a/src/core/types/type_impl.cc
+++ b/src/core/types/type_impl.cc
@@ -19,6 +19,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
+#include "python/obj.h"
 #include "types/type_impl.h"
 namespace dt {
 
@@ -65,6 +66,10 @@ bool TypeImpl::can_be_read_as_pyobject() const { return false; }
 bool TypeImpl::equals(const TypeImpl* other) const {
   return stype_ == other->stype_;
 }
+
+
+py::oobj TypeImpl::min() const { return py::None(); }
+py::oobj TypeImpl::max() const { return py::None(); }
 
 
 

--- a/src/core/types/type_impl.h
+++ b/src/core/types/type_impl.h
@@ -41,6 +41,8 @@ class TypeImpl {
 
     SType stype() const { return stype_; }
     virtual size_t hash() const noexcept;
+    virtual py::oobj min() const;
+    virtual py::oobj max() const;
 
     virtual bool is_boolean() const;
     virtual bool is_integer() const;

--- a/src/core/types/type_int.h
+++ b/src/core/types/type_int.h
@@ -21,6 +21,8 @@
 //------------------------------------------------------------------------------
 #ifndef dt_TYPES_TYPE_INT_h
 #define dt_TYPES_TYPE_INT_h
+#include <limits>
+#include "python/int.h"
 #include "types/type_impl.h"
 #include "utils/assert.h"
 namespace dt {
@@ -42,6 +44,8 @@ class Type_Int8 : public Type_Int {
     Type_Int8() : Type_Int(SType::INT8) {}
     bool can_be_read_as_int8()  const override { return true; }
     std::string to_string() const override { return "int8"; }
+    py::oobj min() const override { return py::oint(-127); }
+    py::oobj max() const override { return py::oint(127); }
 };
 
 
@@ -50,6 +54,8 @@ class Type_Int16 : public Type_Int {
     Type_Int16() : Type_Int(SType::INT16) {}
     bool can_be_read_as_int16()  const override { return true; }
     std::string to_string() const override { return "int16"; }
+    py::oobj min() const override { return py::oint(-32767); }
+    py::oobj max() const override { return py::oint(32767); }
 };
 
 
@@ -58,6 +64,13 @@ class Type_Int32 : public Type_Int {
     Type_Int32() : Type_Int(SType::INT32) {}
     bool can_be_read_as_int32()  const override { return true; }
     std::string to_string() const override { return "int32"; }
+
+    py::oobj min() const override {
+      return py::oint(-std::numeric_limits<int32_t>::max());
+    }
+    py::oobj max() const override {
+      return py::oint(std::numeric_limits<int32_t>::max());
+    }
 };
 
 
@@ -66,6 +79,13 @@ class Type_Int64 : public Type_Int {
     Type_Int64() : Type_Int(SType::INT64) {}
     bool can_be_read_as_int64()  const override { return true; }
     std::string to_string() const override { return "int64"; }
+
+    py::oobj min() const override {
+      return py::oint(-std::numeric_limits<int64_t>::max());
+    }
+    py::oobj max() const override {
+      return py::oint(std::numeric_limits<int64_t>::max());
+    }
 };
 
 

--- a/src/core/types/type_string.h
+++ b/src/core/types/type_string.h
@@ -35,10 +35,6 @@ class Type_String : public TypeImpl {
   public:
     bool is_string() const override { return true; }
     bool can_be_read_as_cstring() const override { return true; }
-
-    py::oobj min() const override {
-      return py::ostring("");
-    }
 };
 
 

--- a/src/core/types/type_string.h
+++ b/src/core/types/type_string.h
@@ -21,6 +21,7 @@
 //------------------------------------------------------------------------------
 #ifndef dt_TYPES_TYPE_STRING_h
 #define dt_TYPES_TYPE_STRING_h
+#include "python/string.h"
 #include "types/type_impl.h"
 #include "utils/assert.h"
 namespace dt {
@@ -34,6 +35,10 @@ class Type_String : public TypeImpl {
   public:
     bool is_string() const override { return true; }
     bool can_be_read_as_cstring() const override { return true; }
+
+    py::oobj min() const override {
+      return py::ostring("");
+    }
 };
 
 

--- a/tests/test-types.py
+++ b/tests/test-types.py
@@ -195,6 +195,31 @@ def test_type_hashable():
     assert dt.Type.int64 not in m
 
 
+def test_type_minmax():
+    assert dt.Type.bool8.min is False
+    assert dt.Type.bool8.max is True
+    assert dt.Type.int8.min == -127
+    assert dt.Type.int8.max == 127
+    assert dt.Type.int16.min == -32767
+    assert dt.Type.int16.max == 32767
+    assert dt.Type.int32.min == -(2**31 - 1)
+    assert dt.Type.int32.max == +(2**31 - 1)
+    assert dt.Type.int64.min == -(2**63 - 1)
+    assert dt.Type.int64.max == +(2**63 - 1)
+    assert dt.Type.float32.min == float.fromhex("-0x1.fffffep+127")
+    assert dt.Type.float32.max == float.fromhex("+0x1.fffffep+127")
+    assert dt.Type.float64.min == float.fromhex("-0x1.fffffffffffffp+1023")
+    assert dt.Type.float64.max == float.fromhex("+0x1.fffffffffffffp+1023")
+    assert dt.Type.void.min is None
+    assert dt.Type.void.max is None
+    assert dt.Type.str32.min is None
+    assert dt.Type.str32.max is None
+    assert dt.Type.str64.min is None
+    assert dt.Type.str64.max is None
+    assert dt.Type.obj64.min is None
+    assert dt.Type.obj64.max is None
+
+
 
 #-------------------------------------------------------------------------------
 # Test stype enum

--- a/tests/types/test-date32.py
+++ b/tests/types/test-date32.py
@@ -77,3 +77,27 @@ def test_date32_repr():
         " 2 | 5756-05-09\n"
         "[3 rows x 1 column]\n"
     )
+
+
+def test_date32_min():
+    DT = dt.Type.date32.min
+    assert isinstance(DT, dt.Frame)
+    assert str(DT) == (
+        "   | min           \n"
+        "   | date32        \n"
+        "-- + --------------\n"
+        " 0 | -5877641-06-24\n"
+        "[1 row x 1 column]\n"
+    )
+
+
+def test_date32_max():
+    DT = dt.Type.date32.max
+    assert isinstance(DT, dt.Frame)
+    assert str(DT) == (
+        "   | max          \n"
+        "   | date32       \n"
+        "-- + -------------\n"
+        " 0 | 5879610-09-09\n"
+        "[1 row x 1 column]\n"
+    )


### PR DESCRIPTION
These are the same as stype's .min / .max.
For date32 column the returned value is a frame instead of datetime.date object (which is rather unfortunate), but that's because python has very limited range for their date object -- only years 1..9999.