### PR TITLE
Implement creating a date32 column from a numpy datetime64 array

### DIFF
--- a/src/core/column/date_from_months.cc
+++ b/src/core/column/date_from_months.cc
@@ -1,0 +1,62 @@
+//------------------------------------------------------------------------------
+// Copyright 2021 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#include "column/date_from_months.h"
+#include "lib/hh/date.h"
+#include "stype.h"
+namespace dt {
+
+
+DateFromMonths_ColumnImpl::DateFromMonths_ColumnImpl(Column&& arg)
+  : Virtual_ColumnImpl(arg.nrows(), SType::DATE32),
+    arg_(std::move(arg))
+{
+  xassert(arg_.type().can_be_read_as<int64_t>());
+}
+
+
+bool DateFromMonths_ColumnImpl::get_element(size_t i, int32_t* out) const {
+  int64_t value;
+  bool valid = arg_.get_element(i, &value);
+  int year = static_cast<int>(value / 12) + 1970;
+  int month = static_cast<int>(value % 12) + 1;
+  *out = hh::days_from_civil(year, month, 1);
+  return valid;
+}
+
+
+ColumnImpl* DateFromMonths_ColumnImpl::clone() const {
+  return new DateFromMonths_ColumnImpl(Column(arg_));
+}
+
+size_t DateFromMonths_ColumnImpl::n_children() const noexcept {
+  return 1;
+}
+
+const Column& DateFromMonths_ColumnImpl::child(size_t i) const {
+  xassert(i == 0); (void) i;
+  return arg_;
+}
+
+
+
+
+}

--- a/src/core/column/date_from_months.cc
+++ b/src/core/column/date_from_months.cc
@@ -36,9 +36,10 @@ DateFromMonths_ColumnImpl::DateFromMonths_ColumnImpl(Column&& arg)
 bool DateFromMonths_ColumnImpl::get_element(size_t i, int32_t* out) const {
   int64_t value;
   bool valid = arg_.get_element(i, &value);
-  int year = static_cast<int>(value / 12) + 1970;
-  int month = static_cast<int>(value % 12) + 1;
-  *out = hh::days_from_civil(year, month, 1);
+  auto y = value >= 0? value/12 : (value - 11)/12;
+  auto m = (value - y * 12);
+  *out = hh::days_from_civil(static_cast<int>(y) + 1970,
+                             static_cast<int>(m) + 1, 1);
   return valid;
 }
 

--- a/src/core/column/date_from_months.h
+++ b/src/core/column/date_from_months.h
@@ -1,0 +1,43 @@
+//------------------------------------------------------------------------------
+// Copyright 2021 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#include "_dt.h"
+#include "column/virtual.h"
+namespace dt {
+
+
+class DateFromMonths_ColumnImpl : public Virtual_ColumnImpl {
+  private:
+    Column arg_;
+
+  public:
+    DateFromMonths_ColumnImpl(Column&& arg);
+
+    ColumnImpl* clone() const override;
+    size_t n_children() const noexcept override;
+    const Column& child(size_t i) const override;
+
+    bool get_element(size_t i, int32_t* out) const override;
+};
+
+
+
+}

--- a/src/core/column/date_from_weeks.cc
+++ b/src/core/column/date_from_weeks.cc
@@ -1,0 +1,59 @@
+//------------------------------------------------------------------------------
+// Copyright 2021 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#include "column/date_from_weeks.h"
+#include "stype.h"
+namespace dt {
+
+
+DateFromWeeks_ColumnImpl::DateFromWeeks_ColumnImpl(Column&& arg)
+  : Virtual_ColumnImpl(arg.nrows(), SType::DATE32),
+    arg_(std::move(arg))
+{
+  xassert(arg_.type().can_be_read_as<int64_t>());
+}
+
+
+bool DateFromWeeks_ColumnImpl::get_element(size_t i, int32_t* out) const {
+  int64_t value;
+  bool valid = arg_.get_element(i, &value);
+  *out = static_cast<int32_t>(value * 7);
+  return valid;
+}
+
+
+ColumnImpl* DateFromWeeks_ColumnImpl::clone() const {
+  return new DateFromWeeks_ColumnImpl(Column(arg_));
+}
+
+size_t DateFromWeeks_ColumnImpl::n_children() const noexcept {
+  return 1;
+}
+
+const Column& DateFromWeeks_ColumnImpl::child(size_t i) const {
+  xassert(i == 0); (void) i;
+  return arg_;
+}
+
+
+
+
+}

--- a/src/core/column/date_from_weeks.h
+++ b/src/core/column/date_from_weeks.h
@@ -1,0 +1,43 @@
+//------------------------------------------------------------------------------
+// Copyright 2021 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#include "_dt.h"
+#include "column/virtual.h"
+namespace dt {
+
+
+class DateFromWeeks_ColumnImpl : public Virtual_ColumnImpl {
+  private:
+    Column arg_;
+
+  public:
+    DateFromWeeks_ColumnImpl(Column&& arg);
+
+    ColumnImpl* clone() const override;
+    size_t n_children() const noexcept override;
+    const Column& child(size_t i) const override;
+
+    bool get_element(size_t i, int32_t* out) const override;
+};
+
+
+
+}

--- a/src/core/column/date_from_years.cc
+++ b/src/core/column/date_from_years.cc
@@ -1,0 +1,61 @@
+//------------------------------------------------------------------------------
+// Copyright 2021 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#include "column/date_from_years.h"
+#include "lib/hh/date.h"
+#include "stype.h"
+namespace dt {
+
+
+DateFromYears_ColumnImpl::DateFromYears_ColumnImpl(Column&& arg)
+  : Virtual_ColumnImpl(arg.nrows(), SType::DATE32),
+    arg_(std::move(arg))
+{
+  xassert(arg_.type().can_be_read_as<int64_t>());
+}
+
+
+bool DateFromYears_ColumnImpl::get_element(size_t i, int32_t* out) const {
+  int64_t value;
+  bool valid = arg_.get_element(i, &value);
+  int year = static_cast<int>(value) + 1970;
+  *out = hh::days_from_civil(year, 1, 1);
+  return valid;
+}
+
+
+ColumnImpl* DateFromYears_ColumnImpl::clone() const {
+  return new DateFromYears_ColumnImpl(Column(arg_));
+}
+
+size_t DateFromYears_ColumnImpl::n_children() const noexcept {
+  return 1;
+}
+
+const Column& DateFromYears_ColumnImpl::child(size_t i) const {
+  xassert(i == 0); (void) i;
+  return arg_;
+}
+
+
+
+
+}

--- a/src/core/column/date_from_years.h
+++ b/src/core/column/date_from_years.h
@@ -1,0 +1,43 @@
+//------------------------------------------------------------------------------
+// Copyright 2021 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#include "_dt.h"
+#include "column/virtual.h"
+namespace dt {
+
+
+class DateFromYears_ColumnImpl : public Virtual_ColumnImpl {
+  private:
+    Column arg_;
+
+  public:
+    DateFromYears_ColumnImpl(Column&& arg);
+
+    ColumnImpl* clone() const override;
+    size_t n_children() const noexcept override;
+    const Column& child(size_t i) const override;
+
+    bool get_element(size_t i, int32_t* out) const override;
+};
+
+
+
+}

--- a/src/core/py_buffers.cc
+++ b/src/core/py_buffers.cc
@@ -69,15 +69,16 @@ static char strB[] = "B";
 // Construct a Column from a python object implementing Buffers protocol
 //------------------------------------------------------------------------------
 
-Column Column::from_pybuffer(const py::robj& pyobj)
-{
+Column Column::from_pybuffer(const py::robj& pyobj) {
   // Check if this is a datetime64 column, in which case it must be converted
   if (pyobj.is_numpy_array()) {
     auto dtype = pyobj.get_attr("dtype");
     auto kind = dtype.get_attr("kind").to_string();
     if (kind == "M") {  // datetime64
+      // datetime64 column does not support PyBuffers interface, so it has to
+      // be cast into int64 first.
       Column tmp = Column::from_pybuffer(
-          pyobj.invoke("view", py::ostring("int64"))
+        pyobj.invoke("view", py::ostring("int64"))
       );
       xassert(tmp.stype() == dt::SType::INT64);
       auto str = dtype.get_attr("str").to_string();

--- a/tests/types/test-date32.py
+++ b/tests/types/test-date32.py
@@ -90,3 +90,11 @@ def test_date32_from_numpy_datetime64(np, scale):
     arr = np.array(range(-100, 1000), dtype=f'datetime64[{scale}]')
     DT = dt.Frame(arr)
     assert DT.to_list() == [arr.tolist()]
+
+
+def test_from_numpy_with_nats(np):
+    arr = np.array(['2000-01-01', '2020-05-11', 'NaT'], dtype='datetime64[D]')
+    DT = dt.Frame(arr)
+    assert DT.to_list() == [
+        [datetime.date(2000, 1, 1), datetime.date(2020, 5, 11), None]
+    ]

--- a/tests/types/test-date32.py
+++ b/tests/types/test-date32.py
@@ -89,12 +89,14 @@ def test_date32_repr():
 def test_date32_from_numpy_datetime64(np, scale):
     arr = np.array(range(-100, 1000), dtype=f'datetime64[{scale}]')
     DT = dt.Frame(arr)
+    assert DT.types == [dt.Type.date32]
     assert DT.to_list() == [arr.tolist()]
 
 
 def test_from_numpy_with_nats(np):
     arr = np.array(['2000-01-01', '2020-05-11', 'NaT'], dtype='datetime64[D]')
     DT = dt.Frame(arr)
+    assert DT.types == [dt.Type.date32]
     assert DT.to_list() == [
         [datetime.date(2000, 1, 1), datetime.date(2020, 5, 11), None]
     ]

--- a/tests/types/test-date32.py
+++ b/tests/types/test-date32.py
@@ -23,6 +23,7 @@
 #-------------------------------------------------------------------------------
 import datetime
 import datatable as dt
+import pytest
 
 
 
@@ -77,3 +78,15 @@ def test_date32_repr():
         " 2 | 5756-05-09\n"
         "[3 rows x 1 column]\n"
     )
+
+
+
+#-------------------------------------------------------------------------------
+# Convert from numpy
+#-------------------------------------------------------------------------------
+
+@pytest.mark.parametrize("scale", ["D", "W", "M", "Y"])
+def test_date32_from_numpy_datetime64(np, scale):
+    arr = np.array(range(-100, 1000), dtype=f'datetime64[{scale}]')
+    DT = dt.Frame(arr)
+    assert DT.to_list() == [arr.tolist()]


### PR DESCRIPTION
This supports arrays with dtypes `datetime64[D]`, `datetime64[W]`, `datetime64[M]`, `datetime64[Y]`.

WIP for  #2858