### PR TITLE
FTRL refactoring, fix debug builds

### DIFF
--- a/docs/develop/create-fexpr.rst
+++ b/docs/develop/create-fexpr.rst
@@ -166,7 +166,7 @@ inside the current file `expr/fexpr_gcd.cc`.
         {
           xassert(acol_.nrows() == bcol_.nrows());
           xassert(acol_.stype() == bcol_.stype());
-          xassert(acol_.type().can_be_read_as<T>());
+          xassert(acol_.can_be_read_as<T>());
         }
 
         ColumnImpl* clone() const override {

--- a/src/core/column.cc
+++ b/src/core/column.cc
@@ -34,7 +34,6 @@
 #include "sort.h"
 
 
-
 Column Column::new_data_column(size_t nrows, dt::SType stype) {
   return dt::Sentinel_ColumnImpl::make_column(nrows, stype);
 }

--- a/src/core/column.cc
+++ b/src/core/column.cc
@@ -34,6 +34,7 @@
 #include "sort.h"
 
 
+
 Column Column::new_data_column(size_t nrows, dt::SType stype) {
   return dt::Sentinel_ColumnImpl::make_column(nrows, stype);
 }

--- a/src/core/column.h
+++ b/src/core/column.h
@@ -287,8 +287,6 @@ class Column
       return type().can_be_read_as<T>();
     }
 
-  public:
-
   private:
     void _acquire_impl(const dt::ColumnImpl*);
     void _release_impl(const dt::ColumnImpl*);

--- a/src/core/column.h
+++ b/src/core/column.h
@@ -23,6 +23,7 @@
 #define dt_COLUMN_h
 #include "_dt.h"
 #include "stats.h"       // Stat (enum), Stats
+#include "types/type.h"
 
 namespace dt {
   class ColumnImpl;
@@ -126,7 +127,6 @@ class Column
     bool   allow_parallel_access() const;
     size_t memory_footprint() const noexcept;
     operator bool() const noexcept;
-
     dt::ColumnImpl* release() &&;
 
   //------------------------------------
@@ -280,6 +280,14 @@ class Column
     // See frame/to_arrow.cc
     std::unique_ptr<dt::OArrowArray> to_arrow() const;
     std::unique_ptr<dt::OArrowSchema> to_arrow_schema() const;
+
+    // A shortcut for `.type().can_be_read_as<T>()`. The latter call
+    // is not compatible with some compilers, for instance Clang 11.
+    template<typename T> bool can_be_read_as() const {
+      return can_be_read_as<T>();
+    }
+
+  public:
 
   private:
     void _acquire_impl(const dt::ColumnImpl*);

--- a/src/core/column.h
+++ b/src/core/column.h
@@ -284,7 +284,7 @@ class Column
     // A shortcut for `.type().can_be_read_as<T>()`. The latter call
     // is not compatible with some compilers, for instance Clang 11.
     template<typename T> bool can_be_read_as() const {
-      return can_be_read_as<T>();
+      return type().can_be_read_as<T>();
     }
 
   public:

--- a/src/core/column/cast_to_bool.cc
+++ b/src/core/column/cast_to_bool.cc
@@ -65,7 +65,7 @@ template class CastNumericToBool_ColumnImpl<double>;
 
 CastStringToBool_ColumnImpl::CastStringToBool_ColumnImpl(Column&& arg)
   : Cast_ColumnImpl(SType::BOOL, std::move(arg))
-{ xassert(arg_.type().can_be_read_as<CString>()); }
+{ xassert(arg_.can_be_read_as<CString>()); }
 
 
 ColumnImpl* CastStringToBool_ColumnImpl::clone() const {

--- a/src/core/column/date_from_months.cc
+++ b/src/core/column/date_from_months.cc
@@ -29,7 +29,7 @@ DateFromMonths_ColumnImpl::DateFromMonths_ColumnImpl(Column&& arg)
   : Virtual_ColumnImpl(arg.nrows(), SType::DATE32),
     arg_(std::move(arg))
 {
-  xassert(arg_.type().can_be_read_as<int64_t>());
+  xassert(arg_.can_be_read_as<int64_t>());
 }
 
 

--- a/src/core/column/date_from_weeks.cc
+++ b/src/core/column/date_from_weeks.cc
@@ -28,7 +28,7 @@ DateFromWeeks_ColumnImpl::DateFromWeeks_ColumnImpl(Column&& arg)
   : Virtual_ColumnImpl(arg.nrows(), SType::DATE32),
     arg_(std::move(arg))
 {
-  xassert(arg_.type().can_be_read_as<int64_t>());
+  xassert(arg_.can_be_read_as<int64_t>());
 }
 
 

--- a/src/core/column/date_from_years.cc
+++ b/src/core/column/date_from_years.cc
@@ -29,7 +29,7 @@ DateFromYears_ColumnImpl::DateFromYears_ColumnImpl(Column&& arg)
   : Virtual_ColumnImpl(arg.nrows(), SType::DATE32),
     arg_(std::move(arg))
 {
-  xassert(arg_.type().can_be_read_as<int64_t>());
+  xassert(arg_.can_be_read_as<int64_t>());
 }
 
 

--- a/src/core/column/func_binary.h
+++ b/src/core/column/func_binary.h
@@ -198,8 +198,8 @@ void FuncBinary2_ColumnImpl<T1, T2, TO>::verify_integrity() const {
   arg1_.verify_integrity();
   arg2_.verify_integrity();
   xassert(type_.can_be_read_as<TO>());
-  xassert(arg1_.type().template can_be_read_as<T1>());
-  xassert(arg2_.type().template can_be_read_as<T2>());
+  xassert(arg1_.can_be_read_as<T1>());
+  xassert(arg2_.can_be_read_as<T2>());
   XAssert(nrows_ <= arg2_.nrows());
   XAssert(nrows_ <= arg1_.nrows());
   XAssert(func_ != nullptr);

--- a/src/core/column/func_binary.h
+++ b/src/core/column/func_binary.h
@@ -198,8 +198,8 @@ void FuncBinary2_ColumnImpl<T1, T2, TO>::verify_integrity() const {
   arg1_.verify_integrity();
   arg2_.verify_integrity();
   xassert(type_.can_be_read_as<TO>());
-  xassert(arg1_.type().can_be_read_as<T1>());
-  xassert(arg2_.type().can_be_read_as<T2>());
+  xassert(arg1_.type().template can_be_read_as<T1>());
+  xassert(arg2_.type().template can_be_read_as<T2>());
   XAssert(nrows_ <= arg2_.nrows());
   XAssert(nrows_ <= arg1_.nrows());
   XAssert(func_ != nullptr);

--- a/src/core/column/isclose.h
+++ b/src/core/column/isclose.h
@@ -48,8 +48,8 @@ class IsClose_ColumnImpl : public Virtual_ColumnImpl {
         rtol_(rtol),
         atol_(atol)
     {
-      xassert(argx_.type().can_be_read_as<T>());
-      xassert(argy_.type().can_be_read_as<T>());
+      xassert(argx_.type().template can_be_read_as<T>());
+      xassert(argy_.type().template can_be_read_as<T>());
     }
 
     ColumnImpl* clone() const override {

--- a/src/core/column/isclose.h
+++ b/src/core/column/isclose.h
@@ -48,8 +48,8 @@ class IsClose_ColumnImpl : public Virtual_ColumnImpl {
         rtol_(rtol),
         atol_(atol)
     {
-      xassert(argx_.type().template can_be_read_as<T>());
-      xassert(argy_.type().template can_be_read_as<T>());
+      xassert(argx_.can_be_read_as<T>());
+      xassert(argy_.can_be_read_as<T>());
     }
 
     ColumnImpl* clone() const override {

--- a/src/core/column/isna.h
+++ b/src/core/column/isna.h
@@ -36,7 +36,7 @@ class Isna_ColumnImpl : public Virtual_ColumnImpl {
       : Virtual_ColumnImpl(col.nrows(), SType::BOOL),
         arg_(std::move(col))
     {
-      xassert(arg_.type().can_be_read_as<T>());
+      xassert(arg_.type().template can_be_read_as<T>());
     }
 
 

--- a/src/core/column/isna.h
+++ b/src/core/column/isna.h
@@ -36,7 +36,7 @@ class Isna_ColumnImpl : public Virtual_ColumnImpl {
       : Virtual_ColumnImpl(col.nrows(), SType::BOOL),
         arg_(std::move(col))
     {
-      xassert(arg_.type().template can_be_read_as<T>());
+      xassert(arg_.can_be_read_as<T>());
     }
 
 

--- a/src/core/column/npmasked.cc
+++ b/src/core/column/npmasked.cc
@@ -45,7 +45,7 @@ ColumnImpl* NpMasked_ColumnImpl::clone() const {
 
 template <typename T>
 void NpMasked_ColumnImpl::_apply_mask(Column& out) {
-  xassert(arg_.type().can_be_read_as<T>());
+  xassert(arg_.can_be_read_as<T>());
   auto mask_data = static_cast<const bool*>(mask_.rptr());
   auto col_data = static_cast<T*>(arg_.get_data_editable());
 

--- a/src/core/expr/fbinary/fexpr__truediv__.cc
+++ b/src/core/expr/fbinary/fexpr__truediv__.cc
@@ -65,7 +65,7 @@ class FExpr__truediv__ : public FExpr_BinaryOp {
       size_t nrows = a.nrows();
       a.cast_inplace(stype);
       b.cast_inplace(stype);
-      xassert(a.type().can_be_read_as<T>());
+      xassert(a.can_be_read_as<T>());
       return Column(new FuncBinary1_ColumnImpl<T, T, T>(
         std::move(a), std::move(b),
         [](T x, T y){

--- a/src/core/expr/fbinary/math.cc
+++ b/src/core/expr/fbinary/math.cc
@@ -24,9 +24,8 @@
 #include "ltype.h"
 #include "python/args.h"
 #include "utils/macros.h"
-#if DT_OS_WINDOWS
-  #undef copysign
-#endif
+
+
 namespace dt {
 namespace expr {
 

--- a/src/core/expr/fexpr_round.cc
+++ b/src/core/expr/fexpr_round.cc
@@ -69,7 +69,7 @@ class RoundNeg_ColumnImpl : public Virtual_ColumnImpl {
         arg_(std::move(arg)),
         scale_(scale)
     {
-      xassert(arg_.type().can_be_read_as<T>());
+      xassert(arg_.type().template can_be_read_as<T>());
     }
 
     ColumnImpl* clone() const override {

--- a/src/core/expr/fexpr_round.cc
+++ b/src/core/expr/fexpr_round.cc
@@ -69,7 +69,7 @@ class RoundNeg_ColumnImpl : public Virtual_ColumnImpl {
         arg_(std::move(arg)),
         scale_(scale)
     {
-      xassert(arg_.type().template can_be_read_as<T>());
+      xassert(arg_.can_be_read_as<T>());
     }
 
     ColumnImpl* clone() const override {

--- a/src/core/frame/join.cc
+++ b/src/core/frame/join.cc
@@ -187,8 +187,8 @@ template <typename TX, typename TJ>
 FwCmp<TX, TJ>::FwCmp(const Column& xcol, const Column& jcol)
   : colX(xcol), colJ(jcol)
 {
-  xassert(xcol.type().can_be_read_as<TX>());
-  xassert(jcol.type().can_be_read_as<TJ>());
+  xassert(xcol.can_be_read_as<TX>());
+  xassert(jcol.can_be_read_as<TJ>());
 }
 
 template <typename TX, typename TJ>

--- a/src/core/models/dt_ftrl.cc
+++ b/src/core/models/dt_ftrl.cc
@@ -29,9 +29,6 @@
 #include "column.h"
 #include "wstringcol.h"
 #include "utils/macros.h"
-#if DT_OS_WINDOWS
-  #undef copysign
-#endif
 
 namespace dt {
 
@@ -149,18 +146,18 @@ template <typename T>
 FtrlFitOutput Ftrl<T>::fit_binomial() {
   dtptr dt_y_train_binomial, dt_y_val_binomial;
   bool validation = _notnan(nepochs_val);
-  create_y_binomial(dt_y_train, dt_y_train_binomial, label_ids_train);
+  create_y_binomial(dt_y_train, dt_y_train_binomial, label_ids_train, dt_labels);
 
-  // NA values are ignored during training, so if we stop training right away,
-  // if got only NA's.
+  // NA values are ignored during training, so we stop training right away,
+  // if got NA's only.
   if (dt_y_train_binomial == nullptr) return {0, static_cast<double>(T_NAN)};
   dt_y_train = dt_y_train_binomial.get();
 
   if (validation) {
-    create_y_binomial(dt_y_val, dt_y_val_binomial, label_ids_val);
+    create_y_binomial(dt_y_val, dt_y_val_binomial, label_ids_val, dt_labels);
     if (dt_y_val_binomial == nullptr) {
       throw ValueError() << "Cannot set early stopping criteria as validation "
-                            "target column got only `NA` targets";
+                            "target column got `NA` targets only";
     }
     dt_y_val = dt_y_val_binomial.get();
   }
@@ -181,105 +178,9 @@ FtrlFitOutput Ftrl<T>::fit_binomial() {
 
 
 /**
- *  Convert target column to boolean type, and set up mapping
- *  between models and the incoming label inficators.
- */
-template <typename T>
-void Ftrl<T>::create_y_binomial(const DataTable* dt,
-                                dtptr& dt_binomial,
-                                std::vector<size_t>& label_ids) {
-  xassert(label_ids.size() == 0);
-  dtptr dt_labels_in;
-  label_encode(dt->get_column(0), dt_labels_in, dt_binomial, true);
-
-  // If we only got NA targets, return to stop training.
-  if (dt_labels_in == nullptr) return;
-  size_t nlabels_in = dt_labels_in->nrows();
-
-  if (nlabels_in > 2) {
-    throw ValueError() << "For binomial regression target column should have "
-                       << "two labels at maximum, got: " << nlabels_in;
-  }
-
-  // By default we assume zero model got zero label id
-  label_ids.push_back(0);
-
-  if (dt_labels == nullptr) {
-    dt_labels = std::move(dt_labels_in);
-  } else {
-
-    RowIndex ri_join = natural_join(*dt_labels_in.get(), *dt_labels.get());
-    size_t nlabels = dt_labels->nrows();
-    xassert(nlabels != 0 && nlabels < 3);
-    auto data_label_ids_in = static_cast<int32_t*>(
-                              dt_labels_in->get_column(1).get_data_editable());
-    auto data_label_ids = static_cast<const int32_t*>(
-                              dt_labels->get_column(1).get_data_readonly());
-
-    size_t ri0_index = 0, ri1_index;
-    bool ri0_valid = (ri_join.size() >= 1) && ri_join.get_element(0, &ri0_index);
-    bool ri1_valid = (ri_join.size() >= 2) && ri_join.get_element(1, &ri1_index);
-
-    switch (nlabels) {
-      case 1: switch (nlabels_in) {
-                 case 1: if (!ri0_valid) {
-                           // The new label we got was encoded with zeros,
-                           // so we train the model on all negatives: 1 == 0
-                           label_ids[0] = 1;
-                           data_label_ids_in[0] = 1;
-                           // Since we cannot rbind anything to a keyed frame, we
-                           // - clear the key;
-                           // - rbind new labels;
-                           // - set the key back, this will sort the resulting `dt_labels`.
-                           dt_labels->clear_key();
-                           dt_labels->rbind({ dt_labels_in.get() }, {{ 0 }, { 1 }});
-                           sztvec keys{ 0 };
-                           dt_labels->set_key(keys);
-                         }
-                         break;
-                 case 2: if (!ri0_valid && !ri1_valid) {
-                           throw ValueError() << "Got two new labels in the target column, "
-                                              << "however, positive label is already set";
-                         }
-                         // If the new label is the zero label,
-                         // then we need to train on the existing label indicator
-                         // i.e. the first one.
-                         label_ids[0] = static_cast<size_t>(data_label_ids_in[!ri0_valid]);
-                         // Reverse labels id order if the new label comes first.
-                         if (label_ids[0] == 1) {
-                           data_label_ids_in[0] = 1;
-                           data_label_ids_in[1] = 0;
-                         }
-                         dt_labels = std::move(dt_labels_in);
-              }
-              break;
-
-      case 2: switch (nlabels_in) {
-                case 1: if (!ri0_valid) {
-                          throw ValueError() << "Got a new label in the target column, however, both "
-                                             << "positive and negative labels are already set";
-                        }
-                        label_ids[0] = (data_label_ids[ri0_index] == 1);
-                        break;
-                case 2: if (!ri0_valid || !ri1_valid) {
-                          throw ValueError() << "Got a new label in the target column, however, both "
-                                             << "positive and negative labels are already set";
-                        }
-                        size_t label_id = static_cast<size_t>(data_label_ids[ri0_index] != 0);
-                        label_ids[0] = static_cast<size_t>(data_label_ids_in[label_id]);
-
-                        break;
-              }
-              break;
-    }
-  }
-}
-
-
-/**
  *  Create labels (in the case of numeric regression there is no actual
  *  labeles, so we just use a column name for this purpose),
- *  set up identity mapping between models and the incoming label inficators,
+ *  set up identity mapping between models and the incoming label indicators,
  *  call to the main `fit` method.
  */
 template <typename T>
@@ -350,7 +251,16 @@ FtrlFitOutput Ftrl<T>::fit_multinomial() {
 
 
   dtptr dt_y_train_multinomial;
-  create_y_multinomial(dt_y_train, dt_y_train_multinomial, label_ids_train);
+  size_t n_new_labels = create_y_multinomial(
+                          dt_y_train, dt_y_train_multinomial, label_ids_train,
+                          dt_labels, params.negative_class
+                        );
+
+  // Adjust trained model if we got new labels
+  if (n_new_labels) {
+    xassert(is_model_trained());
+    adjust_model();
+  }
 
   if (dt_y_train_multinomial == nullptr) return {0, static_cast<double>(T_NAN)};
   dt_y_train = dt_y_train_multinomial.get();
@@ -358,10 +268,11 @@ FtrlFitOutput Ftrl<T>::fit_multinomial() {
   // Create validation targets if needed.
   dtptr dt_y_val_multinomial;
   if (_notnan(nepochs_val)) {
-    create_y_multinomial(dt_y_val, dt_y_val_multinomial, label_ids_val, true);
+    create_y_multinomial(dt_y_val, dt_y_val_multinomial, label_ids_val, dt_labels,
+                         params.negative_class, true);
     if (dt_y_val_multinomial == nullptr)
       throw ValueError() << "Cannot set early stopping criteria as validation "
-                         << "target column got only `NA` targets";
+                         << "target column got `NA` targets only";
     dt_y_val = dt_y_val_multinomial.get();
   }
 
@@ -380,157 +291,6 @@ FtrlFitOutput Ftrl<T>::fit_multinomial() {
   return fit<int32_t, int32_t>(sigmoid<T>, targetfn, targetfn, log_loss<T>);
 }
 
-
-/**
- *  Add negative class label and save its model id.
- */
-template <typename T>
-void Ftrl<T>::add_negative_class() {
-  dt::writable_string_col c_labels(1);
-  dt::writable_string_col::buffer_impl<uint32_t> sb(c_labels);
-  sb.commit_and_start_new_chunk(0);
-  sb.write("_negative_class");
-  sb.order();
-  sb.commit_and_start_new_chunk(1);
-
-  Column c_ids = Column::new_data_column(1, SType::INT32);
-  auto d_ids = static_cast<int32_t*>(c_ids.get_data_editable());
-  d_ids[0] = 0;
-
-  dtptr dt_nc = dtptr(
-                  new DataTable(
-                    {std::move(c_labels).to_ocolumn(), std::move(c_ids)},
-                    dt_labels->get_names()
-                  )
-                );
-
-  dt_labels->clear_key();
-
-  // Increment all the exiting label ids, and then insert
-  // a `_negative_class` label with the zero id.
-  adjust_values<int32_t>(
-    dt_labels->get_column(1),
-    [](int32_t& value, size_t) {
-      ++value;
-    }
-  );
-
-  dt_labels->rbind({dt_nc.get()}, {{ 0 } , { 1 }});
-  sztvec keys{ 0 };
-  dt_labels->set_key(keys);
-}
-
-
-/**
- *  Encode target column with the integer labels, and set up mapping
- *  between models and the incoming label indicators.
- */
-template <typename T>
-void Ftrl<T>::create_y_multinomial(const DataTable* dt,
-                                   dtptr& dt_multinomial,
-                                   std::vector<size_t>& label_ids,
-                                   bool validation /* = false */) {
-  xassert(label_ids.size() == 0);
-  dtptr dt_labels_in;
-  label_encode(dt->get_column(0), dt_labels_in, dt_multinomial);
-
-  // If we only got NA targets, return to stop training.
-  if (dt_labels_in == nullptr) return;
-
-  auto data_label_ids_in = static_cast<const int32_t*>(
-                              dt_labels_in->get_column(1).get_data_readonly()
-                           );
-  size_t nlabels_in = dt_labels_in->nrows();
-
-  // When we start training for the first time, all the incoming labels
-  // become the model labels. Mapping is trivial in this case.
-  if (dt_labels == nullptr) {
-    dt_labels = std::move(dt_labels_in);
-    if (params.negative_class) {
-      add_negative_class();
-      ++nlabels_in;
-    }
-
-    label_ids.resize(nlabels_in);
-    for (size_t i = 0; i < nlabels_in; ++i) {
-      label_ids[i] = i - params.negative_class;
-    }
-
-  } else {
-    // When we already have some labels, and got new ones, we first
-    // set up mapping in such a way, so that models will train
-    // on all the negatives.
-    auto data_label_ids = static_cast<const int32_t*>(
-                            dt_labels->get_column(1).get_data_readonly()
-                          );
-
-    RowIndex ri_join = natural_join(*dt_labels_in.get(), *dt_labels.get());
-    size_t nlabels = dt_labels->nrows();
-
-    for (size_t i = 0; i < nlabels; ++i) {
-      label_ids.push_back(std::numeric_limits<size_t>::max());
-    }
-
-    // Then we go through the list of new labels and relate existing models
-    // to the incoming label indicators.
-    Buffer new_label_indices = Buffer::mem(nlabels_in * sizeof(int64_t));
-    int64_t* data = static_cast<int64_t*>(new_label_indices.xptr());
-    size_t n_new_labels = 0;
-    for (size_t i = 0; i < nlabels_in; ++i) {
-      size_t rii;
-      bool rii_valid = ri_join.get_element(i, &rii);
-      size_t label_id_in = static_cast<size_t>(data_label_ids_in[i]);
-      if (rii_valid) {
-        size_t label_id = static_cast<size_t>(data_label_ids[rii]);
-        label_ids[label_id] = label_id_in;
-      } else {
-        // If there is no corresponding label already set,
-        // we will need to create a new one and its model.
-        data[n_new_labels] = static_cast<int64_t>(i);
-        label_ids.push_back(label_id_in);
-        n_new_labels++;
-      }
-    }
-
-    if (n_new_labels) {
-      // In the case of validation we don't allow unseen labels.
-      if (validation) {
-        throw ValueError() << "Validation target column cannot contain labels, "
-                           << "the model was not trained on";
-      }
-
-      // Extract new labels from `dt_labels_in`, and rbind them to `dt_labels`.
-      new_label_indices.resize(n_new_labels * sizeof(int64_t),
-                               true);  // keep data
-      RowIndex ri_labels(std::move(new_label_indices), RowIndex::ARR64);
-      dt_labels_in->apply_rowindex(ri_labels);
-
-      // Set new ids for the incoming labels, so that they can be rbinded
-      // to the existing ones. NB: this operation won't affect the relation
-      // between the models and label indicators, because at this point
-      // it has been already set in `label_ids`.
-      adjust_values<int32_t>(
-        dt_labels_in->get_column(1),
-        [&] (int32_t& value, size_t irow) {
-          value = static_cast<int32_t>(irow + dt_labels->nrows());
-        }
-      );
-
-      // Since we cannot rbind anything to a keyed frame, we
-      // - clear the key;
-      // - rbind new labels;
-      // - set the key back, this will sort the resulting `dt_labels`.
-      dt_labels->clear_key();
-      dt_labels->rbind({ dt_labels_in.get() }, {{ 0 } , { 1 }});
-      sztvec keys{ 0 };
-      dt_labels->set_key(keys);
-
-      // Add new models for the new labels.
-      if (n_new_labels) adjust_model();
-    }
-
-  }
-}
 
 
 /**
@@ -1168,22 +928,19 @@ void Ftrl<T>::hash_row(uint64ptr& x, std::vector<hasherptr>& hashers,
                            size_t row) {
   // Hash column values adding a column name hash, so that the same value
   // in different columns results in different hashes.
-  for (size_t i = 0; i < hashers.size(); ++i) {
+  size_t i;
+  for (i = 0; i < hashers.size(); ++i) {
     x[i] = (hashers[i]->hash(row) + colname_hashes[i]) % params.nbins;
   }
 
   // Do feature interactions.
-  if (interactions.size() > 0) {
-    size_t count = 0;
-    for (auto interaction : interactions) {
-      size_t i = hashers.size() + count;
-      x[i] = 0;
-      for (auto feature_id : interaction) {
-        x[i] += x[feature_id];
-      }
-      x[i] %= params.nbins;
-      count++;
+  for (auto interaction : interactions) {
+    x[i] = 0;
+    for (auto feature_id : interaction) {
+      x[i] += x[feature_id];
     }
+    x[i] %= params.nbins;
+    i++;
   }
 }
 

--- a/src/core/models/dt_ftrl.h
+++ b/src/core/models/dt_ftrl.h
@@ -32,10 +32,11 @@ namespace dt {
 
 
 /**
- *  Class template that implements all the virtual methods declared in dt::Ftrl.
+ *  Class template that implements all the virtual methods declared in
+ *  dt::FtrlBase.
  */
 template <typename T /* float or double */>
-class Ftrl : public dt::FtrlBase {
+class Ftrl : public FtrlBase {
   private:
     // Model datatable of shape (nbins, 2 * nlabels),
     // a vector of weight pointers, and the model type.
@@ -117,16 +118,11 @@ class Ftrl : public dt::FtrlBase {
     void hash_row(uint64ptr&, std::vector<hasherptr>&, size_t);
 
     // Model helper methods
-    void add_negative_class();
     void create_model();
     void adjust_model();
     void init_model();
     void init_weights();
     void reset_model_stats();
-
-    // Do label encoding and set up mapping information
-    void create_y_binomial(const DataTable*, dtptr&, std::vector<size_t>&);
-    void create_y_multinomial(const DataTable*, dtptr&, std::vector<size_t>&, bool validation = false);
 
     // Feature importance helper methods
     void create_fi();

--- a/src/core/models/label_encode.cc
+++ b/src/core/models/label_encode.cc
@@ -109,4 +109,253 @@ static void label_encode_bool(const Column& col,
 }
 
 
+/**
+ *  Add negative class label and save its model id.
+ */
+void add_negative_class(dtptr& dt_labels) {
+  dt::writable_string_col c_labels(1);
+  dt::writable_string_col::buffer_impl<uint32_t> sb(c_labels);
+  sb.commit_and_start_new_chunk(0);
+  sb.write("_negative_class");
+  sb.order();
+  sb.commit_and_start_new_chunk(1);
+
+  Column c_ids = Column::new_data_column(1, SType::INT32);
+  auto d_ids = static_cast<int32_t*>(c_ids.get_data_editable());
+  d_ids[0] = 0;
+
+  dtptr dt_nc = dtptr(
+                  new DataTable(
+                    {std::move(c_labels).to_ocolumn(), std::move(c_ids)},
+                    dt_labels->get_names()
+                  )
+                );
+
+  dt_labels->clear_key();
+
+  // Increment all the exiting label ids, and then insert
+  // a `_negative_class` label with the zero id.
+  adjust_values<int32_t>(
+    dt_labels->get_column(1),
+    [](int32_t& value, size_t) {
+      ++value;
+    }
+  );
+
+  dt_labels->rbind({dt_nc.get()}, {{ 0 } , { 1 }});
+  sztvec keys{ 0 };
+  dt_labels->set_key(keys);
+}
+
+
+/**
+ *  Convert target column to boolean type, and set up mapping
+ *  between models and the incoming label inficators.
+ */
+void create_y_binomial(const DataTable* dt,
+                       dtptr& dt_binomial,
+                       std::vector<size_t>& label_ids,
+                       dtptr& dt_labels) {
+  xassert(label_ids.size() == 0);
+  dtptr dt_labels_in;
+  label_encode(dt->get_column(0), dt_labels_in, dt_binomial, true);
+
+  // If we only got NA targets, return to stop training.
+  if (dt_labels_in == nullptr) return;
+  size_t nlabels_in = dt_labels_in->nrows();
+
+  if (nlabels_in > 2) {
+    throw ValueError() << "For binomial regression target column should have "
+                       << "two labels at maximum, got: " << nlabels_in;
+  }
+
+  // By default we assume zero model got zero label id
+  label_ids.push_back(0);
+
+  if (dt_labels == nullptr) {
+    dt_labels = std::move(dt_labels_in);
+  } else {
+
+    RowIndex ri_join = natural_join(*dt_labels_in.get(), *dt_labels.get());
+    size_t nlabels = dt_labels->nrows();
+    xassert(nlabels != 0 && nlabels < 3);
+    auto data_label_ids_in = static_cast<int32_t*>(
+                              dt_labels_in->get_column(1).get_data_editable());
+    auto data_label_ids = static_cast<const int32_t*>(
+                              dt_labels->get_column(1).get_data_readonly());
+
+    size_t ri0_index = 0, ri1_index;
+    bool ri0_valid = (ri_join.size() >= 1) && ri_join.get_element(0, &ri0_index);
+    bool ri1_valid = (ri_join.size() >= 2) && ri_join.get_element(1, &ri1_index);
+
+    switch (nlabels) {
+      case 1: switch (nlabels_in) {
+                 case 1: if (!ri0_valid) {
+                           // The new label we got was encoded with zeros,
+                           // so we train the model on all negatives: 1 == 0
+                           label_ids[0] = 1;
+                           data_label_ids_in[0] = 1;
+                           // Since we cannot rbind anything to a keyed frame, we
+                           // - clear the key;
+                           // - rbind new labels;
+                           // - set the key back, this will sort the resulting `dt_labels`.
+                           dt_labels->clear_key();
+                           dt_labels->rbind({ dt_labels_in.get() }, {{ 0 }, { 1 }});
+                           sztvec keys{ 0 };
+                           dt_labels->set_key(keys);
+                         }
+                         break;
+                 case 2: if (!ri0_valid && !ri1_valid) {
+                           throw ValueError() << "Got two new labels in the target column, "
+                                              << "however, positive label is already set";
+                         }
+                         // If the new label is the zero label,
+                         // then we need to train on the existing label indicator
+                         // i.e. the first one.
+                         label_ids[0] = static_cast<size_t>(data_label_ids_in[!ri0_valid]);
+                         // Reverse labels id order if the new label comes first.
+                         if (label_ids[0] == 1) {
+                           data_label_ids_in[0] = 1;
+                           data_label_ids_in[1] = 0;
+                         }
+                         dt_labels = std::move(dt_labels_in);
+              }
+              break;
+
+      case 2: switch (nlabels_in) {
+                case 1: if (!ri0_valid) {
+                          throw ValueError() << "Got a new label in the target column, however, both "
+                                             << "positive and negative labels are already set";
+                        }
+                        label_ids[0] = (data_label_ids[ri0_index] == 1);
+                        break;
+                case 2: if (!ri0_valid || !ri1_valid) {
+                          throw ValueError() << "Got a new label in the target column, however, both "
+                                             << "positive and negative labels are already set";
+                        }
+                        size_t label_id = static_cast<size_t>(data_label_ids[ri0_index] != 0);
+                        label_ids[0] = static_cast<size_t>(data_label_ids_in[label_id]);
+
+                        break;
+              }
+              break;
+    }
+  }
+}
+
+
+/**
+ *  Encode target column with the integer labels, and set up mapping
+ *  between models and the incoming label indicators.
+ */
+size_t create_y_multinomial(const DataTable* dt,
+                          dtptr& dt_multinomial,
+                          std::vector<size_t>& label_ids,
+                          dtptr& dt_labels,
+                          const bool negative_class,
+                          bool validation /* = false */) {
+  xassert(label_ids.size() == 0);
+  dtptr dt_labels_in;
+  label_encode(dt->get_column(0), dt_labels_in, dt_multinomial);
+
+  // If we only got NA targets, return to stop training.
+  if (dt_labels_in == nullptr) return 0;
+
+  auto data_label_ids_in = static_cast<const int32_t*>(
+                              dt_labels_in->get_column(1).get_data_readonly()
+                           );
+  size_t nlabels_in = dt_labels_in->nrows();
+
+  // When we start training for the first time, all the incoming labels
+  // become the model labels. Mapping is trivial in this case.
+  if (dt_labels == nullptr) {
+    dt_labels = std::move(dt_labels_in);
+    if (negative_class) {
+      add_negative_class(dt_labels);
+      ++nlabels_in;
+    }
+
+    label_ids.resize(nlabels_in);
+    for (size_t i = 0; i < nlabels_in; ++i) {
+      label_ids[i] = i - negative_class;
+    }
+
+  } else {
+    // When we already have some labels, and got new ones, we first
+    // set up mapping in such a way, so that models will train
+    // on all the negatives.
+    auto data_label_ids = static_cast<const int32_t*>(
+                            dt_labels->get_column(1).get_data_readonly()
+                          );
+
+    RowIndex ri_join = natural_join(*dt_labels_in.get(), *dt_labels.get());
+    size_t nlabels = dt_labels->nrows();
+
+    for (size_t i = 0; i < nlabels; ++i) {
+      label_ids.push_back(std::numeric_limits<size_t>::max());
+    }
+
+    // Then we go through the list of new labels and relate existing models
+    // to the incoming label indicators.
+    Buffer new_label_indices = Buffer::mem(nlabels_in * sizeof(int64_t));
+    int64_t* data = static_cast<int64_t*>(new_label_indices.xptr());
+    size_t n_new_labels = 0;
+    for (size_t i = 0; i < nlabels_in; ++i) {
+      size_t rii;
+      bool rii_valid = ri_join.get_element(i, &rii);
+      size_t label_id_in = static_cast<size_t>(data_label_ids_in[i]);
+      if (rii_valid) {
+        size_t label_id = static_cast<size_t>(data_label_ids[rii]);
+        label_ids[label_id] = label_id_in;
+      } else {
+        // If there is no corresponding label already set,
+        // we will need to create a new one and its model.
+        data[n_new_labels] = static_cast<int64_t>(i);
+        label_ids.push_back(label_id_in);
+        n_new_labels++;
+      }
+    }
+
+    if (n_new_labels) {
+      // In the case of validation we don't allow unseen labels.
+      if (validation) {
+        throw ValueError() << "Validation target column cannot contain labels, "
+                           << "the model was not trained on";
+      }
+
+      // Extract new labels from `dt_labels_in`, and rbind them to `dt_labels`.
+      new_label_indices.resize(n_new_labels * sizeof(int64_t),
+                               true);  // keep data
+      RowIndex ri_labels(std::move(new_label_indices), RowIndex::ARR64);
+      dt_labels_in->apply_rowindex(ri_labels);
+
+      // Set new ids for the incoming labels, so that they can be rbinded
+      // to the existing ones. NB: this operation won't affect the relation
+      // between the models and label indicators, because at this point
+      // it has been already set in `label_ids`.
+      adjust_values<int32_t>(
+        dt_labels_in->get_column(1),
+        [&] (int32_t& value, size_t irow) {
+          value = static_cast<int32_t>(irow + dt_labels->nrows());
+        }
+      );
+
+      // Since we cannot rbind anything to a keyed frame, we
+      // - clear the key;
+      // - rbind new labels;
+      // - set the key back, this will sort the resulting `dt_labels`.
+      dt_labels->clear_key();
+      dt_labels->rbind({ dt_labels_in.get() }, {{ 0 } , { 1 }});
+      sztvec keys{ 0 };
+      dt_labels->set_key(keys);
+
+      return n_new_labels;
+    }
+
+  }
+
+  return 0;
+}
+
+
 } // namespace dt

--- a/src/core/models/label_encode.h
+++ b/src/core/models/label_encode.h
@@ -230,6 +230,11 @@ void label_encode_str(const Column& ocol,
 }
 
 
+// These functions do label encoding and set up mapping information
+void create_y_binomial(const DataTable*, dtptr&, std::vector<size_t>&, dtptr& dt_labels);
+size_t create_y_multinomial(const DataTable*, dtptr&, std::vector<size_t>&, dtptr&,
+                            const bool, bool validation = false);
+void add_negative_class(dtptr&);
 
 
 } // namespace dt

--- a/src/core/models/py_ftrl.cc
+++ b/src/core/models/py_ftrl.cc
@@ -572,12 +572,6 @@ oobj Ftrl::predict(const PKArgs& args) {
   }
 
 
-  if (!py_params->get_attr("interactions").is_none()
-      && !dtft->get_interactions().size()) {
-    init_dt_interactions();
-  }
-
-
   DataTable* dt_p = dtft->predict(dt_X).release();
   py::oobj df_p = py::Frame::oframe(dt_p);
 

--- a/src/core/models/py_ftrl.h
+++ b/src/core/models/py_ftrl.h
@@ -66,7 +66,6 @@ class Ftrl : public XObject<Ftrl> {
 
     // Getters
     oobj get_labels() const;
-    oobj get_dt_labels() const;
     oobj get_fi() const;
     oobj get_normalized_fi(bool) const;
     oobj get_model() const;

--- a/src/core/py_buffers.cc
+++ b/src/core/py_buffers.cc
@@ -490,7 +490,7 @@ static const char* format_from_stype(dt::SType stype)
 
 template <typename T>
 static void _copy_column_fw(const Column& col, Buffer& buf) {
-  xassert(col.type().can_be_read_as<T>());
+  xassert(col.can_be_read_as<T>());
   xassert(buf.size() == col.nrows() * sizeof(T));
   auto nthreads = dt::NThreads(col.allow_parallel_access());
   auto out_data = static_cast<T*>(buf.wptr());
@@ -504,7 +504,7 @@ static void _copy_column_fw(const Column& col, Buffer& buf) {
 }
 
 static void _copy_column_obj(const Column& col, Buffer& buf) {
-  xassert(col.type().can_be_read_as<py::oobj>());
+  xassert(col.can_be_read_as<py::oobj>());
   xassert(buf.size() == col.nrows() * sizeof(py::oobj));
   xassert(!buf.is_pyobjects());
   auto out_data = reinterpret_cast<PyObject**>(buf.wptr());

--- a/src/core/sort/sorter_float.h
+++ b/src/core/sort/sorter_float.h
@@ -81,7 +81,7 @@ class Sorter_Float : public SSorter<T>
     Sorter_Float(const Column& col)
       : column_(col)
     {
-      xassert(col.type().can_be_read_as<TE>());
+      xassert(col.can_be_read_as<TE>());
     }
 
 

--- a/src/core/sort/sorter_int.h
+++ b/src/core/sort/sorter_int.h
@@ -60,7 +60,7 @@ class Sorter_Int : public SSorter<T>
     Sorter_Int(const Column& col)
       : column_(col)
     {
-      xassert(col.type().can_be_read_as<TI>());
+      xassert(col.can_be_read_as<TI>());
     }
 
 

--- a/src/core/stats.cc
+++ b/src/core/stats.cc
@@ -503,7 +503,7 @@ void StringStats::set_mode(const dt::CString& value, bool isvalid) {
 
 template <typename T>
 static size_t _compute_nacount(const dt::ColumnImpl* col) {
-  xassert(col->type().can_be_read_as<T>());
+  xassert(col->can_be_read_as<T>());
   std::atomic<size_t> total_countna { 0 };
   dt::parallel_region(
     dt::NThreads(col->allow_parallel_access()),
@@ -564,7 +564,7 @@ void BooleanStats::compute_minmax() {
 
 template <typename T>
 void NumericStats<T>::compute_minmax() {
-  xassert(column->type().can_be_read_as<T>());
+  xassert(column->can_be_read_as<T>());
   size_t nrows = column->nrows();
   size_t count_valid = 0;
   T min = infinity<T>();

--- a/src/core/stats.cc
+++ b/src/core/stats.cc
@@ -503,7 +503,7 @@ void StringStats::set_mode(const dt::CString& value, bool isvalid) {
 
 template <typename T>
 static size_t _compute_nacount(const dt::ColumnImpl* col) {
-  xassert(col->can_be_read_as<T>());
+  xassert(col->type().can_be_read_as<T>());
   std::atomic<size_t> total_countna { 0 };
   dt::parallel_region(
     dt::NThreads(col->allow_parallel_access()),
@@ -564,7 +564,7 @@ void BooleanStats::compute_minmax() {
 
 template <typename T>
 void NumericStats<T>::compute_minmax() {
-  xassert(column->can_be_read_as<T>());
+  xassert(column->type().can_be_read_as<T>());
   size_t nrows = column->nrows();
   size_t count_valid = 0;
   T min = infinity<T>();

--- a/src/core/utils/macros.h
+++ b/src/core/utils/macros.h
@@ -65,6 +65,9 @@
   #error Unknown operating system
 #endif
 
+#if DT_OS_WINDOWS
+  #undef copysign
+#endif
 
 
 //------------------------------------------------------------------------------

--- a/tests/models/test-ftrl.py
+++ b/tests/models/test-ftrl.py
@@ -50,10 +50,6 @@ tparams = Params(alpha = 1, beta = 2, lambda1 = 3, lambda2 = 4, nbins = 5,
                  negative_class = True, interactions = (("C0",),),
                  model_type = 'binomial')
 
-tmodel = dt.Frame([[random.random() for _ in range(tparams.nbins)],
-                   [random.random() for _ in range(tparams.nbins)]],
-                   names=['z', 'n'])
-
 default_params = Params(alpha = 0.005, beta = 1, lambda1 = 0, lambda2 = 0,
                         nbins = 10**6, mantissa_nbits = 10, nepochs = 1,
                         double_precision = False, negative_class = False,
@@ -1340,6 +1336,7 @@ def test_ftrl_early_stopping_float(validation_average_niterations):
     assert_equals(ft.model, ft1.model)
     assert_equals(p, p1)
 
+
 @pytest.mark.parametrize('validation_average_niterations', [1,5,10])
 def test_ftrl_early_stopping_regression(validation_average_niterations):
     nepochs = 10000
@@ -1585,7 +1582,7 @@ def test_ftrl_reuse_pickled_empty_model():
     df_target = dt.Frame([True] * ft_unpickled.nbins)
     ft_unpickled.fit(df_train, df_target)
     model = [[0.5] * ft_unpickled.nbins, [0.25] * ft_unpickled.nbins]
-    fi = dt.Frame([["id"], [0.0]])[:, [f[0], dt.float32(f[1])]]
+    fi = dt.Frame([["id"], [0.0]/stype.float32])
     fi.names = ["feature_name", "feature_importance"]
     assert ft_unpickled.model.to_list() == model
     assert_equals(ft_unpickled.feature_importances, fi)


### PR DESCRIPTION
Extract FTRL related changes from https://github.com/h2oai/datatable/pull/2871:
- move label encoding functionality to `label_encode.*`;
- clean-up interactions handling;
- minor improvements and refactoring.

Also, fix `make debug`, so that it doesn't fail due to `error: use 'template' keyword to treat '...' as a dependent template name`.