### PR TITLE
date32 to/from pyarrow

### DIFF
--- a/src/core/column_from_arrow.cc
+++ b/src/core/column_from_arrow.cc
@@ -123,8 +123,15 @@ Column Column::from_arrow(std::shared_ptr<dt::OArrowArray>&& array,
       return  _make_vw<uint64_t>(dt::SType::STR64, std::move(array));
     }
     case 't': {  // various time formats
-      if (format[1] == 'd' && format[2] == 'D') {
-        return _make_fw(dt::SType::DATE32, std::move(array));
+      if (format[1] == 'd') {
+        if (format[2] == 'D') {  // date32
+          return _make_fw(dt::SType::DATE32, std::move(array));
+        }
+        if (format[2] == 'm') {  // date64
+          Column res = _make_fw(dt::SType::INT64, std::move(array));
+          res.cast_inplace(dt::SType::DATE32);
+          return res;
+        }
       }
       break;
     }

--- a/src/core/column_from_arrow.cc
+++ b/src/core/column_from_arrow.cc
@@ -122,6 +122,12 @@ Column Column::from_arrow(std::shared_ptr<dt::OArrowArray>&& array,
     case 'U': {  // large  utf-8 string
       return  _make_vw<uint64_t>(dt::SType::STR64, std::move(array));
     }
+    case 't': {  // various time formats
+      if (format[1] == 'd' && format[2] == 'D') {
+        return _make_fw(dt::SType::DATE32, std::move(array));
+      }
+      break;
+    }
   }
   throw NotImplError()
     << "Cannot create a column from an Arrow array with format `" << format << "`";

--- a/src/core/frame/to_arrow.cc
+++ b/src/core/frame/to_arrow.cc
@@ -166,6 +166,7 @@ std::unique_ptr<dt::OArrowSchema> Column::to_arrow_schema() const {
     case dt::SType::INT64:   (*osch)->format = "l"; break;
     case dt::SType::FLOAT32: (*osch)->format = "f"; break;
     case dt::SType::FLOAT64: (*osch)->format = "g"; break;
+    case dt::SType::DATE32:  (*osch)->format = "tdD"; break;
     case dt::SType::STR32:   (*osch)->format = "u"; break;
     case dt::SType::STR64:   (*osch)->format = "U"; break;
     default:
@@ -345,6 +346,7 @@ Column dt::ColumnImpl::as_arrow() const {
     case SType::INT64: return _as_arrow_fw<int64_t>();
     case SType::FLOAT32: return _as_arrow_fw<float>();
     case SType::FLOAT64: return _as_arrow_fw<double>();
+    case SType::DATE32: return  _as_arrow_fw<int32_t>();
     case SType::STR32: return _as_arrow_str<uint32_t>();
     case SType::STR64: return _as_arrow_str<uint64_t>();
     default: break;

--- a/src/core/frame/to_arrow.cc
+++ b/src/core/frame/to_arrow.cc
@@ -157,6 +157,8 @@ static void release_arrow_schema(dt::ArrowSchema* schema) {
 
 std::unique_ptr<dt::OArrowSchema> Column::to_arrow_schema() const {
   auto osch = std::unique_ptr<dt::OArrowSchema>(new dt::OArrowSchema());
+  // The formats are listed in pyarrow's [CDataInterface / format strings]
+  // manual: https://arrow.apache.org/docs/format/CDataInterface.html
   switch (stype()) {
     case dt::SType::VOID:    (*osch)->format = "n"; break;
     case dt::SType::BOOL:    (*osch)->format = "b"; break;

--- a/tests/types/test-date32.py
+++ b/tests/types/test-date32.py
@@ -167,3 +167,11 @@ def test_from_date32_arrow(pa):
     tbl = pa.Table.from_arrays([a], names=["D32"])
     DT = dt.Frame(tbl)
     assert_equals(DT, dt.Frame({"D32": src}, stype='date32'))
+
+
+def test_from_date64_arrow(pa):
+    src = [1, 1000, 20000, None, -700000]
+    a = pa.array(src, type=pa.date64())
+    tbl = pa.Table.from_arrays([a], names=["D64"])
+    DT = dt.Frame(tbl)
+    assert_equals(DT, dt.Frame({"D64": src}, stype='date32'))

--- a/tests/types/test-date32.py
+++ b/tests/types/test-date32.py
@@ -158,7 +158,7 @@ def test_date32_to_pandas(pd):
 
 
 #-------------------------------------------------------------------------------
-# Create from pyarrow
+# to/from pyarrow
 #-------------------------------------------------------------------------------
 
 def test_from_date32_arrow(pa):
@@ -175,3 +175,13 @@ def test_from_date64_arrow(pa):
     tbl = pa.Table.from_arrays([a], names=["D64"])
     DT = dt.Frame(tbl)
     assert_equals(DT, dt.Frame({"D64": src}, stype='date32'))
+
+
+def test_date32_to_arrow(pa):
+    d = datetime.date
+    DT = dt.Frame([17, 349837, 88888, None, 17777], stype='date32')
+    tbl = DT.to_arrow()
+    assert isinstance(tbl, pa.Table)
+    assert tbl.to_pydict() == {"C0": [
+        d(1970, 1, 18), d(2927, 10, 28), d(2213, 5, 15), None, d(2018, 9, 3)
+    ]}

--- a/tests/types/test-date32.py
+++ b/tests/types/test-date32.py
@@ -24,6 +24,7 @@
 import datetime
 import datatable as dt
 import pytest
+from tests import assert_equals
 
 
 
@@ -105,7 +106,7 @@ def test_date32_max():
 
 
 #-------------------------------------------------------------------------------
-# Convert from numpy
+# Create from numpy
 #-------------------------------------------------------------------------------
 
 @pytest.mark.parametrize("scale", ["D", "W", "M", "Y"])
@@ -153,3 +154,16 @@ def test_date32_to_pandas(pd):
 # we add time64 type, we'd be able to write a function that checks
 # whether a pandas datetime64 column contains dates only, and convert
 # it to dates in such case.
+
+
+
+#-------------------------------------------------------------------------------
+# Create from pyarrow
+#-------------------------------------------------------------------------------
+
+def test_from_date32_arrow(pa):
+    src = [1, 1000, 20000, None, -700000]
+    a = pa.array(src, type=pa.date32())
+    tbl = pa.Table.from_arrays([a], names=["D32"])
+    DT = dt.Frame(tbl)
+    assert_equals(DT, dt.Frame({"D32": src}, stype='date32'))


### PR DESCRIPTION
Our `date32` column can now be converted into pyarrow's `date32` type;
likewise pyarrow's `date32` and `date64` columns can be converted into our `date32`.

WIP for #2858