### PR TITLE
Fix Ftrl segfault when trained on one binomial class only

### DIFF
--- a/ci/ext.py
+++ b/ci/ext.py
@@ -340,6 +340,7 @@ def build_extension(cmd, verbosity=3):
                 "-Wno-global-constructors",
                 "-Wno-reserved-id-macro",
                 "-Wno-switch-enum",
+                "-Wno-poison-system-directories",
                 "-Wno-weak-template-vtables",
                 "-Wno-weak-vtables",
             )

--- a/src/core/models/dt_ftrl.cc
+++ b/src/core/models/dt_ftrl.cc
@@ -616,7 +616,7 @@ dtptr Ftrl<T>::predict(const DataTable* dt_X) {
   });
   job.done();
 
-  if (model_type == FtrlModelType::BINOMIAL) {
+  if (model_type == FtrlModelType::BINOMIAL && nlabels == 2) {
     dt::parallel_for_static(dt_X->nrows(), [&](size_t i){
       data_p[k_binomial][i] = T(1) - data_p[!k_binomial][i];
     });

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -77,7 +77,7 @@ def list_equals(a, b, rel_tol = 1e-7, abs_tol = None):
 
 
 
-def assert_equals(frame1, frame2):
+def assert_equals(frame1, frame2, rel_tol = 1e-7, abs_tol = 0.0):
     """
     Helper function to assert that 2 frames are equal to each other.
     """
@@ -106,7 +106,7 @@ def assert_equals(frame1, frame2):
                 val2 = col2[j]
                 if val1 == val2: continue
                 if isinstance(val1, float) and isinstance(val2, float):
-                    if math.isclose(val1, val2): continue
+                    if math.isclose(val1, val2, rel_tol = rel_tol, abs_tol = abs_tol): continue
                 if len(col1) > 16:
                     arr1 = repr(col1[:16])[:-1] + ", ...]"
                     arr2 = repr(col2[:16])[:-1] + ", ...]"
@@ -123,7 +123,7 @@ def assert_equals(frame1, frame2):
         assert frame1.shape == frame2.shape
         assert list_equals(frame1.names, frame2.names)
         assert list_equals(frame1.stypes, frame2.stypes)
-        assert list_equals(frame1.to_list(), frame2.to_list())
+        assert list_equals(frame1.to_list(), frame2.to_list(), rel_tol, abs_tol)
 
 
 

--- a/tests/models/test-ftrl.py
+++ b/tests/models/test-ftrl.py
@@ -628,6 +628,16 @@ def test_ftrl_fit_none():
     assert res.loss is None
 
 
+def test_ftrl_fit_one():
+    ft = Ftrl(model_type = "binomial", nepochs = 1)
+    df_train = dt.Frame(["cat"])
+    df_target = dt.Frame(["animal"])
+    ft.fit(df_train, df_target)
+    p = ft.predict(df_train)
+    p_ref = dt.Frame({"animal" : [0.5]/dt.float32})
+    assert_equals(p, p_ref, 1e-3)
+
+
 def test_ftrl_fit_unique():
     ft = Ftrl(nbins = 10)
     df_train = dt.Frame(range(ft.nbins))


### PR DESCRIPTION
- fix Ftrl predictions when trained on one binomial class;
- add `rel_tol` and `abs_tol` parameters to `assert_equals()`;
- disable `Wpoison-system-directories` warning issued by Clang 12.

Closes #2894