### PR TITLE
New function time.ymd()

### DIFF
--- a/docs/api/index-api.rst
+++ b/docs/api/index-api.rst
@@ -28,6 +28,9 @@ Submodules
     * - :mod:`models. <datatable.models>`
       - A small set of data analysis tools.
 
+    * - :mod:`time. <datatable.time>`
+      - Functions for working with date/time columns.
+
 
 
 
@@ -196,6 +199,7 @@ Other
     math.             <math>
     models.           <models>
     options.          <options>
+    time.             <time>
     FExpr             <fexpr>
     Frame             <frame>
     ltype             <ltype>

--- a/docs/api/time.rst
+++ b/docs/api/time.rst
@@ -1,0 +1,18 @@
+
+.. xpy:module:: datatable.time
+
+datatable.time
+==============
+
+.. list-table::
+   :widths: auto
+   :class: api-table
+
+   * - :func:`ymd(y,m,d)`
+     - Create a ``date32`` column from year, month, day components.
+
+
+.. toctree::
+    :hidden:
+
+    ymd()   <time/ymd>

--- a/docs/api/time.rst
+++ b/docs/api/time.rst
@@ -9,7 +9,7 @@ datatable.time
    :class: api-table
 
    * - :func:`ymd(y,m,d)`
-     - Create a ``date32`` column from year, month, day components.
+     - Create a ``date32`` column from year, month, and day components.
 
 
 .. toctree::

--- a/docs/api/time/ymd.rst
+++ b/docs/api/time/ymd.rst
@@ -2,3 +2,4 @@
 .. xfunction:: datatable.time.ymd
     :src: src/core/expr/time/fexpr_ymd.cc pyfn_ymd
     :doc: src/core/expr/time/fexpr_ymd.cc doc_ymd
+    :tests: tests/expr/time/test-ymd.py

--- a/docs/api/time/ymd.rst
+++ b/docs/api/time/ymd.rst
@@ -1,0 +1,4 @@
+
+.. xfunction:: datatable.time.ymd
+    :src: src/core/expr/time/fexpr_ymd.cc pyfn_ymd
+    :doc: src/core/expr/time/fexpr_ymd.cc doc_ymd

--- a/docs/releases/v1.0.0.rst
+++ b/docs/releases/v1.0.0.rst
@@ -66,6 +66,9 @@
     -----
     .. current-module:: datatable
 
+    -[new] Function :func:`dt.time.ymd()` can create ``date32`` columns out of
+      individual year/month/day parts.
+
     -[new] Function :func:`ifelse()` can now accept more than 3 arguments,
       implementing a chained-if functionality. This is equivalent to
       ``CASE WHEN`` in SQL. [#2656]

--- a/src/core/expr/eval_context.cc
+++ b/src/core/expr/eval_context.cc
@@ -501,6 +501,7 @@ static void _vivify_workframe(const Workframe& wf) {
       case SType::BOOL:
       case SType::INT8:    _vivify_column<int8_t>(col); break;
       case SType::INT16:   _vivify_column<int16_t>(col); break;
+      case SType::DATE32:
       case SType::INT32:   _vivify_column<int32_t>(col); break;
       case SType::INT64:   _vivify_column<int64_t>(col); break;
       case SType::FLOAT32: _vivify_column<float>(col); break;

--- a/src/core/expr/time/fexpr_ymd.cc
+++ b/src/core/expr/time/fexpr_ymd.cc
@@ -175,6 +175,39 @@ R"(ymd(year, month, day)
 .. x-version-added:: 1.0.0
 
 Create a date32 column out of `year`, `month` and `day` components.
+
+This function performs range checks on `month` and `day` columns: if a
+certain combination of year/month/day is not valid in the Gregorian
+calendar, then an NA value will be produced in that row.
+
+
+Parameters
+----------
+year: FExpr[int]
+    The year part of the resulting date32 column.
+
+month: FExpr[int]
+    The month part of the resulting date32 column. Values in this column
+    are expected to be in the 1 .. 12 range.
+
+day: FExpr[int]
+    The day part of the resulting date32 column. Values in this column
+    should be from 1 to ``last_day_of_month(year, month)``.
+
+result: FExpr[date32]
+
+
+Examples
+--------
+>>> DT = dt.Frame(y=[2005, 2010, 2015], m=[2, 3, 7])
+>>> DT[:, dt.time.ymd(f.y, f.m, 30)]
+   | C0
+   | date32
+-- + ----------
+ 0 | NA
+ 1 | 2010-03-30
+ 2 | 2015-07-30
+[3 rows x 1 column]
 )";
 
 static py::oobj pyfn_ymd(const py::XArgs& args) {

--- a/src/core/expr/time/fexpr_ymd.cc
+++ b/src/core/expr/time/fexpr_ymd.cc
@@ -166,7 +166,7 @@ class FExpr_YMD : public FExpr_Func {
 
 
 //------------------------------------------------------------------------------
-// Python-facing `qcut()` function
+// Python-facing `ymd()` function
 //------------------------------------------------------------------------------
 
 static const char* doc_ymd =

--- a/src/core/expr/time/fexpr_ymd.cc
+++ b/src/core/expr/time/fexpr_ymd.cc
@@ -1,0 +1,197 @@
+//------------------------------------------------------------------------------
+// Copyright 2021 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#include "_dt.h"
+#include "expr/eval_context.h"
+#include "expr/fexpr_func.h"
+#include "lib/hh/date.h"
+#include "python/xargs.h"
+#include "stype.h"
+namespace dt {
+namespace expr {
+
+
+
+//------------------------------------------------------------------------------
+// YMD_ColumnImpl
+//------------------------------------------------------------------------------
+
+class YMD_ColumnImpl : public Virtual_ColumnImpl {
+  private:
+    Column y_, m_, d_;
+
+  public:
+    YMD_ColumnImpl(Column&& y, Column&& m, Column&& d)
+      : Virtual_ColumnImpl(y.nrows(), dt::SType::DATE32),
+        y_(std::move(y)), m_(std::move(m)), d_(std::move(d))
+    {
+      xassert(y_.stype() == dt::SType::INT32);
+      xassert(m_.stype() == dt::SType::INT32);
+      xassert(d_.stype() == dt::SType::INT32);
+    }
+
+    ColumnImpl* clone() const override {
+      return new YMD_ColumnImpl(Column(y_), Column(m_), Column(d_));
+    }
+
+    size_t n_children() const noexcept override {
+      return 3;
+    }
+
+    const Column& child(size_t i) const override {
+      xassert(i <= 2);
+      return i == 0? y_ : i == 1? m_ : d_;
+    }
+
+    bool get_element(size_t i, int32_t* out) const override {
+      int y, m, d;
+      bool validY = y_.get_element(i, &y);
+      bool validM = m_.get_element(i, &m);
+      bool validD = d_.get_element(i, &d);
+      if (validY && validM && validD &&
+          (m >= 1 && m <= 12) &&
+          (d >= 1 && d <= hh::last_day_of_month(y, m)))
+      {
+        *out = hh::days_from_civil(y, m, d);
+        return true;
+      }
+      return false;
+    }
+};
+
+
+
+
+//------------------------------------------------------------------------------
+// FExpr_YMD
+//------------------------------------------------------------------------------
+
+class FExpr_YMD : public FExpr_Func {
+  private:
+    ptrExpr y_, m_, d_;
+
+  public:
+    FExpr_YMD(py::robj argY, py::robj argM, py::robj argD)
+      : y_(as_fexpr(argY)),
+        m_(as_fexpr(argM)),
+        d_(as_fexpr(argD))
+    {}
+
+    std::string repr() const override {
+      std::string out = "time.ymd(";
+      out += y_->repr();
+      out += ", ";
+      out += m_->repr();
+      out += ", ";
+      out += d_->repr();
+      out += ")";
+      return out;
+    }
+
+
+    Workframe evaluate_n(EvalContext& ctx) const override {
+      std::vector<Workframe> wfs;
+      wfs.push_back(y_->evaluate_n(ctx));
+      wfs.push_back(m_->evaluate_n(ctx));
+      wfs.push_back(d_->evaluate_n(ctx));
+
+      size_t ncolsY = wfs[0].ncols();
+      size_t ncolsM = wfs[1].ncols();
+      size_t ncolsD = wfs[2].ncols();
+      size_t ncols = std::max(ncolsY, std::max(ncolsM, ncolsD));
+      if (!((ncolsY == ncols || ncolsY == 1) &&
+            (ncolsM == ncols || ncolsM == 1) &&
+            (ncolsD == ncols || ncolsD == 1))) {
+        throw InvalidOperationError() << "Incompatible numbers of columns for "
+          "the year, month and day arguments of the ymd() function: " << ncolsY
+          << ", " << ncolsM << ", and " << ncolsD;
+      }
+      if (ncolsY == 1) wfs[0].repeat_column(ncols);
+      if (ncolsM == 1) wfs[1].repeat_column(ncols);
+      if (ncolsD == 1) wfs[2].repeat_column(ncols);
+      auto gmode = Workframe::sync_grouping_mode(wfs);
+
+      Workframe result(ctx);
+      for (size_t i = 0; i < ncols; ++i) {
+        Column rescol = evaluate1(wfs[0].retrieve_column(i),
+                                  wfs[1].retrieve_column(i),
+                                  wfs[2].retrieve_column(i), i);
+        result.add_column(std::move(rescol), std::string(), gmode);
+      }
+      return result;
+    }
+
+    static Column evaluate1(Column&& ycol, Column&& mcol, Column&& dcol,
+                            size_t i)
+    {
+      if (!ycol.type().is_integer()) {
+        throw TypeError() << "The year column at index " << i << " is of type "
+            << ycol.type() << ", integer expected";
+      }
+      if (!mcol.type().is_integer()) {
+        throw TypeError() << "The month column at index " << i << " is of type "
+            << mcol.type() << ", integer expected";
+      }
+      if (!dcol.type().is_integer()) {
+        throw TypeError() << "The day column at index " << i << " is of type "
+            << dcol.type() << ", integer expected";
+      }
+      ycol.cast_inplace(dt::Type::int32());
+      mcol.cast_inplace(dt::Type::int32());
+      dcol.cast_inplace(dt::Type::int32());
+      return Column(new YMD_ColumnImpl(
+          std::move(ycol), std::move(mcol), std::move(dcol)));
+    }
+};
+
+
+
+
+//------------------------------------------------------------------------------
+// Python-facing `qcut()` function
+//------------------------------------------------------------------------------
+
+static const char* doc_ymd =
+R"(ymd(year, month, day)
+--
+.. x-version-added:: 1.0.0
+
+Create a date32 column out of `year`, `month` and `day` components.
+)";
+
+static py::oobj pyfn_ymd(const py::XArgs& args) {
+  auto y = args[0].to_oobj();
+  auto m = args[1].to_oobj();
+  auto d = args[2].to_oobj();
+  return PyFExpr::make(new FExpr_YMD(y, m, d));
+}
+
+DECLARE_PYFN(&pyfn_ymd)
+    ->name("ymd")
+    ->docs(doc_ymd)
+    ->arg_names({"year", "month", "day"})
+    ->n_positional_or_keyword_args(3)
+    ->n_required_args(3);
+
+
+
+
+}}  // dt::expr

--- a/src/datatable/__init__.py
+++ b/src/datatable/__init__.py
@@ -64,6 +64,7 @@ import datatable.math
 import datatable.internal
 import datatable.exceptions
 import datatable.options
+import datatable.time
 try:
     from ._build_info import build_info
     __version__ = build_info.version

--- a/src/datatable/time.py
+++ b/src/datatable/time.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+#-------------------------------------------------------------------------------
+# Copyright 2021 H2O.ai
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#-------------------------------------------------------------------------------
+from .lib._datatable import (
+    ymd,
+)

--- a/tests/expr/time/test-ymd.py
+++ b/tests/expr/time/test-ymd.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#-------------------------------------------------------------------------------
+# Copyright 2021 H2O.ai
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#-------------------------------------------------------------------------------
+import pytest
+from datatable import dt, f
+from datatable.time import ymd
+from datetime import date as d
+from tests import assert_equals
+
+
+def test_ymd_simple():
+    DT = dt.Frame(Y=[2001, 2003, 2005, 2020],
+                  M=[1, 5, 4, 11],
+                  D=[12, 18, 30, 1])
+    RES = DT[:, ymd(f.Y, f.M, f.D)]
+    assert_equals(RES,
+        dt.Frame([d(2001, 1, 12), d(2003, 5, 18), d(2005, 4, 30),
+                  d(2020, 11, 1)]))
+
+
+def test_ymd_wrong_types():
+    DT = dt.Frame(A=[2000], B=[2.1], C=[1])
+
+    msg = "The year column at index 0 is of type float64, integer expected"
+    with pytest.raises(TypeError, match=msg):
+        DT[:, ymd(f.B, f.A, f.C)]
+
+    msg = "The month column at index 0 is of type float64, integer expected"
+    with pytest.raises(TypeError, match=msg):
+        DT[:, ymd(f.A, f.B, f.C)]
+
+    msg = "The day column at index 0 is of type float64, integer expected"
+    with pytest.raises(TypeError, match=msg):
+        DT[:, ymd(f.A, f.C, f.B)]
+
+
+def test_ymd_wrong_shape():
+    DT = dt.Frame(A=range(5), B=range(5), C=range(5))
+    msg = r"Incompatible numbers of columns for the year, month and day " \
+          r"arguments of the ymd\(\) function: 3, 2, and 1"
+    with pytest.raises(dt.exceptions.InvalidOperationError, match=msg):
+        DT[:, ymd(f[:], f[1:], f[0])]
+
+
+def test_ymd_multi_column():
+    DT = dt.Frame(A=range(5), B=range(5), C=range(5))
+    RES = DT[:, ymd(2000, 5 + f[:], 1 + 2*f[:])]
+    exp = [d(2000, 5 + i, i*2 + 1) for i in range(5)]
+    assert_equals(RES, dt.Frame([exp] * 3))
+
+
+def test_ymd_partial_groupby():
+    DT = dt.Frame(A=range(5), B=range(5), C=range(1, 11, 2))
+    RES = DT[:, ymd(2000, dt.max(f.B), f.C)]
+    assert_equals(RES, dt.Frame([d(2000, 4, 1 + 2*i) for i in range(5)]))
+
+
+def test_ymd_with_different_types():
+    DT = dt.Frame(A=[2010, 2011, 2012]/dt.int32,
+                  B=[3, 5, 7]/dt.int8,
+                  C=[4, 1, 1]/dt.int64)
+    RES = DT[:, ymd(f.A, f.B, f.C)]
+    assert_equals(RES, dt.Frame([d(2010, 3, 4), d(2011, 5, 1), d(2012, 7, 1)]))
+
+
+def test_ymd_nones():
+    DT = dt.Frame(A=[1, 2, 3, None, None, 4],
+                  B=[1, 2, None, 3, None, 4],
+                  C=[1, None, 2, 3, None, 4])
+    RES = DT[:, ymd(f.A, f.B, f.C)]
+    assert_equals(RES, dt.Frame([d(1, 1, 1), None, None, None, None, d(4, 4, 4)]))
+
+
+def test_invalid_dates():
+    DT = dt.Frame(Y=[2000, 2001, 2002, 2003, 2004],
+                  M=[1, 2, 3, 4, 5],
+                  D=[-1, 0, 1, 100, 100000])
+    assert_equals(DT[:, ymd(f.Y, 2, 29)],
+                  dt.Frame([d(2000, 2, 29), None, None, None, d(2004, 2, 29)]))
+    assert_equals(DT[:, ymd(2020, f.M, 31)],
+                  dt.Frame([d(2020, 1, 31), None, d(2020, 3, 31), None, d(2020, 5, 31)]))
+    assert_equals(DT[:, ymd(2020, 1, f.D)],
+                  dt.Frame([None, None, d(2020, 1, 1), None, None]))
+
+
+def test_invalid_months():
+    DT = dt.Frame(range(5))
+    assert_equals(DT[:, ymd(2021, f[0], 1)],
+                  dt.Frame([None] + [d(2021, i, 1) for i in range(1, 5)]))

--- a/tests/expr/time/test-ymd.py
+++ b/tests/expr/time/test-ymd.py
@@ -38,6 +38,12 @@ def test_ymd_simple():
                   d(2020, 11, 1)]))
 
 
+def test_ymd_named():
+    DT = dt.Frame(Y=[2001, 2002, 2003], M=[3, 9, 1], D=[31, 3, 1])
+    RES = DT[:, ymd(month=f.M, day=f.D, year=f.Y)]
+    assert_equals(RES, dt.Frame([d(2001, 3, 31), d(2002, 9, 3), d(2003, 1, 1)]))
+
+
 def test_ymd_wrong_types():
     DT = dt.Frame(A=[2000], B=[2.1], C=[1])
 


### PR DESCRIPTION
Function `dt.time.ymd()` can be  used to create `date32` columns out of year/month/day components.

I've decided that all date/time functions will leave in the `datatable.time` namespace, so that they can be easily discovered  and run less chance of clashing with some other functionality.

WIP for #2858