### PR TITLE
Various date32-related functionality

### DIFF
--- a/src/core/column/column_impl.cc
+++ b/src/core/column/column_impl.cc
@@ -128,6 +128,7 @@ void ColumnImpl::materialize(Column& out, bool to_memory) {
     case SType::BOOL:
     case SType::INT8:    return _materialize_fw<int8_t> (out);
     case SType::INT16:   return _materialize_fw<int16_t>(out);
+    case SType::DATE32:
     case SType::INT32:   return _materialize_fw<int32_t>(out);
     case SType::INT64:   return _materialize_fw<int64_t>(out);
     case SType::FLOAT32: return _materialize_fw<float>  (out);

--- a/src/core/column/const.cc
+++ b/src/core/column/const.cc
@@ -164,6 +164,7 @@ Column Const_ColumnImpl::from_1row_column(const Column& col) {
     case SType::FLOAT64: return _make<ConstFloat_ColumnImpl, SType::FLOAT64>(col);
     case SType::STR32:   return _make<ConstString_ColumnImpl, SType::STR32>(col);
     case SType::STR64:   return _make<ConstString_ColumnImpl, SType::STR64>(col);
+    case SType::DATE32:  return _make<ConstInt_ColumnImpl, SType::DATE32>(col);
     default:
       throw NotImplError() << "Cannot convert 1-row column of stype "
                            << col.stype();

--- a/src/core/column/const_na.cc
+++ b/src/core/column/const_na.cc
@@ -113,6 +113,7 @@ void ConstNa_ColumnImpl::materialize(Column& out, bool) {
     case SType::BOOL:    out = _special_col<int8_t,  SentinelBool_ColumnImpl>(nrows_); break;
     case SType::INT8:    out = _fw_col<int8_t,  SentinelFw_ColumnImpl<int8_t>>(nrows_, st); break;
     case SType::INT16:   out = _fw_col<int16_t, SentinelFw_ColumnImpl<int16_t>>(nrows_, st); break;
+    case SType::DATE32:
     case SType::INT32:   out = _fw_col<int32_t, SentinelFw_ColumnImpl<int32_t>>(nrows_, st); break;
     case SType::INT64:   out = _fw_col<int64_t, SentinelFw_ColumnImpl<int64_t>>(nrows_, st); break;
     case SType::FLOAT32: out = _fw_col<float,   SentinelFw_ColumnImpl<float>>(nrows_, st); break;

--- a/src/core/column/latent.cc
+++ b/src/core/column/latent.cc
@@ -115,6 +115,7 @@ ColumnImpl* Latent_ColumnImpl::vivify(bool to_memory) const {
     case SType::BOOL:    new (ptr) SentinelBool_ColumnImpl(std::move(new_pcol)); break;
     case SType::INT8:    new (ptr) SentinelFw_ColumnImpl<int8_t>(std::move(new_pcol)); break;
     case SType::INT16:   new (ptr) SentinelFw_ColumnImpl<int16_t>(std::move(new_pcol)); break;
+    case SType::DATE32:
     case SType::INT32:   new (ptr) SentinelFw_ColumnImpl<int32_t>(std::move(new_pcol)); break;
     case SType::INT64:   new (ptr) SentinelFw_ColumnImpl<int64_t>(std::move(new_pcol)); break;
     case SType::FLOAT32: new (ptr) SentinelFw_ColumnImpl<float>(std::move(new_pcol)); break;

--- a/src/core/column/npmasked.cc
+++ b/src/core/column/npmasked.cc
@@ -65,6 +65,7 @@ void NpMasked_ColumnImpl::materialize(Column& out, bool to_memory) {
       case SType::BOOL:
       case SType::INT8:    return _apply_mask<int8_t>(out);
       case SType::INT16:   return _apply_mask<int16_t>(out);
+      case SType::DATE32:
       case SType::INT32:   return _apply_mask<int32_t>(out);
       case SType::INT64:   return _apply_mask<int64_t>(out);
       case SType::FLOAT32: return _apply_mask<float>(out);

--- a/src/core/expr/fexpr_literal_type.cc
+++ b/src/core/expr/fexpr_literal_type.cc
@@ -39,7 +39,7 @@ static stypevec stBOOL  = {SType::BOOL};
 static stypevec stINT   = {SType::INT8, SType::INT16, SType::INT32, SType::INT64};
 static stypevec stFLOAT = {SType::FLOAT32, SType::FLOAT64};
 static stypevec stSTR   = {SType::STR32, SType::STR64};
-static stypevec stTIME  = {};
+static stypevec stDATE  = {SType::DATE32};
 static stypevec stOBJ   = {SType::OBJ};
 
 
@@ -108,6 +108,9 @@ Workframe FExpr_Literal_Type::evaluate_f(EvalContext& ctx, size_t fid) const {
     if (et == &PyUnicode_Type)    return _select_types(ctx, fid, stSTR);
     if (et == &PyBool_Type)       return _select_types(ctx, fid, stBOOL);
     if (et == &PyBaseObject_Type) return _select_types(ctx, fid, stOBJ);
+    if (et == py::odate::type()) {
+      return _select_types(ctx, fid, stDATE);
+    }
   }
   if (value_.is_ltype()) {
     auto lt = static_cast<LType>(value_.get_attr("value").to_size_t());
@@ -116,7 +119,7 @@ Workframe FExpr_Literal_Type::evaluate_f(EvalContext& ctx, size_t fid) const {
     if (lt == LType::INT)      return _select_types(ctx, fid, stINT);
     if (lt == LType::REAL)     return _select_types(ctx, fid, stFLOAT);
     if (lt == LType::STRING)   return _select_types(ctx, fid, stSTR);
-    if (lt == LType::DATETIME) return _select_types(ctx, fid, stTIME);
+    if (lt == LType::DATETIME) return _select_types(ctx, fid, stDATE);
     if (lt == LType::OBJECT)   return _select_types(ctx, fid, stOBJ);
   }
   if (value_.is_stype()) {

--- a/src/core/expr/head_reduce_unary.cc
+++ b/src/core/expr/head_reduce_unary.cc
@@ -1008,6 +1008,7 @@ static Column compute_count(Column&& arg, const Groupby& gby) {
     case SType::BOOL:
     case SType::INT8:    return _count<int8_t>(std::move(arg), gby);
     case SType::INT16:   return _count<int16_t>(std::move(arg), gby);
+    case SType::DATE32:
     case SType::INT32:   return _count<int32_t>(std::move(arg), gby);
     case SType::INT64:   return _count<int64_t>(std::move(arg), gby);
     case SType::FLOAT32: return _count<float>(std::move(arg), gby);
@@ -1078,6 +1079,7 @@ static Column compute_gcount(Column&& arg, const Groupby& gby) {
     case SType::BOOL:
     case SType::INT8:    return _gcount<int8_t>(std::move(arg), gby);
     case SType::INT16:   return _gcount<int16_t>(std::move(arg), gby);
+    case SType::DATE32:
     case SType::INT32:   return _gcount<int32_t>(std::move(arg), gby);
     case SType::INT64:   return _gcount<int64_t>(std::move(arg), gby);
     case SType::FLOAT32: return _gcount<float>(std::move(arg), gby);
@@ -1298,24 +1300,26 @@ bool minmax_reducer(const Column& col, size_t i0, size_t i1, T* out) {
 
 
 template <typename T, bool MM>
-static Column _minmax(Column&& arg, const Groupby& gby) {
+static Column _minmax(SType stype, Column&& arg, const Groupby& gby) {
   return Column(
           new Latent_ColumnImpl(
             new Reduced_ColumnImpl<T, T>(
-                 stype_from<T>, std::move(arg), gby, minmax_reducer<T, MM>
+                 stype, std::move(arg), gby, minmax_reducer<T, MM>
             )));
 }
 
 template <bool MIN>
 static Column compute_minmax(Column&& arg, const Groupby& gby) {
-  switch (arg.stype()) {
+  auto st = arg.stype();
+  switch (st) {
     case SType::BOOL:
-    case SType::INT8:    return _minmax<int8_t, MIN>(std::move(arg), gby);
-    case SType::INT16:   return _minmax<int16_t, MIN>(std::move(arg), gby);
-    case SType::INT32:   return _minmax<int32_t, MIN>(std::move(arg), gby);
-    case SType::INT64:   return _minmax<int64_t, MIN>(std::move(arg), gby);
-    case SType::FLOAT32: return _minmax<float, MIN>(std::move(arg), gby);
-    case SType::FLOAT64: return _minmax<double, MIN>(std::move(arg), gby);
+    case SType::INT8:    return _minmax<int8_t, MIN>(st, std::move(arg), gby);
+    case SType::INT16:   return _minmax<int16_t, MIN>(st, std::move(arg), gby);
+    case SType::DATE32:
+    case SType::INT32:   return _minmax<int32_t, MIN>(st, std::move(arg), gby);
+    case SType::INT64:   return _minmax<int64_t, MIN>(st, std::move(arg), gby);
+    case SType::FLOAT32: return _minmax<float, MIN>(st, std::move(arg), gby);
+    case SType::FLOAT64: return _minmax<double, MIN>(st, std::move(arg), gby);
     default: throw _error(MIN? "min" : "max", arg.stype());
   }
 }

--- a/src/core/frame/join.cc
+++ b/src/core/frame/join.cc
@@ -311,6 +311,7 @@ static void _init_comparators() {
   size_t flt64 = static_cast<size_t>(dt::SType::FLOAT64);
   size_t str32 = static_cast<size_t>(dt::SType::STR32);
   size_t str64 = static_cast<size_t>(dt::SType::STR64);
+  size_t dat32 = static_cast<size_t>(dt::SType::DATE32);
   cmps[bool8][bool8] = FwCmp<int8_t, int8_t>::make;
   cmps[bool8][int08] = FwCmp<int8_t, int8_t>::make;
   cmps[bool8][int16] = FwCmp<int8_t, int16_t>::make;
@@ -364,6 +365,7 @@ static void _init_comparators() {
   cmps[str32][str64] = StringCmp::make;
   cmps[str64][str32] = StringCmp::make;
   cmps[str64][str64] = StringCmp::make;
+  cmps[dat32][dat32] = FwCmp<int32_t, int32_t>::make;
 }
 
 

--- a/src/core/frame/repr/html_styles.cc
+++ b/src/core/frame/repr/html_styles.cc
@@ -91,6 +91,7 @@ static py::oobj generate_stylesheet() {
           ".datatable .int     { background: #5D9E5D; }\n"
           ".datatable .float   { background: #4040CC; }\n"
           ".datatable .str     { background: #CC4040; }\n"
+          ".datatable .time    { background: #40CC40; }\n"
           ".datatable .row_index {"
           "  background: var(--jp-border-color3);"
           "  border-right: 1px solid var(--jp-border-color0);"

--- a/src/core/frame/repr/html_widget.h
+++ b/src/core/frame/repr/html_widget.h
@@ -22,6 +22,7 @@
 #ifndef dt_FRAME_REPR_HTML_WIDGET_h
 #define dt_FRAME_REPR_HTML_WIDGET_h
 #include <algorithm>                   // std::min
+#include "csv/toa.h"
 #include "frame/repr/widget.h"
 #include "ltype.h"
 #include "python/_all.h"
@@ -179,6 +180,7 @@ class HtmlWidget : public dt::Widget {
           case SType::FLOAT64: _render_fw_value<double>(col, i); break;
           case SType::STR32:
           case SType::STR64:   _render_str_value(col, i); break;
+          case SType::DATE32:  _render_date_value(col, i); break;
           case SType::OBJ:     _render_obj_value(col, i); break;
           default:
             html << "(unknown stype)";
@@ -247,6 +249,25 @@ class HtmlWidget : public dt::Widget {
       bool isvalid = col.get_element(row, &val);
       if (isvalid) {
         _render_escaped_string(val.data(), val.size());
+      } else {
+        _render_na();
+      }
+    }
+
+    void _render_date_value(const Column& col, size_t row) {
+      static char out[15];
+      int32_t value;
+      bool isvalid = col.get_element(row, &value);
+      if (isvalid) {
+        char* ch = out;
+        date32_toa(&ch, value);
+        *ch = '\0';
+        if (out[0] == '-') {
+          html << "&minus;";
+          html << (out + 1);
+        } else {
+          html << out;
+        }
       } else {
         _render_na();
       }

--- a/src/core/frame/repr/text_column.cc
+++ b/src/core/frame/repr/text_column.cc
@@ -21,6 +21,7 @@
 //------------------------------------------------------------------------------
 #include <algorithm>                  // std::min, std::max
 #include <iomanip>                    // std::setfill, std::setw
+#include "csv/toa.h"
 #include "frame/repr/repr_options.h"
 #include "frame/repr/text_column.h"
 #include "lib/hh/date.h"
@@ -179,16 +180,17 @@ tstring Data_TextColumn::_render_value_float(const Column& col, size_t i) const
 }
 
 tstring Data_TextColumn::_render_value_date(const Column& col, size_t i) const {
+  static char tmp[15];
   int32_t value;
   bool isvalid = col.get_element(i, &value);
-  hh::ymd parsed = hh::civil_from_days(value);
-  if (!isvalid) return na_value_;
-  std::ostringstream out;
-  out << std::setfill('0');
-  out << std::setw(4) << parsed.year << '-'
-      << std::setw(2) << parsed.month << '-'
-      << std::setw(2) << parsed.day;
-  return tstring(out.str());
+  if (isvalid) {
+    char* ch = tmp;
+    date32_toa(&ch, value);
+    *ch = '\0';
+    return tstring(std::string(tmp));
+  } else {
+    return na_value_;
+  }
 }
 
 

--- a/src/core/models/aggregate.cc
+++ b/src/core/models/aggregate.cc
@@ -362,6 +362,7 @@ void Aggregator<T>::aggregate(DataTable* dt_in,
         case dt::SType::INT64:   contcol = contcol_maker<int64_t>(col, agg_stype); break;
         case dt::SType::FLOAT32: contcol = contcol_maker<float>(col, agg_stype); break;
         case dt::SType::FLOAT64: contcol = contcol_maker<double>(col, agg_stype); break;
+        case dt::SType::DATE32:  contcol = col.cast(agg_stype); break;
         case dt::SType::STR32:
         case dt::SType::STR64:   is_continuous = false;
                              if (ncols < ND_COLS) {

--- a/src/core/models/label_encode.cc
+++ b/src/core/models/label_encode.cc
@@ -43,6 +43,7 @@ void label_encode(const Column& col, dtptr& dt_labels, dtptr& dt_encoded,
                            col, dt_labels, dt_encoded, is_binomial
                          );
                          break;
+    case SType::DATE32:
     case SType::INT32:   label_encode_fw<SType::INT32>(
                            col, dt_labels, dt_encoded, is_binomial
                           );

--- a/src/core/python/date.cc
+++ b/src/core/python/date.cc
@@ -70,6 +70,10 @@ void odate::init() {
   PyDateTime_IMPORT;
 }
 
+PyTypeObject* odate::type() {
+  return PyDateTimeAPI->DateType;
+}
+
 
 
 

--- a/src/core/python/date.h
+++ b/src/core/python/date.h
@@ -43,6 +43,8 @@ class odate : public oobj {
 
     int get_days() const;
 
+    static PyTypeObject* type();
+
   private:
     explicit odate(PyObject*);
 };

--- a/src/datatable/include/datatable.h
+++ b/src/datatable/include/datatable.h
@@ -38,6 +38,7 @@ extern "C" {
 #define DtStype_FLOAT64  7
 #define DtStype_STR32    11
 #define DtStype_STR64    12
+#define DtStype_DATE32   17
 #define DtStype_OBJ      21
 
 /**

--- a/tests/types/test-date32.py
+++ b/tests/types/test-date32.py
@@ -82,6 +82,21 @@ def test_date32_repr():
     )
 
 
+def test_date32_repr_negative_dates():
+    DT = dt.Frame([-700000, -720000, -730000, -770000, -2000000], stype='date32')
+    assert str(DT) == (
+        "   | C0         \n"
+        "   | date32     \n"
+        "-- + -----------\n"
+        " 0 | 0053-06-19 \n"
+        " 1 | -002-09-16 \n"
+        " 2 | -029-05-01 \n"
+        " 3 | -139-10-24 \n"
+        " 4 | -3506-03-09\n"
+        "[5 rows x 1 column]\n"
+    )
+
+
 def test_date32_min():
     DT = dt.Type.date32.min
     assert isinstance(DT, dt.Frame)

--- a/tests/types/test-date32.py
+++ b/tests/types/test-date32.py
@@ -287,3 +287,12 @@ def test_date32_stats():
     assert DT.max1() == datetime.date(1970, 4, 11)
     assert DT.mode1() == datetime.date(1970, 1, 13)
     assert DT.countna1() == 1
+
+
+def date32_materialize():
+    DT = dt.Frame(A = range(1, 5))
+    RES = DT[:, dt.time.ymd(2000, 1, f.A)]
+    assert dt.internal.frame_columns_virtual(R)[0]
+    RES.materialize()
+    assert_equals(RES,
+        dt.Frame([datetime.date(2000, 1, i) for i in range(1, 5)]))

--- a/tests/types/test-date32.py
+++ b/tests/types/test-date32.py
@@ -298,7 +298,16 @@ def test_date32_materialize():
         dt.Frame([datetime.date(2000, 1, i) for i in range(1, 5)]))
 
 
+def test_date32_materialize_na():
+    DT = dt.Frame(A=[1, 3, 5], stype='date32')
+    DT['A'] = None
+    DT.materialize()
+    assert_equals(DT, dt.Frame(A = [None]*3, stype='date32'))
+
+
 def test_date32_repeat():
     DT = dt.Frame([11], stype='date32')
     RES = dt.repeat(DT, 10)
     assert_equals(RES, dt.Frame([11]*10, stype='date32'))
+    RES2 = dt.repeat(RES, 5)
+    assert_equals(RES2, dt.Frame([11]*50, stype='date32'))

--- a/tests/types/test-date32.py
+++ b/tests/types/test-date32.py
@@ -289,10 +289,16 @@ def test_date32_stats():
     assert DT.countna1() == 1
 
 
-def date32_materialize():
+def test_date32_materialize():
     DT = dt.Frame(A = range(1, 5))
     RES = DT[:, dt.time.ymd(2000, 1, f.A)]
-    assert dt.internal.frame_columns_virtual(R)[0]
+    assert dt.internal.frame_columns_virtual(RES)[0]
     RES.materialize()
     assert_equals(RES,
         dt.Frame([datetime.date(2000, 1, i) for i in range(1, 5)]))
+
+
+def test_date32_repeat():
+    DT = dt.Frame([11], stype='date32')
+    RES = dt.repeat(DT, 10)
+    assert_equals(RES, dt.Frame([11]*10, stype='date32'))

--- a/tests/types/test-date32.py
+++ b/tests/types/test-date32.py
@@ -344,3 +344,15 @@ def test_date32_in_groupby():
                  max = [2997, 2998, 2999] / date32,
                  first = [0, 1, 2] / date32,
                  last = [2997, 2998, 2999] / date32))
+
+
+def test_select_dates():
+    d = datetime.date
+    DT = dt.Frame(A=[12], B=[d(2000, 12, 20)], C=[True])
+    assert DT.types == [dt.Type.int32, dt.Type.date32, dt.Type.bool8]
+    RES1 = DT[:, f[d]]
+    RES2 = DT[:, d]
+    RES3 = DT[:, dt.ltype.time]
+    assert_equals(RES1, DT['B'])
+    assert_equals(RES2, DT['B'])
+    assert_equals(RES3, DT['B'])

--- a/tests/types/test-date32.py
+++ b/tests/types/test-date32.py
@@ -311,3 +311,21 @@ def test_date32_repeat():
     assert_equals(RES, dt.Frame([11]*10, stype='date32'))
     RES2 = dt.repeat(RES, 5)
     assert_equals(RES2, dt.Frame([11]*50, stype='date32'))
+
+
+def test_date32_in_groupby():
+    DT = dt.Frame(A=[1, 2, 3]*1000, B=list(range(3000)), stypes={"B": "date32"})
+    RES = DT[:, {"count": dt.count(f.B),
+                 "min": dt.min(f.B),
+                 "max": dt.max(f.B),
+                 "first": dt.first(f.B),
+                 "last": dt.last(f.B)},
+            dt.by(f.A)]
+    date32 = dt.stype.date32
+    assert_equals(RES,
+        dt.Frame(A=[1, 2, 3],
+                 count = [1000] * 3 / dt.int64,
+                 min = [0, 1, 2] / date32,
+                 max = [2997, 2998, 2999] / date32,
+                 first = [0, 1, 2] / date32,
+                 last = [2997, 2998, 2999] / date32))


### PR DESCRIPTION
Allow the following functions to work with date32 columns:
- `materialize()`
- `repeat()`
- `join()`
- assign `None`
- reduce functions `min()`, `max()`, `first()`, `last()`
- `aggregate()`
- display in Jupyter Lab
- fix display of negative dates in text console

WIP for #2858