### PR TITLE
Rbind() no longer auto-promote among incompatible types

### DIFF
--- a/docs/releases/v1.0.0.rst
+++ b/docs/releases/v1.0.0.rst
@@ -54,6 +54,9 @@
       if the user explicitly requests promotion into the object type then
       there won't be any error.
 
+    -[api] Rbinding frames with columns of incompatible types will now raise
+      an error instead of auto-promoting to string type. [#2790]
+
     -[api] When a frame is converted into a numpy array of floatinng type,
       then we will produce a regular ``np.ndarray`` instead of a masked array.
 

--- a/src/core/column/const.h
+++ b/src/core/column/const.h
@@ -63,6 +63,8 @@ class ConstNa_ColumnImpl : public Const_ColumnImpl {
     ColumnImpl* clone() const override;
     void materialize(Column&, bool) override;
     void na_pad(size_t nrows, Column&) override;
+    void rbind_impl(
+        colvec& columns, size_t new_nrows, bool col_empty, dt::SType&) override;
 };
 
 

--- a/src/core/column/const_na.cc
+++ b/src/core/column/const_na.cc
@@ -109,7 +109,7 @@ static Column _str_col(size_t nrows) {
 void ConstNa_ColumnImpl::materialize(Column& out, bool) {
   auto st = stype();
   switch (st) {
-    case SType::VOID:    // TODO: make void column "material"
+    case SType::VOID:    break;
     case SType::BOOL:    out = _special_col<int8_t,  SentinelBool_ColumnImpl>(nrows_); break;
     case SType::INT8:    out = _fw_col<int8_t,  SentinelFw_ColumnImpl<int8_t>>(nrows_, st); break;
     case SType::INT16:   out = _fw_col<int16_t, SentinelFw_ColumnImpl<int16_t>>(nrows_, st); break;

--- a/src/core/frame/rbind.cc
+++ b/src/core/frame/rbind.cc
@@ -23,16 +23,17 @@
 #include <functional>   // std::function
 #include <numeric>
 #include <unordered_map>
+#include "column/const.h"
 #include "column/sentinel_fw.h"
 #include "column/sentinel_str.h"
+#include "datatable.h"
+#include "datatablemodule.h"
 #include "frame/py_frame.h"
 #include "ltype.h"
 #include "python/_all.h"
+#include "stype.h"
 #include "utils/assert.h"
 #include "utils/misc.h"
-#include "datatable.h"
-#include "datatablemodule.h"
-#include "stype.h"
 
 
 static void _check_ncols(size_t n0, size_t n1) {
@@ -489,6 +490,25 @@ void Column::rbind(colvec& columns) {
   // Replace current column's impl with the newcol's
   std::swap(impl_, newcol.impl_);
 }
+
+
+
+//------------------------------------------------------------------------------
+// rbind VOID column
+//------------------------------------------------------------------------------
+
+void dt::ConstNa_ColumnImpl::rbind_impl(
+        colvec& columns, size_t new_nrows, bool, dt::SType&)
+{
+  #if DT_DEBUG
+    for (const Column& col : columns) {
+      xassert(col.type().is_void());
+    }
+  #endif
+  (void)columns;
+  nrows_ = new_nrows;
+}
+
 
 
 

--- a/src/core/frame/rbind.cc
+++ b/src/core/frame/rbind.cc
@@ -67,8 +67,13 @@ This method modifies the current frame in-place. If you do not want
 the current frame modified, then use the :func:`dt.rbind()` function.
 
 If frame(s) being appended have columns of types different from the
-current frame, then these columns will be promoted to the largest of
-their types: bool -> int -> float -> string.
+current frame, then these columns will be promoted according to the
+standard promotion rules. In particular, booleans can be promoted into
+integers, which in turn get promoted into floats. However, they are
+not promoted into strings or objects.
+
+If frames have columns of incompatible types, a TypeError will be
+raised.
 
 If you need to append multiple frames, then it is more efficient to
 collect them into an array first and then do a single `rbind()`, than
@@ -249,7 +254,7 @@ static const char* doc_py_rbind =
 R"(rbind(*frames, force=False, bynames=True)
 --
 
-Produce a new frame by appending rows of `frames`.
+Produce a new frame by appending rows of several `frames`.
 
 This function is equivalent to::
 
@@ -305,7 +310,8 @@ Examples
      5 |      5     169
     [6 rows x 2 columns]
 
-:func:`rbind()` by default combines frames by names. The frames can also be bound by column position by setting the `bynames` parameter to ``False``::
+:func:`rbind()` by default combines frames by names. The frames can also be
+bound by column position by setting the `bynames` parameter to ``False``::
 
     >>> dt.rbind(DT1, DT2, bynames = False)
        | Weight  Height
@@ -320,8 +326,8 @@ Examples
     [6 rows x 2 columns]
 
 
-If the number of columns are not equal or the column names are different, you can force the row binding by setting
-the `force` parameter to `True`::
+If the number of columns are not equal or the column names are different,
+you can force the row binding by setting the `force` parameter to `True`::
 
     >>> DT2["Age"] = dt.Frame([25, 50, 67])
     >>> DT2
@@ -439,17 +445,21 @@ void Column::rbind(colvec& columns) {
   _get_mutable_impl();
   // Is the current column "empty" ?
   bool col_empty = (stype() == dt::SType::VOID);
-  if (!col_empty) this->materialize();
 
   // Compute the final number of rows and stype
   size_t new_nrows = nrows();
-  dt::SType new_stype = col_empty? dt::SType::BOOL : stype();
+  dt::Type new_type = type();
   for (auto& col : columns) {
     col.materialize();
     new_nrows += col.nrows();
-    // TODO: need better stype promotion mechanism than mere max()
-    new_stype = std::max(new_stype, col.stype());
+    auto next_type = dt::Type::common(new_type, col.type());
+    if (next_type.is_invalid()) {
+      throw TypeError() << "Cannot rbind column of type `" << col.type()
+          << "` to a column of type `" << new_type << "`";
+    }
+    new_type = std::move(next_type);
   }
+  auto new_stype = new_type.stype();
 
   // Create the resulting Column object. It can be either: an empty column
   // filled with NAs; the current column; or a type-cast of the current column.

--- a/tests/munging/test-rbind.py
+++ b/tests/munging/test-rbind.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #-------------------------------------------------------------------------------
-# Copyright 2018-2020 H2O.ai
+# Copyright 2018-2021 H2O.ai
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/tests/munging/test-rbind.py
+++ b/tests/munging/test-rbind.py
@@ -391,6 +391,13 @@ def test_rbind_view4():
                   dt.Frame(A=['c', 'd', None, None, 'c', 'd', 'e']))
 
 
+def test_rbind_void():
+    DT1 = dt.Frame([None] * 10)
+    DT2 = dt.Frame([None] * 3)
+    res = dt.rbind(DT1, DT2)
+    assert res.types == [dt.Type.void]
+
+
 def test_rbind_different_stypes1():
     dt0 = dt.Frame([[1, 5, 24, 100]], stype=dt.int8)
     dt1 = dt.Frame([[1000, 2000]], stype=dt.int16)

--- a/tests/test-sets.py
+++ b/tests/test-sets.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #-------------------------------------------------------------------------------
-# Copyright 2018-2020 H2O.ai
+# Copyright 2018-2021 H2O.ai
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -97,7 +97,7 @@ def test_setfns_between_empty_frames1(fn):
 def test_setfns_between_empty_frames2(fn):
     DT = dt.Frame(A=[])
     res = fn(DT, DT)
-    assert_equals(res, dt.Frame(A=[], stype=bool))
+    assert_equals(res, dt.Frame(A=[]))
 
 
 def test_union_badargs():


### PR DESCRIPTION
- `rbind()`'s behavior now adheres to the general rules of type promotion: numeric columns are compatible with each other, but not with date / string columns.
- rbinding void columns now produces a void column (instead of a boolean).

Closes #2790