### PR TITLE
Do data shuffling when fitting a linear model

### DIFF
--- a/src/core/models/aggregate.cc
+++ b/src/core/models/aggregate.cc
@@ -789,7 +789,7 @@ bool Aggregator<T>::group_2d_categorical() {
       }
     });
 
-    std::vector<size_t> na_bins {na_bin1, na_bin2, na_bin3};
+    sztvec na_bins {na_bin1, na_bin2, na_bin3};
     size_t n_groups_merged = n_merged_nas(na_bins);
     size_t n_na_bins = (na_bin1 > 0) + (na_bin2 > 0) + (na_bin3 > 0);
 
@@ -904,8 +904,8 @@ bool Aggregator<T>::group_nd() {
   size_t ndims = std::min(max_dimensions, ncols);
 
   std::vector<exptr> exemplars; // Current exemplars
-  std::vector<size_t> ids; // All the exemplar's ids, including the merged ones
-  std::vector<size_t> coprimes;
+  sztvec ids; // All the exemplar's ids, including the merged ones
+  sztvec coprimes;
   size_t nexemplars = 0;
   size_t ncoprimes = 0;
 
@@ -1002,7 +1002,7 @@ bool Aggregator<T>::group_nd() {
             if (exemplars.size() > max_bins) {
               adjust_delta(delta, exemplars, ids, ndims);
             }
-            calculate_coprimes(exemplars.size(), coprimes);
+            coprimes = calculate_coprimes(exemplars.size());
             nexemplars = exemplars.size();
             ncoprimes = coprimes.size();
           } else {
@@ -1033,7 +1033,7 @@ bool Aggregator<T>::group_nd() {
  */
 template <typename T>
 void Aggregator<T>::adjust_delta(T& delta, std::vector<exptr>& exemplars,
-                                 std::vector<size_t>& ids, size_t ndims) {
+                                 sztvec& ids, size_t ndims) {
   size_t n = exemplars.size();
   size_t n_distances = (n * n - n) / 2;
   size_t k = 0;
@@ -1088,7 +1088,7 @@ void Aggregator<T>::adjust_delta(T& delta, std::vector<exptr>& exemplars,
  *  i.e. set which exemplar they belong to.
  */
 template <typename T>
-void Aggregator<T>::adjust_members(std::vector<size_t>& ids) {
+void Aggregator<T>::adjust_members(sztvec& ids) {
   auto d_members = static_cast<int32_t*>(dt_members->get_column(0).get_data_editable());
   auto map = std::unique_ptr<size_t[]>(new size_t[ids.size()]);
   auto nids = ids.size();
@@ -1111,7 +1111,7 @@ void Aggregator<T>::adjust_members(std::vector<size_t>& ids) {
  *  For each exemplar find the one it was merged to.
  */
 template <typename T>
-size_t Aggregator<T>::calculate_map(std::vector<size_t>& ids, size_t id) {
+size_t Aggregator<T>::calculate_map(sztvec& ids, size_t id) {
   if (id == ids[id]) {
     return id;
   } else {

--- a/src/core/models/dt_linearmodel.cc
+++ b/src/core/models/dt_linearmodel.cc
@@ -147,9 +147,9 @@ LinearModelFitOutput LinearModel<T>::fit_impl() {
   NThreads nthreads = nthreads_from_niters(iteration_nrows, MIN_ROWS_PER_THREAD);
 
   // Calculate parameters for the modular quasi-random generator.
-  // By default, when seed is zero, we don't do data shuffling.
-  ModularParams mp;
-  if (seed_) mp = modular_random_gen(dt_X_fit_->nrows(), seed_);
+  // By default, when seed is zero, modular_random_gen() will return
+  // multiplier == 1 and increment == 0, so we don't do any data shuffling,
+  auto mp = modular_random_gen(dt_X_fit_->nrows(), seed_);
 
   dt::parallel_region(nthreads,
     [&]() {

--- a/src/core/models/dt_linearmodel.cc
+++ b/src/core/models/dt_linearmodel.cc
@@ -146,8 +146,10 @@ LinearModelFitOutput LinearModel<T>::fit_impl() {
   job.set_message("Fitting...");
   NThreads nthreads = nthreads_from_niters(iteration_nrows, MIN_ROWS_PER_THREAD);
 
-  // Calculate parameters for the modular quasi-random generator
-  auto mp = modular_random_gen(dt_X_fit_->nrows(), seed_);
+  // Calculate parameters for the modular quasi-random generator.
+  // By default, when seed is zero, we don't do data shuffling.
+  ModularParams mp;
+  if (seed_) mp = modular_random_gen(dt_X_fit_->nrows(), seed_);
 
   dt::parallel_region(nthreads,
     [&]() {

--- a/src/core/models/dt_linearmodel.cc
+++ b/src/core/models/dt_linearmodel.cc
@@ -63,6 +63,7 @@ LinearModelFitOutput LinearModel<T>::fit(
   lambda2_ = static_cast<T>(params->lambda2);
   nepochs_ = static_cast<T>(params->nepochs);
   negative_class_ = params->negative_class;
+  seed_ = params->seed;
 
   dt_X_fit_ = dt_X_fit; dt_y_fit_ = dt_y_fit; dt_X_val_ = dt_X_val;
   dt_y_val_ = dt_y_val;
@@ -103,7 +104,7 @@ LinearModelFitOutput LinearModel<T>::fit_impl() {
   // Since `nepochs` can be a float value
   // - the model is trained `niterations - 1` times on
   //   `iteration_nrows` rows, where `iteration_nrows == dt_X_fit_->nrows()`;
-  // - then, the model is trained on the remaining `last_iteration_nrows` rows,
+  // - then, the model is trained once on the remaining `last_iteration_nrows` rows,
   //   where `0 < last_iteration_nrows <= dt_X_fit_->nrows()`.
   // If `nepochs_` is an integer number, `last_iteration_nrows == dt_X_fit_->nrows()`,
   // so that the last epoch becomes identical to all the others.
@@ -145,6 +146,9 @@ LinearModelFitOutput LinearModel<T>::fit_impl() {
   job.set_message("Fitting...");
   NThreads nthreads = nthreads_from_niters(iteration_nrows, MIN_ROWS_PER_THREAD);
 
+  // Calculate parameters for the modular quasi-random generator
+  auto mp = modular_random_gen(dt_X_fit_->nrows(), seed_);
+
   dt::parallel_region(nthreads,
     [&]() {
       // Each thread gets a private storage for observations and feature importances.
@@ -168,7 +172,8 @@ LinearModelFitOutput LinearModel<T>::fit_impl() {
 
         // Training
         dt::nested_for_static(iteration_size, ChunkSize(MIN_ROWS_PER_THREAD), [&](size_t i) {
-          size_t ii = (iteration_start + i) % dt_X_fit_->nrows();
+          // Do quasi-random data shuffling
+          size_t ii = ((iteration_start + i) * mp.multiplier + mp.increment) % dt_X_fit_->nrows();
           U target;
           bool isvalid = col_y_fit_.get_element(ii, &target);
           if (isvalid && _isfinite(target) && read_row(ii, cols, x)) {

--- a/src/core/models/dt_linearmodel.h
+++ b/src/core/models/dt_linearmodel.h
@@ -52,10 +52,12 @@ class LinearModel : public LinearModelBase {
     T lambda1_;
     T lambda2_;
     T nepochs_;
+    unsigned int seed_;
     bool negative_class_;
+    size_t : 16;
+
     // SType that corresponds to `T`
     SType stype_;
-    size_t : 48;
 
     // Labels that are automatically extracted from the target column.
     // For binomial classification, labels are stored as

--- a/src/core/models/dt_linearmodel_types.h
+++ b/src/core/models/dt_linearmodel_types.h
@@ -53,10 +53,10 @@ struct LinearModelParams {
   size_t : 16;
   unsigned int seed;
   LinearModelParams() : model_type(LinearModelType::AUTO),
-                 eta(0.005), lambda1(0.0), lambda2(0.0),
-                 nepochs(1.0), double_precision(false),
-                 negative_class(false), seed(0)
-                 {}
+                        eta(0.005), lambda1(0.0), lambda2(0.0),
+                        nepochs(1.0), double_precision(false),
+                        negative_class(false), seed(0)
+                        {}
 };
 
 

--- a/src/core/models/dt_linearmodel_types.h
+++ b/src/core/models/dt_linearmodel_types.h
@@ -50,11 +50,12 @@ struct LinearModelParams {
   double nepochs;
   bool double_precision;
   bool negative_class;
-  size_t : 48;
+  size_t : 16;
+  unsigned int seed;
   LinearModelParams() : model_type(LinearModelType::AUTO),
                  eta(0.005), lambda1(0.0), lambda2(0.0),
                  nepochs(1.0), double_precision(false),
-                 negative_class(false)
+                 negative_class(false), seed(0)
                  {}
 };
 

--- a/src/core/models/py_linearmodel.cc
+++ b/src/core/models/py_linearmodel.cc
@@ -120,6 +120,7 @@ model_type: "binomial" | "multinomial" | "regression" | "auto"
 
 seed: seed for the quasi-random number generator that is used for
     data shuffling when fitting the model, should be non-negative.
+    If seed is zero, no shuffling is performed.
 
 params: LinearModelParams
     Named tuple of the above parameters. One can pass either this tuple,
@@ -1020,7 +1021,8 @@ void LinearModel::set_model_type(const Arg& py_model_type) {
 static const char* doc_seed =
 R"(
 Seed for the quasi-random number generator that is used for
-data shuffling when fitting the model.
+data shuffling when fitting the model. If seed is zero,
+no shuffling is performed.
 
 Parameters
 ----------

--- a/src/core/models/py_linearmodel.h
+++ b/src/core/models/py_linearmodel.h
@@ -77,6 +77,7 @@ class LinearModel : public XObject<LinearModel> {
     oobj get_double_precision() const;
     oobj get_negative_class() const;
     oobj get_model_type() const;
+    oobj get_seed() const;
 
     // Setters
     void set_model(robj);                   // Not exposed, used for unpickling only
@@ -90,6 +91,7 @@ class LinearModel : public XObject<LinearModel> {
     void set_double_precision(const Arg&);  // Not exposed, used for unpickling only
     void set_negative_class(const Arg&);    // Disabled for a trained model
     void set_model_type(const Arg&);        // Disabled for a trained model
+    void set_seed(const Arg&);
 };
 
 

--- a/src/core/models/utils.cc
+++ b/src/core/models/utils.cc
@@ -26,16 +26,19 @@
 
 /**
  *  Generate a random multiplier and increment for quasi-random generator
- *  based on the modular arithmentics.
+ *  based on the modular arithmetics. When seed is zero, we just return
+ *  the default parameters: multiplier == 1 and increment == 0.
  */
 ModularParams modular_random_gen(size_t n, unsigned int seed) {
   ModularParams mp;
-  auto multipliers = calculate_coprimes(n);
-  std::default_random_engine gen(seed);
-  std::uniform_int_distribution<size_t> multiplier_dist(0, multipliers.size() - 1);
-  std::uniform_int_distribution<size_t> increment_dist(0, n - 1);
-  mp.multiplier = multipliers[multiplier_dist(gen)];
-  mp.increment = increment_dist(gen);
+  if (seed) {
+    auto multipliers = calculate_coprimes(n);
+    std::default_random_engine gen(seed);
+    std::uniform_int_distribution<size_t> multiplier_dist(0, multipliers.size() - 1);
+    std::uniform_int_distribution<size_t> increment_dist(0, n - 1);
+    mp.multiplier = multipliers[multiplier_dist(gen)];
+    mp.increment = increment_dist(gen);
+  }
   return mp;
 }
 

--- a/src/core/models/utils.cc
+++ b/src/core/models/utils.cc
@@ -52,18 +52,21 @@ sztvec calculate_coprimes(size_t n) {
   if (n == 1) {
     coprimes.push_back(1);
   } else {
-    std::vector<bool> mask(n - 1, false);
+    // Create mask and set `mask[i]` to `true` iff `i` is not coprime with `n`.
+    // We use `n` elements mask, instead of `n - 1`, to avoid shifting the
+    // mask index by one all the time.
+    std::vector<bool> mask(n, false);
     for (size_t i = 2; i <= n / 2; ++i) {
-      if (mask[i - 1]) continue;
+      if (mask[i]) continue;
       if (n % i == 0) {
         for (size_t ji = i; ji < n; ji += i) {
-          mask[ji - 1] = true;
+          mask[ji] = true;
         }
       }
     }
 
     for (size_t i = 1; i < n; ++i) {
-      if (mask[i - 1] == false) {
+      if (mask[i] == false) {
         coprimes.push_back(i);
       }
     }

--- a/src/core/models/utils.cc
+++ b/src/core/models/utils.cc
@@ -31,15 +31,30 @@
  */
 ModularParams modular_random_gen(size_t n, unsigned int seed) {
   ModularParams mp;
-  if (seed) {
-    auto multipliers = calculate_coprimes(n);
+  if (seed && n > 1) {
     std::default_random_engine gen(seed);
-    std::uniform_int_distribution<size_t> multiplier_dist(0, multipliers.size() - 1);
     std::uniform_int_distribution<size_t> increment_dist(0, n - 1);
-    mp.multiplier = multipliers[multiplier_dist(gen)];
     mp.increment = increment_dist(gen);
+
+    std::uniform_int_distribution<size_t> multiplier_dist(1, n - 1);
+    do {
+      mp.multiplier = multiplier_dist(gen);
+    } while (mp.multiplier != 1 && gcd(mp.multiplier, n) != 1);
   }
   return mp;
+}
+
+
+/**
+ *  Calculate greatest common divisor for `a` and `b`.
+ */
+size_t gcd(size_t a, size_t b) {
+  while (b) {
+    size_t tmp = b;
+    b = a % b;
+    a = tmp;
+  }
+  return a;
 }
 
 

--- a/src/core/models/utils.cc
+++ b/src/core/models/utils.cc
@@ -44,8 +44,8 @@ ModularParams modular_random_gen(size_t n, unsigned int seed) {
 
 
 /**
- *  For a given `n` calculate all the coprime numbers and return them
- *  as a `coprimes` vector.
+ *  For a given `n` calculate all the coprime numbers
+ *  that are less than `n` and return them as a `coprimes` vector.
  */
 sztvec calculate_coprimes(size_t n) {
   sztvec coprimes;
@@ -56,10 +56,8 @@ sztvec calculate_coprimes(size_t n) {
     for (size_t i = 2; i <= n / 2; ++i) {
       if (mask[i - 1]) continue;
       if (n % i == 0) {
-        size_t j = 1;
-        while (j * i < n) {
-          mask[j * i - 1] = true;
-          j++;
+        for (size_t ji = i; ji < n; ji += i) {
+          mask[ji - 1] = true;
         }
       }
     }

--- a/src/core/models/utils.cc
+++ b/src/core/models/utils.cc
@@ -23,35 +23,53 @@
 #include "models/utils.h"
 #include "parallel/api.h"
 
+
+/**
+ *  Generate a random multiplier and increment for quasi-random generator
+ *  based on the modular arithmentics.
+ */
+ModularParams modular_random_gen(size_t n, unsigned int seed) {
+  ModularParams mp;
+  auto multipliers = calculate_coprimes(n);
+  std::default_random_engine gen(seed);
+  std::uniform_int_distribution<size_t> multiplier_dist(0, multipliers.size() - 1);
+  std::uniform_int_distribution<size_t> increment_dist(0, n - 1);
+  mp.multiplier = multipliers[multiplier_dist(gen)];
+  mp.increment = increment_dist(gen);
+  return mp;
+}
+
+
 /**
  *  For a given `n` calculate all the coprime numbers and return them
  *  as a `coprimes` vector.
  */
-void calculate_coprimes(size_t n, sztvec& coprimes) {
-  coprimes.clear();
+sztvec calculate_coprimes(size_t n) {
+  sztvec coprimes;
   if (n == 1) {
     coprimes.push_back(1);
-    return;
-  }
+  } else {
+    std::vector<bool> mask(n - 1, false);
+    for (size_t i = 2; i <= n / 2; ++i) {
+      if (mask[i - 1]) continue;
+      if (n % i == 0) {
+        size_t j = 1;
+        while (j * i < n) {
+          mask[j * i - 1] = true;
+          j++;
+        }
+      }
+    }
 
-  std::vector<bool> mask(n - 1, false);
-  for (size_t i = 2; i <= n / 2; ++i) {
-    if (mask[i - 1]) continue;
-    if (n % i == 0) {
-      size_t j = 1;
-      while (j * i < n) {
-        mask[j * i - 1] = true;
-        j++;
+    for (size_t i = 1; i < n; ++i) {
+      if (mask[i - 1] == false) {
+        coprimes.push_back(i);
       }
     }
   }
-
-  for (size_t i = 1; i < n; ++i) {
-    if (mask[i - 1] == 0) {
-      coprimes.push_back(i);
-    }
-  }
+  return coprimes;
 }
+
 
 
 /**

--- a/src/core/models/utils.h
+++ b/src/core/models/utils.h
@@ -52,6 +52,7 @@ struct ModularParams {
 
 ModularParams modular_random_gen(size_t, unsigned int);
 sztvec calculate_coprimes(size_t);
+size_t gcd(size_t, size_t);
 
 
 /**

--- a/src/core/models/utils.h
+++ b/src/core/models/utils.h
@@ -44,6 +44,9 @@ using sizetptr = std::unique_ptr<size_t[]>;
 struct ModularParams {
   size_t multiplier;
   size_t increment;
+  ModularParams() : multiplier(1),
+                    increment(0)
+                    {}
 };
 
 

--- a/src/core/models/utils.h
+++ b/src/core/models/utils.h
@@ -26,6 +26,7 @@
 #include <limits>
 #include <memory>
 #include <numeric>      // std::iota
+#include <random>
 #include "datatable.h"
 #include "parallel/api.h"
 
@@ -35,7 +36,19 @@ using tptr = typename std::unique_ptr<T[]>;
 using uint64ptr = std::unique_ptr<uint64_t[]>;
 using sizetptr = std::unique_ptr<size_t[]>;
 
-void calculate_coprimes(size_t, sztvec&);
+
+/**
+ *  Structure to store parameters of the modular quasi-random
+ *  generator.
+ */
+struct ModularParams {
+  size_t multiplier;
+  size_t increment;
+};
+
+
+ModularParams modular_random_gen(size_t, unsigned int);
+sztvec calculate_coprimes(size_t);
 
 
 /**
@@ -66,14 +79,6 @@ inline T sigmoid(T x) {
   return T(1) / (T(1) + std::exp(-x));
 }
 
-/**
- *  Derivative of sigmoid function.
- */
-template<typename T>
-inline T dsigmoid(T x) {
-  return std::exp(-x) / pow(T(1) + std::exp(-x), T(2));
-}
-
 
 /**
  *  Identity function.
@@ -81,16 +86,6 @@ inline T dsigmoid(T x) {
 template<typename T>
 inline T identity(T x) {
   return x;
-}
-
-
-/**
- *  Derivative of identity function.
- */
-template<typename T>
-inline T didentity(T x) {
-  (void) x;
-  return T(1);
 }
 
 


### PR DESCRIPTION
In general, it is recommended to shuffle training data when fitting the model with SGD. The same is suggested in the [paper](http://martin.zinkevich.org/publications/nips2010.pdf) that we base our parallel implementation on. 

In this PR we implement quasi-random data shuffling for the training data, similar to what we currently do in Aggregator. The shuffling could be disabled by setting the seed to zero.

WIP for #2358 