### PR TITLE
Fix frame's terminal display when data contains special characters 

### DIFF
--- a/docs/releases/v1.0.0.rst
+++ b/docs/releases/v1.0.0.rst
@@ -49,6 +49,9 @@
     -[fix] Passing an invalid value to the ``column=`` argument of the
       :meth:`.to_numpy()` method will no longer result in a crash.
 
+    -[fix] Frame terminal display no longer overflows terminal's width if
+      it contains strings with special characters. [#2844]
+
     -[api] Converting a frame with incompatible types into a numpy array will
       now raise an error (instead of auto-promoting to object type). However,
       if the user explicitly requests promotion into the object type then

--- a/src/core/frame/repr/terminal_widget.cc
+++ b/src/core/frame/repr/terminal_widget.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019-2020 H2O.ai
+// Copyright 2019-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -189,10 +189,10 @@ void TerminalWidget::_prerender_columns(int terminal_width)
   *     ellipsis having more priority;
   *
   *   - the order in which columns from the left and from the right
-  *     are taken is such the taken and the remaining columns on both
+  *     are taken is such that the counts of remaining columns on both
   *     sides are roughly proportional to their initial counts.
   *
-  *   - the ellipsis column is rendered lsat, if present.
+  *   - the ellipsis column is rendered last, if present.
   *
   */
 std::vector<size_t> TerminalWidget::_order_colindices() const {
@@ -265,13 +265,11 @@ void TerminalWidget::_render_header_separator() {
 
 void TerminalWidget::_render_data() {
   for (size_t k = 0; k < rowindices_.size(); ++k) {
-    if (has_rowindex_column_) {
-      out_ << style::grey;
-      text_columns_[0]->print_value(out_, k);
-      out_ << style::end;
-    }
-    for (size_t i = has_rowindex_column_; i < text_columns_.size(); ++i) {
+    for (size_t i = 0; i < text_columns_.size(); ++i) {
+      bool grey = (i == 0) && has_rowindex_column_;
+      if (grey) out_ << style::grey;
       text_columns_[i]->print_value(out_, k);
+      if (grey) out_ << style::end;
     }
     out_ << '\n';
   }

--- a/src/core/frame/repr/terminal_widget.cc
+++ b/src/core/frame/repr/terminal_widget.cc
@@ -91,15 +91,9 @@ void TerminalWidget::_prerender_columns(int terminal_width)
   // If there are no keys, we add a "row numbers" column + a vertical
   // separator column.
   if (nkeys == 0) {
-    auto irows = static_cast<int64_t>(dt_->nrows());
-    text_columns_[0] = text_column(
-      new Data_TextColumn("",
-                          Column(new Range_ColumnImpl(0, irows, 1)),
-                          rowindices_,
-                          remaining_width)
-    );
+    text_columns_[0] = text_column(new RowIndex_TextColumn(rowindices_));
     text_columns_[1] = text_column(new VSep_TextColumn());
-    remaining_width -= text_columns_[0]->get_width();
+    remaining_width -= text_columns_[0]->get_width() + 1;
     remaining_width -= text_columns_[1]->get_width();
     has_rowindex_column_ = true;
     k0 = 2;
@@ -266,10 +260,7 @@ void TerminalWidget::_render_header_separator() {
 void TerminalWidget::_render_data() {
   for (size_t k = 0; k < rowindices_.size(); ++k) {
     for (size_t i = 0; i < text_columns_.size(); ++i) {
-      bool grey = (i == 0) && has_rowindex_column_;
-      if (grey) out_ << style::grey;
       text_columns_[i]->print_value(out_, k);
-      if (grey) out_ << style::end;
     }
     out_ << '\n';
   }

--- a/src/core/frame/repr/text_column.cc
+++ b/src/core/frame/repr/text_column.cc
@@ -265,11 +265,12 @@ tstring Data_TextColumn::_escape_string(const CString& str) const
     }
     // C0 block + \x7F (DEL) character
     else if (c <= 0x1F || c == 0x7F) {
-      ch++;
-      if (ch == end) remaining_width++;
+      if (ch + 1 == end) remaining_width++;
       auto escaped = _escaped_char(c);
       if (static_cast<int>(escaped.size()) > remaining_width) break;
+      remaining_width -= static_cast<int>(escaped.size());
       out << std::move(escaped);
+      ch++;
     }
     // unicode character
     else {

--- a/src/core/frame/repr/text_column.cc
+++ b/src/core/frame/repr/text_column.cc
@@ -446,4 +446,72 @@ void Ellipsis_TextColumn::print_value(TerminalStream& out, size_t) const {
 
 
 
+//------------------------------------------------------------------------------
+// RowIndex_TextColumn
+//------------------------------------------------------------------------------
+
+RowIndex_TextColumn::RowIndex_TextColumn(const sztvec& indices) {
+  row_numbers_ = indices;
+  width_ = 0;
+  if (!indices.empty()) {
+    size_t max_value = indices.back();
+    if (max_value == NA_index) {
+      max_value = indices.size() >= 2? indices[indices.size() - 2] : 0;
+    }
+    while (max_value) {
+      width_++;
+      max_value /= 10;
+    }
+  }
+  if (width_ < 2) width_ = 2;
+  if (width_ < ellipsis_.size()) {
+    bool has_ellipsis = false;
+    for (size_t k : row_numbers_) {
+      if (k == NA_index) {
+        has_ellipsis = true;
+        break;
+      }
+    }
+    if (has_ellipsis) {
+      width_ = ellipsis_.size();
+    }
+  }
+  margin_left_ = false;
+  margin_right_ = true;
+}
+
+
+void RowIndex_TextColumn::print_name(TerminalStream& out) const {
+  out << std::string(width_ + 1, ' ');
+}
+
+void RowIndex_TextColumn::print_type(TerminalStream& out) const {
+  out << std::string(width_ + 1, ' ');
+}
+
+void RowIndex_TextColumn::print_separator(TerminalStream& out) const {
+  out << std::string(width_, '-')
+      << " ";
+}
+
+void RowIndex_TextColumn::print_value(TerminalStream& out, size_t i) const {
+  size_t row_index = row_numbers_[i];
+  if (row_index == NA_index) {
+    out << std::string(width_ - ellipsis_.size(), ' ')
+        << ellipsis_ << " ";
+  }
+  else {
+    auto rendered_value = std::to_string(row_numbers_[i]);
+    xassert(width_ >= rendered_value.size());
+    out << style::grey
+        << std::string(width_ - rendered_value.size(), ' ')
+        << rendered_value
+        << " "
+        << style::end;
+  }
+}
+
+
+
+
 }  // namespace dt

--- a/src/core/frame/repr/text_column.cc
+++ b/src/core/frame/repr/text_column.cc
@@ -90,16 +90,12 @@ Data_TextColumn::Data_TextColumn(const std::string& name,
   xassert(max_width >= 4);
   // -2 takes into account column's margins
   max_width_ = std::min(max_width - 2, display_max_column_width);
+  std::string type_name = col.type().to_string();
   name_ = _escape_string(CString(name));
-  type_ = _escape_string(CString::from_null_terminated_string(
-                            stype_name(col.stype())));
+  type_ = _escape_string(CString(type_name));
   width_ = std::max(std::max(width_, name_.size()),
                     name_.empty()? 0 : type_.size());
-  LType ltype = col.ltype();
-  align_right_ = (ltype == LType::MU) ||
-                 (ltype == LType::BOOL) ||
-                 (ltype == LType::INT) ||
-                 (ltype == LType::REAL);
+  align_right_ = col.type().is_numeric();
   margin_left_ = true;
   margin_right_ = true;
   _render_all_data(col, indices);

--- a/src/core/frame/repr/text_column.cc
+++ b/src/core/frame/repr/text_column.cc
@@ -419,8 +419,9 @@ void VSep_TextColumn::print_value(TerminalStream& out, size_t) const {
 //------------------------------------------------------------------------------
 
 Ellipsis_TextColumn::Ellipsis_TextColumn() : TextColumn() {
-  ell_ = tstring(term_->unicode_allowed()? "\xE2\x80\xA6" : "~",
+  ell_ = tstring(term_->unicode_allowed()? " \xE2\x80\xA6 " : " ~ ",
                  style::dim|style::nobold);
+  space_ = tstring("   ");
   width_ = 1;
   margin_left_ = true;
   margin_right_ = true;
@@ -428,27 +429,19 @@ Ellipsis_TextColumn::Ellipsis_TextColumn() : TextColumn() {
 
 
 void Ellipsis_TextColumn::print_name(TerminalStream& out) const {
-  out << std::string(margin_left_, ' ');
   out << ell_;
-  out << std::string(margin_right_, ' ');
 }
-
 
 void Ellipsis_TextColumn::print_type(TerminalStream& out) const {
-  out << std::string(margin_left_ + margin_right_ + width_, ' ');
+  out << space_;
 }
 
-
 void Ellipsis_TextColumn::print_separator(TerminalStream& out) const {
-  out << std::string(margin_left_, ' ');
-  out << ' ';
-  out << std::string(margin_right_, ' ');
+  out << space_;
 }
 
 void Ellipsis_TextColumn::print_value(TerminalStream& out, size_t) const {
-  out << std::string(margin_left_, ' ');
   out << ell_;
-  out << std::string(margin_right_, ' ');
 }
 
 

--- a/src/core/frame/repr/text_column.h
+++ b/src/core/frame/repr/text_column.h
@@ -139,6 +139,7 @@ class VSep_TextColumn : public TextColumn {
 class Ellipsis_TextColumn : public TextColumn {
   private:
     tstring ell_;
+    tstring space_;
 
   public:
     Ellipsis_TextColumn();

--- a/src/core/frame/repr/text_column.h
+++ b/src/core/frame/repr/text_column.h
@@ -154,5 +154,22 @@ class Ellipsis_TextColumn : public TextColumn {
 
 
 
+class RowIndex_TextColumn : public TextColumn {
+  private:
+    sztvec row_numbers_;
+
+  public:
+    RowIndex_TextColumn(const sztvec& indices);
+    RowIndex_TextColumn(const RowIndex_TextColumn&) = default;
+    RowIndex_TextColumn(RowIndex_TextColumn&&) noexcept = default;
+
+    void print_name(TerminalStream&) const override;
+    void print_type(TerminalStream&) const override;
+    void print_separator(TerminalStream&) const override;
+    void print_value(TerminalStream&, size_t i) const override;
+};
+
+
+
 }  // namespace dt
 #endif

--- a/src/core/frame/repr/widget.cc
+++ b/src/core/frame/repr/widget.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019-2020 H2O.ai
+// Copyright 2019-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -29,6 +29,8 @@ constexpr size_t Widget::NA_index;
 Widget::SplitViewTag Widget::split_view_tag;
 Widget::WindowedTag Widget::windowed_tag;
 
+
+
 //------------------------------------------------------------------------------
 // Construction
 //------------------------------------------------------------------------------
@@ -44,27 +46,27 @@ Widget::Widget(DataTable* dt) {
 
 Widget::Widget(DataTable* dt, SplitViewTag) : Widget(dt)
 {
-  startcol_ = NA_index;
-  startrow_ = NA_index;
+  is_split_view_ = true;
 
   constexpr size_t maxcols = 15;
-  cols0_ = (ncols_ <= maxcols) ? ncols_ : maxcols * 2 / 3;
-  cols1_ = (ncols_ <= maxcols) ? 0 : maxcols - cols0_;
-  cols0_ = std::max(cols0_, dt->nkeys());
+  col0_ = (ncols_ <= maxcols) ? ncols_ : maxcols * 2 / 3;
+  col1_ = (ncols_ <= maxcols) ? 0 : maxcols - col0_;
+  col0_ = std::max(col0_, dt->nkeys());
 
   size_t max_nrows = std::max(display_max_nrows,
                               display_head_nrows + display_tail_nrows);
-  rows0_ = (nrows_ > max_nrows) ? display_head_nrows : nrows_;
-  rows1_ = (nrows_ > max_nrows) ? display_tail_nrows : 0;
+  row0_ = (nrows_ > max_nrows) ? display_head_nrows : nrows_;
+  row1_ = (nrows_ > max_nrows) ? display_tail_nrows : 0;
 }
 
 
 Widget::Widget(DataTable* dt, WindowedTag) : Widget(dt)
 {
-  startcol_ = 0;
-  startrow_ = 0;
-  cols0_ = 15;
-  rows0_ = 30;
+  is_split_view_ = false;
+  col0_ = nkeys_;
+  col1_ = 15;
+  row0_ = 0;
+  row1_ = 30;
 }
 
 
@@ -75,36 +77,37 @@ Widget::Widget(DataTable* dt, WindowedTag) : Widget(dt)
 //------------------------------------------------------------------------------
 
 void Widget::render_all() {
-  _generate_column_indices();
-  _generate_row_indices();
+  if (is_split_view_) {
+    _generate_column_indices_split_view();
+    _generate_row_indices_split_view();
+  } else {
+    _generate_column_indices_windowed_view();
+    _generate_row_indices_windowed_view();
+  }
   _render();
 }
 
 
-void Widget::_generate_column_indices() {
-  colindices_.clear();
-
-  // Split view mode
-  if (startcol_ == NA_index) {
-    colindices_.reserve(cols0_ + cols1_ + 1);
-    for (size_t i = 0; i < ncols_; ++i) {
-      if (i == cols0_) {
-        colindices_.push_back(NA_index);
-        if (cols1_ == 0) break;
-        i = ncols_ - cols1_;
-      }
-      colindices_.push_back(i);
+void Widget::_generate_column_indices_split_view() {
+  colindices_.reserve(col0_ + col1_ + 1);
+  for (size_t i = 0; i < ncols_; ++i) {
+    if (i == col0_) {
+      colindices_.push_back(NA_index);
+      if (col1_ == 0) break;
+      i = ncols_ - col1_;
     }
+    colindices_.push_back(i);
   }
-  // Windowed mode
-  else {
-    colindices_.reserve(nkeys_ + cols0_);
-    for (size_t i = 0; i < nkeys_; ++i) {
-      colindices_.push_back(i);
-    }
-    for (size_t i = 0; i < cols0_; ++i) {
-      colindices_.push_back(i + startcol_);
-    }
+}
+
+
+void Widget::_generate_column_indices_windowed_view() {
+  colindices_.reserve(nkeys_ + col0_);
+  for (size_t i = 0; i < nkeys_; ++i) {
+    colindices_.push_back(i);
+  }
+  for (size_t i = col0_; i < col1_; ++i) {
+    colindices_.push_back(i);
   }
 }
 
@@ -112,30 +115,26 @@ void Widget::_generate_column_indices() {
 // Populate array `rowindices_` with indices of the rows that shall be
 // rendered. The array may also contain `NA_index`, which indicates an
 // "ellipsis" row.
-void Widget::_generate_row_indices() {
-  rowindices_.clear();
+void Widget::_generate_row_indices_split_view() {
+  rowindices_.reserve(row0_ + row1_ + 1);
+  for (size_t i = 0; i < nrows_; ++i) {
+    if (i == row0_) {
+      rowindices_.push_back(NA_index);
+      if (row1_ == 0) break;
+      i = nrows_ - row1_;
+    }
+    rowindices_.push_back(i);
+  }
+}
 
-  // Split view mode
-  if (startrow_ == NA_index) {
-    rowindices_.reserve(rows0_ + rows1_ + 1);
-    for (size_t i = 0; i < nrows_; ++i) {
-      if (i == rows0_) {
-        rowindices_.push_back(NA_index);
-        if (rows1_ == 0) break;
-        i = nrows_ - rows1_;
-      }
-      rowindices_.push_back(i);
-    }
+
+void Widget::_generate_row_indices_windowed_view() {
+  rowindices_.reserve(row0_ + 2);
+  if (row0_ > 0) rowindices_.push_back(NA_index);
+  for (size_t i = row0_; i < row1_; ++i) {
+    rowindices_.push_back(i);
   }
-  // Windowed mode
-  else {
-    rowindices_.reserve(rows0_ + 2);
-    if (startrow_ > 0) rowindices_.push_back(NA_index);
-    for (size_t i = 0; i < rows0_; ++i) {
-      rowindices_.push_back(i + startrow_);
-    }
-    if (rows0_ + startrow_ < nrows_) rowindices_.push_back(NA_index);
-  }
+  if (row1_ < nrows_) rowindices_.push_back(NA_index);
 }
 
 

--- a/src/core/frame/repr/widget.h
+++ b/src/core/frame/repr/widget.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019 H2O.ai
+// Copyright 2019-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -34,26 +34,25 @@ namespace dt {
   *
   * The widget normally represents only a subset of Frame's data. Two
   * modes are supported:
-  *   - "split view", when the first + the last rows/columns are
-  *     rendered, with an ellipsis row/column in the middle; and
-  *   - "window view", which renders a simple sub-range of both rows
-  *     and columns.
   *
-  * The "split view" mode is indicated by `startcol_ == startrow_ ==
-  * NA_index`. In this mode we generate first `cols0_` / last `cols1_`
-  * columns, and first `rows0` / last `rows1` rows.
+  *   - "split view", indicated by `is_split_view_ == true`. In this
+  *     mode we generate first `col0_` / last `col1_` columns, and
+  *     first `rows0` / last `rows1` rows.
   *
-  * The "windowed" mode is indicated by `startcol_ != NA_index` and
-  * `startrow_ != NA_index`. In this mode we render a subrange of
-  * `cols0_` columns starting at `startcol_`, and a subrange of
-  * `rows0_` rows starting at index `startrow_`.
+  *   - "window view", indicated by `is_split_view_ == false`. In this
+  *     mode we render a subrange of columns `[col0_; col1_)`, and a
+  *     subrange of rows `[row0_; row1_)`.
   *
+  * Note: we do not use inheritance to implement Split/Windowed view
+  * because we want TerminalWidget / HtmlWidget to inherit from this
+  * class.
   */
 class Widget {
   private:
-    size_t startcol_, startrow_;
-    size_t cols0_, cols1_;
-    size_t rows0_, rows1_;
+    size_t col0_, col1_;
+    size_t row0_, row1_;
+    bool is_split_view_;
+    size_t : 56;
 
   protected:
     DataTable* dt_;
@@ -78,8 +77,10 @@ class Widget {
     explicit Widget(DataTable* dt);
 
     virtual void _render() = 0;
-    void _generate_column_indices();
-    void _generate_row_indices();
+    void _generate_column_indices_split_view();
+    void _generate_row_indices_split_view();
+    void _generate_column_indices_windowed_view();
+    void _generate_row_indices_windowed_view();
 };
 
 

--- a/tests/frame/test-repr-text.py
+++ b/tests/frame/test-repr-text.py
@@ -29,14 +29,14 @@ import sys
 
 
 def color_line(s):
-    return re.sub(r"((?:…|~|NA|\\n|\\r|\\t|\\x..|\\u....|\\U000.....)+)",
+    return re.sub(r"((?: … |…|~|NA|\\n|\\r|\\t|\\x..|\\u....|\\U000.....)+)",
                   "\x1b[2m\\1\x1b[0m", s)
 
 
 def color_header(s):
     return re.sub(r"((?:NA|\\n|\\r|\\t|\\x..|\\u....|\\U000.....)+)",
                   "\x1b[2m\\1\x1b[0;1m",
-                  re.sub("…", "\x1b[0;2m…\x1b[0;1m", s))
+                  re.sub(" … ", "\x1b[0;2m … \x1b[0;1m", s))
 
 
 def check_colored_output(actual, header, types, separator, *body, keyed=False):

--- a/tests/frame/test-repr-text.py
+++ b/tests/frame/test-repr-text.py
@@ -749,3 +749,20 @@ def test_encoding_autodetection(tempfile):
                        "-- + ------\n"
                        " 0 | \\u2728\n"
                        "[1 row x 1 column]\n")
+
+
+def test_issue2844():
+    s = ''.join(chr(i) for i in range(30))
+    DT = dt.Frame([s[:25], s[:26], s[:27], s, "a"*100, "b"*101])
+    assert str(DT) == "\n".join([
+        r"   | C0                                                                                                  ",
+        r"   | str32                                                                                               ",
+        r"-- + ----------------------------------------------------------------------------------------------------",
+        r" 0 | \x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0B\x0C\r\x0E\x0F\x10\x11\x12\x13\x14\x15\x16\x17\x18      ",
+        r" 1 | \x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0B\x0C\r\x0E\x0F\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19  ",
+        r" 2 | \x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0B\x0C\r\x0E\x0F\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19… ",
+        r" 3 | \x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0B\x0C\r\x0E\x0F\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19… ",
+        r" 4 | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        r" 5 | bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb…",
+        r"[6 rows x 1 column]", ""
+    ])


### PR DESCRIPTION
- Fix bug caused by having special characters in a string column (the string was not properly truncated);
- Additionally, fixed a bug where if the string was truncated at last character, it was not displaying ellipsis;
- Several refactorings in the `Widget` class: properties  `startcol_`, `startrow_` removed and replaced with `is_split_view`  boolean tag;
- Created `RowIndex_TextColumn` class

Closes #2844