### PR TITLE
Implement learning rate schedules for linear model

### DIFF
--- a/src/core/models/dt_linearmodel.cc
+++ b/src/core/models/dt_linearmodel.cc
@@ -318,7 +318,7 @@ void LinearModel<T>::adjust_eta(T& eta, size_t iter) {
       eta = eta0_;
       break;
     case LearningRateSchedule::TIME_BASED:
-      eta /= (1 + eta_decay_ * iter);
+      eta = eta0_ / (1 + eta_decay_ * iter);
       break;
     case LearningRateSchedule::STEP_BASED:
       eta = eta0_ * pow(eta_decay_, floor((1 + iter) / eta_drop_rate_));

--- a/src/core/models/dt_linearmodel.cc
+++ b/src/core/models/dt_linearmodel.cc
@@ -59,6 +59,9 @@ LinearModelFitOutput LinearModel<T>::fit(
 {
   // Cast input parameters to `T`
   eta_ = static_cast<T>(params->eta);
+  eta_decay_ = static_cast<T>(params->eta_decay);
+  eta_drop_rate_ = static_cast<T>(params->eta_drop_rate);
+  eta_schedule_ = params->eta_schedule;
   lambda1_ = static_cast<T>(params->lambda1);
   lambda2_ = static_cast<T>(params->lambda2);
   nepochs_ = static_cast<T>(params->nepochs);
@@ -74,13 +77,14 @@ LinearModelFitOutput LinearModel<T>::fit(
 
   auto res = fit_model();
 
-  dt_X_fit_ = nullptr; dt_y_fit_ = nullptr; dt_X_val_ = nullptr;
+  dt_X_fit_ = nullptr;
+  dt_y_fit_ = nullptr;
+  dt_X_val_ = nullptr;
   dt_y_val_ = nullptr;
   nepochs_val_ = T_NAN;
   val_error_ = T_NAN;
   return res;
 }
-
 
 
 /**
@@ -150,6 +154,7 @@ LinearModelFitOutput LinearModel<T>::fit_impl() {
   // By default, when seed is zero, modular_random_gen() will return
   // multiplier == 1 and increment == 0, so we don't do any data shuffling,
   auto mp = modular_random_gen(dt_X_fit_->nrows(), seed_);
+  T eta = eta_;
 
   dt::parallel_region(nthreads,
     [&]() {
@@ -210,12 +215,14 @@ LinearModelFitOutput LinearModel<T>::fit_impl() {
         }); // End training
         barrier();
 
-        // Update global model coefficients by averaging the local ones
+        // Update global model coefficients by averaging the local ones.
+        // Also update `eta` according to the schedule.
         {
-          // First, zero out the global model
+          // First, zero out the global model and update `eta`.
           if (dt::this_thread_index() == 0) {
             init_model();
             betas_ = get_model_data(dt_model_);
+            eta = eta_from_iter(iter + 1);
           }
           barrier();
 
@@ -298,6 +305,30 @@ LinearModelFitOutput LinearModel<T>::fit_impl() {
   LinearModelFitOutput res = {epoch_stopped, static_cast<double>(loss)};
 
   return res;
+}
+
+
+/**
+ *  Calculate learning rate for a particular schedule.
+ */
+template <typename T>
+T LinearModel<T>::eta_from_iter(size_t iter) {
+  T eta;
+  switch (eta_schedule_) {
+    case LearningRateSchedule::CONSTANT:
+      eta = eta_;
+      break;
+    case LearningRateSchedule::TIME_BASED:
+      eta = eta_ / (1 + eta_decay_ * iter);
+      break;
+    case LearningRateSchedule::STEP_BASED:
+      eta = eta_ * pow(eta_decay_, floor((1 + iter) / eta_drop_rate_));
+      break;
+    case LearningRateSchedule::EXPONENTIAL:
+      eta = eta_ / exp(eta_decay_ * iter);
+      break;
+  }
+  return eta;
 }
 
 

--- a/src/core/models/dt_linearmodel.cc
+++ b/src/core/models/dt_linearmodel.cc
@@ -201,7 +201,7 @@ LinearModelFitOutput LinearModel<T>::fit_impl() {
                 gradient += 2 * lambda2_ * betas[k][j];      // L2 regularization
 
                 if (_isfinite(gradient)) {
-                  betas[k][j] -= eta_ * gradient;
+                  betas[k][j] -= eta * gradient;
                 }
               }
             }

--- a/src/core/models/dt_linearmodel.cc
+++ b/src/core/models/dt_linearmodel.cc
@@ -58,7 +58,7 @@ LinearModelFitOutput LinearModel<T>::fit(
 )
 {
   // Cast input parameters to `T`
-  eta_ = static_cast<T>(params->eta);
+  eta0_ = static_cast<T>(params->eta0);
   eta_decay_ = static_cast<T>(params->eta_decay);
   eta_drop_rate_ = static_cast<T>(params->eta_drop_rate);
   eta_schedule_ = params->eta_schedule;
@@ -154,7 +154,7 @@ LinearModelFitOutput LinearModel<T>::fit_impl() {
   // By default, when seed is zero, modular_random_gen() will return
   // multiplier == 1 and increment == 0, so we don't do any data shuffling,
   auto mp = modular_random_gen(dt_X_fit_->nrows(), seed_);
-  T eta = eta_;
+  T eta = eta0_;
 
   dt::parallel_region(nthreads,
     [&]() {
@@ -315,16 +315,16 @@ template <typename T>
 void LinearModel<T>::adjust_eta(T& eta, size_t iter) {
   switch (eta_schedule_) {
     case LearningRateSchedule::CONSTANT:
-      eta = eta_;
+      eta = eta0_;
       break;
     case LearningRateSchedule::TIME_BASED:
       eta /= (1 + eta_decay_ * iter);
       break;
     case LearningRateSchedule::STEP_BASED:
-      eta = eta_ * pow(eta_decay_, floor((1 + iter) / eta_drop_rate_));
+      eta = eta0_ * pow(eta_decay_, floor((1 + iter) / eta_drop_rate_));
       break;
     case LearningRateSchedule::EXPONENTIAL:
-      eta = eta_ / exp(eta_decay_ * iter);
+      eta = eta0_ / exp(eta_decay_ * iter);
   }
 }
 

--- a/src/core/models/dt_linearmodel.h
+++ b/src/core/models/dt_linearmodel.h
@@ -49,15 +49,19 @@ class LinearModel : public LinearModelBase {
 
     // Individual parameters converted to T type.
     T eta_;
+    T eta_decay_;
+    T eta_drop_rate_;
     T lambda1_;
     T lambda2_;
     T nepochs_;
     unsigned int seed_;
     bool negative_class_;
-    size_t : 16;
 
     // SType that corresponds to `T`
     SType stype_;
+    size_t : 16;
+
+    LearningRateSchedule eta_schedule_;
 
     // Labels that are automatically extracted from the target column.
     // For binomial classification, labels are stored as
@@ -96,6 +100,7 @@ class LinearModel : public LinearModelBase {
     T predict_row(const tptr<T>& x, const std::vector<T*>, const size_t);
     dtptr create_p(size_t);
     virtual void finalize_predict(std::vector<T*>, const size_t, const int32_t*) {}
+    T eta_from_iter(size_t);
 
     // Model helper methods
     void create_model();

--- a/src/core/models/dt_linearmodel.h
+++ b/src/core/models/dt_linearmodel.h
@@ -100,7 +100,7 @@ class LinearModel : public LinearModelBase {
     T predict_row(const tptr<T>& x, const std::vector<T*>, const size_t);
     dtptr create_p(size_t);
     virtual void finalize_predict(std::vector<T*>, const size_t, const int32_t*) {}
-    T eta_from_iter(size_t);
+    void adjust_eta(T&, size_t);
 
     // Model helper methods
     void create_model();

--- a/src/core/models/dt_linearmodel.h
+++ b/src/core/models/dt_linearmodel.h
@@ -48,7 +48,7 @@ class LinearModel : public LinearModelBase {
     dtptr dt_fi_;
 
     // Individual parameters converted to T type.
-    T eta_;
+    T eta0_;
     T eta_decay_;
     T eta_drop_rate_;
     T lambda1_;

--- a/src/core/models/dt_linearmodel_types.h
+++ b/src/core/models/dt_linearmodel_types.h
@@ -31,11 +31,22 @@ namespace dt {
  *  Supported linear model types.
  */
 enum class LinearModelType : size_t {
-  UNKNOWN     = 0, // Unknown model type
-  AUTO        = 1, // Automatically detect model type
-  REGRESSION  = 2, // Numerical regression
-  BINOMIAL    = 3, // Binomial logistic regression
-  MULTINOMIAL = 4  // Multinomial logistic regression
+  AUTO        = 0, // Automatically detect model type
+  REGRESSION  = 1, // Numerical regression
+  BINOMIAL    = 2, // Binomial logistic regression
+  MULTINOMIAL = 3  // Multinomial logistic regression
+};
+
+
+/**
+ *  Supported learning rate schedules, see
+ *  https://en.wikipedia.org/wiki/Learning_rate#Learning_rate_schedule
+ */
+enum class LearningRateSchedule : size_t {
+  CONSTANT    = 0, // eta
+  TIME_BASED  = 1, // eta / (1 + decay * iteration)
+  STEP_BASED  = 2, // eta * decay ^ floor((1 + iteration) / drop_rate)
+  EXPONENTIAL = 3, // eta / exp(decay * iteration)
 };
 
 
@@ -45,6 +56,9 @@ enum class LinearModelType : size_t {
 struct LinearModelParams {
   LinearModelType model_type;
   double eta;
+  double eta_decay;
+  double eta_drop_rate;
+  LearningRateSchedule eta_schedule;
   double lambda1;
   double lambda2;
   double nepochs;
@@ -53,7 +67,9 @@ struct LinearModelParams {
   size_t : 16;
   unsigned int seed;
   LinearModelParams() : model_type(LinearModelType::AUTO),
-                        eta(0.005), lambda1(0.0), lambda2(0.0),
+                        eta(0.005), eta_decay(0.5), eta_drop_rate(1.0),
+                        eta_schedule(LearningRateSchedule::CONSTANT),
+                        lambda1(0.0), lambda2(0.0),
                         nepochs(1.0), double_precision(false),
                         negative_class(false), seed(0)
                         {}

--- a/src/core/models/dt_linearmodel_types.h
+++ b/src/core/models/dt_linearmodel_types.h
@@ -55,7 +55,7 @@ enum class LearningRateSchedule : size_t {
  */
 struct LinearModelParams {
   LinearModelType model_type;
-  double eta;
+  double eta0;
   double eta_decay;
   double eta_drop_rate;
   LearningRateSchedule eta_schedule;
@@ -67,7 +67,7 @@ struct LinearModelParams {
   size_t : 16;
   unsigned int seed;
   LinearModelParams() : model_type(LinearModelType::AUTO),
-                        eta(0.005), eta_decay(0.0001), eta_drop_rate(10.0),
+                        eta0(0.005), eta_decay(0.0001), eta_drop_rate(10.0),
                         eta_schedule(LearningRateSchedule::CONSTANT),
                         lambda1(0.0), lambda2(0.0),
                         nepochs(1.0), double_precision(false),

--- a/src/core/models/dt_linearmodel_types.h
+++ b/src/core/models/dt_linearmodel_types.h
@@ -67,7 +67,7 @@ struct LinearModelParams {
   size_t : 16;
   unsigned int seed;
   LinearModelParams() : model_type(LinearModelType::AUTO),
-                        eta(0.005), eta_decay(0.5), eta_drop_rate(1.0),
+                        eta(0.005), eta_decay(0.0001), eta_drop_rate(10.0),
                         eta_schedule(LearningRateSchedule::CONSTANT),
                         lambda1(0.0), lambda2(0.0),
                         nepochs(1.0), double_precision(false),

--- a/src/core/models/dt_linearmodel_types.h
+++ b/src/core/models/dt_linearmodel_types.h
@@ -44,7 +44,7 @@ enum class LinearModelType : size_t {
  */
 enum class LearningRateSchedule : size_t {
   CONSTANT    = 0, // eta = eta0
-  TIME_BASED  = 1, // eta /= (1 + decay * iteration)
+  TIME_BASED  = 1, // eta = eta0 / (1 + decay * iteration)
   STEP_BASED  = 2, // eta = eta0 * decay ^ floor((1 + iteration) / drop_rate)
   EXPONENTIAL = 3, // eta = eta0 / exp(decay * iteration)
 };

--- a/src/core/models/dt_linearmodel_types.h
+++ b/src/core/models/dt_linearmodel_types.h
@@ -43,10 +43,10 @@ enum class LinearModelType : size_t {
  *  https://en.wikipedia.org/wiki/Learning_rate#Learning_rate_schedule
  */
 enum class LearningRateSchedule : size_t {
-  CONSTANT    = 0, // eta
-  TIME_BASED  = 1, // eta / (1 + decay * iteration)
-  STEP_BASED  = 2, // eta * decay ^ floor((1 + iteration) / drop_rate)
-  EXPONENTIAL = 3, // eta / exp(decay * iteration)
+  CONSTANT    = 0, // eta = eta0
+  TIME_BASED  = 1, // eta /= (1 + decay * iteration)
+  STEP_BASED  = 2, // eta = eta0 * decay ^ floor((1 + iteration) / drop_rate)
+  EXPONENTIAL = 3, // eta = eta0 / exp(decay * iteration)
 };
 
 

--- a/src/core/models/py_linearmodel.cc
+++ b/src/core/models/py_linearmodel.cc
@@ -89,7 +89,7 @@ eta_schedule: "constant" | "time-based" | "step-based" | "exponential"
     Learning rate schedule. When it is `"constant"` the learning rate
     `eta` is constant and equals to `eta0`. Otherwise,
     after each training iteration `eta` is updated as follows:
-    - for `"time-based"` schedule as `eta / (1 + eta_decay * epoch)`;
+    - for `"time-based"` schedule as `eta0 / (1 + eta_decay * epoch)`;
     - for `"step-based"` schedule as `eta0 * eta_decay ^ floor((1 + epoch) / eta_drop_rate)`;
     - for `"exponential"` schedule as `eta0 / exp(eta_decay * epoch)`.
     By default, the size of the training iteration is one epoch, it becomes

--- a/src/core/models/py_linearmodel.h
+++ b/src/core/models/py_linearmodel.h
@@ -70,7 +70,7 @@ class LinearModel : public XObject<LinearModel> {
     oobj get_model() const;
     oobj get_params_namedtuple() const;
     oobj get_params_tuple() const;
-    oobj get_eta() const;
+    oobj get_eta0() const;
     oobj get_eta_decay() const;
     oobj get_eta_drop_rate() const;
     oobj get_eta_schedule() const;
@@ -87,7 +87,7 @@ class LinearModel : public XObject<LinearModel> {
     void set_labels(robj);                  // Not exposed, used for unpickling only
     void set_params_tuple(robj);            // Not exposed, used for unpickling only
     void set_params_namedtuple(robj);       // Not exposed, used in `m__init__` only
-    void set_eta(const Arg&);
+    void set_eta0(const Arg&);
     void set_eta_decay(const Arg&);
     void set_eta_drop_rate(const Arg&);
     void set_eta_schedule(const Arg&);

--- a/src/core/models/py_linearmodel.h
+++ b/src/core/models/py_linearmodel.h
@@ -50,7 +50,7 @@ class LinearModel : public XObject<LinearModel> {
     // Initializers and deallocator
     void m__init__(const PKArgs&);
     void m__dealloc__();
-    void init_py_params();
+    void init_params();
     template <typename T>
     void init_dt_model(dt::LType ltype = dt::LType::MU);
     static std::map<dt::LinearModelType, std::string> create_model_type_name();
@@ -71,6 +71,9 @@ class LinearModel : public XObject<LinearModel> {
     oobj get_params_namedtuple() const;
     oobj get_params_tuple() const;
     oobj get_eta() const;
+    oobj get_eta_decay() const;
+    oobj get_eta_drop_rate() const;
+    oobj get_eta_schedule() const;
     oobj get_lambda1() const;
     oobj get_lambda2() const;
     oobj get_nepochs() const;
@@ -85,6 +88,9 @@ class LinearModel : public XObject<LinearModel> {
     void set_params_tuple(robj);            // Not exposed, used for unpickling only
     void set_params_namedtuple(robj);       // Not exposed, used in `m__init__` only
     void set_eta(const Arg&);
+    void set_eta_decay(const Arg&);
+    void set_eta_drop_rate(const Arg&);
+    void set_eta_schedule(const Arg&);
     void set_lambda1(const Arg&);
     void set_lambda2(const Arg&);
     void set_nepochs(const Arg&);

--- a/tests/models/test-linearmodel.py
+++ b/tests/models/test-linearmodel.py
@@ -42,12 +42,12 @@ from tests import assert_equals, noop
 # Define namedtuple of test/default parameters and accuracy
 #-------------------------------------------------------------------------------
 Params = collections.namedtuple("LinearModelParams",
-          ["eta", "eta_decay", "eta_drop_rate", "eta_schedule",
+          ["eta0", "eta_decay", "eta_drop_rate", "eta_schedule",
            "lambda1", "lambda2", "nepochs", "double_precision",
            "negative_class", "model_type", "seed"]
          )
 
-params_test = Params(eta = 1,
+params_test = Params(eta0 = 1,
                  eta_decay = 1.0,
                  eta_drop_rate = 2.0,
                  eta_schedule = 'exponential',
@@ -60,7 +60,7 @@ params_test = Params(eta = 1,
                  seed = 1)
 
 
-params_default = Params(eta = 0.005,
+params_default = Params(eta0 = 0.005,
                         eta_decay = 0.0001,
                         eta_drop_rate = 10.0,
                         eta_schedule = 'constant',
@@ -81,8 +81,8 @@ epsilon = 0.01 # Accuracy required for some tests
 
 def test_linearmodel_construct_wrong_eta_type():
     with pytest.raises(TypeError) as e:
-        noop(LinearModel(eta = "1.0"))
-    assert ("Argument eta in LinearModel() constructor should be a float, instead "
+        noop(LinearModel(eta0 = "1.0"))
+    assert ("Argument eta0 in LinearModel() constructor should be a float, instead "
             "got <class 'str'>" == str(e.value))
 
 
@@ -144,9 +144,9 @@ def test_linearmodel_construct_wrong_seed_type():
 
 def test_linearmodel_construct_wrong_combination():
     with pytest.raises(ValueError) as e:
-        noop(LinearModel(params=params_test, eta = params_test.eta))
+        noop(LinearModel(params=params_test, eta0 = params_test.eta0))
     assert ("You can either pass all the parameters with params or any of "
-            "the individual parameters with eta, eta_decay, eta_drop_rate, "
+            "the individual parameters with eta0, eta_decay, eta_drop_rate, "
             "eta_schedule, lambda1, lambda2, nepochs, double_precision, "
             "negative_class, model_type or seed to LinearModel constructor, "
             "but not both at the same time"
@@ -161,16 +161,16 @@ def test_linearmodel_construct_unknown_arg():
 
 
 def test_linearmodel_construct_wrong_params_type():
-    params = params_test._replace(eta = "1.0")
+    params = params_test._replace(eta0 = "1.0")
     with pytest.raises(TypeError) as e:
         LinearModel(params)
-    assert ("LinearModelParams.eta should be a float, instead got <class 'str'>"
+    assert ("LinearModelParams.eta0 should be a float, instead got <class 'str'>"
             == str(e.value))
 
 
 def test_linearmodel_construct_wrong_params_name():
-    WrongParams = collections.namedtuple("WrongParams",["eta", "lambda1"])
-    wrong_params = WrongParams(eta = 1, lambda1 = 0.01)
+    WrongParams = collections.namedtuple("WrongParams",["eta0", "lambda1"])
+    wrong_params = WrongParams(eta0 = 1, lambda1 = 0.01)
     with pytest.raises(ValueError) as e:
         LinearModel(wrong_params)
     assert ("Tuple of LinearModel parameters should have 11 elements, instead got: 2"
@@ -183,8 +183,8 @@ def test_linearmodel_construct_wrong_params_name():
 
 def test_linearmodel_construct_wrong_eta_value():
     with pytest.raises(ValueError) as e:
-        noop(LinearModel(eta = 0.0))
-    assert ("Argument eta in LinearModel() constructor should be positive: 0.0"
+        noop(LinearModel(eta0 = 0.0))
+    assert ("Argument eta0 in LinearModel() constructor should be positive: 0.0"
             == str(e.value))
 
 def test_linearmodel_construct_wrong_eta_decay_value():
@@ -261,7 +261,7 @@ def test_linearmodel_create_params():
 
 
 def test_linearmodel_create_individual():
-    lm = LinearModel(eta = params_test.eta,
+    lm = LinearModel(eta0 = params_test.eta0,
               eta_decay = params_test.eta_decay,
               eta_drop_rate = params_test.eta_drop_rate,
               eta_schedule = params_test.eta_schedule,
@@ -271,7 +271,7 @@ def test_linearmodel_create_individual():
               negative_class = params_test.negative_class,
               model_type = params_test.model_type,
               seed = params_test.seed)
-    assert lm.params == (params_test.eta,
+    assert lm.params == (params_test.eta0,
                          params_test.eta_decay,
                          params_test.eta_drop_rate,
                          params_test.eta_schedule,
@@ -290,11 +290,11 @@ def test_linearmodel_get_params():
     lm = LinearModel(params_test)
     params = lm.params
     assert params == params_test
-    assert (lm.eta, lm.eta_decay, lm.eta_drop_rate, lm.eta_schedule,
+    assert (lm.eta0, lm.eta_decay, lm.eta_drop_rate, lm.eta_schedule,
            lm.lambda1, lm.lambda2,
            lm.nepochs, lm.double_precision, lm.negative_class,
            lm.model_type, lm.seed) == params_test
-    assert (params.eta, params.eta_decay, params.eta_drop_rate, params.eta_schedule,
+    assert (params.eta0, params.eta_decay, params.eta_drop_rate, params.eta_schedule,
             params.lambda1, params.lambda2,
             params.nepochs, params.double_precision,
             params.negative_class, params.model_type,
@@ -303,7 +303,7 @@ def test_linearmodel_get_params():
 
 def test_linearmodel_set_individual():
     lm = LinearModel(double_precision = params_test.double_precision)
-    lm.eta = params_test.eta
+    lm.eta0 = params_test.eta0
     lm.eta_decay = params_test.eta_decay
     lm.eta_drop_rate = params_test.eta_drop_rate
     lm.eta_schedule = params_test.eta_schedule
@@ -319,16 +319,16 @@ def test_linearmodel_set_individual():
 def test_linearmodel_set_individual_after_params():
     lm = LinearModel()
     params = lm.params
-    lm.eta = params_test.eta
+    lm.eta0 = params_test.eta0
     params_new = lm.params
     assert params == LinearModel().params
-    assert (params_new.eta, params_new.eta_decay, params_new.eta_drop_rate,
+    assert (params_new.eta0, params_new.eta_decay, params_new.eta_drop_rate,
             params_new.eta_schedule,
             params_new.lambda1, params_new.lambda2,
             params_new.nepochs,
             params_new.double_precision, params_new.negative_class,
             params_new.model_type, params_new.seed) == params_new
-    assert (lm.eta, lm.eta_decay, lm.eta_drop_rate, lm.eta_schedule,
+    assert (lm.eta0, lm.eta_decay, lm.eta_drop_rate, lm.eta_schedule,
             lm.lambda1, lm.lambda2,
             lm.nepochs,
             lm.double_precision, lm.negative_class,
@@ -342,8 +342,8 @@ def test_linearmodel_set_individual_after_params():
 def test_linearmodel_set_wrong_eta_type():
     lm = LinearModel()
     with pytest.raises(TypeError) as e:
-        lm.eta = "0.0"
-    assert (".eta should be a float, instead got <class 'str'>" == str(e.value))
+        lm.eta0 = "0.0"
+    assert (".eta0 should be a float, instead got <class 'str'>" == str(e.value))
 
 
 def test_linearmodel_set_wrong_lambda1_type():
@@ -379,15 +379,15 @@ def test_linearmodel_set_wrong_seed_type():
 #-------------------------------------------------------------------------------
 
 @pytest.mark.parametrize('value, message',
-                         [[0.0, ".eta should be positive: 0.0"],
-                          [None, ".eta should be positive: None"],
-                          [math.nan, ".eta should be positive: nan"],
-                          [math.inf, ".eta should be finite: inf"]
+                         [[0.0, ".eta0 should be positive: 0.0"],
+                          [None, ".eta0 should be positive: None"],
+                          [math.nan, ".eta0 should be positive: nan"],
+                          [math.inf, ".eta0 should be finite: inf"]
                          ])
 def test_linearmodel_set_bad_eta_value(value, message):
     lm = LinearModel()
     with pytest.raises(ValueError) as e:
-        lm.eta = value
+        lm.eta0 = value
     assert (message == str(e.value))
 
 
@@ -583,7 +583,7 @@ def test_linearmodel_fit_unique_ignore_none():
 
 
 def test_linearmodel_fit_predict_bool():
-    lm = LinearModel(eta = 0.1, nepochs = 10000)
+    lm = LinearModel(eta0 = 0.1, nepochs = 10000)
     df_train = dt.Frame([[True, False]])
     df_target = dt.Frame([[True, False]])
     lm.fit(df_train, df_target)
@@ -600,7 +600,7 @@ def test_linearmodel_fit_predict_bool():
 
 
 def test_linearmodel_fit_predict_int():
-    lm = LinearModel(eta = 0.1, nepochs = 10000)
+    lm = LinearModel(eta0 = 0.1, nepochs = 10000)
     df_train = dt.Frame([[0, 1]])
     df_target = dt.Frame([[True, False]])
     lm.fit(df_train, df_target)
@@ -613,7 +613,7 @@ def test_linearmodel_fit_predict_int():
 
 
 def test_linearmodel_fit_predict_float():
-    lm = LinearModel(eta = 0.1, nepochs = 10000)
+    lm = LinearModel(eta0 = 0.1, nepochs = 10000)
     df_train = dt.Frame([[0.0, 1.0, math.inf]])
     df_target = dt.Frame([[True, False, False]])
     lm.fit(df_train, df_target)
@@ -627,7 +627,7 @@ def test_linearmodel_fit_predict_float():
 
 @pytest.mark.skip(reason="Fix me: linear model do not support categoricals")
 def test_linearmodel_fit_predict_string():
-    lm = LinearModel(eta = 0.1, nepochs = 10000)
+    lm = LinearModel(eta0 = 0.1, nepochs = 10000)
     df_train = dt.Frame([["Monday", None, "", "Tuesday"]])
     df_target = dt.Frame([[True, False, False, True]])
     lm.fit(df_train, df_target)
@@ -645,7 +645,7 @@ def test_linearmodel_fit_predict_string():
                          [20, 10],
                          [0.5, -0.5]])
 def test_linearmodel_fit_predict_bool_binomial(target):
-    lm = LinearModel(eta = 0.1, nepochs = 10000, model_type = "binomial")
+    lm = LinearModel(eta0 = 0.1, nepochs = 10000, model_type = "binomial")
     df_train = dt.Frame([True, False])
     df_target = dt.Frame(target)
     lm.fit(df_train, df_target)
@@ -722,7 +722,7 @@ def test_linearmodel_disable_setters_after_fit(parameter, value):
 
 
 # def test_linearmodel_fit_predict_binomial_online_1_1():
-#     lm = LinearModel(eta = 0.1, nepochs = 10000, model_type = "binomial")
+#     lm = LinearModel(eta0 = 0.1, nepochs = 10000, model_type = "binomial")
 #     df_train_odd = dt.Frame([[1, 3, 7, 5, 9]])
 #     df_target_odd = dt.Frame([["odd", "odd", "odd", "odd", "odd"]])
 #     lm.fit(df_train_odd, df_target_odd)
@@ -766,7 +766,7 @@ def test_linearmodel_disable_setters_after_fit(parameter, value):
 
 
 # def test_linearmodel_fit_predict_binomial_online_1_2():
-#     lm = LinearModel(eta = 0.1, nepochs = 10000, model_type = "binomial")
+#     lm = LinearModel(eta0 = 0.1, nepochs = 10000, model_type = "binomial")
 #     df_train_odd = dt.Frame([[1, 3, 7, 5, 9]])
 #     df_target_odd = dt.Frame([["odd", "odd", "odd", "odd", "odd"]])
 #     lm.fit(df_train_odd, df_target_odd)
@@ -809,7 +809,7 @@ def test_linearmodel_disable_setters_after_fit(parameter, value):
 
 
 # def test_linearmodel_fit_predict_binomial_online_2_1():
-#     lm = LinearModel(eta = 0.1, nepochs = 10000, model_type = "binomial")
+#     lm = LinearModel(eta0 = 0.1, nepochs = 10000, model_type = "binomial")
 #     df_train_even_odd = dt.Frame([[2, 1, 8, 3]])
 #     df_target_even_odd = dt.Frame([["even", "odd", "even", "odd"]])
 #     lm.fit(df_train_even_odd, df_target_even_odd)
@@ -853,7 +853,7 @@ def test_linearmodel_disable_setters_after_fit(parameter, value):
 
 
 # def test_linearmodel_fit_predict_binomial_online_2_2():
-#     lm = LinearModel(eta = 0.1, nepochs = 10000, model_type = "binomial")
+#     lm = LinearModel(eta0 = 0.1, nepochs = 10000, model_type = "binomial")
 #     df_train_even_odd = dt.Frame([[2, 1, 8, 3]])
 #     df_target_even_odd = dt.Frame([["even", "odd", "even", "odd"]])
 #     lm.fit(df_train_even_odd, df_target_even_odd)
@@ -941,7 +941,7 @@ def test_linearmodel_fit_predict_multinomial_vs_binomial():
 def test_linearmodel_fit_predict_multinomial(negative_class):
     negative_class_label = ["_negative_class"] if negative_class else []
     nepochs = 1000
-    lm = LinearModel(eta = 0.2, nepochs = nepochs, double_precision = True)
+    lm = LinearModel(eta0 = 0.2, nepochs = nepochs, double_precision = True)
     lm.negative_class = negative_class
     labels = negative_class_label + ["blue", "green", "red"]
 
@@ -980,7 +980,7 @@ def test_linearmodel_fit_predict_multinomial(negative_class):
 @pytest.mark.skip(reason="Fix me: linear model do not support categoricals")
 @pytest.mark.parametrize('negative_class', [False, True])
 def test_linearmodel_fit_predict_multinomial_online(negative_class):
-    lm = LinearModel(eta = 0.2, nepochs = 1000, double_precision = True)
+    lm = LinearModel(eta0 = 0.2, nepochs = 1000, double_precision = True)
     lm.negative_class = negative_class
     negative_class_label = ["_negative_class"] if negative_class else []
 
@@ -1106,7 +1106,7 @@ def test_linearmodel_regression_fit_simple_one(eta_schedule):
     df_target = dt.Frame([1])
     lm.fit(df_train, df_target)
     assert lm.model_type == "regression"
-    assert_equals(lm.model, dt.Frame([lm.eta, lm.eta]), rel_tol = 1e-3)
+    assert_equals(lm.model, dt.Frame([lm.eta0, lm.eta0]), rel_tol = 1e-3)
 
 
 @pytest.mark.parametrize('eta_schedule', ["constant", "time-based", "step-based", "exponential"])
@@ -1157,7 +1157,7 @@ def test_linearmodel_regression_fit_predict(eta_schedule):
 
 def test_linearmodel_regression_fit_predict_large():
     N = 40000
-    lm = LinearModel(eta = 1e-4, nepochs = 100, double_precision = True)
+    lm = LinearModel(eta0 = 1e-4, nepochs = 100, double_precision = True)
 
     df_train0 = dt.Frame([range(N), range(0, 2*N - 1, 2)])
     df_target0 = df_train0[:, dt.float64(1 - f[0] + 2 * f[1])]
@@ -1179,7 +1179,7 @@ def test_linearmodel_wrong_validation_target_type():
     nepochs = 1234
     nepochs_validation = 56
     nrows = 78
-    lm = LinearModel(eta = 0.5, nepochs = nepochs)
+    lm = LinearModel(eta0 = 0.5, nepochs = nepochs)
     r = range(nrows)
     df_X = dt.Frame(r)
     df_y = dt.Frame(r)
@@ -1197,7 +1197,7 @@ def test_linearmodel_wrong_validation_parameters():
     nepochs = 1234
     nepochs_validation = 56
     nrows = 78
-    lm = LinearModel(eta = 0.5, nepochs = nepochs)
+    lm = LinearModel(eta0 = 0.5, nepochs = nepochs)
     r = range(nrows)
     df_X = dt.Frame(r)
     df_y = dt.Frame(r)
@@ -1219,7 +1219,7 @@ def test_linearmodel_wrong_validation_parameters():
 def test_linearmodel_no_validation_set(double_precision_value):
     nepochs = 1234
     nrows = 56
-    lm = LinearModel(eta = 0.5, nepochs = nepochs,
+    lm = LinearModel(eta0 = 0.5, nepochs = nepochs,
                      double_precision = double_precision_value)
     r = range(nrows)
     df_X = dt.Frame(r)
@@ -1243,7 +1243,7 @@ def test_linearmodel_no_early_stopping():
 
 
 def test_linearmodel_wrong_validation_stypes():
-    lm = LinearModel(eta = 0.5)
+    lm = LinearModel(eta0 = 0.5)
     r = range(10)
     df_X = dt.Frame(r)
     df_y = dt.Frame(r) # int32 stype
@@ -1349,7 +1349,7 @@ def test_linearmodel_early_stopping_regression(validation_average_niterations):
 @pytest.mark.skip(reason="Fix me: linear model do not support categoricals")
 def test_linearmodel_early_stopping_multinomial():
     nepochs = 2000
-    lm = LinearModel(eta = 0.2, nepochs = nepochs, double_precision = True)
+    lm = LinearModel(eta0 = 0.2, nepochs = nepochs, double_precision = True)
     labels = ["blue", "green", "red"]
 
     df_train = dt.Frame(["cucumber", None, "shilm", "sky", "day", "orange",
@@ -1400,7 +1400,7 @@ def test_linearmodel_reuse_pickled_empty_model():
     df_train = dt.Frame({"id" : [1]})
     df_target = dt.Frame([1.0])
     lm_unpickled.fit(df_train, df_target)
-    assert_equals(lm_unpickled.model, dt.Frame([lm.eta, lm.eta]/stype.float32))
+    assert_equals(lm_unpickled.model, dt.Frame([lm.eta0, lm.eta0]/stype.float32))
 
 
 def test_linearmodel_pickling_binomial():
@@ -1434,7 +1434,7 @@ def test_linearmodel_pickling_binomial():
 
 @pytest.mark.skip(reason="Fix me: linear model do not support categoricals")
 def test_linearmodel_pickling_multinomial():
-    lm = LinearModel(eta = 0.2, nbins = 100, nepochs = 1, double_precision = False)
+    lm = LinearModel(eta0 = 0.2, nbins = 100, nepochs = 1, double_precision = False)
     df_train = dt.Frame(["cucumber", None, "shilm", "sky", "day", "orange",
                          "ocean"])
     df_target = dt.Frame(["green", "red", "red", "blue", "green", None,

--- a/tests/models/test-linearmodel.py
+++ b/tests/models/test-linearmodel.py
@@ -1111,8 +1111,8 @@ def test_linearmodel_regression_fit_simple_one(eta_schedule):
 
 @pytest.mark.parametrize('eta_schedule', ["constant", "time-based", "step-based", "exponential"])
 def test_linearmodel_regression_fit_predict_simple_linear(eta_schedule):
-    lm = LinearModel(nepochs = 10000, double_precision = True,
-                     eta_drop_rate = 5000, eta_schedule=eta_schedule)
+    lm = LinearModel(nepochs = 10000, double_precision = True, eta_decay = 1e-8,
+                     eta_drop_rate = 50000, eta_schedule=eta_schedule)
     df_train = dt.Frame([1, 2])
     df_target = dt.Frame([1, 2])
     lm.fit(df_train, df_target)
@@ -1139,7 +1139,8 @@ def test_linearmodel_regression_fit_predict_simple_one_epoch(eta_schedule):
 
 @pytest.mark.parametrize('eta_schedule', ["constant", "time-based", "step-based", "exponential"])
 def test_linearmodel_regression_fit_predict(eta_schedule):
-    lm = LinearModel(nepochs = 10000, eta_drop_rate = 5000, eta_schedule=eta_schedule)
+    lm = LinearModel(nepochs = 10000, eta_drop_rate = 5000,
+                     eta_schedule=eta_schedule, eta_decay = 1e-7)
     r = list(range(9))
     df_train = dt.Frame(r + [0])
     df_target = dt.Frame(r + [math.inf])

--- a/tests/models/test-linearmodel.py
+++ b/tests/models/test-linearmodel.py
@@ -1112,7 +1112,7 @@ def test_linearmodel_regression_fit_simple_one(eta_schedule):
 @pytest.mark.parametrize('eta_schedule', ["constant", "time-based", "step-based", "exponential"])
 def test_linearmodel_regression_fit_predict_simple_linear(eta_schedule):
     lm = LinearModel(nepochs = 10000, double_precision = True, eta_decay = 1e-8,
-                     eta_drop_rate = 50000, eta_schedule=eta_schedule)
+                     eta_drop_rate = 5000, eta_schedule=eta_schedule)
     df_train = dt.Frame([1, 2])
     df_target = dt.Frame([1, 2])
     lm.fit(df_train, df_target)
@@ -1139,7 +1139,7 @@ def test_linearmodel_regression_fit_predict_simple_one_epoch(eta_schedule):
 
 @pytest.mark.parametrize('eta_schedule', ["constant", "time-based", "step-based", "exponential"])
 def test_linearmodel_regression_fit_predict(eta_schedule):
-    lm = LinearModel(nepochs = 10000, eta_drop_rate = 5000,
+    lm = LinearModel(nepochs = 10000, eta_drop_rate = 1000,
                      eta_schedule=eta_schedule, eta_decay = 1e-7)
     r = list(range(9))
     df_train = dt.Frame(r + [0])


### PR DESCRIPTION
Implement constant, time-based, step-based and exponential learning rate schedules for linear model.

Closes https://github.com/h2oai/datatable/issues/2920