### PR TITLE
Documentation directive x-comparison-table

### DIFF
--- a/docs/_ext/xcomparisontable.py
+++ b/docs/_ext/xcomparisontable.py
@@ -52,19 +52,23 @@ class XComparisonTableDirective(SphinxDirective):
     def run(self):
         self.header1 = self.options["header1"].strip()
         self.header2 = self.options["header2"].strip()
-        # import pdb; pdb.set_trace()
         tbl = xnodes.table(classes=["x-comparison-table"])
-        tbl += xnodes.tr(xnodes.th(self.header1), xnodes.th(self.header2),
-                                classes=["table-header"])
+        tbl += xnodes.tr(
+            xnodes.th(xnodes.div(self.header1)),
+            xnodes.th(xnodes.div(self.header2)),
+            classes=["table-header"])
         for header, col1, col2 in self.parse_content():
-            th = xnodes.td(colspan=2)
+            classes=["section-header"]
+            if header:
+                th = xnodes.td(colspan=2)
+                self.state.nested_parse(header, 0, th)
+                tbl += xnodes.tr(th, classes=classes)
+                classes = []
             td1 = xnodes.td()
             td2 = xnodes.td()
-            self.state.nested_parse(header, 0, th)
             self.state.nested_parse(col1, 0, td1)
             self.state.nested_parse(col2, 0, td2)
-            tbl += xnodes.tr(th, classes=["section-header"])
-            tbl += xnodes.tr(td1, td2)
+            tbl += xnodes.tr(td1, td2, classes=classes)
         return [tbl]
 
     def parse_content(self):
@@ -73,7 +77,7 @@ class XComparisonTableDirective(SphinxDirective):
             if len(parts) == 3:
                 yield parts
             elif len(parts) == 2:
-                yield ("", parts[0], parts[1])
+                yield (None, parts[0], parts[1])
             else:
                 raise self.error("Wrong number of sub-sections at %s lines %d-%d" %
                                  (section.source(0), section.offset(0), section.offset(-1)))
@@ -81,8 +85,9 @@ class XComparisonTableDirective(SphinxDirective):
 
 
 def setup(app):
-    # app.setup_extension("_ext.xnodes")
+    app.setup_extension("_ext.xnodes")
     app.add_directive("x-comparison-table", XComparisonTableDirective)
+    app.add_css_file("x-comparison-table.css")
     return {"parallel_read_safe": True,
             "parallel_write_safe": True}
 

--- a/docs/_ext/xcomparisontable.py
+++ b/docs/_ext/xcomparisontable.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+#-------------------------------------------------------------------------------
+# Copyright 2021 H2O.ai
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#-------------------------------------------------------------------------------
+from docutils import nodes
+from docutils.parsers.rst import directives
+from docutils.statemachine import StringList
+# from sphinx import addnodes
+# from sphinx.util import logging
+from sphinx.util.docutils import SphinxDirective
+from . import xnodes
+
+
+def split_stringlist(slist, sep):
+    i0 = 0
+    for i, line in enumerate(slist):
+        if line == sep:
+            if i > 0:
+                yield slist[i0:i]
+            i0 = i + 1
+    if i0 < len(slist):
+        yield slist[i0:]
+
+
+class XComparisonTableDirective(SphinxDirective):
+    has_content = True
+    required_arguments = 0
+    optional_arguments = 0
+    option_spec = {
+        "header1": directives.unchanged_required,
+        "header2": directives.unchanged,
+    }
+
+    def run(self):
+        self.header1 = self.options["header1"].strip()
+        self.header2 = self.options["header2"].strip()
+        # import pdb; pdb.set_trace()
+        tbl = xnodes.table(classes=["x-comparison-table"])
+        tbl += xnodes.tr(xnodes.th(self.header1), xnodes.th(self.header2),
+                                classes=["table-header"])
+        for header, col1, col2 in self.parse_content():
+            th = xnodes.td(colspan=2)
+            td1 = xnodes.td()
+            td2 = xnodes.td()
+            self.state.nested_parse(header, 0, th)
+            self.state.nested_parse(col1, 0, td1)
+            self.state.nested_parse(col2, 0, td2)
+            tbl += xnodes.tr(th, classes=["section-header"])
+            tbl += xnodes.tr(td1, td2)
+        return [tbl]
+
+    def parse_content(self):
+        for section in split_stringlist(self.content, "===="):
+            parts = list(split_stringlist(section, '----'))
+            if len(parts) == 3:
+                yield parts
+            elif len(parts) == 2:
+                yield ("", parts[0], parts[1])
+            else:
+                raise self.error("Wrong number of sub-sections at %s lines %d-%d" %
+                                 (section.source(0), section.offset(0), section.offset(-1)))
+
+
+
+def setup(app):
+    # app.setup_extension("_ext.xnodes")
+    app.add_directive("x-comparison-table", XComparisonTableDirective)
+    return {"parallel_read_safe": True,
+            "parallel_write_safe": True}
+

--- a/docs/_ext/xcomparisontable.py
+++ b/docs/_ext/xcomparisontable.py
@@ -46,7 +46,7 @@ class XComparisonTableDirective(SphinxDirective):
     optional_arguments = 0
     option_spec = {
         "header1": directives.unchanged_required,
-        "header2": directives.unchanged,
+        "header2": directives.unchanged_required,
     }
 
     def run(self):

--- a/docs/_static/x-comparison-table.css
+++ b/docs/_static/x-comparison-table.css
@@ -1,0 +1,46 @@
+
+table.x-comparison-table {
+    width: 100%;
+}
+
+table.x-comparison-table th,
+table.x-comparison-table td {
+    vertical-align: top;
+    width: 50%;
+}
+
+table.x-comparison-table td:first-child,
+table.x-comparison-table th:first-child {
+    padding-right: 4px;
+}
+
+table.x-comparison-table td:last-child,
+table.x-comparison-table th:last-child {
+    padding-left: 4px;
+}
+
+
+
+table.x-comparison-table tr.table-header th div {
+    background-color: #e8eaea;
+    border-radius: 4px;
+    box-shadow: 1px 1px 2px #888;
+    padding: 4px 8px;
+}
+
+table.x-comparison-table tr.section-header td p:first-child {
+    margin-top: 1rem;
+}
+
+table.x-comparison-table tr.section-header td p:last-child {
+    margin-bottom: 0;
+}
+
+table.x-comparison-table div.xcode div.output,
+table.x-comparison-table div.xcode code {
+    margin-left: 0;
+}
+
+table.x-comparison-table div.xcode:last-child {
+    margin-bottom: 0;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,6 +50,7 @@ needs_sphinx = '1.8'
 # ones.
 extensions = [
     '_ext.xcode',
+    '_ext.xcomparisontable',
     '_ext.xcontributors',
     '_ext.xfunction',
     '_ext.xpython',

--- a/docs/develop/documentation.rst
+++ b/docs/develop/documentation.rst
@@ -284,6 +284,32 @@ immeditately after a heading:
 
     .. seealso:: :ref:`columnsets`
 
+Directive ``.. x-comparison-table::`` allows to create a two-column table
+specifically designed for comparing two entities across multiple comparison
+points. It is primarily used to create the "compare datatable with another
+library" manual pages. The content of this directive is comprised of multiple
+"sections" separated with ``====``, and each section has 2 or 3 parts
+(separated with ``----``): an optional common header, then the content of the
+first column, and then the second:
+
+.. code-block:: rst
+
+    .. x-comparison-table::
+        :header1: datatable
+        :header2: another-library
+
+        Section 1 header
+        ----
+        Column 1
+        ----
+        Column 2
+
+        ====
+        Section 2 header
+        ----
+        Column 1
+        ----
+        Column 2
 
 
 Changelog support
@@ -344,6 +370,7 @@ The effect of this declaration is the following:
   and it should list the contributors who participated in creation of this
   particular release. The list of contributors is prepared using the script
   ``ci/gh.py``
+
 
 
 Documenting API

--- a/docs/develop/documentation.rst
+++ b/docs/develop/documentation.rst
@@ -121,19 +121,23 @@ indented, and there has to be an empty line between the ``.. code-block::``
 declaration and the actual code.
 
 When writing python code examples, the best practice is to use python console
-format, i.e. prepend all input lines with ``>>>``, and all output lines will
-have no prefix. For example:
+format, i.e. prepend all input lines with ``>>>`` (or ``...`` for continuation
+lines), and keep all output lines without a prefix. When documenting an error,
+remove all traceback information and leave only the error message:
 
 .. code-block:: rst
 
     >>> import datatable as dt
     >>> DT = dt.Frame(A=[5], B=[17], D=['zelo'])
     >>> DT
-       |  A   B  D
-    -- + --  --  ----
-     0 |  5  17  zelo
-
+       |     A      B  D
+       | int32  int32  str32
+    -- + -----  -----  -----
+     0 |     5     17  zelo
     [1 row x 3 columns]
+
+    >>> DT.hello()
+    AttributeError: 'datatable.Frame' object has no attribute 'hello'
 
 This code snippet will be rendered as follows:
 
@@ -142,11 +146,14 @@ This code snippet will be rendered as follows:
     >>> import datatable as dt
     >>> DT = dt.Frame(A=[5], B=[17], D=['zelo'])
     >>> DT
-       |  A   B  D
-    -- + --  --  ----
-     0 |  5  17  zelo
-
+       |     A      B  D
+       | int32  int32  str32
+    -- + -----  -----  -----
+     0 |     5     17  zelo
     [1 row x 3 columns]
+
+    >>> DT.hello()
+    AttributeError: 'datatable.Frame' object has no attribute 'hello'
 
 
 Hyperlinks

--- a/docs/manual/comparison_with_pandas.rst
+++ b/docs/manual/comparison_with_pandas.rst
@@ -38,9 +38,9 @@ Row and Column Selection
     :header1: pandas
     :header2: datatable
 
-    Select **a single** row
+    Select a single row
     ----
-    .. code-block:: R
+    .. code-block::
 
         df.loc[2]
 
@@ -50,235 +50,470 @@ Row and Column Selection
         DT[2, :]
 
 
+    ====
+    Select several rows by their indices
+    ----
+    .. code-block::
 
-=================================================  ============================================
-pandas                                              datatable
-=================================================  ============================================
-Select a single row
-``df.loc[2]``                                        ``DT[2, :]``
+        df.iloc[[2, 3, 4]]
 
-Select several rows by their indices
-``df.iloc[[2,3,4]]``                                  ``DT[[2,3,4], :]``
+    ----
+    .. code-block::
 
-Select a slice of rows by position
-``df.iloc[2:5]``                                      ``DT[2:5, :]``
-
-
-Same as above
-``df.iloc[range(2,5)]``                               ``DT[range(2,5), :]``
+        DT[[2, 3, 4], :]
 
 
-Select every second row
-``df.iloc[::2]``                                       ``DT[::2, :]``
+    ====
+    Select a slice of rows by position
+    ----
+    .. code-block::
 
-Select rows using a Boolean mask
-``df.iloc[[True, True, False, False, True]]``            ``DT[[True, True, False, False, True], :]``
+        df.iloc[2:5]
+        # or
+        df.iloc[range(2, 5)]
 
-Select rows on a condition
-``df.loc[df['A']>3]``                                   ``DT[f.A>3, :]``
+    ----
+    .. code-block::
 
-Select rows on multiple conditions, using ``OR``
-``df.loc[(df['A'] > 3) | (df['B']<5)]``                   ``DT[(f.A>3) | (f.B<5), :]``
-
-Select rows on multiple conditions, using ``AND``
-``df.loc[(df['A'] > 3) & (df['B']<8)]``                  ``DT[(f.A>3) & (f.B<8), :]``
-
-Select a single column by column name
-       ``df['A']``                                     ``DT['A']``
-
-Same as above
-       ``df.loc[:, 'A']``                              ``DT[:, 'A']``
-
-Select a single column by position
-``df.iloc[:, 1]``                                       ``DT[1]`` or ``DT[:, 1]``
-
-Select multiple columns by column names
-``df.loc[:, ["A", "B"]]``                              ``DT[:, ["A", "B"]]``
-
-Select multiple columns by position
-``df.iloc[:, [0, 1]]``                                ``DT[:, [0, 1]]``
-
-Select multiple columns by slicing
-``df.loc[:, "A":"B"]``                                 ``DT[:, "A":"B"]``
-
-Same as above, by position
-``df.iloc[:, 1:3]``                                      ``DT[:, 1:3]``
-
-Select columns by Boolean mask
-``df.loc[:, [True,False,False,True]]``                ``DT[:, [True,False,False,True]]``
-
-Select multiple rows and columns
-``df.loc[2:5, "A":"B"]``                              ``DT[2:5, "A":"B"]``
-
-Same as above, by position
-``df.iloc[2:5, :2]``                                    ``DT[2:5, :2]``
-
-Select a single value (returns a scalar)
-``df.at[2, 'A']`` or ``df.loc[2, 'A']``                 ``DT[2,"A"]``
-
-Same as above, by position
-``df.iat[2, 0]``  or  ``df.iloc[2, 0]``                 ``DT[2, 0]``
-
-Select a single value, return as Series                Returns a Frame
-``df.loc[2, ["A"]]``                                  ``DT[2, ["A"]]``
-
-Same as above, by position
-``df.iloc[2, [0]]``                                  ``DT[2, [0]]``
-=================================================  ============================================
+        DT[2:5, :]
+        # or
+        DT[range(2, 5), :]
 
 
-In pandas every frame has a row index, and if a filtration is executed,
-the row numbers are kept::
+    ====
+    Select every second row
+    ----
+    .. code-block::
 
-    >>> # pandas
-    >>> df.loc[df['A'] > 3]
-        A   B   C    D
-    3   4   7   10   9
-    4   5   8   11  -1
+        df.iloc[::2]
 
+    ----
+    .. code-block::
 
-Datatable has no notion of a row index; the row numbers displayed are just
-for convenience::
-
-    >>> DT[f.A > 3, :]
-       |     A      B      C      D
-       | int32  int32  int32  int32
-    -- + -----  -----  -----  -----
-     0 |     4      7     10      9
-     1 |     5      8     11     -1
-    [2 rows x 4 columns]
+        DT[::2, :]
 
 
-In pandas, the index can be numbers, or characters, or intervals, or even
-``MultiIndex``es; you can subset rows on these labels::
+    ====
+    Select rows using a boolean mask
+    ----
+    .. code-block::
 
-    >>> # pandas
-    >>> df1 = df.set_index(pd.Index(['a','b','c','d','e']))
-        A   B   C    D
-    a   1   4   7    5
-    b   2   5   8    7
-    c   3   6   9    2
-    d   4   7   10   9
-    e   5   8   11  -1
+        df.iloc[[True, True, False, False, True]]
 
-    >>> df1.loc["a":"c"]
-        A   B   C   D
-    a   1   4   7   5
-    b   2   5   8   7
-    c   3   6   9   2
+    ----
+    .. code-block::
+
+        DT[[True, True, False, False, True], :]
 
 
-Datatable has the :attr:`key <dt.Frame.key>` property, which is meant as
-an equivalent of pandas indices, but its purpose at the moment is for joins,
-not for subsetting data::
+    ====
+    Select rows on a condition
+    ----
+    .. code-block::
 
-    >>> data = {"A": [1, 2, 3, 4, 5],
-    ...         "B": [4, 5, 6, 7, 8],
-    ...         "C": [7, 8, 9, 10, 11],
-    ...         "D": [5, 7, 2, 9, -1],
-    ...         "E": ['a','b','c','d','e']}
-    >>> DT1 = dt.Frame(data)
-    >>> DT1.key = 'E'
-    >>> DT1
-    E     |     A      B      C      D
-    str32 | int32  int32  int32  int32
-    ----- + -----  -----  -----  -----
-    a     |     1      4      7      5
-    b     |     2      5      8      7
-    c     |     3      6      9      2
-    d     |     4      7     10      9
-    e     |     5      8     11     -1
-    [5 rows x 5 columns]
+        df.loc[df['A']>3]
 
-    >>> DT1["a":"c", :]  # this will fail
-    TypeError: A string slice cannot be used as a row selector
+    ----
+    .. code-block::
+
+        DT[f.A>3, :]
 
 
-Pandas' ``.loc`` notation works on labels, while ``.iloc`` works on actual
-positions. This is noticeable during row selection. Datatable, however, works
-only on positions::
+    ====
+    Select rows on multiple conditions, using OR
+    ----
+    .. code-block::
 
-    >>> # pandas
-    >>> df1 = df.set_index('C')
-        A   B   D
-    C
-    7   1   4   5
-    8   2   5   7
-    9   3   6   2
-    10  4   7   9
-    11  5   8  -1
+        df.loc[(df['A'] > 3) | (df['B']<5)]
 
-Selecting with ``.loc`` for the row with number 7 returns no error::
+    ----
+    .. code-block::
 
-    >>> # pandas
-    >>> df1.loc[7]
-    A    1
-    B    4
-    D    5
-    Name: 7, dtype: int64
-
-However, selecting with ``iloc`` for the row with number 7 returns an error,
-because positionally, there is no row 7::
-
-    >>> # pandas
-    >>> df.iloc[7]
-    IndexError: single positional indexer is out-of-bounds
+        DT[(f.A>3) | (f.B<5), :]
 
 
-As stated earlier, datatable has the :attr:`dt.Frame.key` property, which is
-used for joins, not row subsetting, and as such selection similar to ``loc``
-with the row label is not possible::
+    ====
+    Select rows on multiple conditions, using AND
+    ----
+    .. code-block::
 
-    >>> DT.key = 'C'
-    >>> DT
-        C |     A      B      D
-    int32 | int32  int32  int32
-    ----- + -----  -----  -----
-        7 |     1      4      5
-        8 |     2      5      7
-        9 |     3      6      2
-       10 |     4      7      9
-       11 |     5      8     -1
-    [5 rows x 4 columns]
+        df.loc[(df['A'] > 3) & (df['B']<8)]
 
-    >>> # this will fail
-    >>> DT[7, :]
-    ValueError: Row 7 is invalid for a frame with 5 rows
+    ----
+    .. code-block::
+
+        DT[(f.A>3) & (f.B<8), :]
+
+
+    ====
+    Select a single column by column name
+    ----
+    .. code-block::
+
+        df['A']
+        df.loc[:, 'A']
+
+    ----
+    .. code-block::
+
+        DT['A']
+        DT[:, 'A']
+
+
+    ====
+    Select a single column by position
+    ----
+    .. code-block::
+
+        df.iloc[:, 1]
+
+    ----
+    .. code-block::
+
+        DT[1]
+        DT[:, 1]
+
+
+    ====
+    Select multiple columns by column names
+    ----
+    .. code-block::
+
+        df.loc[:, ["A", "B"]]
+
+    ----
+    .. code-block::
+
+        DT[:, ["A", "B"]]
+
+
+    ====
+    Select multiple columns by position
+    ----
+    .. code-block::
+
+        df.iloc[:, [0, 1]]
+
+    ----
+    .. code-block::
+
+        DT[:, [0, 1]]
+
+
+    ====
+    Select multiple columns by slicing
+    ----
+    .. code-block::
+
+        df.loc[:, "A":"B"]
+
+    ----
+    .. code-block::
+
+        DT[:, "A":"B"]
+
+
+    ====
+    Select multiple columns by position
+    ----
+    .. code-block::
+
+        df.iloc[:, 1:3]
+
+    ----
+    .. code-block::
+
+        DT[:, 1:3]
+
+
+    ====
+    Select columns by Boolean mask
+    ----
+    .. code-block::
+
+        df.loc[:, [True,False,False,True]]
+
+    ----
+    .. code-block::
+
+        DT[:, [True,False,False,True]]
+
+
+    ====
+    Select multiple rows and columns
+    ----
+    .. code-block::
+
+        df.loc[2:5, "A":"B"]
+
+    ----
+    .. code-block::
+
+        DT[2:5, "A":"B"]
+
+
+    ====
+    Select multiple rows and columns by position
+    ----
+    .. code-block::
+
+        df.iloc[2:5, :2]
+
+    ----
+    .. code-block::
+
+        DT[2:5, :2]
+
+
+    ====
+    Select a single value (returns a scalar)
+    ----
+    .. code-block::
+
+        df.at[2, 'A']
+        df.loc[2, 'A']
+
+    ----
+    .. code-block::
+
+        DT[2, "A"]
+
+
+    ====
+    Select a single value by position
+    ----
+    .. code-block::
+
+        df.iat[2, 0]
+        df.iloc[2, 0]
+
+    ----
+    .. code-block::
+
+        DT[2, 0]
+
+
+    ====
+    Select a single value, return as Series
+    ----
+    .. code-block::
+
+        df.loc[2, ["A"]]
+
+    ----
+    .. code-block::
+
+        DT[2, ["A"]]
+
+
+    ====
+    Select a single value (return as Series/Frame) by position
+    ----
+    .. code-block::
+
+        df.iloc[2, [0]]
+
+    ----
+    .. code-block::
+
+        DT[2, [0]]
+
+
+    ====
+    In pandas every frame has a row index, and if a filtration is executed,
+    the row numbers are kept::
+
+        >>> df.loc[df['A'] > 3]
+            A   B   C    D
+        3   4   7   10   9
+        4   5   8   11  -1
+
+    ----
+    Datatable has no notion of a row index; the row numbers displayed are just
+    for convenience::
+
+        >>> DT[f.A > 3, :]
+           |     A      B      C      D
+           | int32  int32  int32  int32
+        -- + -----  -----  -----  -----
+         0 |     4      7     10      9
+         1 |     5      8     11     -1
+        [2 rows x 4 columns]
+
+
+    ====
+    In pandas, the index can be numbers, or characters, or intervals, or even
+    ``MultiIndex``es; you can subset rows on these labels::
+
+        >>> df1 = df.set_index(pd.Index(['a','b','c','d','e']))
+            A   B   C    D
+        a   1   4   7    5
+        b   2   5   8    7
+        c   3   6   9    2
+        d   4   7   10   9
+        e   5   8   11  -1
+
+        >>> df1.loc["a":"c"]
+            A   B   C   D
+        a   1   4   7   5
+        b   2   5   8   7
+        c   3   6   9   2
+
+    ----
+    Datatable has the :attr:`key <dt.Frame.key>` property, which is meant as
+    an equivalent of pandas indices, but its purpose at the moment is for joins,
+    not for subsetting data::
+
+        >>> data = {"A": [1, 2, 3, 4, 5],
+        ...         "B": [4, 5, 6, 7, 8],
+        ...         "C": [7, 8, 9, 10, 11],
+        ...         "D": [5, 7, 2, 9, -1],
+        ...         "E": ['a','b','c','d','e']}
+        >>> DT1 = dt.Frame(data)
+        >>> DT1.key = 'E'
+        >>> DT1
+        E     |     A      B      C      D
+        str32 | int32  int32  int32  int32
+        ----- + -----  -----  -----  -----
+        a     |     1      4      7      5
+        b     |     2      5      8      7
+        c     |     3      6      9      2
+        d     |     4      7     10      9
+        e     |     5      8     11     -1
+        [5 rows x 5 columns]
+
+        >>> DT1["a":"c", :]  # this will fail
+        TypeError: A string slice cannot be used as a row selector
+
+
+    ====
+    Pandas' ``.loc`` notation works on labels, while ``.iloc`` works on actual
+    positions. This is noticeable during row selection. Datatable, however, works
+    only on positions::
+
+        >>> df1 = df.set_index('C')
+            A   B   D
+        C
+        7   1   4   5
+        8   2   5   7
+        9   3   6   2
+        10  4   7   9
+        11  5   8  -1
+
+    Selecting with ``.loc`` for the row with number 7 returns no error::
+
+        >>> df1.loc[7]
+        A    1
+        B    4
+        D    5
+        Name: 7, dtype: int64
+
+    However, selecting with ``iloc`` for the row with number 7 returns an error,
+    because positionally, there is no row 7::
+
+        >>> df.iloc[7]
+        IndexError: single positional indexer is out-of-bounds
+
+    ----
+    Datatable has the :attr:`dt.Frame.key` property, which is
+    used for joins, not row subsetting, and as such selection similar to ``loc``
+    with the row label is not possible::
+
+        >>> DT.key = 'C'
+        >>> DT
+            C |     A      B      D
+        int32 | int32  int32  int32
+        ----- + -----  -----  -----
+            7 |     1      4      5
+            8 |     2      5      7
+            9 |     3      6      2
+           10 |     4      7      9
+           11 |     5      8     -1
+        [5 rows x 4 columns]
+
+        >>> DT[7, :]   # this will fail
+        ValueError: Row 7 is invalid for a frame with 5 rows
 
 
 
 Add new/update existing columns
 -------------------------------
 
-=======================================================  ===============================================================
-pandas                                                      datatable
-=======================================================  ===============================================================
-Add a new column with a scalar value
-``df['new_col'] = 2``                                        ``DT['new_col'] = 2``
+.. x-comparison-table::
+    :header1: pandas
+    :header2: datatable
 
-Same as above
-``df = df.assign(new_col = 2)``                              ``DT[:, update(new_col=2)]``
+    Add a new column with a scalar value
+    ----
+    .. code-block::
 
-Add a new column with a list of values
-``df['new_col'] = range(len(df))``                           ``DT['new_col_1'] = range(DT.nrows)``
+        df['new_col'] = 2
+        df = df.assign(new_col = 2)
 
-Same as above
-``df = df.assign(new_col = range(len(df))``                  ``DT[:, update(new_col=range(DT.nrows)]``
+    ----
+    .. code-block::
 
-Update a single value
-``df.at[2, 'new_col'] = 200``                                ``DT[2, 'new_col'] = 200``
+        DT['new_col'] = 2
+        DT[:, update(new_col=2)]
 
-Update an entire column
-``df.loc[:, "A"] = 5``  or ``df["A"] = 5``                   ``DT["A"] = 5``
+    ====
+    Add a new column with a list of values
+    ----
+    .. code-block::
 
-Same as above
-``df = df.assign(A = 5)``                                    ``DT[:, update(A = 5)]``
+        df['new_col'] = range(len(df))
+        df = df.assign(new_col = range(len(df))
 
-Update multiple columns
-``df.loc[:, "A":"C"] = np.arange(15).reshape(-1,3)``        ``DT[:, "A":"C"] = np.arange(15).reshape(-1,3)``
-=======================================================  ===============================================================
+    ----
+    .. code-block::
 
-.. note:: In datatable, the :func:`update()` method is in-place; reassigment to the Frame ``DT`` is not required.
+        DT['new_col_1'] = range(DT.nrows)
+        DT[:, update(new_col=range(DT.nrows)]
+
+    ====
+    Update a single value
+    ----
+    .. code-block::
+
+        df.at[2, 'new_col'] = 200
+
+    ----
+    .. code-block::
+
+        DT[2, 'new_col'] = 200
+
+    ====
+    Update an entire column
+    ----
+    .. code-block::
+
+        df.loc[:, "A"] = 5  # or
+        df["A"] = 5
+        df = df.assign(A = 5)
+
+    ----
+    .. code-block::
+
+        DT["A"] = 5
+        DT[:, update(A = 5)]
+
+    ====
+    Update multiple columns
+    ----
+    .. code-block::
+
+        df.loc[:, "A":"C"] = np.arange(15).reshape(-1,3)
+
+    ----
+    .. code-block::
+
+        DT[:, "A":"C"] = np.arange(15).reshape(-1,3)
+
+
+.. note::
+
+    In datatable, the :func:`update()` method is in-place; reassigment to
+    the Frame ``DT`` is not required.
 
 
 

--- a/docs/manual/comparison_with_pandas.rst
+++ b/docs/manual/comparison_with_pandas.rst
@@ -520,15 +520,33 @@ Add new/update existing columns
 Rename columns
 --------------
 
-=======================================================  ===============================================================
-pandas                                                      datatable
-=======================================================  ===============================================================
-Rename a column
-``df = df.rename(columns={"A":"col_A"})``                    ``DT.names = {"A" : "col_A"}``
+.. x-comparison-table::
+    :header1: pandas
+    :header2: datatable
 
-Rename multiple columns
-``df = df.rename(columns={"A":"col_A", "B":"col_B"})``      ``DT.names = {"A" : "col_A", "B": "col_B"}``
-=======================================================  ===============================================================
+    Rename a column
+    ----
+    .. code-block::
+
+        df = df.rename(columns={"A": "col_A"})
+
+    ----
+    .. code-block::
+
+        DT.names = {"A": "col_A"}
+
+    ====
+    Rename multiple columns
+    ----
+    .. code-block::
+
+        df = df.rename(columns={"A": "col_A", "B": "col_B"})
+
+    ----
+    .. code-block::
+
+        DT.names = {"A": "col_A", "B": "col_B"}
+
 
 In datatable, you can select and rename columns at the same time, by passing
 a dictionary of :ref:`f-expressions` into the ``j`` section::
@@ -550,48 +568,124 @@ a dictionary of :ref:`f-expressions` into the ``j`` section::
 Delete Columns
 --------------
 
-=======================================================  ===============================================================
-pandas                                                      datatable
-=======================================================  ===============================================================
-Delete a column
-``del df['B']``                                                ``del DT['B']``
+.. x-comparison-table::
+    :header1: pandas
+    :header2: datatable
 
-Same as above
-``df = df.drop('B', axis=1)``                                 ``DT = DT[:, f[:].remove(f.B)]``
+    ====
+    Delete a column
+    ----
+    .. code-block::
 
-Remove multiple columns
-``df = df.drop(['B', 'C'], axis=1)``                         | ``del DT[: , ['B', 'C']]`` or
-                                                             | ``DT = DT[:, f[:].remove([f.B, f.C])]``
-=======================================================  ===============================================================
+        del df['B']
+
+    ----
+    .. code-block::
+
+        del DT['B']
+
+    ====
+    Same as above
+    ----
+    .. code-block::
+
+        df = df.drop('B', axis=1)
+
+    ----
+    .. code-block::
+
+        DT = DT[:, f[:].remove(f.B)]
+
+    ====
+    Remove multiple columns
+    ----
+    .. code-block::
+
+        df = df.drop(['B', 'C'], axis=1)
+
+    ----
+    .. code-block::
+
+        del DT[: , ['B', 'C']]   # or
+        DT = DT[:, f[:].remove([f.B, f.C])]
+
 
 
 
 Sorting
 -------
 
-===========================================================  ===============================================================
-pandas                                                       datatable
-===========================================================  ===============================================================
-Sort by a column - default ascending
-``df.sort_values('A')``                                       ``DT.sort('A')`` or ``DT[:, : , sort('A')]``
+.. x-comparison-table::
+    :header1: pandas
+    :header2: datatable
 
-Sort by a column - descending
-``df.sort_values('A',ascending=False)``                       | ``DT.sort(-f.A)`` or ``DT[:, :, sort(-f.A)]`` or
-                                                              | ``DT[:, :, sort('A', reverse=True)]``
+    Sort by a column -- default ascending
+    ----
+    .. code-block::
 
-Sort by multiple columns - default ascending
-``df.sort_values(['A','C'])``                                 ``DT.sort('A','C')`` or ``DT[:, :, sort('A','C')]``
+        df.sort_values('A')
 
-Sort by multiple columns - both descending
-``df.sort_values(['A','C'],ascending=[False,False])``         | ``DT.sort(-f.A, -f.C)`` or
-                                                              | ``DT[:, :, sort(-f.A, -f.C)]`` or
-                                                              | ``DT[:, :, sort('A', 'C', reverse=[True, True])]``
+    ----
+    .. code-block::
 
-Sort by multiple columns - different sort directions
-``df.sort_values(['A', 'C'], ascending=[True, False])``       | ``DT.sort(f.A, -f.C)`` or
-                                                              | ``DT[:, :, sort(f.A, -f.C)]`` or
-                                                              | ``DT[:, :, sort('A', 'C', reverse=[False, True])]``
-===========================================================  ===============================================================
+        DT.sort('A')                       # or
+        DT[:, : , sort('A')]
+
+    ====
+    Sort by a column -- descending
+    ----
+    .. code-block::
+
+        df.sort_values('A',ascending=False)
+
+    ----
+    .. code-block::
+
+        DT.sort(-f.A)                      # or
+        DT[:, :, sort(-f.A)]               # or
+        DT[:, :, sort('A', reverse=True)]
+
+    ====
+    Sort by multiple columns -- default ascending
+    ----
+    .. code-block::
+
+        df.sort_values(['A', 'C'])
+
+    ----
+    .. code-block::
+
+        DT.sort('A', 'C')                  # or
+        DT[:, :, sort('A', 'C')]
+
+    ====
+    Sort by multiple columns -- both descending
+    ----
+    .. code-block::
+
+        df.sort_values(['A','C'],ascending=[False,False])
+
+    ----
+    .. code-block::
+
+        DT.sort(-f.A, -f.C)                # or
+        DT[:, :, sort(-f.A, -f.C)]         # or
+        DT[:, :, sort('A', 'C', reverse=[True, True])]
+
+    ====
+    Sort by multiple columns -- different sort directions
+    ----
+    .. code-block::
+
+        df.sort_values(['A', 'C'], ascending=[True, False])
+
+    ----
+    .. code-block::
+
+        DT.sort(f.A, -f.C)                 # or
+        DT[:, :, sort(f.A, -f.C)]          # or
+        DT[:, :, sort('A', 'C', reverse=[False, True])]
+
 
 .. note::
 
@@ -636,33 +730,108 @@ Grouping and Aggregation
     [5 rows x 3 columns]
 
 
-===========================================================  ===============================================================
-pandas                                                         datatable
-===========================================================  ===============================================================
-Group by ``a`` and sum the other columns
-``df.groupby("a").agg("sum")``                                  ``DT[:, dt.sum(f[:]), by("a")]``
+.. x-comparison-table::
+    :header1: pandas
+    :header2: datatable
 
-Group by ``a`` and ``b`` and sum ``c``
-``df.groupby(["a", "b"]).agg("sum")``                           ``DT[:, dt.sum(f.c), by("a", "b")]``
+    ====
+    Group by column ``a`` and sum the other columns
+    ----
+    .. code-block::
 
-Get size per group
-``df.groupby("a").size()``                                      ``DT[:, dt.count(), by("a")]``
+        df.groupby("a").agg("sum")
 
-Grouping with multiple aggregation functions
-``df.groupby("a").agg({"b": "sum", "c": "mean"})``              | ``DT[:, {"b": dt.sum(f.b), "c": dt.mean(f.c)}, by("a")]``
+    ----
+    .. code-block::
 
-Get the first row per group
-``df.groupby("a").first()``                                     ``DT[0, :, by("a")]``
+        DT[:, dt.sum(f[:]), by("a")]
 
-Get the last row per group
-``df.groupby('a').last()``                                      ``DT[-1, :, by("a")]``
+    ====
+    Group by ``a`` and ``b`` and sum ``c``
+    ----
+    .. code-block::
 
-Get the first two rows per group
-``df.groupby("a").head(2)``                                     ``DT[:2, :, by("a")]``
+        df.groupby(["a", "b"]).agg("sum")
 
-Get the last two rows per group
-``df.groupby("a").tail(2)``                                     ``DT[-2:, :, by("a")]``
-===========================================================  ===============================================================
+    ----
+    .. code-block::
+
+        DT[:, dt.sum(f.c), by("a", "b")]
+
+
+    ====
+    Get size per group
+    ----
+    .. code-block::
+
+        df.groupby("a").size()
+
+    ----
+    .. code-block::
+
+        DT[:, dt.count(), by("a")]
+
+
+    ====
+    Grouping with multiple aggregation functions
+    ----
+    .. code-block::
+
+        df.groupby("a").agg({"b": "sum", "c": "mean"})
+
+    ----
+    .. code-block::
+
+        DT[:, {"b": dt.sum(f.b), "c": dt.mean(f.c)}, by("a")]
+
+    ====
+    Get the first row per group
+    ----
+    .. code-block::
+
+        df.groupby("a").first()
+
+    ----
+    .. code-block::
+
+        DT[0, :, by("a")]
+
+    ====
+    Get the last row per group
+    ----
+    .. code-block::
+
+        df.groupby('a').last()
+
+    ----
+    .. code-block::
+
+        DT[-1, :, by("a")]
+
+    ====
+    Get the first two rows per group
+    ----
+    .. code-block::
+
+        df.groupby("a").head(2)
+
+    ----
+    .. code-block::
+
+        DT[:2, :, by("a")]
+
+    ====
+    Get the last two rows per group
+    ----
+    .. code-block::
+
+        df.groupby("a").tail(2)
+
+    ----
+    .. code-block::
+
+        DT[-2:, :, by("a")]
+
 
 Transformations within groups in pandas is done using the `pd.transform`_
 function::

--- a/docs/manual/comparison_with_pandas.rst
+++ b/docs/manual/comparison_with_pandas.rst
@@ -34,6 +34,23 @@ and datatable ``Frame``.
 Row and Column Selection
 ------------------------
 
+.. x-comparison-table::
+    :header1: pandas
+    :header2: datatable
+
+    Select **a single** row
+    ----
+    .. code-block:: R
+
+        df.loc[2]
+
+    ----
+    .. code-block::
+
+        DT[2, :]
+
+
+
 =================================================  ============================================
 pandas                                              datatable
 =================================================  ============================================


### PR DESCRIPTION
- Added new directive `.. x-comparison-table::` which can be used in "comparison of datatable  to other libraries" documentation pages;
- Reformatted the "comparison_with_pandas" manual page to use the new directive.

Note that this PR does not change "comparison_with_rdatatable" or "comparison_with_sql": these can be modified in separate PRs.

Closes #2625