### PR TITLE
Fix warnings

### DIFF
--- a/src/core/models/dt_linearmodel.cc
+++ b/src/core/models/dt_linearmodel.cc
@@ -321,13 +321,13 @@ void LinearModel<T>::adjust_eta(T& eta, size_t iter) {
       eta = eta0_;
       break;
     case LearningRateSchedule::TIME_BASED:
-      eta = eta0_ / (1 + eta_decay_ * iter);
+      eta = eta0_ / (1 + eta_decay_ * static_cast<T>(iter));
       break;
     case LearningRateSchedule::STEP_BASED:
-      eta = eta0_ * pow(eta_decay_, floor((1 + iter) / eta_drop_rate_));
+      eta = eta0_ * std::pow(eta_decay_, std::floor(static_cast<T>(1 + iter) / eta_drop_rate_));
       break;
     case LearningRateSchedule::EXPONENTIAL:
-      eta = eta0_ / exp(eta_decay_ * iter);
+      eta = eta0_ / std::exp(eta_decay_ * static_cast<T>(iter));
   }
 }
 


### PR DESCRIPTION
Fixed the following compiler warnings:
```
src/core/models/dt_linearmodel.cc:324:39: warning: implicit conversion from 'size_t' (aka 'unsigned long') to 'float' may lose precision [-Wimplicit-int-float-conversion]
      eta = eta0_ / (1 + eta_decay_ * iter);
                                    ~ ^~~~
src/core/models/dt_linearmodel.cc:643:16: note: in instantiation of member function 'dt::LinearModel<float>::adjust_eta' requested here
template class LinearModel<float>;
               ^
src/core/models/dt_linearmodel.cc:327:46: warning: implicit conversion from 'unsigned long' to 'float' may lose precision [-Wimplicit-int-float-conversion]
      eta = eta0_ * pow(eta_decay_, floor((1 + iter) / eta_drop_rate_));
                                           ~~^~~~~~  ~
src/core/models/dt_linearmodel.cc:330:38: warning: implicit conversion from 'size_t' (aka 'unsigned long') to 'float' may lose precision [-Wimplicit-int-float-conversion]
      eta = eta0_ / exp(eta_decay_ * iter);
                                   ~ ^~~~
src/core/models/dt_linearmodel.cc:324:39: warning: implicit conversion from 'size_t' (aka 'unsigned long') to 'double' may lose precision [-Wimplicit-int-float-conversion]
      eta = eta0_ / (1 + eta_decay_ * iter);
                                    ~ ^~~~
src/core/models/dt_linearmodel.cc:644:16: note: in instantiation of member function 'dt::LinearModel<double>::adjust_eta' requested here
template class LinearModel<double>;
               ^
src/core/models/dt_linearmodel.cc:327:46: warning: implicit conversion from 'unsigned long' to 'double' may lose precision [-Wimplicit-int-float-conversion]
      eta = eta0_ * pow(eta_decay_, floor((1 + iter) / eta_drop_rate_));
                                           ~~^~~~~~  ~
src/core/models/dt_linearmodel.cc:330:38: warning: implicit conversion from 'size_t' (aka 'unsigned long') to 'double' may lose precision [-Wimplicit-int-float-conversion]
      eta = eta0_ / exp(eta_decay_ * iter);
                                   ~ ^~~~
6 warnings generated.
```