### PR TITLE
py::XArgs can now be used to declare methods

### DIFF
--- a/src/core/_dt.h
+++ b/src/core/_dt.h
@@ -26,6 +26,7 @@
 #include <exception>    // std::exception_ptr
 #include <memory>       // std::unique_ptr
 #include <string>       // std::string
+#include <type_traits>  //
 #include <utility>      // std::move, std::pair
 #include <vector>       // std::vector
 

--- a/src/core/call_logger.cc
+++ b/src/core/call_logger.cc
@@ -348,6 +348,7 @@ class CallLogger::Impl
     void init_function  (const py::PKArgs* pkargs, py::robj args, py::robj kwds) noexcept;
     void init_function  (const py::XArgs* xargs, py::robj args, py::robj kwds) noexcept;
     void init_method    (const py::PKArgs* pkargs, py::robj obj, py::robj args, py::robj kwds) noexcept;
+    void init_method    (const py::XArgs* xargs, py::robj obj, py::robj args, py::robj kwds) noexcept;
     void init_dealloc   (py::robj obj) noexcept;
     void init_getset    (py::robj obj, py::robj val, void* closure) noexcept;
     void init_getattr   (py::robj obj, py::robj attr) noexcept;
@@ -418,6 +419,18 @@ void CallLogger::Impl::init_method(
 {
   safe_init([&] {
     *out_ << R(obj) << '.' << pkargs->get_short_name() << '(';
+    print_arguments(args, kwds);
+    *out_ << ')';
+  });
+}
+
+
+void CallLogger::Impl::init_method(
+    const py::XArgs* xargs, py::robj obj, py::robj args, py::robj kwds)
+    noexcept
+{
+  safe_init([&] {
+    *out_ << R(obj) << '.' << xargs->qualified_name() << '(';
     print_arguments(args, kwds);
     *out_ << ')';
   });
@@ -661,6 +674,18 @@ CallLogger CallLogger::method(const py::PKArgs* pkargs,
   CallLogger cl;
   if (cl.impl_) {
     cl.impl_->init_method(pkargs, py::robj(pyobj), py::robj(pyargs),
+                          py::robj(pykwds));
+  }
+  return cl;
+}
+
+
+CallLogger CallLogger::method(const py::XArgs* xargs,
+    PyObject* pyobj, PyObject* pyargs, PyObject* pykwds) noexcept
+{
+  CallLogger cl;
+  if (cl.impl_) {
+    cl.impl_->init_method(xargs, py::robj(pyobj), py::robj(pyargs),
                           py::robj(pykwds));
   }
   return cl;

--- a/src/core/call_logger.h
+++ b/src/core/call_logger.h
@@ -77,6 +77,7 @@ class CallLogger {
     static CallLogger function  (const py::PKArgs*, PyObject* pyargs, PyObject* pykwds) noexcept;
     static CallLogger function  (const py::XArgs*, PyObject* pyargs, PyObject* pykwds) noexcept;
     static CallLogger method    (const py::PKArgs*, PyObject* pyobj, PyObject* pyargs, PyObject* pykwds) noexcept;
+    static CallLogger method    (const py::XArgs*, PyObject* pyobj, PyObject* pyargs, PyObject* pykwds) noexcept;
     static CallLogger dealloc   (PyObject* pyobj) noexcept;
     static CallLogger getset    (PyObject* pyobj, PyObject* val, void* closure) noexcept;
     static CallLogger getattr   (PyObject* pyobj, PyObject* key) noexcept;

--- a/src/core/datatablemodule.cc
+++ b/src/core/datatablemodule.cc
@@ -448,7 +448,6 @@ void py::DatatableModule::init_methods() {
   }
 
   init_methods_aggregate();
-  init_methods_cbind();
   init_methods_csv();
   init_methods_isclose();
   init_methods_jay();

--- a/src/core/datatablemodule.h
+++ b/src/core/datatablemodule.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2020 H2O.ai
+// Copyright 2018-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -37,7 +37,6 @@ class DatatableModule : public ExtModule<DatatableModule> {
 
     void init_methods();
     void init_methods_aggregate(); // models/aggregate.cc
-    void init_methods_cbind();     // frame/cbind.cc
     void init_methods_csv();       // csv/py_csv.cc
     void init_methods_isclose();   // expr/head_func_isclose.cc
     void init_methods_jay();       // open_jay.cc

--- a/src/core/frame/cbind.cc
+++ b/src/core/frame/cbind.cc
@@ -16,6 +16,7 @@
 #include <functional>
 #include "frame/py_frame.h"
 #include "python/_all.h"
+#include "python/xargs.h"
 #include "utils/assert.h"
 #include "datatable.h"
 #include "datatablemodule.h"
@@ -122,12 +123,9 @@ See also
 - :meth:`.rbind()` -- method for row-binding frames.
 )";
 
-static PKArgs args_cbind(0, 0, 1, true, false, {"force"}, "cbind", doc_cbind);
+// static PKArgs args_cbind(0, 0, 1, true, false, {"force"}, "cbind", doc_cbind);
 
-
-
-void Frame::cbind(const PKArgs& args)
-{
+void Frame::cbind(const XArgs& args) {
   std::vector<py::oobj> frame_objs;
   std::vector<DataTable*> datatables;
 
@@ -171,6 +169,12 @@ void Frame::cbind(const PKArgs& args)
   _clear_types();
 }
 
+DECLARE_METHODv(&Frame::cbind)
+    ->name("cbind")
+    ->docs(doc_cbind)
+    ->n_keyword_args(1)
+    ->allow_varargs()
+    ->arg_names({"force"});
 
 
 
@@ -264,10 +268,7 @@ the `force` parameter to `True`::
     [4 rows x 3 columns]
 )";
 
-static PKArgs args_py_cbind(
-  0, 0, 1, true, false, {"force"}, "cbind", doc_py_cbind);
-
-static oobj py_cbind(const PKArgs& args) {
+static oobj py_cbind(const XArgs& args) {
   oobj r = oobj::import("datatable", "Frame").call();
   xassert(r.is_frame());
   PyObject* rv = r.to_borrowed_ref();
@@ -275,15 +276,12 @@ static oobj py_cbind(const PKArgs& args) {
   return r;
 }
 
-
-
-void Frame::_init_cbind(XTypeMaker& xt) {
-  xt.add(METHOD(&Frame::cbind, args_cbind));
-}
-
-void DatatableModule::init_methods_cbind() {
-  ADD_FN(&py_cbind, args_py_cbind);
-}
+DECLARE_PYFN(&py_cbind)
+    ->name("cbind")
+    ->n_keyword_args(1)
+    ->allow_varargs()
+    ->arg_names({"force"})
+    ->docs(doc_py_cbind);
 
 
 

--- a/src/core/frame/cbind.cc
+++ b/src/core/frame/cbind.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2020 H2O.ai
+// Copyright 2018-2021 H2O.ai
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -122,8 +122,6 @@ See also
 
 - :meth:`.rbind()` -- method for row-binding frames.
 )";
-
-// static PKArgs args_cbind(0, 0, 1, true, false, {"force"}, "cbind", doc_cbind);
 
 void Frame::cbind(const XArgs& args) {
   std::vector<py::oobj> frame_objs;

--- a/src/core/frame/py_frame.cc
+++ b/src/core/frame/py_frame.cc
@@ -250,10 +250,7 @@ Notes
 
 )";
 
-static PKArgs args_copy(0, 0, 1, false, false, {"deep"}, "copy", doc_copy);
-
-
-oobj Frame::copy(const PKArgs& args) {
+oobj Frame::copy(const XArgs& args) {
   bool deepcopy = args[0].to<bool>(false);
 
   oobj res = Frame::oframe(deepcopy? new DataTable(*dt, DataTable::deep_copy)
@@ -266,21 +263,26 @@ oobj Frame::copy(const PKArgs& args) {
   return res;
 }
 
+DECLARE_METHOD(&Frame::copy)
+    ->name("copy")
+    ->n_keyword_args(1)
+    ->arg_names({"deep"})
+    ->docs(doc_copy);
 
 
-static PKArgs args___deepcopy__(
-  0, 1, 0, false, false, {"memo"}, "__deepcopy__", nullptr);
 
-oobj Frame::m__deepcopy__(const PKArgs&) {
-  py::odict dict_arg;
-  dict_arg.set(py::ostring("deep"), py::True());
-  args_copy.bind(nullptr, dict_arg.to_borrowed_ref());
-  return copy(args_copy);
+oobj Frame::m__deepcopy__(const XArgs&) {
+  return robj(this).get_attr("copy")
+          .call({}, {py::ostring("deep"), py::True()});
 }
 
+DECLARE_METHOD(&Frame::m__deepcopy__)
+    ->name("__deepcopy__")
+    ->n_positional_or_keyword_args(1)
+    ->arg_names({"memo"});
+
 oobj Frame::m__copy__() {
-  args_copy.bind(nullptr, nullptr);
-  return copy(args_copy);
+  return robj(this).invoke("copy");
 }
 
 
@@ -1204,12 +1206,10 @@ void Frame::impl_init_type(XTypeMaker& xt) {
   xt.add(GETTER(&Frame::get_stypes, args_stypes));
   xt.add(GETTER(&Frame::get_types, args_types));
 
-  xt.add(METHOD(&Frame::copy, args_copy));
   xt.add(METHOD(&Frame::materialize, args_materialize));
   xt.add(METHOD(&Frame::export_names, args_export_names));
   xt.add(METHOD0(&Frame::get_names, "keys"));
   xt.add(METHOD0(&Frame::m__copy__, "__copy__"));
-  xt.add(METHOD(&Frame::m__deepcopy__, args___deepcopy__));
 
   INIT_METHODS_FOR_CLASS(Frame);
 }

--- a/src/core/frame/py_frame.cc
+++ b/src/core/frame/py_frame.cc
@@ -353,10 +353,7 @@ Notes
 
 )";
 
-static PKArgs args_export_names(
-  0, 0, 0, false, false, {}, "export_names", doc_export_names);
-
-oobj Frame::export_names(const PKArgs&) {
+oobj Frame::export_names(const XArgs&) {
   py::oobj f = py::oobj::import("datatable", "f");
   py::otuple names = dt->get_pynames();
   py::otuple out_vars(names.size());
@@ -365,6 +362,10 @@ oobj Frame::export_names(const PKArgs&) {
   }
   return std::move(out_vars);
 }
+
+DECLARE_METHOD(&Frame::export_names)
+    ->name("export_names")
+    ->docs(doc_export_names);
 
 
 
@@ -460,13 +461,17 @@ return: None
     This operation modifies the frame in-place.
 )";
 
-static PKArgs args_materialize(
-  0, 1, 0, false, false, {"to_memory"}, "materialize", doc_materialize);
-
-void Frame::materialize(const PKArgs& args) {
+void Frame::materialize(const XArgs& args) {
   bool to_memory = args[0].to<bool>(false);
   dt->materialize(to_memory);
 }
+
+DECLARE_METHODv(&Frame::materialize)
+    ->name("materialize")
+    ->n_positional_or_keyword_args(1)
+    ->arg_names({"to_memory"})
+    ->docs(doc_materialize);
+
 
 
 //------------------------------------------------------------------------------
@@ -1206,8 +1211,6 @@ void Frame::impl_init_type(XTypeMaker& xt) {
   xt.add(GETTER(&Frame::get_stypes, args_stypes));
   xt.add(GETTER(&Frame::get_types, args_types));
 
-  xt.add(METHOD(&Frame::materialize, args_materialize));
-  xt.add(METHOD(&Frame::export_names, args_export_names));
   xt.add(METHOD0(&Frame::get_names, "keys"));
   xt.add(METHOD0(&Frame::m__copy__, "__copy__"));
 

--- a/src/core/frame/py_frame.cc
+++ b/src/core/frame/py_frame.cc
@@ -1197,7 +1197,6 @@ void Frame::impl_init_type(XTypeMaker& xt) {
   _init_tocsv(xt);
   _init_tonumpy(xt);
   _init_topython(xt);
-  _init_to_pandas(xt);
 
   xt.add(GETTER(&Frame::get_ltypes, args_ltypes));
   xt.add(GETSET(&Frame::get_meta, &Frame::set_meta, args_meta));

--- a/src/core/frame/py_frame.cc
+++ b/src/core/frame/py_frame.cc
@@ -1181,7 +1181,6 @@ void Frame::impl_init_type(XTypeMaker& xt) {
   xt.add(METHOD__GETBUFFER__(&Frame::m__getbuffer__, &Frame::m__releasebuffer__));
   Frame_Type = xt.get_type_object();
 
-  _init_cbind(xt);
   _init_key(xt);
   _init_init(xt);
   _init_iter(xt);

--- a/src/core/frame/py_frame.cc
+++ b/src/core/frame/py_frame.cc
@@ -25,6 +25,7 @@
 #include "ltype.h"
 #include "python/_all.h"
 #include "python/string.h"
+#include "python/xargs.h"
 #include "stype.h"
 #include "types/py_type.h"
 namespace py {
@@ -80,16 +81,29 @@ See also
 - :meth:`.tail` -- return the last `n` rows of the Frame.
 )";
 
-static PKArgs args_head(
-    1, 0, 0, false, false, {"n"}, "head", doc_head);
+// static PKArgs args_head(
+//     1, 0, 0, false, false, {"n"}, "head", doc_head);
 
 
-oobj Frame::head(const PKArgs& args) {
-  size_t n = std::min(args.get<size_t>(0, 10),
+// oobj Frame::head(const PKArgs& args) {
+//   size_t n = std::min(args.get<size_t>(0, 10),
+//                       dt->nrows());
+//   return m__getitem__(otuple(oslice(0, static_cast<int64_t>(n), 1),
+//                              None()));
+// }
+
+oobj Frame::head(const XArgs& args) {
+  size_t n = std::min(args[0].to<size_t>(10),
                       dt->nrows());
   return m__getitem__(otuple(oslice(0, static_cast<int64_t>(n), 1),
                              None()));
 }
+
+DECLARE_METHOD(&Frame::head)
+    ->name("head")
+    ->docs(doc_head)
+    ->n_positional_args(1)
+    ->arg_names({"n"});
 
 
 
@@ -1199,7 +1213,7 @@ void Frame::impl_init_type(XTypeMaker& xt) {
   xt.add(GETTER(&Frame::get_stypes, args_stypes));
   xt.add(GETTER(&Frame::get_types, args_types));
 
-  xt.add(METHOD(&Frame::head, args_head));
+  // xt.add(METHOD(&Frame::head, args_head));
   xt.add(METHOD(&Frame::tail, args_tail));
   xt.add(METHOD(&Frame::copy, args_copy));
   xt.add(METHOD(&Frame::materialize, args_materialize));
@@ -1207,6 +1221,8 @@ void Frame::impl_init_type(XTypeMaker& xt) {
   xt.add(METHOD0(&Frame::get_names, "keys"));
   xt.add(METHOD0(&Frame::m__copy__, "__copy__"));
   xt.add(METHOD(&Frame::m__deepcopy__, args___deepcopy__));
+
+  INIT_METHODS_FOR_CLASS(Frame);
 }
 
 

--- a/src/core/frame/py_frame.cc
+++ b/src/core/frame/py_frame.cc
@@ -1193,8 +1193,6 @@ void Frame::impl_init_type(XTypeMaker& xt) {
   _init_stats(xt);
   _init_sort(xt);
   _init_newsort(xt);
-  _init_toarrow(xt);
-  _init_tocsv(xt);
   _init_tonumpy(xt);
   _init_topython(xt);
 

--- a/src/core/frame/py_frame.cc
+++ b/src/core/frame/py_frame.cc
@@ -81,17 +81,6 @@ See also
 - :meth:`.tail` -- return the last `n` rows of the Frame.
 )";
 
-// static PKArgs args_head(
-//     1, 0, 0, false, false, {"n"}, "head", doc_head);
-
-
-// oobj Frame::head(const PKArgs& args) {
-//   size_t n = std::min(args.get<size_t>(0, 10),
-//                       dt->nrows());
-//   return m__getitem__(otuple(oslice(0, static_cast<int64_t>(n), 1),
-//                              None()));
-// }
-
 oobj Frame::head(const XArgs& args) {
   size_t n = std::min(args[0].to<size_t>(10),
                       dt->nrows());
@@ -155,18 +144,20 @@ See also
 - :meth:`.head` -- return the first `n` rows of the Frame.
 )";
 
-static PKArgs args_tail(
-    1, 0, 0, false, false, {"n"}, "tail", doc_tail);
-
-
-oobj Frame::tail(const PKArgs& args) {
-  size_t n = std::min(args.get<size_t>(0, 10),
+oobj Frame::tail(const XArgs& args) {
+  size_t n = std::min(args[0].to<size_t>(10),
                       dt->nrows());
   // Note: usual slice `-n::` doesn't work as expected when `n = 0`
   int64_t start = static_cast<int64_t>(dt->nrows() - n);
   return m__getitem__(otuple(oslice(start, oslice::NA, 1),
                              None()));
 }
+
+DECLARE_METHOD(&Frame::tail)
+    ->name("tail")
+    ->docs(doc_tail)
+    ->n_positional_args(1)
+    ->arg_names({"n"});
 
 
 
@@ -1213,8 +1204,6 @@ void Frame::impl_init_type(XTypeMaker& xt) {
   xt.add(GETTER(&Frame::get_stypes, args_stypes));
   xt.add(GETTER(&Frame::get_types, args_types));
 
-  // xt.add(METHOD(&Frame::head, args_head));
-  xt.add(METHOD(&Frame::tail, args_tail));
   xt.add(METHOD(&Frame::copy, args_copy));
   xt.add(METHOD(&Frame::materialize, args_materialize));
   xt.add(METHOD(&Frame::export_names, args_export_names));

--- a/src/core/frame/py_frame.h
+++ b/src/core/frame/py_frame.h
@@ -56,8 +56,6 @@ class Frame : public XObject<Frame> {
     static void _init_sort(XTypeMaker&);
     static void _init_newsort(XTypeMaker&);
     static void _init_stats(XTypeMaker&);
-    static void _init_toarrow(XTypeMaker&);
-    static void _init_tocsv(XTypeMaker&);
     static void _init_tonumpy(XTypeMaker&);
     static void _init_topython(XTypeMaker&);
 
@@ -128,8 +126,8 @@ class Frame : public XObject<Frame> {
     oobj export_names(const XArgs&);
 
     // Conversion methods
-    oobj to_arrow(const PKArgs&);
-    oobj to_csv(const PKArgs&);
+    oobj to_arrow(const XArgs&);
+    oobj to_csv(const XArgs&);
     oobj to_dict(const PKArgs&);
     oobj to_jay(const PKArgs&);  // See jay/save_jay.cc
     oobj to_list(const PKArgs&);

--- a/src/core/frame/py_frame.h
+++ b/src/core/frame/py_frame.h
@@ -59,7 +59,6 @@ class Frame : public XObject<Frame> {
     static void _init_toarrow(XTypeMaker&);
     static void _init_tocsv(XTypeMaker&);
     static void _init_tonumpy(XTypeMaker&);
-    static void _init_to_pandas(XTypeMaker&);
     static void _init_topython(XTypeMaker&);
 
     // Internal "constructor" of Frame objects. We do not use real constructors
@@ -135,7 +134,7 @@ class Frame : public XObject<Frame> {
     oobj to_jay(const PKArgs&);  // See jay/save_jay.cc
     oobj to_list(const PKArgs&);
     oobj to_numpy(const PKArgs&);
-    oobj to_pandas(const PKArgs&);
+    oobj to_pandas(const XArgs&);
     oobj to_tuples(const PKArgs&);
 
     // Stats functions

--- a/src/core/frame/py_frame.h
+++ b/src/core/frame/py_frame.h
@@ -119,7 +119,6 @@ class Frame : public XObject<Frame> {
     void cbind(const PKArgs&);
     oobj colindex(const PKArgs&);
     oobj copy(const PKArgs&);
-    // oobj head(const PKArgs&);
     oobj head(const XArgs&);
     void materialize(const PKArgs&);
     void rbind(const PKArgs&);
@@ -127,7 +126,7 @@ class Frame : public XObject<Frame> {
     void replace(const PKArgs&);
     oobj sort(const PKArgs&);
     oobj newsort(const PKArgs&);
-    oobj tail(const PKArgs&);
+    oobj tail(const XArgs&);
     oobj export_names(const PKArgs&);
 
     // Conversion methods

--- a/src/core/frame/py_frame.h
+++ b/src/core/frame/py_frame.h
@@ -86,7 +86,7 @@ class Frame : public XObject<Frame> {
     oobj m__iter__();
     oobj m__reversed__();
     oobj m__copy__();
-    oobj m__deepcopy__(const PKArgs&);
+    oobj m__deepcopy__(const XArgs&);
     size_t m__len__() const;
 
     // Frame display
@@ -118,7 +118,7 @@ class Frame : public XObject<Frame> {
 
     void cbind(const PKArgs&);
     oobj colindex(const PKArgs&);
-    oobj copy(const PKArgs&);
+    oobj copy(const XArgs&);
     oobj head(const XArgs&);
     void materialize(const PKArgs&);
     void rbind(const PKArgs&);

--- a/src/core/frame/py_frame.h
+++ b/src/core/frame/py_frame.h
@@ -119,7 +119,8 @@ class Frame : public XObject<Frame> {
     void cbind(const PKArgs&);
     oobj colindex(const PKArgs&);
     oobj copy(const PKArgs&);
-    oobj head(const PKArgs&);
+    // oobj head(const PKArgs&);
+    oobj head(const XArgs&);
     void materialize(const PKArgs&);
     void rbind(const PKArgs&);
     void repeat(const PKArgs&);

--- a/src/core/frame/py_frame.h
+++ b/src/core/frame/py_frame.h
@@ -120,14 +120,14 @@ class Frame : public XObject<Frame> {
     oobj colindex(const PKArgs&);
     oobj copy(const XArgs&);
     oobj head(const XArgs&);
-    void materialize(const PKArgs&);
+    void materialize(const XArgs&);
     void rbind(const PKArgs&);
     void repeat(const PKArgs&);
     void replace(const PKArgs&);
     oobj sort(const PKArgs&);
     oobj newsort(const PKArgs&);
     oobj tail(const XArgs&);
-    oobj export_names(const PKArgs&);
+    oobj export_names(const XArgs&);
 
     // Conversion methods
     oobj to_arrow(const PKArgs&);

--- a/src/core/frame/py_frame.h
+++ b/src/core/frame/py_frame.h
@@ -44,7 +44,6 @@ class Frame : public XObject<Frame> {
 
   public:
     static void impl_init_type(XTypeMaker&);
-    static void _init_cbind(XTypeMaker&);
     static void _init_init(XTypeMaker&);
     static void _init_iter(XTypeMaker&);
     static void _init_jay(XTypeMaker&);
@@ -116,7 +115,7 @@ class Frame : public XObject<Frame> {
     void set_nrows(const Arg&);
     void set_source(const std::string&);  // internal use only
 
-    void cbind(const PKArgs&);
+    void cbind(const XArgs&);
     oobj colindex(const PKArgs&);
     oobj copy(const XArgs&);
     oobj head(const XArgs&);

--- a/src/core/frame/to_arrow.cc
+++ b/src/core/frame/to_arrow.cc
@@ -27,6 +27,7 @@
 #include "column/arrow_void.h"
 #include "frame/py_frame.h"
 #include "parallel/api.h"
+#include "python/xargs.h"
 #include "stype.h"
 #include "utils/arrow_structs.h"
 namespace py {
@@ -54,11 +55,7 @@ except: ImportError
     If the `pyarrow` module is not installed.
 )";
 
-static PKArgs args_to_arrow(
-    0, 0, 0, false, false, {}, "to_arrow", doc_to_arrow);
-
-
-oobj Frame::to_arrow(const PKArgs&) {
+oobj Frame::to_arrow(const XArgs&) {
   oobj pyarrow = oobj::import("pyarrow");
   oobj pa_Array = pyarrow.get_attr("Array");
   oobj pa_Table = pyarrow.get_attr("Table");
@@ -82,13 +79,10 @@ oobj Frame::to_arrow(const PKArgs&) {
   return res;
 }
 
+DECLARE_METHOD(&Frame::to_arrow)
+    ->name("to_arrow")
+    ->docs(doc_to_arrow);
 
-
-
-
-void Frame::_init_toarrow(XTypeMaker& xt) {
-  xt.add(METHOD(&Frame::to_arrow, args_to_arrow));
-}
 
 
 

--- a/src/core/frame/to_csv.cc
+++ b/src/core/frame/to_csv.cc
@@ -23,6 +23,7 @@
 #include "parallel/api.h"
 #include "python/_all.h"
 #include "python/string.h"
+#include "python/xargs.h"
 #include "write/csv_writer.h"
 #include "options.h"
 
@@ -138,15 +139,7 @@ return: None | str | bytes
     turned on, a bytes object will be returned instead.
 )";
 
-static PKArgs args_to_csv(
-    0, 1, 8, false, false,
-    {"path", "quoting", "append", "header", "bom", "hex", "compression",
-     "verbose", "method"},
-    "to_csv", doc_to_csv);
-
-
-oobj Frame::to_csv(const PKArgs& args)
-{
+oobj Frame::to_csv(const XArgs& args) {
   const Arg& arg_path     = args[0];
   const Arg& arg_quoting  = args[1];
   const Arg& arg_append   = args[2];
@@ -253,17 +246,16 @@ oobj Frame::to_csv(const PKArgs& args)
   return writer.get_result();
 }
 
+DECLARE_METHOD(&Frame::to_csv)
+    ->name("to_csv")
+    ->docs(doc_to_csv)
+    ->n_positional_or_keyword_args(1)
+    ->n_keyword_args(8)
+    ->arg_names({"path", "quoting", "append", "header", "bom", "hex",
+                 "compression", "verbose", "method"})
+    ->add_synonym_arg("_strategy", "method");
 
 
-
-//------------------------------------------------------------------------------
-// Declare Frame methods
-//------------------------------------------------------------------------------
-
-void Frame::_init_tocsv(XTypeMaker& xt) {
-  args_to_csv.add_synonym_arg("_strategy", "method");
-  xt.add(METHOD(&Frame::to_csv, args_to_csv));
-}
 
 
 }  // namespace py

--- a/src/core/frame/to_pandas.cc
+++ b/src/core/frame/to_pandas.cc
@@ -22,6 +22,7 @@
 #include "datatablemodule.h"
 #include "frame/py_frame.h"
 #include "python/_all.h"
+#include "python/xargs.h"
 #include "stype.h"
 namespace py {
 
@@ -45,11 +46,7 @@ except: ImportError
     If the `pandas` module is not installed.
 )";
 
-static PKArgs args_to_pandas(
-    0, 0, 0, false, false, {}, "to_pandas", doc_to_pandas);
-
-
-oobj Frame::to_pandas(const PKArgs&) {
+oobj Frame::to_pandas(const XArgs&) {
   const size_t ncols = dt->ncols();
   const size_t nkeys = dt->nkeys();
 
@@ -94,9 +91,9 @@ oobj Frame::to_pandas(const PKArgs&) {
 }
 
 
-void Frame::_init_to_pandas(XTypeMaker& xt) {
-  xt.add(METHOD(&Frame::to_pandas, args_to_pandas));
-}
+DECLARE_METHOD(&Frame::to_pandas)
+    ->name("to_pandas")
+    ->docs(doc_to_pandas);
 
 
 

--- a/src/core/python/xargs.cc
+++ b/src/core/python/xargs.cc
@@ -32,10 +32,11 @@ namespace py {
 // Construction
 //------------------------------------------------------------------------------
 
-XArgs::XArgs(implfn_t fn)
-  : ccfn_(fn),
+XArgs::XArgs()
+  : ccfn_{.fn = nullptr},
     pyfn_(nullptr),
     docstring_(nullptr),
+    classId_(0),
     nargs_required_(0),
     nargs_posonly_(0),
     nargs_pos_kwd_(0),
@@ -48,6 +49,14 @@ XArgs::XArgs(implfn_t fn)
   store().push_back(this);
 }
 
+XArgs::XArgs(impl_function_t fn) : XArgs() {
+  ccfn_.fn = fn;
+}
+
+XArgs::XArgs(impl_method_t method, size_t classId) : XArgs() {
+  ccfn_.meth = method;
+  classId_ = classId;
+}
 
 std::vector<XArgs*>& XArgs::store() {
   static std::vector<XArgs*> xargs_repo;
@@ -65,6 +74,15 @@ PyMethodDef XArgs::get_method_def() {
   };
 }
 
+PyCFunctionWithKeywords XArgs::get_pyfunction() {
+  finish_initialization();
+  return pyfn_;
+}
+
+const char* XArgs::get_docstring() const {
+  return docstring_;
+}
+
 
 void XArgs::finish_initialization() {
   nargs_all_ = nargs_posonly_ + nargs_pos_kwd_ + nargs_kwdonly_;
@@ -75,7 +93,7 @@ void XArgs::finish_initialization() {
 
   xassert(arg_names_.size() == nargs_all_);
   xassert(nargs_required_ <= nargs_all_);
-  xassert(ccfn_);
+  xassert(ccfn_.fn);
   xassert(pyfn_);
   xassert(!function_name_.empty());
   xassert(function_name_.find('.') == std::string::npos);
@@ -161,6 +179,10 @@ XArgs* XArgs::add_synonym_arg(const char* new_name, const char* old_name) {
   return this;
 }
 
+XArgs* XArgs::set_class_name(const char* className) {
+  class_name_ = className;
+  return this;
+}
 
 
 size_t XArgs::n_positional_args() const {
@@ -198,13 +220,15 @@ int XArgs::get_info() const {
 // Names
 //------------------------------------------------------------------------------
 
-std::string XArgs::proper_name() const {
+const std::string& XArgs::proper_name() const {
   return function_name_;
 }
 
 std::string XArgs::qualified_name() const {
-  std::string out = "datatable.";
-  if (!class_name_.empty()) {
+  std::string out;
+  if (class_name_.empty()) {
+    out += "datatable.";
+  } else {
     out += class_name_;
     out += '.';
   }
@@ -214,7 +238,7 @@ std::string XArgs::qualified_name() const {
 
 std::string XArgs::descriptive_name(bool lowercase) const {
   if (function_name_ == "__init__") {
-    return "`datatable." + class_name_ + "()` constructor";
+    return "`" + class_name_ + "()` constructor";
   }
   std::string out = lowercase? (class_name_.empty()? "function" : "method")
                              : (class_name_.empty()? "Function" : "Method");
@@ -371,9 +395,21 @@ PyObject* XArgs::exec_function(PyObject* args, PyObject* kwds) noexcept {
   auto cl = dt::CallLogger::function(this, args, kwds);
   try {
     bind(args, kwds);
-    return ccfn_(*this).release();
+    return (ccfn_.fn)(*this).release();
 
   } catch (const std::exception& e) {
+    exception_to_python(e);
+    return nullptr;
+  }
+}
+
+PyObject* XArgs::exec_method(PyObject* obj, PyObject* args, PyObject* kwds) noexcept {
+  // auto cl = dt::CallLogger::method(this, obj, args, kwds);
+  try {
+    bind(args, kwds);
+    return (obj->*ccfn_.meth)(*this).release();
+  }
+  catch (const std::exception& e) {
     exception_to_python(e);
     return nullptr;
   }

--- a/src/core/python/xargs.cc
+++ b/src/core/python/xargs.cc
@@ -33,8 +33,7 @@ namespace py {
 //------------------------------------------------------------------------------
 
 XArgs::XArgs()
-  : ccfn_{.fn = nullptr},
-    pyfn_(nullptr),
+  : pyfn_(nullptr),
     docstring_(nullptr),
     classId_(0),
     nargs_required_(0),

--- a/src/core/python/xargs.cc
+++ b/src/core/python/xargs.cc
@@ -58,6 +58,11 @@ XArgs::XArgs(impl_method_t method, size_t classId) : XArgs() {
   classId_ = classId;
 }
 
+XArgs::XArgs(impl_methodv_t method, size_t classId) : XArgs() {
+  ccfn_.methv = method;
+  classId_ = classId;
+}
+
 std::vector<XArgs*>& XArgs::store() {
   static std::vector<XArgs*> xargs_repo;
   return xargs_repo;
@@ -408,6 +413,20 @@ PyObject* XArgs::exec_method(PyObject* obj, PyObject* args, PyObject* kwds) noex
   try {
     bind(args, kwds);
     return (obj->*ccfn_.meth)(*this).release();
+  }
+  catch (const std::exception& e) {
+    exception_to_python(e);
+    return nullptr;
+  }
+}
+
+
+PyObject* XArgs::exec_methodv(PyObject* obj, PyObject* args, PyObject* kwds) noexcept {
+  // auto cl = dt::CallLogger::method(this, obj, args, kwds);
+  try {
+    bind(args, kwds);
+    (obj->*ccfn_.methv)(*this);
+    return py::None().release();
   }
   catch (const std::exception& e) {
     exception_to_python(e);

--- a/src/core/python/xargs.cc
+++ b/src/core/python/xargs.cc
@@ -409,7 +409,7 @@ PyObject* XArgs::exec_function(PyObject* args, PyObject* kwds) noexcept {
 }
 
 PyObject* XArgs::exec_method(PyObject* obj, PyObject* args, PyObject* kwds) noexcept {
-  // auto cl = dt::CallLogger::method(this, obj, args, kwds);
+  auto cl = dt::CallLogger::method(this, obj, args, kwds);
   try {
     bind(args, kwds);
     return (obj->*ccfn_.meth)(*this).release();
@@ -422,7 +422,7 @@ PyObject* XArgs::exec_method(PyObject* obj, PyObject* args, PyObject* kwds) noex
 
 
 PyObject* XArgs::exec_methodv(PyObject* obj, PyObject* args, PyObject* kwds) noexcept {
-  // auto cl = dt::CallLogger::method(this, obj, args, kwds);
+  auto cl = dt::CallLogger::method(this, obj, args, kwds);
   try {
     bind(args, kwds);
     (obj->*ccfn_.methv)(*this);

--- a/src/core/python/xobject.cc
+++ b/src/core/python/xobject.cc
@@ -20,6 +20,7 @@
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #include "python/xobject.h"
+#include "python/xargs.h"
 namespace py {
 
 
@@ -211,6 +212,17 @@ void XTypeMaker::add(PyCFunctionWithKeywords meth, PKArgs& args, MethodTag) {
     reinterpret_cast<PyCFunction>(meth),
     METH_VARARGS | METH_KEYWORDS,
     args.get_docstring()
+  });
+}
+
+void XTypeMaker::add(PyCFunctionWithKeywords meth, XArgs* args, MethodTag) {
+  xassert(type);
+  args->set_class_name(type->tp_name);
+  meth_defs.push_back(PyMethodDef {
+    args->proper_name().data(),
+    reinterpret_cast<PyCFunction>(meth),
+    METH_VARARGS | METH_KEYWORDS,
+    args->get_docstring()
   });
 }
 

--- a/src/core/python/xobject.h
+++ b/src/core/python/xobject.h
@@ -115,6 +115,7 @@ class XTypeMaker {
 
     // PyCFunctionWithKeywords = PyObject*(*)(PyObject*, PyObject*, PyObject*)
     void add(PyCFunctionWithKeywords meth, PKArgs& args, MethodTag);
+    void add(PyCFunctionWithKeywords meth, XArgs* args, MethodTag);
 
     // unaryfunc = PyObject*(*)(PyObject*)
     void add(unaryfunc meth, const char* name, Method0Tag);

--- a/src/core/python/xobject.h
+++ b/src/core/python/xobject.h
@@ -576,19 +576,6 @@ PyObject* _safe_cmp(PyObject* x, PyObject* y, int op) noexcept {
 // Helper macros
 //------------------------------------------------------------------------------
 
-DISABLE_CLANG_WARNING("-Wunused-template")
-
-template <typename T, typename R, typename... Args>
-static T _class_of_impl(R(T::*)(Args...));
-
-template <typename T, typename R, typename... Args>
-static T _class_of_impl(R(T::*)(Args...) const);
-
-#define CLASS_OF(METH) decltype(_class_of_impl(METH))
-
-RESTORE_CLANG_WARNING("-Wunused-template")
-
-
 #define CONSTRUCTOR(METH, ARGS)                                                \
     [](PyObject* self, PyObject* args, PyObject* kwds) noexcept -> int {       \
       return _call_method_int(METH, ARGS, self, args, kwds);                   \

--- a/src/core/utils/macros.h
+++ b/src/core/utils/macros.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2020 H2O.ai
+// Copyright 2018-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),

--- a/src/core/utils/macros.h
+++ b/src/core/utils/macros.h
@@ -233,7 +233,7 @@ struct alignas(CACHELINE_SIZE) cache_aligned {
 
 
 //------------------------------------------------------------------------------
-// Types
+// Miscellaneous
 //------------------------------------------------------------------------------
 
 #if LONG_MAX==9223372036854775807
@@ -243,6 +243,20 @@ struct alignas(CACHELINE_SIZE) cache_aligned {
 #else
   #error "Cannot determine size of `long`"
 #endif
+
+
+DISABLE_CLANG_WARNING("-Wunused-template")
+
+template <typename T, typename R, typename... Args>
+static T _class_of_impl(R(T::*)(Args...));
+
+template <typename T, typename R, typename... Args>
+static T _class_of_impl(R(T::*)(Args...) const);
+
+#define CLASS_OF(METHOD) decltype(_class_of_impl(METHOD))
+
+RESTORE_CLANG_WARNING("-Wunused-template")
+
 
 
 #endif

--- a/tests/test-dt.py
+++ b/tests/test-dt.py
@@ -907,14 +907,12 @@ def test_tail():
 
 def test_head_bad():
     d0 = dt.Frame(range(10))
-    with pytest.raises(ValueError) as e:
+    msg = r"The argument in method datatable.Frame.head\(\) cannot be negative"
+    with pytest.raises(ValueError, match=msg):
         d0.head(-5)
-    assert ("The argument in Frame.head() cannot be negative"
-            in str(e.value))
-    with pytest.raises(TypeError) as e:
+    msg = r"The argument in method datatable.Frame.head\(\) should be an integer"
+    with pytest.raises(TypeError, match=msg) as e:
         d0.head(5.0)
-    assert ("The argument in Frame.head() should be an integer"
-            in str(e.value))
 
 
 def test_tail_bad():

--- a/tests/test-dt.py
+++ b/tests/test-dt.py
@@ -968,7 +968,7 @@ def test_materialize_to_memory(tempfile_jay):
 
 def test_materialize_to_memory_bad_type():
     DT = dt.Frame(range(5))
-    msg = r"Argument to_memory in Frame.materialize\(\) should be a boolean"
+    msg = r"Argument to_memory in method datatable.Frame.materialize\(\) should be a boolean"
     with pytest.raises(TypeError, match=msg):
         DT.materialize(to_memory=0)
 

--- a/tests/test-dt.py
+++ b/tests/test-dt.py
@@ -917,14 +917,12 @@ def test_head_bad():
 
 def test_tail_bad():
     d0 = dt.Frame(range(10))
-    with pytest.raises(ValueError) as e:
+    msg = r"The argument in method datatable.Frame.tail\(\) cannot be negative"
+    with pytest.raises(ValueError, match=msg) as e:
         d0.tail(-5)
-    assert ("The argument in Frame.tail() cannot be negative"
-            in str(e.value))
+    msg = r"The argument in method datatable.Frame.tail\(\) should be an integer"
     with pytest.raises(TypeError) as e:
         d0.tail(5.0)
-    assert ("The argument in Frame.tail() should be an integer"
-            in str(e.value))
 
 
 

--- a/tests/test-options.py
+++ b/tests/test-options.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #-------------------------------------------------------------------------------
-# Copyright 2018-2020 H2O.ai
+# Copyright 2018-2021 H2O.ai
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/tests/test-options.py
+++ b/tests/test-options.py
@@ -282,7 +282,7 @@ def test_debug_logger_default_without_report_args(capsys):
             dt.cbind(3)
         out, err = capsys.readouterr()
         assert not err
-        assert "dt.cbind() {" in out
+        assert "datatable.cbind() {" in out
         assert re.search(r"} # \d+(?:\.\d+)?(?:[eE][+-]?\d+)? s \(failed\)", out)
 
 
@@ -302,7 +302,7 @@ def test_debug_logger_default_with_report_args(capsys):
             dt.cbind(3)
         out, err = capsys.readouterr()
         assert not err
-        assert "dt.cbind(3) {" in out
+        assert "datatable.cbind(3) {" in out
         assert re.search(r"} # \d+(?:\.\d+)?(?:[eE][+-]?\d+)? s \(failed\)", out)
 
 

--- a/tests/test-tocsv.py
+++ b/tests/test-tocsv.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #-------------------------------------------------------------------------------
-# Copyright 2018-2020 H2O.ai
+# Copyright 2018-2021 H2O.ai
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -504,16 +504,14 @@ def test_quoting():
 def test_quoting_invalid():
     DT = dt.Frame(A=range(5))
 
-    with pytest.raises(TypeError) as e:
+    msg = r"Argument quoting in method datatable.Frame.to_csv\(\) should be an integer"
+    with pytest.raises(TypeError, match=msg):
         DT.to_csv(quoting=1.7)
-    assert ("Argument quoting in Frame.to_csv() should be an integer"
-            in str(e.value))
 
     for q in [-1, 4, 99, "ANY"]:
-        with pytest.raises(ValueError) as e:
+        msg = r"Invalid value of the quoting parameter in Frame.to_csv\(\)"
+        with pytest.raises(ValueError, match=msg):
             DT.to_csv(quoting=q)
-        assert ("Invalid value of the quoting parameter in Frame.to_csv()"
-                in str(e.value))
 
 
 def test_compress1():
@@ -553,10 +551,10 @@ def test_compress2(tempfile):
 
 def test_compress_invalid():
     DT = dt.Frame()
-    with pytest.raises(TypeError) as e:
+    msg = (r"Argument compression in method datatable.Frame.to_csv\(\) "
+           r"should be a string, instead got <class 'int'>")
+    with pytest.raises(TypeError, match=msg):
         DT.to_csv(compression=0)
-    assert ("Argument compression in Frame.to_csv() should be a string, "
-            "instead got <class 'int'>" in str(e.value))
 
     msg = r"Unsupported compression method 'rar' in Frame\.to_csv\(\)"
     with pytest.raises(ValueError, match=msg):
@@ -596,7 +594,7 @@ def test_header_valid():
 
 
 def test_header_invalid():
-    msg = r"Argument header in Frame\.to_csv\(\) should be a boolean"
+    msg = r"Argument header in method datatable\.Frame\.to_csv\(\) should be a boolean"
     DT = dt.Frame()
     with pytest.raises(TypeError, match=msg):
         DT.to_csv(header=1)
@@ -656,7 +654,7 @@ def test_append_valid(tempfile):
 
 def test_append_invalid(tempfile):
     os.unlink(tempfile)
-    msg = r"Argument append in Frame\.to_csv\(\) should be a boolean"
+    msg = r"Argument append in method datatable\.Frame\.to_csv\(\) should be a boolean"
     DT = dt.Frame()
     with pytest.raises(TypeError, match=msg):
         DT.to_csv('tmp', append=1)


### PR DESCRIPTION
At some point, `XArgs` should be able to completely replace `PKArgs`.
This PR makes it possible for `XArgs` to be used in methods, with the help of macros `DECLARE_METHOD` and `DECLARE_METHODv` (the latter is for methods returning `void`). These macros provide automatic registration of methods with their python class, avoiding the need to declare the methods in multiple places.

Some methods of `py::Frame` were converted into the new format.