### PR TITLE
Ensure linear model doesn't crash in the presence of the progress bar

### DIFF
--- a/docs/api/models/linear_model.rst
+++ b/docs/api/models/linear_model.rst
@@ -27,14 +27,14 @@
         * - :meth:`fit() <datatable.models.LinearModel.fit>`
           - Train model on the input samples and targets.
 
+        * - :meth:`is_fitted() <datatable.models.LinearModel.is_fitted>`
+          - Report model status.
+
         * - :meth:`predict() <datatable.models.LinearModel.predict>`
           - Predict for the input samples.
 
         * - :meth:`reset() <datatable.models.LinearModel.reset>`
           - Reset the model.
-
-        * - :meth:`is_fitted() <datatable.models.LinearModel.is_fitted>`
-          - Report model status.
 
 
     Properties

--- a/src/core/models/dt_linearmodel.cc
+++ b/src/core/models/dt_linearmodel.cc
@@ -162,14 +162,13 @@ LinearModelFitOutput LinearModel<T>::fit_impl() {
     [&]() {
       // Each thread gets a private storage for observations and feature importances.
       tptr<T> x = tptr<T>(new T[nfeatures_]);
+      dtptr dt_model;
 
       for (size_t iter = 0; iter < niterations; ++iter) {
-
         // Each thread gets its own copy of the model
-        dtptr dt_model;
         std::vector<T*> betas;
         {
-          std::lock_guard<std::mutex> lock(m);
+          PythonLock pylock;
           dt_model = dtptr(new DataTable(*dt_model_));
           betas = get_model_data(dt_model);
         }
@@ -299,6 +298,11 @@ LinearModelFitOutput LinearModel<T>::fit_impl() {
         } // End validation
 
       } // End iteration
+
+      {
+        PythonLock pylock;
+        dt_model = nullptr;
+      }
 
     }
   );

--- a/src/core/models/py_linearmodel.cc
+++ b/src/core/models/py_linearmodel.cc
@@ -135,7 +135,7 @@ model_type: "binomial" | "multinomial" | "regression" | "auto"
     the target column `stype`.
 
 seed: int
-    seed for the quasi-random number generator that is used for
+    Seed for the quasi-random number generator that is used for
     data shuffling when fitting the model, should be non-negative.
     If seed is zero, no shuffling is performed.
 
@@ -1406,7 +1406,7 @@ R"(This class implements the
 with the
 `stochastic gradient descent <https://en.wikipedia.org/wiki/Stochastic_gradient_descent>`_
 learning. It supports linear regression, as well as binomial and multinomial
-classifications. Both :meth:`.fit` and :meth:`.predict` methods are fully parallel.
+classification. Both :meth:`.fit` and :meth:`.predict` methods are fully parallel.
 )";
 
 void LinearModel::impl_init_type(XTypeMaker& xt) {


### PR DESCRIPTION
Use `PythonLock` instead of a mutex, when communication with python is involved. Also, minor docs updates.