### PR TITLE
Fix code.literal style spillovers

### DIFF
--- a/docs/_ext/xfunction.py
+++ b/docs/_ext/xfunction.py
@@ -985,25 +985,24 @@ class XobjectDirective(SphinxDirective):
                                      classes=["sig-open-paren"])
             params = xnodes.div(classes=["sig-parameters"])
             last_i = len(self.parsed_params) - 1
-            printed = False
             for i, param in enumerate(self.parsed_params):
                 classes = ["param"]
+                comma = None
                 if param == "self": continue
                 if param in ["*" , "/", "..."]: classes += ["special"]
-                if i == last_i: classes += ["final"]
+                if i == last_i:
+                    classes += ["final"]
+                else:
+                    comma = nodes.inline("", nodes.Text(", "), classes=["punct"])
                 if isinstance(param, str):
-                    if printed:
-                        params += nodes.inline("", nodes.Text(", "), classes=["punct"])
                     if param in ["self", "*", "/", "..."]:
                         ref = nodes.Text(param)
                     else:
                         ref = a_node(text=param, href="#" + param.lstrip("*"))
-                    params += xnodes.div(ref, classes=classes)
+                    params += xnodes.div(children=[ref, comma], classes=classes)
                 else:
                     assert isinstance(param, tuple)
                     if len(param) == 2:
-                        if printed:
-                            params += nodes.inline("", nodes.Text(", "), classes=["punct"])
                         param_node = a_node(text=param[0], href="#" + param[0])
                         equal_sign_node = nodes.inline("", nodes.Text("="), classes=["punct"])
                         # Add as nodes.literal, so that Sphinx wouldn't try to
@@ -1013,17 +1012,17 @@ class XobjectDirective(SphinxDirective):
                         params += xnodes.div(classes=classes, children=[
                                                 param_node,
                                                 equal_sign_node,
-                                                default_value_node
+                                                default_value_node,
+                                                comma
                                              ])
                     else:
                         assert len(param) == 1
-                        params += nodes.inline("", nodes.Text("["), classes=["punct"])
-                        if printed:
-                            params += nodes.inline("", nodes.Text(", "), classes=["punct"])
-                        param_node = a_node(text=param[0], href="#" + param[0])
-                        params += xnodes.div(param_node, classes=classes)
-                        params += nodes.inline("", nodes.Text("]"), classes=["punct"])
-                printed = True
+                        params += xnodes.div(classes=classes, children=[
+                                nodes.inline("", nodes.Text("["), classes=["punct"]),
+                                a_node(text=param[0], href="#" + param[0]),
+                                nodes.inline("", nodes.Text("]"), classes=["punct"]),
+                                comma
+                            ])
 
             if self.obj_name in square_bracket_functions:
                 params += nodes.inline("", nodes.Text(']'), classes=["sig-name"])

--- a/docs/_ext/xnodes.py
+++ b/docs/_ext/xnodes.py
@@ -51,6 +51,8 @@ class xElement(nodes.Element):
         if args:
             assert not children
             children = [a for a in args if a is not None]
+        else:
+            children = [a for a in children if a is not None]
         for i, child in enumerate(children):
             if isinstance(child, str):
                 children[i] = nodes.Text(child)

--- a/docs/_static/wren.css
+++ b/docs/_static/wren.css
@@ -76,8 +76,16 @@ code.literal {
   background: #f2f2f2;
   border: 1px solid #e2e2e2;
   border-radius: 3px;
+  color: #c13094;
   padding: 0 3px;
 }
+
+a > code.literal {
+  background: inherit;
+  border: inherit;
+  color: inherit;
+}
+
 
 
 /*------------------------------------------------------------------------------
@@ -575,6 +583,7 @@ table.api-table tr td > p {
 
 table.api-table td:first-child code.xref.literal {
   background: transparent;
+  border: none;
   padding: 0;
 }
 

--- a/docs/_static/xfunction.css
+++ b/docs/_static/xfunction.css
@@ -94,6 +94,7 @@
 }
 .x-function .sig-parameters .param .default.literal {
     background: none;
+    border: none;
     color: #8da4d2;
     font-size: inherit;
     padding: 0;
@@ -199,6 +200,7 @@
 
 .xparam-head .types code.literal {
     background: none;
+    border: none;
     color: rgba(0, 0, 0, 0.35);
     padding: 0;
 }


### PR DESCRIPTION
Follow-up for #2953

Also: fixed an issue where a comma would sometimes start a new line in a function's parameters list.