### PR TITLE
Minor correction to LinearModel docs

### DIFF
--- a/src/core/models/py_linearmodel.cc
+++ b/src/core/models/py_linearmodel.cc
@@ -65,7 +65,7 @@ static const std::unordered_map<std::string, dt::LearningRateSchedule> LearningR
 
 static const char* doc___init__ =
 R"(__init__(self,
-eta0=0.005, eta_decay=0.5, eta_drop_rate=1.0, eta_schedule='constant',
+eta0=0.005, eta_decay=0.0001, eta_drop_rate=10.0, eta_schedule='constant',
 lambda1=0, lambda2=0, nepochs=1, double_precision=False, negative_class=False,
 model_type='auto', seed=0, params=None)
 --


### PR DESCRIPTION
Make docs be consistent with the default parameters in C++.