### PR TITLE
Add fread option to prevent parsing date columns

### DIFF
--- a/src/core/csv/reader.cc
+++ b/src/core/csv/reader.cc
@@ -88,8 +88,26 @@ new_escape_unicode: bool
 
 )";
 
+static const char * doc_options_fread_parse_dates =
+R"(
+If True, fread will attempt to detect columns of date32 type. If False,
+then columns with date values will be returned as strings.
+
+This option is temporary and will be removed in the future.
+)";
+
+static const char * doc_options_fread_parse_times =
+R"(
+If True, fread will attempt to detect columns of time64 type. If False,
+then columns with timestamps will be returned as strings.
+
+This option is temporary and will be removed in the future.
+)";
+
 static bool log_anonymize = false;
 static bool log_escape_unicode = false;
+bool parse_dates = true;
+bool parse_times = true;
 
 
 static py::oobj get_anonymize() {
@@ -129,6 +147,20 @@ void GenericReader::init_options() {
     get_escape_unicode,
     set_escape_unicode,
     doc_options_fread_log_escape_unicode
+  );
+
+  dt::register_option(
+    "fread.parse_dates",
+    []{ return py::obool(parse_dates); },
+    [](const py::Arg& value){ parse_dates = value.to_bool_strict(); },
+    doc_options_fread_parse_dates
+  );
+
+  dt::register_option(
+    "fread.parse_times",
+    []{ return py::obool(parse_times); },
+    [](const py::Arg& value){ parse_times = value.to_bool_strict(); },
+    doc_options_fread_parse_times
   );
 }
 

--- a/src/core/csv/reader.h
+++ b/src/core/csv/reader.h
@@ -31,6 +31,9 @@
 namespace dt {
 namespace read {
 
+extern bool parse_dates;
+extern bool parse_times;
+
 
 // What fread() should do if the input contains multiple sources
 enum class FreadMultiSourceStrategy : int8_t {

--- a/src/core/read/parsers/ptype_iterator.cc
+++ b/src/core/read/parsers/ptype_iterator.cc
@@ -19,6 +19,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
+#include "csv/reader.h"
 #include "read/parsers/ptype_iterator.h"
 namespace dt {
 namespace read {
@@ -37,12 +38,16 @@ RT PTypeIterator::get_rtype() const {
 }
 
 PTypeIterator& PTypeIterator::operator++() {
-  if (curr_ptype < PT::Str32) {
-    curr_ptype = static_cast<PT>(curr_ptype + 1);
-  } else {
-    *pqr = *pqr + 1;
+  while (true) {
+    if (curr_ptype < PT::Str32) {
+      curr_ptype = static_cast<PT>(curr_ptype + 1);
+      if (curr_ptype == PT::Date32ISO && !parse_dates) continue;
+      if (curr_ptype == PT::Time64ISO && !parse_times) continue;
+    } else {
+      *pqr = *pqr + 1;
+    }
+    return *this;
   }
-  return *this;
 }
 
 bool PTypeIterator::has_incremented() const {

--- a/tests/test-options.py
+++ b/tests/test-options.py
@@ -65,6 +65,8 @@ def test_options_all():
     assert set(dir(dt.options.fread)) == {
         "anonymize",
         "log",
+        "parse_dates",
+        "parse_times",
     }
     assert set(dir(dt.options.progress)) == {
         "callback",

--- a/tests/types/test-date32.py
+++ b/tests/types/test-date32.py
@@ -173,7 +173,7 @@ def test_with_stats(tempfile_jay):
 
 
 #-------------------------------------------------------------------------------
-# Write to csv
+# Convert to/from csv
 #-------------------------------------------------------------------------------
 
 def test_write_to_csv():
@@ -208,6 +208,24 @@ def test_write_huge_dates():
     assert DT.to_csv() == ("Kind,Value\n"
                            "min,-5877641-06-24\n"
                            "max,5879610-09-09\n")
+
+
+
+
+def test_read_date32_from_csv():
+    d = datetime.date
+    DT = dt.fread("a-b-c\n1999-01-01\n2010-11-11\n2020-12-31\n")
+    assert_equals(DT, dt.Frame([d(1999,1,1), d(2010,11,11), d(2020,12,31)],
+                               names=["a-b-c"]))
+
+
+def test_do_not_read_from_csv():
+    d = datetime.date
+    assert dt.options.fread.parse_dates is True
+    with dt.options.context(**{"fread.parse_dates": False}):
+        DT = dt.fread("X\n1990-10-10\n2011-11-11\n2020-02-05\n")
+        assert_equals(DT,
+                      dt.Frame(X=["1990-10-10", "2011-11-11", "2020-02-05"]))
 
 
 


### PR DESCRIPTION
Added option `dt.options.fread.parse_dates` (and similarly `.parse_times`) that will prevent fread from recognizing date columns. This is intended as a temporary option, for the purpose of easing the transition of existing code.