### PR TITLE
Added property Frame.type

### DIFF
--- a/docs/api/frame.rst
+++ b/docs/api/frame.rst
@@ -122,6 +122,9 @@
         * - :attr:`.stypes`
           - Storage types (:class:`dt.stype`s) of all columns.
 
+        * - :attr:`.type`
+          - The common type (:class:`dt.Type`) for the entire frame.
+
         * - :attr:`.types`
           - types (:class:`dt.Type`s) of all columns.
 
@@ -265,5 +268,6 @@
     .to_numpy()      <frame/to_numpy>
     .to_pandas()     <frame/to_pandas>
     .to_tuples()     <frame/to_tuples>
+    .type            <frame/type>
     .types           <frame/types>
     .view()          <frame/view>

--- a/docs/api/frame/type.rst
+++ b/docs/api/frame/type.rst
@@ -1,0 +1,4 @@
+
+.. xattr:: datatable.Frame.type
+    :src: src/core/frame/py_frame.cc Frame::get_type
+    :doc: src/core/frame/py_frame.cc doc_type

--- a/docs/releases/v1.0.0.rst
+++ b/docs/releases/v1.0.0.rst
@@ -9,6 +9,9 @@
       objects for each column of the frame. These types are a generalization
       of previous stypes, and will eventually replace them.
 
+      Property :attr:`.type` returns the common :class:`dt.Type` for all
+      columns of the frame (provided that it exists).
+
     -[new] New column type :attr:`dt.Type.date32` added, which can store a
       calendar date [#2858]::
 

--- a/src/core/frame/py_frame.h
+++ b/src/core/frame/py_frame.h
@@ -105,6 +105,7 @@ class Frame : public XObject<Frame> {
     oobj get_source() const;
     oobj get_stype() const;
     oobj get_stypes() const;
+    oobj get_type() const;
     oobj get_types() const;
     void set_key(const Arg&);
     void set_meta(const Arg&);

--- a/tests/test-dt.py
+++ b/tests/test-dt.py
@@ -399,6 +399,31 @@ def test_modify_types_list():
     assert DT.types == [dt.Type.int32, dt.Type.str32]
 
 
+def test_dt0_type(dt0):
+    assert dt0[0].type == dt.Type.int32
+    assert dt0[1].type == dt.Type.bool8
+    assert dt0[2].type == dt.Type.int8
+    assert dt0[3].type == dt.Type.float64
+    assert dt0[4].type == dt.Type.void
+    assert dt0[5].type == dt.Type.int8
+    assert dt0[6].type == dt.Type.str32
+    assert dt0[:, [2, 5]].type == dt.Type.int8
+
+
+def test_type_empty_frame():
+    DT = dt.Frame()
+    assert DT.type is None
+    DT.nrows = 3
+    assert DT.type is None
+
+
+def test_type_invalid(dt0):
+    msg = "The type of column 'B' is bool8, which is different from " \
+          "the type of the previous column"
+    with pytest.raises(dt.exceptions.InvalidOperationError, match=msg):
+        assert dt0.type
+
+
 
 
 #-------------------------------------------------------------------------------

--- a/tests/types/test-date32.py
+++ b/tests/types/test-date32.py
@@ -56,14 +56,14 @@ def test_date32_create_from_python():
     d = datetime.date
     src = [d(2000, 1, 5), d(2010, 11, 23), d(2020, 2, 29), None]
     DT = dt.Frame(src)
-    assert DT.types == [dt.Type.date32]
+    assert DT.type == dt.Type.date32
     assert DT.to_list() == [src]
 
 
 def test_date32_create_from_python_force():
     d = datetime.date
     DT = dt.Frame([18675, -100000, None, 0.75, 'hello'], stype='date32')
-    assert DT.types == [dt.Type.date32]
+    assert DT.type == dt.Type.date32
     assert DT.to_list() == [
         [d(2021, 2, 17), d(1696, 3, 17), None, d(1970, 1, 1), None]
     ]
@@ -123,14 +123,14 @@ def test_date32_minmax():
 def test_date32_from_numpy_datetime64(np, scale):
     arr = np.array(range(-100, 1000), dtype=f'datetime64[{scale}]')
     DT = dt.Frame(arr)
-    assert DT.types == [dt.Type.date32]
+    assert DT.type == dt.Type.date32
     assert DT.to_list() == [arr.tolist()]
 
 
 def test_from_numpy_with_nats(np):
     arr = np.array(['2000-01-01', '2020-05-11', 'NaT'], dtype='datetime64[D]')
     DT = dt.Frame(arr)
-    assert DT.types == [dt.Type.date32]
+    assert DT.type == dt.Type.date32
     assert DT.to_list() == [
         [datetime.date(2000, 1, 1), datetime.date(2020, 5, 11), None]
     ]
@@ -149,7 +149,7 @@ def test_save_to_jay(tempfile_jay):
     del DT
     DT2 = dt.fread(tempfile_jay)
     assert DT2.shape == (5, 1)
-    assert DT2.types == [dt.Type.date32]
+    assert DT2.type == dt.Type.date32
     assert DT2.to_list()[0] == src
 
 

--- a/tests/types/test-time64.py
+++ b/tests/types/test-time64.py
@@ -72,7 +72,7 @@ def test_time64_create_from_python():
            d(2010, 11, 13, 15, 11, 59),
            d(2020, 2, 29, 20, 20, 20, 20), None]
     DT = dt.Frame(src)
-    assert DT.types == [dt.Type.time64]
+    assert DT.type == dt.Type.time64
     assert DT.to_list() == [src]
 
 
@@ -119,7 +119,7 @@ def test_time64_read_from_csv():
                   "2001-05-12T12:00:00\n"
                   "2013-06-24T14:00:01\n"
                   "2023-11-02T23:59:59.999999\n")
-    assert DT.types == [dt.Type.time64]
+    assert DT.type == dt.Type.time64
     assert DT.shape == (3, 1)
     assert DT.to_list()[0] == [d(2001, 5, 12, 12),
                                d(2013, 6, 24, 14, 0, 1),
@@ -194,7 +194,7 @@ def test_convert_to_numpy(np):
            None,
            d(1911, 11, 11, 11, 11, 11, 11)]
     DT = dt.Frame(src)
-    assert DT.types == [dt.Type.time64]
+    assert DT.type == dt.Type.time64
     arr = DT.to_numpy()
     assert isinstance(arr, np.ndarray)
     assert arr.shape == DT.shape
@@ -214,7 +214,7 @@ def test_convert_from_numpy(np):
                     '2021-06-01 23:18:30'],
                    dtype='datetime64[ns]')
     DT = dt.Frame(arr)
-    assert DT.types == [dt.Type.time64]
+    assert DT.type == dt.Type.time64
     # we use stringification here only because converting to python
     # literals would have lost the nanosecond precision
     assert str(DT) == (
@@ -232,7 +232,7 @@ def test_convert_from_numpy(np):
 def test_convert_from_numpy_us(np):
     arr = np.array([-1, 5, 9], dtype='datetime64[us]')
     DT = dt.Frame(arr)
-    assert DT.types == [dt.Type.time64]
+    assert DT.type == dt.Type.time64
     assert DT.to_list() == [[
         d(1969, 12, 31, 23, 59, 59, 999999),
         d(1970, 1, 1, 0, 0, 0, 5),
@@ -243,7 +243,7 @@ def test_convert_from_numpy_us(np):
 def test_convert_from_numpy_ms(np):
     arr = np.array([-1, 5, 9], dtype='datetime64[ms]')
     DT = dt.Frame(arr)
-    assert DT.types == [dt.Type.time64]
+    assert DT.type == dt.Type.time64
     assert DT.to_list() == [[
         d(1969, 12, 31, 23, 59, 59, 999000),
         d(1970, 1, 1, 0, 0, 0, 5000),
@@ -254,7 +254,7 @@ def test_convert_from_numpy_ms(np):
 def test_convert_from_numpy_s(np):
     arr = np.array([-1, 5, 9], dtype='datetime64[s]')
     DT = dt.Frame(arr)
-    assert DT.types == [dt.Type.time64]
+    assert DT.type == dt.Type.time64
     assert DT.to_list() == [[
         d(1969, 12, 31, 23, 59, 59),
         d(1970, 1, 1, 0, 0, 5),
@@ -265,7 +265,7 @@ def test_convert_from_numpy_s(np):
 def test_convert_from_numpy_min(np):
     arr = np.array([-1, 5, 9], dtype='datetime64[m]')
     DT = dt.Frame(arr)
-    assert DT.types == [dt.Type.time64]
+    assert DT.type == dt.Type.time64
     assert DT.to_list() == [[
         d(1969, 12, 31, 23, 59, 0),
         d(1970, 1, 1, 0, 5, 0),
@@ -276,7 +276,7 @@ def test_convert_from_numpy_min(np):
 def test_convert_from_numpy_hour(np):
     arr = np.array([-1, 5, 9], dtype='datetime64[h]')
     DT = dt.Frame(arr)
-    assert DT.types == [dt.Type.time64]
+    assert DT.type == dt.Type.time64
     assert DT.to_list() == [[
         d(1969, 12, 31, 23, 0, 0),
         d(1970, 1, 1, 5, 0, 0),


### PR DESCRIPTION
The new property is equivalent to the current `Frame.stype`, only it returns the common `Type` instead of an `stype`.