### PR TITLE
Fix table alignment in the docs

### DIFF
--- a/docs/_static/wren.css
+++ b/docs/_static/wren.css
@@ -90,6 +90,10 @@ a > code.literal {
   text-align: left;
 }
 
+table.align-default {
+  margin-left: 0;
+}
+
 table.docutils td, table.docutils th {
   padding: 0;
   border: none;


### PR DESCRIPTION
Currently, readthedocs makes all tables centered, which interferes with our api-tables.