### PR TITLE
Expand documentation for various types, add examples

### DIFF
--- a/docs/_ext/xcode.py
+++ b/docs/_ext/xcode.py
@@ -71,6 +71,47 @@ def comma_separated(n):
         return str(n) + nstr
 
 
+class Column:
+    def __init__(self, start, end):
+        self.start = start
+        self.end = end
+        self.name = ""
+        self.type = ""
+        self.data = []
+        self.classes = []
+        self.classstr = ""
+
+    def detect_right_aligned(self):
+        ra = self.type in {"bool8", "int8", "int16", "int32", "int64",
+                           "float32", "float64", "date32", "time64"}
+        if ra:
+            self.classes.append('r')
+
+    def process_data(self):
+        dot_width = 0
+        if self.type in ['time64']:
+            for value in self.data:
+                if '.' in value:
+                    t = len(value) - value.rindex('.')
+                    dot_width = max(dot_width, t)
+
+        for i, value in enumerate(self.data):
+            value = escape_html(value)
+            if value == "NA":
+                value = "<span class=NA>NA</span>"
+            if value == '…':
+                value = "<span class=dim>…</span>"
+            if dot_width:
+                if '.' in value:
+                    t = len(value) - value.rindex('.')
+                else:
+                    t = 0
+                value += " " * (dot_width - t)
+            if self.type == "time64":
+                value = value.replace("T", "<span class=dim>T</span>")
+            self.data[i] = value
+
+
 
 #-------------------------------------------------------------------------------
 # XHtmlFormatter
@@ -183,39 +224,55 @@ class XHtmlFormatter(pygments.formatter.Formatter):
                             continue
             yield (tok.Text, line)
 
+
     def process_dtframe(self, header_lines, sep_line, body_lines,
                         nrows, ncols):
         sep = sep_line.find('+')
         key_class = "row_index" if header_lines[0][:sep].strip() == '' else \
                     "key"
-        columns = [mm.span() for mm in re.finditer('-+', sep_line)]
+        columns = []
+        for mm in re.finditer('-+', sep_line):
+            start, end = mm.span()
+            column = Column(start, end)
+            if end < sep:
+                column.classes.append(key_class)
+            columns.append(column)
+
+        for i, line in enumerate(header_lines):
+            for column in columns:
+                value = line[column.start:column.end].strip()
+                if i == 0:
+                    column.name = value
+                else:
+                    column.type = value
+        for line in body_lines:
+            for column in columns:
+                value = line[column.start:column.end].strip()
+                column.data.append(value)
+        for column in columns:
+            column.detect_right_aligned()
+            column.classstr = ' '.join(column.classes)
+            column.process_data()
+
         out = "<div class='dtframe'><table>"
         out += "<thead>"
-        for line in header_lines:
-            cls = "colnames" if line == header_lines[0] else "coltypes"
-            out += f"<tr class={cls}>"
-            for i, j in columns:
-                out += f"<th class={key_class}>" if j < sep else "<th>"
-                out += line[i:j].strip()
+        for rowkind in ["name", "type"]:
+            out += f"<tr class=col{rowkind}s>"
+            for column in columns:
+                value = getattr(column, rowkind)
+                classes = column.classstr
+                out += f"<th class='{classes}'>" if classes else "<th>"
+                out += value
                 out += "</th>"
             out += "<th></th></tr>"
         out += "</thead>"
         out += "<tbody>"
-        for line in body_lines:
+        for i in range(len(body_lines)):
             out += "<tr>"
-            for i, j in columns:
-                classes = []
-                value = escape_html(line[i:j].strip())
-                if j < sep:
-                    classes.append(key_class)
-                if value == '…':
-                    classes.append("etc")
-                if value == 'NA':
-                    classes.append("NA")
-                if classes:
-                    out += f"<td class='{' '.join(classes)}'>"
-                else:
-                    out += "<td>"
+            for column in columns:
+                classes = column.classstr
+                value = column.data[i]
+                out += f"<td class='{classes}'>" if classes else "<td>"
                 out += value
                 out += "</td>"
             out += "<td></td></tr>"

--- a/docs/_static/wren.css
+++ b/docs/_static/wren.css
@@ -84,6 +84,7 @@ a > code.literal {
   background: inherit;
   border: inherit;
   color: inherit;
+  padding: 0;
 }
 
 .align-default {

--- a/docs/_static/xcode.css
+++ b/docs/_static/xcode.css
@@ -354,6 +354,10 @@ div.xcode > code.sql:before {
 
 .dtframe td {
     padding: .2em .5em;
+}
+
+.dtframe td.r,
+.dtframe th.r {
     text-align: right;
 }
 
@@ -361,6 +365,7 @@ div.xcode > code.sql:before {
     background-color: #3331;
     font-size: 80%;
     color: #aaa;
+    text-align: right;
 }
 
 .dtframe td.key {
@@ -372,11 +377,11 @@ div.xcode > code.sql:before {
     border-left: 1px solid #0003;
 }
 
-.dtframe td.etc {
+.dtframe td span.dim {
     color: #0003;
 }
 
-.dtframe td.NA {
+.dtframe td span.NA {
     color: #0003;
 }
 

--- a/docs/api/type.rst
+++ b/docs/api/type.rst
@@ -46,10 +46,10 @@
     date32   <type/date32>
     float32  <type/float32>
     float64  <type/float64>
+    int8     <type/int8>
     int16    <type/int16>
     int32    <type/int32>
     int64    <type/int64>
-    int8     <type/int8>
     min      <type/min>
     max      <type/max>
     name     <type/name>

--- a/docs/api/type/bool8.rst
+++ b/docs/api/type/bool8.rst
@@ -13,5 +13,14 @@
 
     Examples
     --------
-    >>> dt.Frame([True, False, None]).types
-    [Type.bool8]
+    >>> DT = dt.Frame([True, False, None]).type
+    >>> DT.type
+    Type.bool8
+    >>> DT
+       |    C0
+       | bool8
+    -- + -----
+     0 |     1
+     1 |     0
+     2 |    NA
+    [3 rows x 1 column]

--- a/docs/api/type/date32.rst
+++ b/docs/api/type/date32.rst
@@ -12,7 +12,8 @@
 
     The calendar used for this type is `proleptic Gregorian`_, meaning that it
     extends the modern-day Gregorian calendar into the past before this calendar
-    was first adopted.
+    was first adopted, and into the future, long after it will have been
+    replaced.
 
     This type corresponds to ``datetime.date`` in Python, ``pa.date32()`` in
     pyarrow, and ``np.dtype('<M8[D]')`` in numpy.
@@ -20,7 +21,7 @@
     .. note::
 
         Python's ``datetime.date`` object can accommodate dates from year 1 to
-        year 9999, which is much smaller than what ``date32`` type allows.
+        year 9999, which is much smaller than what our ``date32`` type allows.
         As a consequence, when ``date32`` values that are outside of year range
         1-9999 are converted to python, they become integers instead of
         ``datetime.date`` objects.
@@ -30,4 +31,33 @@
 
     .. _`proleptic gregorian`: https://en.wikipedia.org/wiki/Proleptic_Gregorian_calendar
 
+
+    Examples
+    --------
+    >>> from datetime import date
+    >>> DT = dt.Frame([date(2020, 1, 30), date(2020, 3, 11), None, date(2021, 6, 15)])
+    >>> DT.type
+    Type.date32
+    >>> DT
+       | C0
+       | date32
+    -- + ----------
+     0 | 2020-01-30
+     1 | 2020-03-11
+     2 | NA
+     3 | 2021-06-15
+    [4 rows x 1 column]
+
+    >>> dt.Type.date32.min
+    -2147483647
+    >>> dt.Type.date32.max
+    2146764179
+    >>> dt.Frame([dt.Type.date32.min, date(2021, 6, 15), dt.Type.date32.max], stype='date32')
+       | C0
+       | date32
+    -- + --------------
+     0 | -5877641-06-24
+     1 | 2021-06-15
+     2 | 5879610-09-09
+    [3 rows x 1 column]
 

--- a/docs/api/type/int32.rst
+++ b/docs/api/type/int32.rst
@@ -9,3 +9,24 @@
     This is the most common type for handling integer data. When a python list
     of integers is converted into a Frame, a column of this type will usually
     be created.
+
+
+    Examples
+    --------
+    >>> DT = dt.Frame([None, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55])
+    >>> DT
+       |    C0
+       | int32
+    -- + -----
+     0 |    NA
+     1 |     1
+     2 |     1
+     3 |     2
+     4 |     3
+     5 |     5
+     6 |     8
+     7 |    13
+     8 |    21
+     9 |    34
+    10 |    55
+    [11 rows x 1 column]

--- a/docs/api/type/str32.rst
+++ b/docs/api/type/str32.rst
@@ -2,4 +2,35 @@
 .. xattr:: datatable.Type.str32
     :src: --
 
-    String type, where the offsets buffer uses 32-bit integers.
+    The type of a column with string data.
+
+    Internally, this column stores data using 2 buffers: a character buffer,
+    where all values in the column are stored together as a single large
+    concatenated string in UTF8 encoding, and an ``int32`` array of offsets
+    into the character buffer. Consequently, this type can only store up to
+    2Gb of total character data per column.
+
+    Whenever any operation on a string column exceeds the 2Gb limit, this type
+    will be silently replaced with :attr:`dt.Type.str64`.
+
+    A virtual column that produces string data may have either ``str32`` or
+    ``str64`` type regardless of how it stores its data.
+
+    This column converts to ``str`` type in Python, ``pa.string()`` in
+    pyarrow, and ``dtype('object')`` in numpy and pandas.
+
+
+    Examples
+    --------
+    >>> DT = dt.Frame({"to persist": ["one teaspoon", "at a time,",
+    ...                               "the rain turns", "mountains", "into valleys"]})
+    >>> DT
+       | to persist
+       | str32
+    -- + --------------
+     0 | one teaspoon
+     1 | at a time,
+     2 | the rain turns
+     3 | mountains
+     4 | into valleys
+    [5 rows x 1 column]

--- a/docs/api/type/time64.rst
+++ b/docs/api/type/time64.rst
@@ -14,13 +14,42 @@
     difference between two ``time64`` moments may be off by the number of leap
     seconds that have occurred between them.
 
-    A ``time64`` column may also carry a time zone as meta information. This time
-    zone is used to convert the timestamp from the absolute UTC time to the local
-    calendar. For example, suppose you have two ``time64`` columns: one is in UTC
-    while the other is in *America/Los\_Angeles* time zone. Assume both columns
-    store the same value ``1577836800000``. Then these two columns represent the
-    same moment in time, however their calendar representations are different:
-    ``2020-01-01T00:00:00Z`` and ``2019-12-31T16:00:00-0800`` respectively.
+    Currently, ``time64`` type is not timezone-aware, addition of time zones is
+    planned for the next release.
+
+    ..
+        A ``time64`` column may also carry a time zone as meta information. This time
+        zone is used to convert the timestamp from the absolute UTC time to the local
+        calendar. For example, suppose you have two ``time64`` columns: one is in UTC
+        while the other is in *America/Los\_Angeles* time zone. Assume both columns
+        store the same value ``1577836800000``. Then these two columns represent the
+        same moment in time, however their calendar representations are different:
+        ``2020-01-01T00:00:00Z`` and ``2019-12-31T16:00:00-0800`` respectively.
+
+    A time64 column converts into ``datetime.datetime`` objects in python, a
+    ``pa.timestamp('ns')`` type in pyarrow and ``dtype('datetime64[ns]')`` in
+    numpy and pandas.
+
+
+    Examples
+    --------
+    >>> DT = dt.Frame(["2018-01-31 03:16:57", "2021-06-15 15:44:23.951", None, "1965-11-25 19:29:00"])
+    >>> DT[0] = dt.Type.time64
+    >>> DT
+       | C0
+       | time64
+    -- + -----------------------
+     0 | 2018-01-31T03:16:57
+     1 | 2021-06-15T15:44:23.951
+     2 | NA
+     3 | 1965-11-25T19:29:00
+    [4 rows x 1 column]
+
+    >>> dt.Type.time64.min
+    datetime.datetime(1677, 9, 22, 0, 12, 43, 145225)
+    >>> dt.Type.time64.max
+    datetime.datetime(2262, 4, 11, 23, 47, 16, 854775)
+
 
 
 .. _`leap-seconds`: https://en.wikipedia.org/wiki/Leap_second

--- a/docs/api/type/void.rst
+++ b/docs/api/type/void.rst
@@ -4,13 +4,27 @@
 
     The type of a column where all values are NAs.
 
-    In ``datatable``, any column can have NA values in it. There is, however,
+    In datatable, any column can have NA values in it. There is, however,
     a special type that can be assigned for a column where *all* values are
     NAs: ``void``. This type's special property is that it can be used in
     place where any other type could be expected.
 
+    A column of this type does not occupy any storage space. Unlike other types,
+    it does not use the validity buffer either: all values are known to be
+    invalid.
+
+    It converts into pyarrow's ``pa.null()`` type, or ``'|V0'`` dtype in numpy.
 
     Examples
     --------
-    >>> dt.Frame([None, None, None]).types
-    [Type.void]
+    >>> DT = dt.Frame([None, None, None])
+    >>> DT.type
+    Type.void
+    >>> DT
+       |   C0
+       | void
+    -- + ----
+     0 |   NA
+     1 |   NA
+     2 |   NA
+    [3 rows x 1 column]

--- a/src/core/types/py_type.cc
+++ b/src/core/types/py_type.cc
@@ -337,11 +337,7 @@ Examples
 >>> dt.Type.float32.min
 -3.4028234663852886e+38
 >>> dt.Type.date32.min
-   | min
-   | date32
--- + --------------
- 0 | -5877641-06-24
-[1 row x 1 column]
+-2147483647
 
 
 See also
@@ -368,11 +364,8 @@ Examples
 >>> dt.Type.float64.max
 1.7976931348623157e+308
 >>> dt.Type.date32.max
-   | max
-   | date32
--- + -------------
- 0 | 5879610-09-09
-[1 row x 1 column]
+2146764179
+
 
 See also
 --------


### PR DESCRIPTION
In addition, improved rendering of `dtframe` widget in the documentation: now it can properly align time values. 