### PR TITLE
Visually separate Type variables from properties/methods in docs

### DIFF
--- a/docs/api/type.rst
+++ b/docs/api/type.rst
@@ -42,19 +42,19 @@
 .. toctree::
     :hidden:
 
-    bool8    <type/bool8>
-    date32   <type/date32>
-    float32  <type/float32>
-    float64  <type/float64>
-    int8     <type/int8>
-    int16    <type/int16>
-    int32    <type/int32>
-    int64    <type/int64>
-    min      <type/min>
-    max      <type/max>
-    name     <type/name>
-    obj64    <type/obj64>
-    str32    <type/str32>
-    str64    <type/str64>
-    time64   <type/time64>
-    void     <type/void>
+    ⭑ bool8    <type/bool8>
+    ⭑ date32   <type/date32>
+    ⭑ float32  <type/float32>
+    ⭑ float64  <type/float64>
+    ⭑ int8     <type/int8>
+    ⭑ int16    <type/int16>
+    ⭑ int32    <type/int32>
+    ⭑ int64    <type/int64>
+    ⭑ obj64    <type/obj64>
+    ⭑ str32    <type/str32>
+    ⭑ str64    <type/str64>
+    ⭑ time64   <type/time64>
+    ⭑ void     <type/void>
+    max        <type/max>
+    min        <type/min>
+    name       <type/name>


### PR DESCRIPTION
So, the problem with documenting `Type` class is that it has static members such as `Type.str32` or `Type.float64`, and also regular properties such as `Type().name` or `Type().max`. These obviously have different usage (although technically static members are accessible on instances too, it's not how they are supposed to be used), and therefore mixing them up in the documentation creates lots of confusion. 

This PR addresses this problem by adding a small star icon next to each static member, to indicate that they are "special".