### PR TITLE
Renamed "types" arguments in Frame constructor

### DIFF
--- a/docs/_ext/xfunction.py
+++ b/docs/_ext/xfunction.py
@@ -1348,7 +1348,9 @@ class XversionActionDirective(SphinxDirective):
                 reftarget=target))
         node = xnodes.div(node, classes=["x-version", action])
 
-        self.state.nested_parse(self.content, self.content_offset, node)
+        if self.content:
+            node.attributes['classes'].extend(["admonition", "warning"])
+            self.state.nested_parse(self.content, self.content_offset, node)
         return [node]
 
 

--- a/docs/_static/xversion.css
+++ b/docs/_static/xversion.css
@@ -3,14 +3,14 @@
  * x-version (common)
  *-----------------------------------------------------------------------------*/
 
-.x-version > div:first-child {
+.x-version:not(.admonition) > div:first-child {
     display: inline-block;
     padding: 3px 8px;
     font-style: italic;
     font-size: 90%;
 }
 
-.x-version > div:first-child:before {
+.x-version:not(.admonition) > div:first-child:before {
     font-family: 'FontAwesome';
     font-style: normal;
     padding-right: 8px;
@@ -47,17 +47,22 @@
  * x-version-deprecated
  *-----------------------------------------------------------------------------*/
 
-.x-version.deprecated {
+.x-version.deprecated:not(.admonition) {
     margin: -7px 0 8px 32px;
     text-align: right;
 }
 
-.x-version.deprecated > div {
+.x-version.deprecated > div:first-child {
     background: #fcf2e4;
     color: #ff7700;
 }
 
-.x-version.deprecated > div:first-child:before {
+.x-version.deprecated.admonition > div:first-child {
+    background: inherit;
+    color: darkred;
+}
+
+.x-version.deprecated:not(.admonition) > div:first-child:before {
     content: "\f071";
 }
 

--- a/docs/releases/v1.0.0.rst
+++ b/docs/releases/v1.0.0.rst
@@ -73,6 +73,9 @@
       the stype of each column, as a second line under the column names.
       [#2810]
 
+    -[enh] Parameter ``types=`` in Frame's constructor can now accept arguments
+      of class :class:`Type`, and also pyarrow's types. [#2986]
+
     -[fix] A Frame can now be created properly from a list of numpy bool
       objects. [#2762]
 
@@ -105,6 +108,10 @@
       a :exc:`dt.exceptions.TypeError` will  be thrown. An ``object`` column
       can still be created by an explicit request via the ``stype=``
       parameter in the constructor.
+
+    -[api] Parameter ``stypes=`` in Frame constructor was renamed into
+      ``types=``, and similarly ``stype=`` into ``type=``. The old parameter
+      names are still recognized, but no longer documented.
 
 
     FExpr

--- a/src/core/column.h
+++ b/src/core/column.h
@@ -99,10 +99,10 @@ class Column
     static Column new_mbuf_column(size_t nrows, dt::SType, Buffer&&);
     static Column new_string_column(size_t n, Buffer&& data, Buffer&& str);
     static Column from_pybuffer(const py::robj& buffer);
-    static Column from_pylist(const py::olist& list, dt::SType stype0);
-    static Column from_pylist_of_tuples(const py::olist& list, size_t index, dt::SType stype0);
-    static Column from_pylist_of_dicts(const py::olist& list, py::robj name, dt::SType stype0);
-    static Column from_range(int64_t start, int64_t stop, int64_t step, dt::SType);
+    static Column from_pylist(const py::olist& list, dt::Type);
+    static Column from_pylist_of_tuples(const py::olist& list, size_t index, dt::Type);
+    static Column from_pylist_of_dicts(const py::olist& list, py::robj name, dt::Type);
+    static Column from_range(int64_t start, int64_t stop, int64_t step, dt::Type);
     static Column from_arrow(std::shared_ptr<dt::OArrowArray>&&, const dt::ArrowSchema*);
 
     // Move-semantics for the pointer here indicates to the user that

--- a/src/core/column/range.cc
+++ b/src/core/column/range.cc
@@ -39,40 +39,39 @@ static size_t compute_nrows(int64_t start, int64_t stop, int64_t step) {
   return (length < 0) ? 0 : static_cast<size_t>(length);
 }
 
-static SType compute_stype(int64_t start, int64_t stop, SType stype) {
-  if (stype == SType::AUTO) {
+static Type compute_type(int64_t start, int64_t stop, Type type) {
+  if (!type) {
     bool start_is_int32 = (start == static_cast<int32_t>(start));
     bool stop_is_int32  = (stop == static_cast<int32_t>(stop));
-    return (start_is_int32 && stop_is_int32) ? SType::INT32 : SType::INT64;
+    return (start_is_int32 && stop_is_int32) ? Type::int32() : Type::int64();
   }
-  auto ltype = stype_to_ltype(stype);
-  if (ltype == LType::INT || ltype == LType::REAL) {
-    return stype;
+  if (type.is_integer() || type.is_float()) {
+    return type;
   }
-  throw ValueError() << "Invalid stype " << stype << " for a range column";
+  throw ValueError() << "Invalid type " << type << " for a range column";
 }
 
 
 
 Range_ColumnImpl::Range_ColumnImpl(int64_t start, int64_t stop, int64_t step,
-                                   SType stype)
+                                   Type type)
   : Virtual_ColumnImpl(compute_nrows(start, stop, step),
-                       compute_stype(start, stop, stype)),
+                       compute_type(start, stop, type).stype()),
     start_(start),
     step_(step) {}
 
 
 // private constructor (used for cloning)
-Range_ColumnImpl::Range_ColumnImpl(size_t nrows, SType stype, int64_t start,
+Range_ColumnImpl::Range_ColumnImpl(size_t nrows, Type type, int64_t start,
                                    int64_t step)
-  : Virtual_ColumnImpl(nrows, stype),
+  : Virtual_ColumnImpl(nrows, type.stype()),
     start_(start),
     step_(step) {}
 
 
 
 ColumnImpl* Range_ColumnImpl::clone() const {
-  return new Range_ColumnImpl(nrows_, stype(), start_, step_);
+  return new Range_ColumnImpl(nrows_, type_, start_, step_);
 }
 
 

--- a/src/core/column/range.h
+++ b/src/core/column/range.h
@@ -43,8 +43,7 @@ class Range_ColumnImpl : public Virtual_ColumnImpl {
     int64_t step_;
 
   public:
-    Range_ColumnImpl(int64_t start, int64_t stop, int64_t step,
-                     SType stype = SType::AUTO);
+    Range_ColumnImpl(int64_t start, int64_t stop, int64_t step, Type type);
 
     ColumnImpl* clone() const override;
     size_t n_children() const noexcept override;
@@ -63,7 +62,7 @@ class Range_ColumnImpl : public Virtual_ColumnImpl {
     void apply_rowindex(const RowIndex& ri, Column& out) override;
 
   private:
-    Range_ColumnImpl(size_t, SType, int64_t, int64_t);  // for cloning
+    Range_ColumnImpl(size_t, Type, int64_t, int64_t);  // for cloning
 
     // Helper for get_element() accessors
     template <typename T> inline bool _get(size_t, T*) const;

--- a/src/core/expr/fexpr_literal_range.cc
+++ b/src/core/expr/fexpr_literal_range.cc
@@ -51,7 +51,7 @@ Workframe FExpr_Literal_Range::evaluate_n(EvalContext& ctx) const {
   Workframe out(ctx);
   out.add_column(Column(new Range_ColumnImpl(value_.start(),
                                              value_.stop(),
-                                             value_.step())),
+                                             value_.step(), dt::Type())),
                  "", Grouping::GtoALL);
   return out;
 }

--- a/src/core/frame/__init__.cc
+++ b/src/core/frame/__init__.cc
@@ -369,8 +369,6 @@ class FrameInitializationManager {
       if (res.is_frame()) {
         Frame* resframe = static_cast<Frame*>(res.to_borrowed_ref());
         std::swap(frame->dt,      resframe->dt);
-        std::swap(frame->stypes,  resframe->stypes);
-        std::swap(frame->ltypes,  resframe->ltypes);
         std::swap(frame->source_, resframe->source_);
       } else {
         xassert(res.is_dict());
@@ -754,8 +752,6 @@ void Frame::m__init__(const PKArgs& args) {
   if (dt) m__dealloc__();
   dt = nullptr;
   source_ = nullptr;
-  stypes = nullptr;
-  ltypes = nullptr;
   if (Frame::internal_construction) return;
 
   FrameInitializationManager fim(args, this);
@@ -791,8 +787,6 @@ void Frame::m__setstate__(const PKArgs& args) {
   // Clean up any previous state of the Frame (since pickle first creates an
   // empty Frame object, and then calls __setstate__ on it).
   m__dealloc__();
-  stypes = nullptr;
-  ltypes = nullptr;
 
   const char* data = PyBytes_AS_STRING(_state);
   size_t length = static_cast<size_t>(PyBytes_GET_SIZE(_state));

--- a/src/core/frame/__init__.cc
+++ b/src/core/frame/__init__.cc
@@ -72,8 +72,8 @@ class FrameInitializationManager {
       defined_stypes = !(stypes_arg.is_undefined() || stypes_arg.is_none());
       defined_stype  = !(stype_arg.is_undefined() || stype_arg.is_none());
       if (defined_stype && defined_stypes) {
-        throw TypeError() << "You can pass either parameter `stypes` or "
-            "`stype` to Frame() constructor, but not both at the same time";
+        throw TypeError() << "You can pass either parameter `types` or "
+            "`type` to Frame() constructor, but not both at the same time";
       }
       if (defined_stype) {
         stype0 = stype_arg.to_stype(em());
@@ -345,7 +345,7 @@ class FrameInitializationManager {
       check_names_count(ncols);
       if (stypes_arg || stype_arg) {
         // TODO: allow this use case
-        throw TypeError() << "Parameter `stypes` is not allowed when making "
+        throw TypeError() << "Parameter `types` is not allowed when making "
             "a copy of a Frame";
       }
       for (size_t i = 0; i < ncols; ++i) {
@@ -390,7 +390,7 @@ class FrameInitializationManager {
 
     void init_from_pandas() {
       if (stypes_arg || stype_arg) {
-        throw TypeError() << "Argument `stypes` is not supported in Frame() "
+        throw TypeError() << "Argument `types` is not supported in Frame() "
             "constructor when creating a Frame from pandas DataFrame";
       }
       py::robj pdsrc = src.to_robj();
@@ -439,7 +439,7 @@ class FrameInitializationManager {
 
     void init_from_numpy() {
       if (stypes_arg || stype_arg) {
-        throw TypeError() << "Argument `stypes` is not supported in Frame() "
+        throw TypeError() << "Argument `types` is not supported in Frame() "
             "constructor when creating a Frame from a numpy array";
       }
       py::oobj npsrc = src.to_robj();
@@ -486,7 +486,7 @@ class FrameInitializationManager {
 
     void init_from_arrow() {
       if (stypes_arg || stype_arg) {
-        throw TypeError() << "Argument `stypes` is not supported in Frame() "
+        throw TypeError() << "Argument `types` is not supported in Frame() "
             "constructor when creating a Frame from an arrow Table";
       }
       auto pasrc = src.to_robj();
@@ -581,11 +581,11 @@ class FrameInitializationManager {
       }
       else {
         throw TypeError() << stypes_arg.name() << " should be a list of "
-            "stypes, instead received " << stypes_arg.typeobj();
+            "types, instead received " << stypes_arg.typeobj();
       }
       if (nstypes != ncols) {
         throw ValueError()
-            << "The `stypes` argument contains " << nstypes
+            << "The `types` argument contains " << nstypes
             << " element" << (nstypes==1? "" : "s") << ", which is "
             << (nstypes < ncols? "less" : "more") << " than the number of "
                "columns being created (" << ncols << ")";
@@ -615,7 +615,7 @@ class FrameInitializationManager {
           py::robj oname(nullptr);
           if (name == nullptr) {
             if (!defined_names) {
-              throw TypeError() << "When parameter `stypes` is a dictionary, "
+              throw TypeError() << "When parameter `types` is a dictionary, "
                   "column `names` must be explicitly specified";
             }
             py::olist names = names_arg.to_pylist();
@@ -740,7 +740,7 @@ class FrameInitializationManager {
 //------------------------------------------------------------------------------
 
 Error FrameInitializationManager::em::error_not_stype(PyObject*) const {
-  return TypeError() << "Invalid value for `stype` parameter in Frame() "
+  return TypeError() << "Invalid value for `type` parameter in Frame() "
                         "constructor";
 } // LCOV_EXCL_LINE
 

--- a/src/core/frame/__sizeof__.cc
+++ b/src/core/frame/__sizeof__.cc
@@ -43,8 +43,6 @@ static PKArgs args__sizeof__(
 oobj Frame::m__sizeof__(const PKArgs&) {
   size_t sz = dt->memory_footprint();
   sz += sizeof(*this);
-  if (ltypes) sz += _PySys_GetSizeOf(ltypes);
-  if (stypes) sz += _PySys_GetSizeOf(stypes);
   return oint(sz);
 }
 

--- a/src/core/frame/integrity_check.cc
+++ b/src/core/frame/integrity_check.cc
@@ -38,47 +38,7 @@ void py::Frame::integrity_check() {
   if (!dt) {
     throw AssertionError() << "py::Frame.dt is NULL";
   }
-
   dt->verify_integrity();
-
-  if (stypes) {
-    if (!py::robj(stypes).is_tuple()) {
-      throw AssertionError() << "py::Frame.stypes is not a tuple";
-    }
-    auto stypes_tuple = py::robj(stypes).to_otuple();
-    if (stypes_tuple.size() != dt->ncols()) {
-      throw AssertionError() << "len(.stypes) = " << stypes_tuple.size()
-          << " is different from .ncols = " << dt->ncols();
-    }
-    for (size_t i = 0; i < dt->ncols(); ++i) {
-      dt::SType col_stype = dt->get_column(i).stype();
-      auto elem = stypes_tuple[i];
-      auto eexp = dt::stype_to_pyobj(col_stype);
-      if (elem != eexp) {
-        throw AssertionError() << "Element " << i << " of .stypes is "
-            << elem << ", but the column's stype is " << col_stype;
-      }
-    }
-  }
-  if (ltypes) {
-    if (!py::robj(ltypes).is_tuple()) {
-      throw AssertionError() << "py::Frame.ltypes is not a tuple";
-    }
-    auto ltypes_tuple = py::robj(ltypes).to_otuple();
-    if (ltypes_tuple.size() != dt->ncols()) {
-      throw AssertionError() << "len(.ltypes) = " << ltypes_tuple.size()
-          << " is different from .ncols = " << dt->ncols();
-    }
-    for (size_t i = 0; i < dt->ncols(); ++i) {
-      dt::SType col_stype = dt->get_column(i).stype();
-      auto elem = ltypes_tuple[i];
-      auto eexp = dt::ltype_to_pyobj(stype_to_ltype(col_stype));
-      if (elem != eexp) {
-        throw AssertionError() << "Element " << i << " of .ltypes is "
-            << elem << ", but the column's ltype is " << col_stype;
-      }
-    }
-  }
 }
 
 

--- a/src/core/frame/py_frame.cc
+++ b/src/core/frame/py_frame.cc
@@ -745,7 +745,7 @@ return: List[Type]
 
 See also
 --------
-- :attr:`.stypes` -- old interface for column types
+- :attr:`.type` -- common type for all columns
 )";
 
 static GSArgs args_types("types", doc_types);
@@ -766,9 +766,9 @@ oobj Frame::get_types() const {
 
 static const char* doc_stypes =
 R"(
-.. x-deprecated::
+.. x-version-deprecated:: 1.0.0
 
-  Use :attr:`.types` instead.
+    Use property :attr:`.types` instead.
 
 The tuple of each column's stypes ("storage types").
 
@@ -803,7 +803,11 @@ oobj Frame::get_stypes() const {
 
 static const char* doc_stype =
 R"(
-.. x-version-added:: v0.10.0
+.. x-version-deprecated:: 1.0.0
+
+    Use property :attr:`.type` instead.
+
+.. x-version-added:: 0.10.0
 
 The common :class:`dt.stype` for all columns.
 
@@ -851,6 +855,10 @@ oobj Frame::get_stype() const {
 
 static const char* doc_ltypes =
 R"(
+.. x-version-deprecated:: 1.0.0
+
+    Use property :attr:`.types` instead.
+
 The tuple of each column's ltypes ("logical types").
 
 Parameters
@@ -908,7 +916,7 @@ _data: Any
 **cols: Any
     Sequence of varkwd column initializers. The keys become column
     names, and the values contain column data. Using varkwd arguments
-    is equivalent to passing a `dict` as the `_data` argument.
+    is equivalent to passing a ``dict`` as the `_data` argument.
 
     When varkwd initializers are used, the `names` parameter may not
     be given.
@@ -935,7 +943,7 @@ return: Frame
     returned.
 
 except: ValueError
-    The exception is raised if the lengths of `names` or `stypes`
+    The exception is raised if the lengths of `names` or `types`
     lists are different from the number of columns created, or when
     creating several columns and they have incompatible lengths.
 
@@ -980,7 +988,7 @@ the first argument::
 The argument `_data` accepts a wide range of input types. The
 following list describes possible choices:
 
-`List[List | Frame | np.array | pd.DataFrame | pd.Series | range | typed_list]`
+``List[List | Frame | np.array | pd.DataFrame | pd.Series | range | typed_list]``
     When the source is a non-empty list containing other lists or
     compound objects, then each item will be interpreted as a column
     initializer, and the resulting frame will have as many columns
@@ -1007,7 +1015,7 @@ following list describes possible choices:
     a Frame from a row-oriented store of data, you can use a list of
     dictionaries or a list of tuples as described below.
 
-`List[Dict]`
+``List[Dict]``
     If the source is a list of `dict` objects, then each element
     in this list is interpreted as a single row. The keys
     in each dictionary are column names, and the values contain
@@ -1031,7 +1039,7 @@ following list describes possible choices:
     in the list of names will be taken into account, all extra
     fields will be discarded.
 
-`List[Tuple]`
+``List[Tuple]``
     If the source is a list of `tuple`s, then each tuple
     represents a single row. The tuples must have the same size,
     otherwise an exception will be raised::
@@ -1052,7 +1060,7 @@ following list describes possible choices:
     check is made whether the named tuples in fact belong to the
     same class.
 
-`List[Any]`
+``List[Any]``
     If the list's first element does not match any of the cases
     above, then it is considered a "list of primitives". Such list
     will be parsed as a single column.
@@ -1079,16 +1087,16 @@ following list describes possible choices:
     will have stype `str32` if the total size of the character is
     less than 2Gb, or `str64` otherwise.
 
-`typed_list`
+``typed_list``
     A typed list can be created by taking a regular list and
     dividing it by an stype. It behaves similarly to a simple
     list of primitives, except that it is parsed into the specific
     stype.
 
-        >>> dt.Frame([1.5, 2.0, 3.87] / dt.float32).stype
-        stype.float32
+        >>> dt.Frame([1.5, 2.0, 3.87] / dt.float32).type
+        Type.float32
 
-`Dict[str, Any]`
+``Dict[str, Any]``
     The keys are column names, and values can be any objects from
     which a single-column frame can be constructed: list, range,
     np.array, single-column Frame, pandas series, etc.
@@ -1096,18 +1104,18 @@ following list describes possible choices:
     Constructing a frame from a dictionary `d` is exactly equivalent
     to calling `dt.Frame(list(d.values()), names=list(d.keys()))`.
 
-`range`
+``range``
     Same as if the range was expanded into a list of integers,
     except that the column created from a range is virtual and
     its creation time is nearly instant regardless of the range's
     length.
 
-`Frame`
+``Frame``
     If the argument is a :class:`Frame <datatable.Frame>`, then
     a shallow copy of that frame will be created, same as
     :meth:`.copy()`.
 
-`str`
+``str``
     If the source is a simple string, then the frame is created
     by :func:`fread <datatable.fread>`-ing this string.
     In particular, if the string contains the name of a file, the
@@ -1129,7 +1137,7 @@ following list describes possible choices:
          2 | Lily        NA
         [3 rows x 2 columns]
 
-`pd.DataFrame | pd.Series`
+``pd.DataFrame | pd.Series``
     A pandas DataFrame (Series) will be converted into a datatable
     Frame. Column names will be preserved.
 
@@ -1142,7 +1150,7 @@ following list describes possible choices:
     it into a more specific stype. In particular, we can detect a
     string or boolean column stored as object in pandas.
 
-`np.array`
+``np.array``
     A numpy array will get converted into a Frame of the same shape
     (provided that it is 2- or less- dimensional) and the same type.
 
@@ -1150,14 +1158,14 @@ following list describes possible choices:
     (however, this is subject to numpy's approval). The resulting
     frame will have a copy-on-write semantics.
 
-`pyarrow.Table`
+``pyarrow.Table``
     An arrow table will be converted into a datatable Frame, preserving
     column names and types.
 
     If the arrow table has columns of types not supported by datatable
     (for example lists or structs), an exception will be raised.
 
-`None`
+``None``
     When the source is not given at all, then a 0x0 frame will be
     created; unless a `names` parameter is provided, in which
     case the resulting frame will have 0 rows but as many columns

--- a/src/core/frame/py_frame.cc
+++ b/src/core/frame/py_frame.cc
@@ -256,8 +256,6 @@ oobj Frame::copy(const XArgs& args) {
   oobj res = Frame::oframe(deepcopy? new DataTable(*dt, DataTable::deep_copy)
                                    : new DataTable(*dt));
   Frame* newframe = static_cast<Frame*>(res.to_borrowed_ref());
-  newframe->stypes = stypes;  Py_XINCREF(stypes);
-  newframe->ltypes = ltypes;  Py_XINCREF(ltypes);
   newframe->meta_ = meta_;
   newframe->source_ = source_;
   return res;
@@ -399,8 +397,6 @@ oobj Frame::oframe(robj src) {
 
 
 void Frame::m__dealloc__() {
-  Py_XDECREF(stypes);
-  Py_XDECREF(ltypes);
   delete dt;
   dt = nullptr;
   source_ = nullptr;
@@ -408,10 +404,6 @@ void Frame::m__dealloc__() {
 
 
 void Frame::_clear_types() {
-  Py_XDECREF(stypes);
-  Py_XDECREF(ltypes);
-  stypes = nullptr;
-  ltypes = nullptr;
   source_ = nullptr;
 }
 
@@ -774,6 +766,10 @@ oobj Frame::get_types() const {
 
 static const char* doc_stypes =
 R"(
+.. x-deprecated::
+
+  Use :attr:`.types` instead.
+
 The tuple of each column's stypes ("storage types").
 
 Parameters
@@ -791,15 +787,12 @@ See also
 static GSArgs args_stypes("stypes", doc_stypes);
 
 oobj Frame::get_stypes() const {
-  if (stypes == nullptr) {
-    py::otuple ostypes(dt->ncols());
-    for (size_t i = 0; i < ostypes.size(); ++i) {
-      dt::SType st = dt->get_column(i).stype();
-      ostypes.set(i, dt::stype_to_pyobj(st));
-    }
-    stypes = std::move(ostypes).release();
+  py::otuple stypes(dt->ncols());
+  for (size_t i = 0; i < stypes.size(); ++i) {
+    dt::SType st = dt->get_column(i).stype();
+    stypes.set(i, dt::stype_to_pyobj(st));
   }
-  return oobj(stypes);
+  return std::move(stypes);
 }
 
 
@@ -874,15 +867,12 @@ See also
 static GSArgs args_ltypes("ltypes", doc_ltypes);
 
 oobj Frame::get_ltypes() const {
-  if (ltypes == nullptr) {
-    py::otuple oltypes(dt->ncols());
-    for (size_t i = 0; i < oltypes.size(); ++i) {
-      dt::SType st = dt->get_column(i).stype();
-      oltypes.set(i, dt::ltype_to_pyobj(stype_to_ltype(st)));
-    }
-    ltypes = std::move(oltypes).release();
+  py::otuple ltypes(dt->ncols());
+  for (size_t i = 0; i < ltypes.size(); ++i) {
+    dt::SType st = dt->get_column(i).stype();
+    ltypes.set(i, dt::ltype_to_pyobj(stype_to_ltype(st)));
   }
-  return oobj(ltypes);
+  return std::move(ltypes);
 }
 
 

--- a/src/core/frame/py_frame.cc
+++ b/src/core/frame/py_frame.cc
@@ -893,7 +893,7 @@ oobj Frame::get_ltypes() const {
 //------------------------------------------------------------------------------
 
 static const char* doc___init__ =
-R"(__init__(self, _data=None, *, names=None, stypes=None, stype=None, **cols)
+R"(__init__(self, _data=None, *, names=None, types=None, type=None, **cols)
 --
 
 Create a new Frame from a single or multiple sources.
@@ -931,15 +931,14 @@ names: List[str|None]
     This parameter should not be used when constructing the frame
     from `**cols`.
 
-stypes: List[stype-like] | Dict[str, stype-like]
-    Explicit list (or tuple) of column types. The number of elements
+types: List[Type] | Dict[str, Type]
+    Explicit list (or dict) of column types. The number of elements
     in the list must be the same as the number of columns being
     constructed.
 
-stype: stype | type
-    Similar to `stypes`, but provide a single type that will be used
-    for all columns. This option cannot be specified together with
-    `stypes`.
+type: Type | type
+    Similar to `types`, but provide a single type that will be used
+    for all columns. This option cannot be used together with `types`.
 
 return: Frame
     A :class:`Frame <datatable.Frame>` object is constructed and
@@ -1176,7 +1175,7 @@ following list describes possible choices:
 )";
 
 static PKArgs args___init__(1, 0, 3, false, true,
-                            {"_data", "names", "stypes", "stype"},
+                            {"_data", "names", "types", "type"},
                             "__init__", doc___init__);
 
 
@@ -1230,6 +1229,8 @@ void Frame::impl_init_type(XTypeMaker& xt) {
   xt.add(METHOD__SETITEM__(&Frame::m__setitem__));
   xt.add(METHOD__GETBUFFER__(&Frame::m__getbuffer__, &Frame::m__releasebuffer__));
   Frame_Type = xt.get_type_object();
+  args___init__.add_synonym_arg("stypes", "types");
+  args___init__.add_synonym_arg("stype", "type");
 
   _init_key(xt);
   _init_init(xt);

--- a/src/core/frame/py_frame.h
+++ b/src/core/frame/py_frame.h
@@ -39,8 +39,6 @@ class Frame : public XObject<Frame> {
                     // destructor is never called by Python)
     py::oobj source_;
     py::oobj meta_;
-    mutable PyObject* stypes;  // memoized tuple of stypes
-    mutable PyObject* ltypes;  // memoized tuple of ltypes
 
   public:
     static void impl_init_type(XTypeMaker&);

--- a/src/core/python/arg.cc
+++ b/src/core/python/arg.cc
@@ -149,7 +149,7 @@ std::string Arg::to_string()       const { return pyobj.to_string(*this); }
 strvec      Arg::to_stringlist()   const { return pyobj.to_stringlist(*this); }
 dt::SType   Arg::to_stype()        const { return pyobj.to_stype(*this); }
 dt::SType   Arg::to_stype(const error_manager& em) const { return pyobj.to_stype(em); }
-dt::Type    Arg::to_type_force()   const { return pyobj.to_type_force(*this); }
+dt::Type    Arg::to_type_force()   const { return pyobj.to_type_force(); }
 py::oiter   Arg::to_oiter()        const { return pyobj.to_oiter(*this); }
 DataTable*  Arg::to_datatable()    const { return pyobj.to_datatable(*this); }
 

--- a/src/core/python/obj.cc
+++ b/src/core/python/obj.cc
@@ -903,7 +903,7 @@ dt::Type _obj::to_type(const error_manager& em) const {
 }
 
 
-dt::Type _obj::to_type_force(const error_manager&) const {
+dt::Type _obj::to_type_force() const {
   if (!v) return dt::Type();
   if (dt::PyType::check(v)) {
     auto typePtr = dt::PyType::unchecked(v);

--- a/src/core/python/obj.h
+++ b/src/core/python/obj.h
@@ -266,7 +266,7 @@ class _obj {
     py::Frame*  to_pyframe        (const error_manager& = _em0) const;
     dt::SType   to_stype          (const error_manager& = _em0) const;
     dt::Type    to_type           (const error_manager& = _em0) const;
-    dt::Type    to_type_force     (const error_manager& = _em0) const;
+    dt::Type    to_type_force     () const;
     py::ojoin   to_ojoin_lax      () const;
     py::oby     to_oby_lax        () const;
     py::osort   to_osort_lax      () const;

--- a/src/core/rowindex.cc
+++ b/src/core/rowindex.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2020 H2O.ai
+// Copyright 2018-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -237,7 +237,7 @@ Column RowIndex::as_column(size_t nrows) const {
   } else {
     // No RowIndex is equivalent to having RowIndex over all rows
     auto inrows = static_cast<int64_t>(nrows);
-    return Column(new dt::Range_ColumnImpl(0, inrows, 1));
+    return Column(new dt::Range_ColumnImpl(0, inrows, 1, dt::Type()));
   }
 }
 

--- a/src/core/rowindex_slice.cc
+++ b/src/core/rowindex_slice.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2020 H2O.ai
+// Copyright 2018-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -78,7 +78,8 @@ bool SliceRowIndexImpl::get_element(size_t i, size_t* out) const {
 Column SliceRowIndexImpl::as_column() const {
   return Column(new dt::Range_ColumnImpl(static_cast<int64_t>(start),
                                          static_cast<int64_t>(length),
-                                         static_cast<int64_t>(step)));
+                                         static_cast<int64_t>(step),
+                                         dt::Type()));
 }
 
 

--- a/src/core/types/type.cc
+++ b/src/core/types/type.cc
@@ -140,30 +140,30 @@ Type Type::common(const Type& type1, const Type& type2) {
 }
 
 
-bool Type::is_void()    const { return impl_->stype_ == SType::VOID; }
-bool Type::is_invalid() const { return impl_->is_invalid(); }
-bool Type::is_boolean() const { return impl_->is_boolean(); }
-bool Type::is_integer() const { return impl_->is_integer(); }
-bool Type::is_float()   const { return impl_->is_float(); }
-bool Type::is_numeric() const { return impl_->is_numeric(); }
-bool Type::is_string()  const { return impl_->is_string(); }
-bool Type::is_object()  const { return impl_->is_object(); }
-bool Type::is_time()    const { return impl_->is_time(); }
+bool Type::is_void()    const { return impl_ && impl_->stype_ == SType::VOID; }
+bool Type::is_invalid() const { return impl_ && impl_->is_invalid(); }
+bool Type::is_boolean() const { return impl_ && impl_->is_boolean(); }
+bool Type::is_integer() const { return impl_ && impl_->is_integer(); }
+bool Type::is_float()   const { return impl_ && impl_->is_float(); }
+bool Type::is_numeric() const { return impl_ && impl_->is_numeric(); }
+bool Type::is_string()  const { return impl_ && impl_->is_string(); }
+bool Type::is_object()  const { return impl_ && impl_->is_object(); }
+bool Type::is_time()    const { return impl_ && impl_->is_time(); }
 
 
 template<typename T> bool Type::can_be_read_as() const { return false; }
-template<> bool Type::can_be_read_as<int8_t>()   const { return impl_->can_be_read_as_int8(); }
-template<> bool Type::can_be_read_as<int16_t>()  const { return impl_->can_be_read_as_int16(); }
-template<> bool Type::can_be_read_as<int32_t>()  const { return impl_->can_be_read_as_int32(); }
-template<> bool Type::can_be_read_as<int64_t>()  const { return impl_->can_be_read_as_int64(); }
-template<> bool Type::can_be_read_as<float>()    const { return impl_->can_be_read_as_float32(); }
-template<> bool Type::can_be_read_as<double>()   const { return impl_->can_be_read_as_float64(); }
-template<> bool Type::can_be_read_as<CString>()  const { return impl_->can_be_read_as_cstring(); }
-template<> bool Type::can_be_read_as<py::oobj>() const { return impl_->can_be_read_as_pyobject(); }
+template<> bool Type::can_be_read_as<int8_t>()   const { return impl_ && impl_->can_be_read_as_int8(); }
+template<> bool Type::can_be_read_as<int16_t>()  const { return impl_ && impl_->can_be_read_as_int16(); }
+template<> bool Type::can_be_read_as<int32_t>()  const { return impl_ && impl_->can_be_read_as_int32(); }
+template<> bool Type::can_be_read_as<int64_t>()  const { return impl_ && impl_->can_be_read_as_int64(); }
+template<> bool Type::can_be_read_as<float>()    const { return impl_ && impl_->can_be_read_as_float32(); }
+template<> bool Type::can_be_read_as<double>()   const { return impl_ && impl_->can_be_read_as_float64(); }
+template<> bool Type::can_be_read_as<CString>()  const { return impl_ && impl_->can_be_read_as_cstring(); }
+template<> bool Type::can_be_read_as<py::oobj>() const { return impl_ && impl_->can_be_read_as_pyobject(); }
 
 
 bool Type::operator==(const Type& other) const {
-  return (impl_ == other.impl_) || (impl_->equals(other.impl_));
+  return (impl_ == other.impl_) || (impl_ && impl_->equals(other.impl_));
 }
 
 Type::operator bool() const {

--- a/tests/frame/test-create.py
+++ b/tests/frame/test-create.py
@@ -620,7 +620,7 @@ def test_create_from_list_of_dicts_bad3():
 
 
 #-------------------------------------------------------------------------------
-# Stype auto-detection
+# Type auto-detection
 #-------------------------------------------------------------------------------
 
 def test_auto_bool8():
@@ -772,7 +772,7 @@ def test_no_auto_object_column():
 
 
 #-------------------------------------------------------------------------------
-# Create specific stypes
+# types= argument
 #-------------------------------------------------------------------------------
 
 def test_create_from_nones():
@@ -783,7 +783,7 @@ def test_create_from_nones():
 
 
 def test_create_as_int8():
-    d0 = dt.Frame([1, None, -1, 1000, 2.7, "123", "boo"], stype=stype.int8)
+    d0 = dt.Frame([1, None, -1, 1000, 2.7, "123", "boo"], type=stype.int8)
     frame_integrity_check(d0)
     assert d0.stypes == (stype.int8, )
     assert d0.shape == (7, 1)
@@ -791,7 +791,7 @@ def test_create_as_int8():
 
 
 def test_create_as_int16():
-    d0 = dt.Frame([1e50, 1000, None, "27", "?", True], stype=stype.int16)
+    d0 = dt.Frame([1e50, 1000, None, "27", "?", True], type=stype.int16)
     frame_integrity_check(d0)
     assert d0.stypes == (stype.int16, )
     assert d0.shape == (6, 1)
@@ -800,7 +800,7 @@ def test_create_as_int16():
 
 
 def test_create_as_int32():
-    d0 = dt.Frame([1, 2, 5, 3.14, (1, 2)], stype=stype.int32)
+    d0 = dt.Frame([1, 2, 5, 3.14, (1, 2)], type=stype.int32)
     frame_integrity_check(d0)
     assert d0.stypes == (stype.int32, )
     assert d0.shape == (5, 1)
@@ -837,7 +837,7 @@ def test_create_as_str32():
 
 
 def test_create_as_str64():
-    d0 = dt.Frame(range(10), stype=stype.str64)
+    d0 = dt.Frame(range(10), type=dt.Type.str64)
     frame_integrity_check(d0)
     assert d0.stypes == (stype.str64, )
     assert d0.shape == (10, 1)
@@ -854,6 +854,30 @@ def test_create_range_as_stype(st):
         assert d0.to_list()[0] == [str(x) for x in range(10)]
     else:
         assert d0.to_list()[0] == list(range(10))
+
+
+@pytest.mark.parametrize('t', [stype.float64, dt.Type.float64, float, 'double',
+                               'float64'])
+def test_create_from_various_types(t):
+    DT = dt.Frame(range(5), type=t)
+    frame_integrity_check(DT)
+    assert DT.type == dt.Type.float64
+    assert_equals(DT, dt.Frame([0.0, 1.0, 2.0, 3.0, 4.0]))
+
+
+def test_create_from_numpy_dtype1(np):
+    DT = dt.Frame(range(5), type=np.dtype('float64'))
+    assert_equals(DT, dt.Frame([0.0, 1.0, 2.0, 3.0, 4.0]))
+
+
+def test_create_from_numpy_dtype2(np):
+    DT = dt.Frame(range(5), type=np.float64)
+    assert_equals(DT, dt.Frame([0.0, 1.0, 2.0, 3.0, 4.0]))
+
+
+def test_create_from_arrow_type(pa):
+    DT = dt.Frame(range(5), type=pa.float64())
+    assert_equals(DT, dt.Frame([0.0, 1.0, 2.0, 3.0, 4.0]))
 
 
 

--- a/tests/frame/test-create.py
+++ b/tests/frame/test-create.py
@@ -48,8 +48,8 @@ def test_types_type():
 
 
 def test_bad_type():
-    msg = r"Invalid value for type parameter in Frame\(\) constructor"
-    with pytest.raises(TypeError, match=msg):
+    msg = r"Cannot create Type object from -1"
+    with pytest.raises(ValueError, match=msg):
         dt.Frame(type=-1)
 
 

--- a/tests/frame/test-create.py
+++ b/tests/frame/test-create.py
@@ -40,70 +40,77 @@ from tests import list_equals, assert_equals
 # Test wrong parameters
 #-------------------------------------------------------------------------------
 
-def test_stypes_stype():
-    with pytest.raises(TypeError) as e:
-        dt.Frame(stypes=[], stype="float32")
-    assert ("You can pass either parameter stypes or stype to Frame() "
-            "constructor, but not both at the same time" == str(e.value))
+def test_types_type():
+    msg = r"You can pass either parameter types or type to Frame\(\) " \
+          r"constructor, but not both at the same time"
+    with pytest.raises(TypeError, match=msg):
+        dt.Frame(types=[], type="float32")
 
 
-def test_bad_stype():
-    with pytest.raises(TypeError) as e:
-        dt.Frame(stype=-1)
-    assert ("Invalid value for stype parameter in Frame() constructor" ==
-            str(e.value))
+def test_bad_type():
+    msg = r"Invalid value for type parameter in Frame\(\) constructor"
+    with pytest.raises(TypeError, match=msg):
+        dt.Frame(type=-1)
 
 
-def test_bad_stypes():
-    with pytest.raises(TypeError) as e:
-        dt.Frame([], stypes=2.5)
-    assert ("Argument stypes in Frame() constructor should be a list of "
-            "stypes, instead received <class 'float'>" == str(e.value))
+def test_bad_types():
+    msg = r"Argument types in Frame\(\) constructor should be a list of " \
+          r"types, instead received <class 'float'>"
+    with pytest.raises(TypeError, match=msg):
+        dt.Frame([], types=2.5)
 
 
 def test_unknown_arg():
-    with pytest.raises(TypeError) as e:
+    msg = r"Frame\(\) constructor got an unexpected keyword argument 'dtype'"
+    with pytest.raises(TypeError, match=msg):
         dt.Frame([1], dtype="int32")
-    assert ("Frame() constructor got an unexpected keyword argument 'dtype'" ==
-            str(e.value))
 
 
-def test_unknown_args():
-    with pytest.raises(TypeError) as e:
+def test_unknown_args1():
+    msg = r"Frame\(\) constructor got 2 unexpected keyword arguments: " \
+          r"'A' and 'B'"
+    with pytest.raises(TypeError, match=msg):
         dt.Frame([1], A=1, B=2)
-    assert ("Frame() constructor got 2 unexpected keyword arguments: "
-            "'A' and 'B'" == str(e.value))
-    with pytest.raises(TypeError) as e:
+
+
+def test_unknown_args2():
+    msg = r"Frame\(\) constructor got 3 unexpected keyword arguments: " \
+          r"'A', 'B' and 'C'"
+    with pytest.raises(TypeError, match=msg):
         dt.Frame([1], A=1, B=2, C=3)
-    assert ("Frame() constructor got 3 unexpected keyword arguments: "
-            "'A', 'B' and 'C'" == str(e.value))
-    with pytest.raises(TypeError) as e:
+
+
+def test_unknown_args3():
+    msg = r"Frame\(\) constructor got 4 unexpected keyword arguments: " \
+          r"'A', 'B', ..., 'D'"
+    with pytest.raises(TypeError, match=msg):
         dt.Frame([1], A=1, B=2, C=3, D=4)
-    assert ("Frame() constructor got 4 unexpected keyword arguments: "
-            "'A', 'B', ..., 'D'" == str(e.value))
-    with pytest.raises(TypeError) as e:
+
+
+def test_unknown_args4():
+    msg = r"Frame\(\) constructor got 5 unexpected keyword arguments: " \
+          r"'A', 'B', ..., 'E'"
+    with pytest.raises(TypeError, match=msg):
         dt.Frame([1], A=1, B=2, C=3, D=4, E=5)
-    assert ("Frame() constructor got 5 unexpected keyword arguments: "
-            "'A', 'B', ..., 'E'" == str(e.value))
 
 
-def test_stypes_dict():
-    with pytest.raises(TypeError) as e:
+def test_types_dict():
+    msg = "When parameter types is a dictionary, column names must " \
+          "be explicitly specified"
+    with pytest.raises(TypeError, match=msg):
         dt.Frame([1, 2, 3], stypes={"A": float})
-    assert ("When parameter stypes is a dictionary, column names must "
-            "be explicitly specified" == str(e.value))
 
 
 def test_create_from_set():
-    with pytest.raises(TypeError) as e:
+    msg = "Cannot create Frame from <class 'set'>"
+    with pytest.raises(TypeError, match=msg):
         dt.Frame({1, 13, 15, -16, -10, 7, 9, 1})
-    assert ("Cannot create Frame from <class 'set'>" == str(e.value))
 
 
 def test_wrong_source():
-    with pytest.raises(TypeError) as e:
+    msg = "Cannot create a column from <class 'int'>"
+    with pytest.raises(TypeError, match=msg):
         dt.Frame(A=[1], B=2)
-    assert ("Cannot create a column from <class 'int'>" == str(e.value))
 
 
 def test_wrong_source_heavy():
@@ -117,18 +124,18 @@ def test_wrong_source_heavy():
 
 
 def test_different_column_lengths():
-    with pytest.raises(ValueError) as e:
+    msg = r"Column 1 has different number of rows \(3\) than the preceding " \
+          r"columns \(10\)"
+    with pytest.raises(ValueError, match=msg):
         dt.Frame([range(10), [3, 4, 6]])
-    assert ("Column 1 has different number of rows (3) than the preceding "
-            "columns (10)" == str(e.value))
 
 
 def test_from_frame_as_column():
     DT = dt.Frame(A=[1, 2, 3], B=[7, 4, 1])
-    with pytest.raises(ValueError) as e:
+    msg = "A column cannot be constructed from a Frame with 2 columns"
+    with pytest.raises(ValueError, match=msg):
         dt.Frame(X=DT)
-    assert ("A column cannot be constructed from a Frame with 2 columns"
-            == str(e.value))
+
 
 
 
@@ -141,8 +148,7 @@ def test_create_from_nothing():
     frame_integrity_check(d0)
     assert d0.shape == (0, 0)
     assert d0.names == tuple()
-    assert d0.ltypes == tuple()
-    assert d0.stypes == tuple()
+    assert d0.types == []
 
 
 def test_create_from_none():
@@ -150,8 +156,7 @@ def test_create_from_none():
     frame_integrity_check(d0)
     assert d0.shape == (0, 0)
     assert d0.names == tuple()
-    assert d0.ltypes == tuple()
-    assert d0.stypes == tuple()
+    assert d0.types == []
 
 
 def test_create_from_empty_list():
@@ -159,15 +164,14 @@ def test_create_from_empty_list():
     frame_integrity_check(d0)
     assert d0.shape == (0, 0)
     assert d0.names == tuple()
-    assert d0.ltypes == tuple()
-    assert d0.stypes == tuple()
+    assert d0.types == []
 
 
 def test_create_from_empty_list_with_params():
-    d0 = dt.Frame([], names=[], stypes=[])
+    d0 = dt.Frame([], names=[], types=[])
     frame_integrity_check(d0)
     assert d0.shape == (0, 0)
-    d1 = dt.Frame([], stype=stype.int64)
+    d1 = dt.Frame([], type=dt.int64)
     frame_integrity_check(d1)
     assert d1.shape == (0, 0)
 
@@ -182,7 +186,7 @@ def test_create_from_nothing_with_names():
 def test_create_from_empty_list_bad():
     with pytest.raises(ValueError) as e:
         dt.Frame([], stypes=["int32", "str32"])
-    assert ("The stypes argument contains 2 elements, which is more than the "
+    assert ("The types argument contains 2 elements, which is more than the "
             "number of columns being created (0)" in str(e.value))
 
 
@@ -250,7 +254,7 @@ def test_create_from_list_of_lists_with_stypes_dict():
 def test_create_from_list_of_lists_with_stypes_dict_bad():
     with pytest.raises(TypeError) as e:
         dt.Frame([[4], [9], [3]], stypes={"c": float})
-    assert ("When parameter stypes is a dictionary, column names must be "
+    assert ("When parameter types is a dictionary, column names must be "
             "explicitly specified" == str(e.value))
 
 
@@ -399,7 +403,7 @@ def test_create_from_frame_error():
     frame_integrity_check(d0)
     with pytest.raises(TypeError) as e1:
         dt.Frame(d0, stypes=[stype.int64, stype.float64, stype.str64])
-    assert ("Parameter stypes is not allowed when making a copy of a "
+    assert ("Parameter types is not allowed when making a copy of a "
             "Frame" == str(e1.value))
     with pytest.raises(TypeError) as e2:
         dt.Frame(d0, stypes=[stype.str32])
@@ -507,7 +511,7 @@ def test_create_from_list_of_tuples_bad():
 
     with pytest.raises(ValueError) as e:
         dt.Frame([(1, 2, 3)], stypes=(stype.float32,) * 10)
-    assert ("The stypes argument contains 10 elements, which is more than "
+    assert ("The types argument contains 10 elements, which is more than "
             "the number of columns being created (3)" == str(e.value))
 
 
@@ -974,7 +978,7 @@ def test_create_from_pandas_with_stypes(pandas):
     with pytest.raises(TypeError) as e:
         p = pandas.DataFrame([[1, 2, 3]])
         dt.Frame(p, stype=str)
-    assert ("Argument stypes is not supported in Frame() constructor "
+    assert ("Argument types is not supported in Frame() constructor "
             "when creating a Frame from pandas DataFrame" == str(e.value))
 
 


### PR DESCRIPTION
Two arguments in Frame's constructor were renamed:
   - `stypes=` into `types=`, and
   - `stype=` into `type=`.
 
The old arguments are still available and continue to work as before, although they were excluded from the documentation.

The new parameters now support `Type` values, and also pyarrow's types (in addition to all the types that were supported before).

Some of the tests were converted into using the new `types=` argument, while others continue using `stypes=`. This ensures that both the new and the old arguments work.

Closes #2986