### PR TITLE
New mechanism for writing documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ temp/
 
 # Auto-generated files
 src/datatable/_build_info.py
+src/core/documentation.cc
 
 # vscode settings
 .vscode/settings.json

--- a/ci/ext.py
+++ b/ci/ext.py
@@ -354,9 +354,22 @@ def build_extension(cmd, verbosity=3):
                 "-Wno-unknown-pragmas"
             )
 
+    ext.add_prebuild_trigger(generate_documentation)
+
     # Setup is complete, ready to build
     ext.build()
     return ext.output_file
+
+
+def generate_documentation(ext):
+    hfile = "src/core/documentation.h"
+    ccfile = "src/core/documentation.cc"
+    docfiles = glob.glob("docs/api/**/*.rst", recursive=True)
+    if ext.is_modified(hfile):
+        import gendoc
+        ext.log.report_generating_docs(ccfile)
+        gendoc.generate_documentation(hfile, ccfile, docfiles)
+        ext.add_sources(ccfile)
 
 
 

--- a/ci/gendoc.py
+++ b/ci/gendoc.py
@@ -28,7 +28,7 @@ import time
 def generate_documentation(infile, outfile, docfiles):
     variables = read_header_file(infile)
     docstrings = read_documentation_files(docfiles)
-    with open(outfile, 'wt') as out:
+    with open(outfile, 'wt', encoding='utf-8') as out:
         write_intro(out)
         for var in variables:
             write_variable(out, var, docstrings.get(var))
@@ -43,7 +43,7 @@ def read_header_file(hfile):
     """
     rx = re.compile(r"\s*extern\s+const\s+char\*\s+(doc\w+);")
     out = []
-    with open(hfile, 'rt') as inp:
+    with open(hfile, 'rt', encoding='utf-8') as inp:
         for line in inp:
             mm = re.match(rx, line)
             if mm:
@@ -58,7 +58,7 @@ def read_documentation_files(docfiles):
     rx_option = re.compile(r"(\s+):(\w+):\s*(.*)")
     out = {}
     for docfile in docfiles:
-        with open(docfile, 'rt') as inp:
+        with open(docfile, 'rt', encoding='utf-8') as inp:
             indent = 0  # indent within the xfunction's body
             xkind = None
             cvar_name = None

--- a/ci/gendoc.py
+++ b/ci/gendoc.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#-------------------------------------------------------------------------------
+# Copyright 2021 H2O.ai
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#-------------------------------------------------------------------------------
+import re
+import time
+
+
+def generate_documentation(infile, outfile, docfiles):
+    variables = read_header_file(infile)
+    docstrings = read_documentation_files(docfiles)
+    with open(outfile, 'wt') as out:
+        write_intro(out)
+        for var in variables:
+            write_variable(out, var, docstrings.get(var))
+        write_outro(out)
+
+
+
+def read_header_file(hfile):
+    """
+    Read the .h file where all documentation constants are declared
+    and return the list of all doc-variables declared there.
+    """
+    rx = re.compile(r"\s*extern\s+const\s+char\*\s+(doc\w+);")
+    out = []
+    with open(hfile, 'rt') as inp:
+        for line in inp:
+            mm = re.match(rx, line)
+            if mm:
+                out.append(mm.group(1))
+    return out
+
+
+
+def read_documentation_files(docfiles):
+    rx_directive = re.compile(
+            r"\.\. (xfunction|xmethod|xclass|xattr|xparam|xexc)::")
+    rx_option = re.compile(r"(\s+):(\w+):\s*(.*)")
+    out = {}
+    for docfile in docfiles:
+        with open(docfile, 'rt') as inp:
+            indent = 0  # indent within the xfunction's body
+            xkind = None
+            cvar_name = None
+            signature = None
+            state = "initial"
+            in_function_options = False
+            in_function_body = False
+            content = ""
+            for iline, line in enumerate(inp):
+                if state == "initial":
+                    mm = re.match(rx_directive, line)
+                    if mm:
+                        xkind = mm.group(1)
+                        state = "options"
+
+                elif state == "options":
+                    mm = re.match(rx_option, line)
+                    if mm:
+                        if indent == 0:
+                            indent = len(mm.group(1))
+                        if indent != len(mm.group(1)):
+                            raise Error("Inconsistent indentation in %s's options "
+                                        "at %s:L%d" % (xkind, docfile, iline+1))
+                        option = mm.group(2)
+                        value = mm.group(3).strip()
+                        if option == "cvar":
+                            cvar_name = value
+                        if option == "signature":
+                            signature = value
+                    elif line.strip() == "":
+                        # The body of the function follows after a blank line
+                        if not cvar_name: break
+                        state = "body"
+
+                elif state == "body":
+                    if line.strip() == '':
+                        content += '\n'
+                    else:
+                        # If the indent level of this line is less than
+                        # `indent`, then it means we are done reading the
+                        # function's body
+                        if line[:indent].strip():
+                            break
+                        content += line[indent:]
+
+            if cvar_name:
+                content = content.strip() + '\n'
+                if signature:
+                    content = signature + "\n--\n\n" + content
+                out[cvar_name] = content
+    return out
+
+
+
+def write_intro(out):
+    out.write(
+        '//------------------------------------------------------------------------------\n'
+        '// Copyright %d H2O.ai\n'
+        '//\n'
+        '// Permission is hereby granted, free of charge, to any person obtaining a\n'
+        '// copy of this software and associated documentation files (the "Software"),\n'
+        '// to deal in the Software without restriction, including without limitation\n'
+        '// the rights to use, copy, modify, merge, publish, distribute, sublicense,\n'
+        '// and/or sell copies of the Software, and to permit persons to whom the\n'
+        '// Software is furnished to do so, subject to the following conditions:\n'
+        '//\n'
+        '// The above copyright notice and this permission notice shall be included in\n'
+        '// all copies or substantial portions of the Software.\n'
+        '//\n'
+        '// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n'
+        '// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n'
+        '// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\n'
+        '// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n'
+        '// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING\n'
+        '// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS\n'
+        '// IN THE SOFTWARE.\n'
+        '//------------------------------------------------------------------------------\n'
+        '// This file is auto-generated by ci/gendoc.py\n'
+        '//------------------------------------------------------------------------------\n'
+         % time.gmtime().tm_year
+    )
+    out.write('#include "documentation.h"\n')
+    out.write('namespace dt {\n')
+    out.write('\n\n')
+
+
+def write_outro(out):
+    out.write('\n\n')
+    out.write('}\n')
+
+
+def write_variable(out, variable, content):
+    out.write("const char* %s =" % variable)
+    if content:
+        out.write('\n')
+        out.write('R"(')
+        out.write(content)
+        out.write(')";\n')
+    else:
+        out.write(" nullptr;\n")
+    out.write('\n\n')

--- a/ci/xbuild/logger.py
+++ b/ci/xbuild/logger.py
@@ -52,6 +52,7 @@ class Logger0:
     def report_deduplicated(self, files): pass
     def report_destdir(self, dd): pass
     def report_full_rebuild(self): pass
+    def report_generating_docs(self, docfile): pass
     def report_include_dir(self, dd): pass
     def report_includes(self, inlcudes): pass
     def report_lib_dir(self, dd): pass
@@ -143,6 +144,11 @@ class Logger1(Logger0):
     def report_output_file(self, filename):
         self._output_file = filename
 
+    def report_generating_docs(self, docfile):
+        msg = "Generating documentation %s" % docfile
+        print("\r\x1B[90m" + msg + "\x1B[m\x1B[K")
+        self._redraw()
+
     def _redraw(self):
         line = "\r\x1B[90m" + self._msg
         if self._msg == "Compiling":
@@ -183,6 +189,9 @@ class Logger2(Logger0):
 
     def report_output_file(self, filename):
         self.info("Output file name will be `%r`" % filename)
+
+    def report_generating_docs(self, docfile):
+        self.info("Generating documentation %s" % docfile)
 
     def step_compile(self, files):
         if files:
@@ -293,6 +302,9 @@ class Logger3(Logger0):
 
     def report_full_rebuild(self):
         self.info("All source files will be recompiled")
+
+    def report_generating_docs(self, docfile):
+        self.info("Generating documentation %s" % docfile)
 
     def report_include_dir(self, dd):
         self.info("Added include directory %r" % dd)

--- a/docs/_ext/xfunction.py
+++ b/docs/_ext/xfunction.py
@@ -40,13 +40,19 @@ This makes several directives available for use in the .rst files:
 
     .. xmethod: datatable.Frame.cbind
         :src: c/frame/cbind.cc Frame::cbind
-        :doc: c/frame/cbind.cc doc_cbind
         :tests: tests/frame/test-cbind.py
+        :cvar: doc_Frame_cbind
+        :signature: cbind(*frames)
+
+        content...
 
     .. xclass: datatable.Frame
 
 The :src: option is required, but it may be "--" to indicate that the object
 has no identifiable source (use sparingly!).
+
+The :cvar: option has no effect on the output, but it helps auto-generator
+to find which documentation belongs where.
 """
 import pathlib
 import re
@@ -227,6 +233,8 @@ class XobjectDirective(SphinxDirective):
         "deletable": directives.unchanged,
         "noindex": directives.unchanged,
         "qual-type": directives.unchanged,
+        "cvar": directives.unchanged,
+        "signature": directives.unchanged,
     }
 
     def __init__(self, *args):
@@ -243,6 +251,7 @@ class XobjectDirective(SphinxDirective):
         self.tests_github_url = None
         self.qualifier = None
         self.qualifier_reftype = None
+        self.signature = None
 
 
     def run(self):
@@ -258,6 +267,7 @@ class XobjectDirective(SphinxDirective):
         self._parse_option_settable()
         self._parse_option_deletable()
         self._parse_option_qualtype()
+        self._parse_option_signature()
         self._register_title_override()
 
         if self.src_fnname:
@@ -266,9 +276,10 @@ class XobjectDirective(SphinxDirective):
         if self.src_fnname2:
             self.src2_github_url = self._locate_fn_source(
                                     self.src_file, self.src_fnname2)
-        self._extract_docs_from_source()
-        if self.content:
-            self.doc_lines.extend(self.content)
+        if not self.signature:
+            self._extract_docs_from_source()
+            if self.content:
+                self.doc_lines.extend(self.content)
         self._parse_docstring()
 
         return self._generate_nodes()
@@ -369,7 +380,9 @@ class XobjectDirective(SphinxDirective):
         `self.src_file` and `self.src_fnname`.
         """
         if "src" not in self.options:
-            raise self.error("Option :src: is required for ..%s directive"
+            raise self.error("Option :src: is required for ..%s directive. "
+                             "If the object's source cannot be reasonably "
+                             "given, write `:src: --`."
                              % self.name)
         src = self.options["src"].strip()
         if src == '--':
@@ -484,6 +497,16 @@ class XobjectDirective(SphinxDirective):
         if not reftype:
             reftype = "class" if self.name in ["xmethod", "xattr"] else "module"
         self.qualifier_reftype = reftype
+
+
+    def _parse_option_signature(self):
+        if "signature" not in self.options:
+            return
+        if "doc" in self.options:
+            raise self.error("Option :signature: cannot be used together with "
+                             "option :doc:")
+        self.signature = self.options['signature'].strip()
+
 
 
     #---------------------------------------------------------------------------
@@ -607,14 +630,21 @@ class XobjectDirective(SphinxDirective):
         that, defers parsing of each part to :meth:`_parse_parameters`
         and :meth:`_parse_body` respectively.
         """
-        if (self.name in ["xdata", "xattr", "xclass", "xexc"] or
-                "--" not in self.doc_lines):
-            self.parsed_params = []
-            self._parse_body(self.doc_lines)
-            return
+        if self.signature:
+            signature = self.signature
+            body = self.content
 
-        iddash = self.doc_lines.index("--")
-        signature = "\n".join(self.doc_lines.data[:iddash])
+        else:
+            if (self.name in ["xdata", "xattr", "xclass", "xexc"] or
+                    "--" not in self.doc_lines):
+                self.parsed_params = []
+                self._parse_body(self.doc_lines)
+                return
+
+            iddash = self.doc_lines.index("--")
+            signature = "\n".join(self.doc_lines.data[:iddash])
+            body = self.doc_lines[iddash + 1:]
+
         if not (signature.startswith(self.obj_name + "(") and
                 signature.endswith(")")):
             raise self.error("Unexpected docstring: should have started with "
@@ -623,7 +653,7 @@ class XobjectDirective(SphinxDirective):
         # strip objname and the parentheses
         signature = signature[(len(self.obj_name) + 1):-1]
         self._parse_parameters(signature)
-        self._parse_body(self.doc_lines[iddash + 1:])
+        self._parse_body(body)
 
 
     def _parse_parameters(self, sig):

--- a/docs/api/frame/head.rst
+++ b/docs/api/frame/head.rst
@@ -1,4 +1,44 @@
 
 .. xmethod:: datatable.Frame.head
     :src: src/core/frame/py_frame.cc Frame::head
-    :doc: src/core/frame/py_frame.cc doc_head
+    :cvar: doc_Frame_head
+    :signature: head(self, n=10)
+
+    Return the first `n` rows of the frame.
+
+    If the number of rows in the frame is less than `n`, then all rows
+    are returned.
+
+    This is a convenience function and it is equivalent to `DT[:n, :]`.
+
+
+    Parameters
+    ----------
+    n : int
+        The maximum number of rows to return, 10 by default. This number
+        cannot be negative.
+
+    return: Frame
+        A frame containing the first up to `n` rows from the original
+        frame, and same columns.
+
+
+    Examples
+    --------
+    >>> DT = dt.Frame(A=["apples", "bananas", "cherries", "dates",
+    ...                  "eggplants", "figs", "grapes", "kiwi"])
+    >>> DT.head(4)
+       | A
+       | str32
+    -- + --------
+     0 | apples
+     1 | bananas
+     2 | cherries
+     3 | dates
+    [4 rows x 1 column]
+
+
+    See also
+    --------
+    - :meth:`.tail` -- return the last `n` rows of the Frame.
+

--- a/docs/api/frame/tail.rst
+++ b/docs/api/frame/tail.rst
@@ -1,4 +1,43 @@
 
 .. xmethod:: datatable.Frame.tail
     :src: src/core/frame/py_frame.cc Frame::tail
-    :doc: src/core/frame/py_frame.cc doc_tail
+    :cvar: doc_Frame_tail
+    :signature: tail(self, n=10)
+
+    Return the last `n` rows of the frame.
+
+    If the number of rows in the frame is less than `n`, then all rows
+    are returned.
+
+    This is a convenience function and it is equivalent to `DT[-n:, :]`
+    (except when `n` is 0).
+
+    Parameters
+    ----------
+    n : int
+        The maximum number of rows to return, 10 by default. This number
+        cannot be negative.
+
+    return: Frame
+        A frame containing the last up to `n` rows from the original
+        frame, and same columns.
+
+
+    Examples
+    --------
+
+    >>> DT = dt.Frame(A=["apples", "bananas", "cherries", "dates",
+    ...                  "eggplants", "figs", "grapes", "kiwi"])
+    >>> DT.tail(3)
+       | A
+       | str32
+    -- + ------
+     0 | figs
+     1 | grapes
+     2 | kiwi
+    [3 rows x 1 column]
+
+
+    See also
+    --------
+    - :meth:`.head` -- return the first `n` rows of the Frame.

--- a/src/core/documentation.h
+++ b/src/core/documentation.h
@@ -1,0 +1,32 @@
+//------------------------------------------------------------------------------
+// Copyright 2021 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#ifndef dt_DOCUMENTATION_h
+#define dt_DOCUMENTATION_h
+namespace dt {
+
+
+extern const char* doc_Frame_head;
+extern const char* doc_Frame_tail;
+
+
+}  // namespace dt
+#endif

--- a/src/core/frame/py_frame.cc
+++ b/src/core/frame/py_frame.cc
@@ -21,6 +21,7 @@
 //------------------------------------------------------------------------------
 #include <algorithm>          // std::min
 #include <iostream>
+#include "documentation.h"
 #include "frame/py_frame.h"
 #include "ltype.h"
 #include "python/_all.h"
@@ -38,49 +39,6 @@ PyObject* Frame_Type = nullptr;
 // head()
 //------------------------------------------------------------------------------
 
-static const char* doc_head =
-R"(head(self, n=10)
---
-
-Return the first `n` rows of the frame.
-
-If the number of rows in the frame is less than `n`, then all rows
-are returned.
-
-This is a convenience function and it is equivalent to `DT[:n, :]`.
-
-Parameters
-----------
-n : int
-    The maximum number of rows to return, 10 by default. This number
-    cannot be negative.
-
-return: Frame
-    A frame containing the first up to `n` rows from the original
-    frame, and same columns.
-
-
-Examples
---------
-
->>> DT = dt.Frame(A=["apples", "bananas", "cherries", "dates",
-...                  "eggplants", "figs", "grapes", "kiwi"])
->>> DT.head(4)
-   | A
-   | str32
--- + --------
- 0 | apples
- 1 | bananas
- 2 | cherries
- 3 | dates
-[4 rows x 1 column]
-
-
-See also
---------
-- :meth:`.tail` -- return the last `n` rows of the Frame.
-)";
-
 oobj Frame::head(const XArgs& args) {
   size_t n = std::min(args[0].to<size_t>(10),
                       dt->nrows());
@@ -90,7 +48,7 @@ oobj Frame::head(const XArgs& args) {
 
 DECLARE_METHOD(&Frame::head)
     ->name("head")
-    ->docs(doc_head)
+    ->docs(dt::doc_Frame_head)
     ->n_positional_args(1)
     ->arg_names({"n"});
 
@@ -100,49 +58,6 @@ DECLARE_METHOD(&Frame::head)
 //------------------------------------------------------------------------------
 // tail()
 //------------------------------------------------------------------------------
-
-static const char* doc_tail =
-R"(tail(self, n=10)
---
-
-Return the last `n` rows of the frame.
-
-If the number of rows in the frame is less than `n`, then all rows
-are returned.
-
-This is a convenience function and it is equivalent to `DT[-n:, :]`
-(except when `n` is 0).
-
-Parameters
-----------
-n : int
-    The maximum number of rows to return, 10 by default. This number
-    cannot be negative.
-
-return: Frame
-    A frame containing the last up to `n` rows from the original
-    frame, and same columns.
-
-
-Examples
---------
-
->>> DT = dt.Frame(A=["apples", "bananas", "cherries", "dates",
-...                  "eggplants", "figs", "grapes", "kiwi"])
->>> DT.tail(3)
-   | A
-   | str32
--- + ------
- 0 | figs
- 1 | grapes
- 2 | kiwi
-[3 rows x 1 column]
-
-
-See also
---------
-- :meth:`.head` -- return the first `n` rows of the Frame.
-)";
 
 oobj Frame::tail(const XArgs& args) {
   size_t n = std::min(args[0].to<size_t>(10),
@@ -155,7 +70,7 @@ oobj Frame::tail(const XArgs& args) {
 
 DECLARE_METHOD(&Frame::tail)
     ->name("tail")
-    ->docs(doc_tail)
+    ->docs(dt::doc_Frame_tail)
     ->n_positional_args(1)
     ->arg_names({"n"});
 


### PR DESCRIPTION
This PR changes the way we write documentation: instead of embedding the API docs into the code, the documentation can now be written entirely in `doc/` folder, and it will be brought into C++ through an automatic process.

Specifically, the proposed process is as follows:
  - the API documentation is written entirely within the `.rst` files in the `docs/` folder;
  - the ``.. xfunction`` (&co) directive now has an additional parameter `:cvar:` which describes where this documentation should be copied in order to be available from C++;
  - the auto-generator script, which runs automatically on `make build` (or `make debug`), copies the content of the xfunction directive into the specified variable name. The name must be declared in the "documentation.h" file;
  - test `test_documentation_h()` verifies that the correspondence is unbroken: that each variable that is declared in "documentation.h" has a corresponding ":cvar:" declaration within the documentation, and vice versa.

The advantages of the new approach are the following:
  - the documentation is declared within `.rst` files, which allows a text editor to properly highlight the syntax;
  - updating existing documentation is now easier, as it doesn't require editing source code files;
  - updating documentation is now less scary for newcomers;
  - the code base is not over-encumbered with documentation text, and can now have a smaller LoC count overall;
  - it is now possible to extend this approach and write additional filters that would pre-process the RST text, converting it into a format that might be more suitable for pure-text python.

This PR only adds a mechanism for writing new documentation; the actual documentation migration can happen later on. Currently, only 2 docstrings were converted into the new format: `Frame.head()` and `Frame.tail()`, as a proof of concept.
