### PR TITLE
Add Travis build for macOS arm64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,3 +69,5 @@ script:
   - pip install -r requirements_extra.txt
   - python -m pytest -ra --showlocals -Werror tests
 
+
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,14 @@ jobs:
         - DT_HARNESS=Travis
         - CXX=$LLVM10/bin/clang-10
 
+    - name: "Python 3.8 on macOS arm64"
+      python: 3.8
+      os: osx
+      arch: arm64
+      compiler: gcc
+      env:
+        - DT_HARNESS=Travis
+
 cache:
   pip: true
   ccache: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,3 +68,4 @@ script:
   - pip install -r requirements_docs.txt
   - pip install -r requirements_extra.txt
   - python -m pytest -ra --showlocals -Werror tests
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,4 +69,3 @@ script:
   - pip install -r requirements_extra.txt
   - python -m pytest -ra --showlocals -Werror tests
 
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,4 +68,3 @@ script:
   - pip install -r requirements_docs.txt
   - pip install -r requirements_extra.txt
   - python -m pytest -ra --showlocals -Werror tests
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,4 +70,3 @@ script:
   - python -m pytest -ra --showlocals -Werror tests
 
 
-


### PR DESCRIPTION
Try to build on Travis on macOS arm64 architecture, see #3003.