### PR TITLE
Miscellaneous time64 functionality

### DIFF
--- a/src/core/column/const.cc
+++ b/src/core/column/const.cc
@@ -165,6 +165,7 @@ Column Const_ColumnImpl::from_1row_column(const Column& col) {
     case SType::STR32:   return _make<ConstString_ColumnImpl, SType::STR32>(col);
     case SType::STR64:   return _make<ConstString_ColumnImpl, SType::STR64>(col);
     case SType::DATE32:  return _make<ConstInt_ColumnImpl, SType::DATE32>(col);
+    case SType::TIME64:  return _make<ConstInt_ColumnImpl, SType::TIME64>(col);
     default:
       throw NotImplError() << "Cannot convert 1-row column of stype "
                            << col.stype();

--- a/src/core/column/latent.cc
+++ b/src/core/column/latent.cc
@@ -117,6 +117,7 @@ ColumnImpl* Latent_ColumnImpl::vivify(bool to_memory) const {
     case SType::INT16:   new (ptr) SentinelFw_ColumnImpl<int16_t>(std::move(new_pcol)); break;
     case SType::DATE32:
     case SType::INT32:   new (ptr) SentinelFw_ColumnImpl<int32_t>(std::move(new_pcol)); break;
+    case SType::TIME64:
     case SType::INT64:   new (ptr) SentinelFw_ColumnImpl<int64_t>(std::move(new_pcol)); break;
     case SType::FLOAT32: new (ptr) SentinelFw_ColumnImpl<float>(std::move(new_pcol)); break;
     case SType::FLOAT64: new (ptr) SentinelFw_ColumnImpl<double>(std::move(new_pcol)); break;

--- a/src/core/column/npmasked.cc
+++ b/src/core/column/npmasked.cc
@@ -67,6 +67,7 @@ void NpMasked_ColumnImpl::materialize(Column& out, bool to_memory) {
       case SType::INT16:   return _apply_mask<int16_t>(out);
       case SType::DATE32:
       case SType::INT32:   return _apply_mask<int32_t>(out);
+      case SType::TIME64:
       case SType::INT64:   return _apply_mask<int64_t>(out);
       case SType::FLOAT32: return _apply_mask<float>(out);
       case SType::FLOAT64: return _apply_mask<double>(out);

--- a/src/core/expr/fbinary/fexpr__eq__.cc
+++ b/src/core/expr/fbinary/fexpr__eq__.cc
@@ -74,6 +74,7 @@ Column FExpr__eq__::evaluate1(Column&& lcol, Column&& rcol) const {
       case SType::INT16:   return Column(new Isna_ColumnImpl<int16_t>(std::move(lcol)));
       case SType::DATE32:
       case SType::INT32:   return Column(new Isna_ColumnImpl<int32_t>(std::move(lcol)));
+      case SType::TIME64:
       case SType::INT64:   return Column(new Isna_ColumnImpl<int64_t>(std::move(lcol)));
       case SType::FLOAT32: return Column(new Isna_ColumnImpl<float>(std::move(lcol)));
       case SType::FLOAT64: return Column(new Isna_ColumnImpl<double>(std::move(lcol)));
@@ -88,6 +89,7 @@ Column FExpr__eq__::evaluate1(Column&& lcol, Column&& rcol) const {
       case SType::INT16:   return make<int16_t>(std::move(lcol), std::move(rcol), type0);
       case SType::DATE32:
       case SType::INT32:   return make<int32_t>(std::move(lcol), std::move(rcol), type0);
+      case SType::TIME64:
       case SType::INT64:   return make<int64_t>(std::move(lcol), std::move(rcol), type0);
       case SType::FLOAT32: return make<float>(std::move(lcol), std::move(rcol), type0);
       case SType::FLOAT64: return make<double>(std::move(lcol), std::move(rcol), type0);

--- a/src/core/expr/fbinary/fexpr__ge__.cc
+++ b/src/core/expr/fbinary/fexpr__ge__.cc
@@ -67,6 +67,7 @@ Column FExpr__ge__::evaluate1(Column&& lcol, Column&& rcol) const {
     case SType::INT16:   type0 = dt::Type::int32(); FALLTHROUGH;
     case SType::DATE32:
     case SType::INT32:   return make<int32_t>(std::move(lcol), std::move(rcol), type0);
+    case SType::TIME64:
     case SType::INT64:   return make<int64_t>(std::move(lcol), std::move(rcol), type0);
     case SType::FLOAT32: return make<float>(std::move(lcol), std::move(rcol), type0);
     case SType::FLOAT64: return make<double>(std::move(lcol), std::move(rcol), type0);

--- a/src/core/expr/fbinary/fexpr__gt__.cc
+++ b/src/core/expr/fbinary/fexpr__gt__.cc
@@ -67,6 +67,7 @@ Column FExpr__gt__::evaluate1(Column&& lcol, Column&& rcol) const {
     case SType::INT16:   type0 = dt::Type::int32(); FALLTHROUGH;
     case SType::DATE32:
     case SType::INT32:   return make<int32_t>(std::move(lcol), std::move(rcol), type0);
+    case SType::TIME64:
     case SType::INT64:   return make<int64_t>(std::move(lcol), std::move(rcol), type0);
     case SType::FLOAT32: return make<float>(std::move(lcol), std::move(rcol), type0);
     case SType::FLOAT64: return make<double>(std::move(lcol), std::move(rcol), type0);

--- a/src/core/expr/fbinary/fexpr__le__.cc
+++ b/src/core/expr/fbinary/fexpr__le__.cc
@@ -67,6 +67,7 @@ Column FExpr__le__::evaluate1(Column&& lcol, Column&& rcol) const {
     case SType::INT16:   type0 = dt::Type::int32();  FALLTHROUGH;
     case SType::DATE32:
     case SType::INT32:   return make<int32_t>(std::move(lcol), std::move(rcol), type0);
+    case SType::TIME64:
     case SType::INT64:   return make<int64_t>(std::move(lcol), std::move(rcol), type0);
     case SType::FLOAT32: return make<float>(std::move(lcol), std::move(rcol), type0);
     case SType::FLOAT64: return make<double>(std::move(lcol), std::move(rcol), type0);

--- a/src/core/expr/fbinary/fexpr__lt__.cc
+++ b/src/core/expr/fbinary/fexpr__lt__.cc
@@ -67,6 +67,7 @@ Column FExpr__lt__::evaluate1(Column&& lcol, Column&& rcol) const {
     case SType::INT16:   type0 = dt::Type::int32();  FALLTHROUGH;
     case SType::DATE32:
     case SType::INT32:   return make<int32_t>(std::move(lcol), std::move(rcol), type0);
+    case SType::TIME64:
     case SType::INT64:   return make<int64_t>(std::move(lcol), std::move(rcol), type0);
     case SType::FLOAT32: return make<float>(std::move(lcol), std::move(rcol), type0);
     case SType::FLOAT64: return make<double>(std::move(lcol), std::move(rcol), type0);

--- a/src/core/expr/fbinary/fexpr__ne__.cc
+++ b/src/core/expr/fbinary/fexpr__ne__.cc
@@ -67,6 +67,7 @@ Column FExpr__ne__::evaluate1(Column&& lcol, Column&& rcol) const {
     case SType::INT16:   return make<int16_t>(std::move(lcol), std::move(rcol), type0);
     case SType::DATE32:
     case SType::INT32:   return make<int32_t>(std::move(lcol), std::move(rcol), type0);
+    case SType::TIME64:
     case SType::INT64:   return make<int64_t>(std::move(lcol), std::move(rcol), type0);
     case SType::FLOAT32: return make<float>(std::move(lcol), std::move(rcol), type0);
     case SType::FLOAT64: return make<double>(std::move(lcol), std::move(rcol), type0);

--- a/src/core/expr/head_reduce_unary.cc
+++ b/src/core/expr/head_reduce_unary.cc
@@ -700,6 +700,11 @@ static Column compute_mean(Column&& arg, const Groupby& gby) {
     case SType::INT64:   return _mean<int64_t>(std::move(arg), gby);
     case SType::FLOAT32: return _mean<float>  (std::move(arg), gby);
     case SType::FLOAT64: return _mean<double> (std::move(arg), gby);
+    case SType::TIME64: {
+      auto col = _mean<int64_t>(std::move(arg), gby);
+      col.cast_inplace(SType::TIME64);
+      return col;
+    }
     default: throw _error("mean", arg.stype());
   }
 }
@@ -1010,6 +1015,7 @@ static Column compute_count(Column&& arg, const Groupby& gby) {
     case SType::INT16:   return _count<int16_t>(std::move(arg), gby);
     case SType::DATE32:
     case SType::INT32:   return _count<int32_t>(std::move(arg), gby);
+    case SType::TIME64:
     case SType::INT64:   return _count<int64_t>(std::move(arg), gby);
     case SType::FLOAT32: return _count<float>(std::move(arg), gby);
     case SType::FLOAT64: return _count<double>(std::move(arg), gby);
@@ -1081,6 +1087,7 @@ static Column compute_gcount(Column&& arg, const Groupby& gby) {
     case SType::INT16:   return _gcount<int16_t>(std::move(arg), gby);
     case SType::DATE32:
     case SType::INT32:   return _gcount<int32_t>(std::move(arg), gby);
+    case SType::TIME64:
     case SType::INT64:   return _gcount<int64_t>(std::move(arg), gby);
     case SType::FLOAT32: return _gcount<float>(std::move(arg), gby);
     case SType::FLOAT64: return _gcount<double>(std::move(arg), gby);
@@ -1317,6 +1324,7 @@ static Column compute_minmax(Column&& arg, const Groupby& gby) {
     case SType::INT16:   return _minmax<int16_t, MIN>(st, std::move(arg), gby);
     case SType::DATE32:
     case SType::INT32:   return _minmax<int32_t, MIN>(st, std::move(arg), gby);
+    case SType::TIME64:
     case SType::INT64:   return _minmax<int64_t, MIN>(st, std::move(arg), gby);
     case SType::FLOAT32: return _minmax<float, MIN>(st, std::move(arg), gby);
     case SType::FLOAT64: return _minmax<double, MIN>(st, std::move(arg), gby);

--- a/src/core/frame/join.cc
+++ b/src/core/frame/join.cc
@@ -312,6 +312,7 @@ static void _init_comparators() {
   size_t str32 = static_cast<size_t>(dt::SType::STR32);
   size_t str64 = static_cast<size_t>(dt::SType::STR64);
   size_t dat32 = static_cast<size_t>(dt::SType::DATE32);
+  size_t tim64 = static_cast<size_t>(dt::SType::TIME64);
   cmps[bool8][bool8] = FwCmp<int8_t, int8_t>::make;
   cmps[bool8][int08] = FwCmp<int8_t, int8_t>::make;
   cmps[bool8][int16] = FwCmp<int8_t, int16_t>::make;
@@ -366,6 +367,7 @@ static void _init_comparators() {
   cmps[str64][str32] = StringCmp::make;
   cmps[str64][str64] = StringCmp::make;
   cmps[dat32][dat32] = FwCmp<int32_t, int32_t>::make;
+  cmps[tim64][tim64] = FwCmp<int64_t, int64_t>::make;
 }
 
 

--- a/src/core/models/aggregate.cc
+++ b/src/core/models/aggregate.cc
@@ -342,6 +342,7 @@ void Aggregator<T>::aggregate(DataTable* dt_in,
         case dt::SType::INT64:   contcol = make_inf2na_casted_column<int64_t, T>(col, agg_stype); break;
         case dt::SType::FLOAT32: contcol = make_inf2na_casted_column<float, T>(col, agg_stype); break;
         case dt::SType::FLOAT64: contcol = make_inf2na_casted_column<double, T>(col, agg_stype); break;
+        case dt::SType::TIME64:
         case dt::SType::DATE32:  contcol = col.cast(agg_stype); break;
         case dt::SType::STR32:
         case dt::SType::STR64:   is_continuous = false;

--- a/src/core/models/label_encode.cc
+++ b/src/core/models/label_encode.cc
@@ -48,6 +48,7 @@ void label_encode(const Column& col, dtptr& dt_labels, dtptr& dt_encoded,
                            col, dt_labels, dt_encoded, is_binomial
                           );
                          break;
+    case SType::TIME64:
     case SType::INT64:   label_encode_fw<SType::INT64>(
                            col, dt_labels, dt_encoded, is_binomial
                          );

--- a/src/core/sort.cc
+++ b/src/core/sort.cc
@@ -690,6 +690,7 @@ class SortContext {
       case dt::SType::INT16:   _initI<ASC, int16_t, uint16_t>(); break;
       case dt::SType::DATE32:
       case dt::SType::INT32:   _initI<ASC, int32_t, uint32_t>(); break;
+      case dt::SType::TIME64:
       case dt::SType::INT64:   _initI<ASC, int64_t, uint64_t>(); break;
       case dt::SType::FLOAT32: _initF<ASC, uint32_t>(); break;
       case dt::SType::FLOAT64: _initF<ASC, uint64_t>(); break;

--- a/src/core/sort/sorter.cc
+++ b/src/core/sort/sorter.cc
@@ -49,6 +49,7 @@ static std::unique_ptr<SSorter<T>> _make_sorter(const Column& col)
     case SType::INT16:   return so(new Sorter_Int<T, ASC, int16_t>(col));
     case SType::DATE32:
     case SType::INT32:   return so(new Sorter_Int<T, ASC, int32_t>(col));
+    case SType::TIME64:
     case SType::INT64:   return so(new Sorter_Int<T, ASC, int64_t>(col));
     case SType::FLOAT32: return so(new Sorter_Float<T, ASC, float>(col));
     case SType::FLOAT64: return so(new Sorter_Float<T, ASC, double>(col));

--- a/tests/types/test-time64.py
+++ b/tests/types/test-time64.py
@@ -612,3 +612,21 @@ def test_sort():
     DT = dt.Frame([d(2010, 11, 5, i*17 % 23, 0, 0) for i in range(23)])
     assert_equals(DT.sort(0),
                   dt.Frame([d(2010, 11, 5, i, 0, 0) for i in range(23)]))
+
+
+def test_compare():
+    DT = dt.Frame(A=[d(2010, 11, 5, i*17 % 11, 0, 0) for i in range(11)])
+    DT['B'] = DT.sort(0)
+    RES = DT[:, {"EQ": (f.A == f.B),
+                 "NE": (f.A != f.B),
+                 "LT": (f.A < f.B),
+                 "LE": (f.A <= f.B),
+                 "GE": (f.A >= f.B),
+                 "GT": (f.A > f.B)}]
+    assert_equals(RES, dt.Frame(EQ = [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                NE = [0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+                                LT = [0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1],
+                                LE = [1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1],
+                                GE = [1, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0],
+                                GT = [0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0],
+                                type=dt.bool8))

--- a/tests/types/test-time64.py
+++ b/tests/types/test-time64.py
@@ -630,3 +630,9 @@ def test_compare():
                                 GE = [1, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0],
                                 GT = [0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0],
                                 type=dt.bool8))
+
+
+def test_repeat():
+    DT = dt.Frame(A=[d(2001, 10, 12, 0, 0, 0)])
+    DT = dt.repeat(DT, 5)
+    assert_equals(DT, dt.Frame(A=[d(2001, 10, 12, 0, 0, 0)] * 5))

--- a/tests/types/test-time64.py
+++ b/tests/types/test-time64.py
@@ -596,3 +596,19 @@ def test_rbind2():
     EXP = dt.Frame([5, 7, 9] * 2)
     EXP[0] = dt.Type.time64
     assert_equals(RES, EXP)
+
+
+def test_materialize():
+    DT = dt.Frame([d(2021, 4, 1, i, 0, 0) for i in range(24)])
+    assert DT.type == dt.Type.time64
+    RES = DT[::2, :]
+    EXP = dt.Frame([d(2021, 4, 1, i, 0, 0) for i in range(24)[::2]])
+    assert_equals(RES, EXP)
+    RES.materialize()
+    assert_equals(RES, EXP)
+
+
+def test_sort():
+    DT = dt.Frame([d(2010, 11, 5, i*17 % 23, 0, 0) for i in range(23)])
+    assert_equals(DT.sort(0),
+                  dt.Frame([d(2010, 11, 5, i, 0, 0) for i in range(23)]))

--- a/tests/types/test-time64.py
+++ b/tests/types/test-time64.py
@@ -636,3 +636,54 @@ def test_repeat():
     DT = dt.Frame(A=[d(2001, 10, 12, 0, 0, 0)])
     DT = dt.repeat(DT, 5)
     assert_equals(DT, dt.Frame(A=[d(2001, 10, 12, 0, 0, 0)] * 5))
+
+
+def test_reducers():
+    DT = dt.Frame(TIME = [d(2001, 7, 12, 0, 0, 0),
+                          d(2005, 3, 14, 15, 9, 26),
+                          None,
+                          d(2007, 11, 2, 19, 7, 38),
+                          d(1965, 6, 19, 2, 17, 7),
+                          d(2004, 4, 18, 12, 3, 31)])
+    RES = DT[:, {"count": dt.count(f.TIME),
+                 "min": dt.min(f.TIME),
+                 "max": dt.max(f.TIME),
+                 "mean": dt.mean(f.TIME),
+                 "first": dt.first(f.TIME),
+                 "last": dt.last(f.TIME)}]
+    assert_equals(
+        RES,
+        dt.Frame(count = [5] / dt.int64,
+                 min = [d(1965, 6, 19, 2, 17, 7)],
+                 max = [d(2007, 11, 2, 19, 7, 38)],
+                 mean = [d(1996, 11, 12, 4, 55, 32, 400000)],
+                 first = [d(2001, 7, 12, 0, 0, 0)],
+                 last = [d(2004, 4, 18, 12, 3, 31)])
+    )
+
+
+def test_groupby():
+    DT = dt.Frame(A = [1, 1, 1, 2, 2, 2],
+                  B = [d(2001, 7, 12, 0, 0, 0),
+                       d(2005, 3, 14, 15, 9, 26),
+                       None,
+                       d(2007, 11, 2, 19, 7, 38),
+                       d(1965, 6, 19, 2, 17, 7),
+                       d(2004, 4, 18, 12, 3, 31)])
+    RES = DT[:, {"count": dt.count(f.B),
+                 "min": dt.min(f.B),
+                 "max": dt.max(f.B),
+                 "mean": dt.mean(f.B),
+                 "first": dt.first(f.B),
+                 "last": dt.last(f.B)}, dt.by(f.A)]
+    assert_equals(
+        RES,
+        dt.Frame(A = [1, 2],
+                 count = [2, 3] / dt.int64,
+                 min = [d(2001, 7, 12, 0, 0, 0), d(1965, 6, 19, 2, 17, 7)],
+                 max = [d(2005, 3, 14, 15, 9, 26), d(2007, 11, 2, 19, 7, 38)],
+                 mean = [d(2003, 5, 13, 19, 34, 43), d(1992, 7, 13, 19, 9, 25, 333333)],
+                 first = [d(2001, 7, 12, 0, 0, 0), d(2007, 11, 2, 19, 7, 38)],
+                 last = [None, d(2004, 4, 18, 12, 3, 31)]
+                 )
+    )


### PR DESCRIPTION
Add tests, and make sure the following operations work with time64 columns:
  - `repeat()` function;
  - `materialize()`;
  - `sort()`;
  - relational operators `==`, `>`, etc;
  - reeducer functions `min()`, `max()`, `count()`, `first()`, `last()`, and `mean()` -- both with and without a groupby.