### PR TITLE
Force-create a column into date32 and time64 types

### DIFF
--- a/src/core/column/cast_to_date32.cc
+++ b/src/core/column/cast_to_date32.cc
@@ -110,7 +110,7 @@ bool CastObjToDate32_ColumnImpl::get_element(size_t i, int32_t* out) const {
   py::oobj value;
   bool isvalid = arg_.get_element(i, &value);
   if (isvalid) {
-    return value.parse_date(out);
+    return value.parse_date_as_date(out);
   }
   return false;
 }

--- a/src/core/column/cast_to_date32.cc
+++ b/src/core/column/cast_to_date32.cc
@@ -110,7 +110,10 @@ bool CastObjToDate32_ColumnImpl::get_element(size_t i, int32_t* out) const {
   py::oobj value;
   bool isvalid = arg_.get_element(i, &value);
   if (isvalid) {
-    return value.parse_date_as_date(out);
+    return value.parse_date_as_date(out) ||
+           value.parse_int_as_date(out) ||
+           value.parse_datetime_as_date(out) ||
+           value.parse_string_as_date(out);
   }
   return false;
 }

--- a/src/core/column/cast_to_date32.cc
+++ b/src/core/column/cast_to_date32.cc
@@ -109,13 +109,11 @@ bool CastObjToDate32_ColumnImpl::allow_parallel_access() const {
 bool CastObjToDate32_ColumnImpl::get_element(size_t i, int32_t* out) const {
   py::oobj value;
   bool isvalid = arg_.get_element(i, &value);
-  if (isvalid) {
-    return value.parse_date_as_date(out) ||
-           value.parse_int_as_date(out) ||
-           value.parse_datetime_as_date(out) ||
-           value.parse_string_as_date(out);
-  }
-  return false;
+  return isvalid &&
+         (value.parse_date_as_date(out) ||
+          value.parse_int_as_date(out) ||
+          value.parse_datetime_as_date(out) ||
+          value.parse_string_as_date(out));
 }
 
 

--- a/src/core/column/cast_to_time64.cc
+++ b/src/core/column/cast_to_time64.cc
@@ -52,7 +52,7 @@ bool CastObjToTime64_ColumnImpl::get_element(size_t i, int64_t* out) const {
   bool isvalid = arg_.get_element(i, &value);
   if (isvalid) {
     return value.parse_datetime(out) ||
-           value.parse_date(out) ||
+           value.parse_date_as_time(out) ||
            false;
   }
   return false;

--- a/src/core/column/cast_to_time64.cc
+++ b/src/core/column/cast_to_time64.cc
@@ -51,7 +51,7 @@ bool CastObjToTime64_ColumnImpl::get_element(size_t i, int64_t* out) const {
   py::oobj value;
   bool isvalid = arg_.get_element(i, &value);
   if (isvalid) {
-    return value.parse_datetime(out) ||
+    return value.parse_datetime_as_time(out) ||
            value.parse_date_as_time(out) ||
            false;
   }

--- a/src/core/column/cast_to_time64.cc
+++ b/src/core/column/cast_to_time64.cc
@@ -50,12 +50,11 @@ bool CastObjToTime64_ColumnImpl::allow_parallel_access() const {
 bool CastObjToTime64_ColumnImpl::get_element(size_t i, int64_t* out) const {
   py::oobj value;
   bool isvalid = arg_.get_element(i, &value);
-  if (isvalid) {
-    return value.parse_datetime_as_time(out) ||
-           value.parse_date_as_time(out) ||
-           false;
-  }
-  return false;
+  return isvalid &&
+         (value.parse_datetime_as_time(out) ||
+          value.parse_date_as_time(out) ||
+          value.parse_int_as_time(out) ||
+          value.parse_string_as_time(out));
 }
 
 

--- a/src/core/column_from_python.cc
+++ b/src/core/column_from_python.cc
@@ -279,7 +279,7 @@ static Column force_as_real(const Column& inputcol)
 static size_t parse_as_date32(const Column& inputcol, Buffer& mbuf, size_t i0) {
   return parse_as_X<int32_t>(inputcol, mbuf, i0,
             [](const py::oobj& item, int32_t* out) {
-              return item.parse_date(out) ||
+              return item.parse_date_as_date(out) ||
                      item.parse_none(out);
             });
 }
@@ -322,7 +322,7 @@ static size_t parse_as_time64(const Column& inputcol, Buffer& mbuf, size_t i0) {
   return parse_as_X<int64_t>(inputcol, mbuf, i0,
             [](const py::oobj& item, int64_t* out) {
               return item.parse_datetime(out) ||
-                     item.parse_date(out) ||
+                     item.parse_date_as_time(out) ||
                      item.parse_none(out);
             });
 }

--- a/src/core/python/obj.cc
+++ b/src/core/python/obj.cc
@@ -559,6 +559,16 @@ bool _obj::parse_string_as_date(int32_t* out) const {
   return false;
 }
 
+bool _obj::parse_string_as_time(int64_t* out) const {
+  if (PyUnicode_Check(v)) {
+    Py_ssize_t str_size;
+    const char* str = PyUnicode_AsUTF8AndSize(v, &str_size);
+    if (!str) throw PyError();
+    return dt::read::parse_time64_iso(str, str + str_size, out);
+  }
+  return false;
+}
+
 
 
 

--- a/src/core/python/obj.cc
+++ b/src/core/python/obj.cc
@@ -507,7 +507,7 @@ bool _obj::parse_double(double* out) const {
 }
 
 
-bool _obj::parse_date(int32_t* out) const {
+bool _obj::parse_date_as_date(int32_t* out) const {
   if (py::odate::check(v)) {
     *out = py::odate::unchecked(v).get_days();
     return true;
@@ -515,7 +515,7 @@ bool _obj::parse_date(int32_t* out) const {
   return false;
 }
 
-bool _obj::parse_date(int64_t* out) const {
+bool _obj::parse_date_as_time(int64_t* out) const {
   constexpr int64_t SECONDS = 1000000000;
   constexpr int64_t DAYS = 24 * 3600 * SECONDS;
   if (py::odate::check(v)) {

--- a/src/core/python/obj.cc
+++ b/src/core/python/obj.cc
@@ -32,6 +32,7 @@
 #include "python/list.h"
 #include "python/obj.h"
 #include "python/string.h"
+#include "read/parsers/info.h"
 #include "stype.h"
 #include "types/py_type.h"
 #include "utils/macros.h"
@@ -423,6 +424,9 @@ bool _obj::parse_int(int8_t* out) const  { return _parse_int(v, out); }
 bool _obj::parse_int(int16_t* out) const { return _parse_int(v, out); }
 bool _obj::parse_int(int32_t* out) const { return _parse_int(v, out); }
 bool _obj::parse_int(int64_t* out) const { return _parse_int(v, out); }
+bool _obj::parse_int_as_date(int32_t* out) const { return _parse_int(v, out); }
+bool _obj::parse_int_as_time(int64_t* out) const { return _parse_int(v, out); }
+
 
 bool _obj::parse_int(double* out) const {
   if (PyLong_Check(v)) {
@@ -516,19 +520,41 @@ bool _obj::parse_date_as_date(int32_t* out) const {
 }
 
 bool _obj::parse_date_as_time(int64_t* out) const {
-  constexpr int64_t SECONDS = 1000000000;
-  constexpr int64_t DAYS = 24 * 3600 * SECONDS;
+  constexpr int64_t NANOSECONDS_PER_DAY = 24ll * 3600ll * 1000000000ll;
   if (py::odate::check(v)) {
-    *out = py::odate::unchecked(v).get_days() * DAYS;
+    *out = py::odate::unchecked(v).get_days() * NANOSECONDS_PER_DAY;
     return true;
   }
   return false;
 }
 
-bool _obj::parse_datetime(int64_t* out) const {
+bool _obj::parse_datetime_as_date(int32_t* out) const {
+  constexpr int64_t NANOSECONDS_PER_DAY = 24ll * 3600ll * 1000000000ll;
+  if (py::odatetime::check(v)) {
+    int64_t value = py::odatetime::unchecked(v).get_time();
+    if (value < 0) {
+      value -= NANOSECONDS_PER_DAY - 1;
+    }
+    *out = static_cast<int32_t>(value / NANOSECONDS_PER_DAY);
+    return true;
+  }
+  return false;
+}
+
+bool _obj::parse_datetime_as_time(int64_t* out) const {
   if (py::odatetime::check(v)) {
     *out = py::odatetime::unchecked(v).get_time();
     return true;
+  }
+  return false;
+}
+
+bool _obj::parse_string_as_date(int32_t* out) const {
+  if (PyUnicode_Check(v)) {
+    Py_ssize_t str_size;
+    const char* str = PyUnicode_AsUTF8AndSize(v, &str_size);
+    if (!str) throw PyError();
+    return dt::read::parse_date32_iso(str, str + str_size, out);
   }
   return false;
 }

--- a/src/core/python/obj.h
+++ b/src/core/python/obj.h
@@ -225,8 +225,8 @@ class _obj {
     bool parse_numpy_float(float*) const;
     bool parse_numpy_float(double*) const;
     bool parse_double(double*) const;
-    bool parse_date(int32_t*) const;
-    bool parse_date(int64_t*) const;
+    bool parse_date_as_date(int32_t*) const;
+    bool parse_date_as_time(int64_t*) const;
     bool parse_datetime(int64_t*) const;
 
     struct error_manager;  // see below

--- a/src/core/python/obj.h
+++ b/src/core/python/obj.h
@@ -217,6 +217,8 @@ class _obj {
     bool parse_int(int32_t*) const;
     bool parse_int(int64_t*) const;
     bool parse_int(double*) const;
+    bool parse_int_as_date(int32_t*) const;
+    bool parse_int_as_time(int64_t*) const;
     bool parse_numpy_bool(int8_t*) const;
     bool parse_numpy_int(int8_t*) const;
     bool parse_numpy_int(int16_t*) const;
@@ -227,7 +229,10 @@ class _obj {
     bool parse_double(double*) const;
     bool parse_date_as_date(int32_t*) const;
     bool parse_date_as_time(int64_t*) const;
-    bool parse_datetime(int64_t*) const;
+    bool parse_datetime_as_date(int32_t*) const;
+    bool parse_datetime_as_time(int64_t*) const;
+    bool parse_string_as_date(int32_t*) const;
+    bool parse_string_as_time(int64_t*) const;
 
     struct error_manager;  // see below
     int8_t      to_bool           (const error_manager& = _em0) const;

--- a/tests/types/test-date32.py
+++ b/tests/types/test-date32.py
@@ -60,13 +60,21 @@ def test_date32_create_from_python():
     assert DT.to_list() == [src]
 
 
-def test_date32_create_from_python_force():
-    DT = dt.Frame([18675, -100000, None, 0.75, 'hello'], stype='date32')
+def test_date32_create_from_string_list():
+    DT = dt.Frame(['1901-04-11', '1969-12-31', 'NaT', '2000-10-07', '2015-11-21'],
+                  type=dt.Type.date32)
+    assert DT.type == dt.Type.date32
+    assert DT.to_list() == [
+        [d(1901, 4, 11), d(1969, 12, 31), None, d(2000, 10, 7), d(2015, 11, 21)]
+    ]
+
+
+def test_date32_create_from_mixed_list():
+    DT = dt.Frame([18675, -100000, None, 0, 'hello'], type='date32')
     assert DT.type == dt.Type.date32
     assert DT.to_list() == [
         [d(2021, 2, 17), d(1696, 3, 17), None, d(1970, 1, 1), None]
     ]
-
 
 
 def test_date32_repr():

--- a/tests/types/test-time64.py
+++ b/tests/types/test-time64.py
@@ -91,6 +91,16 @@ def test_time64_create_from_mixed_list2():
                                 d(1999, 12, 31, 8, 30, 50)]))
 
 
+def test_time64_create_from_mixed_list3():
+    DT = dt.Frame(['2001-10-10 12:34:00',
+                   '2013-05-03T17:11:35.900',
+                   '1939-09-01T06:00:00'],
+                  type='time64')
+    assert_equals(DT, dt.Frame([d(2001, 10, 10, 12, 34, 0),
+                                d(2013, 5, 3, 17, 11, 35, 900000),
+                                d(1939, 9, 1, 6, 0, 0)]))
+
+
 
 #-------------------------------------------------------------------------------
 # Basic properties
@@ -480,12 +490,13 @@ def test_cast_date32_to_time64():
 
 def test_cast_object_to_time64():
     from datetime import date
-    DT = dt.Frame([d(2001, 1, 1, 12, 0, 0), date(2021, 10, 15), 6, None, dict],
+    DT = dt.Frame([d(2001, 1, 1, 12, 0, 0), date(2021, 10, 15), 6000, None, dict],
                   stype=object)
     DT[0] = dt.Type.time64
     assert_equals(DT, dt.Frame([d(2001, 1, 1, 12, 0, 0),
                                 d(2021, 10, 15, 0, 0, 0),
-                                None, None, None]))
+                                d(1970, 1, 1, 0, 0, 0, 6),
+                                None, None]))
 
 
 @pytest.mark.parametrize('ttype', [dt.str32, dt.str64])
@@ -590,11 +601,9 @@ def test_rbind():
 
 
 def test_rbind2():
-    DT = dt.Frame([5, 7, 9])
-    DT[0] = dt.Type.time64
+    DT = dt.Frame([5, 7, 9], type=dt.Type.time64)
     RES = dt.rbind(DT, DT)
-    EXP = dt.Frame([5, 7, 9] * 2)
-    EXP[0] = dt.Type.time64
+    EXP = dt.Frame([5, 7, 9] * 2, type=dt.Type.time64)
     assert_equals(RES, EXP)
 
 


### PR DESCRIPTION
The function for converting object type into date32 / time64 now expanded to also recognize ints and strings. This allows us to reimplement frame creation via a simple typecast of an obj column into the target type.

In the future, it might be good to use the same approach for force-creation of columns of all other types.

Closes #2915
Closes #3010