### PR TITLE
Expanded dt.build_info

### DIFF
--- a/ci/ext.py
+++ b/ci/ext.py
@@ -479,6 +479,8 @@ def generate_build_info(mode=None, strict=False):
     if git_date:
         git_date = time.strftime("%Y-%m-%d %H:%M:%S",
                                  time.gmtime(int(git_date)))
+    if mode == 'build':
+        mode = 'normal'
 
     info_file = os.path.join("src", "datatable", "_build_info.py")
     with open(info_file, "wt") as out:
@@ -514,9 +516,17 @@ def generate_build_info(mode=None, strict=False):
             % time.gmtime().tm_year
         )
         out.write("import types\n\n")
+        out.write("try:\n")
+        out.write("    import datatable.lib._datatable as _dt\n")
+        out.write("    _compiler = _dt.compiler_version()\n")
+        out.write("except:\n")
+        out.write("    _compiler = 'unknown'\n")
+        out.write("\n")
         out.write("build_info = types.SimpleNamespace(\n")
         out.write("    version='%s',\n" % version)
         out.write("    build_date='%s',\n" % build_date)
+        out.write("    build_mode='%s',\n" % mode)
+        out.write("    compiler=_compiler,\n")
         out.write("    git_revision='%s',\n" % git_hash)
         out.write("    git_branch='%s',\n" % git_branch)
         out.write("    git_date='%s',\n" % git_date)

--- a/ci/ext.py
+++ b/ci/ext.py
@@ -480,7 +480,7 @@ def generate_build_info(mode=None, strict=False):
         git_date = time.strftime("%Y-%m-%d %H:%M:%S",
                                  time.gmtime(int(git_date)))
     if mode == 'build':
-        mode = 'normal'
+        mode = 'release'
 
     info_file = os.path.join("src", "datatable", "_build_info.py")
     with open(info_file, "wt") as out:

--- a/docs/api/dt/build_info.rst
+++ b/docs/api/dt/build_info.rst
@@ -34,6 +34,16 @@
 
         UTC timestamp (date + time) of the build.
 
+    .. xparam:: .build_mode: str
+
+        The type of datatable build. Usually this will be ``"release"``, but
+        may also be ``"debug"`` if datatable was built in debug mode. Other
+        build modes exist, or may be added in the future.
+
+    .. xparam:: .compiler: str
+
+        The version of the compiler used to build the C++ datatable extension.
+        This will include both the name and the version of the compiler.
 
     .. xparam:: .git_revision: str
 

--- a/docs/api/internal.rst
+++ b/docs/api/internal.rst
@@ -13,9 +13,6 @@ datatable.internal
     :widths: auto
     :class: api-table
 
-    * - :func:`compiler_version()`
-      - Compiler used when building datatable.
-
     * - :func:`frame_column_data_r()`
       - C pointer to column's data
 
@@ -28,20 +25,12 @@ datatable.internal
     * - :func:`get_thread_ids()`
       - Get ids of threads spawned by datatable.
 
-    * - :func:`in_debug_mode()`
-      - Was datatable built in debug mode?
-
-    * - :func:`regex_supported()`
-      - Was datatable built with support for regular expressions?
 
 
 .. toctree::
     :hidden:
 
-    compiler_version()       <internal/compiler_version>
     frame_column_data_r()    <internal/frame_column_data_r>
     frame_columns_virtual()  <internal/frame_columns_virtual>
     frame_integrity_check()  <internal/frame_integrity_check>
     get_thread_ids()         <internal/get_thread_ids>
-    in_debug_mode()          <internal/in_debug_mode>
-    regex_supported()        <internal/regex_supported>

--- a/docs/api/internal/compiler_version.rst
+++ b/docs/api/internal/compiler_version.rst
@@ -1,4 +1,0 @@
-
-.. xfunction:: datatable.internal.compiler_version
-    :src: src/core/datatablemodule.cc get_compiler_version_string
-    :doc: src/core/datatablemodule.cc doc_compiler_version

--- a/docs/api/internal/in_debug_mode.rst
+++ b/docs/api/internal/in_debug_mode.rst
@@ -1,4 +1,0 @@
-
-.. xfunction:: datatable.internal.in_debug_mode
-    :src: src/core/datatablemodule.cc in_debug_mode
-    :doc: src/core/datatablemodule.cc doc_in_debug_mode

--- a/docs/api/internal/regex_supported.rst
+++ b/docs/api/internal/regex_supported.rst
@@ -1,4 +1,0 @@
-
-.. xfunction:: datatable.internal.regex_supported
-    :src: src/core/datatablemodule.cc regex_supported
-    :doc: src/core/datatablemodule.cc doc_regex_supported

--- a/docs/releases/v1.0.0.rst
+++ b/docs/releases/v1.0.0.rst
@@ -116,6 +116,12 @@
       ``types=``, and similarly ``stype=`` into ``type=``. The old parameter
       names are still recognized, but no longer documented.
 
+    -[api] Internal functions ``dt.internal.compiler_version()`` and
+      ``dt.internal.in_debug_mode()`` removed and replaced with flags
+      ``.compiler`` and ``.build_mode`` in :data:`dt.build_info`. Function
+      ``dt.interenal.regex_supported()`` removed entirely -- datatable will
+      now always have support for regular expressions. [#2636]
+
 
     FExpr
     -----

--- a/src/core/datatablemodule.cc
+++ b/src/core/datatablemodule.cc
@@ -215,26 +215,6 @@ static void frame_integrity_check(const py::PKArgs& args) {
 }
 
 
-static const char* doc_in_debug_mode =
-R"(
-.. x-version-deprecated:: 0.11.0
-
-Return `True` if :mod:`datatable` was compiled in debug mode.
-)";
-
-static py::PKArgs args_in_debug_mode(
-    0, 0, 0, false, false, {}, "in_debug_mode",
-    doc_in_debug_mode);
-
-static py::oobj in_debug_mode(const py::PKArgs&) {
-  #if DT_DEBUG
-    return py::True();
-  #else
-    return py::False();
-  #endif
-}
-
-
 static const char* doc_get_thread_ids =
 R"(
 Return system ids of all threads used internally by datatable.
@@ -337,23 +317,6 @@ static py::oobj compiler_version(const py::PKArgs&) {
 
 
 
-static const char* doc_regex_supported =
-R"(
-.. x-version-deprecated:: 0.11.0
-
-Was the datatable built with regular expression support?
-)";
-
-static py::PKArgs args_regex_supported(
-  0, 0, 0, false, false, {}, "regex_supported",
-  doc_regex_supported);
-
-static py::oobj regex_supported(const py::PKArgs&) {
-  return py::obool(REGEX_SUPPORTED);
-}
-
-
-
 static py::PKArgs args_apply_color(
   2, 0, 0, false ,false, {"color", "text"}, "apply_color",
   "Paint the text into the specified color with by appending "
@@ -433,14 +396,12 @@ DECLARE_PYFN(&initialize_final)
 
 void py::DatatableModule::init_methods() {
   ADD_FN(&_register_function, args__register_function);
-  ADD_FN(&in_debug_mode, args_in_debug_mode);
   ADD_FN(&frame_columns_virtual, args_frame_columns_virtual);
   ADD_FN(&frame_column_data_r, args_frame_column_data_r);
   ADD_FN(&frame_integrity_check, args_frame_integrity_check);
   ADD_FN(&get_thread_ids, args_get_thread_ids);
   ADD_FN(&initialize_options, args_initialize_options);
   ADD_FN(&compiler_version, args_compiler_version);
-  ADD_FN(&regex_supported, args_regex_supported);
   ADD_FN(&apply_color, args_apply_color);
 
   for (py::XArgs* xarg : py::XArgs::store()) {

--- a/src/core/expr/head_func_other.cc
+++ b/src/core/expr/head_func_other.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019-2020 H2O.ai
+// Copyright 2019-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -103,30 +103,23 @@ ptrHead Head_Func_Re_Match::make(Op, const py::otuple& params) {
 
 Head_Func_Re_Match::Head_Func_Re_Match(py::robj arg_pattern, py::robj arg_flags) {
   (void) arg_flags;
-  #if REGEX_SUPPORTED
-    // Pattern
-    if (arg_pattern.is_string()) {
-      pattern = arg_pattern.to_string();
-    }
-    else if (arg_pattern.has_attr("pattern")) {
-      pattern = arg_pattern.get_attr("pattern").to_string();
-    }
-    else {
-      throw TypeError() << "Parameter `pattern` in .match_re() should be "
-          "a string, instead got " << arg_pattern.typeobj();
-    }
+  // Pattern
+  if (arg_pattern.is_string()) {
+    pattern = arg_pattern.to_string();
+  }
+  else if (arg_pattern.has_attr("pattern")) {
+    pattern = arg_pattern.get_attr("pattern").to_string();
+  }
+  else {
+    throw TypeError() << "Parameter `pattern` in .match_re() should be "
+        "a string, instead got " << arg_pattern.typeobj();
+  }
 
-    try {
-      regex = std::regex(pattern, std::regex::nosubs);
-    } catch (const std::regex_error& e) {
-      throw translate_exception(e);
-    }
-  #else
-    (void) arg_pattern;
-    throw NotImplError() << "Regular expressions are not supported in your "
-        "build of datatable (compiler: "
-        << get_compiler_version_string() << ')';
-  #endif
+  try {
+    regex = std::regex(pattern, std::regex::nosubs);
+  } catch (const std::regex_error& e) {
+    throw translate_exception(e);
+  }
 }
 
 

--- a/src/core/utils/macros.h
+++ b/src/core/utils/macros.h
@@ -142,15 +142,6 @@
 #endif
 
 
-#if DT_COMPILER_CLANG || DT_COMPILER_MSVC
-  #define REGEX_SUPPORTED 1
-#elif DT_COMPILER_GCC > 0 && DT_COMPILER_GCC <= 4
-  #define REGEX_SUPPORTED 0
-#else
-  #define REGEX_SUPPORTED 1
-#endif
-
-
 
 // Cache line size: equivalent of std::hardware_destructive_interference_size
 // from C++17.

--- a/src/datatable/internal.py
+++ b/src/datatable/internal.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #-------------------------------------------------------------------------------
-# Copyright 2018 H2O.ai
+# Copyright 2018-2021 H2O.ai
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -22,21 +22,15 @@
 #-------------------------------------------------------------------------------
 
 from .lib._datatable import (
-    compiler_version,
     frame_column_data_r,
     frame_columns_virtual,
     frame_integrity_check,
     get_thread_ids,
-    in_debug_mode,
-    regex_supported
 )
 
 __all__ = [
-    "compiler_version",
     "frame_column_data_r",
     "frame_columns_virtual",
     "frame_integrity_check",
     "get_thread_ids",
-    "in_debug_mode",
-    "regex_supported",
 ]

--- a/tests/munging/test-str.py
+++ b/tests/munging/test-str.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #-------------------------------------------------------------------------------
-# Copyright 2018-2020 H2O.ai
+# Copyright 2018-2021 H2O.ai
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -193,10 +193,6 @@ def test_split_into_nhot_view():
 # re_match()
 #-------------------------------------------------------------------------------
 
-regexp_test = pytest.mark.skipif(not dt.internal.regex_supported(),
-                                 reason="Regex not supported")
-
-@regexp_test
 def test_re_match():
     f0 = dt.Frame(A=["abc", "abd", "cab", "acc", None, "aaa"])
     f1 = f0[:, f.A.re_match("ab.")]
@@ -204,7 +200,6 @@ def test_re_match():
     assert f1.to_list() == [[True, True, False, False, None, False]]
 
 
-@regexp_test
 def test_re_match2():
     # re_match() matches the entire string, not just the beginning...
     f0 = dt.Frame(A=["a", "ab", "abc", "aaaa"])
@@ -213,7 +208,6 @@ def test_re_match2():
     assert f1.to_list() == [[True, True, False, False]]
 
 
-@regexp_test
 def test_re_match_ignore_groups():
     # Groups within the regular expression ought to be ignored
     f0 = dt.Frame(list("abcdibaldfn"))
@@ -221,7 +215,6 @@ def test_re_match_ignore_groups():
     assert f1.to_list() == [["a", "b", "c", "b", "a"]]
 
 
-@regexp_test
 def test_re_match_bad_regex1():
     with pytest.raises(ValueError):
         noop(dt.Frame(A=["abc"])[f.A.re_match("(."), :])
@@ -229,7 +222,6 @@ def test_re_match_bad_regex1():
     #         in str(e.value))
 
 
-@regexp_test
 def test_re_match_bad_regex2():
     with pytest.raises(ValueError):
         noop(dt.Frame(A=["abc"])[f.A.re_match("\\"), :])
@@ -238,7 +230,6 @@ def test_re_match_bad_regex2():
     #         in str(e.value))
 
 
-@regexp_test
 def test_re_match_bad_regex3():
     with pytest.raises(ValueError):
         noop(dt.Frame(A=["abc"])[f.A.re_match("???"), :])
@@ -247,7 +238,6 @@ def test_re_match_bad_regex3():
     #         in str(e.value))
 
 
-@regexp_test
 @pytest.mark.parametrize("seed", [random.getrandbits(32) for _ in range(5)])
 def test_re_match_random(seed):
     random.seed(seed)

--- a/tests/test-dt.py
+++ b/tests/test-dt.py
@@ -138,6 +138,8 @@ def test_dt_version():
     assert isinstance(dt.__version__, str)
     assert dt.build_info
     assert isinstance(dt.build_info.build_date, str)
+    assert isinstance(dt.build_info.build_mode, str)
+    assert isinstance(dt.build_info.compiler, str)
     assert isinstance(dt.build_info.git_revision, str)
     assert isinstance(dt.build_info.git_branch, str)
     assert isinstance(dt.build_info.git_date, str)
@@ -151,6 +153,7 @@ def test_dt_version():
         assert dt.build_info.version
         assert len(dt.build_info.git_revision) == 40
         assert dt.build_info.version == dt.__version__
+    assert dt.build_info.compiler.lower() != "unknown"
 
 
 def test_dt_help():
@@ -203,14 +206,6 @@ def test_check_suites():
     found = core.get_test_suites()
     expected = ["parallel", "progress", "coverage", "fread"]
     assert set(found) == set(expected)
-
-
-
-def test_internal_compiler_version():
-    ver = dt.internal.compiler_version()
-    assert ver
-    assert ver != "Unknown"
-
 
 
 def test_dt_getitem(dt0):


### PR DESCRIPTION
- Added fields to `dt.build_info`:
  - `.build_mode` -- which mode datatable was built in;
  - `.compiler` -- version string of the compiler;
- Removed function `dt.internal.in_debug_mode()` (was previously deprecated);
- Removed function `dt.inernal.compiler_version()` (was previously deprecated);
- Removed macro `REGEX_SUPPORTED` and function `dt.internal.regex_supported()` -- we now always support regular expressions; 

Closes #2636