### PR TITLE
String slicing

### DIFF
--- a/docs/api/fexpr.rst
+++ b/docs/api/fexpr.rst
@@ -189,6 +189,9 @@
         * - :meth:`.__bool__()`
           - Implicitly convert FExpr into a boolean value.
 
+        * - :meth:`.__getitem__()`
+          - Apply slice to a string column.
+
         * - :meth:`.__repr__()`
           - Used by Python function :ext-func:`repr() <repr>`.
 
@@ -208,6 +211,7 @@
     .__eq__()       <fexpr/__eq__>
     .__floordiv__() <fexpr/__floordiv__>
     .__ge__()       <fexpr/__ge__>
+    .__getitem__()  <fexpr/__getitem__>
     .__gt__()       <fexpr/__gt__>
     .__init__()     <fexpr/__init__>
     .__invert__()   <fexpr/__invert__>

--- a/docs/api/fexpr/__getitem__.rst
+++ b/docs/api/fexpr/__getitem__.rst
@@ -1,0 +1,35 @@
+
+.. xmethod:: datatable.FExpr.__getitem__
+    :src: src/core/expr/fexpr_slice.cc FExpr_Slice::evaluate_n
+    :signature: __getitem__(self, selector)
+
+    Apply a slice to the string column represented by this FExpr.
+
+
+    Parameters
+    ----------
+    self: FExpr[str]
+
+    selector: slice
+        The slice will be applied to each value in the string column `self`.
+
+    return: FExpr[str]
+
+
+    Examples
+    --------
+    >>> DT = dt.Frame(season=["Winter", "Summer", "Autumn", "Spring"], i=[1, 2, 3, 4])
+    >>> DT[:, {"start": f.season[:-f.i], "end": f.season[-f.i:]}]
+       | start  end  
+       | str32  str32
+    -- + -----  -----
+     0 | Winte  r    
+     1 | Summ   er   
+     2 | Aut    umn  
+     3 | Sp     ring 
+    [4 rows x 2 columns]
+
+
+    See Also
+    --------
+    - :func:`dt.str.slice()` -- the equivalent function in :mod:`dt.str` module.

--- a/docs/api/index-api.rst
+++ b/docs/api/index-api.rst
@@ -28,6 +28,9 @@ Submodules
     * - :mod:`models. <datatable.models>`
       - A small set of data analysis tools.
 
+    * - :mod:`str. <datatable.str>`
+      - Functions for working with string columns.
+
     * - :mod:`time. <datatable.time>`
       - Functions for working with date/time columns.
 
@@ -199,6 +202,7 @@ Other
     math.             <math>
     models.           <models>
     options.          <options>
+    str.              <str>
     time.             <time>
     FExpr             <fexpr>
     Frame             <frame>

--- a/docs/api/str.rst
+++ b/docs/api/str.rst
@@ -1,0 +1,19 @@
+
+.. xpy:module:: datatable.str
+
+datatable.str
+=============
+
+.. list-table::
+   :widths: auto
+   :class: api-table
+
+   * - :func:`slice()`
+     - Apply a slice to a string column.
+
+
+
+.. toctree::
+    :hidden:
+
+    slice()          <str/slice>

--- a/docs/api/str/slice.rst
+++ b/docs/api/str/slice.rst
@@ -1,0 +1,42 @@
+
+.. xfunction:: datatable.str.slice
+    :src: src/core/expr/fexpr_slice.cc FExpr_Slice::evaluate_n
+    :cvar: doc_str_slice
+    :signature: slice(column, start, stop, step=1)
+
+    Apply slice ``[start:stop:step]`` to each value in a `column` of string
+    type.
+
+    Instead of this function you can directly apply a slice expression to
+    the column expression::
+
+        - ``f.A[1:-1]`` is equivalent to
+        - ``dt.str.slice(f.A, 1, -1)``.
+
+
+    Parameters
+    ----------
+    column : FExpr[str]
+        The column to which the slice should be applied.
+
+    return: FExpr[str]
+        A column containing sliced string values from the source column.
+
+
+    Examples
+    --------
+    >>> DT = dt.Frame(A=["apples", "bananas", "cherries", "dates",
+    ...                  "eggplants", "figs", "grapes", "kiwi"])
+    >>> DT[:, dt.str.slice(f.A, None, 5)]
+       | A
+       | str32
+    -- + -----
+     0 | apple
+     1 | banan
+     2 | cherr
+     3 | dates
+     4 | eggpl
+     5 | figs
+     6 | grape
+     7 | kiwi
+    [8 rows x 1 column]

--- a/docs/releases/v1.0.0.rst
+++ b/docs/releases/v1.0.0.rst
@@ -144,6 +144,9 @@
     -[new] New function :func:`dt.time.day_of_week()` for computing the day
       of week (Monday to Sunday) for the given date column.
 
+    -[new] New function :func:`dt.str.slice()` for applying a slice to a
+      string column. [#1667]
+
     -[enh] Function :func:`sort()` can now accept argument ``na_positon``.
       It can take three values: ``"first"`` (default), ``"last"`` and
       ``"remove"``. The values describe the position assigned to NAs after

--- a/src/core/column/string_slice.cc
+++ b/src/core/column/string_slice.cc
@@ -1,0 +1,154 @@
+//------------------------------------------------------------------------------
+// Copyright 2021 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#include <cstring>
+#include "column/string_slice.h"
+namespace dt {
+
+
+StringSlice_ColumnImpl::StringSlice_ColumnImpl(
+    Column&& src, Column&& start, Column&& stop, Column&& step)
+  : Virtual_ColumnImpl(src.nrows(), src.stype()),
+    src_(std::move(src)),
+    start_(std::move(start)),
+    stop_(std::move(stop)),
+    step_(std::move(step))
+{
+  xassert(src_.nrows() == nrows_ && src_.can_be_read_as<CString>());
+  xassert(start_.nrows() == nrows_ && start_.can_be_read_as<int64_t>());
+  xassert(stop_.nrows() == nrows_ && stop_.can_be_read_as<int64_t>());
+  xassert(step_.nrows() == nrows_ && step_.can_be_read_as<int64_t>());
+}
+
+
+ColumnImpl* StringSlice_ColumnImpl::clone() const {
+  return new StringSlice_ColumnImpl(
+      Column(src_), Column(start_), Column(stop_), Column(step_)
+  );
+}
+
+
+size_t StringSlice_ColumnImpl::n_children() const noexcept {
+  return 4;
+}
+
+const Column& StringSlice_ColumnImpl::child(size_t i) const {
+  xassert(i <= 3);
+  return i == 0? src_ : i == 1? start_ : i == 2? stop_ : step_;
+}
+
+
+/**
+  * Iterate over utf8 string `[*pch, end)` and move the pointer `*pch`
+  * to a character at position `index` in the string. If the `index`
+  * is larger than the length of the string, then move to `end`
+  * instead. If the `index` is negative, then the pointer is not moved.
+  */
+static void moveToIndex(int64_t index, const uint8_t** pch, const uint8_t* end) {
+  auto ch = *pch;
+  int64_t i = 0;
+  while (ch < end && i < index) {
+    uint8_t c = *ch;
+    ch += (c < 0x80)? 1 :
+          ((c & 0xE0) == 0xC0)? 2 :
+          ((c & 0xF0) == 0xE0)? 3 : 4;
+    i++;
+  }
+  *pch = ch;
+}
+
+/**
+  * Calculate and return unicode length of string `[ch, end)`.
+  */
+static int64_t getStringLength(const uint8_t* ch, const uint8_t* end) {
+  int64_t i = 0;
+  while (ch < end) {
+    uint8_t c = *ch;
+    ch += (c < 0x80)? 1 :
+          ((c & 0xE0) == 0xC0)? 2 :
+          ((c & 0xF0) == 0xE0)? 3 : 4;
+    i++;
+  }
+  return i;
+}
+
+
+bool StringSlice_ColumnImpl::get_element(size_t i, CString* out) const {
+  CString str;
+  bool isvalid = src_.get_element(i, &str);
+  if (!isvalid) return false;
+  if (!str.size()) {  // Any slice of an empty string is still empty
+    *out = std::move(str);
+    return true;
+  }
+  auto ch = reinterpret_cast<const uint8_t*>(str.data());
+  auto eof = ch + str.size();
+
+  int64_t istart, istop, istep;
+  bool startValid = start_.get_element(i, &istart);
+  bool stopValid = stop_.get_element(i, &istop);
+  bool stepValid = step_.get_element(i, &istep);
+
+  if (!stepValid || istep == 1) {
+    int64_t ilength = 0;  // Number of unicode characters in `str`
+    if (!startValid) istart = 0;
+    if (istart < 0) {
+      ilength = getStringLength(ch, eof);
+      istart += ilength;
+      if (istart < 0) istart = 0;
+    }
+    xassert(istart >= 0);
+    moveToIndex(istart, &ch, eof);
+    xassert(ch <= eof);
+
+    if (!stopValid) {
+      auto len = static_cast<size_t>(eof - ch);
+      char* ptr = out->prepare_buffer(len);
+      if (len) std::memcpy(ptr, ch, len);
+      return true;
+    }
+    if (istop < 0) {
+      if (ilength == 0) ilength = getStringLength(ch, eof) + istart;
+      istop += ilength;
+    }
+    auto ch0 = ch;
+    moveToIndex(istop - istart, &ch, eof);  // noop if istop<=istart
+    auto len = static_cast<size_t>(ch - ch0);
+    char* ptr = out->prepare_buffer(len);
+    if (len) std::memcpy(ptr, ch0, len);
+    return true;
+  }
+  else if (istep > 1) {
+    throw NotImplError() << "Cannot create string slice with step > 1";
+  }
+  else if (istep < 0) {
+    throw NotImplError() << "Cannot create string slice with step < 0";
+  }
+  else {
+    xassert(istep == 0);
+    return false;  // Step of 0 is invalid in a slice
+  }
+}
+
+
+
+
+}  // namespace dt

--- a/src/core/column/string_slice.h
+++ b/src/core/column/string_slice.h
@@ -1,0 +1,52 @@
+//------------------------------------------------------------------------------
+// Copyright 2021 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#ifndef dt_COLUMN_STRING_SLICE_h
+#define dt_COLUMN_STRING_SLICE_h
+#include "column/virtual.h"
+namespace dt {
+
+
+
+class StringSlice_ColumnImpl : public Virtual_ColumnImpl {
+  private:
+    Column src_;
+    Column start_;
+    Column stop_;
+    Column step_;
+
+  public:
+    StringSlice_ColumnImpl(
+        Column&& src, Column&& sliceStart, Column&& sliceStop,
+        Column&& sliceStep);
+
+    ColumnImpl* clone() const override;
+    size_t n_children() const noexcept override;
+    const Column& child(size_t i) const override;
+
+    bool get_element(size_t i, CString* out) const override;
+};
+
+
+
+
+}  // namespace dt
+#endif

--- a/src/core/documentation.h
+++ b/src/core/documentation.h
@@ -26,6 +26,9 @@ namespace dt {
 
 extern const char* doc_dt_cbind;
 extern const char* doc_dt_rbind;
+
+extern const char* doc_str_slice;
+
 extern const char* doc_Frame;
 extern const char* doc_Frame___init__;
 extern const char* doc_Frame___sizeof__;

--- a/src/core/expr/fexpr.cc
+++ b/src/core/expr/fexpr.cc
@@ -19,17 +19,18 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
+#include <iostream>
+#include "expr/expr.h"            // OldExpr
 #include "expr/fexpr.h"
+#include "expr/fexpr_column.h"
 #include "expr/fexpr_dict.h"
 #include "expr/fexpr_frame.h"
 #include "expr/fexpr_list.h"
 #include "expr/fexpr_literal.h"
-#include "expr/fexpr_column.h"
-#include "expr/expr.h"            // OldExpr
+#include "expr/fexpr_slice.h"
 #include "python/obj.h"
 #include "python/xargs.h"
 #include "utils/exceptions.h"
-#include <iostream>
 namespace dt {
 namespace expr {
 
@@ -151,7 +152,7 @@ oobj PyFExpr::m__getitem__(py::robj item) {
   // but if the user tries to instantiate it manually then the
   // `expr_` may end up as nullptr.
   return PyFExpr::make(
-              new dt::expr::FExpr_ColumnAsSlice(item));
+              new dt::expr::FExpr_Slice(expr_, item));
 }
 
 

--- a/src/core/expr/fexpr.cc
+++ b/src/core/expr/fexpr.cc
@@ -148,11 +148,18 @@ oobj PyFExpr::m__repr__() const {
 }
 
 oobj PyFExpr::m__getitem__(py::robj item) {
-  // Normally we would never create an object with an empty `expr_`,
-  // but if the user tries to instantiate it manually then the
-  // `expr_` may end up as nullptr.
-  return PyFExpr::make(
-              new dt::expr::FExpr_Slice(expr_, item));
+  if (item.is_slice()) {
+    auto slice = item.to_oslice();
+    return PyFExpr::make(
+                new dt::expr::FExpr_Slice(
+                    expr_,
+                    slice.start_obj(),
+                    slice.stop_obj(),
+                    slice.step_obj()
+           ));
+  }
+  // TODO: we could also support single-item selectors
+  throw TypeError() << "Selector inside FExpr[...] must be a slice";
 }
 
 

--- a/src/core/expr/fexpr.cc
+++ b/src/core/expr/fexpr.cc
@@ -28,6 +28,7 @@
 #include "python/obj.h"
 #include "python/xargs.h"
 #include "utils/exceptions.h"
+#include <iostream>
 namespace dt {
 namespace expr {
 
@@ -144,6 +145,13 @@ oobj PyFExpr::m__repr__() const {
   return ostring("FExpr<" + expr_->repr() + '>');
 }
 
+py::oobj PyFExpr::m__getitem__(py::robj item) {
+  // Normally we would never create an object with an empty `expr_`,
+  // but if the user tries to instantiate it manually then the
+  // `expr_` may end up as nullptr.
+  
+  return py::ostring("FExpr<" + expr_->repr() + '>');
+}
 
 
 //----- Basic arithmetics ------------------------------------------------------
@@ -652,6 +660,7 @@ void PyFExpr::impl_init_type(XTypeMaker& xt) {
   xt.add(METHOD__NEG__(&PyFExpr::nb__neg__));
   xt.add(METHOD__POS__(&PyFExpr::nb__pos__));
   xt.add(METHOD__CMP__(&PyFExpr::m__compare__));
+  xt.add(METHOD__GETITEM__(&PyFExpr::m__getitem__));
 
   FExpr_Type = xt.get_type_object();
 

--- a/src/core/expr/fexpr.cc
+++ b/src/core/expr/fexpr.cc
@@ -24,6 +24,7 @@
 #include "expr/fexpr_frame.h"
 #include "expr/fexpr_list.h"
 #include "expr/fexpr_literal.h"
+#include "expr/fexpr_column.h"
 #include "expr/expr.h"            // OldExpr
 #include "python/obj.h"
 #include "python/xargs.h"
@@ -145,12 +146,12 @@ oobj PyFExpr::m__repr__() const {
   return ostring("FExpr<" + expr_->repr() + '>');
 }
 
-py::oobj PyFExpr::m__getitem__(py::robj item) {
+oobj PyFExpr::m__getitem__(py::robj item) {
   // Normally we would never create an object with an empty `expr_`,
   // but if the user tries to instantiate it manually then the
   // `expr_` may end up as nullptr.
-  
-  return py::ostring("FExpr<" + expr_->repr() + '>');
+  return PyFExpr::make(
+              new dt::expr::FExpr_ColumnAsSlice(item));
 }
 
 

--- a/src/core/expr/fexpr.h
+++ b/src/core/expr/fexpr.h
@@ -156,6 +156,7 @@ class PyFExpr : public py::XObject<PyFExpr> {
     void m__init__(const py::PKArgs&);
     void m__dealloc__();
     py::oobj m__repr__() const;
+    py::oobj m__getitem__(py::robj);
 
     static py::oobj m__compare__  (py::robj, py::robj, int op);
     static py::oobj nb__add__     (py::robj, py::robj);

--- a/src/core/expr/fexpr_column_asslice.cc
+++ b/src/core/expr/fexpr_column_asslice.cc
@@ -19,71 +19,40 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
-#ifndef dt_EXPR_FEXPR_COLUMN_h
-#define dt_EXPR_FEXPR_COLUMN_h
-#include "expr/fexpr_func.h"
-#include "python/obj.h"
+#include "expr/fexpr_column.h"
+#include "expr/eval_context.h"
+#include "expr/workframe.h"
+#include "utils/assert.h"
 namespace dt {
 namespace expr {
 
 
-/**
-  * Class for expressions such as `f.A`.
-  */
-class FExpr_ColumnAsAttr : public FExpr_Func {
-  private:
-    size_t namespace_;
-    py::oobj pyname_;
-
-  public:
-    FExpr_ColumnAsAttr(size_t ns, py::robj name);
-
-    Workframe evaluate_n(EvalContext&) const override;
-    int precedence() const noexcept override;
-    std::string repr() const override;
-
-    py::oobj get_pyname() const;
-};
+FExpr_ColumnAsSlice::FExpr_ColumnAsSlice(py::robj arg) {
+  arg_ = as_fexpr(arg);
+}
 
 
-
-/**
-  * Class for expressions such as `f[x]`.
-  */
-class FExpr_ColumnAsArg : public FExpr_Func {
-  private:
-    size_t namespace_;
-    ptrExpr arg_;
-
-  public:
-    FExpr_ColumnAsArg(size_t ns, py::robj arg);
-
-    Workframe evaluate_n(EvalContext&) const override;
-    int precedence() const noexcept override;
-    std::string repr() const override;
-
-    ptrExpr get_arg() const;
-};
+Workframe FExpr_ColumnAsSlice::evaluate_n(EvalContext& ctx) const {
+  Workframe outputs(ctx);
+  return outputs;
+}
 
 
-/**
-  * Class for expressions such as `f.A[1:]`.
-  */
-class FExpr_ColumnAsSlice : public FExpr_Func {
-  private:
-    ptrExpr arg_;
+int FExpr_ColumnAsSlice::precedence() const noexcept {
+  return 0;
+}
 
-  public:
-    FExpr_ColumnAsSlice(py::robj arg);
 
-    Workframe evaluate_n(EvalContext&) const override;
-    int precedence() const noexcept override;
-    std::string repr() const override;
+std::string FExpr_ColumnAsSlice::repr() const {
+}
 
-    ptrExpr get_arg() const;
-};
+
+
+ptrExpr FExpr_ColumnAsSlice::get_arg() const {
+  return arg_;
+}
+
 
 
 
 }}  // namespace dt::expr
-#endif

--- a/src/core/expr/fexpr_slice.cc
+++ b/src/core/expr/fexpr_slice.cc
@@ -19,6 +19,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
+#include "column/string_slice.h"
 #include "expr/fexpr_column.h"
 #include "expr/fexpr_slice.h"
 #include "expr/eval_context.h"

--- a/src/core/expr/fexpr_slice.cc
+++ b/src/core/expr/fexpr_slice.cc
@@ -20,15 +20,20 @@
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #include "column/string_slice.h"
+#include "documentation.h"
 #include "expr/fexpr_column.h"
 #include "expr/fexpr_slice.h"
 #include "expr/eval_context.h"
 #include "expr/workframe.h"
+#include "python/xargs.h"
 #include "utils/assert.h"
 namespace dt {
 namespace expr {
 
 
+//------------------------------------------------------------------------------
+// FExpr_Slice
+//------------------------------------------------------------------------------
 
 FExpr_Slice::FExpr_Slice(ptrExpr arg, py::robj start, py::robj stop, py::robj step)
   : arg_(std::move(arg)),
@@ -127,6 +132,28 @@ Workframe FExpr_Slice::evaluate_n(EvalContext& ctx) const {
   );
   return result;
 }
+
+
+
+//------------------------------------------------------------------------------
+// Python dt.str.slice() function
+//------------------------------------------------------------------------------
+
+static py::oobj py_slice(const py::XArgs& args) {
+  auto src = args[0].to_oobj();
+  auto a = args[1].to_oobj();
+  auto b = args[2].to_oobj();
+  auto c = args[3].to_oobj_or_none();
+  return PyFExpr::make(new FExpr_Slice(as_fexpr(src), a, b, c));
+}
+
+DECLARE_PYFN(&py_slice)
+    ->name("slice")
+    ->docs(dt::doc_str_slice)
+    ->arg_names({"column", "start", "stop", "step"})
+    ->n_positional_args(1)
+    ->n_positional_or_keyword_args(3)
+    ->n_required_args(3);
 
 
 

--- a/src/core/expr/fexpr_slice.cc
+++ b/src/core/expr/fexpr_slice.cc
@@ -73,7 +73,9 @@ std::string FExpr_Slice::repr() const {
     out += stop_->repr();
   }
   if (hasStep) {
-    out += addSpaces? " : " : ":";
+    if (addSpaces && hasStop) out += " ";
+    out += ":";
+    if (addSpaces) out += " ";
     out += step_->repr();
   }
   out += "]";

--- a/src/core/expr/fexpr_slice.h
+++ b/src/core/expr/fexpr_slice.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2020 H2O.ai
+// Copyright 2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -19,40 +19,35 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
-#include "expr/fexpr_column.h"
-#include "expr/eval_context.h"
-#include "expr/workframe.h"
-#include "utils/assert.h"
+#ifndef dt_EXPR_FEXPR_SLICE_h
+#define dt_EXPR_FEXPR_SLICE_h
+#include "expr/fexpr_func.h"
+#include "python/obj.h"
 namespace dt {
 namespace expr {
 
 
-FExpr_ColumnAsSlice::FExpr_ColumnAsSlice(py::robj arg) {
-  arg_ = as_fexpr(arg);
-}
+
+/**
+  * Class for expressions such as `f.A[1:]`. This is only relevant
+  * for string-type columns; and in the future for list-types
+  * and maybe some others too.
+  */
+class FExpr_Slice : public FExpr_Func {
+  private:
+    ptrExpr arg_;
+    py::oobj slice_;
 
 
-Workframe FExpr_ColumnAsSlice::evaluate_n(EvalContext& ctx) const {
-  Workframe outputs(ctx);
-  return outputs;
-}
+  public:
+    FExpr_Slice(ptrExpr arg, py::robj sliceobj);
 
-
-int FExpr_ColumnAsSlice::precedence() const noexcept {
-  return 0;
-}
-
-
-std::string FExpr_ColumnAsSlice::repr() const {
-}
-
-
-
-ptrExpr FExpr_ColumnAsSlice::get_arg() const {
-  return arg_;
-}
-
+    int precedence() const noexcept override;
+    std::string repr() const override;
+    Workframe evaluate_n(EvalContext&) const override;
+};
 
 
 
 }}  // namespace dt::expr
+#endif

--- a/src/core/expr/fexpr_slice.h
+++ b/src/core/expr/fexpr_slice.h
@@ -32,20 +32,31 @@ namespace expr {
   * Class for expressions such as `f.A[1:]`. This is only relevant
   * for string-type columns; and in the future for list-types
   * and maybe some others too.
+  *
+  * Also note that we want to support the case when the slice
+  * expression itself is an expression. For example, a formula like
+  * this to remove everything after and including the '#' symbol is
+  * perfectly common:
+  *
+  *     (f.A)[f.A.index('#') + 1:]
+  *
   */
 class FExpr_Slice : public FExpr_Func {
   private:
     ptrExpr arg_;
-    py::oobj slice_;
+    ptrExpr start_;
+    ptrExpr stop_;
+    ptrExpr step_;
 
 
   public:
-    FExpr_Slice(ptrExpr arg, py::robj sliceobj);
+    FExpr_Slice(ptrExpr arg, py::robj start, py::robj stop, py::robj step);
 
     int precedence() const noexcept override;
     std::string repr() const override;
     Workframe evaluate_n(EvalContext&) const override;
 };
+
 
 
 

--- a/src/core/python/slice.cc
+++ b/src/core/python/slice.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018 H2O.ai
+// Copyright 2018-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -184,6 +184,10 @@ oobj oslice::start_obj() const {
 
 oobj oslice::stop_obj() const {
   return oobj(reinterpret_cast<PySliceObject*>(v)->stop);
+}
+
+oobj oslice::step_obj() const {
+  return oobj(reinterpret_cast<PySliceObject*>(v)->step);
 }
 
 

--- a/src/core/python/slice.h
+++ b/src/core/python/slice.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018 H2O.ai
+// Copyright 2018-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -71,6 +71,7 @@ class oslice : public oobj {
     bool is_string() const;
     oobj start_obj() const;
     oobj stop_obj() const;
+    oobj step_obj() const;
 
     void normalize(
         size_t len, size_t* pstart, size_t* pcount, size_t* pstep) const;

--- a/src/datatable/str.py
+++ b/src/datatable/str.py
@@ -14,7 +14,13 @@
 # limitations under the License.
 #-------------------------------------------------------------------------------
 
-from datatable.lib._datatable import split_into_nhot
+from datatable.lib._datatable import (
+    slice,
+    split_into_nhot,
+)
 
 
-__all__ = ["split_into_nhot"]
+__all__ = [
+    "slice",
+    "split_into_nhot"
+]

--- a/tests/expr/str/test-slice.py
+++ b/tests/expr/str/test-slice.py
@@ -55,8 +55,56 @@ def test_slice_wrong_types2(ttype):
     [slice(None, 5), slice(3, None), slice(None, None, 1), slice(-1, None),
      slice(2, 7), slice(3, -1), slice(5, -8), slice(-8, 5), slice(None, -2)])
 def test_slice_normal(slice):
-    src = ["Hydrogen", "Helium", "Lithium", "Berillium", "Boron"]
+    src = ["Hydrogen", "Helium", "Lithium", "Berillium", "Boron", "Carbon",
+           None, "Praseodymium"]
     DT = dt.Frame(A=src)
     RES = DT[:, f.A[slice]]
-    EXP = dt.Frame(A=[s[slice] for s in src])
+    EXP = dt.Frame(A=[None if s is None else s[slice] for s in src])
+    assert_equals(RES, EXP)
+
+
+@pytest.mark.parametrize('seed', [random.getrandbits(32) for _ in range(10)])
+def test_slice_unicode_random(seed):
+    random.seed(seed)
+    src = [
+        "По улиці вітер віє",
+        "Та сніг замітає.",
+        "По улиці попідтинню",
+        "Вдова шкандибає",
+        "Під дзвіницю, сердешная,",
+        "Руки простягати",
+        "До тих самих, до багатих,",
+        "Що сина в солдати",
+        "Позаторік заголили.",
+        "А думала жити...",
+        "Хоч на старість у невістки",
+        "В добрі одпочити.",
+        "Не довелось. Виблагала",
+        "Тую копійчину...",
+        "Та пречистій поставила",
+        "Свічечку за сина.",
+        "",
+        "møøse",
+        "𝔘𝔫𝔦𝔠𝔬𝔡𝔢",
+        "J̲o̲s̲é̲",
+        "🚑🐧💚💥✅",
+        "[Ⅰ] 💥, [Ⅱ] 🐕, [Ⅲ] 🦊, [Ⅳ] 🐽"
+    ]
+    a = None if random.random() < 0.2 else \
+        random.randint(-3, 10)
+    b = None if random.random() < 0.5 else \
+        random.randint(-8, 0) if random.random() < 0.6 else \
+        random.randint(15, 25)
+    DT = dt.Frame(src)
+    RES = DT[:, f[0][a:b]]
+    EXP = dt.Frame([s[a:b] for s in src])
+    assert_equals(RES, EXP)
+
+
+def test_slice_expression():
+    DT = dt.Frame(A=["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"],
+                  s=[0, 3, 2, 1, -4],
+                  e=[5, 4, 0, -1, None])
+    RES = DT[:, (f.A)[f.s:f.e]]
+    EXP = dt.Frame(A=["Monda", "s", "", "hursda", "iday"])
     assert_equals(RES, EXP)

--- a/tests/expr/str/test-slice.py
+++ b/tests/expr/str/test-slice.py
@@ -95,7 +95,20 @@ def test_slice_large_step(slice):
     assert_equals(RES, EXP)
 
 
-@pytest.mark.parametrize('seed', [random.getrandbits(32) for _ in range(10)])
+@pytest.mark.parametrize('slice',
+    [slice(None, None, -1), slice(None, None, -2), slice(2, None, -1),
+     slice(1, -1, -3), slice(-15, -2, -2), slice(None, -1, -2),
+     slice(None, 3, -2)])
+def test_slice_negative_step(slice):
+    src = ["Juneteenth", "Independence Day", "Christmas", "Halloween",
+           "Labor Day", "Memorial Day", "Native American Day", "MLK Day"]
+    DT = dt.Frame(Planet=src)
+    RES = DT[:, f.Planet[slice]]
+    EXP = dt.Frame(Planet=[s[slice] for s in src])
+    assert_equals(RES, EXP)
+
+
+@pytest.mark.parametrize('seed', [random.getrandbits(32) for _ in range(20)])
 def test_slice_unicode_random(seed):
     random.seed(seed)
     src = [
@@ -128,7 +141,8 @@ def test_slice_unicode_random(seed):
         random.randint(-8, 0) if random.random() < 0.6 else \
         random.randint(15, 25)
     c = None if random.random() < 0.6 else \
-        random.randint(2, 5)
+        random.randint(2, 5) if random.random() < 0.5 else \
+        random.randint(-4, -1)
     DT = dt.Frame(src)
     RES = DT[:, f[0][a:b:c]]
     EXP = dt.Frame([s[a:b:c] for s in src])
@@ -141,4 +155,12 @@ def test_slice_expression():
                   e=[5, 4, 0, -1, None])
     RES = DT[:, (f.A)[f.s:f.e]]
     EXP = dt.Frame(A=["Monda", "s", "", "hursda", "iday"])
+    assert_equals(RES, EXP)
+
+
+def test_slice_zero_step():
+    # Check that zero step in a slice produces an NA value
+    DT = dt.Frame(A=["abcdefghij", "ABCDEFGHIJ", "---"], B=[2, 1, 0])
+    RES = DT[:, f.A[::f.B]]
+    EXP = dt.Frame(A=["acegi", "ABCDEFGHIJ", None])
     assert_equals(RES, EXP)

--- a/tests/expr/str/test-slice.py
+++ b/tests/expr/str/test-slice.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#-------------------------------------------------------------------------------
+# Copyright 2021 H2O.ai
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#-------------------------------------------------------------------------------
+import pytest
+import random
+from datatable import dt, f, FExpr
+from tests import assert_equals
+
+
+@pytest.mark.parametrize('ttype',
+    [dt.bool8, dt.int8, dt.int16, dt.int32, dt.int64, dt.float32, dt.float64,
+     dt.Type.date32, dt.Type.time64, dt.obj64])
+def test_slice_wrong_types(ttype):
+    msg = "Slice expression can only be applied to a column of string type"
+    with pytest.raises(TypeError, match=msg):
+        DT = dt.Frame(A=[None], type=ttype)
+        DT[:, f.A[:1]]
+
+
+@pytest.mark.parametrize('ttype',
+    [dt.bool8, dt.float32, dt.float64, dt.str32, dt.str64,
+     dt.Type.date32, dt.Type.time64, dt.obj64])
+def test_slice_wrong_types2(ttype):
+    DT = dt.Frame(A=[None], B=["Hello"], types={"A": ttype})
+    msg = 'Non-integer expressions cannot be used inside a slice'
+    with pytest.raises(TypeError, match=msg):
+        DT[:, f.B[f.A:]]
+    with pytest.raises(TypeError, match=msg):
+        DT[:, f.B[:f.A]]
+    with pytest.raises(TypeError, match=msg):
+        DT[:, f.B[::f.A]]
+
+
+@pytest.mark.parametrize('slice',
+    [slice(None, 5), slice(3, None), slice(None, None, 1), slice(-1, None),
+     slice(2, 7), slice(3, -1), slice(5, -8), slice(-8, 5), slice(None, -2)])
+def test_slice_normal(slice):
+    src = ["Hydrogen", "Helium", "Lithium", "Berillium", "Boron"]
+    DT = dt.Frame(A=src)
+    RES = DT[:, f.A[slice]]
+    EXP = dt.Frame(A=[s[slice] for s in src])
+    assert_equals(RES, EXP)

--- a/tests/expr/str/test-slice.py
+++ b/tests/expr/str/test-slice.py
@@ -172,3 +172,16 @@ def test_slice_zero_step():
     RES = DT[:, f.A[::f.B]]
     EXP = dt.Frame(A=["acegi", "ABCDEFGHIJ", None])
     assert_equals(RES, EXP)
+
+
+def test_slice_with_void_column():
+    DT = dt.Frame(A=["alpha", "beta", "gamma"],
+                  B=[None, None, None])
+    assert DT.types == [dt.Type.str32, dt.Type.void]
+    RES = DT[:, {"start": f[0][f.B:2],
+                 "end": f[0][2:f.B],
+                 "mid": f.A[1:-1:f.B]}]
+    EXP = dt.Frame(start=["al", "be", "ga"],
+                   end=["pha", "ta", "mma"],
+                   mid=["lph", "et", "amm"])
+    assert_equals(RES, EXP)

--- a/tests/expr/str/test-slice.py
+++ b/tests/expr/str/test-slice.py
@@ -47,6 +47,14 @@ def test_repr():
     assert str(f.N[f.w:f.x:f.s]) == "FExpr<(f.N)[f.w : f.x : f.s]>"
 
 
+def test_slice_function():
+    from datatable.str import slice
+    assert str(slice(f[0], 5, 6)) == "FExpr<(f[0])[5:6]>"
+    assert str(slice(f[3], 1, 2, 3)) == "FExpr<(f[3])[1:2:3]>"
+    assert str(slice(f.X, start=f.y, stop=f.z)) == "FExpr<(f.X)[f.y : f.z]>"
+    assert str(slice(f.X, f.a, None, step=f.b)) == "FExpr<(f.X)[f.a :: f.b]>"
+
+
 @pytest.mark.parametrize('ttype',
     [dt.bool8, dt.int8, dt.int16, dt.int32, dt.int64, dt.float32, dt.float64,
      dt.Type.date32, dt.Type.time64, dt.obj64])

--- a/tests/expr/str/test-slice.py
+++ b/tests/expr/str/test-slice.py
@@ -83,6 +83,18 @@ def test_slice_normal(slice):
     assert_equals(RES, EXP)
 
 
+@pytest.mark.parametrize('slice',
+    [slice(None, None, 2), slice(None, None, 3), slice(2, None, 2),
+     slice(1, -1, 3), slice(-5, -1, 2), slice(None, -1, 2)])
+def test_slice_large_step(slice):
+    src = ["Mercury", "Venus", "Earth", "Mars", "Jupiter", "Saturn", "Uranus",
+           "Neptune"]
+    DT = dt.Frame(Planet=src)
+    RES = DT[:, f.Planet[slice]]
+    EXP = dt.Frame(Planet=[s[slice] for s in src])
+    assert_equals(RES, EXP)
+
+
 @pytest.mark.parametrize('seed', [random.getrandbits(32) for _ in range(10)])
 def test_slice_unicode_random(seed):
     random.seed(seed)
@@ -115,9 +127,11 @@ def test_slice_unicode_random(seed):
     b = None if random.random() < 0.5 else \
         random.randint(-8, 0) if random.random() < 0.6 else \
         random.randint(15, 25)
+    c = None if random.random() < 0.6 else \
+        random.randint(2, 5)
     DT = dt.Frame(src)
-    RES = DT[:, f[0][a:b]]
-    EXP = dt.Frame([s[a:b] for s in src])
+    RES = DT[:, f[0][a:b:c]]
+    EXP = dt.Frame([s[a:b:c] for s in src])
     assert_equals(RES, EXP)
 
 

--- a/tests/expr/str/test-slice.py
+++ b/tests/expr/str/test-slice.py
@@ -27,6 +27,26 @@ from datatable import dt, f, FExpr
 from tests import assert_equals
 
 
+def test_repr():
+    assert str(f.a[:]) == "FExpr<(f.a)[:]>"
+    assert str(f.b[3:]) == "FExpr<(f.b)[3:]>"
+    assert str(f.c[:4]) == "FExpr<(f.c)[:4]>"
+    assert str(f.d[1:4]) == "FExpr<(f.d)[1:4]>"
+    assert str(f.e[::-1]) == "FExpr<(f.e)[::-1]>"
+    assert str(f.f[-1::-1]) == "FExpr<(f.f)[-1::-1]>"
+    assert str(f.g[:4:5]) == "FExpr<(f.g)[:4:5]>"
+    assert str(f.h[3:4:5]) == "FExpr<(f.h)[3:4:5]>"
+    assert str(f.A[0:1]) == "FExpr<(f.A)[0:1]>"
+    assert str((f.A + f.B)[:32]) == "FExpr<(f.A + f.B)[:32]>"
+    assert str(f.S[:-3] + f.S[-2:]) == "FExpr<(f.S)[:-3] + (f.S)[-2:]>"
+    assert str(f.N[f.a:f.b]) == "FExpr<(f.N)[f.a : f.b]>"
+    assert str(f.N[f.a:-1]) == "FExpr<(f.N)[f.a : -1]>"
+    assert str(f.N[f.a::4]) == "FExpr<(f.N)[f.a :: 4]>"
+    assert str(f.N[::f.s]) == "FExpr<(f.N)[:: f.s]>"
+    assert str(f.N[:f.x:f.s]) == "FExpr<(f.N)[: f.x : f.s]>"
+    assert str(f.N[f.w:f.x:f.s]) == "FExpr<(f.N)[f.w : f.x : f.s]>"
+
+
 @pytest.mark.parametrize('ttype',
     [dt.bool8, dt.int8, dt.int16, dt.int32, dt.int64, dt.float32, dt.float64,
      dt.Type.date32, dt.Type.time64, dt.obj64])


### PR DESCRIPTION
This implements string-slicing function `FExpr[a:b:c]`, or alternatively as a regular function `dt.str.slice(col, start=a, stop=b, step=c)`.

The new function supports both constant slices and expression-slices. 

The reason to have both a function and a slice expression `[a:b]` is that a function is much easier to find in the documentation (esp. once we have more string functions in `dt.str` module), whereas `[]`-based slices are easier to write.

Closes #1667