### PR TITLE
Move some API documentation into docs/

### DIFF
--- a/ci/ext.py
+++ b/ci/ext.py
@@ -518,7 +518,7 @@ def generate_build_info(mode=None, strict=False):
         out.write("import types\n\n")
         out.write("try:\n")
         out.write("    import datatable.lib._datatable as _dt\n")
-        out.write("    _compiler = _dt.compiler_version()\n")
+        out.write("    _compiler = _dt._compiler()\n")
         out.write("except:\n")
         out.write("    _compiler = 'unknown'\n")
         out.write("\n")

--- a/docs/api/dt/as_type.rst
+++ b/docs/api/dt/as_type.rst
@@ -1,5 +1,89 @@
 
 .. xfunction:: datatable.as_type
     :src: src/core/expr/fexpr_astype.cc pyfn_astype
-    :doc: src/core/expr/fexpr_astype.cc doc_astype
     :tests: tests/dt/test-astype.py
+    :cvar: doc_dt_as_type
+    :signature: as_type(cols, new_type)
+
+    .. x-version-added:: 1.0
+
+    Convert columns `cols` into the prescribed stype.
+
+    This function does not modify the data in the original column. Instead
+    it returns a new column which converts the values into the new type on
+    the fly.
+
+    Parameters
+    ----------
+    cols: FExpr
+        Single or multiple columns that need to be converted.
+
+    new_type: Type | stype
+        Target type.
+
+    return: FExpr
+        The output will have the same number of rows and columns as the
+        input; column names will be preserved too.
+
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> from datatable import dt, f, as_type
+        >>>
+        >>> df = dt.Frame({'A': ['1', '1', '2', '1', '2'],
+        ...                'B': [None, '2', '3', '4', '5'],
+        ...                'C': [1, 2, 1, 1, 2]})
+        >>> df
+           | A      B          C
+           | str32  str32  int32
+        -- + -----  -----  -----
+         0 | 1      NA         1
+         1 | 1      2          2
+         2 | 2      3          1
+         3 | 1      4          1
+         4 | 2      5          2
+        [5 rows x 3 columns]
+
+
+    Convert column A from string to integer type::
+
+        >>> df[:, as_type(f.A, int)]
+           |     A
+           | int64
+        -- + -----
+         0 |     1
+         1 |     1
+         2 |     2
+         3 |     1
+         4 |     2
+        [5 rows x 1 column]
+
+
+    The exact dtype can be specified::
+
+        >>> df[:, as_type(f.A, dt.Type.int32)]
+           |     A
+           | int32
+        -- + -----
+         0 |     1
+         1 |     1
+         2 |     2
+         3 |     1
+         4 |     2
+        [5 rows x 1 column]
+
+
+    Convert multiple columns to different types::
+
+        >>> df[:, [as_type(f.A, int), as_type(f.C, dt.str32)]]
+           |     A  C
+           | int64  str32
+        -- + -----  -----
+         0 |     1  1
+         1 |     1  2
+         2 |     2  1
+         3 |     1  1
+         4 |     2  2
+        [5 rows x 2 columns]

--- a/docs/api/dt/corr.rst
+++ b/docs/api/dt/corr.rst
@@ -1,5 +1,51 @@
 
 .. xfunction:: datatable.corr
     :src: src/core/expr/head_reduce_binary.cc compute_corr
-    :doc: src/core/expr/head_reduce_binary.cc doc_corr
     :tests: tests/test-reduce.py
+    :cvar: doc_dt_corr
+    :signature: corr(col1, col2)
+
+    Calculate the
+    `Pearson correlation <https://en.wikipedia.org/wiki/Pearson_correlation_coefficient>`_
+    between `col1` and `col2`.
+
+    Parameters
+    ----------
+    col1, col2: Expr
+        Input columns.
+
+    return: Expr
+        f-expression having one row, one column and the correlation coefficient
+        as the value. If one of the columns is non-numeric, the value is `NA`.
+        The column stype is `float32` if both `col1` and `col2` are `float32`,
+        and `float64` in all the other cases.
+
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> from datatable import dt, f
+        >>>
+        >>> DT = dt.Frame(A = [0, 1, 2, 3], B = [0, 2, 4, 6])
+        >>> DT
+           |     A      B
+           | int32  int32
+        -- + -----  -----
+         0 |     0      0
+         1 |     1      2
+         2 |     2      4
+         3 |     3      6
+        [4 rows x 2 columns]
+
+        >>> DT[:, dt.corr(f.A, f.B)]
+           |      C0
+           | float64
+        -- + -------
+         0 |       1
+        [1 row x 1 column]
+
+
+    See Also
+    --------
+    - :func:`cov()` -- function to calculate covariance between two columns.

--- a/docs/api/dt/cov.rst
+++ b/docs/api/dt/cov.rst
@@ -1,5 +1,52 @@
 
 .. xfunction:: datatable.cov
     :src: src/core/expr/head_reduce_binary.cc compute_cov
-    :doc: src/core/expr/head_reduce_binary.cc doc_cov
     :tests: tests/test-reduce.py
+    :cvar: doc_dt_cov
+    :signature: cov(col1, col2)
+
+    Calculate `covariance <https://en.wikipedia.org/wiki/Covariance>`_
+    between `col1` and `col2`.
+
+
+    Parameters
+    ----------
+    col1, col2: Expr
+        Input columns.
+
+    return: Expr
+        f-expression having one row, one column and the covariance between
+        `col1` and `col2` as the value. If one of the input columns is non-numeric,
+        the value is `NA`. The output column stype is `float32` if both `col1`
+        and `col2` are `float32`, and `float64` in all the other cases.
+
+
+    Examples
+    --------
+
+    .. code-block:: python
+
+        >>> from datatable import dt, f
+        >>>
+        >>> DT = dt.Frame(A = [0, 1, 2, 3], B = [0, 2, 4, 6])
+        >>> DT
+           |     A      B
+           | int32  int32
+        -- + -----  -----
+         0 |     0      0
+         1 |     1      2
+         2 |     2      4
+         3 |     3      6
+        [4 rows x 2 columns]
+
+        >>> DT[:, dt.cov(f.A, f.B)]
+           |      C0
+           | float64
+        -- + -------
+         0 | 3.33333
+        [1 row x 1 column]
+
+
+    See Also
+    --------
+    - :func:`corr()` -- function to calculate correlation between two columns.

--- a/docs/api/dt/cut.rst
+++ b/docs/api/dt/cut.rst
@@ -1,5 +1,46 @@
 
 .. xfunction:: datatable.cut
     :src: src/core/expr/fexpr_cut.cc pyfn_cut
-    :doc: src/core/expr/fexpr_cut.cc doc_cut
     :tests: tests/expr/test-cut.py
+    :cvar: doc_dt_cut
+    :signature: cut(cols, nbins=10, bins=None, right_closed=True)
+
+    .. x-version-added:: 0.11
+
+    For each column from `cols` bin its values into equal-width intervals,
+    when `nbins` is specified, or into arbitrary-width intervals,
+    when interval edges are provided as `bins`.
+
+    Parameters
+    ----------
+    cols: FExpr
+        Input data for equal-width interval binning.
+
+    nbins: int | List[int]
+        When a single number is specified, this number of bins
+        will be used to bin each column from `cols`.
+        When a list or a tuple is provided, each column will be binned
+        by using its own number of bins. In the latter case,
+        the list/tuple length must be equal to the number of columns
+        in `cols`.
+
+    bins: List[Frame]
+        List/tuple of single-column frames containing interval edges
+        in strictly increasing order, that will be used for binning
+        of the corresponding columns from `cols`. The list/tuple
+        length must be equal to the number of columns in `cols`.
+
+    right_closed: bool
+        Each binning interval is `half-open`_. This flag indicates whether
+        the right edge of the interval is closed, or not.
+
+    return: FExpr
+        f-expression that converts input columns into the columns filled
+        with the respective bin ids.
+
+    See also
+    --------
+    :func:`qcut()` -- function for equal-population binning.
+
+    .. _`half-open`: https://en.wikipedia.org/wiki/Interval_(mathematics)#Terminology
+

--- a/docs/api/dt/ifelse.rst
+++ b/docs/api/dt/ifelse.rst
@@ -1,8 +1,115 @@
 
 .. xfunction:: datatable.ifelse
     :src: src/core/expr/fexpr_ifelse.cc FExpr_IfElse::evaluate_n
-    :doc: src/core/expr/fexpr_ifelse.cc doc_ifelse
+    :cvar: doc_dt_ifelse
     :tests: tests/expr/test-ifelse.py
+    :signature: ifelse(condition1, value1, condition2, value2, ..., default)
+
+    .. x-version-added:: 0.11.0
+
+    An expression that chooses its value based on one or more
+    conditions.
+
+    This is roughly equivalent to the following Python code::
+
+        >>> result = value1 if condition1 else \
+        ...          value2 if condition2 else \
+        ...          ...                  else \
+        ...          default
+
+    For every row this function evaluates the smallest number of expressions
+    necessary to get the result. Thus, it evaluates `condition1`, `condition2`,
+    and so on until it finds the first condition that evaluates to `True`.
+    It then computes and returns the corresponding `value`. If all conditions
+    evaluate to `False`, then the `default` value is computed and returned.
+
+    Also, if any of the conditions produces NA then the result of the expression
+    also becomes NA without evaluating any further conditions or values.
 
 
+    Parameters
+    ----------
+    condition1, condition2, ...: FExpr[bool]
+        Expressions each producing a single boolean column. These conditions
+        will be evaluated in order until we find the one equal to `True`.
+
+    value1, value2, ...: FExpr
+        Values that will be used when the corresponding condition evaluates
+        to `True`. These must be single columns.
+
+    default: FExpr
+        Value that will be used when all conditions evaluate to `False`.
+        This must be a single column.
+
+    return: FExpr
+        The resulting expression is a single column whose stype is the
+        common stype for all `value1`, ..., `default` columns.
+
+
+    Notes
+    -----
+    .. x-version-changed:: 1.0.0
+
+        Earlier this function accepted a single condition only.
+
+    Examples
+    --------
+
+    Single condition
+    ~~~~~~~~~~~~~~~~
+    Task: Create a new column `Colour`, where if `Set` is `'Z'` then the
+    value should be `'Green'`, else `'Red'`::
+
+        >>> from datatable import dt, f, by, ifelse, update
+        >>>
+        >>> df = dt.Frame("""Type       Set
+        ...                   A          Z
+        ...                   B          Z
+        ...                   B          X
+        ...                   C          Y""")
+        >>> df[:, update(Colour = ifelse(f.Set == "Z",  # condition
+        ...                              "Green",       # if condition is True
+        ...                              "Red"))        # if condition is False
+        ... ]
+        >>> df
+           | Type   Set    Colour
+           | str32  str32  str32
+        -- + -----  -----  ------
+         0 | A      Z      Green
+         1 | B      Z      Green
+         2 | B      X      Red
+         3 | C      Y      Red
+        [4 rows x 3 columns]
+
+
+    Multiple conditions
+    ~~~~~~~~~~~~~~~~~~~
+    Task: Create new column ``value`` whose value is taken from columns ``a``,
+    ``b``, or ``c`` -- whichever is nonzero first::
+
+        >>> df = dt.Frame({"a": [0,0,1,2],
+        ...                "b": [0,3,4,5],
+        ...                "c": [6,7,8,9]})
+        >>> df
+           |     a      b      c
+           | int32  int32  int32
+        -- + -----  -----  -----
+         0 |     0      0      6
+         1 |     0      3      7
+         2 |     1      4      8
+         3 |     2      5      9
+        [4 rows x 3 columns]
+
+        >>> df['value'] = ifelse(f.a > 0, f.a,  # first condition and result
+        ...                      f.b > 0, f.b,  # second condition and result
+        ...                      f.c)           # default if no condition is True
+        >>> df
+           |     a      b      c  value
+           | int32  int32  int32  int32
+        -- + -----  -----  -----  -----
+         0 |     0      0      6      6
+         1 |     0      3      7      3
+         2 |     1      4      8      1
+         3 |     2      5      9      2
+        [4 rows x 4 columns]
 

--- a/docs/api/dt/qcut.rst
+++ b/docs/api/dt/qcut.rst
@@ -1,5 +1,38 @@
 
 .. xfunction:: datatable.qcut
     :src: src/core/expr/fexpr_qcut.cc pyfn_qcut
-    :doc: src/core/expr/fexpr_qcut.cc doc_qcut
+    :cvar: doc_dt_qcut
     :tests: tests/expr/test-qcut.py
+    :signature: qcut(cols, nquantiles=10)
+
+    .. x-version-added:: 0.11
+
+    Bin all the columns from `cols` into intervals with approximately
+    equal populations. Thus, the intervals are chosen according to
+    the sample quantiles of the data.
+
+    If there are duplicate values in the data, they will all be placed
+    into the same bin. In extreme cases this may cause the bins to be
+    highly unbalanced.
+
+    Parameters
+    ----------
+    cols: FExpr
+        Input data for quantile binning.
+
+    nquantiles: int | List[int]
+        When a single number is specified, this number of quantiles
+        will be used to bin each column from `cols`.
+
+        When a list or a tuple is provided, each column will be binned
+        by using its own number of quantiles. In the latter case,
+        the list/tuple length must be equal to the number of columns
+        in `cols`.
+
+    return: FExpr
+        f-expression that converts input columns into the columns filled
+        with the respective quantile ids.
+
+    See also
+    --------
+    :func:`cut()` -- function for equal-width interval binning.

--- a/docs/api/dt/shift.rst
+++ b/docs/api/dt/shift.rst
@@ -1,5 +1,80 @@
 
 .. xfunction:: datatable.shift
     :src: src/core/expr/head_func_shift.cc pyfn_shift
-    :doc: src/core/expr/head_func_shift.cc doc_shift
+    :cvar: doc_dt_shift
     :tests: tests/expr/test-shift.py
+    :signature: shift(col, n=1)
+
+    Produce a column obtained from `col` shifting it  `n` rows forward.
+
+    The shift amount, `n`, can be both positive and negative. If positive,
+    a "lag" column is created, if negative it will be a "lead" column.
+
+    The shifted column will have the same number of rows as the original
+    column, with `n` observations in the beginning becoming missing, and
+    `n` observations at the end discarded.
+
+    This function is group-aware, i.e. in the presence of a groupby it
+    will perform the shift separately within each group.
+
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> from datatable import dt, f, by
+        >>>
+        >>> DT = dt.Frame({"object": [1, 1, 1, 2, 2],
+        >>>                "period": [1, 2, 4, 4, 23],
+        >>>                "value": [24, 67, 89, 5, 23]})
+        >>>
+        >>> DT
+           | object  period  value
+           |  int32   int32  int32
+        -- + ------  ------  -----
+         0 |      1       1     24
+         1 |      1       2     67
+         2 |      1       4     89
+         3 |      2       4      5
+         4 |      2      23     23
+        [5 rows x 3 columns]
+
+    Shift forward - Create a "lag" column::
+
+        >>> DT[:, dt.shift(f.period,  n = 3)]
+           | period
+           |  int32
+        -- + ------
+         0 |     NA
+         1 |     NA
+         2 |     NA
+         3 |      1
+         4 |      2
+        [5 rows x 1 column]
+
+    Shift backwards - Create "lead" columns::
+
+        >>> DT[:, dt.shift(f[:], n = -3)]
+           | object  period  value
+           |  int32   int32  int32
+        -- + ------  ------  -----
+         0 |      2       4      5
+         1 |      2      23     23
+         2 |     NA      NA     NA
+         3 |     NA      NA     NA
+         4 |     NA      NA     NA
+        [5 rows x 3 columns]
+
+    Shift in the presence of :func:`by()`::
+
+        >>> DT[:, f[:].extend({"prev_value": dt.shift(f.value)}), by("object")]
+           | object  period  value  prev_value
+           |  int32   int32  int32       int32
+        -- + ------  ------  -----  ----------
+         0 |      1       1     24          NA
+         1 |      1       2     67          24
+         2 |      1       4     89          67
+         3 |      2       4      5          NA
+         4 |      2      23     23           5
+        [5 rows x 4 columns]
+

--- a/docs/api/math/isclose.rst
+++ b/docs/api/math/isclose.rst
@@ -1,4 +1,18 @@
 
 .. xfunction:: datatable.math.isclose
     :src: src/core/expr/head_func_isclose.cc pyfn_isclose
-    :doc: src/core/expr/head_func_isclose.cc doc_isclose
+    :cvar: doc_math_isclose
+    :signature: isclose(x, y, *, rtol=1e-5, atol=1e-8)
+
+    Compare two numbers x and y, and return True if they are close
+    within the requested relative/absolute tolerance. This function
+    only returns True/False, never NA.
+
+    More specifically, isclose(x, y) is True if either of the following
+    are true:
+
+    - ``x == y`` (including the case when x and y are NAs),
+    - ``abs(x - y) <= atol + rtol * abs(y)`` and neither x nor y are NA
+
+    The tolerance parameters ``rtol``, ``atol`` must be positive floats,
+    and cannot be expressions.

--- a/docs/api/math/round.rst
+++ b/docs/api/math/round.rst
@@ -1,5 +1,66 @@
 
 .. xfunction:: datatable.math.round
-    :doc: src/core/expr/fexpr_round.cc doc_round
     :src: src/core/expr/fexpr_round.cc pyfn_round
     :tests: tests/expr/math/test-round.py
+    :cvar: doc_math_round
+    :signature: round(cols, ndigits=None)
+
+    .. x-version-added:: 0.11
+
+    Round the values in `cols` up to the specified number of the digits
+    of precision `ndigits`. If the number of digits is omitted, rounds
+    to the nearest integer.
+
+    Generally, this operation is equivalent to::
+
+        >>> rint(col * 10**ndigits) / 10**ndigits
+
+    where function `rint()` rounds to the nearest integer.
+
+    Parameters
+    ----------
+    cols: FExpr
+        Input data for rounding. This could be an expression yielding
+        either a single or multiple columns. The `round()` function will
+        apply to each column independently and produce as many columns
+        in the output as there were in the input.
+
+        Only numeric columns are allowed: boolean, integer or float.
+        An exception will be raised if `cols` contains a non-numeric
+        column.
+
+    ndigits: int | None
+        The number of precision digits to retain. This parameter could
+        be either positive or negative (or None). If positive then it
+        gives the number of digits after the decimal point. If negative,
+        then it rounds the result up to the corresponding power of 10.
+
+        For example, `123.45` rounded to `ndigits=1` is `123.4`, whereas
+        rounded to `ndigits=-1` it becomes `120.0`.
+
+    return: FExpr
+        f-expression that rounds the values in its first argument to
+        the specified number of precision digits.
+
+        Each input column will produce the column of the same stype in
+        the output; except for the case when `ndigits` is `None` and
+        the input is either `float32` or `float64`, in which case an
+        `int64` column is produced (similarly to python's `round()`).
+
+    Notes
+    -----
+    Values that are exactly half way in between their rounded neighbors
+    are converted towards their nearest even value. For example, both
+    `7.5` and `8.5` are rounded into `8`, whereas `6.5` is rounded as `6`.
+
+    Rounding integer columns may produce unexpected results for values
+    that are close to the min/max value of that column's storage type.
+    For example, when an `int8` value `127` is rounded to nearest `10`, it
+    becomes `130`. However, since `130` cannot be represented as `int8` a
+    wrap-around occurs and the result becomes `-126`.
+
+    Rounding an integer column to a positive `ndigits` is a noop: the
+    column will be returned unchanged.
+
+    Rounding an integer column to a large negative `ndigits` will produce
+    a constant all-0 column.

--- a/src/core/datatablemodule.cc
+++ b/src/core/datatablemodule.cc
@@ -279,41 +279,27 @@ static void _register_function(const py::PKArgs& args) {
 }
 
 
-static const char* doc_compiler_version =
-R"(
-.. x-version-deprecated:: 0.11.0
-
-Return the version of the C++ compiler used to compile this module.
-)";
-
-static py::PKArgs args_compiler_version(
-  0, 0, 0, false, false, {}, "compiler_version",
-  doc_compiler_version);
-
-const char* get_compiler_version_string() {
+// This is a private function, used from build_info.py only.
+static py::oobj compiler_version(const py::XArgs&) {
   #define STR(x) STR1(x)
   #define STR1(x) #x
-  #if DT_COMPILER_CLANG
-    return "CLang " STR(__clang_major__) "." STR(__clang_minor__) "."
-           STR(__clang_patchlevel__);
-  #elif DT_COMPILER_MSVC
-    return "MSVC " STR(_MSC_FULL_VER);
-  #elif defined(__MINGW64__)
-    return "MinGW64 " STR(__MINGW64_VERSION_MAJOR) "."
-           STR(__MINGW64_VERSION_MINOR);
-  #elif DT_COMPILER_GCC
-    return "GCC " STR(__GNUC__) "." STR(__GNUC_MINOR__) "."
-           STR(__GNUC_PATCHLEVEL__);
-  #else
-    return "Unknown";
-  #endif
-  #undef STR
-  #undef STR1
+  const char* compiler =
+    #if DT_COMPILER_CLANG
+      "CLang " STR(__clang_major__) "." STR(__clang_minor__) "." STR(__clang_patchlevel__);
+    #elif DT_COMPILER_MSVC
+      "MSVC " STR(_MSC_FULL_VER);
+    #elif defined(__MINGW64__)
+      "MinGW64 " STR(__MINGW64_VERSION_MAJOR) "." STR(__MINGW64_VERSION_MINOR);
+    #elif DT_COMPILER_GCC
+      "GCC " STR(__GNUC__) "." STR(__GNUC_MINOR__) "." STR(__GNUC_PATCHLEVEL__);
+    #else
+      "Unknown";
+    #endif
+  return py::ostring(compiler);
 }
 
-static py::oobj compiler_version(const py::PKArgs&) {
-  return py::ostring(get_compiler_version_string());
-}
+DECLARE_PYFN(&compiler_version)
+    ->name("_compiler");
 
 
 
@@ -401,7 +387,6 @@ void py::DatatableModule::init_methods() {
   ADD_FN(&frame_integrity_check, args_frame_integrity_check);
   ADD_FN(&get_thread_ids, args_get_thread_ids);
   ADD_FN(&initialize_options, args_initialize_options);
-  ADD_FN(&compiler_version, args_compiler_version);
   ADD_FN(&apply_color, args_apply_color);
 
   for (py::XArgs* xarg : py::XArgs::store()) {

--- a/src/core/datatablemodule.cc
+++ b/src/core/datatablemodule.cc
@@ -390,7 +390,9 @@ void py::DatatableModule::init_methods() {
   ADD_FN(&apply_color, args_apply_color);
 
   for (py::XArgs* xarg : py::XArgs::store()) {
-    add(xarg->get_method_def());
+    if (xarg->get_class_id() == 0) {
+      add(xarg->get_method_def());
+    }
   }
 
   init_methods_aggregate();

--- a/src/core/datatablemodule.cc
+++ b/src/core/datatablemodule.cc
@@ -395,7 +395,6 @@ void py::DatatableModule::init_methods() {
 
   init_methods_aggregate();
   init_methods_csv();
-  init_methods_isclose();
   init_methods_jay();
   init_methods_join();
   init_methods_kfold();

--- a/src/core/datatablemodule.cc
+++ b/src/core/datatablemodule.cc
@@ -401,7 +401,6 @@ void py::DatatableModule::init_methods() {
   init_methods_rbind();
   init_methods_repeat();
   init_methods_sets();
-  init_methods_shift();
   init_methods_str();
   init_methods_styles();
 

--- a/src/core/datatablemodule.h
+++ b/src/core/datatablemodule.h
@@ -38,7 +38,6 @@ class DatatableModule : public ExtModule<DatatableModule> {
     void init_methods();
     void init_methods_aggregate(); // models/aggregate.cc
     void init_methods_csv();       // csv/py_csv.cc
-    void init_methods_isclose();   // expr/head_func_isclose.cc
     void init_methods_jay();       // open_jay.cc
     void init_methods_join();      // frame/join.cc
     void init_methods_kfold();     // models/kfold.cc

--- a/src/core/datatablemodule.h
+++ b/src/core/datatablemodule.h
@@ -44,7 +44,6 @@ class DatatableModule : public ExtModule<DatatableModule> {
     void init_methods_rbind();     // frame/rbind.cc
     void init_methods_repeat();    // frame/repeat.cc
     void init_methods_sets();      // set_funcs.cc
-    void init_methods_shift();     // expr/head_func_shift.cc
     void init_methods_str();       // str/py_str.cc
     void init_methods_styles();    // frame/repr/html_styles.cc
     void init_fbinary();           // expr/fbinary/pyfn.cc

--- a/src/core/datatablemodule.h
+++ b/src/core/datatablemodule.h
@@ -62,8 +62,6 @@ class DatatableModule : public ExtModule<DatatableModule> {
 
 
 
-const char* get_compiler_version_string();
-
 extern "C" {
 
   PyMODINIT_FUNC PyInit__datatable() noexcept;

--- a/src/core/documentation.h
+++ b/src/core/documentation.h
@@ -24,7 +24,9 @@
 namespace dt {
 
 
+extern const char* doc_dt_as_type;
 extern const char* doc_dt_cbind;
+extern const char* doc_dt_cut;
 extern const char* doc_dt_rbind;
 
 extern const char* doc_re_match;

--- a/src/core/documentation.h
+++ b/src/core/documentation.h
@@ -28,6 +28,7 @@ extern const char* doc_dt_as_type;
 extern const char* doc_dt_cbind;
 extern const char* doc_dt_cut;
 extern const char* doc_dt_ifelse;
+extern const char* doc_dt_qcut;
 extern const char* doc_dt_rbind;
 
 extern const char* doc_re_match;

--- a/src/core/documentation.h
+++ b/src/core/documentation.h
@@ -30,6 +30,7 @@ extern const char* doc_dt_cut;
 extern const char* doc_dt_ifelse;
 extern const char* doc_dt_qcut;
 extern const char* doc_dt_rbind;
+extern const char* doc_dt_shift;
 
 extern const char* doc_math_isclose;
 extern const char* doc_math_round;

--- a/src/core/documentation.h
+++ b/src/core/documentation.h
@@ -26,6 +26,8 @@ namespace dt {
 
 extern const char* doc_dt_as_type;
 extern const char* doc_dt_cbind;
+extern const char* doc_dt_corr;
+extern const char* doc_dt_cov;
 extern const char* doc_dt_cut;
 extern const char* doc_dt_ifelse;
 extern const char* doc_dt_qcut;

--- a/src/core/documentation.h
+++ b/src/core/documentation.h
@@ -31,6 +31,7 @@ extern const char* doc_dt_ifelse;
 extern const char* doc_dt_qcut;
 extern const char* doc_dt_rbind;
 
+extern const char* doc_math_isclose;
 extern const char* doc_math_round;
 
 extern const char* doc_re_match;

--- a/src/core/documentation.h
+++ b/src/core/documentation.h
@@ -31,6 +31,8 @@ extern const char* doc_dt_ifelse;
 extern const char* doc_dt_qcut;
 extern const char* doc_dt_rbind;
 
+extern const char* doc_math_round;
+
 extern const char* doc_re_match;
 
 extern const char* doc_str_len;

--- a/src/core/documentation.h
+++ b/src/core/documentation.h
@@ -27,6 +27,7 @@ namespace dt {
 extern const char* doc_dt_as_type;
 extern const char* doc_dt_cbind;
 extern const char* doc_dt_cut;
+extern const char* doc_dt_ifelse;
 extern const char* doc_dt_rbind;
 
 extern const char* doc_re_match;

--- a/src/core/expr/fexpr_astype.cc
+++ b/src/core/expr/fexpr_astype.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2020 H2O.ai
+// Copyright 2020-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -20,6 +20,7 @@
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #include "_dt.h"
+#include "documentation.h"
 #include "expr/fexpr_func_unary.h"
 #include "python/xargs.h"
 #include "stype.h"
@@ -67,93 +68,6 @@ class FExpr_AsType : public FExpr_FuncUnary {
 // Python-facing `as_type()` function
 //------------------------------------------------------------------------------
 
-static const char* doc_astype =
-R"(as_type(cols, new_type)
---
-.. x-version-added:: 1.0
-
-Convert columns `cols` into the prescribed stype.
-
-This function does not modify the data in the original column. Instead
-it returns a new column which converts the values into the new type on
-the fly.
-
-Parameters
-----------
-cols: FExpr
-    Single or multiple columns that need to be converted.
-
-new_type: Type | stype
-    Target type.
-
-return: FExpr
-    The output will have the same number of rows and columns as the
-    input; column names will be preserved too.
-
-
-Examples
---------
-.. code-block:: python
-
-    >>> from datatable import dt, f, as_type
-    >>>
-    >>> df = dt.Frame({'A': ['1', '1', '2', '1', '2'],
-    ...                'B': [None, '2', '3', '4', '5'],
-    ...                'C': [1, 2, 1, 1, 2]})
-    >>> df
-       | A      B          C
-       | str32  str32  int32
-    -- + -----  -----  -----
-     0 | 1      NA         1
-     1 | 1      2          2
-     2 | 2      3          1
-     3 | 1      4          1
-     4 | 2      5          2
-    [5 rows x 3 columns]
-
-
-Convert column A from string to integer type::
-
-    >>> df[:, as_type(f.A, int)]
-       |     A
-       | int64
-    -- + -----
-     0 |     1
-     1 |     1
-     2 |     2
-     3 |     1
-     4 |     2
-    [5 rows x 1 column]
-
-
-The exact dtype can be specified::
-
-    >>> df[:, as_type(f.A, dt.Type.int32)]
-       |     A
-       | int32
-    -- + -----
-     0 |     1
-     1 |     1
-     2 |     2
-     3 |     1
-     4 |     2
-    [5 rows x 1 column]
-
-
-Convert multiple columns to different types::
-
-    >>> df[:, [as_type(f.A, int), as_type(f.C, dt.str32)]]
-       |     A  C
-       | int64  str32
-    -- + -----  -----
-     0 |     1  1
-     1 |     1  2
-     2 |     2  1
-     3 |     1  1
-     4 |     2  2
-    [5 rows x 2 columns]
-)";
-
 static py::oobj pyfn_astype(const py::XArgs& args) {
   auto cols = args[0].to_oobj();
   dt::Type newtype = args[1].to_type_force();
@@ -162,7 +76,7 @@ static py::oobj pyfn_astype(const py::XArgs& args) {
 
 DECLARE_PYFN(&pyfn_astype)
     ->name("as_type")
-    ->docs(doc_astype)
+    ->docs(doc_dt_as_type)
     ->arg_names({"cols", "new_type"})
     ->n_positional_args(2)
     ->n_required_args(2);

--- a/src/core/expr/fexpr_cut.cc
+++ b/src/core/expr/fexpr_cut.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2020 H2O.ai
+// Copyright 2020-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -21,12 +21,11 @@
 //------------------------------------------------------------------------------
 #include "_dt.h"
 #include "column/cut.h"
+#include "documentation.h"
 #include "expr/eval_context.h"
 #include "expr/fexpr_func.h"
 #include "frame/py_frame.h"
 #include "python/xargs.h"
-
-
 namespace dt {
 namespace expr {
 
@@ -215,55 +214,11 @@ class FExpr_Cut : public FExpr_Func {
 // Python-facing `cut()` function
 //------------------------------------------------------------------------------
 
-static const char* doc_cut =
-R"(cut(cols, nbins=10, bins=None, right_closed=True)
---
-.. x-version-added:: 0.11
-
-For each column from `cols` bin its values into equal-width intervals,
-when `nbins` is specified, or into arbitrary-width intervals,
-when interval edges are provided as `bins`.
-
-Parameters
-----------
-cols: FExpr
-    Input data for equal-width interval binning.
-
-nbins: int | List[int]
-    When a single number is specified, this number of bins
-    will be used to bin each column from `cols`.
-    When a list or a tuple is provided, each column will be binned
-    by using its own number of bins. In the latter case,
-    the list/tuple length must be equal to the number of columns
-    in `cols`.
-
-bins: List[Frame]
-    List/tuple of single-column frames containing interval edges
-    in strictly increasing order, that will be used for binning
-    of the corresponding columns from `cols`. The list/tuple
-    length must be equal to the number of columns in `cols`.
-
-right_closed: bool
-    Each binning interval is `half-open`_. This flag indicates whether
-    the right edge of the interval is closed, or not.
-
-return: FExpr
-    f-expression that converts input columns into the columns filled
-    with the respective bin ids.
-
-See also
---------
-:func:`qcut()` -- function for equal-population binning.
-
-.. _`half-open`: https://en.wikipedia.org/wiki/Interval_(mathematics)#Terminology
-
-)";
-
 static py::oobj pyfn_cut(const py::XArgs& args) {
   auto arg0         = args[0].to_oobj();
-  auto nbins_arg     = args[1].to<py::oobj>(py::None());
-  auto bins_arg      = args[2].to<py::oobj>(py::None());
-  auto right_closed  = args[3].to<bool>(true);
+  auto nbins_arg    = args[1].to<py::oobj>(py::None());
+  auto bins_arg     = args[2].to<py::oobj>(py::None());
+  auto right_closed = args[3].to<bool>(true);
   std::vector<std::shared_ptr<dblvec>> bin_edges_vec;
   int32_t nbins_default = 10;
   int32vec nbins_vec;
@@ -340,11 +295,13 @@ static py::oobj pyfn_cut(const py::XArgs& args) {
 
 DECLARE_PYFN(&pyfn_cut)
     ->name("cut")
-    ->docs(doc_cut)
+    ->docs(doc_dt_cut)
     ->arg_names({"cols", "nbins", "bins", "right_closed"})
     ->n_positional_args(1)
     ->n_keyword_args(3)
     ->n_required_args(1);
+
+
 
 
 }}  // dt::expr

--- a/src/core/expr/fexpr_ifelse.cc
+++ b/src/core/expr/fexpr_ifelse.cc
@@ -21,6 +21,7 @@
 //------------------------------------------------------------------------------
 #include "column/ifelse.h"        // IfElse_ColumnImpl
 #include "column/ifelsen.h"       // IfElseN_ColumnImpl
+#include "documentation.h"
 #include "expr/eval_context.h"    // EvalContext
 #include "expr/fexpr_func.h"      // FExpr_Func
 #include "expr/workframe.h"       // Workframe
@@ -141,118 +142,6 @@ std::string FExpr_IfElse::repr() const {
 // Python interface
 //------------------------------------------------------------------------------
 
-static const char* doc_ifelse =
-R"(ifelse(condition1, value1, condition2, value2, ..., default)
---
-.. x-version-added:: 0.11.0
-
-An expression that chooses its value based on one or more
-conditions.
-
-This is roughly equivalent to the following Python code::
-
-    >>> result = value1 if condition1 else \
-    ...          value2 if condition2 else \
-    ...          ...                  else \
-    ...          default
-
-For every row this function evaluates the smallest number of expressions
-necessary to get the result. Thus, it evaluates `condition1`, `condition2`,
-and so on until it finds the first condition that evaluates to `True`.
-It then computes and returns the corresponding `value`. If all conditions
-evaluate to `False`, then the `default` value is computed and returned.
-
-Also, if any of the conditions produces NA then the result of the expression
-also becomes NA without evaluating any further conditions or values.
-
-
-Parameters
-----------
-condition1, condition2, ...: FExpr[bool]
-    Expressions each producing a single boolean column. These conditions
-    will be evaluated in order until we find the one equal to `True`.
-
-value1, value2, ...: FExpr
-    Values that will be used when the corresponding condition evaluates
-    to `True`. These must be single columns.
-
-default: FExpr
-    Value that will be used when all conditions evaluate to `False`.
-    This must be a single column.
-
-return: FExpr
-    The resulting expression is a single column whose stype is the
-    common stype for all `value1`, ..., `default` columns.
-
-
-Notes
------
-.. x-version-changed:: 1.0.0
-
-    Earlier this function accepted a single condition only.
-
-Examples
---------
-
-Single condition
-~~~~~~~~~~~~~~~~
-Task: Create a new column `Colour`, where if `Set` is `'Z'` then the
-value should be `'Green'`, else `'Red'`::
-
-    >>> from datatable import dt, f, by, ifelse, update
-    >>>
-    >>> df = dt.Frame("""Type       Set
-    ...                   A          Z
-    ...                   B          Z
-    ...                   B          X
-    ...                   C          Y""")
-    >>> df[:, update(Colour = ifelse(f.Set == "Z",  # condition
-    ...                              "Green",       # if condition is True
-    ...                              "Red"))        # if condition is False
-    ... ]
-    >>> df
-       | Type   Set    Colour
-       | str32  str32  str32
-    -- + -----  -----  ------
-     0 | A      Z      Green
-     1 | B      Z      Green
-     2 | B      X      Red
-     3 | C      Y      Red
-    [4 rows x 3 columns]
-
-
-Multiple conditions
-~~~~~~~~~~~~~~~~~~~
-Task: Create new column ``value`` whose value is taken from columns ``a``,
-``b``, or ``c`` -- whichever is nonzero first::
-
-    >>> df = dt.Frame({"a": [0,0,1,2],
-    ...                "b": [0,3,4,5],
-    ...                "c": [6,7,8,9]})
-    >>> df
-       |     a      b      c
-       | int32  int32  int32
-    -- + -----  -----  -----
-     0 |     0      0      6
-     1 |     0      3      7
-     2 |     1      4      8
-     3 |     2      5      9
-    [4 rows x 3 columns]
-
-    >>> df['value'] = ifelse(f.a > 0, f.a,  # first condition and result
-    ...                      f.b > 0, f.b,  # second condition and result
-    ...                      f.c)           # default if no condition is True
-    >>> df
-       |     a      b      c  value
-       | int32  int32  int32  int32
-    -- + -----  -----  -----  -----
-     0 |     0      0      6      6
-     1 |     0      3      7      3
-     2 |     1      4      8      1
-     3 |     2      5      9      2
-    [4 rows x 4 columns]
-)";
-
 static py::oobj ifelse(const py::XArgs& args) {
   auto n = args.num_varargs();
   if (n < 3) {
@@ -279,8 +168,9 @@ static py::oobj ifelse(const py::XArgs& args) {
 
 DECLARE_PYFN(&ifelse)
     ->name("ifelse")
-    ->docs(doc_ifelse)
+    ->docs(doc_dt_ifelse)
     ->allow_varargs();
+
 
 
 

--- a/src/core/expr/fexpr_qcut.cc
+++ b/src/core/expr/fexpr_qcut.cc
@@ -23,6 +23,7 @@
 #include "column/latent.h"
 #include "column/sentinel_fw.h"
 #include "column/qcut.h"
+#include "documentation.h"
 #include "expr/eval_context.h"
 #include "expr/fexpr_func.h"
 #include "frame/py_frame.h"
@@ -136,43 +137,6 @@ class FExpr_Qcut : public FExpr_Func {
 // Python-facing `qcut()` function
 //------------------------------------------------------------------------------
 
-static const char* doc_qcut =
-R"(qcut(cols, nquantiles=10)
---
-.. x-version-added:: 0.11
-
-Bin all the columns from `cols` into intervals with approximately
-equal populations. Thus, the intervals are chosen according to
-the sample quantiles of the data.
-
-If there are duplicate values in the data, they will all be placed
-into the same bin. In extreme cases this may cause the bins to be
-highly unbalanced.
-
-Parameters
-----------
-cols: FExpr
-    Input data for quantile binning.
-
-nquantiles: int | List[int]
-    When a single number is specified, this number of quantiles
-    will be used to bin each column from `cols`.
-
-    When a list or a tuple is provided, each column will be binned
-    by using its own number of quantiles. In the latter case,
-    the list/tuple length must be equal to the number of columns
-    in `cols`.
-
-return: FExpr
-    f-expression that converts input columns into the columns filled
-    with the respective quantile ids.
-
-See also
---------
-:func:`cut()` -- function for equal-width interval binning.
-
-)";
-
 static py::oobj pyfn_qcut(const py::XArgs& args) {
   auto cols       = args[0].to_oobj();
   auto nquantiles = args[1].to<py::oobj>(py::None());
@@ -181,7 +145,7 @@ static py::oobj pyfn_qcut(const py::XArgs& args) {
 
 DECLARE_PYFN(&pyfn_qcut)
     ->name("qcut")
-    ->docs(doc_qcut)
+    ->docs(doc_dt_qcut)
     ->arg_names({"cols", "nquantiles"})
     ->n_positional_args(1)
     ->n_keyword_args(1)

--- a/src/core/expr/fexpr_round.cc
+++ b/src/core/expr/fexpr_round.cc
@@ -24,6 +24,7 @@
 #include "_dt.h"
 #include "column/const.h"
 #include "column/virtual.h"
+#include "documentation.h"
 #include "expr/eval_context.h"
 #include "expr/fexpr_func_unary.h"
 #include "python/xargs.h"
@@ -299,70 +300,6 @@ class FExpr_Round : public FExpr_FuncUnary {
 // Python-facing `round()` function
 //------------------------------------------------------------------------------
 
-static const char* doc_round =
-R"(round(cols, ndigits=None)
---
-.. x-version-added:: 0.11
-
-Round the values in `cols` up to the specified number of the digits
-of precision `ndigits`. If the number of digits is omitted, rounds
-to the nearest integer.
-
-Generally, this operation is equivalent to::
-
-    >>> rint(col * 10**ndigits) / 10**ndigits
-
-where function `rint()` rounds to the nearest integer.
-
-Parameters
-----------
-cols: FExpr
-    Input data for rounding. This could be an expression yielding
-    either a single or multiple columns. The `round()` function will
-    apply to each column independently and produce as many columns
-    in the output as there were in the input.
-
-    Only numeric columns are allowed: boolean, integer or float.
-    An exception will be raised if `cols` contains a non-numeric
-    column.
-
-ndigits: int | None
-    The number of precision digits to retain. This parameter could
-    be either positive or negative (or None). If positive then it
-    gives the number of digits after the decimal point. If negative,
-    then it rounds the result up to the corresponding power of 10.
-
-    For example, `123.45` rounded to `ndigits=1` is `123.4`, whereas
-    rounded to `ndigits=-1` it becomes `120.0`.
-
-return: FExpr
-    f-expression that rounds the values in its first argument to
-    the specified number of precision digits.
-
-    Each input column will produce the column of the same stype in
-    the output; except for the case when `ndigits` is `None` and
-    the input is either `float32` or `float64`, in which case an
-    `int64` column is produced (similarly to python's `round()`).
-
-Notes
------
-Values that are exactly half way in between their rounded neighbors
-are converted towards their nearest even value. For example, both
-`7.5` and `8.5` are rounded into `8`, whereas `6.5` is rounded as `6`.
-
-Rounding integer columns may produce unexpected results for values
-that are close to the min/max value of that column's storage type.
-For example, when an `int8` value `127` is rounded to nearest `10`, it
-becomes `130`. However, since `130` cannot be represented as `int8` a
-wrap-around occurs and the result becomes `-126`.
-
-Rounding an integer column to a positive `ndigits` is a noop: the
-column will be returned unchanged.
-
-Rounding an integer column to a large negative `ndigits` will produce
-a constant all-0 column.
-)";
-
 static py::oobj pyfn_round(const py::XArgs& args) {
   auto cols    = args[0].to_oobj();
   auto ndigits = args[1].to<int>(NODIGITS);
@@ -371,7 +308,7 @@ static py::oobj pyfn_round(const py::XArgs& args) {
 
 DECLARE_PYFN(&pyfn_round)
     ->name("round")
-    ->docs(doc_round)
+    ->docs(doc_math_round)
     ->arg_names({"cols", "ndigits"})
     ->n_positional_args(1)
     ->n_keyword_args(1)

--- a/src/core/expr/head_reduce_binary.cc
+++ b/src/core/expr/head_reduce_binary.cc
@@ -110,58 +110,6 @@ class BinaryReduced_ColumnImpl : public Virtual_ColumnImpl {
 //------------------------------------------------------------------------------
 // cov(X, Y)
 //------------------------------------------------------------------------------
-#if 0
-static const char* doc_cov =
-R"(cov(col1, col2)
---
-
-Calculate `covariance <https://en.wikipedia.org/wiki/Covariance>`_
-between `col1` and `col2`.
-
-
-Parameters
-----------
-col1, col2: Expr
-    Input columns.
-
-return: Expr
-    f-expression having one row, one column and the covariance between
-    `col1` and `col2` as the value. If one of the input columns is non-numeric,
-    the value is `NA`. The output column stype is `float32` if both `col1`
-    and `col2` are `float32`, and `float64` in all the other cases.
-
-
-Examples
---------
-
-.. code-block:: python
-
-    >>> from datatable import dt, f
-    >>>
-    >>> DT = dt.Frame(A = [0, 1, 2, 3], B = [0, 2, 4, 6])
-    >>> DT
-       |     A      B
-       | int32  int32
-    -- + -----  -----
-     0 |     0      0
-     1 |     1      2
-     2 |     2      4
-     3 |     3      6
-    [4 rows x 2 columns]
-
-    >>> DT[:, dt.cov(f.A, f.B)]
-       |      C0
-       | float64
-    -- + -------
-     0 | 3.33333
-    [1 row x 1 column]
-
-
-See Also
---------
-- :func:`corr()` -- function to calculate correlation between two columns.
-)";
-#endif
 
 template <typename T>
 static bool cov_reducer(const Column& col1, const Column& col2,
@@ -216,57 +164,6 @@ static Column compute_cov(Column&& arg1, Column&& arg2, const Groupby& gby) {
 //------------------------------------------------------------------------------
 // corr(X, Y)
 //------------------------------------------------------------------------------
-#if 0
-static const char* doc_corr =
-R"(corr(col1, col2)
---
-
-Calculate the
-`Pearson correlation <https://en.wikipedia.org/wiki/Pearson_correlation_coefficient>`_
-between `col1` and `col2`.
-
-Parameters
-----------
-col1, col2: Expr
-    Input columns.
-
-return: Expr
-    f-expression having one row, one column and the correlation coefficient
-    as the value. If one of the columns is non-numeric, the value is `NA`.
-    The column stype is `float32` if both `col1` and `col2` are `float32`,
-    and `float64` in all the other cases.
-
-
-Examples
---------
-.. code-block:: python
-
-    >>> from datatable import dt, f
-    >>>
-    >>> DT = dt.Frame(A = [0, 1, 2, 3], B = [0, 2, 4, 6])
-    >>> DT
-       |     A      B
-       | int32  int32
-    -- + -----  -----
-     0 |     0      0
-     1 |     1      2
-     2 |     2      4
-     3 |     3      6
-    [4 rows x 2 columns]
-
-    >>> DT[:, dt.corr(f.A, f.B)]
-       |      C0
-       | float64
-    -- + -------
-     0 |       1
-    [1 row x 1 column]
-
-
-See Also
---------
-- :func:`cov()` -- function to calculate covariance between two columns.
-)";
-#endif
 
 template <typename T>
 static bool corr_reducer(const Column& col1, const Column& col2,

--- a/src/core/frame/to_arrow.cc
+++ b/src/core/frame/to_arrow.cc
@@ -34,9 +34,6 @@
 namespace py {
 
 
-static const char* doc_to_arrow =
-R"()";
-
 oobj Frame::to_arrow(const XArgs&) {
   oobj pyarrow = oobj::import("pyarrow");
   oobj pa_Array = pyarrow.get_attr("Array");
@@ -63,7 +60,7 @@ oobj Frame::to_arrow(const XArgs&) {
 
 DECLARE_METHOD(&Frame::to_arrow)
     ->name("to_arrow")
-    ->docs(doc_to_arrow);
+    ->docs(dt::doc_Frame_to_arrow);
 
 
 

--- a/src/core/python/xargs.cc
+++ b/src/core/python/xargs.cc
@@ -53,11 +53,13 @@ XArgs::XArgs(impl_function_t fn) : XArgs() {
 }
 
 XArgs::XArgs(impl_method_t method, size_t classId) : XArgs() {
+  xassert(classId);
   ccfn_.meth = method;
   classId_ = classId;
 }
 
 XArgs::XArgs(impl_methodv_t method, size_t classId) : XArgs() {
+  xassert(classId);
   ccfn_.methv = method;
   classId_ = classId;
 }

--- a/src/core/python/xargs.h
+++ b/src/core/python/xargs.h
@@ -23,6 +23,7 @@
 #define dt_PYTHON_XARGS_h
 #include <iterator>        // std::input_iterator_tag
 #include <string>          // std::string
+#include <typeinfo>        // typeid
 #include <unordered_map>   // std::unordered_map
 #include <vector>          // std::vector
 #include "utils/macros.h"

--- a/tests/expr/test-shift.py
+++ b/tests/expr/test-shift.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #-------------------------------------------------------------------------------
-# Copyright 2018-2020 H2O.ai
+# Copyright 2018-2021 H2O.ai
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -164,7 +164,7 @@ def test_shift_wrong_signature2():
 
 
 def test_shift_wrong_signature3():
-    msg = r"Argument n in shift\(\) should be an integer"
+    msg = r"Argument n in function datatable\.shift\(\) should be an integer"
     for n in ["one", 0.0, f.B, range(3), [1, 2, 3]]:
         with pytest.raises(TypeError, match=msg):
             shift(f.A, n=n)


### PR DESCRIPTION
- Moved documentation for 9 functions into docs/ folder;
- Two functions (`isclose()` and `shift()`) changed into using XArgs;
- Internal method `compiler_version()` renamed into `_compiler()` and simplified;
- Fixed bug in XArgs where methods were improperly added to main namespace as functions.

WIP for #3029