### PR TITLE
Minor documentation and tests changes related to deprecation

### DIFF
--- a/docs/api/frame/ltypes.rst
+++ b/docs/api/frame/ltypes.rst
@@ -5,7 +5,7 @@
 
     .. x-version-deprecated:: 1.0.0
 
-        This property is deprecated and will be removed in version 1.1.0.
+        This property is deprecated and will be removed in version 1.2.0.
         Please use :attr:`.types` instead.
 
     The tuple of each column's ltypes ("logical types").

--- a/docs/api/frame/ltypes.rst
+++ b/docs/api/frame/ltypes.rst
@@ -5,7 +5,8 @@
 
     .. x-version-deprecated:: 1.0.0
 
-        Use property :attr:`.types` instead.
+        This property is deprecated and will be removed in version 1.1.0.
+        Please use :attr:`.types` instead.
 
     The tuple of each column's ltypes ("logical types").
 

--- a/docs/api/frame/stype.rst
+++ b/docs/api/frame/stype.rst
@@ -5,7 +5,8 @@
 
     .. x-version-deprecated:: 1.0.0
 
-        Use property :attr:`.type` instead.
+        This property is deprecated and will be removed in version 1.1.0.
+        Please use :attr:`.types` instead.
 
     .. x-version-added:: 0.10.0
 

--- a/docs/api/frame/stype.rst
+++ b/docs/api/frame/stype.rst
@@ -5,7 +5,7 @@
 
     .. x-version-deprecated:: 1.0.0
 
-        This property is deprecated and will be removed in version 1.1.0.
+        This property is deprecated and will be removed in version 1.2.0.
         Please use :attr:`.types` instead.
 
     .. x-version-added:: 0.10.0

--- a/docs/api/frame/stypes.rst
+++ b/docs/api/frame/stypes.rst
@@ -5,7 +5,8 @@
 
     .. x-version-deprecated:: 1.0.0
 
-        Use property :attr:`.types` instead.
+        This property is deprecated and will be removed in version 1.2.0.
+        Please use :attr:`.types` instead.
 
     The tuple of each column's stypes ("storage types").
 

--- a/docs/api/ltype.rst
+++ b/docs/api/ltype.rst
@@ -2,6 +2,20 @@
 .. xclass:: datatable.ltype
     :src: src/datatable/types.py ltype
 
+    .. x-version-deprecated:: 1.0.0
+
+        This class is deprecated and will be removed in version 1.2.0.
+        Please use :class:`dt.Type` instead.
+
+    Enumeration of possible "logical" types of a column.
+
+    Logical type is the type stripped away from the details of its physical
+    storage. For example, ``ltype.int`` represents an integer. Under the hood,
+    this integer can be stored in several "physical" formats: from
+    ``stype.int8`` to ``stype.int64``. Thus, there is a one-to-many relationship
+    between ltypes and stypes.
+
+
     Values
     ------
     The following ltype values are currently available:

--- a/docs/api/stype.rst
+++ b/docs/api/stype.rst
@@ -2,6 +2,22 @@
 .. xclass:: datatable.stype
     :src: src/datatable/types.py stype
 
+    .. x-version-deprecated:: 1.0.0
+
+        This class is deprecated and will be removed in version 1.2.0.
+        Please use :class:`dt.Type` instead.
+
+    Enumeration of possible "storage" types of columns in a Frame.
+
+    Each column in a Frame is a vector of values of the same type. We call
+    this column's type the "stype". Most stypes correspond to primitive C types,
+    such as ``int32_t`` or ``double``. However some stypes (corresponding to
+    strings and categoricals) have a more complicated underlying structure.
+
+    Notably, :mod:`datatable` does not support arbitrary structures as
+    elements of a Column, so the set of stypes is small.
+
+
     Values
     ------
     The following stype values are currently available:

--- a/src/core/expr/fexpr.h
+++ b/src/core/expr/fexpr.h
@@ -178,7 +178,7 @@ class PyFExpr : public py::XObject<PyFExpr> {
 
     py::oobj extend(const py::PKArgs&);
     py::oobj remove(const py::PKArgs&);
-    py::oobj len();                     // [DEPRECATED]
+    py::oobj len();                         // [DEPRECATED]
     py::oobj re_match(const py::PKArgs&);   // [DEPRECATED]
 
     py::oobj sum(const py::XArgs&);

--- a/src/datatable/types.py
+++ b/src/datatable/types.py
@@ -36,6 +36,11 @@ class typed_list(list):
 @enum.unique
 class stype(enum.Enum):
     """
+    .. x-version-deprecated:: 1.0.0
+
+        This class is deprecated and will be removed in version 1.2.0.
+        Please use :class:`dt.Type` instead.
+
     Enumeration of possible "storage" types of columns in a Frame.
 
     Each column in a Frame is a vector of values of the same type. We call
@@ -143,6 +148,11 @@ class stype(enum.Enum):
 @enum.unique
 class ltype(enum.Enum):
     """
+    .. x-version-deprecated:: 1.0.0
+
+        This class is deprecated and will be removed in version 1.2.0.
+        Please use :class:`dt.Type` instead.
+
     Enumeration of possible "logical" types of a column.
 
     Logical type is the type stripped away from the details of its physical

--- a/src/datatable/types.py
+++ b/src/datatable/types.py
@@ -35,22 +35,7 @@ class typed_list(list):
 
 @enum.unique
 class stype(enum.Enum):
-    """
-    .. x-version-deprecated:: 1.0.0
 
-        This class is deprecated and will be removed in version 1.2.0.
-        Please use :class:`dt.Type` instead.
-
-    Enumeration of possible "storage" types of columns in a Frame.
-
-    Each column in a Frame is a vector of values of the same type. We call
-    this column's type the "stype". Most stypes correspond to primitive C types,
-    such as ``int32_t`` or ``double``. However some stypes (corresponding to
-    strings and categoricals) have a more complicated underlying structure.
-
-    Notably, :mod:`datatable` does not support arbitrary structures as
-    elements of a Column, so the set of stypes is small.
-    """
     void = 0
     bool8 = 1
     int8 = 2
@@ -147,20 +132,7 @@ class stype(enum.Enum):
 
 @enum.unique
 class ltype(enum.Enum):
-    """
-    .. x-version-deprecated:: 1.0.0
 
-        This class is deprecated and will be removed in version 1.2.0.
-        Please use :class:`dt.Type` instead.
-
-    Enumeration of possible "logical" types of a column.
-
-    Logical type is the type stripped away from the details of its physical
-    storage. For example, ``ltype.int`` represents an integer. Under the hood,
-    this integer can be stored in several "physical" formats: from
-    ``stype.int8`` to ``stype.int64``. Thus, there is a one-to-many relationship
-    between ltypes and stypes.
-    """
     void = 0
     bool = 1
     int = 2

--- a/tests/munging/test-str.py
+++ b/tests/munging/test-str.py
@@ -186,3 +186,11 @@ def test_split_into_nhot_view():
            [[1, None, 0, 1], [1, None, 0, 1], [0, None, 1, 1]]
     assert set(f2.names) == {"cat", "dog"}
     assert f2[:, ["cat", "dog"]].to_list() == [[1], [1]]
+
+
+def test_split_into_nhot_deprecated():
+    DT = dt.Frame(["a, b, c"])
+    with pytest.warns(FutureWarning):
+        RES = dt.split_into_nhot(DT)
+    EXP = dt.Frame([[1], [1], [1]], names=["a", "b", "c"], stype=dt.bool8)
+    assert_equals(RES, EXP)


### PR DESCRIPTION
- add `ltypes`/`ltype` and `stypes`/`stype` deprecation warnings in documentation;
- move `ltype` and `stype` documentation from python to rst;
- add `dt.split_into_nhot()` deprecation test.