### PR TITLE
Fix readthedocs style errors

### DIFF
--- a/docs/_static/wren.css
+++ b/docs/_static/wren.css
@@ -757,6 +757,11 @@ div.rst-versions div.rst-other-versions dl:nth-child(2) { display: none; }
 div.rst-versions div.rst-other-versions dl:nth-child(4) { display: none; }
 div.rst-versions div.rst-other-versions dl:nth-child(5) { display: none; }
 
+div[class*="highlight-"] {
+  clear: inherit !important;
+  margin: inherit !important;
+}
+
 
 
 /*------------------------------------------------------------------------------


### PR DESCRIPTION
Certain CSS rules injected by readthedocs break our design. This PR attempts to cancel such rules.