### PR TITLE
New types list32 and list64

### DIFF
--- a/docs/api/type.rst
+++ b/docs/api/type.rst
@@ -29,6 +29,8 @@
     - :attr:`dt.Type.int32`
     - :attr:`dt.Type.int64`
     - :attr:`dt.Type.int8`
+    - :meth:`dt.Type.list32(T)`
+    - :meth:`dt.Type.list64(T)`
     - :attr:`dt.Type.obj64`
     - :attr:`dt.Type.str32`
     - :attr:`dt.Type.str64`
@@ -55,19 +57,21 @@
 .. toctree::
     :hidden:
 
-    ⭑ bool8    <type/bool8>
-    ⭑ date32   <type/date32>
-    ⭑ float32  <type/float32>
-    ⭑ float64  <type/float64>
-    ⭑ int8     <type/int8>
-    ⭑ int16    <type/int16>
-    ⭑ int32    <type/int32>
-    ⭑ int64    <type/int64>
-    ⭑ obj64    <type/obj64>
-    ⭑ str32    <type/str32>
-    ⭑ str64    <type/str64>
-    ⭑ time64   <type/time64>
-    ⭑ void     <type/void>
-    max        <type/max>
-    min        <type/min>
-    name       <type/name>
+    ⭑ bool8     <type/bool8>
+    ⭑ date32    <type/date32>
+    ⭑ float32   <type/float32>
+    ⭑ float64   <type/float64>
+    ⭑ int8      <type/int8>
+    ⭑ int16     <type/int16>
+    ⭑ int32     <type/int32>
+    ⭑ int64     <type/int64>
+    ⭑ list32(T) <type/list32>
+    ⭑ list64(T) <type/list64>
+    ⭑ obj64     <type/obj64>
+    ⭑ str32     <type/str32>
+    ⭑ str64     <type/str64>
+    ⭑ time64    <type/time64>
+    ⭑ void      <type/void>
+    max         <type/max>
+    min         <type/min>
+    name        <type/name>

--- a/docs/api/type/list32.rst
+++ b/docs/api/type/list32.rst
@@ -1,0 +1,13 @@
+
+.. xmethod:: datatable.Type.list32
+    :src: src/core/types/py_type.cc PyType::list32
+    :cvar: doc_Type_list32
+    :signature: list32(T)
+
+    List type with 32-bit offsets. In a column of this type, every element
+    is a list of types `T`.
+
+
+    See Also
+    --------
+    :meth:`.list64(T)` -- another list type, but with 64-bit offsets.

--- a/docs/api/type/list64.rst
+++ b/docs/api/type/list64.rst
@@ -1,0 +1,13 @@
+
+.. xmethod:: datatable.Type.list64
+    :src: src/core/types/py_type.cc PyType::list64
+    :cvar: doc_Type_list64
+    :signature: list64(T)
+
+    List type with 64-bit offsets. In a column of this type, every element
+    is a list of types `T`.
+
+
+    See Also
+    --------
+    :meth:`.list32(T)` -- another list type, but with 32-bit offsets.

--- a/src/core/documentation.h
+++ b/src/core/documentation.h
@@ -107,6 +107,8 @@ extern const char* doc_models_LM;
 extern const char* doc_models_LM_params;
 
 extern const char* doc_Type;
+extern const char* doc_Type_list32;
+extern const char* doc_Type_list64;
 extern const char* doc_Type_max;
 extern const char* doc_Type_min;
 extern const char* doc_Type_name;

--- a/src/core/python/xargs.cc
+++ b/src/core/python/xargs.cc
@@ -43,7 +43,8 @@ XArgs::XArgs()
     nargs_all_(0),
     has_varargs_(false),
     has_varkwds_(false),
-    has_renamed_args_(false)
+    has_renamed_args_(false),
+    is_static_method_(false)
 {
   store().push_back(this);
 }
@@ -75,7 +76,7 @@ PyMethodDef XArgs::get_method_def() {
   return PyMethodDef {
     function_name_.data(),
     reinterpret_cast<PyCFunction>(pyfn_),
-    METH_VARARGS | METH_KEYWORDS,
+    METH_VARARGS | METH_KEYWORDS | (is_static_method_? METH_STATIC : 0),
     docstring_
   };
 }
@@ -187,6 +188,17 @@ XArgs* XArgs::add_synonym_arg(const char* new_name, const char* old_name) {
 
 XArgs* XArgs::set_class_name(const char* className) {
   class_name_ = className;
+  return this;
+}
+
+XArgs* XArgs::save_as(XArgs** target) {
+  *target = this;
+  return this;
+}
+
+XArgs* XArgs::staticmethod() {
+  xassert(classId_);
+  is_static_method_ = true;
   return this;
 }
 

--- a/src/core/python/xargs.h
+++ b/src/core/python/xargs.h
@@ -62,7 +62,7 @@ class XArgs : public ArgParent {
     bool has_varargs_;
     bool has_varkwds_;
     bool has_renamed_args_;
-    int : 8;
+    bool is_static_method_;
     int info_;  // custom user info that can be stored inside XArgs
 
     // Runtime arguments
@@ -94,6 +94,8 @@ class XArgs : public ArgParent {
     XArgs* add_info(int);
     XArgs* add_synonym_arg(const char* new_name, const char* old_name);
     XArgs* set_class_name(const char* name);
+    XArgs* save_as(XArgs**);
+    XArgs* staticmethod();
 
     size_t n_positional_args() const override;
     size_t n_positional_or_keyword_args() const override;
@@ -205,7 +207,7 @@ class XArgs : public ArgParent {
 
 
 // #define RESULT_OF(fn)
-//     typename std::result_of<decltype(fn)(CLASS_OF(fn), const XArgs&)>::type
+//     typename std::result_of<decltype(fn)(CLASS_OF(fn), const py::XArgs&)>::type
 
 
 #define ARGS_NAME  PASTE_TOKENS(args_, __LINE__)
@@ -218,7 +220,7 @@ class XArgs : public ArgParent {
 
 #define DECLARE_METHOD(fn)                                                     \
     static py::XArgs* ARGS_NAME = (new py::XArgs(                              \
-        reinterpret_cast<oobj(PyObject::*)(const XArgs&)>(fn),                 \
+        reinterpret_cast<py::oobj(PyObject::*)(const py::XArgs&)>(fn),         \
         typeid(CLASS_OF(fn)).hash_code())                                      \
       )->pyfunction(                                                           \
           [](PyObject* self, PyObject* args, PyObject* kwds) -> PyObject* {    \
@@ -227,7 +229,7 @@ class XArgs : public ArgParent {
 
 #define DECLARE_METHODv(fn)                                                    \
     static py::XArgs* ARGS_NAME = (new py::XArgs(                              \
-        reinterpret_cast<void(PyObject::*)(const XArgs&)>(fn),                 \
+        reinterpret_cast<void(PyObject::*)(const py::XArgs&)>(fn),             \
         typeid(CLASS_OF(fn)).hash_code())                                      \
       )->pyfunction(                                                           \
           [](PyObject* self, PyObject* args, PyObject* kwds) -> PyObject* {    \
@@ -236,9 +238,9 @@ class XArgs : public ArgParent {
 
 #define INIT_METHODS_FOR_CLASS(CLASS)                                          \
     do {                                                                       \
-      for (XArgs* xargs : XArgs::store()) {                                    \
+      for (py::XArgs* xargs : py::XArgs::store()) {                            \
         if (xargs->get_class_id() == typeid(CLASS).hash_code()) {              \
-          xt.add(xargs->get_pyfunction(), xargs, py::XTypeMaker::method_tag);  \
+          xt.add(xargs, py::XTypeMaker::method_tag);                           \
         }                                                                      \
       }                                                                        \
     } while(0)

--- a/src/core/python/xobject.h
+++ b/src/core/python/xobject.h
@@ -115,7 +115,7 @@ class XTypeMaker {
 
     // PyCFunctionWithKeywords = PyObject*(*)(PyObject*, PyObject*, PyObject*)
     void add(PyCFunctionWithKeywords meth, PKArgs& args, MethodTag);
-    void add(PyCFunctionWithKeywords meth, XArgs* args, MethodTag);
+    void add(XArgs* args, MethodTag);
 
     // unaryfunc = PyObject*(*)(PyObject*)
     void add(unaryfunc meth, const char* name, Method0Tag);

--- a/src/core/stype.h
+++ b/src/core/stype.h
@@ -49,6 +49,8 @@ enum class SType : uint8_t {
   FLOAT64 = 7,
   STR32   = 11,
   STR64   = 12,
+  LIST32  = 13,
+  LIST64  = 14,
   DATE32  = 17,
   TIME64  = 18,
   OBJ     = 21,
@@ -64,9 +66,6 @@ constexpr size_t STYPES_COUNT = static_cast<size_t>(SType::INVALID);
 static_assert(STYPES_COUNT <= 64, "Too many stypes");
 
 
-using utc_timestamp_t = int64_t;
-using local_time_t = int64_t;
-using local_date_t = int64_t;
 
 
 //------------------------------------------------------------------------------

--- a/src/core/types/py_type.cc
+++ b/src/core/types/py_type.cc
@@ -324,32 +324,30 @@ py::oobj PyType::get_max() const {
 // Types as methods
 //------------------------------------------------------------------------------
 
-py::oobj PyType::list32(const py::XArgs& args) {
-  auto t = Type::list32(args[0].to_type_force());
+py::oobj PyType::list(const py::XArgs& args) {
+  Type argT = args[0].is_none()? Type::void0()
+                               : args[0].to_type_force();
+  auto t = args.get_info() == 32? Type::list32(argT) : Type::list64(argT);
   return PyType::make(t);
 }
 
-DECLARE_METHOD(&PyType::list32)
+DECLARE_METHOD(&PyType::list)
     ->name("list32")
     ->docs(dt::doc_Type_list32)
     ->n_positional_args(1)
     ->n_required_args(1)
     ->arg_names({"T"})
-    ->staticmethod();
+    ->staticmethod()
+    ->add_info(32);
 
-
-py::oobj PyType::list64(const py::XArgs& args) {
-  auto t = Type::list64(args[0].to_type_force());
-  return PyType::make(t);
-}
-
-DECLARE_METHOD(&PyType::list64)
+DECLARE_METHOD(&PyType::list)
     ->name("list64")
     ->docs(dt::doc_Type_list64)
     ->n_positional_args(1)
     ->n_required_args(1)
     ->arg_names({"T"})
-    ->staticmethod();
+    ->staticmethod()
+    ->add_info(64);
 
 
 

--- a/src/core/types/py_type.cc
+++ b/src/core/types/py_type.cc
@@ -321,6 +321,41 @@ py::oobj PyType::get_max() const {
 
 
 //------------------------------------------------------------------------------
+// Types as methods
+//------------------------------------------------------------------------------
+
+py::oobj PyType::list32(const py::XArgs& args) {
+  auto t = Type::list32(args[0].to_type_force());
+  return PyType::make(t);
+}
+
+DECLARE_METHOD(&PyType::list32)
+    ->name("list32")
+    ->docs(dt::doc_Type_list32)
+    ->n_positional_args(1)
+    ->n_required_args(1)
+    ->arg_names({"T"})
+    ->staticmethod();
+
+
+py::oobj PyType::list64(const py::XArgs& args) {
+  auto t = Type::list64(args[0].to_type_force());
+  return PyType::make(t);
+}
+
+DECLARE_METHOD(&PyType::list64)
+    ->name("list64")
+    ->docs(dt::doc_Type_list64)
+    ->n_positional_args(1)
+    ->n_required_args(1)
+    ->arg_names({"T"})
+    ->staticmethod();
+
+
+
+
+
+//------------------------------------------------------------------------------
 // Class declaration
 //------------------------------------------------------------------------------
 
@@ -335,8 +370,9 @@ void PyType::impl_init_type(py::XTypeMaker& xt) {
   xt.add(GETTER(&PyType::get_name, args_get_name));
   xt.add(GETTER(&PyType::get_min, args_get_min));
   xt.add(GETTER(&PyType::get_max, args_get_max));
-  pythonType = xt.get_type_object();
+  INIT_METHODS_FOR_CLASS(PyType);
 
+  pythonType = xt.get_type_object();
   xt.add_attr("bool8",   PyType::make(Type::bool8()));
   xt.add_attr("date32",  PyType::make(Type::date32()));
   xt.add_attr("float32", PyType::make(Type::float32()));

--- a/src/core/types/py_type.h
+++ b/src/core/types/py_type.h
@@ -22,6 +22,7 @@
 #ifndef dt_TYPES_PY_TYPE_h
 #define dt_TYPES_PY_TYPE_h
 #include "types/type.h"
+#include "python/xargs.h"
 #include "python/xobject.h"
 namespace dt {
 
@@ -57,6 +58,8 @@ class PyType : public py::XObject<PyType, true> {
     py::oobj get_name() const;
     py::oobj get_min() const;
     py::oobj get_max() const;
+    py::oobj list32(const py::XArgs&);
+    py::oobj list64(const py::XArgs&);
 
     Type get_type() const { return type_; }
 

--- a/src/core/types/py_type.h
+++ b/src/core/types/py_type.h
@@ -31,16 +31,13 @@ namespace dt {
   * This class corresponds to python-visible `dt.Type`: it describes
   * a type of a single column.
   *
-  * This class uses "dynamic" initialization mechanism: the class
-  * object is defined via a call to python `type(name, (), {})`, and
-  * then the resulting object is modified to add new methods. This
-  * mechanism is used because the "standard" extension types do not
-  * allow to define class properties (which we need).
+  * This class uses "dynamic" initialization mechanism, which may
+  * cause some of the class featured to not work normally. In case
+  * of any oddities, please check the implementation of XObject
+  * class, specifically the `dynamic_type_` property.
   *
-  * Because of this mechanism, the XObject's field `.type` is not
-  * used: instead we use a static variable defined in "py_type.cc".
-  * This is why methods `init()`, `check()` and `cast_from()` has to
-  * be redefined.
+  * This mechanism is used because the "standard" extension types do
+  * not allow to define class properties (which we need).
   */
 class PyType : public py::XObject<PyType, true> {
   private:
@@ -58,8 +55,7 @@ class PyType : public py::XObject<PyType, true> {
     py::oobj get_name() const;
     py::oobj get_min() const;
     py::oobj get_max() const;
-    py::oobj list32(const py::XArgs&);
-    py::oobj list64(const py::XArgs&);
+    py::oobj list(const py::XArgs&);
 
     Type get_type() const { return type_; }
 

--- a/src/core/types/type.cc
+++ b/src/core/types/type.cc
@@ -27,6 +27,7 @@
 #include "types/type_date.h"
 #include "types/type_float.h"
 #include "types/type_int.h"
+#include "types/type_list.h"
 #include "types/type_object.h"
 #include "types/type_string.h"
 #include "types/type_time.h"
@@ -81,6 +82,8 @@ Type Type::int16()   { return Type(new Type_Int16); }
 Type Type::int32()   { return Type(new Type_Int32); }
 Type Type::int64()   { return Type(new Type_Int64); }
 Type Type::int8()    { return Type(new Type_Int8); }
+Type Type::list32(Type t) { return Type(new Type_List32(t)); }
+Type Type::list64(Type t) { return Type(new Type_List64(t)); }
 Type Type::obj64()   { return Type(new Type_Object); }
 Type Type::str32()   { return Type(new Type_String32); }
 Type Type::str64()   { return Type(new Type_String64); }
@@ -140,15 +143,16 @@ Type Type::common(const Type& type1, const Type& type2) {
 }
 
 
-bool Type::is_void()     const { return impl_ && impl_->stype_ == SType::VOID; }
-bool Type::is_invalid()  const { return impl_ && impl_->is_invalid(); }
 bool Type::is_boolean()  const { return impl_ && impl_->is_boolean(); }
-bool Type::is_integer()  const { return impl_ && impl_->is_integer(); }
+bool Type::is_compound() const { return impl_ && impl_->is_compound(); }
 bool Type::is_float()    const { return impl_ && impl_->is_float(); }
+bool Type::is_integer()  const { return impl_ && impl_->is_integer(); }
+bool Type::is_invalid()  const { return impl_ && impl_->is_invalid(); }
 bool Type::is_numeric()  const { return impl_ && impl_->is_numeric(); }
-bool Type::is_string()   const { return impl_ && impl_->is_string(); }
 bool Type::is_object()   const { return impl_ && impl_->is_object(); }
+bool Type::is_string()   const { return impl_ && impl_->is_string(); }
 bool Type::is_temporal() const { return impl_ && impl_->is_temporal(); }
+bool Type::is_void()     const { return impl_ && impl_->is_void(); }
 
 
 template<typename T> bool Type::can_be_read_as() const { return false; }

--- a/src/core/types/type.h
+++ b/src/core/types/type.h
@@ -63,6 +63,8 @@ class Type {
     static Type int32();
     static Type int64();
     static Type int8();
+    static Type list32(Type);
+    static Type list64(Type);
     static Type obj64();
     static Type str32();
     static Type str64();
@@ -81,15 +83,16 @@ class Type {
     const char* struct_format() const;
 
     SType stype() const;
-    bool is_void() const;
     bool is_boolean() const;
+    bool is_compound() const;
+    bool is_float() const;
     bool is_integer() const;
     bool is_invalid() const;
-    bool is_float() const;
     bool is_numeric() const;
-    bool is_string() const;
     bool is_object() const;
+    bool is_string() const;
     bool is_temporal() const;
+    bool is_void() const;
 
     template<typename T>
     bool can_be_read_as() const;

--- a/src/core/types/type_list.cc
+++ b/src/core/types/type_list.cc
@@ -44,8 +44,9 @@ bool Type_List32::is_list() const {
 }
 
 std::string Type_List32::to_string() const {
-  return "list32[" + elementType_.to_string() + "]";
+  return "list32(" + elementType_.to_string() + ")";
 }
+
 
 TypeImpl* Type_List32::common_type(TypeImpl* other) {
   if (other->is_list()) {
@@ -58,13 +59,23 @@ TypeImpl* Type_List32::common_type(TypeImpl* other) {
 }
 
 
+bool Type_List32::equals(const TypeImpl* other) const {
+  return other->stype() == stype() &&
+         elementType_ == reinterpret_cast<const Type_List32*>(other)->elementType_;
+}
+
+size_t Type_List32::hash() const noexcept {
+  return static_cast<size_t>(stype()) + STYPES_COUNT * elementType_.hash();
+}
+
+
 
 //------------------------------------------------------------------------------
 // Type_List64
 //------------------------------------------------------------------------------
 
 Type_List64::Type_List64(Type t)
-  : TypeImpl(SType::LIST32),
+  : TypeImpl(SType::LIST64),
     elementType_(t) {}
 
 bool Type_List64::is_compound() const { 
@@ -76,8 +87,9 @@ bool Type_List64::is_list() const {
 }
 
 std::string Type_List64::to_string() const {
-  return "list64[" + elementType_.to_string() + "]";
+  return "list64(" + elementType_.to_string() + ")";
 }
+
 
 TypeImpl* Type_List64::common_type(TypeImpl* other) {
   if (other->is_list()) {
@@ -87,6 +99,16 @@ TypeImpl* Type_List64::common_type(TypeImpl* other) {
     return other;
   }
   return new Type_Invalid();
+}
+
+
+bool Type_List64::equals(const TypeImpl* other) const {
+  return other->stype() == stype() &&
+         elementType_ == reinterpret_cast<const Type_List64*>(other)->elementType_;
+}
+
+size_t Type_List64::hash() const noexcept {
+  return static_cast<size_t>(stype()) + STYPES_COUNT * elementType_.hash();
 }
 
 

--- a/src/core/types/type_list.cc
+++ b/src/core/types/type_list.cc
@@ -1,0 +1,95 @@
+//------------------------------------------------------------------------------
+// Copyright 2021 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#include "stype.h"
+#include "types/type_invalid.h"
+#include "types/type_list.h"
+#include "utils/assert.h"
+namespace dt {
+
+
+
+//------------------------------------------------------------------------------
+// Type_List32
+//------------------------------------------------------------------------------
+
+Type_List32::Type_List32(Type t)
+  : TypeImpl(SType::LIST32),
+    elementType_(t) {}
+
+bool Type_List32::is_compound() const { 
+  return true; 
+}
+
+bool Type_List32::is_list() const {
+  return true;
+}
+
+std::string Type_List32::to_string() const {
+  return "list32[" + elementType_.to_string() + "]";
+}
+
+TypeImpl* Type_List32::common_type(TypeImpl* other) {
+  if (other->is_list()) {
+    return other->stype() > stype() ? other : this;
+  }
+  if (other->is_object() || other->is_invalid()) {
+    return other;
+  }
+  return new Type_Invalid();
+}
+
+
+
+//------------------------------------------------------------------------------
+// Type_List64
+//------------------------------------------------------------------------------
+
+Type_List64::Type_List64(Type t)
+  : TypeImpl(SType::LIST32),
+    elementType_(t) {}
+
+bool Type_List64::is_compound() const { 
+  return true; 
+}
+
+bool Type_List64::is_list() const {
+  return true;
+}
+
+std::string Type_List64::to_string() const {
+  return "list64[" + elementType_.to_string() + "]";
+}
+
+TypeImpl* Type_List64::common_type(TypeImpl* other) {
+  if (other->is_list()) {
+    return this;
+  }
+  if (other->is_object() || other->is_invalid()) {
+    return other;
+  }
+  return new Type_Invalid();
+}
+
+
+
+
+}  // namespace dt

--- a/src/core/types/type_list.h
+++ b/src/core/types/type_list.h
@@ -19,29 +19,39 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
-#ifndef dt_TYPES_TYPE_VOID_h
-#define dt_TYPES_TYPE_VOID_h
+#ifndef dt_TYPES_TYPE_LIST_h
+#define dt_TYPES_TYPE_LIST_h
 #include "types/typeimpl.h"
 namespace dt {
 
 
 
-class Type_Void : public TypeImpl {
+class Type_List32 : public TypeImpl {
+  private:
+    Type elementType_;
+
   public:
-    Type_Void();
-
-    bool is_boolean() const override;
-    bool is_integer() const override;
-    bool is_float()   const override;
-    bool is_numeric() const override;
-    bool is_void()    const override;
-    bool can_be_read_as_int8() const override;
-
+    Type_List32(Type t);
+    bool is_compound() const override;
+    bool is_list() const override;
     std::string to_string() const override;
     TypeImpl* common_type(TypeImpl* other) override;
-    const char* struct_format() const override;
-    Column cast_column(Column&& col) const override;
 };
+
+
+
+class Type_List64 : public TypeImpl {
+  private:
+    Type elementType_;
+
+  public:
+    Type_List64(Type t);
+    bool is_compound() const override;
+    bool is_list() const override;
+    std::string to_string() const override;
+    TypeImpl* common_type(TypeImpl* other) override;
+};
+
 
 
 

--- a/src/core/types/type_list.h
+++ b/src/core/types/type_list.h
@@ -35,6 +35,8 @@ class Type_List32 : public TypeImpl {
     bool is_compound() const override;
     bool is_list() const override;
     std::string to_string() const override;
+    bool equals(const TypeImpl* other) const override;
+    size_t hash() const noexcept override;
     TypeImpl* common_type(TypeImpl* other) override;
 };
 
@@ -49,6 +51,8 @@ class Type_List64 : public TypeImpl {
     bool is_compound() const override;
     bool is_list() const override;
     std::string to_string() const override;
+    bool equals(const TypeImpl* other) const override;
+    size_t hash() const noexcept override;
     TypeImpl* common_type(TypeImpl* other) override;
 };
 

--- a/src/core/types/type_void.cc
+++ b/src/core/types/type_void.cc
@@ -34,6 +34,7 @@ bool Type_Void::is_boolean() const { return true; }
 bool Type_Void::is_integer() const { return true; }
 bool Type_Void::is_float()   const { return true; }
 bool Type_Void::is_numeric() const { return true; }
+bool Type_Void::is_void()    const { return true; }
 bool Type_Void::can_be_read_as_int8() const { return true; }
 
 

--- a/src/core/types/typeimpl.cc
+++ b/src/core/types/typeimpl.cc
@@ -47,15 +47,17 @@ size_t TypeImpl::hash() const noexcept {
   return static_cast<size_t>(stype_);
 }
 
-bool TypeImpl::is_void()     const { return stype_ == dt::SType::VOID; }
-bool TypeImpl::is_invalid()  const { return false; }
 bool TypeImpl::is_boolean()  const { return false; }
-bool TypeImpl::is_integer()  const { return false; }
+bool TypeImpl::is_compound() const { return false; }
 bool TypeImpl::is_float()    const { return false; }
+bool TypeImpl::is_integer()  const { return false; }
+bool TypeImpl::is_invalid()  const { return false; }
+bool TypeImpl::is_list()     const { return false; }
 bool TypeImpl::is_numeric()  const { return false; }
+bool TypeImpl::is_object()   const { return false; }
 bool TypeImpl::is_string()   const { return false; }
 bool TypeImpl::is_temporal() const { return false; }
-bool TypeImpl::is_object()   const { return false; }
+bool TypeImpl::is_void()     const { return false; }
 
 
 bool TypeImpl::can_be_read_as_int8()     const { return false; }

--- a/src/core/types/typeimpl.h
+++ b/src/core/types/typeimpl.h
@@ -46,15 +46,17 @@ class TypeImpl {
     virtual const char* struct_format() const;
     virtual TypeImpl* common_type(TypeImpl* other) = 0;
 
-    bool is_void() const;
     virtual bool is_boolean() const;
+    virtual bool is_compound() const;
+    virtual bool is_float() const;
     virtual bool is_integer() const;
     virtual bool is_invalid() const;
-    virtual bool is_float() const;
+    virtual bool is_list() const;
     virtual bool is_numeric() const;
     virtual bool is_object() const;
     virtual bool is_string() const;
     virtual bool is_temporal() const;
+    virtual bool is_void() const;
 
     virtual bool can_be_read_as_int8() const;
     virtual bool can_be_read_as_int16() const;

--- a/tests/types/test-list.py
+++ b/tests/types/test-list.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#-------------------------------------------------------------------------------
+# Copyright 2021 H2O.ai
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#-------------------------------------------------------------------------------
+import pytest
+import random
+from datatable import dt, f
+from tests import assert_equals
+
+
+#-------------------------------------------------------------------------------
+# Type object
+#-------------------------------------------------------------------------------
+
+def test_type_list_repr():
+    assert repr(dt.Type.list32(int)) == "Type.list32(int64)"
+    assert repr(dt.Type.list32(dt.float32)) == "Type.list32(float32)"
+    assert repr(dt.Type.list64(str)) == "Type.list64(str32)"
+    assert repr(dt.Type.list32(dt.Type.list64(dt.str64))) == \
+        "Type.list32(list64(str64))"
+
+
+def test_type_list_name():
+    assert dt.Type.list32(int).name == "list32(int64)"
+    assert dt.Type.list64(None).name == "list64(void)"
+    assert dt.Type.list32(dt.int8).name == "list32(int8)"
+    assert dt.Type.list32(dt.Type.list64(dt.str64)).name == \
+        "list32(list64(str64))"
+
+
+def test_type_list_properties():
+    t = dt.Type.list32(bool)
+    assert t.min is None
+    assert t.max is None
+
+
+def test_type_list_equality():
+    t1 = dt.Type.list32(int)
+    t2 = dt.Type.list64(int)
+    assert t1 != t2
+    assert t1 == dt.Type.list32(dt.int64)
+    assert t1 != dt.Type.list32(dt.int32)
+    assert t1 != dt.Type.list32(dt.Type.void)
+    assert t1 != dt.Type.int64
+    assert t2 == dt.Type.list64(int)
+    assert t2 != dt.Type.list32(int)
+    assert t2 != dt.Type.list64(str)
+    assert dt.Type.list32(dt.Type.list32(int)) != \
+           dt.Type.list32(dt.Type.list32(float))
+
+
+def test_type_list_hashable():
+    store = {dt.Type.list32(str): 1, dt.Type.list64('float32'): 2,
+             dt.Type.list64(str): 3}
+    assert dt.Type.list32(str) in store
+    assert dt.Type.list64(dt.float32) in store
+    assert dt.Type.list64(str) in store
+    assert store[dt.Type.list32("str")] == 1
+    assert store[dt.Type.list64('float32')] == 2
+    assert store[dt.Type.list64(str)] == 3
+    assert dt.Type.list32(int) not in store
+    assert dt.Type.list64(int) not in store
+    assert dt.Type.list64(float) not in store
+    assert dt.Type.list32(dt.Type.list32(bool)) not in store


### PR DESCRIPTION
This PR adds 2 new type objects: `list32(T)` and `list64(T)`. They are not yet used anywhere, but we have to have a `Type` before a column can be implemented.

WIP for #1692