### PR TITLE
Refactor creating column from list

### DIFF
--- a/docs/api/type/bool8.rst
+++ b/docs/api/type/bool8.rst
@@ -1,6 +1,7 @@
 
 .. xattr:: datatable.Type.bool8
     :src: --
+    :tests: tests/types/test-bool8.py
 
     The type of a column with boolean data.
 

--- a/src/core/column/cast_to_bool.cc
+++ b/src/core/column/cast_to_bool.cc
@@ -113,9 +113,8 @@ bool CastObjToBool_ColumnImpl::get_element(size_t i, int8_t* out) const {
   py::oobj value;
   bool isvalid = arg_.get_element(i, &value);
   if (isvalid) {
-    if (value.is_true())       *out = 1;
-    else if (value.is_false()) *out = 0;
-    else                       isvalid = false;
+    *out = value.to_bool_force();
+    if (*out == -128) isvalid = false;
   }
   return isvalid;
 }

--- a/src/core/column_from_python.cc
+++ b/src/core/column_from_python.cc
@@ -557,9 +557,9 @@ static Column parse_column_auto_type(const Column& inputcol) {
       err << "Cannot create column from a python list: element at index "
           << i << " is of type " << item.typeobj();
       if (i) {
-        err << ", while previous elements had type `" << stype;
+        err << ", while previous elements had type `" << stype << "`";
       }
-      err << "`. If you meant to create a column of type obj64, then you must "
+      err << ". If you meant to create a column of type obj64, then you must "
              "request this type explicitly";
       throw err;
     }

--- a/src/core/column_from_python.cc
+++ b/src/core/column_from_python.cc
@@ -337,7 +337,7 @@ static const std::vector<dt::SType>& successors(dt::SType stype) {
 
 
 /**
-  * Parse `inputcol`, auto-detecting its stype.
+  * Parse `inputcol`, auto-detecting its type.
   */
 static Column parse_column_auto_type(const Column& inputcol) {
   xassert(inputcol.type().is_object());

--- a/src/core/column_from_python.cc
+++ b/src/core/column_from_python.cc
@@ -43,23 +43,8 @@ Column _parse_int32(const Column&, size_t);
 Column _parse_int64(const Column&, size_t);
 Column _parse_double(const Column&, size_t);
 Column _parse_string(const Column&, size_t);
-
-
-// Each parser function has the following signature:
-//
-//     bool (*parserfn)(const Column& inputcol, size_t i0, Column* outputcol);
-//
-// Here `inputcol` is the input column of type obj64, `i0` is the
-// index of the first non-None element, and `outputcol` is the variable
-// where the converted column will be stored.
-//
-// The function will attempt to parse `inputcol` into one of the
-// types that it supports, and save the resulting Column into variable
-// `outputcol`. The return value is `true` if the parse was successful,
-// and `false` otherwise. The parser may also throw an exception if
-// it believes no other parser will be able to parse the input (which
-// could happen if the input contained values of incompatible types,
-// such as `[5, "boo", 3.7]`).
+Column _parse_date32(const Column&, size_t);
+Column _parse_time64(const Column&, size_t);
 
 Error _error(size_t i, py::oobj item, const char* expected_type) {
   return TypeError()
@@ -73,35 +58,19 @@ Error _error(size_t i, py::oobj item, const char* expected_type) {
 //------------------------------------------------------------------------------
 // Individual parsers
 //------------------------------------------------------------------------------
-
-/**
-  * Parses a column containing numpy ints (or Nones) of a specific
-  * precision T. We do not allow numpy ints to be mixed with python
-  * ints.
-  */
-template <typename T>
-Column _parse_npint(const Column& inputcol, size_t i0) {
-  size_t n = inputcol.nrows();
-  Buffer databuf = Buffer::mem(n * sizeof(T));
-  auto outptr = static_cast<T*>(databuf.xptr());
-
-  py::oobj item;
-  for (size_t i = 0; i < i0; i++) {
-    *outptr++ = dt::GETNA<T>();
-  }
-  for (size_t i = i0; i < n; i++) {
-    inputcol.get_element(i, &item);
-    if (item.parse_numpy_int(outptr) ||
-        item.parse_none(outptr)) {
-      outptr++;
-    } else {
-      throw _error(i, item, sizeof(T)==1? "np.int8" :
-                            sizeof(T)==2? "np.int16" :
-                            sizeof(T)==4? "np.int32" : "np.int64");
-    }
-  }
-  return Column::new_mbuf_column(n, dt::stype_from<T>, std::move(databuf));
-}
+//
+// Each parser function has the following signature:
+//
+//     Column (*parserfn)(const Column& inputcol, size_t i0);
+//
+// Here `inputcol` is the input column of type obj64, `i0` is the
+// index of the first non-None element, and the function is supposed
+// to return the parsed column (or throw an error if the input is
+// unparseable).
+//
+// Some parsers pass the inputcol to another parser which will be
+// more suitable to for the given input.
+//
 
 
 /**
@@ -236,6 +205,41 @@ Column _parse_int64(const Column& inputcol, size_t i0) {
 }
 
 
+/**
+  * Parses a column containing numpy ints (or Nones) of a specific
+  * precision T. We do not allow numpy ints to be mixed with python
+  * ints.
+  */
+template <typename T>
+Column _parse_npint(const Column& inputcol, size_t i0) {
+  size_t n = inputcol.nrows();
+  Buffer databuf = Buffer::mem(n * sizeof(T));
+  auto outptr = static_cast<T*>(databuf.xptr());
+
+  py::oobj item;
+  for (size_t i = 0; i < i0; i++) {
+    *outptr++ = dt::GETNA<T>();
+  }
+  for (size_t i = i0; i < n; i++) {
+    inputcol.get_element(i, &item);
+    if (item.parse_numpy_int(outptr) ||
+        item.parse_none(outptr)) {
+      outptr++;
+    } else {
+      throw _error(i, item, sizeof(T)==1? "np.int8" :
+                            sizeof(T)==2? "np.int16" :
+                            sizeof(T)==4? "np.int32" : "np.int64");
+    }
+  }
+  return Column::new_mbuf_column(n, dt::stype_from<T>, std::move(databuf));
+}
+
+
+/**
+  * Parses column containing python floats or ints, into a FLOAT64
+  * Column. If any `int` value is too large to fit into a double,
+  * it will be converted into ±inf.
+  */
 Column _parse_double(const Column& inputcol, size_t i0) {
   size_t n = inputcol.nrows();
   Buffer databuf = Buffer::mem(n * sizeof(double));
@@ -248,7 +252,7 @@ Column _parse_double(const Column& inputcol, size_t i0) {
   for (size_t i = i0; i < n; i++) {
     inputcol.get_element(i, &item);
     if (item.parse_double(outptr) ||
-        item.parse_int(outptr) ||   // converts to ±MAX if overflows
+        item.parse_int(outptr) ||   // converts to ±inf if overflows
         item.parse_none(outptr)) {
       outptr++;
     }
@@ -309,6 +313,65 @@ Column _parse_string(const Column& inputcol, size_t i0) {
 }
 
 
+/**
+  * Parse a column containing python `date.date` objects, as a date32
+  * type. If we encounter `date.datetime` objects in the list, then
+  * re-parse as time64 type instead.
+  */
+Column _parse_date32(const Column& inputcol, size_t i0) {
+  size_t n = inputcol.nrows();
+  Buffer databuf = Buffer::mem(n * sizeof(int32_t));
+  auto outptr = static_cast<int32_t*>(databuf.xptr());
+
+  py::oobj item;
+  for (size_t i = 0; i < i0; i++) {
+    *outptr++ = dt::GETNA<int32_t>();
+  }
+  for (size_t i = i0; i < n; i++) {
+    inputcol.get_element(i, &item);
+    if (item.parse_date_as_date(outptr) || item.parse_none(outptr)) {
+      outptr++;
+    }
+    else if (item.is_datetime()) {
+      return _parse_time64(inputcol, i0);
+    }
+    else {
+      throw _error(i, item, "date32");
+    }
+  }
+  return Column::new_mbuf_column(n, dt::SType::DATE32, std::move(databuf));
+}
+
+
+/**
+  * Parse a column containing python `date.date` objects, as a date32
+  * type. If we encounter `date.datetime` objects in the list, then
+  * re-parse as time64 type instead.
+  */
+Column _parse_time64(const Column& inputcol, size_t i0) {
+  size_t n = inputcol.nrows();
+  Buffer databuf = Buffer::mem(n * sizeof(int64_t));
+  auto outptr = static_cast<int64_t*>(databuf.xptr());
+
+  py::oobj item;
+  for (size_t i = 0; i < i0; i++) {
+    *outptr++ = dt::GETNA<int64_t>();
+  }
+  for (size_t i = i0; i < n; i++) {
+    inputcol.get_element(i, &item);
+    if (item.parse_datetime_as_time(outptr) ||
+        item.parse_date_as_time(outptr) ||
+        item.parse_none(outptr)) {
+      outptr++;
+    }
+    else {
+      throw _error(i, item, "time64");
+    }
+  }
+  return Column::new_mbuf_column(n, dt::SType::TIME64, std::move(databuf));
+}
+
+
 
 
 //------------------------------------------------------------------------------
@@ -319,6 +382,7 @@ Column _parse_string(const Column& inputcol, size_t i0) {
   * Main parser that calls all other parsers.
   */
 Column new_parse_column_auto_type(const Column& inputcol) {
+  int npbits;
   size_t nrows = inputcol.nrows();
 
   // First, find how many `None`s we have at the start of the list,
@@ -335,7 +399,6 @@ Column new_parse_column_auto_type(const Column& inputcol) {
 
   // Then, decide which parser to call, based on the type of the
   // first non-None element in the list.
-  int npbits;
   if (item0.is_float()) {
     return _parse_double(inputcol, i0);
   }
@@ -353,6 +416,12 @@ Column new_parse_column_auto_type(const Column& inputcol) {
   else if (item0.is_string() || item0.is_numpy_str()) {
     return _parse_string(inputcol, i0);
   }
+  else if (item0.is_date()) {
+    return _parse_date32(inputcol, i0);
+  }
+  else if (item0.is_datetime()) {
+    return _parse_time64(inputcol, i0);
+  }
   else if ((npbits = item0.is_numpy_float())) {
     if (npbits == 4) return _parse_npfloat<float>(inputcol, i0);
     if (npbits == 8) return _parse_npfloat<double>(inputcol, i0);
@@ -364,402 +433,30 @@ Column new_parse_column_auto_type(const Column& inputcol) {
     if (npbits == 8) return _parse_npint<int64_t>(inputcol, i0);
   }
 
-  return Column();
-  // if (ok) {
-  //   xassert(result);
-  //   return result;
-  // }
-  // py::oobj elem0;
-  // inputcol.get_element(i0, &elem0);
-  // throw TypeError() << "Cannot create column from a python list: element "
-  //     "at index " << i0 << " has type " << elem0.typeobj();
+  // If the type of elements in the column is not known, raise an error
+  throw TypeError() << "Cannot create column from a python list: element "
+      "at index " << i0 << " has type " << item0.typeobj()
+      << ". If you intended to create an obj64 column, please request "
+         "this type explicitly.";
 }
 
 
 
-}  // namespace
-//==============================================================================
-
-/**
-  * parse_as_X(inputcol, mbuf, i0)
-  *   A family of functions for converting an SType::OBJ input column
-  *   into one of the primitive types <X>, if possible. The converted
-  *   values will be written into the provided buffer `mbuf`, which
-  *   will be automatically reallocated to proper size.
-  *
-  *   Index `i0` indicates that elements before this index are known
-  *   to be convertible, whereas the elements starting from `i0` do
-  *   not carry such guarantee. This is a hint variable.
-  *
-  *   The return value is the index of the first entry that failed to
-  *   be converted. If all entries convert successfully, this will be
-  *   equal to `inputcol.nrows()`.
-  */
-template <typename T>
-static size_t parse_as_X(const Column& inputcol, Buffer& mbuf, size_t i0,
-                         bool(*f)(const py::oobj&, T*))
-{
-  size_t nrows = inputcol.nrows();
-  mbuf.resize(nrows * sizeof(T));
-  T* outdata = static_cast<T*>(mbuf.xptr());
-
-  py::oobj item;
-  for (size_t i = i0; i < nrows; ++i) {
-    inputcol.get_element(i, &item);
-    bool ok = f(item, outdata + i);
-    if (!ok) return i;
-  }
-  for (size_t i = 0; i < i0; ++i) {
-    inputcol.get_element(i, &item);
-    bool ok = f(item, outdata + i);
-    xassert(ok); (void)ok;
-  }
-  return nrows;
-}
-
-
-
-//------------------------------------------------------------------------------
-// Void
-//------------------------------------------------------------------------------
-
-static size_t parse_as_void(const Column& inputcol) {
-  size_t i = 0;
-  py::oobj item;
-  for (; i < inputcol.nrows(); ++i) {
-    inputcol.get_element(i, &item);
-    if (!item.is_none()) break;
-  }
-  return i;
-}
-
-
-
-//------------------------------------------------------------------------------
-// Boolean
-//------------------------------------------------------------------------------
-
-// Parse list of booleans, i.e. `True`, `False` and `None`.
-// static size_t parse_as_bool(const Column& inputcol, Buffer& mbuf, size_t i0)
-// {
-//   return parse_as_X<int8_t>(inputcol, mbuf, i0,
-//             [](const py::oobj& item, int8_t* out) {
-//               return item.parse_bool(out) ||
-//                      item.parse_none(out) ||
-//                      item.parse_numpy_bool(out);
-//             });
-// }
-
-
-
-//------------------------------------------------------------------------------
-// Integer
-//------------------------------------------------------------------------------
-
-// Parse list of integers, accepting either regular python ints, or
-// python bools, or numpy ints, or `None`. The ints are parsed only
-// for T==int32_t or T==int64_t. This is because this function is
-// used for type autodetection, and we don't want small integers to
-// be detected as int8_t or int16_t. Thus, the only way to get an
-// auto-detected stype INT8 is to have int8 numpy integers in the
-// list, possibly mixed with Nones and booleans.
-//
-// Integers that are too large for int32/int64 will be promoted to
-// stype INT64/FLOAT64 respectively.
-//
-// template <typename T>
-// static size_t parse_as_int(const Column& inputcol, Buffer& mbuf, size_t i0)
-// {
-//   return parse_as_X<T>(inputcol, mbuf, i0,
-//             [](const py::oobj& item, T* out) {
-//               return (sizeof(T) >= 4 && item.parse_int(out)) ||
-//                      item.parse_none(out) ||
-//                      item.parse_numpy_int(out) ||
-//                      item.parse_bool(out);
-//             });
-// }
-
-
-// static size_t parse_as_int8(const Column& inputcol, Buffer& mbuf, size_t i0)
-// {
-//   return parse_as_X<int8_t>(inputcol, mbuf, i0,
-//             [](const py::oobj& item, int8_t* out) {
-//               return item.parse_01(out) ||
-//                      item.parse_none(out) ||
-//                      item.parse_numpy_int(out) ||
-//                      item.parse_bool(out);
-//             });
-// }
-
-// static size_t parse_as_int16(const Column& inputcol, Buffer& mbuf, size_t i0)
-// {
-//   return parse_as_X<int16_t>(inputcol, mbuf, i0,
-//             [](const py::oobj& item, int16_t* out) {
-//               return item.parse_numpy_int(out) ||
-//                      item.parse_none(out) ||
-//                      item.parse_01(out) ||
-//                      item.parse_bool(out);
-//             });
-// }
-
-
-
-//------------------------------------------------------------------------------
-// Float
-//------------------------------------------------------------------------------
-
-// static size_t parse_as_float32(const Column& inputcol, Buffer& mbuf, size_t i0)
-// {
-//   return parse_as_X<float>(inputcol, mbuf, i0,
-//             [](const py::oobj& item, float* out) {
-//               return item.parse_numpy_float(out) ||
-//                      item.parse_none(out);
-//             });
-// }
-
-
-// static size_t parse_as_float64(const Column& inputcol, Buffer& mbuf, size_t i0)
-// {
-//   return parse_as_X<double>(inputcol, mbuf, i0,
-//             [](const py::oobj& item, double* out) {
-//               return item.parse_double(out) ||
-//                      item.parse_none(out) ||
-//                      item.parse_int(out) ||
-//                      item.parse_numpy_float(out) ||
-//                      item.parse_bool(out) ||
-//                      false;
-//             });
-// }
-
-
-
-//------------------------------------------------------------------------------
-// Date32
-//------------------------------------------------------------------------------
-
-static size_t parse_as_date32(const Column& inputcol, Buffer& mbuf, size_t i0) {
-  return parse_as_X<int32_t>(inputcol, mbuf, i0,
-            [](const py::oobj& item, int32_t* out) {
-              return item.parse_date_as_date(out) ||
-                     item.parse_none(out);
-            });
-}
-
-
-
-
-//------------------------------------------------------------------------------
-// Time64
-//------------------------------------------------------------------------------
-
-static size_t parse_as_time64(const Column& inputcol, Buffer& mbuf, size_t i0) {
-  return parse_as_X<int64_t>(inputcol, mbuf, i0,
-            [](const py::oobj& item, int64_t* out) {
-              return item.parse_datetime_as_time(out) ||
-                     item.parse_date_as_time(out) ||
-                     item.parse_none(out);
-            });
-}
-
-
-
-
-//------------------------------------------------------------------------------
-// String
-//------------------------------------------------------------------------------
-
-// template <typename T>
-// static size_t parse_as_str(const Column& inputcol, Buffer& offbuf,
-//                            Buffer& strbuf)
-// {
-//   static_assert(std::is_unsigned<T>::value, "Wrong T type");
-
-//   size_t nrows = inputcol.nrows();
-//   offbuf.resize((nrows + 1) * sizeof(T));
-//   T* offsets = static_cast<T*>(offbuf.wptr()) + 1;
-//   offsets[-1] = 0;
-//   if (!strbuf) {
-//     strbuf.resize(nrows * 4);  // arbitrarily 4 chars per element
-//   }
-//   char* strptr = static_cast<char*>(strbuf.xptr());
-
-//   T curr_offset = 0;
-//   size_t i = 0;
-//   py::oobj item;
-//   py::oobj tmpitem;
-//   for (i = 0; i < nrows; ++i) {
-//     inputcol.get_element(i, &item);
-
-//     if (item.is_none()) {
-//       offsets[i] = curr_offset ^ dt::GETNA<T>();
-//       continue;
-//     }
-//     if (item.is_string()) {
-//       parse_string:
-//       dt::CString cstr = item.to_cstring();
-//       if (cstr.size()) {
-//         T tlen = static_cast<T>(cstr.size());
-//         T next_offset = curr_offset + tlen;
-//         // Check that length or offset of the string doesn't overflow int32_t
-//         if (std::is_same<T, uint32_t>::value &&
-//               (static_cast<size_t>(tlen) != cstr.size() ||
-//                next_offset < curr_offset)) {
-//           break;
-//         }
-//         // Resize the strbuf if necessary
-//         if (strbuf.size() < static_cast<size_t>(next_offset)) {
-//           double newsize = static_cast<double>(next_offset) *
-//               (static_cast<double>(nrows) / static_cast<double>(i + 1)) * 1.1;
-//           strbuf.resize(static_cast<size_t>(newsize));
-//           strptr = static_cast<char*>(strbuf.xptr());
-//         }
-//         std::memcpy(strptr + curr_offset, cstr.data(), cstr.size());
-//         curr_offset = next_offset;
-//       }
-//       offsets[i] = curr_offset;
-//       continue;
-//     }
-//     if (item.is_int() || item.is_float() || item.is_bool()) {
-//       tmpitem = item.to_pystring_force();
-//       item = tmpitem;
-//       goto parse_string;
-//     }
-//     break;
-//   }
-//   if (i < nrows) {
-//     if (std::is_same<T, uint64_t>::value) {
-//       strbuf.resize(0);
-//     }
-//   } else {
-//     strbuf.resize(static_cast<size_t>(curr_offset));
-//   }
-//   return i;
-// }
-
-
-
-
-//------------------------------------------------------------------------------
-// Parse controller
-//------------------------------------------------------------------------------
-
-static const std::vector<dt::SType>& successors(dt::SType stype) {
-  using styvec = std::vector<dt::SType>;
-  static styvec s_void = {
-    dt::SType::BOOL, dt::SType::INT8, dt::SType::INT16, dt::SType::INT32,
-    dt::SType::INT64, dt::SType::FLOAT32, dt::SType::FLOAT64, dt::SType::STR32,
-    dt::SType::DATE32, dt::SType::TIME64
-  };
-  static styvec s_bool8 = {dt::SType::INT8, dt::SType::INT16, dt::SType::INT32, dt::SType::INT64, dt::SType::FLOAT64, dt::SType::STR32};
-  static styvec s_int8  = {dt::SType::INT16, dt::SType::INT32, dt::SType::INT64, dt::SType::FLOAT64, dt::SType::STR32};
-  static styvec s_int16 = {dt::SType::INT32, dt::SType::INT64, dt::SType::FLOAT64, dt::SType::STR32};
-  static styvec s_int32 = {dt::SType::INT64, dt::SType::FLOAT64, dt::SType::STR32};
-  static styvec s_int64 = {dt::SType::FLOAT64, dt::SType::STR32};
-  static styvec s_float32 = {dt::SType::FLOAT64, dt::SType::STR32};
-  static styvec s_float64 = {dt::SType::STR32};
-  static styvec s_str32 = {dt::SType::STR64};
-  static styvec s_str64 = {};
-  static styvec s_date32 = {dt::SType::TIME64};
-  static styvec s_time64 = {};
-
-  switch (stype) {
-    case dt::SType::VOID:    return s_void;
-    case dt::SType::BOOL:    return s_bool8;
-    case dt::SType::INT8:    return s_int8;
-    case dt::SType::INT16:   return s_int16;
-    case dt::SType::INT32:   return s_int32;
-    case dt::SType::INT64:   return s_int64;
-    case dt::SType::FLOAT32: return s_float32;
-    case dt::SType::FLOAT64: return s_float64;
-    case dt::SType::STR32:   return s_str32;
-    case dt::SType::STR64:   return s_str64;
-    case dt::SType::DATE32:  return s_date32;
-    case dt::SType::TIME64:  return s_time64;
-    default:
-      throw RuntimeError() << "Unknown successors of type " << stype;  // LCOV_EXCL_LINE
-  }
-}
-
-
-/**
-  * Parse `inputcol`, auto-detecting its type.
-  */
-static Column parse_column_auto_type(const Column& inputcol) {
-  xassert(inputcol.type().is_object());
-  Buffer databuf, strbuf;
-  size_t nrows = inputcol.nrows();
-
-  // We start with the VOID type, which is upwards-compatible with all other
-  // types.
-  dt::SType stype = dt::SType::VOID;
-  size_t i = parse_as_void(inputcol);
-  while (i < nrows) {
-    size_t j = i;
-    for (dt::SType next_stype : successors(stype)) {
-      switch (next_stype) {
-        // case dt::SType::BOOL:    j = parse_as_bool(inputcol, databuf, i); break;
-        // case dt::SType::INT8:    j = parse_as_int8(inputcol, databuf, i); break;
-        // case dt::SType::INT16:   j = parse_as_int16(inputcol, databuf, i); break;
-        // case dt::SType::INT32:   j = parse_as_int<int32_t>(inputcol, databuf, i); break;
-        // case dt::SType::INT64:   j = parse_as_int<int64_t>(inputcol, databuf, i); break;
-        // case dt::SType::FLOAT32: j = parse_as_float32(inputcol, databuf, i); break;
-        // case dt::SType::FLOAT64: j = parse_as_float64(inputcol, databuf, i); break;
-        // case dt::SType::STR32:   j = parse_as_str<uint32_t>(inputcol, databuf, strbuf); break;
-        // case dt::SType::STR64:   j = parse_as_str<uint64_t>(inputcol, databuf, strbuf); break;
-        case dt::SType::DATE32:  j = parse_as_date32(inputcol, databuf, i); break;
-        case dt::SType::TIME64:  j = parse_as_time64(inputcol, databuf, i); break;
-        default: continue;  // try another stype
-      }
-      if (j != i) {
-        stype = next_stype;
-        break;
-      }
-    }
-    if (j == i) {
-      py::oobj item;
-      inputcol.get_element(i, &item);
-      auto err = TypeError();
-      err << "Cannot create column from a python list: element at index "
-          << i << " is of type " << item.typeobj();
-      if (i) {
-        err << ", while previous elements had type `" << stype << "`";
-      }
-      err << ". If you meant to create a column of type obj64, then you must "
-             "request this type explicitly";
-      throw err;
-    }
-    i = j;
-  }
-  if (stype == dt::SType::STR32 || stype == dt::SType::STR64) {
-    return Column::new_string_column(nrows, std::move(databuf), std::move(strbuf));
-  }
-  else if (stype == dt::SType::VOID) {
-    return Column::new_na_column(nrows, dt::SType::VOID);
-  }
-  else {
-    return Column::new_mbuf_column(nrows, stype, std::move(databuf));
-  }
-}
-
-
-
-static Column resolve_column(const Column& inputcol, dt::Type type0)
-{
+Column resolve_column(const Column& inputcol, dt::Type type0) {
   if (type0) {
     Column out = inputcol.cast(type0);
     out.materialize();
     return out;
   }
   else {
-    Column out = new_parse_column_auto_type(inputcol);
-    if (!out) out = parse_column_auto_type(inputcol);
-    return out;
+    return new_parse_column_auto_type(inputcol);
   }
 }
 
 
 
 
+}  // namespace
 //------------------------------------------------------------------------------
 // Column API
 //------------------------------------------------------------------------------

--- a/src/core/column_from_python.cc
+++ b/src/core/column_from_python.cc
@@ -373,15 +373,11 @@ Column _parse_time64(const Column& inputcol, size_t i0) {
 
 
 
-
-//------------------------------------------------------------------------------
-// Main
-//------------------------------------------------------------------------------
-
 /**
-  * Main parser that calls all other parsers.
+  * Main parser that attempts to auto-detect the type of the input
+  * column.
   */
-Column new_parse_column_auto_type(const Column& inputcol) {
+Column parse_auto(const Column& inputcol, size_t) {
   int npbits;
   size_t nrows = inputcol.nrows();
 
@@ -449,7 +445,7 @@ Column resolve_column(const Column& inputcol, dt::Type type0) {
     return out;
   }
   else {
-    return new_parse_column_auto_type(inputcol);
+    return parse_auto(inputcol, 0);
   }
 }
 

--- a/src/core/column_from_python.cc
+++ b/src/core/column_from_python.cc
@@ -581,6 +581,7 @@ static Column parse_column_auto_type(const Column& inputcol) {
   * Parse `inputcol` forcing it into the specific stype.
   */
 static Column parse_column_fixed_type(const Column& inputcol, dt::Type type) {
+  return inputcol.cast(type);
   switch (type.stype()) {
     case dt::SType::VOID:    return Column::new_na_column(inputcol.nrows(), dt::SType::VOID);
     case dt::SType::BOOL:    return force_as_bool(inputcol);

--- a/src/core/python/int.cc
+++ b/src/core/python/int.cc
@@ -141,6 +141,7 @@ double oint::ovalue(int* overflow) const {
   if (!v) return dt::GETNA<double>();
   double value = PyLong_AsDouble(v);
   if (value == -1 && PyErr_Occurred()) {
+    PyErr_Clear();
     int sign = _PyLong_Sign(v);
     value = sign > 0 ? std::numeric_limits<double>::infinity()
                      : -std::numeric_limits<double>::infinity();

--- a/src/core/python/obj.cc
+++ b/src/core/python/obj.cc
@@ -225,6 +225,7 @@ bool _obj::is_float()         const noexcept { return v && PyFloat_Check(v); }
 bool _obj::is_string()        const noexcept { return v && PyUnicode_Check(v); }
 bool _obj::is_bytes()         const noexcept { return v && PyBytes_Check(v); }
 bool _obj::is_date()          const noexcept { return v && odate::check(robj(v)); }
+bool _obj::is_datetime()      const noexcept { return v && odatetime::check(robj(v)); }
 bool _obj::is_pytype()        const noexcept { return v && PyType_Check(v); }
 bool _obj::is_ltype()         const noexcept { return v && dt::is_ltype_object(v); }
 bool _obj::is_stype()         const noexcept { return v && dt::is_stype_object(v); }

--- a/src/core/python/obj.cc
+++ b/src/core/python/obj.cc
@@ -466,10 +466,10 @@ template <typename T>
 static bool _parse_npint(PyObject* v, T* out) {
   if (!numpy_int64) init_numpy();
   if (numpy_int64 && v) {
-    if ((sizeof(T) >= 8 && PyObject_IsInstance(v, numpy_int64)) ||
-        (sizeof(T) >= 4 && PyObject_IsInstance(v, numpy_int32)) ||
-        (sizeof(T) >= 2 && PyObject_IsInstance(v, numpy_int16)) ||
-        (sizeof(T) >= 1 && PyObject_IsInstance(v, numpy_int8)))
+    if ((sizeof(T) == 8 && PyObject_IsInstance(v, numpy_int64)) ||
+        (sizeof(T) == 4 && PyObject_IsInstance(v, numpy_int32)) ||
+        (sizeof(T) == 2 && PyObject_IsInstance(v, numpy_int16)) ||
+        (sizeof(T) == 1 && PyObject_IsInstance(v, numpy_int8)))
     {
       *out = static_cast<T>(PyNumber_AsSsize_t(v, nullptr));
       return true;

--- a/src/core/python/obj.h
+++ b/src/core/python/obj.h
@@ -163,6 +163,7 @@ class _obj {
     bool is_bytes()         const noexcept;
     bool is_callable()      const noexcept;
     bool is_date()          const noexcept;
+    bool is_datetime()      const noexcept;
     bool is_dict()          const noexcept;
     bool is_dtexpr()        const noexcept;
     bool is_ellipsis()      const noexcept;

--- a/tests/dt/test-cut.py
+++ b/tests/dt/test-cut.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #-------------------------------------------------------------------------------
-# Copyright 2020 H2O.ai
+# Copyright 2020-2021 H2O.ai
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -336,7 +336,7 @@ def test_cut_vs_pandas_random_nbins(pandas, seed):
         data[1].append(random.randint(-max_value, max_value))
         data[2].append(random.random() * 2 * max_value - max_value)
 
-    DT = dt.Frame(data, stypes = [stype.bool8, stype.int32, stype.float64])
+    DT = dt.Frame(data, types = [dt.bool8, dt.int32, dt.float64])
     DT_cut = DT[:, cut(DT, nbins = nbins, right_closed = right_closed)]
 
     PD_cut = [pandas.cut(data[i], nbins[i], labels=False, right=right_closed) for i in range(3)]

--- a/tests/frame/test-create.py
+++ b/tests/frame/test-create.py
@@ -623,22 +623,6 @@ def test_create_from_list_of_dicts_bad3():
 # Type auto-detection
 #-------------------------------------------------------------------------------
 
-def test_auto_int64():
-    src = [None, 0, 1, 44, 9548, 145928450, 2245982454589145, 333, 2]
-    d0 = dt.Frame(src)
-    frame_integrity_check(d0)
-    assert d0.stype == dt.int64
-    assert d0.to_list()[0] == src
-
-
-def test_auto_float64():
-    src = [5, 12, 5.2, None, 11, 0.998, -1]
-    d0 = dt.Frame(src)
-    frame_integrity_check(d0)
-    assert d0.stype == dt.float64
-    assert d0.to_list()[0] == src
-
-
 def test_auto_str32_1():
     d0 = dt.Frame(["start", None, "end"])
     frame_integrity_check(d0)
@@ -705,16 +689,6 @@ def test_create_as_int32():
     assert d0.stypes == (stype.int32, )
     assert d0.shape == (5, 1)
     assert d0.to_list() == [[1, 2, 5, 3, None]]
-
-
-def test_create_as_float32():
-    d0 = dt.Frame([1, 5, 2.6, "7.7777", -1.2e+50, 1.3e-50],
-                  stype=stype.float32)
-    frame_integrity_check(d0)
-    assert d0.stypes == (stype.float32, )
-    assert d0.shape == (6, 1)
-    # Apparently, float "inf" converts into double "inf" when cast. Good!
-    assert list_equals(d0.to_list(), [[1, 5, 2.6, 7.7777, -math.inf, 0]])
 
 
 def test_create_as_float64():
@@ -1183,15 +1157,6 @@ def test_create_from_numpy_floats(numpy):
     assert DT.to_list() == [[4.0, float(np.float32(3.7)), 88.5],
                             [2.0, 2.5, 7.75],
                             [0.0, 4.4, 99.999]]
-
-
-def test_create_from_numpy_floats_mixed(numpy):
-    np = numpy
-    DT = dt.Frame([np.float32(4), np.float16(3.5), None, np.float64(9.33)])
-    frame_integrity_check(DT)
-    assert DT.shape == (4, 1)
-    assert DT.stype == dt.float64
-    assert DT.to_list() == [[4.0, 3.5, None, 9.33]]
 
 
 def test_create_from_numpy_strings(np):

--- a/tests/munging/test-cast.py
+++ b/tests/munging/test-cast.py
@@ -47,59 +47,6 @@ for source_stype in all_stypes:
 
 
 #-------------------------------------------------------------------------------
-# Cast to bool
-#-------------------------------------------------------------------------------
-
-def test_cast_bool_to_bool():
-    DT = dt.Frame(B=[None, True, False, None, True, True, False, False])
-    assert DT.stypes == (dt.bool8,)
-    RES = DT[:, {"B": dt.bool8(f.B)}]
-    assert_equals(DT, RES)
-
-
-@pytest.mark.parametrize("source_stype", ltype.int.stypes)
-def test_cast_int_to_bool(source_stype):
-    DT = dt.Frame(N=[-11, -1, None, 0, 1, 11, 127], stype=source_stype)
-    assert DT.stypes == (source_stype,)
-    RES = DT[:, dt.bool8(f.N)]
-    frame_integrity_check(RES)
-    assert RES.stypes == (dt.bool8,)
-    assert RES.to_list()[0] == [True, True, None, False, True, True, True]
-
-
-def test_cast_m127_to_bool():
-    DT = dt.Frame([-128, -127, 0, 127, 128, 256])
-    RES = DT[:, dt.bool8(f[0])]
-    frame_integrity_check(RES)
-    assert RES.stypes == (dt.bool8,)
-    assert RES.to_list()[0] == [True, True, False, True, True, True]
-
-
-@pytest.mark.parametrize("source_stype", ltype.real.stypes)
-def test_cast_float_to_bool(source_stype):
-    DT = dt.Frame(G=[-math.inf, math.inf, math.nan, 0.0, 13.4, 1.0, -1.0, -128],
-                  stype=source_stype)
-    assert DT.stypes == (source_stype,)
-    RES = DT[:, dt.bool8(f.G)]
-    frame_integrity_check(RES)
-    assert RES.stypes == (dt.bool8,)
-    assert RES.to_list()[0] == [True, True, None, False, True, True, True, True]
-
-
-def test_cast_str_to_bool():
-    DT = dt.Frame(['True', "False", "bah", None, "true"])
-    DT[0] = bool
-    assert_equals(DT, dt.Frame([1, 0, None, None, None] / dt.bool8))
-
-
-def test_cast_obj_to_bool():
-    DT = dt.Frame([True, False, None, 1, 3.2, "True"] / dt.obj64)
-    DT[0] = bool
-    assert_equals(DT, dt.Frame([True, False, None, None, None, None]))
-
-
-
-#-------------------------------------------------------------------------------
 # Cast to int
 #-------------------------------------------------------------------------------
 

--- a/tests/test-dt-expr.py
+++ b/tests/test-dt-expr.py
@@ -90,6 +90,8 @@ def test_logical_and2(seed):
     src2 = [random.choice([True, False, None]) for _ in range(n)]
 
     df0 = dt.Frame(A=src1, B=src2)
+    assert df0['A'].to_list()[0] == src1
+    assert df0['B'].to_list()[0] == src2
     df1 = df0[:, f.A & f.B]
     assert df1.to_list()[0] == \
         [False if (src1[i] is False or src2[i] is False) else

--- a/tests/test-dt-stats.py
+++ b/tests/test-dt-stats.py
@@ -54,7 +54,7 @@ srcs_str = [["foo", None, "bar", "baaz", None],
             [None, "integrity", None, None, None, None, None] / dt.str64,
             ["f", "c", "e", "a", "c", "d", "f", "c", "e", "A", "a"] / dt.str64]
 
-srcs_obj = [[1, None, "haha", nan, inf, None, (1, 2)] / dt.obj64,
+srcs_obj = [[1, None, "haha", random, inf, None, (1, 2)] / dt.obj64,
             ["a", "bc", "def", None, -2.5, 3.7] / dt.obj64]
 
 srcs_numeric = srcs_bool + srcs_int + srcs_real
@@ -420,7 +420,7 @@ def test_empty_frame(st):
     frame_integrity_check(f1)
     assert f0.shape == (0, 1)
     assert f1.shape == (1, 1)
-    assert f0.stypes == f1.stypes == (st, )
+    assert f0.type == f1.type == dt.Type(st)
     assert f0.countna1() == 0
     assert f0.nunique1() == 0
     assert f1.countna1() == 1
@@ -430,9 +430,9 @@ def test_empty_frame(st):
 
 
 def test_object_column():
-    df = dt.Frame([None, nan, 3, [], "srsh"], stype=dt.obj64)
+    df = dt.Frame([None, pytest, 3, [], "srsh"], type=dt.obj64)
     frame_integrity_check(df)
-    assert df.countna1() == 2
+    assert df.countna1() == 1
     assert df.min1() is None
     assert df.max1() is None
     assert df.mean1() is None
@@ -444,36 +444,36 @@ def test_object_column():
 
 
 def test_object_column2():
-    df = dt.Frame([None, nan, 3, [], "srsh"] / dt.obj64)
+    df = dt.Frame([None, pytest, 3, [], "srsh"] / dt.obj64)
 
     f0 = df.countna()
     frame_integrity_check(f0)
-    assert f0.stypes == (stype.int64, )
-    assert f0[0, 0] == 2
+    assert f0.type == dt.Type.int64
+    assert f0[0, 0] == 1
 
     f1 = df.min()
     frame_integrity_check(f1)
-    assert f1.stypes == (stype.obj64, )
+    assert f1.type == dt.Type.obj64
     assert f1[0, 0] is None
 
     f2 = df.max()
     frame_integrity_check(f2)
-    assert f2.stypes == (stype.obj64, )
+    assert f2.type == dt.Type.obj64
     assert f2[0, 0] is None
 
     f3 = df.sum()
     frame_integrity_check(f3)
-    assert f3.stypes == (stype.float64, )
+    assert f3.type == dt.Type.float64
     assert f3[0, 0] is None
 
     f4 = df.mean()
     frame_integrity_check(f4)
-    assert f4.stypes == (stype.float64, )
+    assert f4.type == dt.Type.float64
     assert f4[0, 0] is None
 
     f5 = df.sd()
     frame_integrity_check(f5)
-    assert f5.stypes == (stype.float64, )
+    assert f5.type == dt.Type.float64
     assert f5[0, 0] is None
 
     assert df.mode()[0, 0] is None

--- a/tests/types/test-bool8.py
+++ b/tests/types/test-bool8.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#-------------------------------------------------------------------------------
+# Copyright 2021 H2O.ai
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#-------------------------------------------------------------------------------
+import math
+import pytest
+from datatable import dt, f
+from tests import assert_equals
+
+
+#-------------------------------------------------------------------------------
+# Create bool column
+#-------------------------------------------------------------------------------
+
+def test_bool_create_column_auto():
+    DT = dt.Frame([True, False, True, None, False, False])
+    assert DT.type == dt.Type.bool8
+    assert DT.to_list() == [[True, False, True, None, False, False]]
+
+
+def test_create_column01():
+    # Creating column from 0s and 1s does not produce bool8
+    DT = dt.Frame([0, 1, 0, 0, 1])
+    assert DT.type != dt.Type.bool8
+
+
+def test_bool_create_column_forced():
+    # When the column is forced into type bool, we effectively apply
+    # bool(x) to each value in the list,
+    # with the only exception being `math.nan`, which is converted into None.
+    DT = dt.Frame([True, False, None, 0, 1, 12, 0.0, -0.0, "", "hi", math.nan],
+                  type=bool)
+    assert DT.type == dt.Type.bool8
+    assert DT.to_list() == [[True, False, None, False, True, True, False, False,
+                             False, True, None]]
+
+
+def test_bool_create_force_from_exceptional():
+    # Here we check what happens if the objects that we are trying to
+    # cast into bools throw an exception. An FExpr is just that kind of
+    # object.
+    # Two things are expected to happen here: the exception-raising objects
+    # become `None`s, and exception objects are discarded.
+    with pytest.raises(TypeError):
+        assert dt.f.A
+
+    DT = dt.Frame([None, dt.f.A, math.nan, dt.f[:], TypeError], type=bool)
+    assert DT.to_list() == [[None, None, None, None, True]]
+
+
+
+
+#-------------------------------------------------------------------------------
+# Cast various types into bool
+#-------------------------------------------------------------------------------
+
+def test_cast_bool_to_bool():
+    DT = dt.Frame(B=[None, True, False, None, True, True, False, False])
+    assert DT.stypes == (dt.bool8,)
+    RES = DT[:, {"B": dt.bool8(f.B)}]
+    assert_equals(DT, RES)
+
+
+@pytest.mark.parametrize("source_stype", [dt.int8, dt.int16, dt.int32, dt.int64])
+def test_cast_int_to_bool(source_stype):
+    DT = dt.Frame(N=[-11, -1, None, 0, 1, 11, 127], stype=source_stype)
+    assert DT.type == dt.Type(source_stype)
+    RES = DT[:, dt.bool8(f.N)]
+    assert_equals(RES, dt.Frame(N=[True, True, None, False, True, True, True]))
+
+
+def test_cast_m127_to_bool():
+    DT = dt.Frame([-128, -127, 0, 127, 128, 256])
+    RES = DT[:, dt.bool8(f[0])]
+    assert_equals(RES, dt.Frame([True, True, False, True, True, True]))
+
+
+@pytest.mark.parametrize("source_type", [dt.float32, dt.float64])
+def test_cast_float_to_bool(source_type):
+    DT = dt.Frame(G=[-math.inf, math.inf, math.nan, 0.0, 13.4, 1.0, -1.0, -128],
+                  type=source_type)
+    assert DT.type == dt.Type(source_type)
+    RES = DT[:, dt.bool8(f.G)]
+    assert_equals(RES, dt.Frame(G=[True, True, None, False, True, True, True, True]))
+
+
+def test_cast_str_to_bool():
+    DT = dt.Frame(['True', "False", "bah", None, "true"])
+    DT[0] = bool
+    assert_equals(DT, dt.Frame([1, 0, None, None, None] / dt.bool8))
+
+
+def test_cast_obj_to_bool():
+    DT = dt.Frame([True, False, None, 1, 3.2, "True"] / dt.obj64)
+    DT[0] = bool
+    assert_equals(DT, dt.Frame([True, False, None, True, True, True]))
+
+

--- a/tests/types/test-bool8.py
+++ b/tests/types/test-bool8.py
@@ -24,6 +24,7 @@
 import math
 import pytest
 from datatable import dt, f
+from datatable.internal import frame_integrity_check
 from tests import assert_equals
 
 
@@ -31,7 +32,13 @@ from tests import assert_equals
 # Create bool column
 #-------------------------------------------------------------------------------
 
-def test_bool_create_column_auto():
+def test_bool_create_column_auto1():
+    DT = dt.Frame([True, False, None])
+    frame_integrity_check(DT)
+    assert DT.type == dt.Type.bool8
+
+
+def test_bool_create_column_auto2():
     DT = dt.Frame([True, False, True, None, False, False])
     assert DT.type == dt.Type.bool8
     assert DT.to_list() == [[True, False, True, None, False, False]]
@@ -65,6 +72,22 @@ def test_bool_create_force_from_exceptional():
 
     DT = dt.Frame([None, dt.f.A, math.nan, dt.f[:], TypeError], type=bool)
     assert DT.to_list() == [[None, None, None, None, True]]
+
+
+def test_bool_cannot_create_from_mixed():
+    msg = "Cannot create column: element at index 3 is of type " \
+        "<class 'int'>, whereas previous elements were boolean"
+    with pytest.raises(TypeError, match=msg):
+        dt.Frame([None, True, False, 0, 12])
+
+
+def test_bool_create_from_large_data():
+    src = [True, False, True, None, False, True, True, False, None, True] * 1000
+    DT = dt.Frame(src)
+    assert DT.type == dt.Type.bool8
+    assert DT.shape == (len(src), 1)
+    assert DT.to_list() == [src]
+
 
 
 

--- a/tests/types/test-float.py
+++ b/tests/types/test-float.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#-------------------------------------------------------------------------------
+# Copyright 2021 H2O.ai
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#-------------------------------------------------------------------------------
+import math
+import pytest
+from datatable import dt, f
+from datatable.internal import frame_integrity_check
+from tests import assert_equals, list_equals
+
+
+#-------------------------------------------------------------------------------
+# Create float32 columns
+#-------------------------------------------------------------------------------
+
+def test_float32_autodetect_from_nplist(np):
+    f32 = np.float32
+    src = [f32(2.5), None, f32(3.25), f32(2.125), f32(None)]
+    DT = dt.Frame(src)
+    frame_integrity_check(DT)
+    assert DT.type == dt.Type.float32
+    assert DT.to_list()[0] == [2.5, None, 3.25, 2.125, None]
+
+
+def test_float32_force():
+    DT = dt.Frame([1, 5, 2.6, "7.7777", -1.2e+50, 1.3e-50],
+                  type=dt.Type.float32)
+    frame_integrity_check(DT)
+    assert DT.type == dt.Type.float32
+    assert DT.shape == (6, 1)
+    # Apparently, float "inf" converts into double "inf" when cast. Good!
+    assert list_equals(DT.to_list(), [[1, 5, 2.6, 7.7777, -math.inf, 0]])
+
+
+
+
+#-------------------------------------------------------------------------------
+# Create float64 columns
+#-------------------------------------------------------------------------------
+
+def test_float64_autodetect_1():
+    # "Normal" case: the source is a list of floats
+    src = [4.5, 17.9384, -34.222, None, 4.5e-76]
+    DT = dt.Frame(src)
+    frame_integrity_check(DT)
+    assert DT.type == dt.Type.float64
+    assert DT.to_list()[0] == src
+
+
+def test_float64_autodetect_2():
+    # First, the list looks like it might be int8, but then converts to float64
+    src = [None, None, 0, 1, 0, 0, 1.0]
+    DT = dt.Frame(src)
+    frame_integrity_check(DT)
+    assert DT.type == dt.Type.float64
+    assert DT.to_list()[0] == src
+
+
+def test_float64_autodetect_3():
+    # First, the list looks like int32, but then becomes float64
+    src = [5, 12, 5.2, None, 11, 0.998, -1]
+    DT = dt.Frame(src)
+    frame_integrity_check(DT)
+    assert DT.type == dt.Type.float64
+    assert DT.to_list()[0] == src
+
+
+def test_float64_autodetect_4():
+    # First, the list looks like int64, but then becomes float64
+    src = [50000000000000, None, 113401871340, 0.998, -1]
+    DT = dt.Frame(src)
+    frame_integrity_check(DT)
+    assert DT.type == dt.Type.float64
+    assert DT.to_list()[0] == src
+
+
+def test_float64_autodetect_5():
+    # The list contains only integers, but they are too large to fit
+    # even into int64
+    DT = dt.Frame([10**n for n in range(30)])
+    frame_integrity_check(DT)
+    assert DT.type == dt.Type.float64
+    assert DT.to_list()[0] == [10.0**n for n in range(30)]
+
+
+def test_float64_overflow():
+    # If the input contains integers that are too large even for float64,
+    # they are transformed into +inf
+    DT = dt.Frame([1, 1000000, 10**500, -10**380])
+    frame_integrity_check(DT)
+    assert DT.type == dt.Type.float64
+    assert DT.to_list()[0] == [1.0, 1e6, dt.math.inf, -dt.math.inf]
+
+
+def test_float64_autodetect_from_nplist(np):
+    f64 = np.float64
+    src = [f64(2.4), None, f64(3.7), f64(2.11), f64(None)]
+    DT = dt.Frame(src)
+    frame_integrity_check(DT)
+    assert DT.type == dt.Type.float64
+    assert DT.to_list()[0] == [2.4, None, 3.7, 2.11, None]
+
+
+def test_create_from_numpy_floats_mixed(np):
+    msg = "Cannot create column: element at index 3 is of type "\
+          "<class 'numpy.float64'>, whereas previous elements were np.float32"
+    with pytest.raises(TypeError, match=msg):
+        DT = dt.Frame([np.float32(4), np.float16(3.5), None, np.float64(9.33)])

--- a/tests/types/test-float.py
+++ b/tests/types/test-float.py
@@ -99,7 +99,8 @@ def test_float64_autodetect_5():
     DT = dt.Frame([10**n for n in range(30)])
     frame_integrity_check(DT)
     assert DT.type == dt.Type.float64
-    assert DT.to_list()[0] == [10.0**n for n in range(30)]
+    # Note: writing 10.0**n causes imprecise results on windows
+    assert DT.to_list()[0] == [float("1e%d" % n) for n in range(30)]
 
 
 def test_float64_overflow():

--- a/tests/types/test-int.py
+++ b/tests/types/test-int.py
@@ -163,3 +163,24 @@ def test_int32_mixed_2(np):
           "<class 'numpy.int32'>, whereas previous elements were int32"
     with pytest.raises(TypeError, match=msg):
         dt.Frame([None, 1, 5, 14, 1000, np.int32(1), 999])
+
+
+
+
+#-------------------------------------------------------------------------------
+# Create int64 columns
+#-------------------------------------------------------------------------------
+
+def test_int64_autodetect_1():
+    src = [None, 0, 1, 44, 9548, 145928450, 2245982454589145, 333, 2]
+    DT = dt.Frame(src)
+    frame_integrity_check(DT)
+    assert DT.type == dt.Type.int64
+    assert DT.to_list()[0] == src
+
+
+def test_int64_autodetect_3(np):
+    i64 = np.int64
+    src = [None, i64(1), i64(2486), i64(-1), None]
+    DT = dt.Frame(src)
+    assert_equals(DT, dt.Frame([None, 1, 2486, -1, None], type='int64'))

--- a/tests/types/test-int.py
+++ b/tests/types/test-int.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#-------------------------------------------------------------------------------
+# Copyright 2021 H2O.ai
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#-------------------------------------------------------------------------------
+import math
+import pytest
+from datatable import dt, f
+from datatable.internal import frame_integrity_check
+from tests import assert_equals
+
+
+#-------------------------------------------------------------------------------
+# Create int8 columns
+#-------------------------------------------------------------------------------
+
+def test_int8_autodetect_1():
+    src = [0, 1, 0, None, 0]
+    DT = dt.Frame(src)
+    frame_integrity_check(DT)
+    assert DT.type == dt.Type.int8
+    assert DT.to_list() == [src]
+
+
+def test_int8_autodetect_2():
+    src = [None, None, None, None, 1, 0, 0, 1, None, 1, 1]
+    DT = dt.Frame(src)
+    frame_integrity_check(DT)
+    assert DT.type == dt.Type.int8
+    assert DT.to_list() == [src]
+
+
+def test_int8_autodetect_3(np):
+    i8 = np.int8
+    src = [i8(3), i8(5), None, i8(1), i8(100), None, i8(-1)]
+    DT = dt.Frame(src)
+    frame_integrity_check(DT)
+    assert DT.type == dt.Type.int8
+    assert DT.to_list() == [[3, 5, None, 1, 100, None, -1]]
+
+
+def test_int8_mixed_1():
+    msg = "Cannot create column: element at index 4 is of type <class 'bool'>" \
+          ", whereas previous elements were int8"
+    with pytest.raises(TypeError, match=msg):
+        dt.Frame([0, 1, 1, 0, False, True])
+
+
+def test_int8_forced():
+    DT = dt.Frame([1, None, -1, 1000, 2.7, "123", "boo"], type='int8')
+    frame_integrity_check(DT)
+    assert DT.type == dt.Type.int8
+    assert DT.shape == (7, 1)
+    assert DT.to_list() == [[1, None, -1, -24, 2, 123, None]]
+
+
+
+
+#-------------------------------------------------------------------------------
+# Create int16 columns
+#-------------------------------------------------------------------------------
+
+def test_int16_autodetect_1(np):
+    i16 = np.int16
+    src = [None, i16(50), i16(2303), None, i16(-45)]
+    DT = dt.Frame(src)
+    frame_integrity_check(DT)
+    assert DT.type == dt.Type.int16
+    assert DT.to_list() == [[None, 50, 2303, None, -45]]
+
+
+def test_int16_autodetect_2(np):
+    i16 = np.int16
+    src = [i16(1), i16(0)]
+    DT = dt.Frame(src)
+    frame_integrity_check(DT)
+    assert DT.type == dt.Type.int16
+    assert DT.to_list() == [[1, 0]]
+
+
+def test_int16_autodetect_3(np):
+    i16 = np.int16
+    src = [i16(1), i16(0), i16(1000), None, i16(1), i16(0), None]
+    DT = dt.Frame(src)
+    frame_integrity_check(DT)
+    assert DT.type == dt.Type.int16
+    assert DT.to_list() == [[1, 0, 1000, None, 1, 0, None]]
+
+
+def test_int16_mixed_1(np):
+    i16 = np.int16
+    msg = "Cannot create column: element at index 2 is of type <class 'numpy.int8'>" \
+          ", whereas previous elements were np.int16"
+    with pytest.raises(TypeError, match=msg):
+        dt.Frame([i16(99), i16(0), np.int8(0), None])
+
+
+def test_int16_forced():
+    DT = dt.Frame([1e50, 1000, None, "27", "?", True], type=dt.Type.int16)
+    frame_integrity_check(DT)
+    assert DT.type == dt.Type.int16
+    assert DT.shape == (6, 1)
+    # int(1e50) = 2407412430484045 * 2**115, which is ≡0 (mod 2**16)
+    assert DT.to_list() == [[0, 1000, None, 27, None, 1]]
+
+
+
+
+#-------------------------------------------------------------------------------
+# Create int32 columns
+#-------------------------------------------------------------------------------
+
+def test_int32_autodetect_1():
+    DT = dt.Frame([0, 1, 2])
+    frame_integrity_check(DT)
+    assert DT.type == dt.Type.int32
+    assert DT.to_list() == [[0, 1, 2]]
+
+
+def test_int32_autodetect_2():
+    src = [None, None, None, 111, 0, 1, 44, 9548, 428570247, -12, None]
+    DT = dt.Frame(src)
+    frame_integrity_check(DT)
+    assert DT.type == dt.Type.int32
+    assert DT.to_list()[0] == src
+
+
+def test_int32_autodetect_3(np):
+    i32 = np.int32
+    src = [None, i32(100), i32(1000), i32(-1)]
+    DT = dt.Frame(src)
+    assert_equals(DT, dt.Frame([None, 100, 1000, -1]))
+
+
+def test_int32_mixed_1(np):
+    i32 = np.int32
+    msg = "Cannot create column: element at index 3 is of type " \
+          "<class 'numpy.int16'>, whereas previous elements were np.int32"
+    with pytest.raises(TypeError, match=msg):
+        dt.Frame([i32(99), i32(0), None, np.int16(1)])
+
+
+def test_int32_mixed_2(np):
+    msg = "Cannot create column: element at index 5 is of type " \
+          "<class 'numpy.int32'>, whereas previous elements were int32"
+    with pytest.raises(TypeError, match=msg):
+        dt.Frame([None, 1, 5, 14, 1000, np.int32(1), 999])


### PR DESCRIPTION
The infrastructure that we had before was based on stypes, which does not allow us to create columns of non-constant types, such as `List<T>`.
The new approach allows each parser more autonomy in the type of column that it creates.

Certain tests moved into separate files.
Parsing of lists of numpy scalars made stricter: now they cannot be mixed with each other.

WIP for #3054