### PR TITLE
rbind(force=True) will no longer produce a TypeError

### DIFF
--- a/docs/api/dt/rbind.rst
+++ b/docs/api/dt/rbind.rst
@@ -17,6 +17,13 @@
     frames: Frame | List[Frame] | None
 
     force: bool
+        If True, then the frames are allowed to have mismatching set of
+        columns (either different counts or different names). Any gaps in
+        the data will be filled with NAs.
+
+        In addition, when this parameter is True, rbind will no longer
+        produce an error when combining columns of unrelated types.
+        Instead, both columns will be converted into strings.
 
     bynames: bool
 

--- a/docs/api/frame/rbind.rst
+++ b/docs/api/frame/rbind.rst
@@ -41,6 +41,10 @@
         If True, then the frames are allowed to have mismatching set of
         columns. Any gaps in the data will be filled with NAs.
 
+        In addition, when this parameter is True, rbind will no longer
+        produce an error when combining columns of unrelated types.
+        Instead, both columns will be converted into strings.
+
     bynames: bool
         If True (default), the columns in frames are matched by their
         names. For example, if one frame has columns ["colA", "colB",

--- a/docs/api/type/list32.rst
+++ b/docs/api/type/list32.rst
@@ -1,6 +1,6 @@
 
 .. xmethod:: datatable.Type.list32
-    :src: src/core/types/py_type.cc PyType::list32
+    :src: src/core/types/py_type.cc PyType::list
     :cvar: doc_Type_list32
     :signature: list32(T)
 

--- a/docs/api/type/list64.rst
+++ b/docs/api/type/list64.rst
@@ -1,6 +1,6 @@
 
 .. xmethod:: datatable.Type.list64
-    :src: src/core/types/py_type.cc PyType::list64
+    :src: src/core/types/py_type.cc PyType::list
     :cvar: doc_Type_list64
     :signature: list64(T)
 

--- a/docs/releases/v1.1.0.rst
+++ b/docs/releases/v1.1.0.rst
@@ -16,5 +16,5 @@
     -------
 
     -[imp] Parameter `force=True` in function :func:`rbind()` (or method
-        :meth:`dt.Frame.rbind()`) will now allow also allow combining of
-        columns of mismatched types. [#3062]
+        :meth:`dt.Frame.rbind()`) will now allow combining columns
+        of incompatible types. [#3062]

--- a/docs/releases/v1.1.0.rst
+++ b/docs/releases/v1.1.0.rst
@@ -14,3 +14,7 @@
 
     General
     -------
+
+    -[imp] Parameter `force=True` in function :func:`rbind()` (or method
+        :meth:`dt.Frame.rbind()`) will now allow also allow combining of
+        columns of mismatched types. [#3062]

--- a/src/core/column.h
+++ b/src/core/column.h
@@ -234,7 +234,7 @@ class Column
   //------------------------------------
   public:
     void materialize(bool to_memory = false);
-    void rbind(colvec& columns);
+    void rbind(colvec& columns, bool force);
     void cast_inplace(dt::SType stype);
     void cast_inplace(dt::Type type);
     Column cast(dt::SType stype) const;

--- a/src/core/datatable.h
+++ b/src/core/datatable.h
@@ -90,7 +90,8 @@ class DataTable {
     void resize_columns(const strvec& new_names);
     void apply_rowindex(const RowIndex&);
     void materialize(bool to_memory);
-    void rbind(const std::vector<DataTable*>&, const std::vector<sztvec>&);
+    void rbind(const std::vector<DataTable*>&, const std::vector<sztvec>&,
+               bool force = false);
     void cbind(const std::vector<DataTable*>&);
     DataTable extract_column(size_t i) const;
     size_t memory_footprint() const noexcept;

--- a/src/core/datatablemodule.cc
+++ b/src/core/datatablemodule.cc
@@ -399,7 +399,6 @@ void py::DatatableModule::init_methods() {
   init_methods_jay();
   init_methods_join();
   init_methods_kfold();
-  init_methods_rbind();
   init_methods_repeat();
   init_methods_sets();
   init_methods_styles();

--- a/src/core/datatablemodule.h
+++ b/src/core/datatablemodule.h
@@ -40,7 +40,6 @@ class DatatableModule : public ExtModule<DatatableModule> {
     void init_methods_jay();       // open_jay.cc
     void init_methods_join();      // frame/join.cc
     void init_methods_kfold();     // models/kfold.cc
-    void init_methods_rbind();     // frame/rbind.cc
     void init_methods_repeat();    // frame/repeat.cc
     void init_methods_sets();      // set_funcs.cc
     void init_methods_styles();    // frame/repr/html_styles.cc

--- a/src/core/frame/py_frame.cc
+++ b/src/core/frame/py_frame.cc
@@ -423,7 +423,6 @@ void Frame::impl_init_type(XTypeMaker& xt) {
   _init_iter(xt);
   _init_jay(xt);
   _init_names(xt);
-  _init_rbind(xt);
   _init_replace(xt);
   _init_repr(xt);
   _init_sizeof(xt);

--- a/src/core/frame/py_frame.h
+++ b/src/core/frame/py_frame.h
@@ -47,7 +47,6 @@ class Frame : public XObject<Frame> {
     static void _init_jay(XTypeMaker&);
     static void _init_key(XTypeMaker&);
     static void _init_names(XTypeMaker&);
-    static void _init_rbind(XTypeMaker&);
     static void _init_replace(XTypeMaker&);
     static void _init_repr(XTypeMaker&);
     static void _init_sizeof(XTypeMaker&);
@@ -116,7 +115,7 @@ class Frame : public XObject<Frame> {
     oobj copy(const XArgs&);
     oobj head(const XArgs&);
     void materialize(const XArgs&);
-    void rbind(const PKArgs&);
+    void rbind(const XArgs&);
     void repeat(const PKArgs&);
     void replace(const PKArgs&);
     oobj sort(const PKArgs&);

--- a/src/core/frame/rbind.cc
+++ b/src/core/frame/rbind.cc
@@ -296,7 +296,8 @@ void Column::rbind(colvec& columns, bool force) {
         next_type = dt::Type::str32();
       } else {
         throw TypeError() << "Cannot rbind column of type `" << col.type()
-            << "` to a column of type `" << new_type << "`";
+            << "` to a column of type `" << new_type << "`. Consider using "
+               "force=True if you want to ignore this error.";
       }
     }
     new_type = std::move(next_type);

--- a/src/core/frame/rbind.cc
+++ b/src/core/frame/rbind.cc
@@ -32,6 +32,7 @@
 #include "frame/py_frame.h"
 #include "ltype.h"
 #include "python/_all.h"
+#include "python/xargs.h"
 #include "stype.h"
 #include "utils/assert.h"
 #include "utils/misc.h"
@@ -55,12 +56,7 @@ static constexpr size_t INVALID_INDEX = size_t(-1);
 //------------------------------------------------------------------------------
 namespace py {
 
-static PKArgs args_rbind(
-  0, 0, 2, true, false, {"force", "bynames"}, "rbind", dt::doc_Frame_rbind);
-
-
-
-void Frame::rbind(const PKArgs& args) {
+void Frame::rbind(const XArgs& args) {
   bool force = args[0].to<bool>(false);
   bool bynames = args[1].to<bool>(true);
 
@@ -192,38 +188,37 @@ void Frame::rbind(const PKArgs& args) {
 }
 
 
+DECLARE_METHODv(&Frame::rbind)
+    ->name("rbind")
+    ->docs(dt::doc_Frame_rbind)
+    ->allow_varargs()
+    ->n_keyword_args(2)
+    ->arg_names({"force", "bynames"});
+
 
 
 //------------------------------------------------------------------------------
 // dt.rbind
 //------------------------------------------------------------------------------
 
-static PKArgs args_py_rbind(
-  0, 0, 2, true, false, {"force", "bynames"}, "rbind", dt::doc_dt_rbind);
-
-static oobj py_rbind(const PKArgs& args) {
+static oobj py_rbind(const XArgs& args) {
   oobj r = oobj::import("datatable", "Frame").call();
   PyObject* rv = r.to_borrowed_ref();
   reinterpret_cast<Frame*>(rv)->rbind(args);
   return r;
 }
 
+DECLARE_PYFN(&py_rbind)
+    ->name("rbind")
+    ->docs(dt::doc_dt_rbind)
+    ->allow_varargs()
+    ->n_keyword_args(2)
+    ->arg_names({"force", "bynames"});
 
 
-void Frame::_init_rbind(XTypeMaker& xt) {
-  xt.add(METHOD(&Frame::rbind, args_rbind));
-}
 
-
-void DatatableModule::init_methods_rbind() {
-  ADD_FN(&py_rbind, args_py_rbind);
-}
 
 }  // namespace py
-
-
-
-
 //------------------------------------------------------------------------------
 // DataTable::rbind
 //------------------------------------------------------------------------------

--- a/src/core/set_funcs.cc
+++ b/src/core/set_funcs.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2020 H2O.ai
+// Copyright 2018-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -114,7 +114,7 @@ static sort_result sort_columns(named_colvec&& ncv) {
     res.column.materialize();
   } else {
     res.column = Column::new_na_column(0, SType::VOID);
-    res.column.rbind(ncv.columns);
+    res.column.rbind(ncv.columns, false);
   }
   auto r = group({res.column}, {SortFlag::NONE});
   res.ri = std::move(r.first);

--- a/tests/munging/test-rbind.py
+++ b/tests/munging/test-rbind.py
@@ -527,6 +527,25 @@ def test_rbind_all_stypes():
                     dt.rbind(f1, f2)
 
 
+def test_rbind_different_types_force():
+    DT1 = dt.Frame(A=[1, 4, 77]),
+    DT2 = dt.Frame(A=["Hi", "there", None])
+    DT3 = dt.Frame(A=['2010-11-01', '2020-08-14', '2022-12-12'], type='date32')
+    with pytest.raises(TypeError):
+        dt.rbind(DT1, DT2)
+    with pytest.raises(TypeError):
+        dt.rbind(DT1, DT3)
+    with pytest.raises(TypeError):
+        dt.rbind(DT3, DT2)
+    assert_equals(dt.rbind(DT1, DT2, force=True),
+                  dt.Frame(A=["1", "4", "77", "Hi", "there", None]))
+    assert_equals(dt.rbind(DT1, DT3, force=True),
+                  dt.Frame(A=["1", "4", "77", "2010-11-01", "2020-08-14", "2022-12-12"]))
+    assert_equals(dt.rbind(DT2, DT3, force=True),
+                  dt.Frame(A=["Hi", "there", None, "2010-11-01", "2020-08-14", "2022-12-12"]))
+
+
+
 def test_rbind_modulefn():
     f0 = dt.Frame([1, 5409, 204])
     f1 = dt.Frame([109813, None, 9385])

--- a/tests/test-options.py
+++ b/tests/test-options.py
@@ -316,13 +316,13 @@ def test_debug_logger_object():
         assert dt.options.debug.enabled is True
 
         DT = dt.rbind([])
-        assert "dt.rbind([]) {" in logger.msg
+        assert "datatable.rbind([]) {" in logger.msg
         assert re.search(r"} # \d+(?:\.\d+)?(?:[eE][+-]?\d+)? s", logger.msg)
         logger.msg = ""
 
         with pytest.raises(TypeError):
             dt.rbind(4)
-        assert "dt.rbind(4) {" in logger.msg
+        assert "datatable.rbind(4) {" in logger.msg
         assert re.search(r"} # \d+(?:\.\d+)?(?:[eE][+-]?\d+)? s \(failed\)", logger.msg)
 
 


### PR DESCRIPTION
Rbind-ing columns of disparate types is now possible with parameter `force=True`.

Closes #3062
