### PR TITLE
Forbid sep='-'|'+'|'.' in fread

### DIFF
--- a/docs/releases/v1.1.0.rst
+++ b/docs/releases/v1.1.0.rst
@@ -15,6 +15,9 @@
     fread
     -----
 
+    -[enh] When reading Excel files, datetime fields will now be converted into
+        ``time64`` columns in the resulting frame.
+
     -[api] Parameter ``sep=`` in :func:`fread()` will no longer accept values
         ``'-'``, ``'+'``, or ``'.'``. Previously, these values were allowed but
         they produced errors during parsing. [#3065]

--- a/docs/releases/v1.1.0.rst
+++ b/docs/releases/v1.1.0.rst
@@ -12,9 +12,17 @@
     .. current-module:: datatable
 
 
+    fread
+    -----
+
+    -[api] Parameter ``sep=`` in :func:`fread()` will no longer accept values
+        ``'-'``, ``'+'``, or ``'.'``. Previously, these values were allowed but
+        they produced errors during parsing. [#3065]
+
+
     General
     -------
 
-    -[imp] Parameter `force=True` in function :func:`rbind()` (or method
+    -[imp] Parameter ``force=True`` in function :func:`rbind()` (or method
         :meth:`dt.Frame.rbind()`) will now allow combining columns
         of incompatible types. [#3062]

--- a/src/core/csv/reader.cc
+++ b/src/core/csv/reader.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2020 H2O.ai
+// Copyright 2018-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -296,8 +296,9 @@ void GenericReader::init_sep(const py::Arg& arg) {
                             "supported: '" << str << "'";
   } else {
     if (c=='"' || c=='\'' || c=='`' || ('0' <= c && c <= '9') ||
-        ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z')) {
-      throw ValueError() << "Separator `" << c << "` is not allowed";
+        ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') ||
+        c=='.' || c=='-' || c=='+') {
+      throw ValueError() << "Separator `'" << c << "'` is not allowed";
     }
     sep = c;
     D() << "sep = '" << sep << "'";

--- a/tests/fread/test-fread-api.py
+++ b/tests/fread/test-fread-api.py
@@ -770,11 +770,11 @@ def test_sep_invalid3():
             in str(e.value))
 
 
-@pytest.mark.parametrize('c', list('019\'`"aAzZoQ'))
+@pytest.mark.parametrize('c', list('019\'`"aAzZoQ-+.'))
 def test_sep_invalid4(c):
     with pytest.raises(Exception) as e:
         dt.fread("A,,B\n", sep=c)
-    assert "Separator %s is not allowed" % c == str(e.value)
+    assert "Separator '%s' is not allowed" % c == str(e.value)
 
 
 

--- a/tests/fread/test-xls.py
+++ b/tests/fread/test-xls.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #-------------------------------------------------------------------------------
-# Copyright 2018-2020 H2O.ai
+# Copyright 2018-2021 H2O.ai
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -115,18 +115,19 @@ def test_large_ids_xlsx():
 
 
 def test_set_xls_new_xlsx():
+    from datetime import datetime
     filename = find_file("h2o-3", "fread", "test_set_xls_new.xlsx")
     DT = dt.fread(filename)
     assert DT.source == filename
     assert DT.shape == (7, 1)
     assert DT.names == ("Data",)
-    assert DT.to_list()[0] == ['2019-05-06 00:00:00',
-                               '2019-05-07 00:00:00',
-                               '2019-05-08 00:00:00',
-                               '2019-05-09 00:00:00',
-                               '2019-05-10 00:00:00',
-                               '2019-05-11 00:00:00',
-                               '2019-05-12 00:00:00']
+    assert DT.to_list()[0] == [datetime(2019, 5, 6),
+                               datetime(2019, 5, 7),
+                               datetime(2019, 5, 8),
+                               datetime(2019, 5, 9),
+                               datetime(2019, 5, 10),
+                               datetime(2019, 5, 11),
+                               datetime(2019, 5, 12)]
 
 
 def test_diabetes_tiny_two_sheets_xlsx():
@@ -173,14 +174,15 @@ def test_excel_testbook_xlsx_2():
 
 
 def test_excel_testbook_xlsx_3():
+    from datetime import datetime
     filename = find_file("h2o-3", "fread", "excelTestbook.xlsx")
     DT3 = dt.fread(filename + "/big sheet")
     assert DT3.source == os.path.abspath(filename) + "/big sheet"
     assert DT3.shape == (20, 2)
     assert DT3.names == ("date1", "time1")
-    assert DT3['date1'].to_list()[0] == ["2020-01-%02d 00:00:00" % i
+    assert DT3['date1'].to_list()[0] == [datetime(2020, 1, i)
                                          for i in range(1, 21)]
-    assert DT3['time1'].to_list()[0] == ["2020-01-01 %02d:24:30" % i
+    assert DT3['time1'].to_list()[0] == [datetime(2020, 1, 1, i, 24, 30)
                                          for i in range(1, 10)] + \
                                         [None] * 11
 


### PR DESCRIPTION
- A `ValueError` will now be thrown if you specify `sep='-'`, `sep='+'`, or `sep='.'` in fread;
- Reading columns with mixed types from Excel file will no longer produce an error -- instead the values will be upcast into strings;
- Fread is now able to read date fields in Excel and convert them into `time64` columns.

Closes #3065