### PR TITLE
obj64 columns can now be saved into CSV

### DIFF
--- a/docs/releases/v1.1.0.rst
+++ b/docs/releases/v1.1.0.rst
@@ -6,6 +6,10 @@
     -----
     .. current-class:: datatable.Frame
 
+    -[enh] Frames with columns of type :attr:`obj64 <dt.Type.obj64>` can now
+        be saved into CSV. The values in the object column will be stringified
+        upon saving. [#3064]
+
 
     FExpr
     -----

--- a/src/core/write/value_writer.cc
+++ b/src/core/write/value_writer.cc
@@ -379,9 +379,10 @@ vptr value_writer::create(const Column& col, const output_options& options)
         case Quoting::NONE:       return vptr(new string_unquoted_writer(col));
       }
     }
-    default:
-      throw NotImplError() << "Cannot write into CSV values of type "
-         << col.type();
+    default: {
+      Column col_as_str = col.cast(Type::str32());
+      return value_writer::create(col_as_str, options);
+    }
   }
 }
 

--- a/tests/frame/test-tocsv.py
+++ b/tests/frame/test-tocsv.py
@@ -27,7 +27,7 @@ import os
 import random
 import re
 import pytest
-from datatable import stype
+from datatable import stype, f
 from datatable.internal import frame_integrity_check
 from tests import assert_equals, list_equals
 
@@ -379,6 +379,18 @@ def test_save_empty_frame_to_file(tempfile):
     dt.Frame().to_csv(tempfile)
     assert os.path.isfile(tempfile)
     assert os.stat(tempfile).st_size == 0
+
+
+def test_save_void_column():
+    DT = dt.Frame([None]*4)
+    out = DT.to_csv()
+    assert out == 'C0\n\n\n\n\n'
+
+
+def test_save_object_column():
+    DT = dt.Frame([f.A, f[0], f[::-1]], type=object)
+    out = DT.to_csv()
+    assert out == 'C0\nFExpr<f.A>\nFExpr<f[0]>\nFExpr<f[::-1]>\n'
 
 
 def test_issue1615():


### PR DESCRIPTION
CSV writer will now attempt to cast into str any column that it doesn't know how to write directly. For now, this is just the obj64 column.

Closes #3064