### PR TITLE
Better convert pandas object column

### DIFF
--- a/docs/api/type/void.rst
+++ b/docs/api/type/void.rst
@@ -14,6 +14,8 @@
     invalid.
 
     It converts into pyarrow's ``pa.null()`` type, or ``'|V0'`` dtype in numpy.
+    When converting into pandas, a Series of ``object`` type is created,
+    consisting of python ``None`` objects.
 
     Examples
     --------

--- a/docs/releases/v1.1.0.rst
+++ b/docs/releases/v1.1.0.rst
@@ -10,6 +10,10 @@
         be saved into CSV. The values in the object column will be stringified
         upon saving. [#3064]
 
+    -[api] Converting a column of :attr:`void <dt.Type.void>` type into pandas
+        now produces a pandas ``object`` column filled with ``None``s. Converting
+        such column back into datatable produces a ``void`` column again. [#3063]
+
 
     FExpr
     -----
@@ -18,6 +22,7 @@
 
     fread
     -----
+    .. current-module:: datatable
 
     -[enh] When reading Excel files, datetime fields will now be converted into
         ``time64`` columns in the resulting frame.

--- a/src/core/column.h
+++ b/src/core/column.h
@@ -1,4 +1,3 @@
-
 //------------------------------------------------------------------------------
 // Copyright 2018-2021 H2O.ai
 //
@@ -239,6 +238,7 @@ class Column
     void cast_inplace(dt::Type type);
     Column cast(dt::SType stype) const;
     Column cast(dt::Type type) const;
+    Column reduce_type(bool strict) const;
     void sort_grouped(const Groupby&);
 
     void replace_values(const RowIndex& replace_at, const Column& replace_with);

--- a/src/core/column_from_python.cc
+++ b/src/core/column_from_python.cc
@@ -308,7 +308,8 @@ Column _parse_string(const Column& inputcol, size_t i0, bool strict) {
   py::oobj item;
   for (size_t i = i0; i < inputcol.nrows(); i++) {
     inputcol.get_element(i, &item);
-    if (!(item.is_string() || item.is_none() || item.is_numpy_str())) {
+    if (!(item.is_string() || item.is_none() || item.is_numpy_str() ||
+          item.is_float_nan())) {
       return _invalid(inputcol, strict, i, item, "string");
     }
   }

--- a/src/core/frame/to_pandas.cc
+++ b/src/core/frame/to_pandas.cc
@@ -57,10 +57,15 @@ oobj Frame::to_pandas(const XArgs&) {
   //       by rows.
   odict data;
   for (size_t i = nkeys; i < ncols; i++) {
-    data.set(
-        names[i],
-        robj(this).invoke("to_numpy", {None(), oint(i)})
-    );
+    oobj column;
+    if (dt->get_column(i).type().is_void()) {
+      olist res { 1 };
+      res.set(0, py::None());
+      column = res.invoke("__mul__", {py::oint(dt->nrows())});
+    } else {
+      column = robj(this).invoke("to_numpy", {None(), oint(i)});
+    }
+    data.set(names[i], column);
   }
 
   oobj columns = names;

--- a/src/core/py_buffers.cc
+++ b/src/core/py_buffers.cc
@@ -107,7 +107,8 @@ Column Column::from_pybuffer(const py::robj& pyobj) {
     res = std::move(view).to_column();
   }
 
-  if (res.stype() == dt::SType::OBJ) {
+  if (res.type().is_object()) {
+
     try_to_resolve_object_column(res);
   }
   return res;

--- a/src/core/py_buffers.cc
+++ b/src/core/py_buffers.cc
@@ -42,7 +42,6 @@
 #include "stype.h"
 
 // Forward declarations
-static void try_to_resolve_object_column(Column& col);
 static Column convert_fwchararray_to_column(py::buffer&& view);
 
 
@@ -108,8 +107,7 @@ Column Column::from_pybuffer(const py::robj& pyobj) {
   }
 
   if (res.type().is_object()) {
-
-    try_to_resolve_object_column(res);
+    res = res.reduce_type(/*strict=*/false);
   }
   return res;
 }
@@ -141,92 +139,4 @@ static Column convert_fwchararray_to_column(py::buffer&& view)
 
   strbuf.resize(static_cast<size_t>(offset));
   return Column::new_string_column(nrows, std::move(offbuf), std::move(strbuf));
-}
-
-
-
-/**
- * If a column was created from Pandas series, it may end up having
- * dtype='object' (because Pandas doesn't support string columns). This function
- * will attempt to convert such column to the string type (or some other type
- * if more appropriate), and return either the original or the new modified
- * column. If a new column is returned, the original one is decrefed.
- */
-static void try_to_resolve_object_column(Column& col)
-{
-  auto data = static_cast<PyObject* const*>(col.get_data_readonly());
-  size_t nrows = col.nrows();
-
-  bool all_strings = true;
-  bool all_booleans = true;
-
-  // Approximate total length of all strings. Do not take into account
-  // possibility that the strings may expand in UTF-8 -- if needed, we'll
-  // realloc the buffer later.
-  size_t total_length = 10;
-  for (size_t i = 0; i < nrows; ++i) {
-    PyObject* v = data[i];
-    if (v == Py_None) {}
-    else if (all_strings && PyUnicode_Check(v)) {
-      all_booleans = false;
-      total_length += static_cast<size_t>(PyUnicode_GetLength(v));
-    }
-    else if (all_booleans && (v == Py_False || v == Py_True)) {
-      all_strings = false;
-    }
-    else if (PyFloat_Check(v) && std::isnan(PyFloat_AS_DOUBLE(v))) {}
-    else {
-      all_strings = false;
-      all_booleans = false;
-      break;
-    }
-  }
-
-  // All values in the list were booleans (or None)
-  if (all_booleans) {
-    Buffer mbuf = Buffer::mem(nrows);
-    auto out = static_cast<int8_t*>(mbuf.xptr());
-    for (size_t i = 0; i < nrows; ++i) {
-      PyObject* v = data[i];
-      out[i] = v == Py_True? 1 : v == Py_False? 0 : dt::GETNA<int8_t>();
-    }
-    col = Column::new_mbuf_column(nrows, dt::SType::BOOL, std::move(mbuf));
-  }
-
-  // All values were strings
-  else if (all_strings) {
-    size_t strbuf_size = total_length;
-    Buffer offbuf = Buffer::mem((nrows + 1) * 4);
-    Buffer strbuf = Buffer::mem(strbuf_size);
-    uint32_t* offsets = static_cast<uint32_t*>(offbuf.xptr());
-    char* strs = static_cast<char*>(strbuf.xptr());
-
-    offsets[0] = 0;
-    ++offsets;
-
-    uint32_t offset = 0;
-    for (size_t i = 0; i < nrows; ++i) {
-      PyObject* v = data[i];
-      if (PyUnicode_Check(v)) {
-        PyObject *z = PyUnicode_AsEncodedString(v, "utf-8", "strict");
-        size_t sz = static_cast<size_t>(PyBytes_Size(z));
-        if (offset + sz > strbuf_size) {
-          strbuf_size = static_cast<size_t>(
-              1.5 * static_cast<double>(strbuf_size) + static_cast<double>(sz));
-          strbuf.resize(strbuf_size);
-          strs = static_cast<char*>(strbuf.xptr());
-        }
-        std::memcpy(strs + offset, PyBytes_AsString(z), sz);
-        Py_DECREF(z);
-        offset += static_cast<uint32_t>(sz);
-        offsets[i] = offset;
-      } else {
-        offsets[i] = offset ^ dt::GETNA<uint32_t>();
-      }
-    }
-
-    xassert(offset <= strbuf.size());
-    strbuf.resize(offset);
-    col = Column::new_string_column(nrows, std::move(offbuf), std::move(strbuf));
-  }
 }

--- a/src/core/python/obj.h
+++ b/src/core/python/obj.h
@@ -170,6 +170,7 @@ class _obj {
     bool is_false()         const noexcept;
     bool is_fexpr()         const noexcept;
     bool is_float()         const noexcept;
+    bool is_float_nan()     const noexcept;
     bool is_frame()         const noexcept;
     bool is_generator()     const noexcept;
     bool is_int()           const noexcept;


### PR DESCRIPTION
When a pandas `object` column is converted into a datatable Column, we will now pass it through the same converter as used when creating a Frame from python list. This allows for better detection of types that datatable can handle natively while pandas cannot.

In addition, conversion of datatable `void` columns into pandas is now special-cased: the produced result is a pandas Series of dtype `object` consisting of `None`s. Before, when we were converting the column into numpy array first, and then sent that array to pandas, the result was a column filled with 0-size `bytes` objects, which is much harder to work with.

Specifically, round trip [datatable]->[pandas]->[datatable] now works void columns.

Closes #3063
WIP for #1692