### PR TITLE
Fix saving void column to jay

### DIFF
--- a/docs/releases/v1.1.0.rst
+++ b/docs/releases/v1.1.0.rst
@@ -10,6 +10,9 @@
         be saved into CSV. The values in the object column will be stringified
         upon saving. [#3064]
 
+    -[fix] Saving a frame with a :attr:`void <dt.Type.void>` column into Jay
+        no longer leads to a crash. [#3074]
+
     -[api] Converting a column of :attr:`void <dt.Type.void>` type into pandas
         now produces a pandas ``object`` column filled with ``None``s. Converting
         such column back into datatable produces a ``void`` column again. [#3063]

--- a/src/core/column/const.h
+++ b/src/core/column/const.h
@@ -62,9 +62,13 @@ class ConstNa_ColumnImpl : public Const_ColumnImpl {
 
     ColumnImpl* clone() const override;
     void materialize(Column&, bool) override;
+    bool allow_parallel_access() const override;
+    bool is_virtual() const noexcept override;
     void na_pad(size_t nrows, Column&) override;
     void rbind_impl(
         colvec& columns, size_t new_nrows, bool col_empty, dt::SType&) override;
+    void write_data_to_jay(
+        Column&, jay::ColumnBuilder&, WritableBuffer*) override;
 };
 
 

--- a/src/core/column/const_na.cc
+++ b/src/core/column/const_na.cc
@@ -54,6 +54,28 @@ void ConstNa_ColumnImpl::na_pad(size_t nrows, Column&) {
 }
 
 
+bool ConstNa_ColumnImpl::allow_parallel_access() const {
+  return true;
+}
+
+
+bool ConstNa_ColumnImpl::is_virtual() const noexcept {
+  return !type_.is_void();  // A VOID column is considered non-virtual
+}
+
+
+void ConstNa_ColumnImpl::write_data_to_jay(
+        Column& thiscol, jay::ColumnBuilder& cb, WritableBuffer* wbb) {
+  if (type_.is_void()) {
+    // no data to write
+  } else {
+    // For NA columns of non-void type, defer to regular writer
+    Virtual_ColumnImpl::write_data_to_jay(thiscol, cb, wbb);
+  }
+}
+
+
+
 //------------------------------------------------------------------------------
 // Materializing
 //------------------------------------------------------------------------------

--- a/src/core/jay/jay.fbs
+++ b/src/core/jay/jay.fbs
@@ -44,6 +44,7 @@ enum Type : uint8 {
   Str64,
   Date32,
   Time64,
+  Void0,
 }
 
 union Stats {

--- a/src/core/jay/jay_generated.h
+++ b/src/core/jay/jay_generated.h
@@ -42,11 +42,12 @@ enum Type {
   Type_Str64 = 8,
   Type_Date32 = 9,
   Type_Time64 = 10,
+  Type_Void0 = 11,
   Type_MIN = Type_Bool8,
-  Type_MAX = Type_Time64
+  Type_MAX = Type_Void0
 };
 
-inline const Type (&EnumValuesType())[11] {
+inline const Type (&EnumValuesType())[12] {
   static const Type values[] = {
     Type_Bool8,
     Type_Int8,
@@ -58,13 +59,14 @@ inline const Type (&EnumValuesType())[11] {
     Type_Str32,
     Type_Str64,
     Type_Date32,
-    Type_Time64
+    Type_Time64,
+    Type_Void0
   };
   return values;
 }
 
 inline const char * const *EnumNamesType() {
-  static const char * const names[12] = {
+  static const char * const names[13] = {
     "Bool8",
     "Int8",
     "Int16",
@@ -76,13 +78,14 @@ inline const char * const *EnumNamesType() {
     "Str64",
     "Date32",
     "Time64",
+    "Void0",
     nullptr
   };
   return names;
 }
 
 inline const char *EnumNameType(Type e) {
-  if (flatbuffers::IsOutRange(e, Type_Bool8, Type_Time64)) return "";
+  if (flatbuffers::IsOutRange(e, Type_Bool8, Type_Void0)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesType()[index];
 }

--- a/src/core/jay/open_jay.cc
+++ b/src/core/jay/open_jay.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2020 H2O.ai
+// Copyright 2018-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -185,15 +185,21 @@ static Column column_from_jay(
     case jay::Type_Str64:   stype = dt::SType::STR64; break;
     case jay::Type_Date32:  stype = dt::SType::DATE32; break;
     case jay::Type_Time64:  stype = dt::SType::TIME64; break;
+    case jay::Type_Void0:   stype = dt::SType::VOID; break;
   }
 
   Column col;
-  Buffer databuf = extract_buffer(jaybuf, jcol->data());
-  if (stype == dt::SType::STR32 || stype == dt::SType::STR64) {
-    Buffer strbuf = extract_buffer(jaybuf, jcol->strdata());
-    col = Column::new_string_column(nrows, std::move(databuf), std::move(strbuf));
-  } else {
-    col = Column::new_mbuf_column(nrows, stype, std::move(databuf));
+  if (stype == dt::SType::VOID) {
+    col = Column::new_na_column(nrows, stype);
+  }
+  else {
+    Buffer databuf = extract_buffer(jaybuf, jcol->data());
+    if (stype == dt::SType::STR32 || stype == dt::SType::STR64) {
+      Buffer strbuf = extract_buffer(jaybuf, jcol->strdata());
+      col = Column::new_string_column(nrows, std::move(databuf), std::move(strbuf));
+    } else {
+      col = Column::new_mbuf_column(nrows, stype, std::move(databuf));
+    }
   }
 
   Stats* stats = col.stats();

--- a/src/core/jay/save_jay.cc
+++ b/src/core/jay/save_jay.cc
@@ -461,6 +461,7 @@ void Frame::_init_jay(XTypeMaker& xt) {
   stype_to_jaytype[int(dt::SType::TIME64)]  = jay::Type_Time64;
   stype_to_jaytype[int(dt::SType::STR32)]   = jay::Type_Str32;
   stype_to_jaytype[int(dt::SType::STR64)]   = jay::Type_Str64;
+  stype_to_jaytype[int(dt::SType::VOID)]    = jay::Type_Void0;
 }
 
 

--- a/tests/test-jay.py
+++ b/tests/test-jay.py
@@ -146,6 +146,24 @@ def test_jay_empty_frame(tempfile_jay):
     assert d1.source == tempfile_jay
 
 
+def test_jay_void_column():
+    DT = dt.Frame([None] * 5)
+    jay = DT.to_jay()
+    RES = dt.fread(jay)
+    assert_equals(DT, RES)
+
+
+def test_jay_void_column_typecast():
+    DT = dt.Frame([None] * 10)
+    assert DT.type == dt.Type.void
+    DT[0] = dt.Type.int32
+    assert DT.type == dt.Type.int32
+    jay = DT.to_jay()
+    RES = dt.fread(jay)
+    assert RES.type == dt.Type.int32
+    assert_equals(RES, dt.Frame([None]*10, type='int32'))
+
+
 def test_jay_all_types(tempfile_jay):
     d0 = dt.Frame([[True, False, None, True, True],
                    [None, 1, -9, 12, 3],


### PR DESCRIPTION
Void column is the only column that is both virtual and materialized, therefore special handling was necessary for writing this column into Jay file.

Closes #3074
Closes #3060