### PR TITLE
fix conversion of nans to/from datatable Frame

### DIFF
--- a/docs/releases/v1.1.0.rst
+++ b/docs/releases/v1.1.0.rst
@@ -17,6 +17,18 @@
         now produces a pandas ``object`` column filled with ``None``s. Converting
         such column back into datatable produces a ``void`` column again. [#3063]
 
+    -[api] When creating Frame from a list of values, a floating-point ``nan``
+        value will now be treated as ``None``. In particular, ``nan``s can now
+        be safely mixed with values of other types, and a list consisting of
+        only ``nan``s will turn into a Column of type
+        :attr:`void <dt.Type.void>`. [#3083]
+
+    -[api] Converting string or object columns to numpy no longer produces a
+        masked array. Instead, we create a regular ``object`` array, filled
+        with ``None``s in place of NAs. Similarly, converting a string or object
+        column to pandas creates a Series with ``None`` values (instead of
+        ``nan``s as before) in place of NAs. [#3083]
+
 
     FExpr
     -----

--- a/src/core/column_from_python.cc
+++ b/src/core/column_from_python.cc
@@ -417,7 +417,7 @@ Column Column::reduce_type(bool strict) const {
   py::oobj item0;
   for (; i0 < nrows(); ++i0) {
     get_element(i0, &item0);
-    if (!item0.is_none()) break;
+    if (!(item0.is_none() || item0.is_float_nan())) break;
   }
   if (i0 == nrows()) {  // Also works when `nrows == 0`
     return Column::new_na_column(nrows(), dt::SType::VOID);

--- a/src/core/frame/to_numpy.cc
+++ b/src/core/frame/to_numpy.cc
@@ -109,7 +109,7 @@ static oobj to_numpy_impl(oobj frame) {
     }
   }
   xassert(common_type);
-  if (common_type.stype() == dt::SType::VOID) {
+  if (common_type.is_void()) {
     return numpy.invoke("empty", {frame.get_attr("shape"), ostring("void")});
   }
 
@@ -164,7 +164,10 @@ static oobj to_numpy_impl(oobj frame) {
 
   // If there are any columns with NAs, replace the numpy.array with
   // numpy.ma.masked_array
-  if (!(common_type.is_float() || common_type.is_temporal()) && datatable_has_nas(dt)) {
+  if (!(common_type.is_float() || common_type.is_temporal() || common_type.is_object() ||
+        common_type.is_string())
+      && datatable_has_nas(dt))
+  {
     size_t dtsize = ncols * dt->nrows();
     Column mask_col = Column::new_data_column(dtsize, dt::SType::BOOL);
     bool* mask_data = static_cast<bool*>(mask_col.get_data_editable());

--- a/tests/frame/test-create.py
+++ b/tests/frame/test-create.py
@@ -623,6 +623,18 @@ def test_create_from_list_of_dicts_bad3():
 # Type auto-detection
 #-------------------------------------------------------------------------------
 
+def test_auto_void1():
+    DT = dt.Frame([None] * 5)
+    assert DT.type == dt.Type.void
+    assert DT.shape == (5, 1)
+
+
+def test_auto_void2():
+    DT = dt.Frame([math.nan] * 15)
+    assert DT.type == dt.Type.void
+    assert DT.shape == (15, 1)
+
+
 def test_auto_str32_1():
     d0 = dt.Frame(["start", None, "end"])
     frame_integrity_check(d0)
@@ -634,6 +646,27 @@ def test_auto_str32_2():
     frame_integrity_check(DT)
     assert DT.stype == stype.str32
     assert DT.to_list() == [[None, "1a", "12", "fini"]]
+
+
+def test_auto_str32_3():
+    DT = dt.Frame([math.nan, "start", None, "end"])
+    frame_integrity_check(DT)
+    assert DT.types == [dt.Type.str32]
+    assert DT.to_list() == [[None, "start", None, "end"]]
+
+
+def test_create_from_strings_and_nans1():
+    DT = dt.Frame(["a", 'bb', math.nan])
+    frame_integrity_check(DT)
+    assert DT.type == dt.Type.str32
+    assert DT.to_list() == [["a", "bb", None]]
+
+
+def test_create_from_strings_and_nans2():
+    DT = dt.Frame([math.nan, None, math.nan, "a", 'bb'])
+    frame_integrity_check(DT)
+    assert DT.type == dt.Type.str32
+    assert DT.to_list() == [[None, None, None, "a", "bb"]]
 
 
 def test_auto_str32_3():

--- a/tests/frame/test-to-numpy.py
+++ b/tests/frame/test-to-numpy.py
@@ -161,7 +161,7 @@ def test_tonumpy_strings_with_NAs(np):
     src = ["faa", None, "", "hooray", None]
     d0 = dt.Frame(src)
     a0 = d0.to_numpy()
-    assert isinstance(a0, np.ma.core.MaskedArray)
+    assert isinstance(a0, np.ndarray)
     assert a0.dtype == np.dtype('object')
     assert a0.T.tolist() == [src]
 

--- a/tests/frame/test-to-pandas.py
+++ b/tests/frame/test-to-pandas.py
@@ -98,6 +98,20 @@ def test_topandas_bool_nas():
 
 
 @pandas_test
+def test_topandas_strings_nas():
+    DT = dt.Frame(["alpha", None, None, "omega"])
+    pf = DT.to_pandas()
+    assert pf.values.tolist() == [["alpha"], [None], [None], ["omega"]]
+
+
+@pandas_test
+def test_topandas_objects_nas():
+    DT = dt.Frame([dt, None, None, [1,2,3]], type=object)
+    pf = DT.to_pandas()
+    assert pf.values.tolist() == [[dt], [None], [None], [[1, 2, 3]]]
+
+
+@pandas_test
 def test_topandas_keyed(pd):
     DT = dt.Frame(A=[3, 5, 9, 11], B=[7, 14, 1, 0], R=['va', 'dfkjv', 'q', '...'])
     DT.key = 'A'

--- a/tests/ijby/test-rowwise.py
+++ b/tests/ijby/test-rowwise.py
@@ -257,7 +257,7 @@ def test_rowmean_wrong_types():
 def test_rowsd_single_column():
     DT = dt.Frame(A=range(5))
     RES = DT[:, rowsd(f[:])]
-    assert_equals(RES, dt.Frame([math.nan]*5))
+    assert_equals(RES, dt.Frame([None]*5, type=float))
 
 
 def test_rowsd_same_columns():

--- a/tests/test-reduce.py
+++ b/tests/test-reduce.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #-------------------------------------------------------------------------------
-# Copyright 2018-2020 H2O.ai
+# Copyright 2018-2021 H2O.ai
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -397,7 +397,7 @@ def test_median_float(st):
 
 
 def test_median_all_nas():
-    DT = dt.Frame(N=[math.nan] * 8)
+    DT = dt.Frame(N=[math.nan] * 8, type=float)
     RES = DT[:, median(f.N)]
     assert RES.shape == (1, 1)
     assert RES.stypes == (dt.float64,)
@@ -525,7 +525,7 @@ def test_corr_small_frame():
 def test_corr_with_constant():
     DT = dt.Frame(A=range(23), B=[2.5] * 23)
     D1 = DT[:, corr(f.A, f.B)]
-    assert_equals(D1, dt.Frame([math.nan]))
+    assert_equals(D1, dt.Frame([None], type=float))
 
 
 @pytest.mark.parametrize("seed", [random.getrandbits(32)])


### PR DESCRIPTION
- When creating Frame from a list of values, a floating-point `nan` value will now be treated as `None`. In particular, `nan`s can now be safely mixed with values of other types, and a list consisting of only `nan`s will turn into a Column of type void.

- Converting string or object columns to numpy no longer produces a masked array. Instead, we create a regular ``object`` array, filled with `None`s in place of NAs. Similarly, converting a string or object column to pandas creates a Series with `None` values (instead of `nan`s as before) in place of NAs.


Closes #3083