### PR TITLE
Sort void column

### DIFF
--- a/docs/releases/v1.1.0.rst
+++ b/docs/releases/v1.1.0.rst
@@ -10,6 +10,10 @@
         be saved into CSV. The values in the object column will be stringified
         upon saving. [#3064]
 
+    -[enh] Void columns can now be used with :func:`dt.sort()`. In addition,
+        datatable will now skip sorting any column that it knows contains
+        constant values. [#3088]
+
     -[fix] Saving a frame with a :attr:`void <dt.Type.void>` column into Jay
         no longer leads to a crash. [#3074]
 
@@ -55,6 +59,6 @@
     General
     -------
 
-    -[imp] Parameter ``force=True`` in function :func:`rbind()` (or method
+    -[enh] Parameter ``force=True`` in function :func:`rbind()` (or method
         :meth:`dt.Frame.rbind()`) will now allow combining columns
         of incompatible types. [#3062]

--- a/tests/ijby/test-sort.py
+++ b/tests/ijby/test-sort.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #-------------------------------------------------------------------------------
-# Copyright 2018-2020 H2O.ai
+# Copyright 2018-2021 H2O.ai
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -1053,6 +1053,7 @@ def test_na_position_value_error(na_pos):
         DT[:, :, dt.sort(0, reverse=True, na_position=na_pos)]
 
 
+
 #-------------------------------------------------------------------------------
 # Misc issues
 #-------------------------------------------------------------------------------
@@ -1131,3 +1132,18 @@ def test_issue2348():
                   dt.Frame([[11], [6]],
                            names=["D", "count"],
                            stypes=[dt.int32, dt.int64]))
+
+
+def test_sort_consts():
+    DT = dt.Frame(A=[5], B=[7.9], C=["Hello"], D=[None])
+    DT = dt.repeat(DT, 1000)
+    assert_equals(DT[:, :, sort(f.A)], DT)
+    assert_equals(DT[:, :, sort(f.B)], DT)
+    assert_equals(DT[:, :, sort(f.C)], DT)
+    assert_equals(DT[:, :, sort(f.D)], DT)
+
+
+def test_sort_consts2():
+    # see issue #3088
+    DT = dt.Frame([dt.math.nan, dt.math.nan])[:, dt.count(), dt.by(0)]
+    assert_equals(DT, dt.Frame(C0=[None], count=[2]/dt.int64))


### PR DESCRIPTION
- Allow void columns to be used in `sort()`
- Sorting will be skipped for any constant column (i.e. having `Const_ColumnImpl`).

Closes #3088