### PR TITLE
Fix fread bug with quoteRule becoming too large

### DIFF
--- a/src/core/csv/reader_fread.cc
+++ b/src/core/csv/reader_fread.cc
@@ -340,7 +340,7 @@ void FreadReader::detect_sep_and_qr() {
           updated = true;
           // Two updates can happen for the same sep and quoteRule (e.g. issue_1113_fread.txt where sep=' ') so the
           // updated flag is just to print once.
-        } else if (topNumFields == 0 && nseps == 1 && quoteRule != 2) {
+        } else if (topNumFields == 0 && nseps == 1 && quoteRule != 3) {
           topNumFields = numFields[i];
           topSep = sep;
           topQuoteRule = quoteRule;

--- a/src/core/read/fread/fread_thread_context.cc
+++ b/src/core/read/fread/fread_thread_context.cc
@@ -172,7 +172,7 @@ void FreadThreadContext::read_chunk(
         }
 
         // Type-bump. This may only happen if cc.is_start_exact() is true, which
-        // is can only happen to one thread at a time. Thus, there is no need
+        // can only happen to one thread at a time. Thus, there is no need
         // for "critical" section here.
         auto& colj = preframe_.column(j);
         if (ptype_iter.has_incremented()) {
@@ -192,21 +192,6 @@ void FreadThreadContext::read_chunk(
         }
         parse_ctx_.target ++;
         j++;
-        if (tch < parse_ctx_.eof && j < ncols && *tch=='\n' && sep!=' ') {
-          const char* prev_tch = tch;
-          while (*tch!=sep) {
-            tch--;
-            if (*tch=='\n') {
-              tch = prev_tch;
-              break;
-            }
-          }
-          if (*tch==sep) {
-            tch++;
-            ++ptype_iter;
-            continue;
-          }
-        }
         if (tch < parse_ctx_.eof && *tch==sep) { tch++; continue; }
         if (fill && (tch == parse_ctx_.eof || *tch=='\n' || *tch=='\r') && j <= ncols) {
           // All parsers have already stored NA to target; except for string

--- a/src/core/read/parsers/parse_string.cc
+++ b/src/core/read/parsers/parse_string.cc
@@ -374,8 +374,10 @@ void parse_string(const ParseContext& ctx) {
   switch (ctx.quoteRule) {
     case 0: parse_string_quoted<DOUBLED>(ctx); break;
     case 1: parse_string_quoted<ESCAPED>(ctx); break;
-    case 2: parse_string_naive(ctx);           break;
-    case 3: parse_string_unquoted<false>(ctx); break;
+    case 2: parse_string_unquoted<false>(ctx); break;
+    case 3: parse_string_naive(ctx);           break;
+    default: throw RuntimeError()
+        << "Invalid quoteRule: " << static_cast<int>(ctx.quoteRule);
   }
   auto len = ctx.target->str32.length;
   auto off = ctx.target->str32.offset;

--- a/src/core/read/parsers/ptype_iterator.cc
+++ b/src/core/read/parsers/ptype_iterator.cc
@@ -45,6 +45,7 @@ PTypeIterator& PTypeIterator::operator++() {
       if (curr_ptype == PT::Time64ISO && !parse_times) continue;
     } else {
       *pqr = *pqr + 1;
+      xassert(*pqr <= 3);
     }
     return *this;
   }

--- a/tests/fread/test-fread-issues.py
+++ b/tests/fread/test-fread-issues.py
@@ -544,9 +544,21 @@ def test_issue2523():
 
 
 def test_issue2680():
-    src = '1\tWild Hogs (2007)\tAdevnture\n' * 500 + '2\t"Great Performances" Cats (1998)\tMusical\n' * 500
+    src = '1\tWild Hogs (2007)\tAdventure\n' * 500 + '2\t"Great Performances" Cats (1998)\tMusical\n' * 500
     DT = dt.fread(src, fill=True)
     assert DT.to_tuples()[900] == (2, '"Great Performances" Cats (1998)', 'Musical')
+
+
+def test_issue3092():
+    src = 'A,B,C,D\n' + '1,abc,3,-3\n' * 500 + '2,"d" ef,4,-1\n' + '3,ghij\n' * 3 + '4,"klmn",7,0\n' * 2
+    DT = dt.fread(src, fill=True)
+    assert_equals(
+        DT,
+        dt.Frame(A=[1]*500 + [2, 3, 3, 3, 4, 4],
+                 B=["abc"] * 500 + ['"d" ef', "ghij", "ghij", "ghij", '"klmn"', '"klmn"'],
+                 C=[3]*500 + [4, None, None, None, 7, 7],
+                 D=[-3]*500 + [-3, None, None, None, 0, 0])
+    )
 
 
 def test_issue934():

--- a/tests/fread/test-fread-issues.py
+++ b/tests/fread/test-fread-issues.py
@@ -557,7 +557,7 @@ def test_issue3092():
         dt.Frame(A=[1]*500 + [2, 3, 3, 3, 4, 4],
                  B=["abc"] * 500 + ['"d" ef', "ghij", "ghij", "ghij", '"klmn"', '"klmn"'],
                  C=[3]*500 + [4, None, None, None, 7, 7],
-                 D=[-3]*500 + [-3, None, None, None, 0, 0])
+                 D=[-3]*500 + [-1, None, None, None, 0, 0])
     )
 
 

--- a/tests/fread/test-fread-small.py
+++ b/tests/fread/test-fread-small.py
@@ -586,11 +586,11 @@ def test_unmatched_quotes():
     assert dt.fread('A,B\n"aa",1\n"bb,2\n"cc",3\n') \
              .to_list() == [['"aa"', '"bb', '"cc"'], [1, 2, 3]]
     assert dt.fread('A,B\n"aa",1\n""bb",2\n"cc",3\n') \
-             .to_list() == [['aa', '"bb', 'cc'], [1, 2, 3]]
+             .to_list() == [['"aa"', '""bb"', '"cc"'], [1, 2, 3]]
     assert dt.fread('A,B\n"aa",1\nbb",2\n"cc",3\n') \
-             .to_list() == [['aa', 'bb"', 'cc'], [1, 2, 3]]
+             .to_list() == [['"aa"', 'bb"', '"cc"'], [1, 2, 3]]
     assert dt.fread('A,B\n"aa",1\n"bb"",2\n"cc",3\n') \
-             .to_list() == [['aa', 'bb"', 'cc'], [1, 2, 3]]
+             .to_list() == [['"aa"', '"bb""', '"cc"'], [1, 2, 3]]
 
 
 def test_unescaped_quotes():


### PR DESCRIPTION
The variable `quoteRule` can have values from 0 to 3. However, the current code sometimes would increase quote rule beyond 3, leading to undefined behavior.

With this PR I add an assert on the value of quoteRule parameter (so that the violation can be detected earlier), and swap the order of quote rules 2 and 3, which allows us to parse the test file correctly.

As a result of this change, only 1 test case had to be modified, but even there the new behavior is arguably better.

Closes #3092