### PR TITLE
Fix latent column materialization routine

### DIFF
--- a/docs/releases/v1.1.0.rst
+++ b/docs/releases/v1.1.0.rst
@@ -36,6 +36,8 @@
 
     -[enh] Added reducer function :func:`countna` [#2999]
 
+    -[fix] :func:`qcut` won't segfault anymore when used as an i-filter [#3061]
+
 
     fread
     -----
@@ -48,7 +50,7 @@
         ``'-'``, ``'+'``, or ``'.'``. Previously, these values were allowed but
         they produced errors during parsing. [#3065]
 
-    -[bug] :func:`fread()` will no longer fail while reading mostly empty
+    -[fix] :func:`fread()` will no longer fail while reading mostly empty
         files. [#3055]
 
 

--- a/src/core/column/latent.cc
+++ b/src/core/column/latent.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019-2020 H2O.ai
+// Copyright 2019-2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),

--- a/src/core/column/latent.cc
+++ b/src/core/column/latent.cc
@@ -111,6 +111,13 @@ ColumnImpl* Latent_ColumnImpl::vivify(bool to_memory) const {
   ColumnImpl* new_pcol = std::move(column_).release();
   SType stype = new_pcol->stype();
 
+  // After the placement-materialization we will need to set up
+  // the correct reference count for the new `Sentinel*_ColumnImpl`.
+  // For that, we save value and reference to the `refcount` member
+  // of the current object.
+  size_t refcount_value = this->refcount_;
+  size_t& refcount_reference = this->refcount_;
+
   switch (stype) {
     case SType::BOOL:    new (ptr) SentinelBool_ColumnImpl(std::move(new_pcol)); break;
     case SType::INT8:    new (ptr) SentinelFw_ColumnImpl<int8_t>(std::move(new_pcol)); break;
@@ -124,6 +131,10 @@ ColumnImpl* Latent_ColumnImpl::vivify(bool to_memory) const {
     default:
       throw NotImplError() << "Cannot vivify column of type " << stype;
   }
+
+  // Set up the correct `refcount` for the newly created `Sentinel*_ColumnImpl` object.
+  refcount_reference = refcount_value;
+
   return static_cast<ColumnImpl*>(ptr);
 }
 

--- a/tests/dt/test-qcut.py
+++ b/tests/dt/test-qcut.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #-------------------------------------------------------------------------------
-# Copyright 2020 H2O.ai
+# Copyright 2020-2021 H2O.ai
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/tests/dt/test-qcut.py
+++ b/tests/dt/test-qcut.py
@@ -261,3 +261,9 @@ def test_qcut_vs_pandas_random(pandas, seed):
 
     assert [list(PD_qcut[i]) for i in range(ncols)] == DT_qcut.to_list()
 
+
+def test_qcut_i_filter_issue_3061():
+    DT = dt.Frame(range(10))
+    DT["q"] = dt.qcut(dt.f.C0)
+    DT_filtered = DT[dt.f.q == 1, :]
+    assert_equals(DT_filtered, dt.Frame({"C0" : [1]/dt.int32, "q" : [1]/dt.int32}))


### PR DESCRIPTION
Latent column materialization routine was missing logic for setting up the `refcount` property. In this PR we fix it, so that the newly created material column gets the same `refcount` as had the original latent column. In some cases, like for the recently added `qcut` functionality, having wrong `refcount` could result in segfaults.

Closes #3061