### PR TITLE
`.is_nnn` properties in Type class

### DIFF
--- a/docs/api/type.rst
+++ b/docs/api/type.rst
@@ -44,6 +44,36 @@
         :widths: auto
         :class: api-table
 
+        * - :attr:`.is_array`
+          - Is this an array type?
+
+        * - :attr:`.is_boolean`
+          - Is this a boolean type?
+
+        * - :attr:`.is_compound`
+          - Is this a compound type?
+
+        * - :attr:`.is_float`
+          - Is this a float type?
+
+        * - :attr:`.is_integer`
+          - Is this an integer type?
+
+        * - :attr:`.is_numeric`
+          - Is this a numeric type?
+
+        * - :attr:`.is_object`
+          - Is this an object type?
+
+        * - :attr:`.is_string`
+          - Is this a string type?
+
+        * - :attr:`.is_temporal`
+          - Is this a temporal type?
+
+        * - :attr:`.is_void`
+          - Is this the void type?
+
         * - :attr:`.max`
           - The maximum value for this type
 
@@ -57,21 +87,31 @@
 .. toctree::
     :hidden:
 
-    ⭑ arr32(T)  <type/arr32>
-    ⭑ arr64(T)  <type/arr64>
-    ⭑ bool8     <type/bool8>
-    ⭑ date32    <type/date32>
-    ⭑ float32   <type/float32>
-    ⭑ float64   <type/float64>
-    ⭑ int8      <type/int8>
-    ⭑ int16     <type/int16>
-    ⭑ int32     <type/int32>
-    ⭑ int64     <type/int64>
-    ⭑ obj64     <type/obj64>
-    ⭑ str32     <type/str32>
-    ⭑ str64     <type/str64>
-    ⭑ time64    <type/time64>
-    ⭑ void      <type/void>
-    max         <type/max>
-    min         <type/min>
-    name        <type/name>
+    ⭑ arr32(T)    <type/arr32>
+    ⭑ arr64(T)    <type/arr64>
+    ⭑ bool8       <type/bool8>
+    ⭑ date32      <type/date32>
+    ⭑ float32     <type/float32>
+    ⭑ float64     <type/float64>
+    ⭑ int8        <type/int8>
+    ⭑ int16       <type/int16>
+    ⭑ int32       <type/int32>
+    ⭑ int64       <type/int64>
+    ⭑ obj64       <type/obj64>
+    ⭑ str32       <type/str32>
+    ⭑ str64       <type/str64>
+    ⭑ time64      <type/time64>
+    ⭑ void        <type/void>
+    is_array      <type/is_array>
+    is_boolean    <type/is_boolean>
+    is_compound   <type/is_compound>
+    is_float      <type/is_float>
+    is_integer    <type/is_integer>
+    is_numeric    <type/is_numeric>
+    is_object     <type/is_object>
+    is_string     <type/is_string>
+    is_temporal   <type/is_temporal>
+    is_void       <type/is_void>
+    max           <type/max>
+    min           <type/min>
+    name          <type/name>

--- a/docs/api/type/arr32.rst
+++ b/docs/api/type/arr32.rst
@@ -4,6 +4,8 @@
     :cvar: doc_Type_arr32
     :signature: arr32(T)
 
+    .. x-version-added:: 1.1.0
+
     Array type with 32-bit offsets. In a column of this type, every element
     is a list of values of type `T`.
 

--- a/docs/api/type/arr64.rst
+++ b/docs/api/type/arr64.rst
@@ -4,6 +4,8 @@
     :cvar: doc_Type_arr64
     :signature: arr64(T)
 
+    .. x-version-added:: 1.1.0
+
     Array type with 64-bit offsets. In a column of this type, every element
     is a list of values of type `T`.
 

--- a/docs/api/type/date32.rst
+++ b/docs/api/type/date32.rst
@@ -1,6 +1,7 @@
 
 .. xattr:: datatable.Type.date32
     :src: --
+    :tests: tests/types/test-date32.py
 
     .. x-version-added:: 1.0.0
 

--- a/docs/api/type/float32.rst
+++ b/docs/api/type/float32.rst
@@ -1,6 +1,7 @@
 
 .. xattr:: datatable.Type.float32
     :src: --
+    :tests: tests/types/test-float.py
 
     Single-precision floating point type. This corresponds to C type ``float``.
     Each element of this type is 4 bytes long.

--- a/docs/api/type/float64.rst
+++ b/docs/api/type/float64.rst
@@ -1,6 +1,7 @@
 
 .. xattr:: datatable.Type.float64
     :src: --
+    :tests: tests/types/test-float.py
 
     Double-precision IEEE-754 floating point type. This corresponds to C type
     ``double``. Each element of this type is 8 bytes long.

--- a/docs/api/type/int16.rst
+++ b/docs/api/type/int16.rst
@@ -1,6 +1,7 @@
 
 .. xattr:: datatable.Type.int16
     :src: --
+    :tests: tests/types/test-int.py
 
     Integer type, corresponding to ``int16_t`` in C. This type uses 2 bytes per
     data element, and can store values in the range ``-32767 .. 32767``.

--- a/docs/api/type/int32.rst
+++ b/docs/api/type/int32.rst
@@ -1,6 +1,7 @@
 
 .. xattr:: datatable.Type.int32
     :src: --
+    :tests: tests/types/test-int.py
 
     Integer type, corresponding to ``int32_t`` in C. This type uses 4 bytes per
     data element, and can store values in the range ``-2,147,483,647 ..

--- a/docs/api/type/int64.rst
+++ b/docs/api/type/int64.rst
@@ -1,6 +1,7 @@
 
 .. xattr:: datatable.Type.int64
     :src: --
+    :tests: tests/types/test-int.py
 
     Integer type which corresponds to ``int64_t`` in C. This type uses 8 bytes per
     data element, and can store values in the range ``-(2**63-1) .. (2**63-1)``.

--- a/docs/api/type/int8.rst
+++ b/docs/api/type/int8.rst
@@ -1,6 +1,7 @@
 
 .. xattr:: datatable.Type.int8
     :src: --
+    :tests: tests/types/test-int.py
 
     Integer type that uses 1 byte per data element and can store values in the
     range ``-127 .. 127``.

--- a/docs/api/type/is_array.rst
+++ b/docs/api/type/is_array.rst
@@ -6,9 +6,8 @@
     .. x-version-added:: 1.1.0
 
     Test whether this type belongs to the category of "array" types. This
-    property returns ``True`` for :meth:`arr32\<T\> <dt.Type.arr32>`,
-    :meth:`arr64\<T\> <dt.Type.arr64>` and :attr:`void <dt.Type.void>`
-    types, and ``False`` otherwise.
+    property returns ``True`` for :meth:`arr32\<T\> <dt.Type.arr32>` and
+    :meth:`arr64\<T\> <dt.Type.arr64>` types only.
 
 
     Parameters
@@ -20,7 +19,7 @@
     --------
     >>> dt.Type.arr32(int).is_array
     True
-    >>> dt.Type.float32.is_array
+    >>> dt.Type.arr64("float32").is_array
     False
     >>> dt.Type.void.is_array
-    True
+    False

--- a/docs/api/type/is_array.rst
+++ b/docs/api/type/is_array.rst
@@ -1,0 +1,26 @@
+
+.. xattr:: datatable.Type.is_array
+    :src: src/core/types/py_type.cc is_array
+    :cvar: doc_Type_is_array
+
+    .. x-version-added:: 1.1.0
+
+    Test whether this type belongs to the category of "array" types. This
+    property returns ``True`` for :meth:`arr32\<T\> <dt.Type.arr32>`,
+    :meth:`arr64\<T\> <dt.Type.arr64>` and :attr:`void <dt.Type.void>`
+    types, and ``False`` otherwise.
+
+
+    Parameters
+    ----------
+    return: bool
+
+
+    Examples
+    --------
+    >>> dt.Type.arr32(int).is_array
+    True
+    >>> dt.Type.float32.is_array
+    False
+    >>> dt.Type.void.is_array
+    True

--- a/docs/api/type/is_boolean.rst
+++ b/docs/api/type/is_boolean.rst
@@ -1,0 +1,25 @@
+
+.. xattr:: datatable.Type.is_boolean
+    :src: src/core/types/py_type.cc is_boolean
+    :cvar: doc_Type_is_boolean
+
+    .. x-version-added:: 1.1.0
+
+    Test whether this type belongs to the category of "boolean" types. This
+    property returns ``True`` for :attr:`bool8 <dt.Type.bool8>`, and
+    :attr:`void <dt.Type.void>` types only.
+
+
+    Parameters
+    ----------
+    return: bool
+
+
+    Examples
+    --------
+    >>> dt.Type.bool8.is_boolean
+    True
+    >>> dt.Type.void.is_boolean
+    True
+    >>> dt.Type.int8.is_boolean
+    False

--- a/docs/api/type/is_boolean.rst
+++ b/docs/api/type/is_boolean.rst
@@ -6,8 +6,7 @@
     .. x-version-added:: 1.1.0
 
     Test whether this type belongs to the category of "boolean" types. This
-    property returns ``True`` for :attr:`bool8 <dt.Type.bool8>`, and
-    :attr:`void <dt.Type.void>` types only.
+    property returns ``True`` for :attr:`bool8 <dt.Type.bool8>` type only.
 
 
     Parameters
@@ -20,6 +19,6 @@
     >>> dt.Type.bool8.is_boolean
     True
     >>> dt.Type.void.is_boolean
-    True
+    False
     >>> dt.Type.int8.is_boolean
     False

--- a/docs/api/type/is_compound.rst
+++ b/docs/api/type/is_compound.rst
@@ -1,0 +1,24 @@
+
+.. xattr:: datatable.Type.is_compound
+    :src: src/core/types/py_type.cc is_compound
+    :cvar: doc_Type_is_compound
+
+    .. x-version-added:: 1.1.0
+
+    Test whether this type represents a "compound" type, i.e. whether it may
+    contain one or more dependent types. Currently, datatable implements only
+    :meth:`arr32 <dt.Type.arr32>` and :meth:`arr64 <dt.Type.arr64>` compound
+    types.
+
+
+    Parameters
+    ----------
+    return: bool
+
+
+    Examples
+    --------
+    >>> dt.Type.arr32(dt.int32).is_compound
+    True
+    >>> dt.Type.void.is_compound
+    False

--- a/docs/api/type/is_float.rst
+++ b/docs/api/type/is_float.rst
@@ -6,9 +6,8 @@
     .. x-version-added:: 1.1.0
 
     Test whether this type belongs to the category of "float" types. This
-    property returns ``True`` for :attr:`float32 <dt.Type.float32>`,
-    :attr:`float64 <dt.Type.float64>`, and :attr:`void <dt.Type.void>` types
-    only.
+    property returns ``True`` for :attr:`float32 <dt.Type.float32>` and
+    :attr:`float64 <dt.Type.float64>` types only.
 
 
     Parameters
@@ -20,7 +19,7 @@
     --------
     >>> dt.Type.float64.is_float
     True
-    >>> dt.Type.void.is_float
+    >>> dt.Type.float32.is_float
     True
     >>> dt.Type.int64.is_float
     False

--- a/docs/api/type/is_float.rst
+++ b/docs/api/type/is_float.rst
@@ -1,0 +1,26 @@
+
+.. xattr:: datatable.Type.is_float
+    :src: src/core/types/py_type.cc is_float
+    :cvar: doc_Type_is_float
+
+    .. x-version-added:: 1.1.0
+
+    Test whether this type belongs to the category of "float" types. This
+    property returns ``True`` for :attr:`float32 <dt.Type.float32>`,
+    :attr:`float64 <dt.Type.float64>`, and :attr:`void <dt.Type.void>` types
+    only.
+
+
+    Parameters
+    ----------
+    return: bool
+
+
+    Examples
+    --------
+    >>> dt.Type.float64.is_float
+    True
+    >>> dt.Type.void.is_float
+    True
+    >>> dt.Type.int64.is_float
+    False

--- a/docs/api/type/is_integer.rst
+++ b/docs/api/type/is_integer.rst
@@ -1,0 +1,28 @@
+
+.. xattr:: datatable.Type.is_integer
+    :src: src/core/types/py_type.cc is_integer
+    :cvar: doc_Type_is_integer
+
+    .. x-version-added:: 1.1.0
+
+    Test whether this type belongs to the category of "integer" types. This
+    property returns ``True`` for :attr:`int8 <dt.Type.int8>`,
+    :attr:`int16 <dt.Type.int16>`, :attr:`int32 <dt.Type.int32>`,
+    :attr:`int64 <dt.Type.int64>`, and :attr:`void <dt.Type.void>` types.
+
+
+    Parameters
+    ----------
+    return: bool
+
+
+    Examples
+    --------
+    >>> dt.Type.int8.is_integer
+    True
+    >>> dt.Type.int64.is_integer
+    True
+    >>> dt.Type.void.is_integer
+    True
+    >>> dt.Type.float64.is_integer
+    False

--- a/docs/api/type/is_integer.rst
+++ b/docs/api/type/is_integer.rst
@@ -7,8 +7,8 @@
 
     Test whether this type belongs to the category of "integer" types. This
     property returns ``True`` for :attr:`int8 <dt.Type.int8>`,
-    :attr:`int16 <dt.Type.int16>`, :attr:`int32 <dt.Type.int32>`,
-    :attr:`int64 <dt.Type.int64>`, and :attr:`void <dt.Type.void>` types.
+    :attr:`int16 <dt.Type.int16>`, :attr:`int32 <dt.Type.int32>`, and
+    :attr:`int64 <dt.Type.int64>` types.
 
 
     Parameters
@@ -21,8 +21,6 @@
     >>> dt.Type.int8.is_integer
     True
     >>> dt.Type.int64.is_integer
-    True
-    >>> dt.Type.void.is_integer
     True
     >>> dt.Type.float64.is_integer
     False

--- a/docs/api/type/is_numeric.rst
+++ b/docs/api/type/is_numeric.rst
@@ -6,8 +6,8 @@
     .. x-version-added:: 1.1.0
 
     Test whether this type belongs to the category of "numeric" types. All
-    boolean, integer and float types are considered numeric. Therefore, this
-    method returns ``True`` for types
+    boolean, integer, float and void types are considered numeric. Therefore,
+    this method returns ``True`` for types
 
         - :attr:`void <dt.Type.void>`
         - :attr:`bool8 <dt.Type.bool8>`

--- a/docs/api/type/is_numeric.rst
+++ b/docs/api/type/is_numeric.rst
@@ -1,0 +1,38 @@
+
+.. xattr:: datatable.Type.is_numeric
+    :src: src/core/types/py_type.cc is_numeric
+    :cvar: doc_Type_is_numeric
+
+    .. x-version-added:: 1.1.0
+
+    Test whether this type belongs to the category of "numeric" types. All
+    boolean, integer and float types are considered numeric. Therefore, this
+    method returns ``True`` for types
+
+        - :attr:`void <dt.Type.void>`
+        - :attr:`bool8 <dt.Type.bool8>`
+        - :attr:`int8 <dt.Type.int8>`
+        - :attr:`int16 <dt.Type.int16>`
+        - :attr:`int32 <dt.Type.int32>`
+        - :attr:`int64 <dt.Type.int64>`
+        - :attr:`float32 <dt.Type.float32>`
+        - :attr:`float64 <dt.Type.float64>`
+
+
+    Parameters
+    ----------
+    return: bool
+
+
+    Examples
+    --------
+    >>> dt.Type.int8.is_numeric
+    True
+    >>> dt.Type.float64.is_numeric
+    True
+    >>> dt.Type.void.is_numeric
+    True
+    >>> dt.Type.bool8.is_numeric
+    True
+    >>> dt.Type.str32.is_numeric
+    False

--- a/docs/api/type/is_numeric.rst
+++ b/docs/api/type/is_numeric.rst
@@ -9,7 +9,6 @@
     boolean, integer, float and void types are considered numeric. Therefore,
     this method returns ``True`` for types
 
-        - :attr:`void <dt.Type.void>`
         - :attr:`bool8 <dt.Type.bool8>`
         - :attr:`int8 <dt.Type.int8>`
         - :attr:`int16 <dt.Type.int16>`
@@ -31,7 +30,7 @@
     >>> dt.Type.float64.is_numeric
     True
     >>> dt.Type.void.is_numeric
-    True
+    False
     >>> dt.Type.bool8.is_numeric
     True
     >>> dt.Type.str32.is_numeric

--- a/docs/api/type/is_object.rst
+++ b/docs/api/type/is_object.rst
@@ -1,0 +1,25 @@
+
+.. xattr:: datatable.Type.is_object
+    :src: src/core/types/py_type.cc is_object
+    :cvar: doc_Type_is_object
+
+    .. x-version-added:: 1.1.0
+
+    Test whether this type belongs to the category of "object" types. This
+    property returns ``True`` for :attr:`obj64 <dt.Type.obj64>`, and
+    :attr:`void <dt.Type.void>` types only.
+
+
+    Parameters
+    ----------
+    return: bool
+
+
+    Examples
+    --------
+    >>> dt.Type.obj64.is_object
+    True
+    >>> dt.Type.void.is_object
+    True
+    >>> dt.Type.int8.is_object
+    False

--- a/docs/api/type/is_object.rst
+++ b/docs/api/type/is_object.rst
@@ -6,8 +6,7 @@
     .. x-version-added:: 1.1.0
 
     Test whether this type belongs to the category of "object" types. This
-    property returns ``True`` for :attr:`obj64 <dt.Type.obj64>`, and
-    :attr:`void <dt.Type.void>` types only.
+    property returns ``True`` for :attr:`obj64 <dt.Type.obj64>` type only.
 
 
     Parameters
@@ -20,6 +19,6 @@
     >>> dt.Type.obj64.is_object
     True
     >>> dt.Type.void.is_object
-    True
+    False
     >>> dt.Type.int8.is_object
     False

--- a/docs/api/type/is_string.rst
+++ b/docs/api/type/is_string.rst
@@ -6,9 +6,8 @@
     .. x-version-added:: 1.1.0
 
     Test whether this type belongs to the category of "string" types. This
-    property returns ``True`` for :attr:`str32 <dt.Type.str32>`,
-    :attr:`str64 <dt.Type.str64>`, and :attr:`void <dt.Type.void>` types
-    only.
+    property returns ``True`` for :attr:`str32 <dt.Type.str32>` and
+    :attr:`str64 <dt.Type.str64>` types only.
 
 
     Parameters
@@ -20,7 +19,7 @@
     --------
     >>> dt.Type.str64.is_string
     True
+    >>> dt.Type.str32.is_string
+    False
     >>> dt.Type.void.is_string
-    True
-    >>> dt.Type.int64.is_string
     False

--- a/docs/api/type/is_string.rst
+++ b/docs/api/type/is_string.rst
@@ -1,0 +1,26 @@
+
+.. xattr:: datatable.Type.is_string
+    :src: src/core/types/py_type.cc is_string
+    :cvar: doc_Type_is_string
+
+    .. x-version-added:: 1.1.0
+
+    Test whether this type belongs to the category of "string" types. This
+    property returns ``True`` for :attr:`str32 <dt.Type.str32>`,
+    :attr:`str64 <dt.Type.str64>`, and :attr:`void <dt.Type.void>` types
+    only.
+
+
+    Parameters
+    ----------
+    return: bool
+
+
+    Examples
+    --------
+    >>> dt.Type.str64.is_string
+    True
+    >>> dt.Type.void.is_string
+    True
+    >>> dt.Type.int64.is_string
+    False

--- a/docs/api/type/is_temporal.rst
+++ b/docs/api/type/is_temporal.rst
@@ -6,9 +6,8 @@
     .. x-version-added:: 1.1.0
 
     Test whether this type belongs to the category of time-related types. This
-    property returns ``True`` for :attr:`date32 <dt.Type.date32>`,
-    :attr:`time64 <dt.Type.time64>`, and :attr:`void <dt.Type.void>` types
-    only.
+    property returns ``True`` for :attr:`date32 <dt.Type.date32>` and
+    :attr:`time64 <dt.Type.time64>` types only.
 
 
     Parameters

--- a/docs/api/type/is_temporal.rst
+++ b/docs/api/type/is_temporal.rst
@@ -1,0 +1,26 @@
+
+.. xattr:: datatable.Type.is_temporal
+    :src: src/core/types/py_type.cc is_temporal
+    :cvar: doc_Type_is_temporal
+
+    .. x-version-added:: 1.1.0
+
+    Test whether this type belongs to the category of time-related types. This
+    property returns ``True`` for :attr:`date32 <dt.Type.date32>`,
+    :attr:`time64 <dt.Type.time64>`, and :attr:`void <dt.Type.void>` types
+    only.
+
+
+    Parameters
+    ----------
+    return: bool
+
+
+    Examples
+    --------
+    >>> dt.Type.date32.is_temporal
+    True
+    >>> dt.Type.time64.is_temporal
+    True
+    >>> dt.Type.str32.is_temporal
+    False

--- a/docs/api/type/is_void.rst
+++ b/docs/api/type/is_void.rst
@@ -1,0 +1,19 @@
+
+.. xattr:: datatable.Type.is_void
+    :src: src/core/types/py_type.cc is_void
+    :cvar: doc_Type_is_void
+
+    .. x-version-added:: 1.1.0
+
+    Returns ``True`` if this type is the :attr:`void <dt.Type.void>` type.
+
+
+    Parameters
+    ----------
+    return: bool
+
+
+    Examples
+    --------
+    >>> dt.Type.void.is_void
+    True

--- a/docs/api/type/obj64.rst
+++ b/docs/api/type/obj64.rst
@@ -1,5 +1,6 @@
 
 .. xattr:: datatable.Type.obj64
     :src: --
+    :tests: tests/types/test-obj64.py
 
     This type can be used to store arbitrary Python objects.

--- a/docs/api/type/str32.rst
+++ b/docs/api/type/str32.rst
@@ -1,6 +1,7 @@
 
 .. xattr:: datatable.Type.str32
     :src: --
+    :tests: tests/types/test-str.py
 
     The type of a column with string data.
 

--- a/docs/api/type/str64.rst
+++ b/docs/api/type/str64.rst
@@ -1,5 +1,6 @@
 
 .. xattr:: datatable.Type.str64
     :src: --
+    :tests: tests/types/test-str.py
 
     String type, where the offsets buffer uses 64-bit integers.

--- a/docs/api/type/time64.rst
+++ b/docs/api/type/time64.rst
@@ -1,6 +1,7 @@
 
 .. xattr:: datatable.Type.time64
     :src: --
+    :tests: tests/types/test-time64.py
 
     .. x-version-added:: 1.0.0
 

--- a/docs/api/type/void.rst
+++ b/docs/api/type/void.rst
@@ -1,6 +1,7 @@
 
 .. xattr:: datatable.Type.void
     :src: --
+    :tests: tests/types/test-void.py
 
     The type of a column where all values are NAs.
 

--- a/docs/releases/v1.1.0.rst
+++ b/docs/releases/v1.1.0.rst
@@ -64,3 +64,14 @@
     -[enh] Parameter ``force=True`` in function :func:`rbind()` (or method
         :meth:`dt.Frame.rbind()`) will now allow combining columns
         of incompatible types. [#3062]
+
+    -[new] Added properties :attr:`.is_array <dt.Type.is_array>`,
+        :attr:`.is_boolean <dt.Type.is_boolean>`,
+        :attr:`.is_compound <dt.Type.is_compound>`,
+        :attr:`.is_float <dt.Type.is_float>`,
+        :attr:`.is_integer <dt.Type.is_integer>`,
+        :attr:`.is_numeric <dt.Type.is_numeric>`,
+        :attr:`.is_object <dt.Type.is_object>`,
+        :attr:`.is_string <dt.Type.is_string>`,
+        :attr:`.is_temporal <dt.Type.is_temporal>`,
+        :attr:`.is_void <dt.Type.is_void>` to class :class:`dt.Type`. [#3101]

--- a/src/core/documentation.h
+++ b/src/core/documentation.h
@@ -45,6 +45,7 @@ extern const char* doc_dt_median;
 extern const char* doc_dt_min;
 extern const char* doc_dt_qcut;
 extern const char* doc_dt_rbind;
+extern const char* doc_dt_repeat;
 extern const char* doc_dt_sd;
 extern const char* doc_dt_setdiff;
 extern const char* doc_dt_shift;
@@ -55,7 +56,6 @@ extern const char* doc_dt_symdiff;
 extern const char* doc_dt_union;
 extern const char* doc_dt_unique;
 extern const char* doc_dt_update;
-extern const char* doc_dt_repeat;
 
 extern const char* doc_math_atan2;
 extern const char* doc_math_copysign;
@@ -74,8 +74,8 @@ extern const char* doc_models_Ftrl;
 extern const char* doc_models_Ftrl___init__;
 extern const char* doc_models_Ftrl_alpha;
 extern const char* doc_models_Ftrl_beta;
-extern const char* doc_models_Ftrl_colnames;
 extern const char* doc_models_Ftrl_colname_hashes;
+extern const char* doc_models_Ftrl_colnames;
 extern const char* doc_models_Ftrl_double_precision;
 extern const char* doc_models_Ftrl_feature_importances;
 extern const char* doc_models_Ftrl_fit;
@@ -83,10 +83,10 @@ extern const char* doc_models_Ftrl_interactions;
 extern const char* doc_models_Ftrl_labels;
 extern const char* doc_models_Ftrl_lambda1;
 extern const char* doc_models_Ftrl_lambda2;
+extern const char* doc_models_Ftrl_mantissa_nbits;
 extern const char* doc_models_Ftrl_model;
 extern const char* doc_models_Ftrl_model_type;
 extern const char* doc_models_Ftrl_model_type_trained;
-extern const char* doc_models_Ftrl_mantissa_nbits;
 extern const char* doc_models_Ftrl_nbins;
 extern const char* doc_models_Ftrl_negative_class;
 extern const char* doc_models_Ftrl_nepochs;
@@ -96,11 +96,11 @@ extern const char* doc_models_Ftrl_reset;
 
 extern const char* doc_models_LinearModel;
 extern const char* doc_models_LinearModel___init__;
+extern const char* doc_models_LinearModel_double_precision;
 extern const char* doc_models_LinearModel_eta0;
 extern const char* doc_models_LinearModel_eta_decay;
 extern const char* doc_models_LinearModel_eta_drop_rate;
 extern const char* doc_models_LinearModel_eta_schedule;
-extern const char* doc_models_LinearModel_double_precision;
 extern const char* doc_models_LinearModel_fit;
 extern const char* doc_models_LinearModel_is_fitted;
 extern const char* doc_models_LinearModel_labels;
@@ -194,9 +194,21 @@ extern const char* doc_Namespace;
 extern const char* doc_Type;
 extern const char* doc_Type_arr32;
 extern const char* doc_Type_arr64;
+extern const char* doc_Type_is_array;
+extern const char* doc_Type_is_boolean;
+extern const char* doc_Type_is_compound;
+extern const char* doc_Type_is_float;
+extern const char* doc_Type_is_integer;
+extern const char* doc_Type_is_numeric;
+extern const char* doc_Type_is_object;
+extern const char* doc_Type_is_string;
+extern const char* doc_Type_is_temporal;
+extern const char* doc_Type_is_void;
 extern const char* doc_Type_max;
 extern const char* doc_Type_min;
 extern const char* doc_Type_name;
+
+
 
 
 }  // namespace dt

--- a/src/core/expr/fexpr_slice.cc
+++ b/src/core/expr/fexpr_slice.cc
@@ -112,8 +112,9 @@ Workframe FExpr_Slice::evaluate_n(EvalContext& ctx) const {
   auto startCol = wfs[1].retrieve_column(0);
   auto stopCol = wfs[2].retrieve_column(0);
   auto stepCol = wfs[3].retrieve_column(0);
-  if (!startCol.type().is_integer() || !stopCol.type().is_integer() ||
-      !stepCol.type().is_integer()) {
+  if (!startCol.type().is_integer_or_void() ||
+      !stopCol.type().is_integer_or_void() ||
+      !stepCol.type().is_integer_or_void()) {
     throw TypeError()
         << "Non-integer expressions cannot be used inside a slice";
   }

--- a/src/core/frame/repr/text_column.cc
+++ b/src/core/frame/repr/text_column.cc
@@ -95,7 +95,7 @@ Data_TextColumn::Data_TextColumn(const std::string& name,
   type_ = _escape_string(CString(type_name));
   width_ = std::max(std::max(width_, name_.size()),
                     name_.empty()? 0 : type_.size());
-  align_right_ = col.type().is_numeric();
+  align_right_ = col.type().is_numeric_or_void();
   margin_left_ = true;
   margin_right_ = true;
   _render_all_data(col, indices);

--- a/src/core/types/py_type.cc
+++ b/src/core/types/py_type.cc
@@ -321,8 +321,19 @@ py::oobj PyType::get_max() const {
 
 
 //------------------------------------------------------------------------------
-// .is_*() methods
+// .is_*() properties
 //------------------------------------------------------------------------------
+
+static py::GSArgs args_is_array   ("is_array",    doc_Type_is_array);
+static py::GSArgs args_is_boolean ("is_boolean",  doc_Type_is_boolean);
+static py::GSArgs args_is_compound("is_compound", doc_Type_is_compound);
+static py::GSArgs args_is_float   ("is_float",    doc_Type_is_float);
+static py::GSArgs args_is_integer ("is_integer",  doc_Type_is_integer);
+static py::GSArgs args_is_numeric ("is_numeric",  doc_Type_is_numeric);
+static py::GSArgs args_is_object  ("is_object",   doc_Type_is_object);
+static py::GSArgs args_is_string  ("is_string",   doc_Type_is_string);
+static py::GSArgs args_is_temporal("is_temporal", doc_Type_is_temporal);
+static py::GSArgs args_is_void    ("is_void",     doc_Type_is_void);
 
 py::oobj PyType::is_array() const    { return py::obool(type_.is_array()); }
 py::oobj PyType::is_boolean() const  { return py::obool(type_.is_boolean()); }
@@ -334,17 +345,6 @@ py::oobj PyType::is_object() const   { return py::obool(type_.is_object()); }
 py::oobj PyType::is_string() const   { return py::obool(type_.is_string()); }
 py::oobj PyType::is_temporal() const { return py::obool(type_.is_temporal()); }
 py::oobj PyType::is_void() const     { return py::obool(type_.is_void()); }
-
-DECLARE_METHOD(&PyType::is_array)   ->name("is_array")   ->docs(doc_Type_is_array);
-DECLARE_METHOD(&PyType::is_boolean) ->name("is_boolean") ->docs(doc_Type_is_boolean);
-DECLARE_METHOD(&PyType::is_compound)->name("is_compound")->docs(doc_Type_is_compound);
-DECLARE_METHOD(&PyType::is_float)   ->name("is_float")   ->docs(doc_Type_is_float);
-DECLARE_METHOD(&PyType::is_integer) ->name("is_integer") ->docs(doc_Type_is_integer);
-DECLARE_METHOD(&PyType::is_numeric) ->name("is_numeric") ->docs(doc_Type_is_numeric);
-DECLARE_METHOD(&PyType::is_object)  ->name("is_object")  ->docs(doc_Type_is_object);
-DECLARE_METHOD(&PyType::is_string)  ->name("is_string")  ->docs(doc_Type_is_string);
-DECLARE_METHOD(&PyType::is_temporal)->name("is_temporal")->docs(doc_Type_is_temporal);
-DECLARE_METHOD(&PyType::is_void)    ->name("is_void")    ->docs(doc_Type_is_void);
 
 
 
@@ -397,6 +397,16 @@ void PyType::impl_init_type(py::XTypeMaker& xt) {
   xt.add(GETTER(&PyType::get_name, args_get_name));
   xt.add(GETTER(&PyType::get_min, args_get_min));
   xt.add(GETTER(&PyType::get_max, args_get_max));
+  xt.add(GETTER(&PyType::is_array,    args_is_array));
+  xt.add(GETTER(&PyType::is_boolean,  args_is_boolean));
+  xt.add(GETTER(&PyType::is_compound, args_is_compound));
+  xt.add(GETTER(&PyType::is_float,    args_is_float));
+  xt.add(GETTER(&PyType::is_integer,  args_is_integer));
+  xt.add(GETTER(&PyType::is_numeric,  args_is_numeric));
+  xt.add(GETTER(&PyType::is_object,   args_is_object));
+  xt.add(GETTER(&PyType::is_string,   args_is_string));
+  xt.add(GETTER(&PyType::is_temporal, args_is_temporal));
+  xt.add(GETTER(&PyType::is_void,     args_is_void));
   INIT_METHODS_FOR_CLASS(PyType);
 
   pythonType = xt.get_type_object();

--- a/src/core/types/py_type.cc
+++ b/src/core/types/py_type.cc
@@ -321,6 +321,35 @@ py::oobj PyType::get_max() const {
 
 
 //------------------------------------------------------------------------------
+// .is_*() methods
+//------------------------------------------------------------------------------
+
+py::oobj PyType::is_array() const    { return py::obool(type_.is_array()); }
+py::oobj PyType::is_boolean() const  { return py::obool(type_.is_boolean()); }
+py::oobj PyType::is_compound() const { return py::obool(type_.is_compound()); }
+py::oobj PyType::is_float() const    { return py::obool(type_.is_float()); }
+py::oobj PyType::is_integer() const  { return py::obool(type_.is_integer()); }
+py::oobj PyType::is_numeric() const  { return py::obool(type_.is_numeric()); }
+py::oobj PyType::is_object() const   { return py::obool(type_.is_object()); }
+py::oobj PyType::is_string() const   { return py::obool(type_.is_string()); }
+py::oobj PyType::is_temporal() const { return py::obool(type_.is_temporal()); }
+py::oobj PyType::is_void() const     { return py::obool(type_.is_void()); }
+
+DECLARE_METHOD(&PyType::is_array)   ->name("is_array")   ->docs(doc_Type_is_array);
+DECLARE_METHOD(&PyType::is_boolean) ->name("is_boolean") ->docs(doc_Type_is_boolean);
+DECLARE_METHOD(&PyType::is_compound)->name("is_compound")->docs(doc_Type_is_compound);
+DECLARE_METHOD(&PyType::is_float)   ->name("is_float")   ->docs(doc_Type_is_float);
+DECLARE_METHOD(&PyType::is_integer) ->name("is_integer") ->docs(doc_Type_is_integer);
+DECLARE_METHOD(&PyType::is_numeric) ->name("is_numeric") ->docs(doc_Type_is_numeric);
+DECLARE_METHOD(&PyType::is_object)  ->name("is_object")  ->docs(doc_Type_is_object);
+DECLARE_METHOD(&PyType::is_string)  ->name("is_string")  ->docs(doc_Type_is_string);
+DECLARE_METHOD(&PyType::is_temporal)->name("is_temporal")->docs(doc_Type_is_temporal);
+DECLARE_METHOD(&PyType::is_void)    ->name("is_void")    ->docs(doc_Type_is_void);
+
+
+
+
+//------------------------------------------------------------------------------
 // Types as methods
 //------------------------------------------------------------------------------
 

--- a/src/core/types/py_type.h
+++ b/src/core/types/py_type.h
@@ -52,10 +52,20 @@ class PyType : public py::XObject<PyType, true> {
     py::oobj m__repr__() const;
     size_t m__hash__() const;
 
-    py::oobj get_name() const;
-    py::oobj get_min() const;
-    py::oobj get_max() const;
     py::oobj array(const py::XArgs&);
+    py::oobj get_max() const;
+    py::oobj get_min() const;
+    py::oobj get_name() const;
+    py::oobj is_array() const;
+    py::oobj is_boolean() const;
+    py::oobj is_compound() const;
+    py::oobj is_float() const;
+    py::oobj is_integer() const;
+    py::oobj is_numeric() const;
+    py::oobj is_object() const;
+    py::oobj is_string() const;
+    py::oobj is_temporal() const;
+    py::oobj is_void() const;
 
     Type get_type() const { return type_; }
 

--- a/src/core/types/type.cc
+++ b/src/core/types/type.cc
@@ -155,6 +155,7 @@ bool Type::is_string()   const { return impl_ && impl_->is_string(); }
 bool Type::is_temporal() const { return impl_ && impl_->is_temporal(); }
 bool Type::is_void()     const { return impl_ && impl_->is_void(); }
 bool Type::is_integer_or_void() const { return impl_ && (impl_->is_integer() || impl_->is_void()); }
+bool Type::is_numeric_or_void() const { return impl_ && (impl_->is_numeric() || impl_->is_void()); }
 
 
 template<typename T> bool Type::can_be_read_as() const { return false; }

--- a/src/core/types/type.cc
+++ b/src/core/types/type.cc
@@ -154,6 +154,7 @@ bool Type::is_object()   const { return impl_ && impl_->is_object(); }
 bool Type::is_string()   const { return impl_ && impl_->is_string(); }
 bool Type::is_temporal() const { return impl_ && impl_->is_temporal(); }
 bool Type::is_void()     const { return impl_ && impl_->is_void(); }
+bool Type::is_integer_or_void() const { return impl_ && (impl_->is_integer() || impl_->is_void()); }
 
 
 template<typename T> bool Type::can_be_read_as() const { return false; }

--- a/src/core/types/type.h
+++ b/src/core/types/type.h
@@ -91,6 +91,7 @@ class Type {
     bool is_integer_or_void() const;
     bool is_invalid() const;
     bool is_numeric() const;
+    bool is_numeric_or_void() const;
     bool is_object() const;
     bool is_string() const;
     bool is_temporal() const;

--- a/src/core/types/type.h
+++ b/src/core/types/type.h
@@ -88,6 +88,7 @@ class Type {
     bool is_compound() const;
     bool is_float() const;
     bool is_integer() const;
+    bool is_integer_or_void() const;
     bool is_invalid() const;
     bool is_numeric() const;
     bool is_object() const;

--- a/src/core/types/type_array.cc
+++ b/src/core/types/type_array.cc
@@ -52,6 +52,9 @@ TypeImpl* Type_Arr32::common_type(TypeImpl* other) {
   if (other->is_array()) {
     return other->stype() > stype() ? other : this;
   }
+  if (other->is_void()) {
+    return this;
+  }
   if (other->is_object() || other->is_invalid()) {
     return other;
   }

--- a/src/core/types/type_time.cc
+++ b/src/core/types/type_time.cc
@@ -60,9 +60,7 @@ const char* Type_Time64::struct_format() const {
 }
 
 TypeImpl* Type_Time64::common_type(TypeImpl* other) {
-  if (other->stype() == SType::TIME64 ||
-      other->stype() == SType::DATE32 ||
-      other->is_void()) {
+  if (other->is_temporal() || other->is_void()) {
     return this;
   }
   if (other->is_object() || other->is_invalid()) {

--- a/src/core/types/type_void.cc
+++ b/src/core/types/type_void.cc
@@ -30,14 +30,14 @@ Type_Void::Type_Void()
   : TypeImpl(SType::VOID) {}
 
 
-bool Type_Void::is_array()    const { return true; }
-bool Type_Void::is_boolean()  const { return true; }
-bool Type_Void::is_float()    const { return true; }
-bool Type_Void::is_integer()  const { return true; }
+// bool Type_Void::is_array()    const { return true; }
+// bool Type_Void::is_boolean()  const { return true; }
+// bool Type_Void::is_float()    const { return true; }
+// bool Type_Void::is_integer()  const { return true; }
 bool Type_Void::is_numeric()  const { return true; }
-bool Type_Void::is_object()   const { return true; }
-bool Type_Void::is_string()   const { return true; }
-bool Type_Void::is_temporal() const { return true; }
+// bool Type_Void::is_object()   const { return true; }
+// bool Type_Void::is_string()   const { return true; }
+// bool Type_Void::is_temporal() const { return true; }
 bool Type_Void::is_void()     const { return true; }
 bool Type_Void::can_be_read_as_int8() const    { return true; }
 bool Type_Void::can_be_read_as_int16() const   { return true; }

--- a/src/core/types/type_void.cc
+++ b/src/core/types/type_void.cc
@@ -30,11 +30,15 @@ Type_Void::Type_Void()
   : TypeImpl(SType::VOID) {}
 
 
-bool Type_Void::is_boolean() const { return true; }
-bool Type_Void::is_integer() const { return true; }
-bool Type_Void::is_float()   const { return true; }
-bool Type_Void::is_numeric() const { return true; }
-bool Type_Void::is_void()    const { return true; }
+bool Type_Void::is_array()    const { return true; }
+bool Type_Void::is_boolean()  const { return true; }
+bool Type_Void::is_float()    const { return true; }
+bool Type_Void::is_integer()  const { return true; }
+bool Type_Void::is_numeric()  const { return true; }
+bool Type_Void::is_object()   const { return true; }
+bool Type_Void::is_string()   const { return true; }
+bool Type_Void::is_temporal() const { return true; }
+bool Type_Void::is_void()     const { return true; }
 bool Type_Void::can_be_read_as_int8() const    { return true; }
 bool Type_Void::can_be_read_as_int16() const   { return true; }
 bool Type_Void::can_be_read_as_int32() const   { return true; }

--- a/src/core/types/type_void.cc
+++ b/src/core/types/type_void.cc
@@ -30,15 +30,8 @@ Type_Void::Type_Void()
   : TypeImpl(SType::VOID) {}
 
 
-// bool Type_Void::is_array()    const { return true; }
-// bool Type_Void::is_boolean()  const { return true; }
-// bool Type_Void::is_float()    const { return true; }
-// bool Type_Void::is_integer()  const { return true; }
-bool Type_Void::is_numeric()  const { return true; }
-// bool Type_Void::is_object()   const { return true; }
-// bool Type_Void::is_string()   const { return true; }
-// bool Type_Void::is_temporal() const { return true; }
 bool Type_Void::is_void()     const { return true; }
+
 bool Type_Void::can_be_read_as_int8() const    { return true; }
 bool Type_Void::can_be_read_as_int16() const   { return true; }
 bool Type_Void::can_be_read_as_int32() const   { return true; }

--- a/src/core/types/type_void.h
+++ b/src/core/types/type_void.h
@@ -30,11 +30,15 @@ class Type_Void : public TypeImpl {
   public:
     Type_Void();
 
-    bool is_boolean() const override;
-    bool is_integer() const override;
-    bool is_float()   const override;
-    bool is_numeric() const override;
-    bool is_void()    const override;
+    bool is_array()    const override;
+    bool is_boolean()  const override;
+    bool is_integer()  const override;
+    bool is_float()    const override;
+    bool is_numeric()  const override;
+    bool is_object()   const override;
+    bool is_string()   const override;
+    bool is_temporal() const override;
+    bool is_void()     const override;
     bool can_be_read_as_int8() const override;
     bool can_be_read_as_int16() const override;
     bool can_be_read_as_int32() const override;

--- a/src/core/types/type_void.h
+++ b/src/core/types/type_void.h
@@ -30,14 +30,14 @@ class Type_Void : public TypeImpl {
   public:
     Type_Void();
 
-    bool is_array()    const override;
-    bool is_boolean()  const override;
-    bool is_integer()  const override;
-    bool is_float()    const override;
+    // bool is_array()    const override;
+    // bool is_boolean()  const override;
+    // bool is_integer()  const override;
+    // bool is_float()    const override;
     bool is_numeric()  const override;
-    bool is_object()   const override;
-    bool is_string()   const override;
-    bool is_temporal() const override;
+    // bool is_object()   const override;
+    // bool is_string()   const override;
+    // bool is_temporal() const override;
     bool is_void()     const override;
     bool can_be_read_as_int8() const override;
     bool can_be_read_as_int16() const override;

--- a/src/core/types/type_void.h
+++ b/src/core/types/type_void.h
@@ -30,14 +30,6 @@ class Type_Void : public TypeImpl {
   public:
     Type_Void();
 
-    // bool is_array()    const override;
-    // bool is_boolean()  const override;
-    // bool is_integer()  const override;
-    // bool is_float()    const override;
-    bool is_numeric()  const override;
-    // bool is_object()   const override;
-    // bool is_string()   const override;
-    // bool is_temporal() const override;
     bool is_void()     const override;
     bool can_be_read_as_int8() const override;
     bool can_be_read_as_int16() const override;

--- a/src/core/types/typeimpl_numeric.cc
+++ b/src/core/types/typeimpl_numeric.cc
@@ -34,7 +34,7 @@ bool TypeImpl_Numeric::is_numeric() const {
 
 
 TypeImpl* TypeImpl_Numeric::common_type(TypeImpl* other) {
-  if (other->is_numeric()) {
+  if (other->is_numeric() || other->is_void()) {
     auto stype1 = static_cast<int>(this->stype());
     auto stype2 = static_cast<int>(other->stype());
     return stype1 >= stype2? this : other;

--- a/tests/types/test-array.py
+++ b/tests/types/test-array.py
@@ -81,3 +81,19 @@ def test_type_array_hashable():
     assert dt.Type.arr64(int) not in store
     assert dt.Type.arr64(float) not in store
     assert dt.Type.arr32(dt.Type.arr32(bool)) not in store
+
+
+@pytest.mark.parametrize('src', [0, 1])
+def test_query_methods(src):
+    tarr = dt.Type.arr32(int) if src else \
+           dt.Type.arr64(str)
+    assert     tarr.is_array()
+    assert not tarr.is_boolean()
+    assert     tarr.is_compound()
+    assert not tarr.is_float()
+    assert not tarr.is_integer()
+    assert not tarr.is_numeric()
+    assert not tarr.is_object()
+    assert not tarr.is_string()
+    assert not tarr.is_temporal()
+    assert not tarr.is_void()

--- a/tests/types/test-array.py
+++ b/tests/types/test-array.py
@@ -87,13 +87,13 @@ def test_type_array_hashable():
 def test_query_methods(src):
     tarr = dt.Type.arr32(int) if src else \
            dt.Type.arr64(str)
-    assert     tarr.is_array()
-    assert not tarr.is_boolean()
-    assert     tarr.is_compound()
-    assert not tarr.is_float()
-    assert not tarr.is_integer()
-    assert not tarr.is_numeric()
-    assert not tarr.is_object()
-    assert not tarr.is_string()
-    assert not tarr.is_temporal()
-    assert not tarr.is_void()
+    assert     tarr.is_array
+    assert not tarr.is_boolean
+    assert     tarr.is_compound
+    assert not tarr.is_float
+    assert not tarr.is_integer
+    assert not tarr.is_numeric
+    assert not tarr.is_object
+    assert not tarr.is_string
+    assert not tarr.is_temporal
+    assert not tarr.is_void

--- a/tests/types/test-bool8.py
+++ b/tests/types/test-bool8.py
@@ -30,16 +30,16 @@ from tests import assert_equals
 
 def test_query_methods():
     tbool = dt.Type.bool8
-    assert not tbool.is_array()
-    assert     tbool.is_boolean()
-    assert not tbool.is_compound()
-    assert not tbool.is_float()
-    assert not tbool.is_integer()
-    assert     tbool.is_numeric()
-    assert not tbool.is_object()
-    assert not tbool.is_string()
-    assert not tbool.is_temporal()
-    assert not tbool.is_void()
+    assert not tbool.is_array
+    assert     tbool.is_boolean
+    assert not tbool.is_compound
+    assert not tbool.is_float
+    assert not tbool.is_integer
+    assert     tbool.is_numeric
+    assert not tbool.is_object
+    assert not tbool.is_string
+    assert not tbool.is_temporal
+    assert not tbool.is_void
 
 
 

--- a/tests/types/test-bool8.py
+++ b/tests/types/test-bool8.py
@@ -28,6 +28,21 @@ from datatable.internal import frame_integrity_check
 from tests import assert_equals
 
 
+def test_query_methods():
+    tbool = dt.Type.bool8
+    assert not tbool.is_array()
+    assert     tbool.is_boolean()
+    assert not tbool.is_compound()
+    assert not tbool.is_float()
+    assert not tbool.is_integer()
+    assert     tbool.is_numeric()
+    assert not tbool.is_object()
+    assert not tbool.is_string()
+    assert not tbool.is_temporal()
+    assert not tbool.is_void()
+
+
+
 #-------------------------------------------------------------------------------
 # Create bool column
 #-------------------------------------------------------------------------------

--- a/tests/types/test-date32.py
+++ b/tests/types/test-date32.py
@@ -57,16 +57,16 @@ def test_date32_type_from_pyarrow(pa):
 
 def test_query_methods():
     tdate = dt.Type.date32
-    assert not tdate.is_array()
-    assert not tdate.is_boolean()
-    assert not tdate.is_compound()
-    assert not tdate.is_float()
-    assert not tdate.is_integer()
-    assert not tdate.is_numeric()
-    assert not tdate.is_object()
-    assert not tdate.is_string()
-    assert     tdate.is_temporal()
-    assert not tdate.is_void()
+    assert not tdate.is_array
+    assert not tdate.is_boolean
+    assert not tdate.is_compound
+    assert not tdate.is_float
+    assert not tdate.is_integer
+    assert not tdate.is_numeric
+    assert not tdate.is_object
+    assert not tdate.is_string
+    assert     tdate.is_temporal
+    assert not tdate.is_void
 
 
 

--- a/tests/types/test-date32.py
+++ b/tests/types/test-date32.py
@@ -55,6 +55,25 @@ def test_date32_type_from_pyarrow(pa):
     assert dt.Type(pa.date32()) == dt.Type.date32
 
 
+def test_query_methods():
+    tdate = dt.Type.date32
+    assert not tdate.is_array()
+    assert not tdate.is_boolean()
+    assert not tdate.is_compound()
+    assert not tdate.is_float()
+    assert not tdate.is_integer()
+    assert not tdate.is_numeric()
+    assert not tdate.is_object()
+    assert not tdate.is_string()
+    assert     tdate.is_temporal()
+    assert not tdate.is_void()
+
+
+
+
+#-------------------------------------------------------------------------------
+# Create column
+#-------------------------------------------------------------------------------
 
 def test_date32_create_from_python():
     src = [d(2000, 1, 5), d(2010, 11, 23), d(2020, 2, 29), None]

--- a/tests/types/test-float.py
+++ b/tests/types/test-float.py
@@ -27,6 +27,21 @@ from datatable import dt, f
 from datatable.internal import frame_integrity_check
 from tests import assert_equals, list_equals
 
+@pytest.mark.parametrize('src', ['float32', 'float64'])
+def test_query_methods(src):
+    tfloat = dt.Type(src)
+    assert not tfloat.is_array()
+    assert not tfloat.is_boolean()
+    assert not tfloat.is_compound()
+    assert     tfloat.is_float()
+    assert not tfloat.is_integer()
+    assert     tfloat.is_numeric()
+    assert not tfloat.is_object()
+    assert not tfloat.is_string()
+    assert not tfloat.is_temporal()
+    assert not tfloat.is_void()
+
+
 
 #-------------------------------------------------------------------------------
 # Create float32 columns

--- a/tests/types/test-float.py
+++ b/tests/types/test-float.py
@@ -30,16 +30,16 @@ from tests import assert_equals, list_equals
 @pytest.mark.parametrize('src', ['float32', 'float64'])
 def test_query_methods(src):
     tfloat = dt.Type(src)
-    assert not tfloat.is_array()
-    assert not tfloat.is_boolean()
-    assert not tfloat.is_compound()
-    assert     tfloat.is_float()
-    assert not tfloat.is_integer()
-    assert     tfloat.is_numeric()
-    assert not tfloat.is_object()
-    assert not tfloat.is_string()
-    assert not tfloat.is_temporal()
-    assert not tfloat.is_void()
+    assert not tfloat.is_array
+    assert not tfloat.is_boolean
+    assert not tfloat.is_compound
+    assert     tfloat.is_float
+    assert not tfloat.is_integer
+    assert     tfloat.is_numeric
+    assert not tfloat.is_object
+    assert not tfloat.is_string
+    assert not tfloat.is_temporal
+    assert not tfloat.is_void
 
 
 

--- a/tests/types/test-int.py
+++ b/tests/types/test-int.py
@@ -31,16 +31,16 @@ from tests import assert_equals
 @pytest.mark.parametrize('src', ['int8', 'int16', 'int32', 'int64'])
 def test_query_methods(src):
     tint = dt.Type(src)
-    assert not tint.is_array()
-    assert not tint.is_boolean()
-    assert not tint.is_compound()
-    assert not tint.is_float()
-    assert     tint.is_integer()
-    assert     tint.is_numeric()
-    assert not tint.is_object()
-    assert not tint.is_string()
-    assert not tint.is_temporal()
-    assert not tint.is_void()
+    assert not tint.is_array
+    assert not tint.is_boolean
+    assert not tint.is_compound
+    assert not tint.is_float
+    assert     tint.is_integer
+    assert     tint.is_numeric
+    assert not tint.is_object
+    assert not tint.is_string
+    assert not tint.is_temporal
+    assert not tint.is_void
 
 
 

--- a/tests/types/test-int.py
+++ b/tests/types/test-int.py
@@ -28,6 +28,22 @@ from datatable.internal import frame_integrity_check
 from tests import assert_equals
 
 
+@pytest.mark.parametrize('src', ['int8', 'int16', 'int32', 'int64'])
+def test_query_methods(src):
+    tint = dt.Type(src)
+    assert not tint.is_array()
+    assert not tint.is_boolean()
+    assert not tint.is_compound()
+    assert not tint.is_float()
+    assert     tint.is_integer()
+    assert     tint.is_numeric()
+    assert not tint.is_object()
+    assert not tint.is_string()
+    assert not tint.is_temporal()
+    assert not tint.is_void()
+
+
+
 #-------------------------------------------------------------------------------
 # Create int8 columns
 #-------------------------------------------------------------------------------

--- a/tests/types/test-obj64.py
+++ b/tests/types/test-obj64.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#-------------------------------------------------------------------------------
+# Copyright 2021 H2O.ai
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#-------------------------------------------------------------------------------
+import math
+import pytest
+from datatable import dt, f
+from datatable.internal import frame_integrity_check
+from tests import assert_equals
+
+
+def test_query_methods():
+    tobj = dt.Type.obj64
+    assert not tobj.is_array
+    assert not tobj.is_boolean
+    assert not tobj.is_compound
+    assert not tobj.is_float
+    assert not tobj.is_integer
+    assert not tobj.is_numeric
+    assert     tobj.is_object
+    assert not tobj.is_string
+    assert not tobj.is_temporal
+    assert not tobj.is_void

--- a/tests/types/test-str.py
+++ b/tests/types/test-str.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#-------------------------------------------------------------------------------
+# Copyright 2021 H2O.ai
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#-------------------------------------------------------------------------------
+import math
+import pytest
+from datatable import dt, f
+from datatable.internal import frame_integrity_check
+from tests import assert_equals
+
+
+@pytest.mark.parametrize('src', ['str32', 'str64'])
+def test_query_methods(src):
+    tstr = dt.Type(src)
+    assert not tstr.is_array()
+    assert not tstr.is_boolean()
+    assert not tstr.is_compound()
+    assert not tstr.is_float()
+    assert not tstr.is_integer()
+    assert not tstr.is_numeric()
+    assert not tstr.is_object()
+    assert     tstr.is_string()
+    assert not tstr.is_temporal()
+    assert not tstr.is_void()

--- a/tests/types/test-str.py
+++ b/tests/types/test-str.py
@@ -31,13 +31,13 @@ from tests import assert_equals
 @pytest.mark.parametrize('src', ['str32', 'str64'])
 def test_query_methods(src):
     tstr = dt.Type(src)
-    assert not tstr.is_array()
-    assert not tstr.is_boolean()
-    assert not tstr.is_compound()
-    assert not tstr.is_float()
-    assert not tstr.is_integer()
-    assert not tstr.is_numeric()
-    assert not tstr.is_object()
-    assert     tstr.is_string()
-    assert not tstr.is_temporal()
-    assert not tstr.is_void()
+    assert not tstr.is_array
+    assert not tstr.is_boolean
+    assert not tstr.is_compound
+    assert not tstr.is_float
+    assert not tstr.is_integer
+    assert not tstr.is_numeric
+    assert not tstr.is_object
+    assert     tstr.is_string
+    assert not tstr.is_temporal
+    assert not tstr.is_void

--- a/tests/types/test-time64.py
+++ b/tests/types/test-time64.py
@@ -80,16 +80,16 @@ def test_time64_repr():
 
 def test_query_methods():
     ttime64 = dt.Type.time64
-    assert not ttime64.is_array()
-    assert not ttime64.is_boolean()
-    assert not ttime64.is_compound()
-    assert not ttime64.is_float()
-    assert not ttime64.is_integer()
-    assert not ttime64.is_numeric()
-    assert not ttime64.is_object()
-    assert not ttime64.is_string()
-    assert     ttime64.is_temporal()
-    assert not ttime64.is_void()
+    assert not ttime64.is_array
+    assert not ttime64.is_boolean
+    assert not ttime64.is_compound
+    assert not ttime64.is_float
+    assert not ttime64.is_integer
+    assert not ttime64.is_numeric
+    assert not ttime64.is_object
+    assert not ttime64.is_string
+    assert     ttime64.is_temporal
+    assert not ttime64.is_void
 
 
 

--- a/tests/types/test-time64.py
+++ b/tests/types/test-time64.py
@@ -78,6 +78,22 @@ def test_time64_repr():
     )
 
 
+def test_query_methods():
+    ttime64 = dt.Type.time64
+    assert not ttime64.is_array()
+    assert not ttime64.is_boolean()
+    assert not ttime64.is_compound()
+    assert not ttime64.is_float()
+    assert not ttime64.is_integer()
+    assert not ttime64.is_numeric()
+    assert not ttime64.is_object()
+    assert not ttime64.is_string()
+    assert     ttime64.is_temporal()
+    assert not ttime64.is_void()
+
+
+
+
 #-------------------------------------------------------------------------------
 # time64 convert to/from list of primitives
 #-------------------------------------------------------------------------------

--- a/tests/types/test-type.py
+++ b/tests/types/test-type.py
@@ -220,6 +220,27 @@ def test_type_minmax():
     assert dt.Type.obj64.max is None
 
 
+def test_type_isxxx_properties():
+    T = dt.Type
+    all_types = [T.void, T.bool8, T.int8, T.int16, T.int32, T.int64, T.float32,
+                 T.float64, T.str32, T.str64, T.date32, T.time64, T.obj64,
+                 T.arr32(T.void), T.arr64(T.str32)]
+    all_properties = ["is_array", "is_boolean", "is_compound", "is_float",
+                      "is_integer", "is_numeric", "is_object", "is_string",
+                      "is_temporal", "is_void"]
+    for ttype in all_types:
+        for prop in all_properties:
+            assert hasattr(ttype, prop)
+            assert isinstance(getattr(ttype, prop), bool)
+            msg = ("attribute '%s' of 'datatable.Type' objects is not writable"
+                   % prop)
+            with pytest.raises(AttributeError, match=msg):
+                setattr(ttype, prop, False)
+            with pytest.raises(AttributeError, match=msg):
+                delattr(ttype, prop)
+
+
+
 
 #-------------------------------------------------------------------------------
 # Test stype enum

--- a/tests/types/test-void.py
+++ b/tests/types/test-void.py
@@ -44,16 +44,16 @@ def test_void_type_from_basic():
 
 def test_query_methods():
     tvoid = dt.Type.void
-    assert tvoid.is_void
-    assert tvoid.is_array
-    assert tvoid.is_boolean
-    assert tvoid.is_integer
-    assert tvoid.is_float
-    assert tvoid.is_numeric
-    assert tvoid.is_string
-    assert tvoid.is_temporal
-    assert tvoid.is_object
+    assert not tvoid.is_array
+    assert not tvoid.is_boolean
     assert not tvoid.is_compound
+    assert not tvoid.is_integer
+    assert not tvoid.is_float
+    assert     tvoid.is_numeric
+    assert not tvoid.is_string
+    assert not tvoid.is_temporal
+    assert not tvoid.is_object
+    assert     tvoid.is_void
 
 
 

--- a/tests/types/test-void.py
+++ b/tests/types/test-void.py
@@ -29,6 +29,36 @@ from datatable import dt, f, join
 
 
 #-------------------------------------------------------------------------------
+# void type basic properties
+#-------------------------------------------------------------------------------
+
+def test_void_name():
+    assert repr(dt.Type.void) == "Type.void"
+    assert dt.Type.void.name == "void"
+
+
+def test_void_type_from_basic():
+    assert dt.Type(None) == dt.Type.void
+    assert dt.Type("void") == dt.Type.void
+
+
+def test_query_methods():
+    tvoid = dt.Type.void
+    assert tvoid.is_void()
+    assert tvoid.is_array()
+    assert tvoid.is_boolean()
+    assert tvoid.is_integer()
+    assert tvoid.is_float()
+    assert tvoid.is_numeric()
+    assert tvoid.is_string()
+    assert tvoid.is_temporal()
+    assert tvoid.is_object()
+    assert not tvoid.is_compound()
+
+
+
+
+#-------------------------------------------------------------------------------
 # Create column of void type
 #-------------------------------------------------------------------------------
 

--- a/tests/types/test-void.py
+++ b/tests/types/test-void.py
@@ -49,7 +49,7 @@ def test_query_methods():
     assert not tvoid.is_compound
     assert not tvoid.is_integer
     assert not tvoid.is_float
-    assert     tvoid.is_numeric
+    assert not tvoid.is_numeric
     assert not tvoid.is_string
     assert not tvoid.is_temporal
     assert not tvoid.is_object

--- a/tests/types/test-void.py
+++ b/tests/types/test-void.py
@@ -44,16 +44,16 @@ def test_void_type_from_basic():
 
 def test_query_methods():
     tvoid = dt.Type.void
-    assert tvoid.is_void()
-    assert tvoid.is_array()
-    assert tvoid.is_boolean()
-    assert tvoid.is_integer()
-    assert tvoid.is_float()
-    assert tvoid.is_numeric()
-    assert tvoid.is_string()
-    assert tvoid.is_temporal()
-    assert tvoid.is_object()
-    assert not tvoid.is_compound()
+    assert tvoid.is_void
+    assert tvoid.is_array
+    assert tvoid.is_boolean
+    assert tvoid.is_integer
+    assert tvoid.is_float
+    assert tvoid.is_numeric
+    assert tvoid.is_string
+    assert tvoid.is_temporal
+    assert tvoid.is_object
+    assert not tvoid.is_compound
 
 
 


### PR DESCRIPTION
Added 10 properties into the `dt.Type` class
- `.is_array`
- `.is_boolean`
- `.is_compound`
- `.is_float`
- `.is_integer`
- `.is_numeric`
- `.is_object`
- `.is_string`
- `.is_temporal`
- `.is_void`

Closes #3101