### PR TITLE
Add void type columns to random attacker

### DIFF
--- a/src/datatable/types.py
+++ b/src/datatable/types.py
@@ -299,6 +299,7 @@ def _additional_stype_members():
         yield (v.name, v)
     for st, code in _stype_2_short.items():
         yield (code, st)
+    yield (None, stype.void)
     yield (bool, stype.bool8)
     yield ("bool", stype.bool8)
     yield ("boolean", stype.bool8)

--- a/tests_random/attacker.py
+++ b/tests_random/attacker.py
@@ -159,6 +159,10 @@ def replace_nas_in_column(frame):
         replacement_value = random.random() * 1000
     elif frame.types[icol] is str:
         replacement_value = random_string()
+    elif frame.types[icol] is None:
+        return
+    else:
+        raise RuntimeError("Unknown type %s" % frame.types[icol])
     res = frame.replace_nas_in_column(icol, replacement_value)
 
 

--- a/tests_random/metaframe.py
+++ b/tests_random/metaframe.py
@@ -404,7 +404,11 @@ class MetaFrame:
     @traced
     def cbind_numpy_column(self):
         import numpy as np
-        coltype = random_type()
+        # Numpy has no concept of "void" column (at least, not similar to ours),
+        # so avoid that random type:
+        coltype = None
+        while coltype is None:
+            coltype = random_type()
         mfraction = random.random()
         data, mmask = random_column(self.nrows, coltype, mfraction, False)
 

--- a/tests_random/metaframe.py
+++ b/tests_random/metaframe.py
@@ -22,9 +22,11 @@
 # IN THE SOFTWARE.
 #-------------------------------------------------------------------------------
 import copy
+import datetime
 import pytest
 import random
 import re
+import sys
 import warnings
 from datatable import dt, f, join
 from datatable.internal import frame_integrity_check
@@ -81,10 +83,10 @@ class MetaFrame:
         assert isinstance(types, list) and len(types) == ncols
         assert isinstance(names, list) and len(names) == ncols
         assert isinstance(missing_fraction, float)
-        tt = {bool: 0, int: 0, float: 0, str: 0}
+        tt = {bool: 0, int: 0, float: 0, str: 0, None: 0}
         for t in types:
             tt[t] += 1
-        assert len(tt) == 4
+        assert len(tt) == 5
         print("# Making a frame with nrows=%d, ncols=%d" % (nrows, ncols))
         print("#   types: bool=%d, int=%d, float=%d, str=%d"
               % (tt[bool], tt[int], tt[float], tt[str]))
@@ -100,7 +102,7 @@ class MetaFrame:
         print(f"{frame.name} = dt.Frame(")
         print(f"    {repr_data(data, 4)},")
         print(f"    names={names},")
-        print(f"    stypes={repr_types(types)}")
+        print(f"    types={repr_types(types)}")
         print(f")")
         return frame
 
@@ -529,9 +531,10 @@ class MetaFrame:
 
 _ltype_to_pytype = {
     dt.ltype.bool: bool,
-    dt.ltype.int: int,
+    dt.ltype.int:  int,
     dt.ltype.real: float,
     dt.ltype.str: str,
-    dt.ltype.time: None,
-    dt.ltype.obj: object
+    dt.ltype.time: datetime.datetime,
+    dt.ltype.obj: object,
+    dt.ltype.void: None,
 }

--- a/tests_random/utils.py
+++ b/tests_random/utils.py
@@ -152,6 +152,8 @@ def repr_type(t):
         return "float"
     if t is str:
         return "str"
+    if t is None:
+        return "'void'"
     raise ValueError("Unknown type %r" % t)
 
 def repr_types(types):
@@ -191,7 +193,7 @@ def random_array(n, positive=False):
 
 
 def random_type():
-    return random.choice([bool, int, float, str])
+    return random.choice([bool, int, float, str]*2 + [None])
 
 
 def random_names(ncols):
@@ -234,8 +236,12 @@ def random_column(nrows, ttype, missing_fraction, missing_nones=True):
         data = random_int_column(nrows)
     elif ttype == float:
         data = random_float_column(nrows)
-    else:
+    elif ttype == str:
         data = random_str_column(nrows)
+    elif ttype is None:
+        data = [None] * nrows
+    else:
+        assert False, "Invalid ttype = %s" % ttype
     if missing_fraction:
         for i in range(nrows):
             if random.random() < missing_fraction:


### PR DESCRIPTION
The random attacker now also tests columns of type `void`.

In addition, added command line parameter `--noforks`, allowing to optionally run the attacker without the "fork_and_run" step (which complicates debugging). This parameter is for manual use only.