### PR TITLE
Create arr32 column from arrow list / large_list

### DIFF
--- a/src/core/column.h
+++ b/src/core/column.h
@@ -157,6 +157,7 @@ class Column
     bool get_element(size_t i, double* out) const;
     bool get_element(size_t i, dt::CString* out) const;
     bool get_element(size_t i, py::oobj* out) const;
+    bool get_element(size_t i, Column* out) const;
 
     // `get_element_as_pyobject(i)` returns the i-th element of the
     // column wrapped into a pyobject of the appropriate type.

--- a/src/core/column/arrow.h
+++ b/src/core/column/arrow.h
@@ -41,8 +41,6 @@ class Arrow_ColumnImpl : public Virtual_ColumnImpl {
 
     virtual size_t num_buffers() const noexcept = 0;
     virtual const void* get_buffer(size_t i) const = 0;
-
-    virtual size_t num_children() const noexcept { return 0; }
 };
 
 

--- a/src/core/column/arrow_array.cc
+++ b/src/core/column/arrow_array.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2020-2021 H2O.ai
+// Copyright 2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -19,71 +19,81 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
-#include "column/arrow_str.h"
-#include "cstring.h"
-#include "stype.h"
-#include "utils/assert.h"
+#include "column/arrow_array.h"
+#include "column/view.h"
 namespace dt {
 
 
 template <typename T>
-ArrowStr_ColumnImpl<T>::ArrowStr_ColumnImpl(
-    size_t nrows, SType stype, Buffer&& valid, Buffer&& offsets, Buffer&& data
-)
-  : Arrow_ColumnImpl(nrows, stype),
+Type _type_with_child(const Type& t) {
+  return (sizeof(T) == 4)? Type::arr32(t) : Type::arr64(t);
+}
+
+
+template <typename T>
+ArrowArray_ColumnImpl<T>::ArrowArray_ColumnImpl(
+    size_t nrows, Buffer&& valid, Buffer&& offsets, Column&& child)
+  : Arrow_ColumnImpl(nrows, _type_with_child<T>(child.type())),
     validity_(std::move(valid)),
     offsets_(std::move(offsets)),
-    strdata_(std::move(data))
+    child_(std::move(child))
 {
-  xassert(!validity_ || validity_.size() >= (nrows + 7) / 8);
+  xassert(!validity_ || validity_.size() >= (nrows + 63)/64 * 8);
   xassert(offsets_.size() >= sizeof(T) * (nrows + 1));
-  xassert(stype_elemsize(stype) == sizeof(T));
+  xassert(child_.nrows() == nrows);
 }
 
 
 template <typename T>
-ColumnImpl* ArrowStr_ColumnImpl<T>::clone() const {
-  return new ArrowStr_ColumnImpl(
-      nrows(), stype(), Buffer(validity_), Buffer(offsets_), Buffer(strdata_));
-}
-
-template <typename T>
-size_t ArrowStr_ColumnImpl<T>::num_buffers() const noexcept {
-  return 3;
-}
-
-template <typename T>
-const void* ArrowStr_ColumnImpl<T>::get_buffer(size_t i) const {
-  xassert(i < 3);
-  return (i == 0)? validity_.rptr() :
-         (i == 1)? offsets_.rptr() :
-         (i == 2)? strdata_.rptr() : nullptr;
+ColumnImpl* ArrowArray_ColumnImpl<T>::clone() const {
+  return new ArrowArray_ColumnImpl<T>(
+      nrows_, Buffer(validity_), Buffer(offsets_), Column(child_));
 }
 
 
+template <typename T>
+size_t ArrowArray_ColumnImpl<T>::n_children() const noexcept {
+  return 1;
+}
 
-//------------------------------------------------------------------------------
-// Element access
-//------------------------------------------------------------------------------
 
 template <typename T>
-bool ArrowStr_ColumnImpl<T>::get_element(size_t i, CString* out) const {
+const Column& ArrowArray_ColumnImpl<T>::child(size_t) const {
+  return child_;
+}
+
+
+template <typename T>
+size_t ArrowArray_ColumnImpl<T>::num_buffers() const noexcept {
+  return 2;
+}
+
+
+template <typename T>
+const void* ArrowArray_ColumnImpl<T>::get_buffer(size_t i) const {
+  xassert(i <= 1);
+  return (i == 0)? validity_.rptr() : offsets_.rptr();
+}
+
+
+
+template <typename T>
+bool ArrowArray_ColumnImpl<T>::get_element(size_t i, Column* out) const {
   xassert(i < nrows_);
   auto validity_data = static_cast<const uint8_t*>(validity_.rptr());
   bool valid = (!validity_data) || (validity_data[i / 8] & (1 << (i & 7)));
   if (valid) {
-    T start = static_cast<const T*>(offsets_.rptr())[i];
-    T end = static_cast<const T*>(offsets_.rptr())[i + 1];
-    xassert(end >= start);
-    out->set(static_cast<const char*>(strdata_.rptr()) + start, end - start);
+    auto offsets_data = static_cast<const T*>(offsets_.rptr());
+    auto start = static_cast<size_t>(offsets_data[i]);
+    auto end = static_cast<size_t>(offsets_data[i + 1]);
+    *out = Column(
+      new SliceView_ColumnImpl(Column(child_), start, end - start, 1)
+    );
   }
   return valid;
 }
 
 
-
-template class ArrowStr_ColumnImpl<uint32_t>;
-template class ArrowStr_ColumnImpl<uint64_t>;
 
 
 }  // namespace dt

--- a/src/core/column/arrow_array.cc
+++ b/src/core/column/arrow_array.cc
@@ -40,7 +40,8 @@ ArrowArray_ColumnImpl<T>::ArrowArray_ColumnImpl(
 {
   xassert(!validity_ || validity_.size() >= (nrows + 63)/64 * 8);
   xassert(offsets_.size() >= sizeof(T) * (nrows + 1));
-  xassert(child_.nrows() == nrows);
+  xassert(child_.nrows() >=
+          static_cast<size_t>(offsets_.get_element<T>(nrows)));
 }
 
 
@@ -94,6 +95,9 @@ bool ArrowArray_ColumnImpl<T>::get_element(size_t i, Column* out) const {
 }
 
 
+
+template class ArrowArray_ColumnImpl<uint32_t>;
+template class ArrowArray_ColumnImpl<uint64_t>;
 
 
 }  // namespace dt

--- a/src/core/column/arrow_array.h
+++ b/src/core/column/arrow_array.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019 H2O.ai
+// Copyright 2021 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -19,56 +19,38 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
-#include "column/virtual.h"
+#ifndef dt_COLUMN_ARROW_ARRAY_h
+#define dt_COLUMN_ARROW_ARRAY_h
+#include "column/arrow.h"
 namespace dt {
 
 
+template <typename T>
+class ArrowArray_ColumnImpl : public Arrow_ColumnImpl {
+  private:
+    Buffer validity_;
+    Buffer offsets_;
+    Column child_;
 
-bool Virtual_ColumnImpl::is_virtual() const noexcept {
-  return true;
-}
+  public:
+    ArrowArray_ColumnImpl(
+        size_t nrows, Buffer&& valid, Buffer&& offsets, Column&& child);
 
-size_t Virtual_ColumnImpl::memory_footprint() const noexcept {
-  return sizeof(*this);
-}
+    ColumnImpl* clone() const override;
+    size_t n_children() const noexcept override;
+    const Column& child(size_t i) const override;
+    size_t num_buffers() const noexcept override;
+    const void* get_buffer(size_t i) const override;
 
-
-
-NaStorage Virtual_ColumnImpl::get_na_storage_method() const noexcept {
-  return NaStorage::VIRTUAL;
-}
-
-
-size_t Virtual_ColumnImpl::get_num_data_buffers() const noexcept {
-  return 0;
-}
-
-
-bool Virtual_ColumnImpl::is_data_editable(size_t) const {
-  throw RuntimeError() << "Invalid data access for a virtual column";
-}
+    bool get_element(size_t i, Column* out) const override;
+};
 
 
-size_t Virtual_ColumnImpl::get_data_size(size_t) const {
-  throw RuntimeError() << "Invalid data access for a virtual column";
-}
-
-
-const void* Virtual_ColumnImpl::get_data_readonly(size_t) const {
-  throw RuntimeError() << "Invalid data access for a virtual column";
-}
-
-
-void* Virtual_ColumnImpl::get_data_editable(size_t) {
-  throw RuntimeError() << "Invalid data access for a virtual column";
-}
-
-
-Buffer Virtual_ColumnImpl::get_data_buffer(size_t) const {
-  throw RuntimeError() << "Invalid data access for a virtual column";
-}
+extern template class ArrowArray_ColumnImpl<uint32_t>;
+extern template class ArrowArray_ColumnImpl<uint64_t>;
 
 
 
 
 }  // namespace dt
+#endif

--- a/src/core/column/column_impl.cc
+++ b/src/core/column/column_impl.cc
@@ -36,10 +36,13 @@ namespace dt {
 // Constructor
 //------------------------------------------------------------------------------
 
-ColumnImpl::ColumnImpl(size_t nrows, SType stype)
-  : type_(Type::from_stype(stype)),
+ColumnImpl::ColumnImpl(size_t nrows, Type type)
+  : type_(std::move(type)),
     nrows_(nrows),
     refcount_(1) {}
+
+ColumnImpl::ColumnImpl(size_t nrows, SType stype)
+  : ColumnImpl(nrows, Type::from_stype(stype)) {}
 
 
 
@@ -48,20 +51,21 @@ ColumnImpl::ColumnImpl(size_t nrows, SType stype)
 // Data access
 //------------------------------------------------------------------------------
 
-[[noreturn]] static void err(SType col_stype, const char* type) {
+[[noreturn]] static void err(Type col_type, const char* type) {
   throw NotImplError()
       << "Cannot retrieve " << type
-      << " values from a column of type " << col_stype;
+      << " values from a column of type " << col_type;
 }
 
-bool ColumnImpl::get_element(size_t, int8_t*)  const { err(stype(), "int8"); }
-bool ColumnImpl::get_element(size_t, int16_t*) const { err(stype(), "int16"); }
-bool ColumnImpl::get_element(size_t, int32_t*) const { err(stype(), "int32"); }
-bool ColumnImpl::get_element(size_t, int64_t*) const { err(stype(), "int64"); }
-bool ColumnImpl::get_element(size_t, float*)   const { err(stype(), "float32"); }
-bool ColumnImpl::get_element(size_t, double*)  const { err(stype(), "float64"); }
-bool ColumnImpl::get_element(size_t, CString*) const { err(stype(), "string"); }
-bool ColumnImpl::get_element(size_t, py::oobj*)const { err(stype(), "object"); }
+bool ColumnImpl::get_element(size_t, int8_t*)  const { err(type(), "int8"); }
+bool ColumnImpl::get_element(size_t, int16_t*) const { err(type(), "int16"); }
+bool ColumnImpl::get_element(size_t, int32_t*) const { err(type(), "int32"); }
+bool ColumnImpl::get_element(size_t, int64_t*) const { err(type(), "int64"); }
+bool ColumnImpl::get_element(size_t, float*)   const { err(type(), "float32"); }
+bool ColumnImpl::get_element(size_t, double*)  const { err(type(), "float64"); }
+bool ColumnImpl::get_element(size_t, CString*) const { err(type(), "string"); }
+bool ColumnImpl::get_element(size_t, py::oobj*)const { err(type(), "object"); }
+bool ColumnImpl::get_element(size_t, Column*)  const { err(type(), "array"); }
 
 
 

--- a/src/core/column/column_impl.h
+++ b/src/core/column/column_impl.h
@@ -61,6 +61,7 @@ class ColumnImpl
   // Constructors
   //------------------------------------
   public:
+    ColumnImpl(size_t nrows, Type type);
     ColumnImpl(size_t nrows, SType stype);
     ColumnImpl(const ColumnImpl&) = delete;
     ColumnImpl(ColumnImpl&&) = delete;
@@ -84,6 +85,7 @@ class ColumnImpl
     virtual bool get_element(size_t i, double* out) const;
     virtual bool get_element(size_t i, CString* out) const;
     virtual bool get_element(size_t i, py::oobj* out) const;
+    virtual bool get_element(size_t i, Column* out) const;
 
 
   //------------------------------------

--- a/src/core/column/view.cc
+++ b/src/core/column/view.cc
@@ -30,23 +30,34 @@ namespace dt {
 
 SliceView_ColumnImpl::SliceView_ColumnImpl(
     Column&& col, const RowIndex& ri)
-  : Virtual_ColumnImpl(ri.size(), col.stype()),
-    arg(std::move(col)),
-    start(ri.slice_start()),
-    step(ri.slice_step())
+  : Virtual_ColumnImpl(ri.size(), col.type()),
+    arg_(std::move(col)),
+    start_(ri.slice_start()),
+    step_(ri.slice_step())
 {
   xassert(ri.isslice());
-  xassert(ri.max() < arg.nrows());
+  xassert(ri.max() < arg_.nrows());
+}
+
+SliceView_ColumnImpl::SliceView_ColumnImpl(
+    Column&& col, size_t start, size_t count, size_t step)
+  : Virtual_ColumnImpl(count, col.type()),
+    arg_(std::move(col)),
+    start_(start),
+    step_(step)
+{
+  xassert(start < arg_.nrows());
+  xassert(start + count*step < arg_.nrows());
 }
 
 
 ColumnImpl* SliceView_ColumnImpl::clone() const {
   return new SliceView_ColumnImpl(
-                Column(arg), RowIndex(start, nrows_, step));
+                Column(arg_), RowIndex(start_, nrows_, step_));
 }
 
 bool SliceView_ColumnImpl::allow_parallel_access() const {
-  return arg.allow_parallel_access();
+  return arg_.allow_parallel_access();
 }
 
 size_t SliceView_ColumnImpl::n_children() const noexcept {
@@ -55,18 +66,18 @@ size_t SliceView_ColumnImpl::n_children() const noexcept {
 
 const Column& SliceView_ColumnImpl::child(size_t i) const {
   xassert(i == 0);  (void)i;
-  return arg;
+  return arg_;
 }
 
 
-bool SliceView_ColumnImpl::get_element(size_t i, int8_t* out)   const { return arg.get_element(start + i*step, out); }
-bool SliceView_ColumnImpl::get_element(size_t i, int16_t* out)  const { return arg.get_element(start + i*step, out); }
-bool SliceView_ColumnImpl::get_element(size_t i, int32_t* out)  const { return arg.get_element(start + i*step, out); }
-bool SliceView_ColumnImpl::get_element(size_t i, int64_t* out)  const { return arg.get_element(start + i*step, out); }
-bool SliceView_ColumnImpl::get_element(size_t i, float* out)    const { return arg.get_element(start + i*step, out); }
-bool SliceView_ColumnImpl::get_element(size_t i, double* out)   const { return arg.get_element(start + i*step, out); }
-bool SliceView_ColumnImpl::get_element(size_t i, CString* out)  const { return arg.get_element(start + i*step, out); }
-bool SliceView_ColumnImpl::get_element(size_t i, py::oobj* out) const { return arg.get_element(start + i*step, out); }
+bool SliceView_ColumnImpl::get_element(size_t i, int8_t* out)   const { return arg_.get_element(start_ + i*step_, out); }
+bool SliceView_ColumnImpl::get_element(size_t i, int16_t* out)  const { return arg_.get_element(start_ + i*step_, out); }
+bool SliceView_ColumnImpl::get_element(size_t i, int32_t* out)  const { return arg_.get_element(start_ + i*step_, out); }
+bool SliceView_ColumnImpl::get_element(size_t i, int64_t* out)  const { return arg_.get_element(start_ + i*step_, out); }
+bool SliceView_ColumnImpl::get_element(size_t i, float* out)    const { return arg_.get_element(start_ + i*step_, out); }
+bool SliceView_ColumnImpl::get_element(size_t i, double* out)   const { return arg_.get_element(start_ + i*step_, out); }
+bool SliceView_ColumnImpl::get_element(size_t i, CString* out)  const { return arg_.get_element(start_ + i*step_, out); }
+bool SliceView_ColumnImpl::get_element(size_t i, py::oobj* out) const { return arg_.get_element(start_ + i*step_, out); }
 
 
 

--- a/src/core/column/view.cc
+++ b/src/core/column/view.cc
@@ -47,7 +47,7 @@ SliceView_ColumnImpl::SliceView_ColumnImpl(
     step_(step)
 {
   xassert(start < arg_.nrows());
-  xassert(start + count*step < arg_.nrows());
+  xassert(start + count*step <= arg_.nrows());
 }
 
 

--- a/src/core/column/view.h
+++ b/src/core/column/view.h
@@ -32,12 +32,13 @@ namespace dt {
 
 class SliceView_ColumnImpl : public Virtual_ColumnImpl {
   private:
-    Column arg;
-    size_t start;
-    size_t step;
+    Column arg_;
+    size_t start_;
+    size_t step_;
 
   public:
     SliceView_ColumnImpl(Column&& col, const RowIndex& ri);
+    SliceView_ColumnImpl(Column&& col, size_t start, size_t count, size_t step);
     ColumnImpl* clone() const override;
     bool allow_parallel_access() const override;
     size_t n_children() const noexcept override;

--- a/src/core/column/virtual.h
+++ b/src/core/column/virtual.h
@@ -32,7 +32,7 @@ namespace dt {
 class Virtual_ColumnImpl : public ColumnImpl
 {
   public:
-    Virtual_ColumnImpl(size_t nrows, SType stype);
+    using ColumnImpl::ColumnImpl;
 
     bool is_virtual() const noexcept override;
     size_t memory_footprint() const noexcept override;

--- a/src/core/types/type.cc
+++ b/src/core/types/type.cc
@@ -165,6 +165,7 @@ template<> bool Type::can_be_read_as<float>()    const { return impl_ && impl_->
 template<> bool Type::can_be_read_as<double>()   const { return impl_ && impl_->can_be_read_as_float64(); }
 template<> bool Type::can_be_read_as<CString>()  const { return impl_ && impl_->can_be_read_as_cstring(); }
 template<> bool Type::can_be_read_as<py::oobj>() const { return impl_ && impl_->can_be_read_as_pyobject(); }
+template<> bool Type::can_be_read_as<Column>()   const { return impl_ && impl_->can_be_read_as_column(); }
 
 
 bool Type::operator==(const Type& other) const {

--- a/src/core/types/type_array.cc
+++ b/src/core/types/type_array.cc
@@ -33,7 +33,7 @@ namespace dt {
 
 Type_Arr32::Type_Arr32(Type t)
   : TypeImpl(SType::ARR32),
-    elementType_(t) {}
+    elementType_(std::move(t)) {}
 
 bool Type_Arr32::is_compound() const {
   return true; 
@@ -42,6 +42,11 @@ bool Type_Arr32::is_compound() const {
 bool Type_Arr32::is_array() const {
   return true;
 }
+
+bool Type_Arr32::can_be_read_as_column() const {
+  return true;
+}
+
 
 std::string Type_Arr32::to_string() const {
   return "arr32(" + elementType_.to_string() + ")";
@@ -77,13 +82,17 @@ size_t Type_Arr32::hash() const noexcept {
 
 Type_Arr64::Type_Arr64(Type t)
   : TypeImpl(SType::ARR64),
-    elementType_(t) {}
+    elementType_(std::move(t)) {}
 
 bool Type_Arr64::is_compound() const {
   return true; 
 }
 
 bool Type_Arr64::is_array() const {
+  return true;
+}
+
+bool Type_Arr64::can_be_read_as_column() const {
   return true;
 }
 

--- a/src/core/types/type_array.h
+++ b/src/core/types/type_array.h
@@ -34,6 +34,7 @@ class Type_Arr32 : public TypeImpl {
     Type_Arr32(Type t);
     bool is_array() const override;
     bool is_compound() const override;
+    bool can_be_read_as_column() const override;
     std::string to_string() const override;
     bool equals(const TypeImpl* other) const override;
     size_t hash() const noexcept override;
@@ -50,6 +51,7 @@ class Type_Arr64 : public TypeImpl {
     Type_Arr64(Type t);
     bool is_array() const override;
     bool is_compound() const override;
+    bool can_be_read_as_column() const override;
     std::string to_string() const override;
     bool equals(const TypeImpl* other) const override;
     size_t hash() const noexcept override;

--- a/src/core/types/typeimpl.cc
+++ b/src/core/types/typeimpl.cc
@@ -69,6 +69,7 @@ bool TypeImpl::can_be_read_as_float64()  const { return false; }
 bool TypeImpl::can_be_read_as_date()     const { return false; }
 bool TypeImpl::can_be_read_as_cstring()  const { return false; }
 bool TypeImpl::can_be_read_as_pyobject() const { return false; }
+bool TypeImpl::can_be_read_as_column()   const { return false; }
 
 bool TypeImpl::equals(const TypeImpl* other) const {
   return stype_ == other->stype_;

--- a/src/core/types/typeimpl.h
+++ b/src/core/types/typeimpl.h
@@ -67,6 +67,7 @@ class TypeImpl {
     virtual bool can_be_read_as_date() const;
     virtual bool can_be_read_as_cstring() const;
     virtual bool can_be_read_as_pyobject() const;
+    virtual bool can_be_read_as_column() const;
 
     // Default implementation only checks the equality of stypes.
     // Override if your TypeImpl contains more information.

--- a/src/core/utils/arrow_structs.h
+++ b/src/core/utils/arrow_structs.h
@@ -162,6 +162,18 @@ class OArrowArray {
     ArrowArray array_;
 
   private:
+    /**
+      * Create a new OArrowArray structure from an existing
+      * ArrowArray* pointer, which will be marked as "released".
+      *
+      * According to Arrow's documentation:
+      *   > The consumer can move the ArrowArray structure by bitwise
+      *   > copying or shallow member-wise copying. Then it MUST mark
+      *   > the source structure released but without calling the release
+      *   > callback. This ensures that only one live copy of the
+      *   > struct is active at any given time and that lifetime is
+      *   > correctly communicated to the producer.
+      */
     OArrowArray(ArrowArray* arr) noexcept {
       array_.length       = arr->length;
       array_.null_count   = arr->null_count;
@@ -229,7 +241,7 @@ class OArrowArray {
       * structure. Effectively, after this call, `this` will be owned
       * by itself.
       *
-      * This method can only be called when there established a
+      * This method can only be called when there is an established
       * promise that its `->release()` callback will be called at a
       * future time.
       */
@@ -238,6 +250,12 @@ class OArrowArray {
       data->store(std::unique_ptr<OArrowArray>(this));
     }
 };
+
+
+static_assert(sizeof(ArrowArray) == sizeof(OArrowArray),
+    "Sizes of ArrowArray and OArrowArray do not match");
+static_assert(sizeof(ArrowSchema) == sizeof(OArrowSchema),
+    "Sizes of ArrowSchema and OArrowSchema do not match");
 
 
 

--- a/tests/types/test-array.py
+++ b/tests/types/test-array.py
@@ -81,3 +81,16 @@ def test_type_array_hashable():
     assert dt.Type.arr64(int) not in store
     assert dt.Type.arr64(float) not in store
     assert dt.Type.arr32(dt.Type.arr32(bool)) not in store
+
+
+
+
+#-------------------------------------------------------------------------------
+# Create from Arrow
+#-------------------------------------------------------------------------------
+
+def test_create_from_arrow(pa):
+    arr = pa.array([[1, 3, 8, -14, 5], [2, 0], None, [4], [], [1, -1, 1]],
+                   type=pa.list_(pa.int32()))
+    tbl = pa.Table([arr], names=["A"])
+    DT = dt.Frame(tbl)

--- a/tests/types/test-array.py
+++ b/tests/types/test-array.py
@@ -90,7 +90,11 @@ def test_type_array_hashable():
 #-------------------------------------------------------------------------------
 
 def test_create_from_arrow(pa):
-    arr = pa.array([[1, 3, 8, -14, 5], [2, 0], None, [4], [], [1, -1, 1]],
-                   type=pa.list_(pa.int32()))
-    tbl = pa.Table([arr], names=["A"])
+    src = [[1, 3, 8, -14, 5], [2, 0], None, [4], [], [1, -1, 1]]
+    arr = pa.array(src, type=pa.list_(pa.int32()))
+    tbl = pa.Table.from_arrays([arr], names=["A"])
     DT = dt.Frame(tbl)
+    assert DT.shape == (6, 1)
+    assert DT.type == dt.Type.arr32(dt.Type.int32)
+    assert DT.names == ("A",)
+    assert DT.to_list() == [src]


### PR DESCRIPTION
- Allow `arr32` / `arr64` columns to be created by converting pyarrow `list` / `large_list` types;
- Array columns can now be converted back into python;
- Internal: added method `Column::get_element(size_t i, Column* out)` in order to accommodate reading data from an array  column.

Closes #3053
Closes #3113