### PR TITLE
Move some of the documentation from C++ into docs/

### DIFF
--- a/docs/api/internal/frame_column_data_r.rst
+++ b/docs/api/internal/frame_column_data_r.rst
@@ -1,4 +1,20 @@
 
 .. xfunction:: datatable.internal.frame_column_data_r
     :src: src/core/datatablemodule.cc frame_column_data_r
-    :doc: src/core/datatablemodule.cc doc_frame_column_data_r
+    :cvar: doc_internal_frame_column_data_r
+    :signature: frame_column_data_r(frame, i)
+
+    Return C pointer to the main data array of the column `frame[i]`.
+    The column will be materialized if it was virtual.
+
+
+    Parameters
+    ----------
+    frame: Frame
+        The :class:`dt.Frame` where to look up the column.
+
+    i: int
+        The index of a column, in the range ``[0; ncols)``.
+
+    return: ctypes.c_void_p
+        The pointer to the column's internal data.

--- a/docs/api/internal/frame_columns_virtual.rst
+++ b/docs/api/internal/frame_columns_virtual.rst
@@ -1,4 +1,20 @@
 
 .. xfunction:: datatable.internal.frame_columns_virtual
     :src: src/core/datatablemodule.cc frame_columns_virtual
-    :doc: src/core/datatablemodule.cc doc_frame_columns_virtual
+    :cvar: doc_internal_frame_columns_virtual
+    :signature: frame_columns_virtual(frame)
+
+    .. x-version-deprecated:: 0.11.0
+
+    Return the list indicating which columns in the `frame` are virtual.
+
+    Parameters
+    ----------
+    return: List[bool]
+        Each element in the list indicates whether the corresponding column
+        is virtual or not.
+
+    Notes
+    -----
+
+    This function will be expanded and moved into the main :class:`dt.Frame` class.

--- a/docs/api/internal/frame_integrity_check.rst
+++ b/docs/api/internal/frame_integrity_check.rst
@@ -1,4 +1,20 @@
 
 .. xfunction:: datatable.internal.frame_integrity_check
     :src: src/core/datatablemodule.cc frame_integrity_check
-    :doc: src/core/datatablemodule.cc doc_frame_integrity_check
+    :cvar: doc_internal_frame_integrity_check
+    :signature: frame_integrity_check(frame)
+
+    This function performs a range of tests on the `frame` to verify
+    that its internal state is consistent. It returns None on success,
+    or throws an ``AssertionError`` if any problems were found.
+
+
+    Parameters
+    ----------
+    frame: Frame
+        A :class:`dt.Frame` object that needs to be checked for internal consistency.
+
+    return: None
+
+    except: AssertionError
+        An exception is raised if there were any issues with the `frame`.

--- a/docs/api/internal/get_thread_ids.rst
+++ b/docs/api/internal/get_thread_ids.rst
@@ -1,4 +1,23 @@
 
 .. xfunction:: datatable.internal.get_thread_ids
     :src: src/core/datatablemodule.cc get_thread_ids
-    :doc: src/core/datatablemodule.cc doc_get_thread_ids
+    :cvar: doc_internal_get_thread_ids
+    :signature: get_thread_ids()
+
+    Return system ids of all threads used internally by datatable.
+
+    Calling this function will cause the threads to spawn if they
+    haven't done already. (This behavior may change in the future).
+
+
+    Parameters
+    ----------
+    return: List[str]
+        The list of thread ids used by the datatable. The first element
+        in the list is the id of the main thread.
+
+
+    See Also
+    --------
+    - :attr:`dt.options.nthreads` -- global option that controls the
+      number of threads in use.

--- a/docs/api/options/debug/arg_max_size.rst
+++ b/docs/api/options/debug/arg_max_size.rst
@@ -1,7 +1,7 @@
 
 .. xattr:: datatable.options.debug.arg_max_size
     :src: src/core/call_logger.cc get_arg_max_size set_arg_max_size
-    :doc: doc_options_debug_arg_max_size
+    :cvar: doc_options_debug_arg_max_size
     :settable: value
 
     This option limits the display size of each argument in order

--- a/docs/api/options/debug/arg_max_size.rst
+++ b/docs/api/options/debug/arg_max_size.rst
@@ -1,5 +1,22 @@
 
 .. xattr:: datatable.options.debug.arg_max_size
     :src: src/core/call_logger.cc get_arg_max_size set_arg_max_size
-    :doc: src/core/call_logger.cc doc_options_debug_arg_max_size
-    :settable: new_arg_max_size
+    :doc: doc_options_debug_arg_max_size
+    :settable: value
+
+    This option limits the display size of each argument in order
+    to prevent potentially huge outputs. It has no effect,
+    if :attr:`debug.report_args <datatable.options.debug.report_args>` is
+    `False`.
+
+    Parameters
+    ----------
+    return: int
+        Current `arg_max_size` value. Initially, this option is set to `100`.
+
+    value: int
+        New `arg_max_size` value, should be non-negative.
+        If `value < 10`, then `arg_max_size` will be set to `10`.
+
+    except: TypeError
+        The exception is raised when `value` is negative.

--- a/docs/api/options/debug/enabled.rst
+++ b/docs/api/options/debug/enabled.rst
@@ -1,5 +1,18 @@
 
 .. xattr:: datatable.options.debug.enabled
     :src: src/core/call_logger.cc get_enabled set_enabled
-    :doc: src/core/call_logger.cc doc_options_debug_enabled
-    :settable: new_enabled
+    :cvar: doc_options_debug_enabled
+    :settable: value
+
+    This option controls whether or not all the calls to the datatable core
+    functions should be logged.
+
+
+    Parameters
+    ----------
+    return: bool
+        Current `enabled` value. Initially, this option is set to `False`.
+
+    value: bool
+        New `enabled` value. If set to `True`, all the calls to the datatable
+        core functions will be logged along with their respective timings.

--- a/docs/api/options/debug/logger.rst
+++ b/docs/api/options/debug/logger.rst
@@ -1,5 +1,22 @@
 
 .. xattr:: datatable.options.debug.logger
     :src: src/core/call_logger.cc get_logger set_logger
-    :doc: src/core/call_logger.cc doc_options_debug_logger
-    :settable: new_logger
+    :cvar: doc_options_debug_logger
+    :settable: value
+
+    The logger object used for reporting calls to datatable core
+    functions. This option has no effect if
+    :attr:`debug.enabled <datatable.options.debug.enabled>` is `False`.
+
+    Parameters
+    ----------
+    return: object
+        Current `logger` value. Initially, this option is set to `None`,
+        meaning that the built-in logger should be used.
+
+    value: object
+        New `logger` value.
+
+    except: TypeError
+        The exception is raised when `value` is not an object
+        having a method `.debug(self, msg)`.

--- a/docs/api/options/debug/report_args.rst
+++ b/docs/api/options/debug/report_args.rst
@@ -1,7 +1,7 @@
 
 .. xattr:: datatable.options.debug.report_args
     :src: src/core/call_logger.cc get_report_args set_report_args
-    :doc: doc_options_debug_report_args
+    :cvar: doc_options_debug_report_args
     :settable: value
 
     This option controls whether log messages for the function

--- a/docs/api/options/debug/report_args.rst
+++ b/docs/api/options/debug/report_args.rst
@@ -1,5 +1,17 @@
 
 .. xattr:: datatable.options.debug.report_args
     :src: src/core/call_logger.cc get_report_args set_report_args
-    :doc: src/core/call_logger.cc doc_options_debug_report_args
-    :settable: new_report_args
+    :doc: doc_options_debug_report_args
+    :settable: value
+
+    This option controls whether log messages for the function
+    and method calls should contain information about the arguments
+    of those calls.
+
+    Parameters
+    ----------
+    return: bool
+        Current `report_args` value. Initially, this option is set to `False`.
+
+    value: object
+        New `report_args` value.

--- a/src/core/call_logger.cc
+++ b/src/core/call_logger.cc
@@ -24,6 +24,7 @@
 #include <iostream>
 #include "call_logger.h"
 #include "cstring.h"
+#include "documentation.h"
 #include "options.h"
 #include "python/args.h"
 #include "python/bool.h"
@@ -88,84 +89,6 @@ static constexpr size_t N_IMPLS = 10;
 //------------------------------------------------------------------------------
 // Options
 //------------------------------------------------------------------------------
-
-static const char* doc_options_debug_enabled =
-R"(
-This option controls whether or not all the calls to the datatable core
-functions should be logged.
-
-
-Parameters
-----------
-return: bool
-    Current `enabled` value. Initially, this option is set to `False`.
-
-new_enabled: bool
-    New `enabled` value. If set to `True`, all the calls to the datatable
-    core functions will be logged along with their respective timings.
-
-)";
-
-static const char* doc_options_debug_logger =
-R"(
-The logger object used for reporting calls to datatable core
-functions. This option has no effect if
-:attr:`debug.enabled <datatable.options.debug.enabled>` is `False`.
-
-Parameters
-----------
-return: object
-    Current `logger` value. Initially, this option is set to `None`,
-    meaning that the built-in logger should be used.
-
-new_logger: object
-    New `logger` value.
-
-except: TypeError
-    The exception is raised when `new_logger` is not an object
-    having a method `.debug(self, msg)`.
-
-)";
-
-static const char* doc_options_debug_report_args =
-R"(
-This option controls whether log messages for the function
-and method calls should contain information about the arguments
-of those calls.
-
-Parameters
-----------
-return: bool
-    Current `report_args` value. Initially, this option is set to `False`.
-
-new_report_args: object
-    New `report_args` value.
-
-)";
-
-
-static const char* doc_options_debug_arg_max_size =
-R"(
-
-This option limits the display size of each argument in order
-to prevent potentially huge outputs. It has no effect,
-if :attr:`debug.report_args <datatable.options.debug.report_args>` is
-`False`.
-
-Parameters
-----------
-return: int
-    Current `arg_max_size` value. Initially, this option is set to `100`.
-
-new_arg_max_size: int
-    New `arg_max_size` value, should be non-negative.
-    If `new_arg_max_size < 10`, then `arg_max_size` will be set to `10`.
-
-except: TypeError
-    The exception is raised when `new_arg_max_size` is negative.
-
-)";
-
 
 static bool opt_report_args = false;
 static size_t opt_arg_max_size = 100;

--- a/src/core/documentation.h
+++ b/src/core/documentation.h
@@ -115,6 +115,11 @@ extern const char* doc_models_LinearModel_predict;
 extern const char* doc_models_LinearModel_reset;
 extern const char* doc_models_LinearModel_seed;
 
+extern const char* doc_options_debug_arg_max_size;
+extern const char* doc_options_debug_enabled;
+extern const char* doc_options_debug_logger;
+extern const char* doc_options_debug_report_args;
+
 extern const char* doc_re_match;
 
 extern const char* doc_str_len;

--- a/src/core/documentation.h
+++ b/src/core/documentation.h
@@ -23,6 +23,7 @@
 #define dt_DOCUMENTATION_h
 namespace dt {
 
+
 extern const char* doc_dt_as_type;
 extern const char* doc_dt_by;
 extern const char* doc_dt_cbind;
@@ -56,6 +57,11 @@ extern const char* doc_dt_symdiff;
 extern const char* doc_dt_union;
 extern const char* doc_dt_unique;
 extern const char* doc_dt_update;
+
+extern const char* doc_internal_frame_column_data_r;
+extern const char* doc_internal_frame_columns_virtual;
+extern const char* doc_internal_frame_integrity_check;
+extern const char* doc_internal_get_thread_ids;
 
 extern const char* doc_math_atan2;
 extern const char* doc_math_copysign;

--- a/src/core/options.cc
+++ b/src/core/options.cc
@@ -125,7 +125,7 @@ void register_option(const char* name,
   auto p = static_cast<py::config_option*>(v);
   p->name = py::ostring(name);
   p->default_value = getter();
-  p->docstring = py::ostring(docstring);
+  p->docstring = py::ostring(docstring? docstring : "");
   p->getter = std::move(getter);
   p->setter = std::move(setter);
   p->arg = new py::Arg(name);

--- a/src/core/sort.cc
+++ b/src/core/sort.cc
@@ -256,39 +256,6 @@ void swap(rmem& left, rmem& right) noexcept {
 // Options
 //------------------------------------------------------------------------------
 
-static const char* doc_sort_insert_method_threshold =
-R"(
-Largest n at which sorting will be performed using insert sort
-method. This setting also governs the recursive parts of the
-radix sort algorithm, when we need to sort smaller sub-parts of
-the input.
-)";
-
-static const char* doc_sort_thread_multiplier =
-R"(
-Internal
-)";
-
-static const char* doc_sort_max_chunk_length =
-R"(
-Internal
-)";
-
-static const char* doc_sort_max_radix_bits =
-R"(
-Internal
-)";
-
-static const char* doc_sort_over_radix_bits =
-R"(
-Internal
-)";
-
-static const char* doc_sort_nthreads =
-R"(
-Internal
-)";
-
 static size_t sort_insert_method_threshold = 64;
 static size_t sort_thread_multiplier = 2;
 static size_t sort_max_chunk_length = 1 << 8;
@@ -306,7 +273,12 @@ void sort_init_options() {
       if (n < 0) n = 0;
       sort_insert_method_threshold = static_cast<size_t>(n);
     },
-    doc_sort_insert_method_threshold
+    R"(
+    Largest n at which sorting will be performed using insert sort
+    method. This setting also governs the recursive parts of the
+    radix sort algorithm, when we need to sort smaller sub-parts of
+    the input.
+    )"
   );
 
   dt::register_option(
@@ -317,7 +289,7 @@ void sort_init_options() {
       if (n < 1) n = 1;
       sort_thread_multiplier = static_cast<size_t>(n);
     },
-    doc_sort_thread_multiplier
+    nullptr
   );
 
   dt::register_option(
@@ -328,7 +300,7 @@ void sort_init_options() {
       if (n < 1) n = 1;
       sort_max_chunk_length = static_cast<size_t>(n);
     },
-    doc_sort_max_chunk_length
+    nullptr
   );
 
   dt::register_option(
@@ -340,7 +312,7 @@ void sort_init_options() {
         throw ValueError() << "Invalid sort.max_radix_bits parameter: " << n;
       sort_max_radix_bits = static_cast<uint8_t>(n);
     },
-    doc_sort_max_radix_bits
+    nullptr
   );
 
   dt::register_option(
@@ -352,7 +324,7 @@ void sort_init_options() {
         throw ValueError() << "Invalid sort.over_radix_bits parameter: " << n;
       sort_over_radix_bits = static_cast<uint8_t>(n);
     },
-    doc_sort_over_radix_bits
+    nullptr
   );
 
   dt::register_option(
@@ -364,7 +336,7 @@ void sort_init_options() {
       if (nth <= 0) nth = 1;
       sort_nthreads = static_cast<uint8_t>(nth);
     },
-    doc_sort_nthreads
+    nullptr
   );
 
   dt::register_option(
@@ -372,7 +344,8 @@ void sort_init_options() {
     []{ return py::obool(sort_new); },
     [](const py::Arg& value) {
       sort_new = value.to_bool_strict();
-    }, "");
+    },
+    nullptr);
 }
 
 


### PR DESCRIPTION
- Moved documentation for several options & internal functions;
- Refactor `dt.internal` functions to use `XArgs` instead of `PKArgs`.

WIP for #3029