### PR TITLE
Fix using set functions with void columns

### DIFF
--- a/src/core/rowindex.cc
+++ b/src/core/rowindex.cc
@@ -220,13 +220,14 @@ static void _extract_into(const RowIndex& ri, T* target) {
 
 
 void RowIndex::extract_into(Buffer& buffer, int flags) const {
-  void* data = buffer.xptr();
   if (flags & RowIndex::ARR32) {
-    xassert(buffer.size() >= size() * sizeof(int32_t));
-    _extract_into<int32_t>(*this, static_cast<int32_t*>(data));
+    buffer.ensuresize(size() * sizeof(int32_t));
+    auto data = static_cast<int32_t*>(buffer.xptr());
+    _extract_into<int32_t>(*this, data);
   } else {
-    xassert(buffer.size() >= size() * sizeof(int64_t));
-    _extract_into<int64_t>(*this, static_cast<int64_t*>(data));
+    buffer.ensuresize(size() * sizeof(int64_t));
+    auto data = static_cast<int64_t*>(buffer.xptr());
+    _extract_into<int64_t>(*this, data);
   }
 }
 

--- a/src/core/set_funcs.cc
+++ b/src/core/set_funcs.cc
@@ -129,18 +129,44 @@ static py::oobj _union(named_colvec&& ncv) {
   }
   sort_result sorted = sort_columns(std::move(ncv));
 
-  size_t ngrps = sorted.gb.size();
-  const int32_t* goffsets = sorted.gb.offsets_r();
-  if (goffsets[ngrps] == 0) ngrps = 0;
-
-  const int32_t* indices = sorted.ri.indices32();
-  Buffer buf = Buffer::mem(ngrps * sizeof(int32_t));
-  int32_t* out_indices = static_cast<int32_t*>(buf.xptr());
-
-  for (size_t i = 0; i < ngrps; ++i) {
-    out_indices[i] = indices[goffsets[i]];
+  size_t numGroups = sorted.gb.size();
+  const int32_t* groupOffsets = sorted.gb.offsets_r();
+  xassert(groupOffsets != nullptr);
+  if (groupOffsets[numGroups] == 0) {
+    return py::Frame::oframe(new DataTable(
+        {Column::new_na_column(0, sorted.column.stype())},
+        {std::move(sorted.colname)}
+    ));
   }
-  return make_pyframe(std::move(sorted), std::move(buf));
+  if (numGroups == 1) {
+    size_t index;
+    bool valid = sorted.ri.get_element(0, &index);
+    if (valid) {
+      xassert(index == 0);
+      sorted.column.resize(1);
+      return py::Frame::oframe(new DataTable(
+          {std::move(sorted.column)},
+          {std::move(sorted.colname)}
+      ));
+    } else {
+      return py::Frame::oframe(new DataTable(
+          {Column::new_na_column(1, sorted.column.stype())},
+          {std::move(sorted.colname)}
+      ));
+    }
+  }
+  if (sorted.ri.isarr32()) {
+    const int32_t* indices = sorted.ri.indices32();
+    Buffer buf = Buffer::mem(numGroups * sizeof(int32_t));
+    int32_t* out_indices = static_cast<int32_t*>(buf.xptr());
+
+    for (size_t i = 0; i < numGroups; ++i) {
+      out_indices[i] = indices[groupOffsets[i]];
+    }
+    return make_pyframe(std::move(sorted), std::move(buf));
+  }
+  throw NotImplError() << "Unexpected RowIndex type "
+      << static_cast<int>(sorted.ri.type()) << " in _union()";
 }
 
 
@@ -205,7 +231,14 @@ static py::oobj _intersect(named_colvec&& cv) {
   const int32_t* goffsets = sorted.gb.offsets_r();
   if (goffsets[ngrps] == 0) ngrps = 0;
 
-  const int32_t* indices = sorted.ri.indices32();
+  const int32_t* indices;
+  Buffer indicesBuffer;
+  if (sorted.ri.isarr32()) {
+    indices = sorted.ri.indices32();
+  } else {
+    sorted.ri.extract_into(indicesBuffer, RowIndex::ARR32);
+    indices = static_cast<const int32_t*>(indicesBuffer.rptr());
+  }
   Buffer buffer = Buffer::mem(ngrps * sizeof(int32_t));
   int32_t* out_indices = static_cast<int32_t*>(buffer.xptr());
   size_t j = 0;
@@ -286,7 +319,14 @@ static py::oobj _setdiff(named_colvec&& cv) {
   const int32_t* goffsets = sorted.gb.offsets_r();
   if (goffsets[ngrps] == 0) ngrps = 0;
 
-  const int32_t* indices = sorted.ri.indices32();
+  const int32_t* indices;
+  Buffer indicesBuffer;
+  if (sorted.ri.isarr32()) {
+    indices = sorted.ri.indices32();
+  } else {
+    sorted.ri.extract_into(indicesBuffer, RowIndex::ARR32);
+    indices = static_cast<const int32_t*>(indicesBuffer.rptr());
+  }
   Buffer buffer = Buffer::mem(ngrps * sizeof(int32_t));
   int32_t* out_indices = static_cast<int32_t*>(buffer.xptr());
   size_t j = 0;
@@ -331,7 +371,14 @@ static py::oobj _symdiff(named_colvec&& cv) {
   const int32_t* goffsets = sr.gb.offsets_r();
   if (goffsets[ngrps] == 0) ngrps = 0;
 
-  const int32_t* indices = sr.ri.indices32();
+  const int32_t* indices;
+  Buffer indicesBuffer;
+  if (sr.ri.isarr32()) {
+    indices = sr.ri.indices32();
+  } else {
+    sr.ri.extract_into(indicesBuffer, RowIndex::ARR32);
+    indices = static_cast<const int32_t*>(indicesBuffer.rptr());
+  }
   Buffer buffer = Buffer::mem(ngrps * sizeof(int32_t));
   int32_t* out_indices = static_cast<int32_t*>(buffer.xptr());
   size_t j = 0;

--- a/tests/types/test-void.py
+++ b/tests/types/test-void.py
@@ -231,3 +231,12 @@ def test_groupby_void_multicolumn():
     DT1 = DT0[:, dt.count(), dt.by(f.A, f.B)]
     EXP = dt.Frame(A=[None]*5, B=range(5), count=([1] * 5)/dt.int64)
     assert_equals(DT1, EXP)
+
+
+def test_void_set_functions():
+    # See issue #3126
+    DT = dt.Frame(Q=[None] * 17)
+    assert_equals(dt.unique(DT), dt.Frame(Q=[None]))
+    assert_equals(dt.union(DT, DT, DT), dt.Frame(Q=[None]))
+    assert_equals(dt.intersect(DT, DT), dt.Frame(Q=[None]))
+    assert_equals(dt.setdiff(DT, DT), dt.Frame(Q=[]))


### PR DESCRIPTION
The issue here was that set functions assumed that the result of a sort/groupby is always a rowindex of type `ARR32`, which is no longer the case since #3111. 

Closes #3126