### PR TITLE
Fix a crash when `.ltypes` or `.stypes` were accessed for frames with array columns

### DIFF
--- a/docs/releases/v1.1.0.rst
+++ b/docs/releases/v1.1.0.rst
@@ -25,6 +25,9 @@
     -[fix] Fixed a crash which could have occurred when sorting very long
         identical or nearly identical strings. [#3134]
 
+    -[fix] Fixed a crash when :attr:`.ltypes` or :attr:`.stypes` properties
+        were accessed for a frame containing array columns. [#3142]
+
     -[api] Converting a column of :attr:`void <dt.Type.void>` type into pandas
         now produces a pandas ``object`` column filled with ``None``s. Converting
         such column back into datatable produces a ``void`` column again. [#3063]

--- a/docs/releases/v1.1.0.rst
+++ b/docs/releases/v1.1.0.rst
@@ -25,9 +25,6 @@
     -[fix] Fixed a crash which could have occurred when sorting very long
         identical or nearly identical strings. [#3134]
 
-    -[fix] Fixed a crash when :attr:`.ltypes` or :attr:`.stypes` properties
-        were accessed for a frame containing array columns. [#3142]
-
     -[api] Converting a column of :attr:`void <dt.Type.void>` type into pandas
         now produces a pandas ``object`` column filled with ``None``s. Converting
         such column back into datatable produces a ``void`` column again. [#3063]

--- a/src/core/ltype.cc
+++ b/src/core/ltype.cc
@@ -72,6 +72,7 @@ void init_py_ltype_objs(PyObject* ltype_enum) {
   _init_py_ltype(LType::STRING);
   _init_py_ltype(LType::DATETIME);
   _init_py_ltype(LType::OBJECT);
+  _init_py_ltype(LType::INVALID);
 }
 
 

--- a/src/core/ltype.h
+++ b/src/core/ltype.h
@@ -92,7 +92,7 @@ enum class LType : uint8_t {
   INVALID  = 8
 };
 
-constexpr size_t LTYPES_COUNT = static_cast<size_t>(LType::INVALID);
+constexpr size_t LTYPES_COUNT = static_cast<size_t>(LType::INVALID) + 1;
 
 
 

--- a/src/core/stype.cc
+++ b/src/core/stype.cc
@@ -151,6 +151,8 @@ void init_py_stype_objs(PyObject* stype_enum) {
   _init_py_stype(SType::FLOAT64);
   _init_py_stype(SType::STR32);
   _init_py_stype(SType::STR64);
+  _init_py_stype(SType::ARR32);
+  _init_py_stype(SType::ARR64);
   _init_py_stype(SType::TIME64);
   _init_py_stype(SType::DATE32);
   _init_py_stype(SType::OBJ);

--- a/src/datatable/types.py
+++ b/src/datatable/types.py
@@ -46,6 +46,8 @@ class stype(enum.Enum):
     float64 = 7
     str32 = 11
     str64 = 12
+    arr32 = 13
+    arr64 = 14
     date32 = 17
     time64 = 18
     obj64 = 21
@@ -140,6 +142,7 @@ class ltype(enum.Enum):
     str = 4
     time = 5
     obj = 7
+    invalid = 8
 
     def __repr__(self):
         return str(self)
@@ -194,6 +197,8 @@ _stype_2_short = {
     stype.float64: "r8",
     stype.str32: "s4",
     stype.str64: "s8",
+    stype.arr32: "a4",
+    stype.arr64: "a8",
     stype.time64: "t8",
     stype.date32: "d4",
     stype.obj64: "o8",
@@ -210,6 +215,8 @@ _stype_2_ltype = {
     stype.float64: ltype.real,
     stype.str32: ltype.str,
     stype.str64: ltype.str,
+    stype.arr32: ltype.invalid,
+    stype.arr64: ltype.invalid,
     stype.date32: ltype.time,
     stype.time64: ltype.time,
     stype.obj64: ltype.obj,

--- a/tests/munging/test-dt-cols.py
+++ b/tests/munging/test-dt-cols.py
@@ -292,7 +292,7 @@ def test_j_type(t, dt1):
 
 @pytest.mark.parametrize("t", ltype)
 def test_j_ltype(t, dt1):
-    if t == ltype.time:
+    if t in (ltype.time, ltype.invalid):
         return
     DT2 = dt1[:, t]
     sl2 = (slice(0, 1) if t == ltype.bool else

--- a/tests/test-dt.py
+++ b/tests/test-dt.py
@@ -851,7 +851,7 @@ def test_single_element_extraction_from_view(dt0):
 @pytest.mark.parametrize('st', list(dt.stype))
 def test_single_element_all_stypes(st):
     from datetime import date as dd
-    if st == dt.stype.time64:
+    if st in (dt.stype.time64, dt.stype.arr32, dt.stype.arr64):
         return
     pt = (bool if st == dt.stype.bool8 else
           int if st.ltype == dt.ltype.int else

--- a/tests/test-f.py
+++ b/tests/test-f.py
@@ -199,6 +199,8 @@ def test_f_columnset_stypes(DT):
 
 def test_f_columnset_ltypes(DT):
     for lt in dt.ltype:
+        if lt == dt.ltype.invalid:
+            return
         assert_equals(DT[:, f[lt]],
                       DT[:, [i for i in range(DT.ncols)
                              if DT.ltypes[i] == lt]])

--- a/tests/types/test-array.py
+++ b/tests/types/test-array.py
@@ -122,6 +122,8 @@ def test_create_from_python1():
     assert DT.shape == (6, 1)
     assert DT.type == dt.Type.arr32(dt.Type.int32)
     assert DT.names == ("A",)
+    assert DT.ltypes == (dt.ltype.invalid,) # These properties are deprecated, also
+    assert DT.stypes == (dt.stype.arr32,)   # see issue #3142
     assert DT.to_list() == [src]
 
 

--- a/tests/types/test-type.py
+++ b/tests/types/test-type.py
@@ -258,11 +258,13 @@ def test_stype():
     assert stype.float64
     assert stype.str32
     assert stype.str64
+    assert stype.arr32
+    assert stype.arr64
     assert stype.date32
     assert stype.time64
     assert stype.obj64
     # When new stypes are added, don't forget to update this test suite
-    assert len(stype) == 13
+    assert len(stype) == 15
 
 
 def test_stype_names():
@@ -277,6 +279,8 @@ def test_stype_names():
     assert stype.float64.name == "float64"
     assert stype.str32.name == "str32"
     assert stype.str64.name == "str64"
+    assert stype.arr32.name == "arr32"
+    assert stype.arr64.name == "arr64"
     assert stype.date32.name == "date32"
     assert stype.time64.name == "time64"
     assert stype.obj64.name == "obj64"
@@ -397,7 +401,7 @@ def test_stype_instantiate_bad():
 def test_stype_minmax(st):
     from datatable import stype, ltype
     if st in (stype.void, stype.str32, stype.str64, stype.obj64, stype.time64,
-              stype.date32):
+              stype.date32, stype.arr32, stype.arr64):
         assert st.min is None
         assert st.max is None
     else:
@@ -440,8 +444,9 @@ def test_ltype():
     assert ltype.time
     assert ltype.str
     assert ltype.obj
+    assert ltype.invalid
     # When new stypes are added, don't forget to update this test suite
-    assert len(ltype) == 7
+    assert len(ltype) == 8
 
 
 def test_ltype_names():


### PR DESCRIPTION
Handling of array columns was fixed by adding `ltype.invalid` and `stype.arr32`/`stype.arr64`. Also, several relevant tests were adjusted.

Closes #3142 