### PR TITLE
Read/write arr32/64 columns from Jay

### DIFF
--- a/src/core/_dt.h
+++ b/src/core/_dt.h
@@ -36,6 +36,7 @@ typedef struct bufferinfo  Py_buffer;
 
 class Buffer;
 class Column;
+class ColumnJayData;
 class DataTable;
 class Groupby;
 class MemoryWritableBuffer;

--- a/src/core/column.cc
+++ b/src/core/column.cc
@@ -156,7 +156,7 @@ size_t Column::nrows() const noexcept {
 }
 
 size_t Column::na_count() const {
-  return stats()->nacount();
+  return impl_->null_count();
 }
 
 const dt::Type& Column::type() const noexcept {

--- a/src/core/column.h
+++ b/src/core/column.h
@@ -273,13 +273,9 @@ class Column
     // erroneous state.
     void verify_integrity() const;
 
-    // Serialize the column into a Jay format.
-    // See jay/save_jay.cc
-    flatbuffers::Offset<jay::Column> write_to_jay(
-        const std::string& name,
-        flatbuffers::FlatBufferBuilder&,
-        WritableBuffer*);
-    void write_data_to_jay(jay::ColumnBuilder&, WritableBuffer*);
+    // Save the column's data into the provided data structure `cj`.
+    // However, do not call `cj.write()`.
+    void save_to_jay(ColumnJayData& cj);
 
     // See frame/to_arrow.cc
     std::unique_ptr<dt::OArrowArray> to_arrow() const;

--- a/src/core/column/arrow.h
+++ b/src/core/column/arrow.h
@@ -40,7 +40,9 @@ class Arrow_ColumnImpl : public Virtual_ColumnImpl {
     }
 
     virtual size_t num_buffers() const noexcept = 0;
-    virtual const void* get_buffer(size_t i) const = 0;
+    virtual Buffer get_buffer(size_t i) const = 0;
+
+    void save_to_jay(ColumnJayData&) override;
 };
 
 

--- a/src/core/column/arrow_array.cc
+++ b/src/core/column/arrow_array.cc
@@ -73,9 +73,9 @@ size_t ArrowArray_ColumnImpl<T>::num_buffers() const noexcept {
 
 
 template <typename T>
-const void* ArrowArray_ColumnImpl<T>::get_buffer(size_t i) const {
+Buffer ArrowArray_ColumnImpl<T>::get_buffer(size_t i) const {
   xassert(i <= 1);
-  return (i == 0)? validity_.rptr() : offsets_.rptr();
+  return (i == 0)? validity_ : offsets_;
 }
 
 

--- a/src/core/column/arrow_array.cc
+++ b/src/core/column/arrow_array.cc
@@ -32,11 +32,13 @@ Type _type_with_child(const Type& t) {
 
 template <typename T>
 ArrowArray_ColumnImpl<T>::ArrowArray_ColumnImpl(
-    size_t nrows, Buffer&& valid, Buffer&& offsets, Column&& child)
-  : Arrow_ColumnImpl(nrows, _type_with_child<T>(child.type())),
+    size_t nrows, size_t nullcount,
+    Buffer&& valid, Buffer&& offsets, Column&& child
+) : Arrow_ColumnImpl(nrows, _type_with_child<T>(child.type())),
     validity_(std::move(valid)),
     offsets_(std::move(offsets)),
-    child_(std::move(child))
+    child_(std::move(child)),
+    null_count_(nullcount)
 {
   xassert(!validity_ || validity_.size() >= (nrows + 63)/64 * 8);
   xassert(offsets_.size() >= sizeof(T) * (nrows + 1));
@@ -48,7 +50,7 @@ ArrowArray_ColumnImpl<T>::ArrowArray_ColumnImpl(
 template <typename T>
 ColumnImpl* ArrowArray_ColumnImpl<T>::clone() const {
   return new ArrowArray_ColumnImpl<T>(
-      nrows_, Buffer(validity_), Buffer(offsets_), Column(child_));
+      nrows_, null_count_, Buffer(validity_), Buffer(offsets_), Column(child_));
 }
 
 
@@ -93,6 +95,13 @@ bool ArrowArray_ColumnImpl<T>::get_element(size_t i, Column* out) const {
   }
   return valid;
 }
+
+
+template <typename T>
+size_t ArrowArray_ColumnImpl<T>::null_count() const {
+  return null_count_;
+}
+
 
 
 

--- a/src/core/column/arrow_array.h
+++ b/src/core/column/arrow_array.h
@@ -31,10 +31,12 @@ class ArrowArray_ColumnImpl : public Arrow_ColumnImpl {
     Buffer validity_;
     Buffer offsets_;
     Column child_;
+    size_t null_count_;
 
   public:
     ArrowArray_ColumnImpl(
-        size_t nrows, Buffer&& valid, Buffer&& offsets, Column&& child);
+        size_t nrows, size_t nullcount,
+        Buffer&& valid, Buffer&& offsets, Column&& child);
 
     ColumnImpl* clone() const override;
     size_t n_children() const noexcept override;
@@ -43,6 +45,8 @@ class ArrowArray_ColumnImpl : public Arrow_ColumnImpl {
     const void* get_buffer(size_t i) const override;
 
     bool get_element(size_t i, Column* out) const override;
+
+    size_t null_count() const override;
 };
 
 

--- a/src/core/column/arrow_array.h
+++ b/src/core/column/arrow_array.h
@@ -42,7 +42,7 @@ class ArrowArray_ColumnImpl : public Arrow_ColumnImpl {
     size_t n_children() const noexcept override;
     const Column& child(size_t i) const override;
     size_t num_buffers() const noexcept override;
-    const void* get_buffer(size_t i) const override;
+    Buffer get_buffer(size_t i) const override;
 
     bool get_element(size_t i, Column* out) const override;
 

--- a/src/core/column/arrow_bool.cc
+++ b/src/core/column/arrow_bool.cc
@@ -48,9 +48,8 @@ size_t ArrowBool_ColumnImpl::num_buffers() const noexcept {
   return 2;
 }
 
-const void* ArrowBool_ColumnImpl::get_buffer(size_t i) const {
-  return (i == 0)? validity_.rptr() :
-         (i == 1)? data_.rptr() : nullptr;
+Buffer ArrowBool_ColumnImpl::get_buffer(size_t i) const {
+  return (i == 0)? validity_ : data_;
 }
 
 

--- a/src/core/column/arrow_bool.h
+++ b/src/core/column/arrow_bool.h
@@ -39,7 +39,7 @@ class ArrowBool_ColumnImpl : public Arrow_ColumnImpl {
     ColumnImpl* clone() const override;
     // void materialize(Column&, bool) override;
     size_t num_buffers() const noexcept override;
-    const void* get_buffer(size_t i) const override;
+    Buffer get_buffer(size_t i) const override;
 
     bool get_element(size_t, int8_t*)  const override;
 };

--- a/src/core/column/arrow_fw.cc
+++ b/src/core/column/arrow_fw.cc
@@ -47,9 +47,8 @@ size_t ArrowFw_ColumnImpl::num_buffers() const noexcept {
   return 2;
 }
 
-const void* ArrowFw_ColumnImpl::get_buffer(size_t i) const {
-  return (i == 0)? validity_.rptr() :
-         (i == 1)? data_.rptr() : nullptr;
+Buffer ArrowFw_ColumnImpl::get_buffer(size_t i) const {
+  return (i == 0)? validity_ : data_;
 }
 
 

--- a/src/core/column/arrow_fw.h
+++ b/src/core/column/arrow_fw.h
@@ -48,7 +48,7 @@ class ArrowFw_ColumnImpl : public Arrow_ColumnImpl {
     bool get_element(size_t, double*)  const override;
 
     size_t num_buffers() const noexcept override;
-    const void* get_buffer(size_t i) const override;
+    Buffer get_buffer(size_t i) const override;
 
   private:
     template <typename T> inline bool _get(size_t, T*) const;

--- a/src/core/column/arrow_str.cc
+++ b/src/core/column/arrow_str.cc
@@ -53,11 +53,9 @@ size_t ArrowStr_ColumnImpl<T>::num_buffers() const noexcept {
 }
 
 template <typename T>
-const void* ArrowStr_ColumnImpl<T>::get_buffer(size_t i) const {
+Buffer ArrowStr_ColumnImpl<T>::get_buffer(size_t i) const {
   xassert(i < 3);
-  return (i == 0)? validity_.rptr() :
-         (i == 1)? offsets_.rptr() :
-         (i == 2)? strdata_.rptr() : nullptr;
+  return (i == 0)? validity_ : (i == 1)? offsets_ : strdata_;
 }
 
 

--- a/src/core/column/arrow_str.h
+++ b/src/core/column/arrow_str.h
@@ -42,7 +42,7 @@ class ArrowStr_ColumnImpl : public Arrow_ColumnImpl {
     ColumnImpl* clone() const override;
     // void materialize(Column&, bool) override;
     size_t num_buffers() const noexcept override;
-    const void* get_buffer(size_t i) const override;
+    Buffer get_buffer(size_t i) const override;
 
     bool get_element(size_t, CString*) const override;
 };

--- a/src/core/column/arrow_void.cc
+++ b/src/core/column/arrow_void.cc
@@ -38,8 +38,8 @@ size_t ArrowVoid_ColumnImpl::num_buffers() const noexcept {
   return 1;
 }
 
-const void* ArrowVoid_ColumnImpl::get_buffer(size_t) const {
-  return validity_.rptr();
+Buffer ArrowVoid_ColumnImpl::get_buffer(size_t) const {
+  return validity_;
 }
 
 

--- a/src/core/column/arrow_void.h
+++ b/src/core/column/arrow_void.h
@@ -35,7 +35,7 @@ class ArrowVoid_ColumnImpl : public Arrow_ColumnImpl {
     ColumnImpl* clone() const override;
 
     size_t num_buffers() const noexcept override;
-    const void* get_buffer(size_t) const override;
+    Buffer get_buffer(size_t) const override;
     bool get_element(size_t, int8_t*) const override;
 };
 

--- a/src/core/column/column_impl.cc
+++ b/src/core/column/column_impl.cc
@@ -230,6 +230,9 @@ void ColumnImpl::truncate(size_t new_nrows, Column& out) {
   out = Column(new Truncated_ColumnImpl(std::move(out), new_nrows));
 }
 
+size_t ColumnImpl::null_count() const {
+  return stats()->nacount();
+}
 
 
 

--- a/src/core/column/column_impl.h
+++ b/src/core/column/column_impl.h
@@ -116,8 +116,7 @@ class ColumnImpl
     virtual void*       get_data_editable(size_t k) = 0;
     virtual Buffer      get_data_buffer(size_t k) const = 0;
 
-    virtual void write_data_to_jay(Column&, jay::ColumnBuilder&,
-                                   WritableBuffer*) = 0;
+    virtual void save_to_jay(ColumnJayData& cj) = 0;
 
 
   //------------------------------------

--- a/src/core/column/column_impl.h
+++ b/src/core/column/column_impl.h
@@ -102,7 +102,7 @@ class ColumnImpl
     virtual size_t n_children() const noexcept = 0;
     virtual const Column& child(size_t i) const;
     Stats* stats() const;
-
+    virtual size_t null_count() const;
 
   //------------------------------------
   // Data buffers

--- a/src/core/column/const.h
+++ b/src/core/column/const.h
@@ -68,8 +68,7 @@ class ConstNa_ColumnImpl : public Const_ColumnImpl {
     void na_pad(size_t nrows, Column&) override;
     void rbind_impl(
         colvec& columns, size_t new_nrows, bool col_empty, dt::SType&) override;
-    void write_data_to_jay(
-        Column&, jay::ColumnBuilder&, WritableBuffer*) override;
+    void save_to_jay(ColumnJayData&) override;
 };
 
 

--- a/src/core/column/const_na.cc
+++ b/src/core/column/const_na.cc
@@ -65,17 +65,6 @@ bool ConstNa_ColumnImpl::is_virtual() const noexcept {
 }
 
 
-void ConstNa_ColumnImpl::write_data_to_jay(
-        Column& thiscol, jay::ColumnBuilder& cb, WritableBuffer* wbb) {
-  if (type_.is_void()) {
-    // no data to write
-  } else {
-    // For NA columns of non-void type, defer to regular writer
-    Virtual_ColumnImpl::write_data_to_jay(thiscol, cb, wbb);
-  }
-}
-
-
 
 //------------------------------------------------------------------------------
 // Materializing

--- a/src/core/column/rbound.h
+++ b/src/core/column/rbound.h
@@ -50,8 +50,7 @@ class Rbound_ColumnImpl : public Virtual_ColumnImpl {
     bool get_element(size_t i, py::oobj* out) const override;
     bool get_element(size_t i, Column* out)   const override;
 
-    void write_data_to_jay(Column&, jay::ColumnBuilder&,
-                           WritableBuffer*) override;
+    void save_to_jay(ColumnJayData& cj) override;
 
   private:
     void calculate_nacount();
@@ -60,9 +59,9 @@ class Rbound_ColumnImpl : public Virtual_ColumnImpl {
     void calculate_float_stats();
 
     // defined in save_jay.cc
-    void _write_fw_to_jay(jay::ColumnBuilder&, WritableBuffer*);
-    void _write_str_offsets_to_jay(jay::ColumnBuilder&, WritableBuffer*);
-    void _write_str_data_to_jay(jay::ColumnBuilder&, WritableBuffer*);
+    void _write_fw_to_jay(ColumnJayData&);
+    void _write_str_offsets_to_jay(ColumnJayData&);
+    void _write_str_data_to_jay(ColumnJayData&);
 };
 
 

--- a/src/core/column/sentinel.h
+++ b/src/core/column/sentinel.h
@@ -42,8 +42,7 @@ class Sentinel_ColumnImpl : public ColumnImpl
     NaStorage get_na_storage_method() const noexcept override;
     size_t n_children() const noexcept override;
 
-    void write_data_to_jay(Column&, jay::ColumnBuilder&,
-                           WritableBuffer*) override;
+    void save_to_jay(ColumnJayData& cj) override;
 
   protected:
     Sentinel_ColumnImpl(size_t nrows, SType stype);

--- a/src/core/column/virtual.h
+++ b/src/core/column/virtual.h
@@ -44,8 +44,7 @@ class Virtual_ColumnImpl : public ColumnImpl
     const void* get_data_readonly(size_t k) const override;
     void* get_data_editable(size_t k) override;
     Buffer get_data_buffer(size_t k) const override;
-    void write_data_to_jay(Column&, jay::ColumnBuilder&,
-                           WritableBuffer*) override;
+    void save_to_jay(ColumnJayData& cj) override;
 
 };
 

--- a/src/core/column_from_arrow.cc
+++ b/src/core/column_from_arrow.cc
@@ -91,8 +91,10 @@ static Column _make_arr(std::shared_ptr<dt::OArrowArray>&& array,
   xassert((*array)->n_children == 1);
   xassert(schema->n_children == 1);
   auto nrows = static_cast<size_t>((*array)->length);
+  auto nullcount = static_cast<size_t>((*array)->null_count);
   return Column(new dt::ArrowArray_ColumnImpl<T>(
     nrows,
+    nullcount,
     Buffer::from_arrowarray((*array)->buffers[0], (nrows + 63)/64*8, array),
     Buffer::from_arrowarray((*array)->buffers[1], (nrows + 1)*sizeof(T), array),
     Column::from_arrow(array->detach_child(0), schema->children[0])

--- a/src/core/column_from_python.cc
+++ b/src/core/column_from_python.cc
@@ -399,6 +399,7 @@ Column _parse_array_impl(const Column& inputcol, size_t nn, bool strict) {
   py::oobj item;
   int validity_shift = 0;
   T current_offset = 0;
+  size_t null_count = 0;
   for (size_t i = 0; i < n; i++) {
     inputcol.get_element(i, &item);
     if (item.is_list()) {
@@ -409,6 +410,8 @@ Column _parse_array_impl(const Column& inputcol, size_t nn, bool strict) {
         *data_ptr++ = py::oobj(list[j]).release();
       }
       current_offset += static_cast<T>(list_size);
+    } else {
+      null_count++;
     }
     *offsets_ptr++ = current_offset;
     validity_shift++;
@@ -427,7 +430,7 @@ Column _parse_array_impl(const Column& inputcol, size_t nn, bool strict) {
     return inputcol;
   }
   return Column(new dt::ArrowArray_ColumnImpl<T>(
-      n,
+      n, null_count,
       std::move(validitybuf),
       std::move(offsetsbuf),
       std::move(child_column)

--- a/src/core/datatablemodule.cc
+++ b/src/core/datatablemodule.cc
@@ -339,7 +339,6 @@ void py::DatatableModule::init_methods() {
     }
   }
 
-  init_methods_jay();
   init_methods_join();
 
   init_fbinary();

--- a/src/core/datatablemodule.h
+++ b/src/core/datatablemodule.h
@@ -36,7 +36,6 @@ class DatatableModule : public ExtModule<DatatableModule> {
     }
 
     void init_methods();
-    void init_methods_jay();       // open_jay.cc
     void init_methods_join();      // frame/join.cc
     void init_fbinary();           // expr/fbinary/pyfn.cc
     void init_fuzzy();             // utils/fuzzy.cc

--- a/src/core/frame/to_arrow.cc
+++ b/src/core/frame/to_arrow.cc
@@ -111,7 +111,7 @@ std::unique_ptr<dt::OArrowArray> Column::to_arrow() const {
   if (n_buffers) {
     data->buffers().reserve(n_buffers);
     for (size_t i = 0; i < n_buffers; ++i) {
-      const void* buffer_ptr = arrow_impl->get_buffer(i);
+      const void* buffer_ptr = arrow_impl->get_buffer(i).rptr();
       data->buffers().push_back( buffer_ptr );
     }
     (*aarr)->buffers = data->buffers().data();

--- a/src/core/jay/jay.fbs
+++ b/src/core/jay/jay.fbs
@@ -32,7 +32,7 @@ namespace jay;
 // Types
 //------------------------------------------------------------------------------
 
-enum Type : uint8 {
+enum SType : uint8 {
   Bool8,
   Int8,
   Int16,
@@ -79,7 +79,7 @@ table Frame {
 }
 
 table Column {
-  type:      Type;
+  stype:     SType;   // deprecated -- use Type instead
   data:      Buffer;
   strdata:   Buffer;
   name:      string;

--- a/src/core/jay/jay.fbs
+++ b/src/core/jay/jay.fbs
@@ -99,6 +99,7 @@ table Column {
   nullcount: uint64;
   stats:     Stats;
   type:      Type;
+  nrows:     uint64;
   buffers:   [Buffer];
   children:  [Column];
 }

--- a/src/core/jay/jay.fbs
+++ b/src/core/jay/jay.fbs
@@ -45,7 +45,19 @@ enum SType : uint8 {
   Date32,
   Time64,
   Void0,
+  Arr32,
+  Arr64,
 }
+
+union TypeData {
+  child : Type
+}
+
+table Type {
+  stype:  SType;
+  extra: TypeData;
+}
+
 
 union Stats {
   Bool    : StatsBool,

--- a/src/core/jay/jay.fbs
+++ b/src/core/jay/jay.fbs
@@ -49,13 +49,13 @@ enum SType : uint8 {
   Arr64,
 }
 
-union TypeData {
+union TypeExtra {
   child : Type
 }
 
 table Type {
-  stype:  SType;
-  extra: TypeData;
+  stype: SType;
+  extra: TypeExtra;
 }
 
 
@@ -97,6 +97,9 @@ table Column {
   name:      string;
   nullcount: uint64;
   stats:     Stats;
+  type:      Type;
+  validity:  Buffer;
+  children:  [Column];
 }
 
 struct Buffer {

--- a/src/core/jay/jay.fbs
+++ b/src/core/jay/jay.fbs
@@ -22,7 +22,7 @@
 // In order to compile:
 //     $ flatc --cpp jay.fbs
 //
-// then fix all warnings emitted by Clang
+// then review the generated file and fix inadvertent changes
 //------------------------------------------------------------------------------
 namespace jay;
 
@@ -91,14 +91,15 @@ table Frame {
 }
 
 table Column {
-  stype:     SType;   // deprecated -- use Type instead
-  data:      Buffer;
-  strdata:   Buffer;
+  stype:     SType;   // deprecated -- use `type` instead
+  data:      Buffer;  // deprecated -- use `buffers` instead
+  strdata:   Buffer;  // deprecated -- use `buffers` instead
+
   name:      string;
   nullcount: uint64;
   stats:     Stats;
   type:      Type;
-  validity:  Buffer;
+  buffers:   [Buffer];
   children:  [Column];
 }
 

--- a/src/core/jay/jay_generated.h
+++ b/src/core/jay/jay_generated.h
@@ -30,42 +30,42 @@ struct ColumnBuilder;
 
 struct Buffer;
 
-enum Type {
-  Type_Bool8 = 0,
-  Type_Int8 = 1,
-  Type_Int16 = 2,
-  Type_Int32 = 3,
-  Type_Int64 = 4,
-  Type_Float32 = 5,
-  Type_Float64 = 6,
-  Type_Str32 = 7,
-  Type_Str64 = 8,
-  Type_Date32 = 9,
-  Type_Time64 = 10,
-  Type_Void0 = 11,
-  Type_MIN = Type_Bool8,
-  Type_MAX = Type_Void0
+enum SType {
+  SType_Bool8 = 0,
+  SType_Int8 = 1,
+  SType_Int16 = 2,
+  SType_Int32 = 3,
+  SType_Int64 = 4,
+  SType_Float32 = 5,
+  SType_Float64 = 6,
+  SType_Str32 = 7,
+  SType_Str64 = 8,
+  SType_Date32 = 9,
+  SType_Time64 = 10,
+  SType_Void0 = 11,
+  SType_MIN = SType_Bool8,
+  SType_MAX = SType_Void0
 };
 
-inline const Type (&EnumValuesType())[12] {
-  static const Type values[] = {
-    Type_Bool8,
-    Type_Int8,
-    Type_Int16,
-    Type_Int32,
-    Type_Int64,
-    Type_Float32,
-    Type_Float64,
-    Type_Str32,
-    Type_Str64,
-    Type_Date32,
-    Type_Time64,
-    Type_Void0
+inline const SType (&EnumValuesSType())[12] {
+  static const SType values[] = {
+    SType_Bool8,
+    SType_Int8,
+    SType_Int16,
+    SType_Int32,
+    SType_Int64,
+    SType_Float32,
+    SType_Float64,
+    SType_Str32,
+    SType_Str64,
+    SType_Date32,
+    SType_Time64,
+    SType_Void0
   };
   return values;
 }
 
-inline const char * const *EnumNamesType() {
+inline const char * const *EnumNamesSType() {
   static const char * const names[13] = {
     "Bool8",
     "Int8",
@@ -84,10 +84,10 @@ inline const char * const *EnumNamesType() {
   return names;
 }
 
-inline const char *EnumNameType(Type e) {
-  if (flatbuffers::IsOutRange(e, Type_Bool8, Type_Void0)) return "";
+inline const char *EnumNameSType(SType e) {
+  if (flatbuffers::IsOutRange(e, SType_Bool8, SType_Void0)) return "";
   const size_t index = static_cast<size_t>(e);
-  return EnumNamesType()[index];
+  return EnumNamesSType()[index];
 }
 
 enum Stats {
@@ -441,7 +441,7 @@ inline flatbuffers::Offset<Frame> CreateFrameDirect(
 struct Column FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef ColumnBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
-    VT_TYPE = 4,
+    VT_STYPE = 4,
     VT_DATA = 6,
     VT_STRDATA = 8,
     VT_NAME = 10,
@@ -449,8 +449,8 @@ struct Column FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
     VT_STATS_TYPE = 14,
     VT_STATS = 16
   };
-  jay::Type type() const {
-    return static_cast<jay::Type>(GetField<uint8_t>(VT_TYPE, 0));
+  jay::SType stype() const {
+    return static_cast<jay::SType>(GetField<uint8_t>(VT_STYPE, 0));
   }
   const jay::Buffer *data() const {
     return GetStruct<const jay::Buffer *>(VT_DATA);
@@ -494,7 +494,7 @@ struct Column FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
-           VerifyField<uint8_t>(verifier, VT_TYPE) &&
+           VerifyField<uint8_t>(verifier, VT_STYPE) &&
            VerifyField<jay::Buffer>(verifier, VT_DATA) &&
            VerifyField<jay::Buffer>(verifier, VT_STRDATA) &&
            VerifyOffset(verifier, VT_NAME) &&
@@ -539,8 +539,8 @@ struct ColumnBuilder {
   typedef Column Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_type(jay::Type type) {
-    fbb_.AddElement<uint8_t>(Column::VT_TYPE, static_cast<uint8_t>(type), 0);
+  void add_stype(jay::SType stype) {
+    fbb_.AddElement<uint8_t>(Column::VT_STYPE, static_cast<uint8_t>(stype), 0);
   }
   void add_data(const jay::Buffer *data) {
     fbb_.AddStruct(Column::VT_DATA, data);
@@ -574,7 +574,7 @@ struct ColumnBuilder {
 
 inline flatbuffers::Offset<Column> CreateColumn(
     flatbuffers::FlatBufferBuilder &_fbb,
-    jay::Type type = jay::Type_Bool8,
+    jay::SType stype = jay::SType_Bool8,
     const jay::Buffer *data = 0,
     const jay::Buffer *strdata = 0,
     flatbuffers::Offset<flatbuffers::String> name = 0,
@@ -588,13 +588,13 @@ inline flatbuffers::Offset<Column> CreateColumn(
   builder_.add_strdata(strdata);
   builder_.add_data(data);
   builder_.add_stats_type(stats_type);
-  builder_.add_type(type);
+  builder_.add_stype(stype);
   return builder_.Finish();
 }
 
 inline flatbuffers::Offset<Column> CreateColumnDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
-    jay::Type type = jay::Type_Bool8,
+    jay::SType stype = jay::SType_Bool8,
     const jay::Buffer *data = 0,
     const jay::Buffer *strdata = 0,
     const char *name = nullptr,
@@ -604,7 +604,7 @@ inline flatbuffers::Offset<Column> CreateColumnDirect(
   auto name__ = name ? _fbb.CreateString(name) : 0;
   return jay::CreateColumn(
       _fbb,
-      type,
+      stype,
       data,
       strdata,
       name__,

--- a/src/core/jay/jay_generated.h
+++ b/src/core/jay/jay_generated.h
@@ -570,8 +570,9 @@ struct Column FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
     VT_STATS_TYPE = 14,
     VT_STATS = 16,
     VT_TYPE = 18,
-    VT_BUFFERS = 20,
-    VT_CHILDREN = 22
+    VT_NROWS = 20,
+    VT_BUFFERS = 22,
+    VT_CHILDREN = 24
   };
   jay::SType stype() const {
     return static_cast<jay::SType>(GetField<uint8_t>(VT_STYPE, 0));
@@ -619,6 +620,9 @@ struct Column FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   const jay::Type *type() const {
     return GetPointer<const jay::Type *>(VT_TYPE);
   }
+  uint64_t nrows() const {
+    return GetField<uint64_t>(VT_NROWS, 0);
+  }
   const flatbuffers::Vector<const jay::Buffer *> *buffers() const {
     return GetPointer<const flatbuffers::Vector<const jay::Buffer *> *>(VT_BUFFERS);
   }
@@ -638,6 +642,7 @@ struct Column FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
            VerifyStats(verifier, stats(), stats_type()) &&
            VerifyOffset(verifier, VT_TYPE) &&
            verifier.VerifyTable(type()) &&
+           VerifyField<uint64_t>(verifier, VT_NROWS) &&
            VerifyOffset(verifier, VT_BUFFERS) &&
            verifier.VerifyVector(buffers()) &&
            VerifyOffset(verifier, VT_CHILDREN) &&
@@ -703,6 +708,9 @@ struct ColumnBuilder {
   void add_type(flatbuffers::Offset<jay::Type> type) {
     fbb_.AddOffset(Column::VT_TYPE, type);
   }
+  void add_nrows(uint64_t nrows) {
+    fbb_.AddElement<uint64_t>(Column::VT_NROWS, nrows, 0);
+  }
   void add_buffers(flatbuffers::Offset<flatbuffers::Vector<const jay::Buffer *>> buffers) {
     fbb_.AddOffset(Column::VT_BUFFERS, buffers);
   }
@@ -731,9 +739,11 @@ inline flatbuffers::Offset<Column> CreateColumn(
     jay::Stats stats_type = jay::Stats_NONE,
     flatbuffers::Offset<void> stats = 0,
     flatbuffers::Offset<jay::Type> type = 0,
+    uint64_t nrows = 0,
     flatbuffers::Offset<flatbuffers::Vector<const jay::Buffer *>> buffers = 0,
     flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<jay::Column>>> children = 0) {
   ColumnBuilder builder_(_fbb);
+  builder_.add_nrows(nrows);
   builder_.add_nullcount(nullcount);
   builder_.add_children(children);
   builder_.add_buffers(buffers);
@@ -757,6 +767,7 @@ inline flatbuffers::Offset<Column> CreateColumnDirect(
     jay::Stats stats_type = jay::Stats_NONE,
     flatbuffers::Offset<void> stats = 0,
     flatbuffers::Offset<jay::Type> type = 0,
+    uint64_t nrows = 0,
     const std::vector<jay::Buffer> *buffers = nullptr,
     const std::vector<flatbuffers::Offset<jay::Column>> *children = nullptr) {
   auto name__ = name ? _fbb.CreateString(name) : 0;
@@ -772,6 +783,7 @@ inline flatbuffers::Offset<Column> CreateColumnDirect(
       stats_type,
       stats,
       type,
+      nrows,
       buffers__,
       children__);
 }

--- a/src/core/jay/jay_nowarnings.h
+++ b/src/core/jay/jay_nowarnings.h
@@ -24,6 +24,7 @@
 DISABLE_CLANG_WARNING("-Wzero-as-null-pointer-constant")
 DISABLE_CLANG_WARNING("-Wcovered-switch-default")
 DISABLE_CLANG_WARNING("-Wpadded")
+#define FLATBUFFERS_ASSERT xassert
 
 #include "jay/jay_generated.h"
 

--- a/src/core/jay/open_jay.cc
+++ b/src/core/jay/open_jay.cc
@@ -170,22 +170,22 @@ static void initStats(Stats* stats, const jay::Column* jcol) {
 static Column column_from_jay(
     size_t nrows, const jay::Column* jcol, const Buffer& jaybuf)
 {
-  jay::Type jtype = jcol->type();
+  jay::SType jtype = jcol->stype();
 
   auto stype = dt::SType::INVALID;
   switch (jtype) {
-    case jay::Type_Bool8:   stype = dt::SType::BOOL; break;
-    case jay::Type_Int8:    stype = dt::SType::INT8; break;
-    case jay::Type_Int16:   stype = dt::SType::INT16; break;
-    case jay::Type_Int32:   stype = dt::SType::INT32; break;
-    case jay::Type_Int64:   stype = dt::SType::INT64; break;
-    case jay::Type_Float32: stype = dt::SType::FLOAT32; break;
-    case jay::Type_Float64: stype = dt::SType::FLOAT64; break;
-    case jay::Type_Str32:   stype = dt::SType::STR32; break;
-    case jay::Type_Str64:   stype = dt::SType::STR64; break;
-    case jay::Type_Date32:  stype = dt::SType::DATE32; break;
-    case jay::Type_Time64:  stype = dt::SType::TIME64; break;
-    case jay::Type_Void0:   stype = dt::SType::VOID; break;
+    case jay::SType_Bool8:   stype = dt::SType::BOOL; break;
+    case jay::SType_Int8:    stype = dt::SType::INT8; break;
+    case jay::SType_Int16:   stype = dt::SType::INT16; break;
+    case jay::SType_Int32:   stype = dt::SType::INT32; break;
+    case jay::SType_Int64:   stype = dt::SType::INT64; break;
+    case jay::SType_Float32: stype = dt::SType::FLOAT32; break;
+    case jay::SType_Float64: stype = dt::SType::FLOAT64; break;
+    case jay::SType_Str32:   stype = dt::SType::STR32; break;
+    case jay::SType_Str64:   stype = dt::SType::STR64; break;
+    case jay::SType_Date32:  stype = dt::SType::DATE32; break;
+    case jay::SType_Time64:  stype = dt::SType::TIME64; break;
+    case jay::SType_Void0:   stype = dt::SType::VOID; break;
   }
 
   Column col;
@@ -204,15 +204,15 @@ static Column column_from_jay(
 
   Stats* stats = col.stats();
   switch (jtype) {
-    case jay::Type_Bool8:   initStats<int8_t,  jay::StatsBool>(stats, jcol); break;
-    case jay::Type_Int8:    initStats<int8_t,  jay::StatsInt8>(stats, jcol); break;
-    case jay::Type_Int16:   initStats<int16_t, jay::StatsInt16>(stats, jcol); break;
-    case jay::Type_Date32:
-    case jay::Type_Int32:   initStats<int32_t, jay::StatsInt32>(stats, jcol); break;
-    case jay::Type_Time64:
-    case jay::Type_Int64:   initStats<int64_t, jay::StatsInt64>(stats, jcol); break;
-    case jay::Type_Float32: initStats<float,   jay::StatsFloat32>(stats, jcol); break;
-    case jay::Type_Float64: initStats<double,  jay::StatsFloat64>(stats, jcol); break;
+    case jay::SType_Bool8:   initStats<int8_t,  jay::StatsBool>(stats, jcol); break;
+    case jay::SType_Int8:    initStats<int8_t,  jay::StatsInt8>(stats, jcol); break;
+    case jay::SType_Int16:   initStats<int16_t, jay::StatsInt16>(stats, jcol); break;
+    case jay::SType_Date32:
+    case jay::SType_Int32:   initStats<int32_t, jay::StatsInt32>(stats, jcol); break;
+    case jay::SType_Time64:
+    case jay::SType_Int64:   initStats<int64_t, jay::StatsInt64>(stats, jcol); break;
+    case jay::SType_Float32: initStats<float,   jay::StatsFloat32>(stats, jcol); break;
+    case jay::SType_Float64: initStats<double,  jay::StatsFloat64>(stats, jcol); break;
     default: break;
   }
 

--- a/src/core/jay/open_jay.cc
+++ b/src/core/jay/open_jay.cc
@@ -280,7 +280,7 @@ static Column column_from_jay2(const jay::Column* jcol, const Buffer& jaybuf) {
 
   Column col;
   if (coltype.is_string()) {
-    xassert((*jbuffers).size() == 3);
+    xassert(buffers.size() == 3);
     if (has_validity && coltype.stype() == dt::SType::STR32) {
       col = Column(new dt::ArrowStr_ColumnImpl<uint32_t>(
         nrows, coltype.stype(), std::move(buffers[0]), std::move(buffers[1]), std::move(buffers[2])
@@ -296,8 +296,8 @@ static Column column_from_jay2(const jay::Column* jcol, const Buffer& jaybuf) {
     }
   }
   else if (coltype.is_array()) {
-    xassert(jbuffers->size() == 2);
-    xassert(jchildren->size() == 1);
+    xassert(buffers.size() == 2);
+    xassert(children.size() == 1);
     if (coltype.stype() == dt::SType::ARR32) {
       col = Column(new dt::ArrowArray_ColumnImpl<uint32_t>(
                 nrows, nullcount,
@@ -312,8 +312,8 @@ static Column column_from_jay2(const jay::Column* jcol, const Buffer& jaybuf) {
   }
   else {
     xassert(!has_validity);
-    xassert(jbuffers->size() == 2);
-    xassert(jchildren->size() == 0);
+    xassert(buffers.size() == 2);
+    xassert(children.size() == 0);
     col = Column::new_mbuf_column(nrows, coltype.stype(), std::move(buffers[1]));
   }
 

--- a/src/core/jay/open_jay.cc
+++ b/src/core/jay/open_jay.cc
@@ -21,10 +21,11 @@
 //------------------------------------------------------------------------------
 #include <string>
 #include <cstring>              // std::memcmp
-#include "frame/py_frame.h"
-#include "jay/jay_nowarnings.h"
 #include "datatable.h"
 #include "datatablemodule.h"
+#include "frame/py_frame.h"
+#include "jay/jay_nowarnings.h"
+#include "python/xargs.h"
 #include "stype.h"
 
 
@@ -226,13 +227,7 @@ static Column column_from_jay(
 //------------------------------------------------------------------------------
 namespace py {
 
-static PKArgs args_open_jay(
-  1, 0, 0, false, false, {"file"}, "open_jay",
-  "open_jay(file)\n--\n\n"
-  "Open a Frame from the provided .jay file.\n");
-
-
-static oobj open_jay(const PKArgs& args)
+static oobj open_jay(const XArgs& args)
 {
   if (args[0].is_bytes()) {
     // TODO: create & use class obytes
@@ -254,9 +249,15 @@ static oobj open_jay(const PKArgs& args)
   }
 }
 
+DECLARE_PYFN(&open_jay)
+    ->name("open_jay")
+    ->n_positional_args(1)
+    ->n_required_args(1)
+    ->arg_names({"file"})
+    ->docs("open_jay(file)\n--\n\n"
+           "Open a Frame from the provided .jay file.\n");
 
-void DatatableModule::init_methods_jay() {
-  ADD_FN(&open_jay, args_open_jay);
-}
+
+
 
 } // namespace py

--- a/src/core/jay/save_jay.cc
+++ b/src/core/jay/save_jay.cc
@@ -37,7 +37,7 @@
 #include "writebuf.h"
 
 using WritableBufferPtr = std::unique_ptr<WritableBuffer>;
-static jay::Type stype_to_jaytype[dt::STYPES_COUNT];
+static jay::SType stype_to_jaytype[dt::STYPES_COUNT];
 static jay::Buffer saveMemoryRange(const void*, size_t, WritableBuffer*);
 template <typename T, typename StatBuilder>
 static flatbuffers::Offset<void> saveStats(
@@ -162,7 +162,7 @@ flatbuffers::Offset<jay::Column> Column::write_to_jay(
   auto sname = fbb.CreateString(name.c_str());
 
   jay::ColumnBuilder cbb(fbb);
-  cbb.add_type(stype_to_jaytype[static_cast<int>(stype())]);
+  cbb.add_stype(stype_to_jaytype[static_cast<int>(stype())]);
   cbb.add_name(sname);
   cbb.add_nullcount(na_count());
   write_data_to_jay(cbb, wb);
@@ -263,7 +263,7 @@ void dt::Rbound_ColumnImpl::_write_str_offsets_to_jay(
         nrows_ > Column::MAX_ARR32_SIZE) {
       // [FIXME]
       // stype_ = SType::STR64;
-      cbb.add_type(stype_to_jaytype[static_cast<int>(SType::STR64)]);
+      cbb.add_stype(stype_to_jaytype[static_cast<int>(SType::STR64)]);
     }
   }
 
@@ -450,18 +450,18 @@ void Frame::_init_jay(XTypeMaker& xt) {
   args_to_jay.add_synonym_arg("_strategy", "method");
   xt.add(METHOD(&Frame::to_jay, args_to_jay));
 
-  stype_to_jaytype[int(dt::SType::BOOL)]    = jay::Type_Bool8;
-  stype_to_jaytype[int(dt::SType::INT8)]    = jay::Type_Int8;
-  stype_to_jaytype[int(dt::SType::INT16)]   = jay::Type_Int16;
-  stype_to_jaytype[int(dt::SType::INT32)]   = jay::Type_Int32;
-  stype_to_jaytype[int(dt::SType::INT64)]   = jay::Type_Int64;
-  stype_to_jaytype[int(dt::SType::FLOAT32)] = jay::Type_Float32;
-  stype_to_jaytype[int(dt::SType::FLOAT64)] = jay::Type_Float64;
-  stype_to_jaytype[int(dt::SType::DATE32)]  = jay::Type_Date32;
-  stype_to_jaytype[int(dt::SType::TIME64)]  = jay::Type_Time64;
-  stype_to_jaytype[int(dt::SType::STR32)]   = jay::Type_Str32;
-  stype_to_jaytype[int(dt::SType::STR64)]   = jay::Type_Str64;
-  stype_to_jaytype[int(dt::SType::VOID)]    = jay::Type_Void0;
+  stype_to_jaytype[int(dt::SType::BOOL)]    = jay::SType_Bool8;
+  stype_to_jaytype[int(dt::SType::INT8)]    = jay::SType_Int8;
+  stype_to_jaytype[int(dt::SType::INT16)]   = jay::SType_Int16;
+  stype_to_jaytype[int(dt::SType::INT32)]   = jay::SType_Int32;
+  stype_to_jaytype[int(dt::SType::INT64)]   = jay::SType_Int64;
+  stype_to_jaytype[int(dt::SType::FLOAT32)] = jay::SType_Float32;
+  stype_to_jaytype[int(dt::SType::FLOAT64)] = jay::SType_Float64;
+  stype_to_jaytype[int(dt::SType::DATE32)]  = jay::SType_Date32;
+  stype_to_jaytype[int(dt::SType::TIME64)]  = jay::SType_Time64;
+  stype_to_jaytype[int(dt::SType::STR32)]   = jay::SType_Str32;
+  stype_to_jaytype[int(dt::SType::STR64)]   = jay::SType_Str64;
+  stype_to_jaytype[int(dt::SType::VOID)]    = jay::SType_Void0;
 }
 
 

--- a/src/core/types/type.cc
+++ b/src/core/types/type.cc
@@ -142,6 +142,10 @@ Type Type::common(const Type& type1, const Type& type2) {
   return Type(std::move(res));
 }
 
+Type Type::child() const {
+  return impl_? impl_->child_type() : Type();
+}
+
 
 bool Type::is_array()    const { return impl_ && impl_->is_array(); }
 bool Type::is_boolean()  const { return impl_ && impl_->is_boolean(); }

--- a/src/core/types/type.h
+++ b/src/core/types/type.h
@@ -104,6 +104,8 @@ class Type {
     operator bool() const;
     std::string to_string() const;
 
+    Type child() const;
+
     // (Optionally) change the current type so that it becomes
     // compatible with the type `other`. This can be used, for
     // example, when two columns of different types are passed to a

--- a/src/core/types/type_array.cc
+++ b/src/core/types/type_array.cc
@@ -77,6 +77,11 @@ size_t Type_Arr32::hash() const noexcept {
 }
 
 
+Type Type_Arr32::child_type() const {
+  return elementType_;
+}
+
+
 
 
 //------------------------------------------------------------------------------
@@ -122,6 +127,11 @@ bool Type_Arr64::equals(const TypeImpl* other) const {
 
 size_t Type_Arr64::hash() const noexcept {
   return static_cast<size_t>(stype()) + STYPES_COUNT * elementType_.hash();
+}
+
+
+Type Type_Arr64::child_type() const {
+  return elementType_;
 }
 
 

--- a/src/core/types/type_array.h
+++ b/src/core/types/type_array.h
@@ -39,6 +39,7 @@ class Type_Arr32 : public TypeImpl {
     bool equals(const TypeImpl* other) const override;
     size_t hash() const noexcept override;
     TypeImpl* common_type(TypeImpl* other) override;
+    Type child_type() const override;
 };
 
 
@@ -56,6 +57,7 @@ class Type_Arr64 : public TypeImpl {
     bool equals(const TypeImpl* other) const override;
     size_t hash() const noexcept override;
     TypeImpl* common_type(TypeImpl* other) override;
+    Type child_type() const override;
 };
 
 

--- a/src/core/types/typeimpl.cc
+++ b/src/core/types/typeimpl.cc
@@ -80,6 +80,7 @@ py::oobj TypeImpl::min() const { return py::None(); }
 py::oobj TypeImpl::max() const { return py::None(); }
 const char* TypeImpl::struct_format() const { return ""; }
 
+Type TypeImpl::child_type() const { return Type(); }
 
 Column TypeImpl::cast_column(Column&&) const {
   throw NotImplError()

--- a/src/core/types/typeimpl.h
+++ b/src/core/types/typeimpl.h
@@ -45,6 +45,7 @@ class TypeImpl {
     virtual py::oobj max() const;
     virtual const char* struct_format() const;
     virtual TypeImpl* common_type(TypeImpl* other) = 0;
+    virtual Type child_type() const;
 
     virtual bool is_array() const;
     virtual bool is_boolean() const;

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,15 +1,31 @@
 #!/usr/bin/env python
-# © H2O.ai 2018; -*- encoding: utf-8 -*-
-#   This Source Code Form is subject to the terms of the Mozilla Public
-#   License, v. 2.0. If a copy of the MPL was not distributed with this
-#   file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -*- coding: utf-8 -*-
+#-------------------------------------------------------------------------------
+# Copyright 2018-2021 H2O.ai
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
 #-------------------------------------------------------------------------------
 import math
 import os
 import platform
 import pytest
 import random
-import sys
 from math import isnan
 from datatable.lib import core
 from datatable.internal import frame_columns_virtual, frame_integrity_check
@@ -96,43 +112,37 @@ def assert_equals(frame1, frame2, rel_tol = 1e-7, abs_tol = None):
         "The left frame has shape %r, while the right has shape %r"
         % (frame1.shape, frame2.shape))
 
-    if sys.version_info >= (3, 6):
-        assert frame1.names == frame2.names, (
-            "The left frame has names %r, while the right has names %r"
-            % (frame1.names, frame2.names))
-        assert frame1.stypes == frame2.stypes, (
-            "The left frame has stypes %r, while the right has stypes %r"
-            % (frame1.stypes, frame2.stypes))
-        data1 = frame1.to_list()
-        data2 = frame2.to_list()
-        assert len(data1) == len(data2)  # shape check should ensure this
-        for i in range(len(data1)):
-            col1 = data1[i]
-            col2 = data2[i]
-            assert len(col1) == len(col2)
-            for j in range(len(col1)):
-                val1 = col1[j]
-                val2 = col2[j]
-                if val1 == val2: continue
-                if isinstance(val1, float) and isinstance(val2, float):
-                    if math.isclose(val1, val2, rel_tol = rel_tol, abs_tol = abs_tol): continue
-                if len(col1) > 16:
-                    arr1 = repr(col1[:16])[:-1] + ", ...]"
-                    arr2 = repr(col2[:16])[:-1] + ", ...]"
-                else:
-                    arr1 = repr(col1)
-                    arr2 = repr(col2)
-                raise AssertionError(
-                    "The frames have different data in column %d `%s` at "
-                    "index %d: LHS has %r, and RHS has %r\n"
-                    "  LHS = %s\n"
-                    "  RHS = %s\n"
-                    % (i, frame1.names[i], j, val1, val2, arr1, arr2))
-    else:
-        assert frame1.shape == frame2.shape
-        assert list_equals(frame1.names, frame2.names)
-        assert list_equals(frame1.stypes, frame2.stypes)
-        assert list_equals(frame1.to_list(), frame2.to_list(), rel_tol, abs_tol)
+    assert frame1.names == frame2.names, (
+        "The left frame has names %r, while the right has names %r"
+        % (frame1.names, frame2.names))
+    assert frame1.types == frame2.types, (
+        "The left frame has types %r, while the right has types %r"
+        % (frame1.types, frame2.types))
+    data1 = frame1.to_list()
+    data2 = frame2.to_list()
+    assert len(data1) == len(data2)  # shape check should ensure this
+    for i in range(len(data1)):
+        col1 = data1[i]
+        col2 = data2[i]
+        assert len(col1) == len(col2)
+        for j in range(len(col1)):
+            val1 = col1[j]
+            val2 = col2[j]
+            if val1 == val2: continue
+            if isinstance(val1, float) and isinstance(val2, float):
+                if math.isclose(val1, val2, rel_tol = rel_tol, abs_tol = abs_tol): continue
+            if len(col1) > 16:
+                arr1 = repr(col1[:16])[:-1] + ", ...]"
+                arr2 = repr(col2[:16])[:-1] + ", ...]"
+            else:
+                arr1 = repr(col1)
+                arr2 = repr(col2)
+            raise AssertionError(
+                "The frames have different data in column %d `%s` at "
+                "index %d: LHS has %r, and RHS has %r\n"
+                "  LHS = %s\n"
+                "  RHS = %s\n"
+                % (i, frame1.names[i], j, val1, val2, arr1, arr2))
 
 
 

--- a/tests/test-jay.py
+++ b/tests/test-jay.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #-------------------------------------------------------------------------------
-# Copyright 2018-2020 H2O.ai
+# Copyright 2018-2021 H2O.ai
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -37,6 +37,14 @@ from tests import assert_equals, noop, isview
 #-------------------------------------------------------------------------------
 # Jay format
 #-------------------------------------------------------------------------------
+
+def test_jay_simplest():
+    DT = dt.Frame(A=range(5))
+    out = DT.to_jay()
+    assert isinstance(out, bytes)
+    RES = dt.fread(out)
+    assert_equals(RES, DT)
+
 
 def test_jay_simple(tempfile_jay):
     dt0 = dt.Frame({"A": [-1, 7, 10000, 12],
@@ -125,10 +133,9 @@ def test_jay_object_columns(tempfile_jay):
     src2 = [(2, 3), (5, 6, 7), 9, {"A": 3}] / dt.obj64
     d0 = dt.Frame(A=src1, B=src2)
     assert d0.stypes == (dt.int32, dt.obj64)
-    with pytest.warns(DatatableWarning) as ws:
+    msg = "Column B of type obj64 cannot be saved to Jay"
+    with pytest.warns(DatatableWarning, match=msg) as ws:
         d0.to_jay(tempfile_jay)
-    assert len(ws) == 1
-    assert "Column `B` of type obj64 was not saved" in ws[0].message.args[0]
     d1 = dt.fread(tempfile_jay)
     frame_integrity_check(d1)
     assert d1.names == ("A",)

--- a/tests/types/test-array.py
+++ b/tests/types/test-array.py
@@ -248,3 +248,11 @@ def test_arr32_of_strings_repr():
         " 2 | [r, w, dfvdf]\n"
         "[3 rows x 1 column]\n"
     )
+
+
+def test_arr32_to_jay():
+    DT = dt.Frame(W=[['ad', 'dfkvjn'], ['b b, f', None], ['r', 'w', 'dfvdf']])
+    assert DT.type == dt.Type.arr32(dt.Type.str32)
+    out = DT.to_jay()
+    RES = DT.fread(out)
+    assert_equals(RES, DT)

--- a/tests/types/test-array.py
+++ b/tests/types/test-array.py
@@ -254,5 +254,5 @@ def test_arr32_to_jay():
     DT = dt.Frame(W=[['ad', 'dfkvjn'], ['b b, f', None], ['r', 'w', 'dfvdf']])
     assert DT.type == dt.Type.arr32(dt.Type.str32)
     out = DT.to_jay()
-    RES = DT.fread(out)
+    RES = dt.fread(out)
     assert_equals(RES, DT)


### PR DESCRIPTION
The purpose of this PR is to be able to store array-typed columns into Jay format and then read them back. Multiple changes were necessary in order to implement this feature:

- the Jay format was significantly expanded: now we support storing an arbitrary `Type` within a jay file (previously only stypes were allowed). This is done in a backward-compatible way by introducing several new fields and deprecating old fields. Removing those deprecated fields will break backwards compatibility, and can only be done by upgrading the JAY format version to 2. This could be done sometime in the future (at least once the new format is sufficiently stabilized).

- the method for writing into Jay was made more flexible, centered around the new `ColumnJayData` class. This class is needed primarily due to the limitations of the flatbuffers interface: while a Table is being written into the output stream, no other Table can be written into the same stream. Since Column structures use multiple levels of nesting, it means the innermost tables must be written out into the stream first, and then referred back when writing their container tables. The `ColumnJayData` class handles all this complexity.

- Classes derived from `ColumnImpl` now have more flexibility in how they handle saving to Jay. In particular, all arrow-based columns now have native procedures for saving to jay.

Closes #3116 
Closes #3138