### PR TITLE
Add categorical types `cat8`, `cat16` and `cat32`

### DIFF
--- a/docs/api/type.rst
+++ b/docs/api/type.rst
@@ -25,6 +25,9 @@
     - :meth:`dt.Type.arr64(T)`
     - :attr:`dt.Type.bool8`
     - :attr:`dt.Type.date32`
+    - :meth:`dt.Type.cat8(T)`
+    - :meth:`dt.Type.cat16(T)`
+    - :meth:`dt.Type.cat32(T)`
     - :attr:`dt.Type.float32`
     - :attr:`dt.Type.float64`
     - :attr:`dt.Type.int16`
@@ -52,6 +55,9 @@
 
         * - :attr:`.is_compound`
           - Is this a compound type?
+
+        * - :attr:`.is_categorical`
+          - Is this a categorical type?
 
         * - :attr:`.is_float`
           - Is this a float type?
@@ -87,31 +93,35 @@
 .. toctree::
     :hidden:
 
-    ⭑ arr32(T)    <type/arr32>
-    ⭑ arr64(T)    <type/arr64>
-    ⭑ bool8       <type/bool8>
-    ⭑ date32      <type/date32>
-    ⭑ float32     <type/float32>
-    ⭑ float64     <type/float64>
-    ⭑ int8        <type/int8>
-    ⭑ int16       <type/int16>
-    ⭑ int32       <type/int32>
-    ⭑ int64       <type/int64>
-    ⭑ obj64       <type/obj64>
-    ⭑ str32       <type/str32>
-    ⭑ str64       <type/str64>
-    ⭑ time64      <type/time64>
-    ⭑ void        <type/void>
-    is_array      <type/is_array>
-    is_boolean    <type/is_boolean>
-    is_compound   <type/is_compound>
-    is_float      <type/is_float>
-    is_integer    <type/is_integer>
-    is_numeric    <type/is_numeric>
-    is_object     <type/is_object>
-    is_string     <type/is_string>
-    is_temporal   <type/is_temporal>
-    is_void       <type/is_void>
-    max           <type/max>
-    min           <type/min>
-    name          <type/name>
+    ⭑ arr32(T)     <type/arr32>
+    ⭑ arr64(T)     <type/arr64>
+    ⭑ bool8        <type/bool8>
+    ⭑ cat8(T)      <type/cat8>
+    ⭑ cat16(T)     <type/cat16>
+    ⭑ cat32(T)     <type/cat32>
+    ⭑ date32       <type/date32>
+    ⭑ float32      <type/float32>
+    ⭑ float64      <type/float64>
+    ⭑ int8         <type/int8>
+    ⭑ int16        <type/int16>
+    ⭑ int32        <type/int32>
+    ⭑ int64        <type/int64>
+    ⭑ obj64        <type/obj64>
+    ⭑ str32        <type/str32>
+    ⭑ str64        <type/str64>
+    ⭑ time64       <type/time64>
+    ⭑ void         <type/void>
+    is_array       <type/is_array>
+    is_boolean     <type/is_boolean>
+    is_categorical <type/is_categorical>
+    is_compound    <type/is_compound>
+    is_float       <type/is_float>
+    is_integer     <type/is_integer>
+    is_numeric     <type/is_numeric>
+    is_object      <type/is_object>
+    is_string      <type/is_string>
+    is_temporal    <type/is_temporal>
+    is_void        <type/is_void>
+    max            <type/max>
+    min            <type/min>
+    name           <type/name>

--- a/docs/api/type/cat16.rst
+++ b/docs/api/type/cat16.rst
@@ -1,0 +1,16 @@
+
+.. xmethod:: datatable.Type.cat16
+    :src: src/core/types/py_type.cc PyType::categorical
+    :cvar: doc_Type_cat16
+    :signature: cat16(T)
+
+    .. x-version-added:: 1.1.0
+
+    Categorical type with 16-bit codes. In a column of this type, every element
+    is a value of type `T`.
+
+
+    See Also
+    --------
+    :meth:`.cat8(T)` -- another categorical type, but with 8-bit codes.
+    :meth:`.cat32(T)` -- another categorical type, but with 32-bit codes.

--- a/docs/api/type/cat32.rst
+++ b/docs/api/type/cat32.rst
@@ -1,0 +1,16 @@
+
+.. xmethod:: datatable.Type.cat32
+    :src: src/core/types/py_type.cc PyType::categorical
+    :cvar: doc_Type_cat32
+    :signature: cat32(T)
+
+    .. x-version-added:: 1.1.0
+
+    Categorical type with 32-bit codes. In a column of this type, every element
+    is a value of type `T`.
+
+
+    See Also
+    --------
+    :meth:`.cat8(T)` -- another categorical type, but with 8-bit codes.
+    :meth:`.cat16(T)` -- another categorical type, but with 16-bit codes.

--- a/docs/api/type/cat8.rst
+++ b/docs/api/type/cat8.rst
@@ -1,0 +1,16 @@
+
+.. xmethod:: datatable.Type.cat8
+    :src: src/core/types/py_type.cc PyType::categorical
+    :cvar: doc_Type_cat8
+    :signature: cat8(T)
+
+    .. x-version-added:: 1.1.0
+
+    Categorical type with 8-bit codes. In a column of this type, every element
+    is a value of type `T`.
+
+
+    See Also
+    --------
+    :meth:`.cat16(T)` -- another categorical type, but with 16-bit codes.
+    :meth:`.cat32(T)` -- another categorical type, but with 32-bit codes.

--- a/docs/api/type/is_array.rst
+++ b/docs/api/type/is_array.rst
@@ -6,8 +6,8 @@
     .. x-version-added:: 1.1.0
 
     Test whether this type belongs to the category of "array" types. This
-    property returns ``True`` for :meth:`arr32\<T\> <dt.Type.arr32>` and
-    :meth:`arr64\<T\> <dt.Type.arr64>` types only.
+    property returns ``True`` for :meth:`arr32(T) <dt.Type.arr32>` and
+    :meth:`arr64(T) <dt.Type.arr64>` types only.
 
 
     Parameters
@@ -20,6 +20,6 @@
     >>> dt.Type.arr32(int).is_array
     True
     >>> dt.Type.arr64("float32").is_array
-    False
+    True
     >>> dt.Type.void.is_array
     False

--- a/docs/api/type/is_categorical.rst
+++ b/docs/api/type/is_categorical.rst
@@ -1,0 +1,25 @@
+
+.. xattr:: datatable.Type.is_categorical
+    :src: src/core/types/py_type.cc is_categorical
+    :cvar: doc_Type_is_categorical
+
+    .. x-version-added:: 1.1.0
+
+    Test whether this type is a categorical one. This
+    property returns ``True`` for :meth:`cat8(T) <dt.Type.cat8>`,
+    :meth:`cat16(T) <dt.Type.cat16>` and :meth:`cat32(T) <dt.Type.cat32>` types only.
+
+
+    Parameters
+    ----------
+    return: bool
+
+
+    Examples
+    --------
+    >>> dt.Type.cat8(int).is_categorical
+    True
+    >>> dt.Type.cat32(dt.Type.str64).is_categorical
+    True
+    >>> dt.Type.void.is_categorical
+    False

--- a/src/core/documentation.h
+++ b/src/core/documentation.h
@@ -300,8 +300,13 @@ extern const char* doc_Namespace;
 extern const char* doc_Type;
 extern const char* doc_Type_arr32;
 extern const char* doc_Type_arr64;
+extern const char* doc_Type_cat8;
+extern const char* doc_Type_cat16;
+extern const char* doc_Type_cat32;
+
 extern const char* doc_Type_is_array;
 extern const char* doc_Type_is_boolean;
+extern const char* doc_Type_is_categorical;
 extern const char* doc_Type_is_compound;
 extern const char* doc_Type_is_float;
 extern const char* doc_Type_is_integer;
@@ -310,6 +315,7 @@ extern const char* doc_Type_is_object;
 extern const char* doc_Type_is_string;
 extern const char* doc_Type_is_temporal;
 extern const char* doc_Type_is_void;
+
 extern const char* doc_Type_max;
 extern const char* doc_Type_min;
 extern const char* doc_Type_name;

--- a/src/core/stype.h
+++ b/src/core/stype.h
@@ -54,9 +54,11 @@ enum class SType : uint8_t {
   DATE32  = 17,
   TIME64  = 18,
   OBJ     = 21,
-
-  AUTO    = 22,
-  INVALID = 23,
+  CAT8    = 22,
+  CAT16   = 23,
+  CAT32   = 24,
+  AUTO    = 30,
+  INVALID = 31,
 };
 
 constexpr size_t STYPES_COUNT = static_cast<size_t>(SType::INVALID);

--- a/src/core/types/py_type.cc
+++ b/src/core/types/py_type.cc
@@ -324,27 +324,29 @@ py::oobj PyType::get_max() const {
 // .is_*() properties
 //------------------------------------------------------------------------------
 
-static py::GSArgs args_is_array   ("is_array",    doc_Type_is_array);
-static py::GSArgs args_is_boolean ("is_boolean",  doc_Type_is_boolean);
-static py::GSArgs args_is_compound("is_compound", doc_Type_is_compound);
-static py::GSArgs args_is_float   ("is_float",    doc_Type_is_float);
-static py::GSArgs args_is_integer ("is_integer",  doc_Type_is_integer);
-static py::GSArgs args_is_numeric ("is_numeric",  doc_Type_is_numeric);
-static py::GSArgs args_is_object  ("is_object",   doc_Type_is_object);
-static py::GSArgs args_is_string  ("is_string",   doc_Type_is_string);
-static py::GSArgs args_is_temporal("is_temporal", doc_Type_is_temporal);
-static py::GSArgs args_is_void    ("is_void",     doc_Type_is_void);
+static py::GSArgs args_is_array      ("is_array",       doc_Type_is_array);
+static py::GSArgs args_is_boolean    ("is_boolean",     doc_Type_is_boolean);
+static py::GSArgs args_is_categorical("is_categorical", doc_Type_is_categorical);
+static py::GSArgs args_is_compound   ("is_compound",    doc_Type_is_compound);
+static py::GSArgs args_is_float      ("is_float",       doc_Type_is_float);
+static py::GSArgs args_is_integer    ("is_integer",     doc_Type_is_integer);
+static py::GSArgs args_is_numeric    ("is_numeric",     doc_Type_is_numeric);
+static py::GSArgs args_is_object     ("is_object",      doc_Type_is_object);
+static py::GSArgs args_is_string     ("is_string",      doc_Type_is_string);
+static py::GSArgs args_is_temporal   ("is_temporal",    doc_Type_is_temporal);
+static py::GSArgs args_is_void       ("is_void",        doc_Type_is_void);
 
-py::oobj PyType::is_array() const    { return py::obool(type_.is_array()); }
-py::oobj PyType::is_boolean() const  { return py::obool(type_.is_boolean()); }
-py::oobj PyType::is_compound() const { return py::obool(type_.is_compound()); }
-py::oobj PyType::is_float() const    { return py::obool(type_.is_float()); }
-py::oobj PyType::is_integer() const  { return py::obool(type_.is_integer()); }
-py::oobj PyType::is_numeric() const  { return py::obool(type_.is_numeric()); }
-py::oobj PyType::is_object() const   { return py::obool(type_.is_object()); }
-py::oobj PyType::is_string() const   { return py::obool(type_.is_string()); }
-py::oobj PyType::is_temporal() const { return py::obool(type_.is_temporal()); }
-py::oobj PyType::is_void() const     { return py::obool(type_.is_void()); }
+py::oobj PyType::is_array() const       { return py::obool(type_.is_array()); }
+py::oobj PyType::is_boolean() const     { return py::obool(type_.is_boolean()); }
+py::oobj PyType::is_categorical() const { return py::obool(type_.is_categorical()); }
+py::oobj PyType::is_compound() const    { return py::obool(type_.is_compound()); }
+py::oobj PyType::is_float() const       { return py::obool(type_.is_float()); }
+py::oobj PyType::is_integer() const     { return py::obool(type_.is_integer()); }
+py::oobj PyType::is_numeric() const     { return py::obool(type_.is_numeric()); }
+py::oobj PyType::is_object() const      { return py::obool(type_.is_object()); }
+py::oobj PyType::is_string() const      { return py::obool(type_.is_string()); }
+py::oobj PyType::is_temporal() const    { return py::obool(type_.is_temporal()); }
+py::oobj PyType::is_void() const        { return py::obool(type_.is_void()); }
 
 
 
@@ -352,6 +354,8 @@ py::oobj PyType::is_void() const     { return py::obool(type_.is_void()); }
 //------------------------------------------------------------------------------
 // Types as methods
 //------------------------------------------------------------------------------
+
+// Array
 
 py::oobj PyType::array(const py::XArgs& args) {
   Type argT = args[0].is_none()? Type::void0()
@@ -379,7 +383,51 @@ DECLARE_METHOD(&PyType::array)
     ->add_info(64);
 
 
+// Categorical
 
+py::oobj PyType::categorical(const py::XArgs& args) {
+  Type argT = args[0].is_none()? Type::void0()
+                               : args[0].to_type_force();
+
+  int info = args.get_info();
+  Type t;
+  switch (info) {
+    case 8 : t = Type::cat8(argT); break;
+    case 16 : t = Type::cat16(argT); break;
+    case 32 : t = Type::cat32(argT); break;
+    default : throw RuntimeError() << "Unknown categorical info: " << info;
+  }
+
+  return PyType::make(t);
+
+}
+
+DECLARE_METHOD(&PyType::categorical)
+    ->name("cat8")
+    ->docs(dt::doc_Type_cat8)
+    ->n_positional_args(1)
+    ->n_required_args(1)
+    ->arg_names({"T"})
+    ->staticmethod()
+    ->add_info(8);
+
+DECLARE_METHOD(&PyType::categorical)
+    ->name("cat16")
+    ->docs(dt::doc_Type_cat16)
+    ->n_positional_args(1)
+    ->n_required_args(1)
+    ->arg_names({"T"})
+    ->staticmethod()
+    ->add_info(16);
+
+DECLARE_METHOD(&PyType::categorical)
+    ->name("cat32")
+    ->docs(dt::doc_Type_cat32)
+    ->n_positional_args(1)
+    ->n_required_args(1)
+    ->arg_names({"T"})
+    ->staticmethod()
+    ->add_info(32);
 
 
 //------------------------------------------------------------------------------
@@ -395,18 +443,19 @@ void PyType::impl_init_type(py::XTypeMaker& xt) {
   xt.add(METHOD__CMP__(&PyType::m__compare__));
   xt.add(METHOD__HASH__(&PyType::m__hash__));
   xt.add(GETTER(&PyType::get_name, args_get_name));
-  xt.add(GETTER(&PyType::get_min, args_get_min));
-  xt.add(GETTER(&PyType::get_max, args_get_max));
-  xt.add(GETTER(&PyType::is_array,    args_is_array));
-  xt.add(GETTER(&PyType::is_boolean,  args_is_boolean));
-  xt.add(GETTER(&PyType::is_compound, args_is_compound));
-  xt.add(GETTER(&PyType::is_float,    args_is_float));
-  xt.add(GETTER(&PyType::is_integer,  args_is_integer));
-  xt.add(GETTER(&PyType::is_numeric,  args_is_numeric));
-  xt.add(GETTER(&PyType::is_object,   args_is_object));
-  xt.add(GETTER(&PyType::is_string,   args_is_string));
-  xt.add(GETTER(&PyType::is_temporal, args_is_temporal));
-  xt.add(GETTER(&PyType::is_void,     args_is_void));
+  xt.add(GETTER(&PyType::get_min,  args_get_min));
+  xt.add(GETTER(&PyType::get_max,  args_get_max));
+  xt.add(GETTER(&PyType::is_array,       args_is_array));
+  xt.add(GETTER(&PyType::is_boolean,     args_is_boolean));
+  xt.add(GETTER(&PyType::is_categorical, args_is_categorical));
+  xt.add(GETTER(&PyType::is_compound,    args_is_compound));
+  xt.add(GETTER(&PyType::is_float,       args_is_float));
+  xt.add(GETTER(&PyType::is_integer,     args_is_integer));
+  xt.add(GETTER(&PyType::is_numeric,     args_is_numeric));
+  xt.add(GETTER(&PyType::is_object,      args_is_object));
+  xt.add(GETTER(&PyType::is_string,      args_is_string));
+  xt.add(GETTER(&PyType::is_temporal,    args_is_temporal));
+  xt.add(GETTER(&PyType::is_void,        args_is_void));
   INIT_METHODS_FOR_CLASS(PyType);
 
   pythonType = xt.get_type_object();

--- a/src/core/types/py_type.h
+++ b/src/core/types/py_type.h
@@ -53,11 +53,13 @@ class PyType : public py::XObject<PyType, true> {
     size_t m__hash__() const;
 
     py::oobj array(const py::XArgs&);
+    py::oobj categorical(const py::XArgs&);
     py::oobj get_max() const;
     py::oobj get_min() const;
     py::oobj get_name() const;
     py::oobj is_array() const;
     py::oobj is_boolean() const;
+    py::oobj is_categorical() const;
     py::oobj is_compound() const;
     py::oobj is_float() const;
     py::oobj is_integer() const;

--- a/src/core/types/type.cc
+++ b/src/core/types/type.cc
@@ -25,6 +25,7 @@
 #include "types/type.h"
 #include "types/type_array.h"
 #include "types/type_bool.h"
+#include "types/type_categorical.h"
 #include "types/type_date.h"
 #include "types/type_float.h"
 #include "types/type_int.h"
@@ -74,21 +75,24 @@ Type::~Type() {
 
 
 
-Type Type::bool8()   { return Type(new Type_Bool8); }
-Type Type::date32()  { return Type(new Type_Date32); }
-Type Type::float32() { return Type(new Type_Float32); }
-Type Type::float64() { return Type(new Type_Float64); }
-Type Type::int16()   { return Type(new Type_Int16); }
-Type Type::int32()   { return Type(new Type_Int32); }
-Type Type::int64()   { return Type(new Type_Int64); }
-Type Type::int8()    { return Type(new Type_Int8); }
 Type Type::arr32(Type t) { return Type(new Type_Arr32(t)); }
 Type Type::arr64(Type t) { return Type(new Type_Arr64(t)); }
-Type Type::obj64()   { return Type(new Type_Object); }
-Type Type::str32()   { return Type(new Type_String32); }
-Type Type::str64()   { return Type(new Type_String64); }
-Type Type::time64()  { return Type(new Type_Time64); }
-Type Type::void0()   { return Type(new Type_Void); }
+Type Type::bool8()       { return Type(new Type_Bool8); }
+Type Type::cat8(Type t)  { return Type(new Type_Cat8(t)); }
+Type Type::cat16(Type t) { return Type(new Type_Cat16(t)); }
+Type Type::cat32(Type t) { return Type(new Type_Cat32(t)); }
+Type Type::date32()      { return Type(new Type_Date32); }
+Type Type::float32()     { return Type(new Type_Float32); }
+Type Type::float64()     { return Type(new Type_Float64); }
+Type Type::int16()       { return Type(new Type_Int16); }
+Type Type::int32()       { return Type(new Type_Int32); }
+Type Type::int64()       { return Type(new Type_Int64); }
+Type Type::int8()        { return Type(new Type_Int8); }
+Type Type::obj64()       { return Type(new Type_Object); }
+Type Type::str32()       { return Type(new Type_String32); }
+Type Type::str64()       { return Type(new Type_String64); }
+Type Type::time64()      { return Type(new Type_Time64); }
+Type Type::void0()       { return Type(new Type_Void); }
 
 Type Type::from_stype(SType stype) {
   switch (stype) {
@@ -143,17 +147,18 @@ Type Type::common(const Type& type1, const Type& type2) {
 }
 
 
-bool Type::is_array()    const { return impl_ && impl_->is_array(); }
-bool Type::is_boolean()  const { return impl_ && impl_->is_boolean(); }
-bool Type::is_compound() const { return impl_ && impl_->is_compound(); }
-bool Type::is_float()    const { return impl_ && impl_->is_float(); }
-bool Type::is_integer()  const { return impl_ && impl_->is_integer(); }
-bool Type::is_invalid()  const { return impl_ && impl_->is_invalid(); }
-bool Type::is_numeric()  const { return impl_ && impl_->is_numeric(); }
-bool Type::is_object()   const { return impl_ && impl_->is_object(); }
-bool Type::is_string()   const { return impl_ && impl_->is_string(); }
-bool Type::is_temporal() const { return impl_ && impl_->is_temporal(); }
-bool Type::is_void()     const { return impl_ && impl_->is_void(); }
+bool Type::is_array()           const { return impl_ && impl_->is_array(); }
+bool Type::is_boolean()         const { return impl_ && impl_->is_boolean(); }
+bool Type::is_categorical()     const { return impl_ && impl_->is_categorical(); }
+bool Type::is_compound()        const { return impl_ && impl_->is_compound(); }
+bool Type::is_float()           const { return impl_ && impl_->is_float(); }
+bool Type::is_integer()         const { return impl_ && impl_->is_integer(); }
+bool Type::is_invalid()         const { return impl_ && impl_->is_invalid(); }
+bool Type::is_numeric()         const { return impl_ && impl_->is_numeric(); }
+bool Type::is_object()          const { return impl_ && impl_->is_object(); }
+bool Type::is_string()          const { return impl_ && impl_->is_string(); }
+bool Type::is_temporal()        const { return impl_ && impl_->is_temporal(); }
+bool Type::is_void()            const { return impl_ && impl_->is_void(); }
 bool Type::is_integer_or_void() const { return impl_ && (impl_->is_integer() || impl_->is_void()); }
 bool Type::is_numeric_or_void() const { return impl_ && (impl_->is_numeric() || impl_->is_void()); }
 

--- a/src/core/types/type.h
+++ b/src/core/types/type.h
@@ -55,7 +55,12 @@ class Type {
     Type& operator=(Type&& other);
     ~Type();
 
+    static Type arr32(Type);
+    static Type arr64(Type);
     static Type bool8();
+    static Type cat8(Type);
+    static Type cat16(Type);
+    static Type cat32(Type);
     static Type date32();
     static Type float32();
     static Type float64();
@@ -63,8 +68,6 @@ class Type {
     static Type int32();
     static Type int64();
     static Type int8();
-    static Type arr32(Type);
-    static Type arr64(Type);
     static Type obj64();
     static Type str32();
     static Type str64();
@@ -85,6 +88,7 @@ class Type {
     SType stype() const;
     bool is_array() const;
     bool is_boolean() const;
+    bool is_categorical() const;
     bool is_compound() const;
     bool is_float() const;
     bool is_integer() const;
@@ -132,6 +136,7 @@ template<> bool Type::can_be_read_as<float>() const;
 template<> bool Type::can_be_read_as<double>() const;
 template<> bool Type::can_be_read_as<CString>() const;
 template<> bool Type::can_be_read_as<py::oobj>() const;
+template<> bool Type::can_be_read_as<Column>() const;
 
 
 

--- a/src/core/types/type_categorical.cc
+++ b/src/core/types/type_categorical.cc
@@ -1,0 +1,145 @@
+//------------------------------------------------------------------------------
+// Copyright 2021 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#include "stype.h"
+#include "types/type_invalid.h"
+#include "types/type_categorical.h"
+#include "utils/assert.h"
+namespace dt {
+
+
+//------------------------------------------------------------------------------
+// Type_Cat
+//------------------------------------------------------------------------------
+
+Type_Cat::Type_Cat(SType st, Type t) : TypeImpl(st) {
+  if (t.is_categorical()) {
+    throw TypeError()
+      << "Categories are not allowed to be of a categorical type";
+  }
+  elementType_ = std::move(t);
+}
+
+bool Type_Cat::is_compound() const {
+  return true;
+}
+
+bool Type_Cat::is_categorical() const {
+  return true;
+}
+
+bool Type_Cat::can_be_read_as_int8() const {
+  return elementType_.can_be_read_as<int8_t>();
+}
+
+bool Type_Cat::can_be_read_as_int16() const {
+  return elementType_.can_be_read_as<int16_t>();
+}
+
+bool Type_Cat::can_be_read_as_int32() const {
+  return elementType_.can_be_read_as<int32_t>();
+}
+
+bool Type_Cat::can_be_read_as_int64() const {
+  return elementType_.can_be_read_as<int64_t>();
+}
+
+bool Type_Cat::can_be_read_as_float32() const {
+  return elementType_.can_be_read_as<float>();
+}
+
+bool Type_Cat::can_be_read_as_float64() const {
+  return elementType_.can_be_read_as<double>();
+}
+
+bool Type_Cat::can_be_read_as_cstring() const {
+  return elementType_.can_be_read_as<CString>();
+}
+
+bool Type_Cat::can_be_read_as_pyobject() const {
+  return elementType_.can_be_read_as<py::oobj>();
+}
+
+bool Type_Cat::can_be_read_as_column() const {
+  return elementType_.can_be_read_as<Column>();
+}
+
+
+TypeImpl* Type_Cat::common_type(TypeImpl* other) {
+  if (other->is_categorical() &&
+      elementType_ == reinterpret_cast<const Type_Cat*>(other)->elementType_)
+  {
+    return other->stype() > stype() ? other : this;
+  }
+  if (other->is_void()) {
+    return this;
+  }
+  if (other->is_object() || other->is_invalid()) {
+    return other;
+  }
+  return new Type_Invalid();
+}
+
+
+bool Type_Cat::equals(const TypeImpl* other) const {
+  return other->stype() == stype() &&
+         elementType_ == reinterpret_cast<const Type_Cat*>(other)->elementType_;
+}
+
+
+size_t Type_Cat::hash() const noexcept {
+  return static_cast<size_t>(stype()) + STYPES_COUNT * elementType_.hash();
+}
+
+
+//------------------------------------------------------------------------------
+// Type_Cat8
+//------------------------------------------------------------------------------
+
+Type_Cat8::Type_Cat8(Type t) : Type_Cat(SType::CAT8, t) {}
+
+std::string Type_Cat8::to_string() const {
+  return "cat8(" + elementType_.to_string() + ")";
+}
+
+
+//------------------------------------------------------------------------------
+// Type_Cat16
+//------------------------------------------------------------------------------
+
+Type_Cat16::Type_Cat16(Type t) : Type_Cat(SType::CAT16, t) {}
+
+std::string Type_Cat16::to_string() const {
+  return "cat16(" + elementType_.to_string() + ")";
+}
+
+//------------------------------------------------------------------------------
+// Type_Cat32
+//------------------------------------------------------------------------------
+
+Type_Cat32::Type_Cat32(Type t) : Type_Cat(SType::CAT32, std::move(t)) {}
+
+std::string Type_Cat32::to_string() const {
+  return "cat32(" + elementType_.to_string() + ")";
+}
+
+
+}  // namespace dt

--- a/src/core/types/type_categorical.h
+++ b/src/core/types/type_categorical.h
@@ -1,0 +1,75 @@
+//------------------------------------------------------------------------------
+// Copyright 2021 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#ifndef dt_TYPES_TYPE_CATEGORICAL_h
+#define dt_TYPES_TYPE_CATEGORICAL_h
+#include "types/typeimpl.h"
+namespace dt {
+
+
+class Type_Cat : public TypeImpl {
+  protected:
+    Type elementType_;
+
+  public:
+    Type_Cat(SType, Type);
+    bool is_categorical() const override;
+    bool is_compound() const override;
+
+    bool can_be_read_as_int8() const override;
+    bool can_be_read_as_int16() const override;
+    bool can_be_read_as_int32() const override;
+    bool can_be_read_as_int64() const override;
+    bool can_be_read_as_float32() const override;
+    bool can_be_read_as_float64() const override;
+    bool can_be_read_as_cstring() const override;
+    bool can_be_read_as_pyobject() const override;
+    bool can_be_read_as_column() const override;
+
+    bool equals(const TypeImpl* other) const override;
+    size_t hash() const noexcept override;
+    TypeImpl* common_type(TypeImpl* other) override;
+};
+
+
+class Type_Cat8 : public Type_Cat {
+  public:
+    Type_Cat8(Type t);
+    std::string to_string() const override;
+};
+
+
+class Type_Cat16 : public Type_Cat {
+  public:
+    Type_Cat16(Type t);
+    std::string to_string() const override;
+};
+
+
+class Type_Cat32 : public Type_Cat {
+  public:
+    Type_Cat32(Type t);
+    std::string to_string() const override;
+};
+
+
+}  // namespace dt
+#endif

--- a/src/core/types/type_void.cc
+++ b/src/core/types/type_void.cc
@@ -38,7 +38,6 @@ bool Type_Void::can_be_read_as_int32() const   { return true; }
 bool Type_Void::can_be_read_as_int64() const   { return true; }
 bool Type_Void::can_be_read_as_float32() const { return true; }
 bool Type_Void::can_be_read_as_float64() const { return true; }
-bool Type_Void::can_be_read_as_date() const    { return true; }
 bool Type_Void::can_be_read_as_cstring() const { return true; }
 
 

--- a/src/core/types/type_void.h
+++ b/src/core/types/type_void.h
@@ -37,7 +37,6 @@ class Type_Void : public TypeImpl {
     bool can_be_read_as_int64() const override;
     bool can_be_read_as_float32() const override;
     bool can_be_read_as_float64() const override;
-    bool can_be_read_as_date() const override;
     bool can_be_read_as_cstring() const override;
 
     std::string to_string() const override;

--- a/src/core/types/typeimpl.cc
+++ b/src/core/types/typeimpl.cc
@@ -47,17 +47,18 @@ size_t TypeImpl::hash() const noexcept {
   return static_cast<size_t>(stype_);
 }
 
-bool TypeImpl::is_array()    const { return false; }
-bool TypeImpl::is_boolean()  const { return false; }
-bool TypeImpl::is_compound() const { return false; }
-bool TypeImpl::is_float()    const { return false; }
-bool TypeImpl::is_integer()  const { return false; }
-bool TypeImpl::is_invalid()  const { return false; }
-bool TypeImpl::is_numeric()  const { return false; }
-bool TypeImpl::is_object()   const { return false; }
-bool TypeImpl::is_string()   const { return false; }
-bool TypeImpl::is_temporal() const { return false; }
-bool TypeImpl::is_void()     const { return false; }
+bool TypeImpl::is_array()       const { return false; }
+bool TypeImpl::is_boolean()     const { return false; }
+bool TypeImpl::is_categorical() const { return false; }
+bool TypeImpl::is_compound()    const { return false; }
+bool TypeImpl::is_float()       const { return false; }
+bool TypeImpl::is_integer()     const { return false; }
+bool TypeImpl::is_invalid()     const { return false; }
+bool TypeImpl::is_numeric()     const { return false; }
+bool TypeImpl::is_object()      const { return false; }
+bool TypeImpl::is_string()      const { return false; }
+bool TypeImpl::is_temporal()    const { return false; }
+bool TypeImpl::is_void()        const { return false; }
 
 
 bool TypeImpl::can_be_read_as_int8()     const { return false; }
@@ -66,7 +67,6 @@ bool TypeImpl::can_be_read_as_int32()    const { return false; }
 bool TypeImpl::can_be_read_as_int64()    const { return false; }
 bool TypeImpl::can_be_read_as_float32()  const { return false; }
 bool TypeImpl::can_be_read_as_float64()  const { return false; }
-bool TypeImpl::can_be_read_as_date()     const { return false; }
 bool TypeImpl::can_be_read_as_cstring()  const { return false; }
 bool TypeImpl::can_be_read_as_pyobject() const { return false; }
 bool TypeImpl::can_be_read_as_column()   const { return false; }

--- a/src/core/types/typeimpl.h
+++ b/src/core/types/typeimpl.h
@@ -48,6 +48,7 @@ class TypeImpl {
 
     virtual bool is_array() const;
     virtual bool is_boolean() const;
+    virtual bool is_categorical() const;
     virtual bool is_compound() const;
     virtual bool is_float() const;
     virtual bool is_integer() const;
@@ -64,7 +65,6 @@ class TypeImpl {
     virtual bool can_be_read_as_int64() const;
     virtual bool can_be_read_as_float32() const;
     virtual bool can_be_read_as_float64() const;
-    virtual bool can_be_read_as_date() const;
     virtual bool can_be_read_as_cstring() const;
     virtual bool can_be_read_as_pyobject() const;
     virtual bool can_be_read_as_column() const;

--- a/tests/types/test-array.py
+++ b/tests/types/test-array.py
@@ -84,7 +84,7 @@ def test_type_array_hashable():
 
 
 @pytest.mark.parametrize('src', [0, 1])
-def test_query_methods(src):
+def test_type_array_query_methods(src):
     tarr = dt.Type.arr32(int) if src else \
            dt.Type.arr64(str)
     assert     tarr.is_array

--- a/tests/types/test-categorical.py
+++ b/tests/types/test-categorical.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#-------------------------------------------------------------------------------
+# Copyright 2021 H2O.ai
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#-------------------------------------------------------------------------------
+import pytest
+import random
+from datatable import dt, f
+from tests import assert_equals
+
+
+#-------------------------------------------------------------------------------
+# Type object
+#-------------------------------------------------------------------------------
+
+def test_type_categorical_wrong():
+    msg = r"Categories are not allowed to be of a categorical type"
+    with pytest.raises(TypeError, match=msg):
+        dt.Type.cat8(dt.Type.cat32(dt.str64))
+
+def test_type_categorical_repr():
+    assert repr(dt.Type.cat8(int)) == "Type.cat8(int64)"
+    assert repr(dt.Type.cat16(dt.float32)) == "Type.cat16(float32)"
+    assert repr(dt.Type.cat32(str)) == "Type.cat32(str32)"
+
+
+def test_type_categorical_name():
+    assert dt.Type.cat8(int).name == "cat8(int64)"
+    assert dt.Type.cat16(dt.int8).name == "cat16(int8)"
+    assert dt.Type.cat32(None).name == "cat32(void)"
+
+
+@pytest.mark.parametrize('t', [dt.Type.cat8(int),
+                               dt.Type.cat16(str),
+                               dt.Type.cat32(float)])
+def test_type_categorical_properties(t):
+    assert t.min is None
+    assert t.max is None
+
+
+def test_type_categorical_equality():
+    t1 = dt.Type.cat8(int)
+    t2 = dt.Type.cat32(int)
+    assert t1 != t2
+    assert t1 == dt.Type.cat8(dt.int64)
+    assert t1 != dt.Type.cat8(dt.int32)
+    assert t1 != dt.Type.cat8(dt.Type.void)
+    assert t1 != dt.Type.int64
+    assert t2 == dt.Type.cat32(int)
+    assert t2 != dt.Type.cat8(int)
+    assert t2 != dt.Type.cat32(str)
+    assert dt.Type.cat8(int) != \
+           dt.Type.cat8(float)
+
+
+def test_type_categorical_hashable():
+    store = {dt.Type.cat8(str): 1, dt.Type.cat32('float32'): 2,
+             dt.Type.cat16(str): 3}
+    assert dt.Type.cat8(str) in store
+    assert dt.Type.cat32(dt.float32) in store
+    assert dt.Type.cat16(str) in store
+    assert store[dt.Type.cat8("str")] == 1
+    assert store[dt.Type.cat32('float32')] == 2
+    assert store[dt.Type.cat16(str)] == 3
+    assert dt.Type.cat8(int) not in store
+    assert dt.Type.cat32(int) not in store
+    assert dt.Type.cat32(float) not in store
+
+
+@pytest.mark.parametrize('t', [dt.Type.cat8(int),
+                               dt.Type.cat16(str),
+                               dt.Type.cat32(float)])
+def test_type_categorical_query_methods(t):
+    assert     t.is_categorical
+    assert not t.is_boolean
+    assert     t.is_compound
+    assert not t.is_float
+    assert not t.is_integer
+    assert not t.is_numeric
+    assert not t.is_object
+    assert not t.is_string
+    assert not t.is_temporal
+    assert not t.is_void
+

--- a/tests/types/test-categorical.py
+++ b/tests/types/test-categorical.py
@@ -31,10 +31,14 @@ from tests import assert_equals
 # Type object
 #-------------------------------------------------------------------------------
 
-def test_type_categorical_wrong():
+@pytest.mark.parametrize('t', [dt.Type.cat8,
+                               dt.Type.cat16,
+                               dt.Type.cat32])
+def test_type_categorical_wrong(t):
     msg = r"Categories are not allowed to be of a categorical type"
     with pytest.raises(TypeError, match=msg):
-        dt.Type.cat8(dt.Type.cat32(dt.str64))
+        t(t(dt.str64))
+
 
 def test_type_categorical_repr():
     assert repr(dt.Type.cat8(int)) == "Type.cat8(int64)"


### PR DESCRIPTION
For the moment, these types are not used anywhere, but we need them in order to implement the `Categorical_ColumnImpl`. This PR also includes minor corrections for array types.

WIP for #1691 