### PR TITLE
Allow other columns to be cast into array type

### DIFF
--- a/src/core/column.cc
+++ b/src/core/column.cc
@@ -40,6 +40,11 @@ Column Column::new_data_column(size_t nrows, dt::SType stype) {
 }
 
 
+Column Column::new_na_column(size_t nrows, dt::Type type) {
+  return Column(new dt::ConstNa_ColumnImpl(nrows, type));
+}
+
+
 Column Column::new_na_column(size_t nrows, dt::SType stype) {
   return Column(new dt::ConstNa_ColumnImpl(nrows, stype));
 }

--- a/src/core/column.cc
+++ b/src/core/column.cc
@@ -200,6 +200,13 @@ size_t Column::memory_footprint() const noexcept {
   return sizeof(Column) + (impl_? impl_->memory_footprint() : 0);
 }
 
+size_t Column::n_children() const noexcept {
+  return impl_? impl_->n_children() : 0;
+}
+
+const Column& Column::child(size_t i) const {
+  return impl_->child(i);
+}
 
 
 //------------------------------------------------------------------------------

--- a/src/core/column.h
+++ b/src/core/column.h
@@ -94,6 +94,7 @@ class Column
     ~Column();
 
     static Column new_data_column(size_t nrows, dt::SType);
+    static Column new_na_column(size_t nrows, dt::Type type);
     static Column new_na_column(size_t nrows, dt::SType stype);
     static Column new_mbuf_column(size_t nrows, dt::SType, Buffer&&);
     static Column new_string_column(size_t n, Buffer&& data, Buffer&& str);

--- a/src/core/column.h
+++ b/src/core/column.h
@@ -199,6 +199,8 @@ class Column
     void*       get_data_editable(size_t k = 0);
     Buffer      get_data_buffer(size_t k = 0) const;
 
+    size_t n_children() const noexcept;
+    const Column& child(size_t i) const;
 
   //------------------------------------
   // Stats
@@ -280,6 +282,9 @@ class Column
     // See frame/to_arrow.cc
     std::unique_ptr<dt::OArrowArray> to_arrow() const;
     std::unique_ptr<dt::OArrowSchema> to_arrow_schema() const;
+
+    // "Materialize" the column into arrow format
+    Column as_arrow() const;
 
     // A shortcut for `.type().can_be_read_as<T>()`. The latter call
     // is not compatible with some compilers, for instance Clang 11.

--- a/src/core/column.h
+++ b/src/core/column.h
@@ -284,6 +284,7 @@ class Column
     std::unique_ptr<dt::OArrowSchema> to_arrow_schema() const;
 
     // "Materialize" the column into arrow format
+    bool is_arrow() const;
     Column as_arrow() const;
 
     // A shortcut for `.type().can_be_read_as<T>()`. The latter call

--- a/src/core/column/arrow.h
+++ b/src/core/column/arrow.h
@@ -39,8 +39,8 @@ class Arrow_ColumnImpl : public Virtual_ColumnImpl {
       return Column(std::move(self));
     }
 
-    virtual size_t num_buffers() const noexcept = 0;
-    virtual Buffer get_buffer(size_t i) const = 0;
+    // virtual size_t get_num_data_buffers() const noexcept = 0;
+    // virtual Buffer get_data_buffer(size_t i) const = 0;
 
     void save_to_jay(ColumnJayData&) override;
 };

--- a/src/core/column/arrow_array.cc
+++ b/src/core/column/arrow_array.cc
@@ -67,13 +67,13 @@ const Column& ArrowArray_ColumnImpl<T>::child(size_t) const {
 
 
 template <typename T>
-size_t ArrowArray_ColumnImpl<T>::num_buffers() const noexcept {
+size_t ArrowArray_ColumnImpl<T>::get_num_data_buffers() const noexcept {
   return 2;
 }
 
 
 template <typename T>
-Buffer ArrowArray_ColumnImpl<T>::get_buffer(size_t i) const {
+Buffer ArrowArray_ColumnImpl<T>::get_data_buffer(size_t i) const {
   xassert(i <= 1);
   return (i == 0)? validity_ : offsets_;
 }

--- a/src/core/column/arrow_bool.cc
+++ b/src/core/column/arrow_bool.cc
@@ -44,11 +44,11 @@ ColumnImpl* ArrowBool_ColumnImpl::clone() const {
 }
 
 
-size_t ArrowBool_ColumnImpl::num_buffers() const noexcept {
+size_t ArrowBool_ColumnImpl::get_num_data_buffers() const noexcept {
   return 2;
 }
 
-Buffer ArrowBool_ColumnImpl::get_buffer(size_t i) const {
+Buffer ArrowBool_ColumnImpl::get_data_buffer(size_t i) const {
   return (i == 0)? validity_ : data_;
 }
 

--- a/src/core/column/arrow_bool.h
+++ b/src/core/column/arrow_bool.h
@@ -38,8 +38,8 @@ class ArrowBool_ColumnImpl : public Arrow_ColumnImpl {
 
     ColumnImpl* clone() const override;
     // void materialize(Column&, bool) override;
-    size_t num_buffers() const noexcept override;
-    Buffer get_buffer(size_t i) const override;
+    size_t get_num_data_buffers() const noexcept override;
+    Buffer get_data_buffer(size_t i) const override;
 
     bool get_element(size_t, int8_t*)  const override;
 };

--- a/src/core/column/arrow_fw.cc
+++ b/src/core/column/arrow_fw.cc
@@ -43,11 +43,11 @@ ColumnImpl* ArrowFw_ColumnImpl::clone() const {
 }
 
 
-size_t ArrowFw_ColumnImpl::num_buffers() const noexcept {
+size_t ArrowFw_ColumnImpl::get_num_data_buffers() const noexcept {
   return 2;
 }
 
-Buffer ArrowFw_ColumnImpl::get_buffer(size_t i) const {
+Buffer ArrowFw_ColumnImpl::get_data_buffer(size_t i) const {
   return (i == 0)? validity_ : data_;
 }
 

--- a/src/core/column/arrow_fw.h
+++ b/src/core/column/arrow_fw.h
@@ -47,8 +47,8 @@ class ArrowFw_ColumnImpl : public Arrow_ColumnImpl {
     bool get_element(size_t, float*)   const override;
     bool get_element(size_t, double*)  const override;
 
-    size_t num_buffers() const noexcept override;
-    Buffer get_buffer(size_t i) const override;
+    size_t get_num_data_buffers() const noexcept override;
+    Buffer get_data_buffer(size_t i) const override;
 
   private:
     template <typename T> inline bool _get(size_t, T*) const;

--- a/src/core/column/arrow_str.cc
+++ b/src/core/column/arrow_str.cc
@@ -48,12 +48,12 @@ ColumnImpl* ArrowStr_ColumnImpl<T>::clone() const {
 }
 
 template <typename T>
-size_t ArrowStr_ColumnImpl<T>::num_buffers() const noexcept {
+size_t ArrowStr_ColumnImpl<T>::get_num_data_buffers() const noexcept {
   return 3;
 }
 
 template <typename T>
-Buffer ArrowStr_ColumnImpl<T>::get_buffer(size_t i) const {
+Buffer ArrowStr_ColumnImpl<T>::get_data_buffer(size_t i) const {
   xassert(i < 3);
   return (i == 0)? validity_ : (i == 1)? offsets_ : strdata_;
 }

--- a/src/core/column/arrow_str.h
+++ b/src/core/column/arrow_str.h
@@ -41,8 +41,8 @@ class ArrowStr_ColumnImpl : public Arrow_ColumnImpl {
 
     ColumnImpl* clone() const override;
     // void materialize(Column&, bool) override;
-    size_t num_buffers() const noexcept override;
-    Buffer get_buffer(size_t i) const override;
+    size_t get_num_data_buffers() const noexcept override;
+    Buffer get_data_buffer(size_t i) const override;
 
     bool get_element(size_t, CString*) const override;
 };

--- a/src/core/column/arrow_void.cc
+++ b/src/core/column/arrow_void.cc
@@ -34,11 +34,11 @@ ColumnImpl* ArrowVoid_ColumnImpl::clone() const {
 }
 
 
-size_t ArrowVoid_ColumnImpl::num_buffers() const noexcept {
+size_t ArrowVoid_ColumnImpl::get_num_data_buffers() const noexcept {
   return 1;
 }
 
-Buffer ArrowVoid_ColumnImpl::get_buffer(size_t) const {
+Buffer ArrowVoid_ColumnImpl::get_data_buffer(size_t) const {
   return validity_;
 }
 

--- a/src/core/column/arrow_void.h
+++ b/src/core/column/arrow_void.h
@@ -34,8 +34,8 @@ class ArrowVoid_ColumnImpl : public Arrow_ColumnImpl {
 
     ColumnImpl* clone() const override;
 
-    size_t num_buffers() const noexcept override;
-    Buffer get_buffer(size_t) const override;
+    size_t get_num_data_buffers() const noexcept override;
+    Buffer get_data_buffer(size_t) const override;
     bool get_element(size_t, int8_t*) const override;
 };
 

--- a/src/core/column/cast.cc
+++ b/src/core/column/cast.cc
@@ -29,6 +29,11 @@ Cast_ColumnImpl::Cast_ColumnImpl(SType new_stype, Column&& col)
     arg_(std::move(col)) {}
 
 
+Cast_ColumnImpl::Cast_ColumnImpl(Type new_type, Column&& col)
+  : Virtual_ColumnImpl(col.nrows(), new_type),
+    arg_(std::move(col)) {}
+
+
 size_t Cast_ColumnImpl::n_children() const noexcept {
   return 1;
 }

--- a/src/core/column/cast.h
+++ b/src/core/column/cast.h
@@ -317,6 +317,17 @@ class CastArrayToArray_ColumnImpl : public Cast_ColumnImpl {
 };
 
 
+class CastObjectToArray_ColumnImpl : public Cast_ColumnImpl {
+  private:
+    Type childType_;
+
+  public:
+    CastObjectToArray_ColumnImpl(Column&&, Type targetType);
+    ColumnImpl* clone() const override;
+    bool get_element(size_t, Column*) const override;
+};
+
+
 
 
 }  // namespace dt

--- a/src/core/column/cast.h
+++ b/src/core/column/cast.h
@@ -35,6 +35,7 @@ class Cast_ColumnImpl : public Virtual_ColumnImpl {
 
   public:
     Cast_ColumnImpl(SType new_stype, Column&& col);
+    Cast_ColumnImpl(Type new_type, Column&& col);
 
     size_t n_children() const noexcept override;
     const Column& child(size_t) const override;
@@ -293,6 +294,26 @@ class CastTime64ToObj64_ColumnImpl : public Cast_ColumnImpl {
     CastTime64ToObj64_ColumnImpl(Column&&);
     ColumnImpl* clone() const override;
     bool get_element(size_t, py::oobj*) const override;
+};
+
+
+
+
+//------------------------------------------------------------------------------
+// Array -> Any casts
+//------------------------------------------------------------------------------
+
+/**
+  * This class is responsible for casting `arr<T>` into `arr<S>`.
+  */
+class CastArrayToArray_ColumnImpl : public Cast_ColumnImpl {
+  private:
+    Type childType_;
+
+  public:
+    CastArrayToArray_ColumnImpl(Column&&, Type targetType);
+    ColumnImpl* clone() const override;
+    bool get_element(size_t, Column*) const override;
 };
 
 

--- a/src/core/column/const.h
+++ b/src/core/column/const.h
@@ -49,6 +49,7 @@ class Const_ColumnImpl : public Virtual_ColumnImpl {
   */
 class ConstNa_ColumnImpl : public Const_ColumnImpl {
   public:
+    ConstNa_ColumnImpl(size_t nrows, Type type);
     ConstNa_ColumnImpl(size_t nrows, SType stype = SType::VOID);
 
     bool get_element(size_t, int8_t*)   const override;

--- a/src/core/column/const_na.cc
+++ b/src/core/column/const_na.cc
@@ -28,6 +28,9 @@ namespace dt {
 
 
 
+ConstNa_ColumnImpl::ConstNa_ColumnImpl(size_t nrows, Type type)
+  : Const_ColumnImpl(nrows, type) {}
+
 ConstNa_ColumnImpl::ConstNa_ColumnImpl(size_t nrows, SType stype)
   : Const_ColumnImpl(nrows, stype) {}
 

--- a/src/core/frame/to_arrow.cc
+++ b/src/core/frame/to_arrow.cc
@@ -98,7 +98,7 @@ std::unique_ptr<dt::OArrowArray> Column::to_arrow() const {
   auto arrow_impl = dynamic_cast<const dt::Arrow_ColumnImpl*>(data->column().impl_);
   xassert(arrow_impl);
   size_t na_count = arrow_impl->stats()->nacount();
-  size_t n_buffers = arrow_impl->num_buffers();
+  size_t n_buffers = arrow_impl->get_num_data_buffers();
   size_t n_children = arrow_impl->n_children();
   xassert(n_children == 0);
 
@@ -111,7 +111,7 @@ std::unique_ptr<dt::OArrowArray> Column::to_arrow() const {
   if (n_buffers) {
     data->buffers().reserve(n_buffers);
     for (size_t i = 0; i < n_buffers; ++i) {
-      const void* buffer_ptr = arrow_impl->get_buffer(i).rptr();
+      const void* buffer_ptr = arrow_impl->get_data_buffer(i).rptr();
       data->buffers().push_back( buffer_ptr );
     }
     (*aarr)->buffers = data->buffers().data();
@@ -156,6 +156,9 @@ std::unique_ptr<dt::OArrowSchema> Column::to_arrow_schema() const {
   return osch;
 }
 
+bool Column::is_arrow() const {
+  return dynamic_cast<const dt::Arrow_ColumnImpl*>(impl_) != nullptr;
+}
 
 Column Column::as_arrow() const {
   return impl_->as_arrow();

--- a/src/core/frame/to_arrow.cc
+++ b/src/core/frame/to_arrow.cc
@@ -157,6 +157,11 @@ std::unique_ptr<dt::OArrowSchema> Column::to_arrow_schema() const {
 }
 
 
+Column Column::as_arrow() const {
+  return impl_->as_arrow();
+}
+
+
 static void _clear_validity_buffer(size_t n, size_t* data) {
   dt::parallel_for_static(n, [=](size_t i){ data[i] = 0; });
 }

--- a/src/core/jay/save_jay.cc
+++ b/src/core/jay/save_jay.cc
@@ -267,10 +267,10 @@ void dt::Arrow_ColumnImpl::save_to_jay(ColumnJayData& cj) {
   auto wb = cj.get_output_buffer();
   cj.store_stats();
   cj.store_type();
-  if (num_buffers()) {
+  if (get_num_data_buffers()) {
     std::vector<jay::Buffer> buffer_vec;
-    for (size_t i = 0; i < num_buffers(); i++) {
-      auto buf = get_buffer(i);
+    for (size_t i = 0; i < get_num_data_buffers(); i++) {
+      auto buf = get_data_buffer(i);
       buffer_vec.push_back(
         saveMemoryRange(buf.rptr(), buf.size(), wb)
       );

--- a/src/core/types/type.h
+++ b/src/core/types/type.h
@@ -126,6 +126,7 @@ class Type {
     Column cast_column(Column&& column) const;
 
   private:
+    friend class TypeImpl;
     Type(TypeImpl*&&) noexcept;
 };
 

--- a/src/core/types/type_array.cc
+++ b/src/core/types/type_array.cc
@@ -113,7 +113,7 @@ Column Type_Array::cast_column(Column&& col) const {
   const auto st = stype();
   switch (col.stype()) {
     case SType::VOID:
-      return Column::new_na_column(col.nrows(), st);
+      return Column::new_na_column(col.nrows(), make_type());
 
     // case SType::STR32:
     // case SType::STR64:

--- a/src/core/types/type_array.cc
+++ b/src/core/types/type_array.cc
@@ -50,8 +50,27 @@ bool Type_Array::can_be_read_as_column() const {
 
 
 TypeImpl* Type_Array::common_type(TypeImpl* other) {
+  if (equals(other)) {
+    return this;
+  }
   if (other->is_array()) {
-    return other->stype() > stype() ? other : this;
+    auto stype0 = stype();
+    auto stype1 = other->stype();
+    auto stypeR = stype0 > stype1 ? stype0 : stype1;
+    auto child0 = child_type();
+    auto child1 = other->child_type();
+    auto childR = Type::common(child0, child1);
+    if (stypeR == stype0 && childR == child0) {
+      return this;
+    }
+    if (stypeR == stype1 && childR == child1) {
+      return other;
+    }
+    if (!childR.is_invalid()) {
+      if (stypeR == SType::ARR32) return new Type_Arr32(childR);
+      if (stypeR == SType::ARR64) return new Type_Arr64(childR);
+    }
+    // otherwise fall-through and return an invalid type
   }
   if (other->is_void()) {
     return this;

--- a/src/core/types/type_array.cc
+++ b/src/core/types/type_array.cc
@@ -101,9 +101,14 @@ Type Type_Array::child_type() const {
 }
 
 
-// Cast column `col` into an array type. This should support all
-// target types.
-//
+/**
+  * Cast column `col` into this array type.
+  *
+  * The following type casts are supported:
+  *   * void    -> arr?<S>
+  *   * arr?<T> -> arr?<S>
+  *   * obj64   -> arr?<S>
+  */
 Column Type_Array::cast_column(Column&& col) const {
   const auto st = stype();
   switch (col.stype()) {
@@ -140,10 +145,11 @@ Column Type_Array::cast_column(Column&& col) const {
         }
       }
       return Column(
-          new CastArrayToArray_ColumnImpl(std::move(col), childType_));
+          new CastArrayToArray_ColumnImpl(std::move(col), make_type()));
     }
     case SType::OBJ:
-      // return Column(new CastObject_ColumnImpl(st, std::move(col)));
+      return Column(
+          new CastObjectToArray_ColumnImpl(std::move(col), make_type()));
 
     default:
       throw NotImplError() << "Unable to cast column of type `" << col.type()

--- a/src/core/types/type_array.cc
+++ b/src/core/types/type_array.cc
@@ -28,32 +28,28 @@ namespace dt {
 
 
 //------------------------------------------------------------------------------
-// Type_Arr32
+// Type_Array
 //------------------------------------------------------------------------------
 
-Type_Arr32::Type_Arr32(Type t)
-  : TypeImpl(SType::ARR32),
-    elementType_(std::move(t)) {}
+Type_Array::Type_Array(Type t, SType stype)
+  : TypeImpl(stype),
+    childType_(std::move(t)) {}
 
-bool Type_Arr32::is_compound() const {
-  return true; 
-}
 
-bool Type_Arr32::is_array() const {
+bool Type_Array::is_compound() const {
   return true;
 }
 
-bool Type_Arr32::can_be_read_as_column() const {
+bool Type_Array::is_array() const {
+  return true;
+}
+
+bool Type_Array::can_be_read_as_column() const {
   return true;
 }
 
 
-std::string Type_Arr32::to_string() const {
-  return "arr32(" + elementType_.to_string() + ")";
-}
-
-
-TypeImpl* Type_Arr32::common_type(TypeImpl* other) {
+TypeImpl* Type_Array::common_type(TypeImpl* other) {
   if (other->is_array()) {
     return other->stype() > stype() ? other : this;
   }
@@ -67,18 +63,35 @@ TypeImpl* Type_Arr32::common_type(TypeImpl* other) {
 }
 
 
-bool Type_Arr32::equals(const TypeImpl* other) const {
+bool Type_Array::equals(const TypeImpl* other) const {
   return other->stype() == stype() &&
-         elementType_ == reinterpret_cast<const Type_Arr32*>(other)->elementType_;
-}
-
-size_t Type_Arr32::hash() const noexcept {
-  return static_cast<size_t>(stype()) + STYPES_COUNT * elementType_.hash();
+         childType_ == reinterpret_cast<const Type_Array*>(other)->childType_;
 }
 
 
-Type Type_Arr32::child_type() const {
-  return elementType_;
+size_t Type_Array::hash() const noexcept {
+  return static_cast<size_t>(stype()) + STYPES_COUNT * childType_.hash();
+}
+
+
+Type Type_Array::child_type() const {
+  return childType_;
+}
+
+
+
+
+
+//------------------------------------------------------------------------------
+// Type_Arr32
+//------------------------------------------------------------------------------
+
+Type_Arr32::Type_Arr32(Type t)
+  : Type_Array(std::move(t), SType::ARR32) {}
+
+
+std::string Type_Arr32::to_string() const {
+  return "arr32(" + childType_.to_string() + ")";
 }
 
 
@@ -89,49 +102,11 @@ Type Type_Arr32::child_type() const {
 //------------------------------------------------------------------------------
 
 Type_Arr64::Type_Arr64(Type t)
-  : TypeImpl(SType::ARR64),
-    elementType_(std::move(t)) {}
+  : Type_Array(std::move(t), SType::ARR64) {}
 
-bool Type_Arr64::is_compound() const {
-  return true; 
-}
-
-bool Type_Arr64::is_array() const {
-  return true;
-}
-
-bool Type_Arr64::can_be_read_as_column() const {
-  return true;
-}
 
 std::string Type_Arr64::to_string() const {
-  return "arr64(" + elementType_.to_string() + ")";
-}
-
-
-TypeImpl* Type_Arr64::common_type(TypeImpl* other) {
-  if (other->is_array()) {
-    return this;
-  }
-  if (other->is_object() || other->is_invalid()) {
-    return other;
-  }
-  return new Type_Invalid();
-}
-
-
-bool Type_Arr64::equals(const TypeImpl* other) const {
-  return other->stype() == stype() &&
-         elementType_ == reinterpret_cast<const Type_Arr64*>(other)->elementType_;
-}
-
-size_t Type_Arr64::hash() const noexcept {
-  return static_cast<size_t>(stype()) + STYPES_COUNT * elementType_.hash();
-}
-
-
-Type Type_Arr64::child_type() const {
-  return elementType_;
+  return "arr64(" + childType_.to_string() + ")";
 }
 
 

--- a/src/core/types/type_array.cc
+++ b/src/core/types/type_array.cc
@@ -19,6 +19,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
+#include "column.h"
 #include "stype.h"
 #include "types/type_invalid.h"
 #include "types/type_array.h"
@@ -96,6 +97,36 @@ size_t Type_Array::hash() const noexcept {
 Type Type_Array::child_type() const {
   return childType_;
 }
+
+
+// Cast column `col` into an array type. This should support all
+// target types.
+//
+Column Type_Array::cast_column(Column&& col) const {
+  const auto st = stype();
+  switch (col.stype()) {
+    case SType::VOID:
+      return Column::new_na_column(col.nrows(), st);
+
+    // case SType::STR32:
+    // case SType::STR64:
+    //   if (st == col.stype()) return std::move(col);
+    //   return Column(new CastString_ColumnImpl(st, std::move(col)));
+
+    case SType::ARR32:
+    case SType::ARR64: {
+
+      // break;
+    }
+    case SType::OBJ:
+      // return Column(new CastObject_ColumnImpl(st, std::move(col)));
+
+    default:
+      throw NotImplError() << "Unable to cast column of type `" << col.type()
+                           << "` into `" << to_string() << "`";
+  }
+}
+
 
 
 

--- a/src/core/types/type_array.h
+++ b/src/core/types/type_array.h
@@ -25,17 +25,15 @@
 namespace dt {
 
 
-
-class Type_Arr32 : public TypeImpl {
-  private:
-    Type elementType_;
+class Type_Array : public TypeImpl {
+  protected:
+    Type childType_;
 
   public:
-    Type_Arr32(Type t);
+    Type_Array(Type t, SType stype);
     bool is_array() const override;
     bool is_compound() const override;
     bool can_be_read_as_column() const override;
-    std::string to_string() const override;
     bool equals(const TypeImpl* other) const override;
     size_t hash() const noexcept override;
     TypeImpl* common_type(TypeImpl* other) override;
@@ -44,20 +42,18 @@ class Type_Arr32 : public TypeImpl {
 
 
 
-class Type_Arr64 : public TypeImpl {
-  private:
-    Type elementType_;
+class Type_Arr32 : public Type_Array {
+  public:
+    Type_Arr32(Type t);
+    std::string to_string() const override;
+};
 
+
+
+class Type_Arr64 : public Type_Array {
   public:
     Type_Arr64(Type t);
-    bool is_array() const override;
-    bool is_compound() const override;
-    bool can_be_read_as_column() const override;
     std::string to_string() const override;
-    bool equals(const TypeImpl* other) const override;
-    size_t hash() const noexcept override;
-    TypeImpl* common_type(TypeImpl* other) override;
-    Type child_type() const override;
 };
 
 

--- a/src/core/types/type_array.h
+++ b/src/core/types/type_array.h
@@ -37,6 +37,7 @@ class Type_Array : public TypeImpl {
     bool equals(const TypeImpl* other) const override;
     size_t hash() const noexcept override;
     TypeImpl* common_type(TypeImpl* other) override;
+    // Column cast_column(Column&& col) const override;
     Type child_type() const override;
 };
 

--- a/src/core/types/type_array.h
+++ b/src/core/types/type_array.h
@@ -37,7 +37,7 @@ class Type_Array : public TypeImpl {
     bool equals(const TypeImpl* other) const override;
     size_t hash() const noexcept override;
     TypeImpl* common_type(TypeImpl* other) override;
-    // Column cast_column(Column&& col) const override;
+    Column cast_column(Column&& col) const override;
     Type child_type() const override;
 };
 

--- a/src/core/types/typeimpl.cc
+++ b/src/core/types/typeimpl.cc
@@ -43,6 +43,13 @@ void TypeImpl::release() noexcept {
   if (refcount_ == 0) delete this;
 }
 
+Type TypeImpl::make_type() const {
+  TypeImpl* copy = const_cast<TypeImpl*>(this);
+  copy->acquire();
+  return Type(std::move(copy));
+}
+
+
 size_t TypeImpl::hash() const noexcept {
   return static_cast<size_t>(stype_);
 }

--- a/src/core/types/typeimpl.h
+++ b/src/core/types/typeimpl.h
@@ -29,7 +29,7 @@ class TypeImpl {
   private:
     SType stype_;
     int : 24;
-    int32_t refcount_;
+    mutable int32_t refcount_;
     friend class Type;
 
     void acquire() noexcept;
@@ -40,6 +40,7 @@ class TypeImpl {
     virtual ~TypeImpl();
 
     SType stype() const { return stype_; }
+    Type make_type() const;
     virtual size_t hash() const noexcept;
     virtual py::oobj min() const;
     virtual py::oobj max() const;

--- a/tests/types/test-array.py
+++ b/tests/types/test-array.py
@@ -271,3 +271,30 @@ def test_void_to_arr32():
     DT[0] = dt.Type.arr32(dt.Type.str32)
     assert DT.type == dt.Type.arr32(dt.Type.str32)
     assert DT.to_list() == [[None] * 11]
+
+
+def test_obj_to_arr32():
+    DT = dt.Frame(A=[None, [1, 2], [5, 8, None], []], type=object)
+    DT['A'] = dt.Type.arr32(dt.Type.int32)
+    assert_equals(DT,
+        dt.Frame(A=[None, [1, 2], [5, 8, None], []])
+    )
+
+
+def test_obj_to_arr32_bad():
+    DT = dt.Frame(A=[["hi"], [1, 2, 3]], type=object)
+    DT['A'] = dt.Type.arr32('int32')
+    assert_equals(DT,
+        dt.Frame(A=[[None], [1, 2, 3]])
+    )
+
+
+def teest_arr_to_arr():
+    DT = dt.Frame(A=[[1, 5], [12, None], [-99]])
+    assert DT.type == dt.Type.arr32(dt.Type.int32)
+    DT['A'] = dt.Type.arr32(dt.Type.int64)
+    assert DT.type == dt.Type.arr32(dt.Type.int64)
+    assert DT.to_list() == [[1, 5], [12, None], [-99]]
+    DT['A'] = dt.Type.arr32(str)
+    assert DT.type == dt.Type.arr32(dt.Type.str32)
+    assert DT.to_list() == [['1', '5'], ['12', None], ['-99']]

--- a/tests/types/test-array.py
+++ b/tests/types/test-array.py
@@ -258,3 +258,16 @@ def test_arr32_to_jay():
     out = DT.to_jay()
     RES = dt.fread(out)
     assert_equals(RES, DT)
+
+
+
+
+#-------------------------------------------------------------------------------
+# Casts
+#-------------------------------------------------------------------------------
+
+def test_void_to_arr32():
+    DT = dt.Frame([None] * 11)
+    DT[0] = dt.Type.arr32(dt.Type.str32)
+    assert DT.type == dt.Type.arr32(dt.Type.str32)
+    assert DT.to_list() == [[None] * 11]


### PR DESCRIPTION
- In `Arrow_ColumnImpl` methods `num_buffers()` and `get_buffer()` renamed into `get_num_data_buffers()` and `get_data_buffer()` respectively, which are defined in the base `ColumnImpl` class;
- Added type casts of `void -> arr32<T>`, `obj -> arr32<T>` and `arr32<S> -> arr32<T>`;
- In `DT[...] = type` assignment, the RHS can now be a compound type (before, only types convertible to an stype were supported);
- Common functionality for `arr32` and `arr64` types moved into the `Type_Array` class;
- Added function `TypeImpl::make_type()` for creating a `Type` object out of an existing `TypeImpl`;