### PR TITLE
Implement casting array columns into obj type

### DIFF
--- a/src/core/column/cast.h
+++ b/src/core/column/cast.h
@@ -328,6 +328,14 @@ class CastObjectToArray_ColumnImpl : public Cast_ColumnImpl {
 };
 
 
+class CastArrayToObject_ColumnImpl : public Cast_ColumnImpl {
+  public:
+    CastArrayToObject_ColumnImpl(Column&&);
+    ColumnImpl* clone() const override;
+    bool get_element(size_t, py::oobj*) const override;
+};
+
+
 
 
 }  // namespace dt

--- a/src/core/column/cast_to_obj.cc
+++ b/src/core/column/cast_to_obj.cc
@@ -75,6 +75,7 @@ bool CastArrayToObject_ColumnImpl::get_element(size_t i, py::oobj* out) const {
   Column value;
   bool isvalid = arg_.get_element(i, &value);
   if (isvalid) {
+    value.cast_inplace(dt::Type::obj64());
     auto n = value.nrows();
     auto res = py::olist(n);
     py::oobj item;

--- a/src/core/frame/to_numpy.cc
+++ b/src/core/frame/to_numpy.cc
@@ -140,6 +140,23 @@ static oobj to_numpy_impl(oobj frame) {
   // `.astype()` after the conversion.
   bool is_time64 = common_type.stype() == dt::SType::TIME64;
 
+  bool convert_to_object = common_type.is_array();
+  if (convert_to_object) {
+    common_type = dt::Type::obj64();
+    colvec columns;
+    columns.reserve(dt->ncols());
+    for (size_t i = 0; i < ncols; i++) {
+      columns.push_back(dt->get_column(i).cast(common_type));
+    }
+    // Note: `frame` is the owner of the `dt` pointer. First line creates a
+    // new (unowned) DataTable object and stores the pointer in the `dt`
+    // variable. The second line puts the new `dt` pointer into the `frame`
+    // object, which will now be its owner. At the same time,
+    // previous DataTable object owned by `frame` is now destroyed.
+    dt = new DataTable(std::move(columns), DataTable::default_names);
+    frame = Frame::oframe(dt);
+  }
+
   oobj res;
   {
     getbuffer_exception = nullptr;

--- a/src/core/types/type_object.cc
+++ b/src/core/types/type_object.cc
@@ -96,6 +96,10 @@ Column Type_Object::cast_column(Column&& col) const {
     case SType::OBJ:
       return std::move(col);
 
+    case SType::ARR32:
+    case SType::ARR64:
+      return Column(new CastArrayToObject_ColumnImpl(std::move(col)));
+
     default:
       throw NotImplError() << "Unable to cast column of type `" << col.type()
                         << "` into `obj64`";

--- a/tests/types/test-array.py
+++ b/tests/types/test-array.py
@@ -289,12 +289,19 @@ def test_obj_to_arr32_bad():
     )
 
 
-def teest_arr_to_arr():
+def test_arr_to_arr():
     DT = dt.Frame(A=[[1, 5], [12, None], [-99]])
     assert DT.type == dt.Type.arr32(dt.Type.int32)
     DT['A'] = dt.Type.arr32(dt.Type.int64)
     assert DT.type == dt.Type.arr32(dt.Type.int64)
-    assert DT.to_list() == [[1, 5], [12, None], [-99]]
+    assert DT.to_list() == [[[1, 5], [12, None], [-99]]]
     DT['A'] = dt.Type.arr32(str)
     assert DT.type == dt.Type.arr32(dt.Type.str32)
-    assert DT.to_list() == [['1', '5'], ['12', None], ['-99']]
+    assert DT.to_list() == [[['1', '5'], ['12', None], ['-99']]]
+
+
+def test_arr_to_obj():
+    DT = dt.Frame(A=[None, [1, 5], [12, None], [-99]])
+    DT['A'] = dt.Type.obj64
+    assert DT.type == dt.Type.obj64
+    assert DT.to_list() == [[None, [1, 5], [12, None], [-99]]]

--- a/tests/types/test-array.py
+++ b/tests/types/test-array.py
@@ -260,6 +260,29 @@ def test_arr32_to_jay():
     assert_equals(RES, DT)
 
 
+def test_arr32_to_and_from_numpy(np):
+    src = [[3, 9, 0], None, [11, -1, 3, 23], [None], [], [0]]
+    DT = dt.Frame(S=src)
+    assert DT.type == dt.Type.arr32(dt.Type.int32)
+    arr = DT.to_numpy()
+    assert arr.dtype == np.dtype('object')
+    assert arr.T.tolist() == [src]
+    DT2 = dt.Frame(arr, names=['S'])
+    assert_equals(DT, DT2)
+
+
+def test_arr32_to_and_from_pandas(pd):
+    src = [[3, 9, 0], None, [11, -1, 3, 23], [None], [], [0]]
+    DT = dt.Frame(S=src)
+    assert DT.type == dt.Type.arr32(dt.Type.int32)
+    pdf = DT.to_pandas()
+    assert pdf.dtypes[0] == object
+    assert pdf.columns.tolist() == ['S']
+    assert pdf['S'].tolist() == src
+    DT2 = dt.Frame(pdf)
+    assert_equals(DT, DT2)
+
+
 
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
- Added type cast from arr32(64) into obj64;
- Implemented conversion of array columns into numpy (as objects), and back;
- Implemented conversion of array columns into pandas (as objects), and back;

Closes #3124
Closes #3121 
Closes #3122
Closes #3119 
Closes #3120