### PR TITLE
Implement `CategoricalColumn_Impl` and support for basic operations

### DIFF
--- a/src/core/column.cc
+++ b/src/core/column.cc
@@ -273,7 +273,10 @@ static inline py::oobj getelem(const Column& col, size_t i) {
 }
 
 py::oobj Column::get_element_as_pyobject(size_t i) const {
-  switch (stype()) {
+  dt::SType st = type().is_categorical()? child(0).stype()
+                                        : stype();
+
+  switch (st) {
     case dt::SType::VOID:    return py::None();
     case dt::SType::BOOL: {
       int8_t x;
@@ -325,7 +328,10 @@ py::oobj Column::get_element_as_pyobject(size_t i) const {
 }
 
 bool Column::get_element_isvalid(size_t i) const {
-  switch (stype()) {
+  dt::SType st = type().is_categorical()? child(0).stype()
+                                        : stype();
+
+  switch (st) {
     case dt::SType::VOID: return false;
     case dt::SType::BOOL:
     case dt::SType::INT8: {
@@ -361,7 +367,7 @@ bool Column::get_element_isvalid(size_t i) const {
     }
     default:
       throw NotImplError() << "Unable to check validity of the element "
-        << "for stype: `" << stype() << "`";
+        << "for type: `" << type() << "`";
   }
 }
 

--- a/src/core/column/categorical.cc
+++ b/src/core/column/categorical.cc
@@ -1,0 +1,161 @@
+//------------------------------------------------------------------------------
+// Copyright 2021 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#include "column/categorical.h"
+
+namespace dt {
+
+
+template <typename T>
+Type _type_with_child(const Type& t) {
+  Type tcat;
+  switch (sizeof(T)) {
+    case 1: tcat = Type::cat8(t); break;
+    case 2: tcat = Type::cat16(t); break;
+    case 4: tcat = Type::cat32(t); break;
+    default : throw RuntimeError() << "Type is not supported";
+  }
+  return tcat;
+}
+
+
+template <typename T>
+Categorical_ColumnImpl<T>::Categorical_ColumnImpl(
+    size_t nrows, Buffer&& codes, Column&& categories
+) : Virtual_ColumnImpl(categories.nrows(),
+                       _type_with_child<T>(categories.type())),
+    codes_(std::move(codes)),
+    categories_(std::move(categories))
+{
+  xassert(codes_.size() >= sizeof(T) * (nrows + 1));
+}
+
+
+template <typename T>
+ColumnImpl* Categorical_ColumnImpl<T>::clone() const {
+  return
+    new Categorical_ColumnImpl(nrows_, Buffer(codes_), Column(categories_));
+}
+
+
+template <typename T>
+size_t Categorical_ColumnImpl<T>::n_children() const noexcept {
+  return 1;
+}
+
+
+template <typename T>
+const Column& Categorical_ColumnImpl<T>::child(size_t) const {
+  return categories_;
+}
+
+
+template <typename T>
+size_t Categorical_ColumnImpl<T>::num_buffers() const noexcept {
+  return 1;
+}
+
+
+template <typename T>
+Buffer Categorical_ColumnImpl<T>::get_buffer() const noexcept {
+  return codes_;
+}
+
+
+template <typename T>
+template <typename U>
+bool Categorical_ColumnImpl<T>::get_element_(size_t i, U* out) const {
+  xassert(i < nrows_);
+  size_t ii = static_cast<size_t>(codes_.get_element<T>(i));
+  bool valid = categories_.get_element(ii, out);
+  return valid;
+}
+
+
+template <typename T>
+bool Categorical_ColumnImpl<T>::get_element(size_t i, int8_t* out) const {
+  bool valid = get_element_(i, out);
+  return valid;
+}
+
+
+template <typename T>
+bool Categorical_ColumnImpl<T>::get_element(size_t i, int16_t* out) const {
+  bool valid = get_element_(i, out);
+  return valid;
+}
+
+
+template <typename T>
+bool Categorical_ColumnImpl<T>::get_element(size_t i, int32_t* out) const {
+  bool valid = get_element_(i, out);
+  return valid;
+}
+
+
+template <typename T>
+bool Categorical_ColumnImpl<T>::get_element(size_t i, int64_t* out) const {
+  bool valid = get_element_(i, out);
+  return valid;
+}
+
+
+template <typename T>
+bool Categorical_ColumnImpl<T>::get_element(size_t i, float* out) const {
+  bool valid = get_element_(i, out);
+  return valid;
+}
+
+
+template <typename T>
+bool Categorical_ColumnImpl<T>::get_element(size_t i, double* out) const {
+  bool valid = get_element_(i, out);
+  return valid;
+}
+
+
+template <typename T>
+bool Categorical_ColumnImpl<T>::get_element(size_t i, CString* out) const {
+  bool valid = get_element_(i, out);
+  return valid;
+}
+
+
+template <typename T>
+bool Categorical_ColumnImpl<T>::get_element(size_t i, py::oobj* out) const {
+  bool valid = get_element_(i, out);
+  return valid;
+}
+
+
+template <typename T>
+bool Categorical_ColumnImpl<T>::get_element(size_t i, Column* out) const {
+  bool valid = get_element_(i, out);
+  return valid;
+}
+
+
+template class Categorical_ColumnImpl<uint8_t>;
+template class Categorical_ColumnImpl<uint16_t>;
+template class Categorical_ColumnImpl<uint32_t>;
+
+
+}  // namespace dt

--- a/src/core/column/categorical.cc
+++ b/src/core/column/categorical.cc
@@ -92,64 +92,55 @@ bool Categorical_ColumnImpl<T>::get_element_(size_t i, U* out) const {
 
 template <typename T>
 bool Categorical_ColumnImpl<T>::get_element(size_t i, int8_t* out) const {
-  bool valid = get_element_(i, out);
-  return valid;
+  return get_element_(i, out);
 }
 
 
 template <typename T>
 bool Categorical_ColumnImpl<T>::get_element(size_t i, int16_t* out) const {
-  bool valid = get_element_(i, out);
-  return valid;
+  return get_element_(i, out);
 }
 
 
 template <typename T>
 bool Categorical_ColumnImpl<T>::get_element(size_t i, int32_t* out) const {
-  bool valid = get_element_(i, out);
-  return valid;
+  return get_element_(i, out);
 }
 
 
 template <typename T>
 bool Categorical_ColumnImpl<T>::get_element(size_t i, int64_t* out) const {
-  bool valid = get_element_(i, out);
-  return valid;
+  return get_element_(i, out);
 }
 
 
 template <typename T>
 bool Categorical_ColumnImpl<T>::get_element(size_t i, float* out) const {
-  bool valid = get_element_(i, out);
-  return valid;
+  return get_element_(i, out);
 }
 
 
 template <typename T>
 bool Categorical_ColumnImpl<T>::get_element(size_t i, double* out) const {
-  bool valid = get_element_(i, out);
-  return valid;
+  return get_element_(i, out);
 }
 
 
 template <typename T>
 bool Categorical_ColumnImpl<T>::get_element(size_t i, CString* out) const {
-  bool valid = get_element_(i, out);
-  return valid;
+  return get_element_(i, out);
 }
 
 
 template <typename T>
 bool Categorical_ColumnImpl<T>::get_element(size_t i, py::oobj* out) const {
-  bool valid = get_element_(i, out);
-  return valid;
+  return get_element_(i, out);
 }
 
 
 template <typename T>
 bool Categorical_ColumnImpl<T>::get_element(size_t i, Column* out) const {
-  bool valid = get_element_(i, out);
-  return valid;
+  return get_element_(i, out);
 }
 
 

--- a/src/core/column/categorical.h
+++ b/src/core/column/categorical.h
@@ -55,6 +55,7 @@ class Categorical_ColumnImpl : public Virtual_ColumnImpl {
     bool get_element(size_t, py::oobj*) const override;
     bool get_element(size_t, Column*)   const override;
 
+    void materialize(Column&, bool) override;
 };
 
 

--- a/src/core/column/categorical.h
+++ b/src/core/column/categorical.h
@@ -22,7 +22,6 @@
 #ifndef dt_COLUMN_CATEGORICAL_h
 #define dt_COLUMN_CATEGORICAL_h
 
-#include "column/categorical.h"
 #include "column/virtual.h"
 
 

--- a/src/core/column/categorical.h
+++ b/src/core/column/categorical.h
@@ -1,0 +1,68 @@
+//------------------------------------------------------------------------------
+// Copyright 2021 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#ifndef dt_COLUMN_CATEGORICAL_h
+#define dt_COLUMN_CATEGORICAL_h
+
+#include "column/categorical.h"
+#include "column/virtual.h"
+
+
+namespace dt {
+
+template <typename T>
+class Categorical_ColumnImpl : public Virtual_ColumnImpl {
+  private:
+    Buffer codes_;
+    Column categories_;
+
+  public:
+    Categorical_ColumnImpl(size_t nrows, Buffer&& codes, Column&& categories);
+
+    ColumnImpl* clone() const override;
+    size_t n_children() const noexcept override;
+    const Column& child(size_t i) const override;
+    size_t num_buffers() const noexcept;
+    Buffer get_buffer() const noexcept;
+
+    template <class U>
+    bool get_element_(size_t, U*) const;
+
+    bool get_element(size_t, int8_t*)   const override;
+    bool get_element(size_t, int16_t*)  const override;
+    bool get_element(size_t, int32_t*)  const override;
+    bool get_element(size_t, int64_t*)  const override;
+    bool get_element(size_t, float*)    const override;
+    bool get_element(size_t, double*)   const override;
+    bool get_element(size_t, CString*)  const override;
+    bool get_element(size_t, py::oobj*) const override;
+    bool get_element(size_t, Column*)   const override;
+
+};
+
+
+extern template class Categorical_ColumnImpl<uint8_t>;
+extern template class Categorical_ColumnImpl<uint16_t>;
+extern template class Categorical_ColumnImpl<uint32_t>;
+
+
+}  // namespace dt
+#endif

--- a/src/core/column/categorical.h
+++ b/src/core/column/categorical.h
@@ -65,4 +65,6 @@ extern template class Categorical_ColumnImpl<uint32_t>;
 
 
 }  // namespace dt
+
+
 #endif

--- a/src/core/column/column_impl.h
+++ b/src/core/column/column_impl.h
@@ -108,8 +108,8 @@ class ColumnImpl
   // Data buffers
   //------------------------------------
   public:
-    virtual NaStorage get_na_storage_method() const noexcept = 0;
-    virtual size_t    get_num_data_buffers() const noexcept = 0;
+    virtual NaStorage   get_na_storage_method() const noexcept = 0;
+    virtual size_t      get_num_data_buffers() const noexcept = 0;
     virtual bool        is_data_editable(size_t k) const = 0;
     virtual size_t      get_data_size(size_t k) const = 0;
     virtual const void* get_data_readonly(size_t k) const = 0;

--- a/src/core/column/range.h
+++ b/src/core/column/range.h
@@ -32,8 +32,8 @@ namespace dt {
   * column is created when a `range` object is passed into Frame
   * constructor.
   *
-  * By default, this column will take stype INT32. However, if the
-  * range is sufficiently large, the stype will become INT64. However,
+  * By default, this column will take stype INT32. If the range is
+  * sufficiently large, the stype will become INT64. However,
   * we do not support further promotion into FLOAT64 stype for even
   * larger integers.
   */

--- a/src/core/frame/repr/text_column.cc
+++ b/src/core/frame/repr/text_column.cc
@@ -369,7 +369,10 @@ tstring Data_TextColumn::_render_value_string(const Column& col, size_t i) const
 
 
 tstring Data_TextColumn::_render_value(const Column& col, size_t i) const {
-  switch (col.stype()) {
+  SType st = col.type().is_categorical()? col.child(0).stype()
+                                        : col.stype();
+
+  switch (st) {
     case SType::VOID:    return na_value_;
     case SType::BOOL:    return _render_value_bool(col, i);
     case SType::INT8:    return _render_value_int<int8_t>(col, i);

--- a/src/core/models/dt_ftrl.cc
+++ b/src/core/models/dt_ftrl.cc
@@ -309,15 +309,13 @@ FtrlFitOutput Ftrl<T>::fit(T(*linkfn)(T),
   init_helper_params();
 
   // Define features, weight pointers, feature importances storage,
-  // as well as column hashers.
+  // column hashers, etc.
   define_features();
   init_weights();
   if (dt_fi == nullptr) create_fi();
-  auto hashers = create_hashers(dt_X_train);
-
-  // Obtain rowindex and data pointers for the target column(s).
-  const Column& target_col0_train = dt_y_train->get_column(0);
   auto data_fi = static_cast<T*>(dt_fi->get_column(1).get_data_editable());
+  auto hashers = create_hashers(dt_X_train);
+  const Column& target_col0_train = dt_y_train->get_column(0);
 
   // Since `nepochs` can be a float value
   // - the model is trained `niterations - 1` times on

--- a/src/core/stype.cc
+++ b/src/core/stype.cc
@@ -81,6 +81,9 @@ const char* stype_name(SType stype) {
     case SType::TIME64 : return "time64";
     case SType::DATE32 : return "date32";
     case SType::OBJ    : return "obj64";
+    case SType::CAT8   : return "cat8";
+    case SType::CAT16  : return "cat16";
+    case SType::CAT32  : return "cat32";
     case SType::AUTO   : return "auto";
     default            : return "unknown";
   }
@@ -104,6 +107,9 @@ size_t stype_elemsize(SType stype) {
     case SType::TIME64 : return sizeof(element_t<SType::TIME64>);
     case SType::DATE32 : return sizeof(element_t<SType::DATE32>);
     case SType::OBJ    : return sizeof(element_t<SType::OBJ>);
+    case SType::CAT8   : return sizeof(element_t<SType::CAT8>);
+    case SType::CAT16  : return sizeof(element_t<SType::CAT16>);
+    case SType::CAT32  : return sizeof(element_t<SType::CAT32>);
     default            : return 0;
   }
 }
@@ -156,6 +162,9 @@ void init_py_stype_objs(PyObject* stype_enum) {
   _init_py_stype(SType::TIME64);
   _init_py_stype(SType::DATE32);
   _init_py_stype(SType::OBJ);
+  _init_py_stype(SType::CAT8);
+  _init_py_stype(SType::CAT16);
+  _init_py_stype(SType::CAT32);
 }
 
 

--- a/src/core/stype.h
+++ b/src/core/stype.h
@@ -101,6 +101,9 @@ template <> struct _elt<SType::STR64>   { using t = uint64_t; };
 template <> struct _elt<SType::ARR32>   { using t = uint32_t; };
 template <> struct _elt<SType::ARR64>   { using t = uint64_t; };
 template <> struct _elt<SType::OBJ>     { using t = PyObject*; };
+template <> struct _elt<SType::CAT8>    { using t = uint8_t; };
+template <> struct _elt<SType::CAT16>   { using t = uint16_t; };
+template <> struct _elt<SType::CAT32>   { using t = uint32_t; };
 
 template <SType s>
 using element_t = typename _elt<s>::t;

--- a/src/core/types/type_categorical.cc
+++ b/src/core/types/type_categorical.cc
@@ -19,10 +19,14 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
+#include "column/categorical.h"
+#include "parallel/api.h"
+#include "sort.h"
 #include "stype.h"
 #include "types/type_invalid.h"
 #include "types/type_categorical.h"
 #include "utils/assert.h"
+
 namespace dt {
 
 
@@ -107,6 +111,77 @@ bool Type_Cat::equals(const TypeImpl* other) const {
 
 size_t Type_Cat::hash() const noexcept {
   return static_cast<size_t>(stype()) + STYPES_COUNT * elementType_.hash();
+}
+
+
+/**
+  * Cast column `col` into the cat? type.
+  *
+  * The following type casts are supported:
+  *   * void    -> cat?<S>
+  *   * obj64   -> cat?<S>
+  */
+Column Type_Cat::cast_column(Column&& col) const {
+  switch (col.stype()) {
+    case SType::VOID:
+      return Column::new_na_column(col.nrows(), make_type());
+
+    case SType::OBJ: {
+      switch (stype()) {
+        case SType::CAT8:  cast_obj_column<uint8_t>(col); break;
+        case SType::CAT16: cast_obj_column<uint16_t>(col); break;
+        case SType::CAT32: cast_obj_column<uint32_t>(col); break;
+        default: throw RuntimeError() << "Unknown categorical type";
+      }
+      return std::move(col);
+    }
+
+    default:
+      throw NotImplError() << "Unable to cast column of type `" << col.type()
+                           << "` into `" << to_string() << "`";
+  }
+}
+
+
+template <typename T>
+void Type_Cat::cast_obj_column(Column& col) const {
+  size_t nrows = col.nrows(); // save nrows as `col` will be modified in-place
+  col.cast_inplace(elementType_);
+  auto res = group({col}, {SortFlag::NONE});
+  RowIndex ri = std::move(res.first);
+  Groupby gb = std::move(res.second);
+  auto offsets = gb.offsets_r();
+
+  Buffer buf = Buffer::mem(col.nrows() * sizeof(T));
+  Buffer buf_cat = Buffer::mem(gb.size() * sizeof(int32_t));
+  auto buf_ptr = static_cast<T*>(buf.xptr());
+  auto buf_cat_ptr = static_cast<int32_t*>(buf_cat.xptr());
+
+  const size_t MAX_CATS = std::numeric_limits<T>::max() + size_t(1);
+
+  if (gb.size() > MAX_CATS) {
+    throw ValueError() << "Number of categories in the column is `" << gb.size()
+      << "`, that is larger than " << to_string() << " type "
+      << "can accomodate, i.e. `" << MAX_CATS << "`";
+  }
+
+  dt::parallel_for_dynamic(gb.size(),
+    [&](size_t i) {
+      size_t jj;
+      ri.get_element(static_cast<size_t>(offsets[i]), &jj);
+      buf_cat_ptr[i] = static_cast<int32_t>(jj);
+
+      for (int32_t j = offsets[i]; j < offsets[i + 1]; ++j) {
+        ri.get_element(static_cast<size_t>(j), &jj);
+        buf_ptr[static_cast<size_t>(jj)] = static_cast<T>(i);
+      }
+    });
+
+  const RowIndex ri_cat(std::move(buf_cat), RowIndex::ARR32);
+  col.apply_rowindex(ri_cat);
+  col.materialize();
+
+  col = Column(new Categorical_ColumnImpl<T>(nrows, std::move(buf), std::move(col)));
 }
 
 

--- a/src/core/types/type_categorical.h
+++ b/src/core/types/type_categorical.h
@@ -29,6 +29,10 @@ namespace dt {
 
 
 class Type_Cat : public TypeImpl {
+  private:
+    template <typename T>
+    void cast_obj_column_(Column& col) const;
+
   protected:
     Type elementType_;
 
@@ -50,11 +54,7 @@ class Type_Cat : public TypeImpl {
     bool equals(const TypeImpl* other) const override;
     size_t hash() const noexcept override;
     TypeImpl* common_type(TypeImpl* other) override;
-
     Column cast_column(Column&& col) const override;
-
-    template <typename T>
-    void cast_obj_column(Column& col) const;
 };
 
 

--- a/src/core/types/type_categorical.h
+++ b/src/core/types/type_categorical.h
@@ -21,7 +21,10 @@
 //------------------------------------------------------------------------------
 #ifndef dt_TYPES_TYPE_CATEGORICAL_h
 #define dt_TYPES_TYPE_CATEGORICAL_h
+
+#include "column.h"
 #include "types/typeimpl.h"
+
 namespace dt {
 
 
@@ -47,6 +50,11 @@ class Type_Cat : public TypeImpl {
     bool equals(const TypeImpl* other) const override;
     size_t hash() const noexcept override;
     TypeImpl* common_type(TypeImpl* other) override;
+
+    Column cast_column(Column&& col) const override;
+
+    template <typename T>
+    void cast_obj_column(Column& col) const;
 };
 
 

--- a/src/datatable/types.py
+++ b/src/datatable/types.py
@@ -51,6 +51,9 @@ class stype(enum.Enum):
     date32 = 17
     time64 = 18
     obj64 = 21
+    cat8 = 22
+    cat16 = 23
+    cat32 = 24
 
     def __repr__(self):
         return str(self)
@@ -202,6 +205,9 @@ _stype_2_short = {
     stype.time64: "t8",
     stype.date32: "d4",
     stype.obj64: "o8",
+    stype.cat8: "c1",
+    stype.cat16: "c2",
+    stype.cat32: "c4",
 }
 
 _stype_2_ltype = {
@@ -220,6 +226,9 @@ _stype_2_ltype = {
     stype.date32: ltype.time,
     stype.time64: ltype.time,
     stype.obj64: ltype.obj,
+    stype.cat8: ltype.invalid,
+    stype.cat16: ltype.invalid,
+    stype.cat32: ltype.invalid,
 }
 
 _stype_2_ctype = {

--- a/tests/test-dt.py
+++ b/tests/test-dt.py
@@ -851,7 +851,8 @@ def test_single_element_extraction_from_view(dt0):
 @pytest.mark.parametrize('st', list(dt.stype))
 def test_single_element_all_stypes(st):
     from datetime import date as dd
-    if st in (dt.stype.time64, dt.stype.arr32, dt.stype.arr64):
+    if st in (dt.stype.time64, dt.stype.arr32, dt.stype.arr64,
+              dt.stype.cat8, dt.stype.cat16, dt.stype.cat32):
         return
     pt = (bool if st == dt.stype.bool8 else
           int if st.ltype == dt.ltype.int else

--- a/tests/types/test-categorical.py
+++ b/tests/types/test-categorical.py
@@ -104,3 +104,175 @@ def test_type_categorical_query_methods(t):
     assert not t.is_temporal
     assert not t.is_void
 
+
+#-------------------------------------------------------------------------------
+# Create from various types
+#-------------------------------------------------------------------------------
+
+@pytest.mark.parametrize('t', [dt.Type.cat8,
+                               dt.Type.cat16,
+                               dt.Type.cat32])
+def test_create_too_many_cats_error(t):
+    src = list(range(1000))
+
+    if t is dt.Type.cat8:
+        msg = r"Number of categories in the column is 1000, that is larger than cat8\(int32\) " \
+               "type can accomodate, i.e. 256"
+        with pytest.raises(ValueError, match=msg):
+            DT = dt.Frame(src, types = [t(dt.Type.int32)])
+    else:
+        DT1 = dt.Frame(src)
+        DT2 = dt.Frame(src, types = [t(dt.Type.int32)])
+        assert DT1.shape == DT2.shape
+        assert DT1.names == DT2.names
+        assert DT1.to_list() == DT2.to_list()
+
+
+@pytest.mark.parametrize('t', [dt.Type.cat8,
+                               dt.Type.cat16,
+                               dt.Type.cat32])
+def test_create_from_void(t):
+    src = [None] * 10
+    DT1 = dt.Frame(src)
+    DT2 = dt.Frame(src, types = [t(dt.Type.bool8)])
+    assert DT2.type == t(dt.Type.bool8)
+    assert DT1.shape == DT2.shape
+    assert DT1.names == DT2.names
+    assert DT1.to_list() == DT2.to_list()
+
+
+@pytest.mark.parametrize('t', [dt.Type.cat8,
+                               dt.Type.cat16,
+                               dt.Type.cat32])
+def test_create_from_bools(t):
+    src = [None, True, False, None, False, False]
+    DT1 = dt.Frame(src)
+    DT2 = dt.Frame(src, types = [t(dt.Type.bool8)])
+    assert DT2.type == t(dt.Type.bool8)
+    assert DT1.shape == DT2.shape
+    assert DT1.names == DT2.names
+    assert DT1.to_list() == DT2.to_list()
+
+
+@pytest.mark.parametrize('t', [dt.Type.cat8,
+                               dt.Type.cat16,
+                               dt.Type.cat32])
+def test_create_from_ints(t):
+    src = [3, None, 1, 4, 1, None, 5, 9, 2, 6]
+    DT1 = dt.Frame(src)
+    DT2 = dt.Frame(src, types = [t(dt.Type.int32)])
+    assert DT2.type == t(dt.Type.int32)
+    assert DT1.shape == DT2.shape
+    assert DT1.names == DT2.names
+    assert DT1.to_list() == DT2.to_list()
+
+
+def test_create_from_ints_large():
+    src = list(range(10**6))
+    DT1 = dt.Frame(src)
+    DT2 = dt.Frame(src, types = [dt.Type.cat32(dt.Type.int32)])
+    assert DT1.shape == DT2.shape
+    assert DT1.names == DT2.names
+    assert DT1.to_list() == DT2.to_list()
+
+
+@pytest.mark.parametrize('t', [dt.Type.cat8,
+                               dt.Type.cat16,
+                               dt.Type.cat32])
+def test_create_from_floats(t):
+    src = [3.14, None, 1.15, 4.92, 1.6, None, 5.5, 9, 2.35, 6.0]
+    DT1 = dt.Frame(src)
+    DT2 = dt.Frame(src, types = [t(dt.Type.float64)])
+    assert DT2.type == t(dt.Type.float64)
+    assert DT1.shape == DT2.shape
+    assert DT1.names == DT2.names
+    assert DT1.to_list() == DT2.to_list()
+
+
+@pytest.mark.parametrize('t', [dt.Type.cat8,
+                               dt.Type.cat16,
+                               dt.Type.cat32])
+def test_create_from_strings(t):
+    src = ["dog", "mouse", None, "dog", "cat", None, "1", "pig"]
+    DT1 = dt.Frame(src)
+    DT2 = dt.Frame(src, types = [t(dt.Type.str32)])
+    assert DT2.type == t(dt.Type.str32)
+    assert DT1.shape == DT2.shape
+    assert DT1.names == DT2.names
+    assert DT1.to_list() == DT2.to_list()
+
+
+@pytest.mark.parametrize('t', [dt.Type.cat8,
+                               dt.Type.cat16,
+                               dt.Type.cat32])
+def test_create_from_dates(t):
+    from datetime import date as d
+    src = [d(1997, 9, 1), d(2002, 7, 31), d(2000, 2, 20), None]
+    DT1 = dt.Frame(src)
+    DT2 = dt.Frame(src, types = [t(dt.Type.date32)])
+    assert DT2.type == t(dt.Type.date32)
+    assert DT1.shape == DT2.shape
+    assert DT1.names == DT2.names
+    assert DT1.to_list() == DT2.to_list()
+
+
+@pytest.mark.parametrize('t', [dt.Type.cat8,
+                               dt.Type.cat16,
+                               dt.Type.cat32])
+def test_create_from_times(t):
+    from datetime import datetime as d
+    src = [d(2000, 10, 18, 3, 30),
+           d(2010, 11, 13, 15, 11, 59),
+           d(2020, 2, 29, 20, 20, 20, 20), None]
+    DT1 = dt.Frame(src)
+    DT2 = dt.Frame(src, types = [t(dt.Type.time64)])
+    assert DT2.type == t(dt.Type.time64)
+    assert DT1.shape == DT2.shape
+    assert DT1.names == DT2.names
+    assert DT1.to_list() == DT2.to_list()
+
+
+#-------------------------------------------------------------------------------
+# Conversion
+#-------------------------------------------------------------------------------
+
+@pytest.mark.parametrize('t', [dt.Type.cat8,
+                               dt.Type.cat16,
+                               dt.Type.cat32])
+def test_repr_strings_in_terminal(t):
+    tcat = t(dt.Type.str32)
+    DT = dt.Frame(Animals=["cat", "dog", None, "cat", "guinea piglet"],
+                  types = [tcat])
+    type_name = tcat.name + (" " if t is dt.Type.cat8 else "")
+    assert str(DT) == (
+        "   | Animals      \n"
+        "   | " + type_name + " \n"
+        "-- + -------------\n"
+        " 0 | cat          \n"
+        " 1 | dog          \n"
+        " 2 | NA           \n"
+        " 3 | cat          \n"
+        " 4 | guinea piglet\n"
+        "[5 rows x 1 column]\n"
+    )
+
+
+@pytest.mark.parametrize('t', [dt.Type.cat8,
+                               dt.Type.cat16,
+                               dt.Type.cat32])
+def test_repr_numbers_in_terminal(t):
+    tcat = t(dt.Type.int32)
+    DT = dt.Frame(Prime_Numbers=[3, 5, None, 47, 7],
+                  types = [tcat])
+    type_name = tcat.name + ("  " if t is dt.Type.cat8 else " ")
+    assert str(DT) == (
+        "   | Prime_Numbers\n"
+        "   | " + type_name + "\n"
+        "-- + -------------\n"
+        " 0 | 3            \n"
+        " 1 | 5            \n"
+        " 2 | NA           \n"
+        " 3 | 47           \n"
+        " 4 | 7            \n"
+        "[5 rows x 1 column]\n"
+    )

--- a/tests/types/test-type.py
+++ b/tests/types/test-type.py
@@ -264,7 +264,7 @@ def test_stype():
     assert stype.time64
     assert stype.obj64
     # When new stypes are added, don't forget to update this test suite
-    assert len(stype) == 15
+    assert len(stype) == 18
 
 
 def test_stype_names():
@@ -401,7 +401,8 @@ def test_stype_instantiate_bad():
 def test_stype_minmax(st):
     from datatable import stype, ltype
     if st in (stype.void, stype.str32, stype.str64, stype.obj64, stype.time64,
-              stype.date32, stype.arr32, stype.arr64):
+              stype.date32, stype.arr32, stype.arr64, stype.cat8, stype.cat16,
+              stype.cat32):
         assert st.min is None
         assert st.max is None
     else:


### PR DESCRIPTION
- implemented `CategoricalColumn_Impl`;
- added support for categorical columns in `dt.Frame()`;
- added support for categorical columns in a terminal, also allowing the element access through `[i, j]` selector;
- added and modified some relevant tests.

WIP for #1691 