### PR TITLE
Fix support for `.max_column_width` in Jupyter notebooks

### DIFF
--- a/docs/releases/v1.1.0.rst
+++ b/docs/releases/v1.1.0.rst
@@ -25,6 +25,9 @@
     -[fix] Fixed a crash which could have occurred when sorting very long
         identical or nearly identical strings. [#3134]
 
+    -[fix] Fixed support for :attr:`.max_column_width <datatable.options.display.max_column_width>`
+        option when rendering frames in Jupyter notebooks. [#3160]
+
     -[api] Converting a column of :attr:`void <dt.Type.void>` type into pandas
         now produces a pandas ``object`` column filled with ``None``s. Converting
         such column back into datatable produces a ``void`` column again. [#3063]

--- a/src/core/frame/__repr__.cc
+++ b/src/core/frame/__repr__.cc
@@ -64,7 +64,7 @@ static PKArgs args__repr_html_(
   0, 0, 0, false, false, {}, "_repr_html_", nullptr);
 
 oobj Frame::_repr_html_(const PKArgs&) {
-  dt::HtmlWidget widget(dt);
+  dt::HtmlWidget widget(dt, dt::display_max_column_width);
   return widget.to_python();
 }
 

--- a/src/core/frame/repr/html_widget.h
+++ b/src/core/frame/repr/html_widget.h
@@ -41,13 +41,15 @@ void emit_stylesheet();
 /**
   * This class is responsible for rendering a Frame into HTML.
   */
-class HtmlWidget : public dt::Widget {
+class HtmlWidget : public Widget {
   private:
     std::ostringstream html;
+    int max_width_;
+    size_t : 32;
 
   public:
-    explicit HtmlWidget(DataTable* dt)
-      : dt::Widget(dt, split_view_tag) {}
+    explicit HtmlWidget(DataTable* dt, int max_width)
+      : dt::Widget(dt, split_view_tag), max_width_(max_width) {}
 
     py::oobj to_python() {
       render_all();
@@ -207,7 +209,7 @@ class HtmlWidget : public dt::Widget {
 
 
     void _render_escaped_string(const char* ch, size_t len) {
-      size_t maxi = std::min(len, size_t(50));
+      size_t maxi = std::min(len, static_cast<size_t>(max_width_));
       uint8_t uc;
       for (size_t i = 0; i < maxi; ++i) {
         char c = ch[i];


### PR DESCRIPTION
It doesn't seem like `.max_column_width` ever worked in Jupyter, instead, we used a hard-coded value of `50` characters as a limit. In this PR we fix it.

Closes #3160 