### PR TITLE
Miscellaneous improvements to tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,13 +55,14 @@ def noppc64():
 
 
 @pytest.fixture(scope="session")
-def is_release():
-    """Helper function to determine the release mode"""
-    return os.environ.get("DT_RELEASE")
+def release_only():
+    """Run this test for release only"""
+    if not os.environ.get("DT_RELEASE"):
+        pytest.skip("Enabled for release only")
 
 
 @pytest.fixture(scope="session")
-def winonly():
+def win_only():
     """Skip this test when running not on Windows"""
     if platform.system() != "Windows":
         pytest.skip("Enabled on Windows only")

--- a/tests/frame/test-create.py
+++ b/tests/frame/test-create.py
@@ -958,6 +958,17 @@ def test_void_frame_roundtrip():
     assert_equals(DT, dt.Frame([None] * 10))
 
 
+# Uncomment the line below when all the tests pass
+# @pytest.mark.usefixtures("release_only")
+def test_create_from_pandas_large(pd):
+    # See issue 3169
+    N1 = 30
+    N2 = 2 * 10**7
+    S = "0123456789" * N1
+    PD = pd.DataFrame([S] * N2)
+    DT = dt.Frame(PD)
+    assert DT[0, 0] == S
+    assert DT.nunique1() == 1
 
 
 #-------------------------------------------------------------------------------

--- a/tests/frame/test-create.py
+++ b/tests/frame/test-create.py
@@ -958,8 +958,7 @@ def test_void_frame_roundtrip():
     assert_equals(DT, dt.Frame([None] * 10))
 
 
-# Uncomment the line below when all the tests pass
-# @pytest.mark.usefixtures("release_only")
+@pytest.mark.usefixtures("release_only")
 def test_create_from_pandas_large(pd):
     # See issue 3169
     N1 = 30

--- a/tests/fread/test-fread-large.py
+++ b/tests/fread/test-fread-large.py
@@ -124,7 +124,7 @@ def f(request):
 #-------------------------------------------------------------------------------
 
 
-@pytest.mark.usefixtures("winonly", "is_release")
+@pytest.mark.usefixtures("win_only", "release_only")
 def test_fread_4gb_jay(tempfile_jay):
     size = 4 * 10**9
     DT = dt.Frame([True])
@@ -137,7 +137,7 @@ def test_fread_4gb_jay(tempfile_jay):
     assert DT.stype == dt.bool8
 
 
-@pytest.mark.usefixtures("winonly", "is_release")
+@pytest.mark.usefixtures("win_only", "release_only")
 def test_fread_4gb_csv(tempfile_csv):
     size = 4 * 10**9
     DT = dt.Frame([True])


### PR DESCRIPTION
- add a large `create_from_pandas` test, see #3169 
- convert `is_release()` function to `release_only` fixture, otherwise several larger tests were actually running for each build;
- rename `winonly` fixture to `win_only` to make it more consistent and readable. 