### PR TITLE
Fix wheel generation on macOS Big Sur, switch to `macos-bigsur` image on AppVeyor

### DIFF
--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -101,6 +101,8 @@ build_script:
 
     python -m pip install --upgrade pip
 
+    python -c "from pip import pep425tags;print(pep425tags.supported_tags)"
+
     python -m pip install $DT_WHEEL pytest docutils pandas
 
     python -m pytest -ra --maxfail=10 -Werror -vv --showlocals ./tests/

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -1,6 +1,6 @@
 image:
-  # - Visual Studio 2019
-  # - Ubuntu
+  - Visual Studio 2019
+  - Ubuntu
   - macos-bigsur
 
 init:
@@ -80,24 +80,18 @@ build_script:
 
 
     # =======================================================================
-    #   Build and test wheel for Python 3.8
+    #   Build and test wheel for Python 3.9
     # =======================================================================
 
-    source $HOME/venv3.8/bin/activate
+    source $HOME/venv3.9/bin/activate
 
     python -V
 
-    python -c "import platform; print(platform.mac_ver())"
-
-    python -c "import distutils.util; print(distutils.util.get_platform())"
-
-    python -m pip debug --verbose
-
     python ci/ext.py wheel
 
-    DT_WHEEL=`ls dist/*-cp38-*.whl`
+    DT_WHEEL=`ls dist/*-cp39-*.whl`
 
-    echo "----- _build_info.py for Python 3.8 ------------------------------"
+    echo "----- _build_info.py for Python 3.9 ------------------------------"
 
     cat src/datatable/_build_info.py
 

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -91,7 +91,7 @@ build_script:
 
     python -c "import wheel; print(wheel.pep425tags.get_supported())"
 
-    print -c "import distutils; print(distutils.util.get_platform())"
+    python -c "import distutils; print(distutils.util.get_platform())"
 
     python ci/ext.py wheel
 

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -1,6 +1,6 @@
 image:
-  - Visual Studio 2019
-  - Ubuntu
+  # - Visual Studio 2019
+  # - Ubuntu
   - macos-bigsur
 
 init:

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -101,7 +101,7 @@ build_script:
 
     python -m pip install --upgrade pip
 
-    python -c "from pip import pep425tags;print(pep425tags.supported_tags)"
+    python -c "import wheel.pep425tags as w; print(w.get_supported())"
 
     python -m pip install $DT_WHEEL pytest docutils pandas
 

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -101,7 +101,9 @@ build_script:
 
     python -m pip install --upgrade pip
 
-    python -c "import wheel.pep425tags as w; print(w.get_supported())"
+    python -c "import wheel; print(wheel.pep425tags.get_supported())"
+
+    print -c "import distutils; print(distutils.util.get_platform())"
 
     python -m pip install $DT_WHEEL pytest docutils pandas
 

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -1,7 +1,7 @@
 image:
   - Visual Studio 2019
   - Ubuntu
-  - macOS
+  - macos-bigsur
 
 init:
   # Uncomment the line below to enable RDP access

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -89,9 +89,9 @@ build_script:
 
     python -c "import platform; print(platform.mac_ver())"
 
-    python -c "import wheel; print(wheel.pep425tags.get_supported())"
+    python -c "import wheel.pep425tags; print(wheel.pep425tags.get_supported())"
 
-    python -c "import distutils; print(distutils.util.get_platform())"
+    python -c "import distutils.util; print(distutils.util.get_platform())"
 
     python ci/ext.py wheel
 

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -80,16 +80,14 @@ build_script:
 
 
     # =======================================================================
-    #   Build and test wheel for Python 3.9
+    #   Build and test wheel for Python 3.8
     # =======================================================================
 
-    source $HOME/venv3.9/bin/activate
+    source $HOME/venv3.8/bin/activate
 
     python -V
 
     python -c "import platform; print(platform.mac_ver())"
-
-    # python -c "import wheel.pep425tags; print(wheel.pep425tags.get_supported())"
 
     python -c "import distutils.util; print(distutils.util.get_platform())"
 
@@ -97,9 +95,9 @@ build_script:
 
     python ci/ext.py wheel
 
-    DT_WHEEL=`ls dist/*-cp39-*.whl`
+    DT_WHEEL=`ls dist/*-cp38-*.whl`
 
-    echo "----- _build_info.py for Python 3.9 ------------------------------"
+    echo "----- _build_info.py for Python 3.8 ------------------------------"
 
     cat src/datatable/_build_info.py
 

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -89,6 +89,10 @@ build_script:
 
     python -c "import platform; print(platform.mac_ver())"
 
+    python -c "import wheel; print(wheel.pep425tags.get_supported())"
+
+    print -c "import distutils; print(distutils.util.get_platform())"
+
     python ci/ext.py wheel
 
     DT_WHEEL=`ls dist/*-cp39-*.whl`
@@ -100,10 +104,6 @@ build_script:
     echo "------------------------------------------------------------------"
 
     python -m pip install --upgrade pip
-
-    python -c "import wheel; print(wheel.pep425tags.get_supported())"
-
-    print -c "import distutils; print(distutils.util.get_platform())"
 
     python -m pip install $DT_WHEEL pytest docutils pandas
 

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -87,6 +87,8 @@ build_script:
 
     python -V
 
+    python -c "import platform; print(platform.mac_ver())"
+
     python ci/ext.py wheel
 
     DT_WHEEL=`ls dist/*-cp39-*.whl`

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -89,9 +89,11 @@ build_script:
 
     python -c "import platform; print(platform.mac_ver())"
 
-    python -c "import wheel.pep425tags; print(wheel.pep425tags.get_supported())"
+    # python -c "import wheel.pep425tags; print(wheel.pep425tags.get_supported())"
 
     python -c "import distutils.util; print(distutils.util.get_platform())"
+
+    python -m pip debug --verbose
 
     python ci/ext.py wheel
 

--- a/ci/xbuild/wheel.py
+++ b/ci/xbuild/wheel.py
@@ -451,7 +451,7 @@ class Wheel:
             abi_tag = self._get_abi_tag()
             # TODO: remove `distutils` dependency as it has been deprecated
             platform = distutils.util.get_platform()
-            # Meanwhile, a workaround for macOS Big Sur
+            # Meanwhile, a workaround for macOS Big Sur, see #3175
             if platform.startswith("macosx-11"):
                 plat_tag = re.sub("-11(.*)-", "_11_0_", platform)
             else:

--- a/ci/xbuild/wheel.py
+++ b/ci/xbuild/wheel.py
@@ -449,8 +449,13 @@ class Wheel:
         if self._tag is None:
             impl_tag = self._get_python_tag()
             abi_tag = self._get_abi_tag()
-            plat_tag = distutils.util.get_platform() \
-                       .replace('.', '_').replace('-', '_')
+            # TODO: remove `distutils` dependency as it has been deprecated
+            platform = distutils.util.get_platform()
+            # Meanwhile, a workaround for macOS Big Sur
+            if platform.startswith("macosx-11"):
+                plat_tag = re.sub("-11(.*)-", "_11_0_", platform)
+            else:
+                plat_tag = platform.replace('.', '_').replace('-', '_')
             self._tag = "%s-%s-%s" % (impl_tag, abi_tag, plat_tag)
         return self._tag
 

--- a/src/core/column/categorical.cc
+++ b/src/core/column/categorical.cc
@@ -69,7 +69,7 @@ size_t Categorical_ColumnImpl<T>::n_children() const noexcept {
 
 template <typename T>
 const Column& Categorical_ColumnImpl<T>::child(size_t i) const {
-  xassert(i == 0);
+  xassert(i == 0); (void) i;
   return categories_;
 }
 


### PR DESCRIPTION
- add a workaround to generate proper wheel names on macOS Big Sur. We should still properly deprecate the `distutils` module at some point;
- switch to the most recent macOS image on AppVeyor.

Closes #3175