### PR TITLE
Replace python `3.6` with python `3.10` in Jenkins pipeline

### DIFF
--- a/ci/Jenkinsfile.groovy
+++ b/ci/Jenkinsfile.groovy
@@ -799,7 +799,6 @@ def get_python_for_docker(String pyver, String image) {
 
 def test_macos(String pyver) {
     try {
-        def pyenv = get_env_for_macos(pyver)
         sh """
             mkdir -p /tmp/cores
             rm -f /tmp/cores/*

--- a/ci/Jenkinsfile.groovy
+++ b/ci/Jenkinsfile.groovy
@@ -251,11 +251,12 @@ ansiColor('xterm') {
                                         -c "cd /dot && \
                                             ls -la && \
                                             ls -la src/datatable && \
+                                            /opt/python/cp37-cp37m/bin/python3.7 ci/ext.py debugwheel --audit && \
                                             /opt/python/cp37-cp37m/bin/python3.7 ci/ext.py wheel --audit && \
                                             /opt/python/cp38-cp38/bin/python3.8 ci/ext.py wheel --audit && \
                                             /opt/python/cp39-cp39/bin/python3.9 ci/ext.py wheel --audit && \
                                             /opt/python/cp310-cp310/bin/python3.10 ci/ext.py wheel --audit && \
-                                            echo '===== Py Debug =====' && unzip -p dist/*debug*.whl datatable/_build_info.py && \
+                                            echo '===== Py3.7 Debug =====' && unzip -p dist/*debug*.whl datatable/_build_info.py && \
                                             mv dist/*debug*.whl . && \
                                             echo '===== Py3.7 =====' && unzip -p dist/*cp37*.whl datatable/_build_info.py && \
                                             echo '===== Py3.8 =====' && unzip -p dist/*cp38*.whl datatable/_build_info.py && \
@@ -334,11 +335,12 @@ ansiColor('xterm') {
                                             -c "cd /dot && \
                                                 ls -la && \
                                                 ls -la src/datatable && \
+                                                /opt/python/cp37-cp37m/bin/python3.7 ci/ext.py debugwheel --audit && \
                                                 /opt/python/cp37-cp37m/bin/python3.7 ci/ext.py wheel --audit && \
                                                 /opt/python/cp38-cp38/bin/python3.8 ci/ext.py wheel --audit && \
                                                 /opt/python/cp39-cp39/bin/python3.9 ci/ext.py wheel --audit && \
                                                 /opt/python/cp310-cp310/bin/python3.10 ci/ext.py wheel --audit && \
-                                                echo '===== Py Debug =====' && unzip -p dist/*debug*.whl datatable/_build_info.py && \
+                                                echo '===== Py3.7 Debug =====' && unzip -p dist/*debug*.whl datatable/_build_info.py && \
                                                 mv dist/*debug*.whl . && \
                                                 echo '===== Py3.7 =====' && unzip -p dist/*cp37*.whl datatable/_build_info.py && \
                                                 echo '===== Py3.8 =====' && unzip -p dist/*cp38*.whl datatable/_build_info.py && \

--- a/ci/Jenkinsfile.groovy
+++ b/ci/Jenkinsfile.groovy
@@ -284,18 +284,22 @@ ansiColor('xterm') {
                                          "DT_BUILD_SUFFIX=${DT_BUILD_SUFFIX}",
                                          "DT_BUILD_NUMBER=${DT_BUILD_NUMBER}"]) {
                                     sh """
-                                        . /Users/jenkins/anaconda/bin/activate datatable-py36-with-pandas
+                                        source /Users/jenkins/datatable_envs/py37/bin/activate
                                         python ci/ext.py wheel
-                                        . /Users/jenkins/anaconda/bin/activate datatable-py37-with-pandas
+                                        deactivate
+                                        source /Users/jenkins/datatable_envs/py38/bin/activate
                                         python ci/ext.py wheel
-                                        . /Users/jenkins/anaconda/bin/activate datatable-py38
+                                        deactivate
+                                        source /Users/jenkins/datatable_envs/py39/bin/activate
                                         python ci/ext.py wheel
-                                        . /Users/jenkins/anaconda/bin/activate datatable-py39
+                                        deactivate
+                                        source /Users/jenkins/datatable_envs/py310/bin/activate
                                         python ci/ext.py wheel
-                                        echo '===== Py3.6 =====' && unzip -p dist/*cp36*.whl datatable/_build_info.py
+                                        deactivate
                                         echo '===== Py3.7 =====' && unzip -p dist/*cp37*.whl datatable/_build_info.py
                                         echo '===== Py3.8 =====' && unzip -p dist/*cp38*.whl datatable/_build_info.py
                                         echo '===== Py3.9 =====' && unzip -p dist/*cp39*.whl datatable/_build_info.py
+                                        echo '===== Py3.10 =====' && unzip -p dist/*cp310*.whl datatable/_build_info.py
                                         ls dist
                                     """
                                     stash name: 'x86_64-macos-wheels', includes: "dist/*.whl"
@@ -501,6 +505,19 @@ ansiColor('xterm') {
                             }
                         }
                     }) <<
+                    namedStage('Test x86_64-macos-py310', { stageName, stageDir ->
+                        node(NODE_MACOS) {
+                            buildSummary.stageWithSummary(stageName, stageDir) {
+                                cleanWs()
+                                dumpInfo()
+                                dir(stageDir) {
+                                    unstash 'datatable-sources'
+                                    unstash 'x86_64-macos-wheels'
+                                    test_macos('310')
+                                }
+                            }
+                        }
+                    }) <<
                     namedStage('Test x86_64-macos-py39', doPy38Tests, { stageName, stageDir ->
                         node(NODE_MACOS) {
                             buildSummary.stageWithSummary(stageName, stageDir) {
@@ -539,19 +556,6 @@ ansiColor('xterm') {
                                 }
                             }
                         }
-                    }) <<
-                    namedStage('Test x86_64-macos-py36', { stageName, stageDir ->
-                        node(NODE_MACOS) {
-                            buildSummary.stageWithSummary(stageName, stageDir) {
-                                cleanWs()
-                                dumpInfo()
-                                dir(stageDir) {
-                                    unstash 'datatable-sources'
-                                    unstash 'x86_64-macos-wheels'
-                                    test_macos('36')
-                                }
-                            }
-                        }
                     })
                 // Execute defined stages in parallel
                 parallel(testStages)
@@ -587,7 +591,7 @@ ansiColor('xterm') {
                                 dir(stageDir) {
                                     unstash 'datatable-sources'
                                     sh """
-                                        . /Users/jenkins/anaconda/bin/activate datatable-py36-with-pandas
+                                        /Users/jenkins/datatable_envs/py310/bin/activate
                                         make coverage
                                     """
                                     testReport "build/coverage-c", "x86_64_osx coverage report for C"
@@ -800,7 +804,7 @@ def test_macos(String pyver) {
             mkdir -p /tmp/cores
             rm -f /tmp/cores/*
             env
-            . /Users/jenkins/anaconda/bin/activate ${pyenv}
+            source /Users/jenkins/datatable_envs/py${pyver}/bin/activate
             pip install --upgrade pip
             pip install dist/datatable-*-cp${pyver}-*.whl
             pip install -r requirements_tests.txt
@@ -818,15 +822,6 @@ def test_macos(String pyver) {
         archiveArtifacts artifacts: "/tmp/cores/*", allowEmptyArchive: true
     }
     junit testResults: "build/test-reports/TEST-datatable.xml", keepLongStdio: true, allowEmptyResults: false
-}
-
-
-def get_env_for_macos(String pyver) {
-    if (pyver == "39") return "datatable-py39"
-    if (pyver == "38") return "datatable-py38"
-    if (pyver == "37") return "datatable-py37-with-pandas"
-    if (pyver == "36") return "datatable-py36-with-pandas"
-    throw new Exception("Unknown python ${pyver} for MacOS")
 }
 
 


### PR DESCRIPTION
In this PR we adjust Jenkins pipeline by removing python `3.6` (it reaches its end of life in a couple of weeks) and replacing it with the new version of python `3.10`. All the datatable virtual environments for particular versions of python have been moved to `/Users/jenkins/datatable_envs/py*/`.  