### PR TITLE
Fix failing tests for python `3.10.1`

### DIFF
--- a/tests/test-dt-stats.py
+++ b/tests/test-dt-stats.py
@@ -26,7 +26,7 @@ import random
 import statistics
 from datatable import stype, ltype
 from datatable.internal import frame_integrity_check
-from math import inf, nan, isnan, isclose
+from math import inf, nan, isnan, isclose, isinf
 from tests import list_equals
 
 
@@ -196,17 +196,21 @@ def test_dt_mean_special_cases(src, res):
 #-------------------------------------------------------------------------------
 
 def t_sd(t):
-    if inf in t or -inf in t:
+    tt = []
+    for i in t:
+        if i is not None and not isnan(i):
+            if isinf(i):
+                return None
+            tt.append(i)
+
+    if len(tt) == 0:
         return None
-    t = [i for i in t
-         if i is not None and not isnan(i)]
-    if len(t) == 0:
-        return None
-    elif len(t) == 1:
+    elif len(tt) == 1:
         return 0
     else:
-        res = statistics.stdev(t)
+        res = statistics.stdev(tt)
         return res if not isnan(res) else None
+
 
 @pytest.mark.parametrize("src", srcs_numeric)
 def test_dt_sd(src):

--- a/tests/test-dt-stats.py
+++ b/tests/test-dt-stats.py
@@ -44,7 +44,7 @@ srcs_int = [[5, -3, 6, 3, 0],
             [-1, 1], [100], [0]]
 srcs_real = [[9.5, 0.2, 5.4857301, -3.14159265358979],
              [1.1, 2.3e12, -.5, None, inf, 0.0],
-             [3.5, 2.36, nan, 696.9, 4097],
+             [3.5, 2.36, -inf, nan, 696.9, 4097],
              [3.1415926535897932], [nan]]
 
 srcs_str = [["foo", None, "bar", "baaz", None],
@@ -196,6 +196,8 @@ def test_dt_mean_special_cases(src, res):
 #-------------------------------------------------------------------------------
 
 def t_sd(t):
+    if inf in t or -inf in t:
+        return None
     t = [i for i in t
          if i is not None and not isnan(i)]
     if len(t) == 0:


### PR DESCRIPTION
It seems like there are some changes in the `statistics.stdev()` and it now throws an exception for data containing infinite values, it returned `nan` in the earlier versions. In this PR we modify tests, so that we never pass infinite data to `statistics.stdev()`.