### PR TITLE
Adjust documentation for newly developed functions

### DIFF
--- a/docs/api/dt/countna.rst
+++ b/docs/api/dt/countna.rst
@@ -5,6 +5,7 @@
     :cvar: doc_dt_countna
     :signature: countna(cols)
 
+    .. x-version-added:: 1.1.0
 
     Count the number of NA values for each column from `cols`.
 

--- a/docs/api/dt/nunique.rst
+++ b/docs/api/dt/nunique.rst
@@ -5,6 +5,7 @@
     :cvar: doc_dt_nunique
     :signature: nunique(cols)
 
+    .. x-version-added:: 1.1.0
 
     Count the number of unique values for each column from `cols`.
 

--- a/docs/api/dt/prod.rst
+++ b/docs/api/dt/prod.rst
@@ -5,6 +5,7 @@
     :cvar: doc_dt_prod
     :signature: prod(cols)
 
+    .. x-version-added:: 1.1.0
 
     Calculate the product of values for each column from `cols`.
 

--- a/docs/api/dt/rowargmax.rst
+++ b/docs/api/dt/rowargmax.rst
@@ -5,6 +5,8 @@
     :cvar: doc_dt_rowargmax
     :signature: rowargmax(*cols)
 
+    .. x-version-added:: 1.1.0
+
     For each row, find the index of the largest value among the columns from `cols`.
     When the largest value occurs more than once, the smallest column index
     is returned.

--- a/docs/api/dt/rowargmin.rst
+++ b/docs/api/dt/rowargmin.rst
@@ -5,6 +5,8 @@
     :cvar: doc_dt_rowargmin
     :signature: rowargmin(*cols)
 
+    .. x-version-added:: 1.1.0
+
     For each row, find the smallest value among the columns from `cols`.
 
 

--- a/docs/api/fexpr/as_type.rst
+++ b/docs/api/fexpr/as_type.rst
@@ -4,5 +4,7 @@
     :cvar: doc_FExpr_as_type
     :signature: as_type(new_type)
 
+    .. x-version-added:: 1.1.0
+
     Equivalent to :func:`dt.as_type(cols, new_type)`.
 

--- a/docs/api/fexpr/rowargmax.rst
+++ b/docs/api/fexpr/rowargmax.rst
@@ -4,4 +4,6 @@
     :cvar: doc_FExpr_rowargmax
     :signature: rowargmax()
 
+    .. x-version-added:: 1.1.0
+
     Equivalent to :func:`dt.rowargmax(self)`.

--- a/docs/api/fexpr/rowargmin.rst
+++ b/docs/api/fexpr/rowargmin.rst
@@ -4,4 +4,6 @@
     :cvar: doc_FExpr_rowargmin
     :signature: rowargmin()
 
+    .. x-version-added:: 1.1.0
+
     Equivalent to :func:`dt.rowargmin(self)`.

--- a/docs/api/re/match.rst
+++ b/docs/api/re/match.rst
@@ -18,9 +18,14 @@
         The regular expression that will be tested against each value
         in the `column`.
 
+
     icase: bool
+
+        .. x-version-added:: 1.1.0
+
         If `True`, character matching will be performed without regard to case.
 
     return: FExpr[bool8]
         A boolean column that tells whether the value in each row of
         `column` matches the `pattern` or not.
+


### PR DESCRIPTION
It seems that we've been missing quite a lot of `x-version-added` on documentation pages for newly developed functions, see #3228. In this PR we fix documentation in this respect.