### PR TITLE
Fix a bug in the gradient calculation for the linear model

### DIFF
--- a/docs/releases/v1.1.0.rst
+++ b/docs/releases/v1.1.0.rst
@@ -96,8 +96,8 @@
     Models
     ------
 
-    -[fix] Fixed a bug in the :class:`LinearModel` that in some cases resulted
-    in the gradient and model coefficients blow up. [#3234]
+    -[fix] Fixed a bug in the :class:`LinearModel <dt.models.LinearModel>` that in some cases resulted
+         in the gradient and model coefficients blow up. [#3234]
 
 
     General

--- a/docs/releases/v1.1.0.rst
+++ b/docs/releases/v1.1.0.rst
@@ -93,6 +93,13 @@
         files. [#3055]
 
 
+    Models
+    ------
+
+    -[fix] Fixed a bug in the linear model that in some cases resulted in the gradient
+    and model coefficients blow up. [#3232]
+
+
     General
     -------
 

--- a/docs/releases/v1.1.0.rst
+++ b/docs/releases/v1.1.0.rst
@@ -96,8 +96,8 @@
     Models
     ------
 
-    -[fix] Fixed a bug in the linear model that in some cases resulted in the gradient
-    and model coefficients blow up. [#3232]
+    -[fix] Fixed a bug in the :class:`LinearModel` that in some cases resulted
+    in the gradient and model coefficients blow up. [#3234]
 
 
     General

--- a/src/core/models/dt_linearmodel.cc
+++ b/src/core/models/dt_linearmodel.cc
@@ -189,14 +189,14 @@ LinearModelFitOutput LinearModel<T>::fit_impl() {
             for (size_t k = 0; k < label_ids_fit_.size(); ++k) {
               T p = activation_fn(predict_row(x, betas, k));
               T y = target_fn(target, label_ids_fit_[k]);
-
-              // If we use sigmoid activation, gradients for linear and logistic
-              // regressions are the same. For other activations the gradient
-              // should be adjusted accordingly.
-              T gradient = (p - y);
+              T delta = p - y;
 
               // Update local betas with SGD, j = 0 corresponds to the bias term
               for (size_t j = 0; j < nfeatures_ + 1; ++j) {
+                // If we use sigmoid activation, gradients for linear and logistic
+                // regressions are the same. For other activations the gradient
+                // should be adjusted accordingly.
+                T gradient = delta;
                 if (j) gradient *= x[j - 1];
                 gradient += copysign(lambda1_, betas[k][j]); // L1 regularization
                 gradient += 2 * lambda2_ * betas[k][j];      // L2 regularization


### PR DESCRIPTION
Gradient calculation in the linear model had a bug that caused cumulative gradient multiplication across all the features. In some cases this resulted in the model coefficients blow-up and totally wrong predictions. In this PR we fix this bug.