### PR TITLE
Fix writing void rbound columns to jay

### DIFF
--- a/docs/releases/v1.1.0.rst
+++ b/docs/releases/v1.1.0.rst
@@ -17,7 +17,7 @@
         constant values. [#3088] [#3104] [#3108] [#3109]
 
     -[fix] Saving a frame with a :attr:`void <dt.Type.void>` column into Jay
-        no longer leads to a crash. [#3074] [#3099]
+        no longer leads to a crash. [#3074] [#3099] [#3246]
 
     -[fix] Joining with void columns now works correctly. [#3094]
 

--- a/src/core/jay/save_jay.cc
+++ b/src/core/jay/save_jay.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2021 H2O.ai
+// Copyright 2018-2022 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -301,12 +301,13 @@ void dt::ConstNa_ColumnImpl::save_to_jay(ColumnJayData& cj) {
 
 
 void dt::Rbound_ColumnImpl::save_to_jay(ColumnJayData& cj) {
+  cj.store_stype(stype());
+  if (stype() == dt::SType::VOID) return;
+
   for (Column& col : chunks_) {
     col.materialize();
   }
-  cj.store_stype(stype());
   cj.store_stats();
-
   if (stype() == dt::SType::STR32 || stype() == dt::SType::STR64) {
     _write_str_offsets_to_jay(cj);
     _write_str_data_to_jay(cj);


### PR DESCRIPTION
Sometimes when doing `fread()` rbound void columns could be produced. In this PR we fix writing this kind of columns to jay.