### PR TITLE
Rearrange items in changelog

### DIFF
--- a/docs/releases/v1.1.0.rst
+++ b/docs/releases/v1.1.0.rst
@@ -62,21 +62,21 @@
     -[new] Class :class:`dt.FExpr` now has method :meth:`.as_type()`,
       which behaves exactly as the equivalent base level function :func:`dt.as_type()`.
 
-    -[enh] Added reducer functions :func:`dt.countna()` and :func:`dt.nunique()`. [#2999]
+    -[new] Added functions :func:`dt.rowargmin()` and :func:`dt.rowargmin()`to find the
+      index of the largest and smallest values among columns of each row. [#2998]
 
     -[new] Added reducer function :func:`dt.prod()`, as well as :meth:`.prod()` method,
       which behaves exactly as :func:`dt.prod()`. [#3140]
+
+    -[enh] Added reducer functions :func:`dt.countna()` and :func:`dt.nunique()`. [#2999]
+
+    -[enh] Function :func:`dt.re.match()` now supports case insensitive matching. [#3216]
 
     -[fix] :func:`dt.qcut()` won't segfault anymore when used as an i-filter. [#3061]
 
     -[fix] Fixed selection of ``time64`` columns by ``ltype``. [#3251]
 
     -[fix] Fixed selection of ``time64`` columns by python class name. [#3253]
-
-    -[new] Added functions :func:`dt.rowargmin()` and :func:`dt.rowargmin()`to find the
-      index of the largest and smallest values among columns of each row. [#2998]
-
-    -[enh] Function :func:`dt.re.match()` now supports case insensitive matching. [#3216]
 
 
     fread
@@ -89,32 +89,27 @@
     -[enh] When reading Excel files, forward slash, backslash,
         and their mix are supported as separators for specifying subpath. [#3221]
 
-    -[api] Parameter ``sep=`` in :func:`fread()` will no longer accept values
-        ``'-'``, ``'+'``, or ``'.'``. Previously, these values were allowed but
-        they produced errors during parsing. [#3065]
-
     -[fix] :func:`fread()` will no longer fail while reading mostly empty
         files. [#3055]
 
     -[fix] Parameter ``tempdir`` is now honored for memory limited :func:`fread()`
         operation. [#3244]
 
+    -[api] Parameter ``sep=`` in :func:`fread()` will no longer accept values
+        ``'-'``, ``'+'``, or ``'.'``. Previously, these values were allowed but
+        they produced errors during parsing. [#3065]
+
 
     Models
     ------
 
-    -[fix] Fixed a bug in the :class:`LinearModel <dt.models.LinearModel>` that in some cases resulted
-         in the gradient and model coefficients blow up. [#3234]
+    -[fix] Fixed a bug in the :class:`LinearModel <dt.models.LinearModel>`
+        that in some cases resulted in the gradient and model coefficients
+        blow up. [#3234]
 
 
     General
     -------
-
-    -[enh] Added support for Python `3.10`. [#3210]
-
-    -[enh] Parameter ``force=True`` in function :func:`rbind()` (or method
-        :meth:`dt.Frame.rbind()`) will now allow combining columns
-        of incompatible types. [#3062]
 
     -[new] Added properties :attr:`.is_array <dt.Type.is_array>`,
         :attr:`.is_boolean <dt.Type.is_boolean>`,
@@ -126,3 +121,10 @@
         :attr:`.is_string <dt.Type.is_string>`,
         :attr:`.is_temporal <dt.Type.is_temporal>`,
         :attr:`.is_void <dt.Type.is_void>` to class :class:`dt.Type`. [#3101]
+
+    -[enh] Added support for Python `3.10`. [#3210]
+
+    -[enh] Parameter ``force=True`` in function :func:`rbind()` (or method
+        :meth:`dt.Frame.rbind()`) will now allow combining columns
+        of incompatible types. [#3062]
+


### PR DESCRIPTION
Use the order `[new]`, `[enh]`, `[fix]` and `[api]` in the current changelog, just like we did for previous releases.