### PR TITLE
Make `qcut()` function to be group-aware

### DIFF
--- a/src/core/expr/fexpr_qcut.cc
+++ b/src/core/expr/fexpr_qcut.cc
@@ -19,7 +19,6 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
-#include <iostream>
 #include "_dt.h"
 #include "column/latent.h"
 #include "column/sentinel_fw.h"

--- a/src/core/expr/fexpr_qcut.cc
+++ b/src/core/expr/fexpr_qcut.cc
@@ -102,10 +102,14 @@ class FExpr_Qcut : public FExpr_Func {
         for (size_t i = 0; i < ncols; ++i) {
           nquantiles[i] = nquantiles_default;
           const Column& coli = wf.get_column(i);
-          if (coli.ltype() == dt::LType::OBJECT) {
+          const dt::Type& typei = coli.type();
+          if (!typei.is_numeric_or_void() &&
+              !typei.is_boolean() &&
+              !typei.is_temporal() &&
+              !typei.is_string())
+          {
             throw TypeError() << "`qcut()` cannot be applied to "
-              << "object columns, instead column `" << i
-              << "` has an stype: `" << coli.stype() << "`";
+              << "columns of type: `" << typei << "`";
           }
         }
       }

--- a/src/core/expr/fexpr_qcut.cc
+++ b/src/core/expr/fexpr_qcut.cc
@@ -128,9 +128,9 @@ class FExpr_Qcut : public FExpr_Func {
             RowIndex ri(static_cast<size_t>(offsets[j]), group_size, 1);
             coli_group.apply_rowindex(ri);
             // qcut j's group
-            colv[j] = Column(new Qcut_ColumnImpl(
+            colv[j] = Column(new Latent_ColumnImpl(new Qcut_ColumnImpl(
               std::move(coli_group), nquantiles[i], is_grouped
-            ));
+            )));
           }
           // rbind all the results
           coli = Column::new_na_column(0, SType::VOID);

--- a/src/core/expr/head_func_shift.cc
+++ b/src/core/expr/head_func_shift.cc
@@ -105,7 +105,6 @@ Workframe Head_Func_Shift::evaluate_n(
     for (size_t i = 0; i < inputs.ncols(); ++i) {
       Column coli = inputs.retrieve_column(i);
       size_t nrows = coli.nrows();
-      // coli.apply_rowindex(ri);
       if (shift_ > 0) {
         coli = Column(new Shift_ColumnImpl<true>(
                         std::move(coli), static_cast<size_t>(shift_), nrows));

--- a/src/core/expr/workframe.cc
+++ b/src/core/expr/workframe.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019 H2O.ai
+// Copyright 2019-2022 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -247,7 +247,20 @@ void Workframe::reshape_for_update(size_t target_nrows, size_t target_ncols) {
 
 
 const Column& Workframe::get_column(size_t i) const {
+  xassert(i < entries_.size());
   return entries_[i].column;
+}
+
+
+uint32_t Workframe::get_column_id(size_t i) const {
+  xassert(i < entries_.size());
+  return entries_[i].column_id;
+}
+
+
+uint32_t Workframe::get_frame_id(size_t i) const {
+  xassert(i < entries_.size());
+  return entries_[i].frame_id;
 }
 
 
@@ -274,7 +287,6 @@ void Workframe::replace_column(size_t i, Column&& col) {
 Grouping Workframe::get_grouping_mode() const {
   return grouping_mode_;
 }
-
 
 
 std::unique_ptr<DataTable> Workframe::convert_to_datatable() && {

--- a/src/core/expr/workframe.h
+++ b/src/core/expr/workframe.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019 H2O.ai
+// Copyright 2019-2022 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -116,6 +116,8 @@ class Workframe {
 
     void reshape_for_update(size_t target_nrows, size_t target_ncols);
     const Column& get_column(size_t i) const;
+    uint32_t get_column_id(size_t i) const;
+    uint32_t get_frame_id(size_t i) const;
     std::string retrieve_name(size_t i);
     Column      retrieve_column(size_t i);
     void        replace_column(size_t i, Column&& col);

--- a/tests/dt/test-qcut.py
+++ b/tests/dt/test-qcut.py
@@ -42,16 +42,14 @@ def test_qcut_error_noargs():
 
 def test_qcut_error_wrong_column_types():
     DT = dt.Frame([[0], [dt]/dt.obj64])
-    msg = r"qcut\(\) cannot be applied to object columns, instead " \
-           "column 1 has an stype: obj64"
+    msg = r"qcut\(\) cannot be applied to columns of type: obj64"
     with pytest.raises(TypeError, match=msg):
         DT[:, qcut(f[:])]
 
 
 def test_qcut_error_wrong_column_type_zero_rows():
     DT = dt.Frame(obj = [] / dt.obj64)
-    msg = r"qcut\(\) cannot be applied to object columns, instead " \
-           "column 0 has an stype: obj64"
+    msg = r"qcut\(\) cannot be applied to columns of type: obj64"
     with pytest.raises(TypeError, match=msg):
         DT[:, qcut(f[:])]
 
@@ -143,10 +141,10 @@ def test_qcut_one_row():
 
 
 def test_qcut_small():
-    nquantiles = [4, 5, 4, 2, 5, 4, 10, 3, 2, 5]
+    nquantiles = [4, 5, 4, 2, 5, 4, 10, 3, 2, 5, 4]
     colnames = ["bool", "one_group_odd", "one_group_even",
                 "int_pos", "int_neg", "int", "float",
-                "inf_max", "inf_min", "inf"]
+                "inf_max", "inf_min", "inf", "str"]
 
     DT = dt.Frame(
            [[True, None, False, False, True, None],
@@ -158,7 +156,8 @@ def test_qcut_small():
            [None, 1.4, 4.1, 1.5, 5.9, 1.4],
            [math.inf, 1.4, 4.1, 1.5, 5.9, 1.4],
            [-math.inf, 1.4, 4.1, 1.5, 5.9, 1.4],
-           [-math.inf, 1.4, 4.1, math.inf, 5.9, 1.4]],
+           [-math.inf, 1.4, 4.1, math.inf, 5.9, 1.4],
+           ["cat", "dog", "mouse", "moose", "dog", "cat2"]],
            names = colnames
          )
 
@@ -172,7 +171,8 @@ def test_qcut_small():
                [None, 0, 6, 3, 9, 0],
                [2, 0, 1, 0, 2, 0],
                [0, 0, 1, 0, 1, 0],
-               [0, 1, 2, 4, 3, 1]],
+               [0, 1, 2, 4, 3, 1],
+               [0, 1, 3, 2, 1, 0]],
                names = colnames,
                stypes = [stype.int32] * DT.ncols
              )


### PR DESCRIPTION
We also allow quantile binning for string columns, just because `dt.qcut()` only depends on group-by that is available for strings.

Closes #3165