### PR TITLE
Make `sum()` and `prod()` reducer be applicable to `void` columns

### DIFF
--- a/docs/api/dt/cumsum.rst
+++ b/docs/api/dt/cumsum.rst
@@ -7,7 +7,8 @@
 
     .. x-version-added:: 1.1.0
 
-    For each column from `cols` calculate cumulative sum. In the presence of :func:`by()`,
+    For each column from `cols` calculate cumulative sum. The sum of
+    the missing values is defined to be zero. In the presence of :func:`by()`,
     the cumulative sum is computed per group.
 
     Parameters

--- a/docs/api/dt/cumsum.rst
+++ b/docs/api/dt/cumsum.rst
@@ -8,7 +8,7 @@
     .. x-version-added:: 1.1.0
 
     For each column from `cols` calculate cumulative sum. The sum of
-    the missing values is defined to be zero. In the presence of :func:`by()`,
+    the missing values is calculated as zero. In the presence of :func:`by()`,
     the cumulative sum is computed per group.
 
     Parameters

--- a/docs/api/dt/prod.rst
+++ b/docs/api/dt/prod.rst
@@ -8,7 +8,7 @@
     .. x-version-added:: 1.1.0
 
     Calculate the product of values for each column from `cols`. The product
-    of missing values is defined to be one.
+    of missing values is calculated as one.
 
     Parameters
     ----------

--- a/docs/api/dt/prod.rst
+++ b/docs/api/dt/prod.rst
@@ -7,7 +7,8 @@
 
     .. x-version-added:: 1.1.0
 
-    Calculate the product of values for each column from `cols`.
+    Calculate the product of values for each column from `cols`. The product
+    of missing values is defined to be one.
 
     Parameters
     ----------

--- a/docs/api/dt/sum.rst
+++ b/docs/api/dt/sum.rst
@@ -6,7 +6,7 @@
     :signature: sum(cols)
 
     Calculate the sum of values for each column from `cols`. The sum of
-    the missing values is defined to be zero.
+    the missing values is calculated as zero.
 
 
     Parameters

--- a/docs/api/dt/sum.rst
+++ b/docs/api/dt/sum.rst
@@ -5,7 +5,8 @@
     :cvar: doc_dt_sum
     :signature: sum(cols)
 
-    Calculate the sum of values for each column from `cols`.
+    Calculate the sum of values for each column from `cols`. The sum of
+    the missing values is defined to be zero.
 
 
     Parameters

--- a/docs/releases/v1.1.0.rst
+++ b/docs/releases/v1.1.0.rst
@@ -94,6 +94,9 @@
 
     -[fix] Fixed :func:`dt.shift()` behaviour on grouped columns. [#3269] [#3272]
 
+    -[fix] Reducer functions :func:`dt.prod()` and :func:`dt.sum()` can now be
+       applied to :attr:`void <dt.Type.void>` columns. [#3281] [#3282]
+
 
     fread
     -----

--- a/src/core/expr/head_reduce_unary.cc
+++ b/src/core/expr/head_reduce_unary.cc
@@ -20,6 +20,7 @@
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #include <unordered_map>
+#include "column/const.h"
 #include "column/latent.h"
 #include "column/virtual.h"
 #include "expr/eval_context.h"
@@ -213,6 +214,7 @@ static Column _prod(Column&& arg, const Groupby& gby) {
 
 static Column compute_prod(Column&& arg, const Groupby& gby) {
   switch (arg.stype()) {
+    case SType::VOID:    return Const_ColumnImpl::make_int_column(gby.size(), 1, SType::INT64);
     case SType::BOOL:
     case SType::INT8:    return _prod<int8_t, int64_t>(std::move(arg), gby);
     case SType::INT16:   return _prod<int16_t, int64_t>(std::move(arg), gby);
@@ -332,6 +334,7 @@ static Column _sum(Column&& arg, const Groupby& gby) {
 
 static Column compute_sum(Column&& arg, const Groupby& gby) {
   switch (arg.stype()) {
+    case SType::VOID:    return Const_ColumnImpl::make_int_column(gby.size(), 0, SType::INT64);
     case SType::BOOL:
     case SType::INT8:    return _sum<int8_t, int64_t>(std::move(arg), gby);
     case SType::INT16:   return _sum<int16_t, int64_t>(std::move(arg), gby);

--- a/src/datatable/__init__.py
+++ b/src/datatable/__init__.py
@@ -144,6 +144,7 @@ __all__ = (
     "unique",
 )
 
+void = stype.void
 bool8 = stype.bool8
 int8 = stype.int8
 int16 = stype.int16

--- a/tests/test-f.py
+++ b/tests/test-f.py
@@ -42,7 +42,6 @@ def DT():
             dt.float64, dt.str32])
 
 
-
 #-------------------------------------------------------------------------------
 # Plain `f`
 #-------------------------------------------------------------------------------
@@ -93,6 +92,7 @@ def test_f_col_selector_invalid():
     # Note: at some point we may start supporting all the expressions below:
     with pytest.raises(TypeError):
         noop(f[lambda: 1])
+
 
 def test_f_col_selector_list_tuple():
     assert str(f[[7, 4]]) == "FExpr<f[[7, 4]]>"
@@ -205,6 +205,7 @@ def test_f_columnset_ltypes(DT):
                       DT[:, [i for i in range(DT.ncols)
                              if DT.ltypes[i] == lt]])
 
+
 def test_columnset_sum(DT):
     assert_equals(DT[:, f[int].extend(f[float])], DT[:, [int, float]])
     assert_equals(DT[:, f[:3].extend(f[-3:])], DT[:, [0, 1, 2, -3, -2, -1]])
@@ -233,11 +234,13 @@ def test_sum():
     DT = dt.Frame(A=range(1, 10))
     assert_equals(DT[:, f.A.sum()], DT[:, dt.sum(f.A)])
 
+
 def test_max():
     assert str(dt.max(f.A)) == str(f.A.max())
     assert str(dt.max(f[:])) == str(f[:].max())
     DT = dt.Frame(A=range(1, 10))
     assert_equals(DT[:, f.A.max()], DT[:, dt.max(f.A)])
+
 
 def test_mean():
     assert str(dt.mean(f.A)) == str(f.A.mean())
@@ -245,28 +248,34 @@ def test_mean():
     DT = dt.Frame(A=range(1, 10))
     assert_equals(DT[:, f.A.mean()], DT[:, dt.mean(f.A)])
 
+
 def test_median():
     assert str(dt.median(f.A)) == str(f.A.median())
     assert str(dt.median(f[:])) == str(f[:].median())
     DT = dt.Frame(A=[2, 3, 5, 5, 9, -1, 2.2])
     assert_equals(DT[:, f.A.median()], DT[:, dt.median(f.A)])
 
+
 def test_min():
     assert str(dt.min(f.A)) == str(f.A.min())
     assert str(dt.min(f[:])) == str(f[:].min())
     DT = dt.Frame(A=[2, 3, 5, 5, 9, -1, 2.2])
     assert_equals(DT[:, f.A.min()], DT[:, dt.min(f.A)])
+
+
 def test_rowall():
     assert str(dt.rowall(f.A)) == str(f.A.rowall())
     assert str(dt.rowall(f[:])) == str(f[:].rowall())
     DT = dt.Frame({'A': [True, True], 'B': [True, False]})
     assert_equals(DT[:, f[:].rowall()], DT[:, dt.rowall(f[:])])
 
+
 def test_rowany():
     assert str(dt.rowany(f.A)) == str(f.A.rowany())
     assert str(dt.rowany(f[:])) == str(f[:].rowany())
     DT = dt.Frame({'A': [True, True], 'B': [True, False]})
     assert_equals(DT[:, f[:].rowany()], DT[:, dt.rowany(f[:])])
+
 
 def test_rowfirst():
     assert str(dt.rowfirst(f.A)) == str(f.A.rowfirst())
@@ -277,6 +286,7 @@ def test_rowfirst():
 
     assert_equals(DT[:, f[:].rowfirst()], DT[:, dt.rowfirst(f[:])])
 
+
 def test_rowlast():
     assert str(dt.rowlast(f.A)) == str(f.A.rowlast())
     assert str(dt.rowlast(f[:])) == str(f[:].rowlast())
@@ -285,6 +295,7 @@ def test_rowlast():
                    'C':[2, None, 5, None]})
 
     assert_equals(DT[:, f[:].rowlast()], DT[:, dt.rowlast(f[:])])
+
 
 def test_rowmax():
     assert str(dt.rowmax(f.A)) == str(f.A.rowmax())
@@ -321,6 +332,7 @@ def test_rowmean():
 
     assert_equals(DT[:, f[:].rowmean()], DT[:, dt.rowmean(f[:])])
 
+
 def test_rowcount():
     assert str(dt.rowcount(f.A)) == str(f.A.rowcount())
     assert str(dt.rowcount(f[:])) == str(f[:].rowcount())
@@ -328,6 +340,7 @@ def test_rowcount():
                    "D": [10, 8, 20, 20, 1]})
 
     assert_equals(DT[:, f[:].rowcount()], DT[:, dt.rowcount(f[:])])
+
 
 def test_rowsd():
     assert str(dt.rowsd(f.A)) == str(f.A.rowsd())
@@ -381,6 +394,7 @@ def test_count():
     assert_equals(DT[:, f.A.count()], DT[:, dt.count(f.A)])
     assert_equals(DT[:, f[:].count()], DT[:, dt.count(f[:])])
 
+
 def test_first():
     assert str(dt.first(f.A)) == str(f.A.first())
     assert str(dt.first(f[:])) == str(f[:].first())
@@ -390,6 +404,7 @@ def test_first():
 
     assert_equals(DT[:, f.A.first()], DT[:, dt.first(f.A)])
     assert_equals(DT[:, f[:].first()], DT[:, dt.first(f[:])])
+
 
 def test_as_type():
     assert str(dt.as_type(f.A, int)) == str(f.A.as_type(int))
@@ -415,11 +430,13 @@ def test_nunique():
     DT = dt.Frame(A=range(1, 5))
     assert_equals(DT[:, f.A.nunique()], DT[:, dt.nunique(f.A)])
 
+
 def test_countna():
     assert str(dt.countna(f.A)) == str(f.A.countna())
     assert str(dt.countna(f[:])) == str(f[:].countna())
     DT = dt.Frame(A = [9, 8, 2, 3, None, None, 3, 0, 5, 5, 8, None, 1])
     assert_equals(DT[:, f.A.countna()], DT[:, dt.countna(f.A)])
+
 
 def test_cumsum():
     assert str(dt.cumsum(f.A)) == str(f.A.cumsum())

--- a/tests/test-reduce.py
+++ b/tests/test-reduce.py
@@ -31,6 +31,7 @@ from datatable import stype, ltype
 from datatable.internal import frame_integrity_check
 from tests import assert_equals, noop
 
+
 #-------------------------------------------------------------------------------
 # Count
 #-------------------------------------------------------------------------------
@@ -137,7 +138,6 @@ def test_count_with_i():
     assert DT[:5, count()][0, 0] == 5
     assert DT[-12:, count()][0, 0] == 12
     assert DT[::3, count()][0, 0] == 34
-
 
 
 
@@ -284,17 +284,25 @@ def test_sum_simple():
 
 
 def test_sum_empty_frame():
-    DT = dt.Frame([[]] * 4, names=list("ABCD"),
-                  stypes=(dt.bool8, dt.int32, dt.float32, dt.float64))
-    assert DT.shape == (0, 4)
+    DT = dt.Frame([[]] * 5, names=list("ABCDE"),
+                  stypes=(dt.bool8, dt.int32, dt.float32, dt.float64, dt.void))
+    assert DT.shape == (0, 5)
     RZ = DT[:, sum(f[:])]
     frame_integrity_check(RZ)
-    assert RZ.shape == (1, 4)
-    assert RZ.names == ("A", "B", "C", "D")
-    assert RZ.stypes == (dt.int64, dt.int64, dt.float32, dt.float64)
-    assert RZ.to_list() == [[0], [0], [0], [0]]
+    assert RZ.shape == (1, 5)
+    assert RZ.names == ("A", "B", "C", "D", "E")
+    assert RZ.stypes == (dt.int64, dt.int64, dt.float32, dt.float64, dt.int64)
+    assert RZ.to_list() == [[0], [0], [0], [0], [0]]
     assert str(RZ)
 
+
+def test_sum_grouped():
+    DT = dt.Frame(A=[True, False, True, True], B=[None, None, None, 10], C=[2,3,5,-5])
+    RES = DT[:, sum(f[:]), by(f.A)]
+    REF = dt.Frame(A=[False, True], B=[0, 10]/dt.int64, C=[3,2]/dt.int64)
+    frame_integrity_check(RES)
+    assert_equals(RES, REF)
+    assert str(RES)
 
 
 
@@ -320,8 +328,6 @@ def test_mean_empty_frame():
     assert RZ.names == ("A", "B", "C", "D")
     assert RZ.stypes == (dt.float64, dt.float64, dt.float32, dt.float64)
     assert RZ.to_list() == [[None]] * 4
-
-
 
 
 
@@ -568,20 +574,26 @@ def test_prod_simple():
 
 
 def test_prod_empty_frame():
-    DT = dt.Frame([[]] * 4, names=list("ABCD"),
-                  stypes=(dt.bool8, dt.int32, dt.float32, dt.float64))
-    assert DT.shape == (0, 4)
+    DT = dt.Frame([[]] * 5, names=list("ABCDE"),
+                  stypes=(dt.bool8, dt.int32, dt.float32, dt.float64, dt.void))
+    assert DT.shape == (0, 5)
     RES = DT[:, prod(f[:])]
     frame_integrity_check(RES)
-    assert_equals(RES, dt.Frame(A=[1]/dt.int64, B=[1]/dt.int64, C=[1]/dt.float32, D=[1]/dt.float64))
+    assert_equals(RES, dt.Frame(A=[1]/dt.int64,
+                                B=[1]/dt.int64,
+                                C=[1]/dt.float32,
+                                D=[1]/dt.float64,
+                                E=[1]/dt.int64))
     assert str(RES)
 
+
 def test_prod_bool():
-    DT = dt.Frame(A= [True, False, True])
+    DT = dt.Frame(A=[True, False, True])
     RES = DT[:, prod(f.A)]
     frame_integrity_check(RES)
     assert RES.to_numpy().item() == np.prod([True, False, True])
     assert str(RES)
+
 
 def test_prod_floats():
     random_numbers = np.random.randn(3)
@@ -589,4 +601,13 @@ def test_prod_floats():
     RES = DT[:, prod(f.A)]
     frame_integrity_check(RES)
     assert RES.to_numpy().item() == np.prod(random_numbers)
+    assert str(RES)
+
+
+def test_prod_grouped():
+    DT = dt.Frame(A=[True, False, True, True], B=[None, None, None, 10], C=[2,3,5,0.1])
+    RES = DT[:, prod(f[:]), by(f.A)]
+    REF = dt.Frame(A=[False, True], B=[1, 10]/dt.int64, C=[3,1.0]/dt.float64)
+    frame_integrity_check(RES)
+    assert_equals(RES, REF)
     assert str(RES)


### PR DESCRIPTION
WIP for #3284 
Closes #3281 
Closes #3282