### PR TITLE
Fix styles for "Changed in version" documentation banner

### DIFF
--- a/docs/_static/xversion.css
+++ b/docs/_static/xversion.css
@@ -77,7 +77,7 @@ div.x-version.deprecated > div:first-child a {
  * x-version-changed
  *-----------------------------------------------------------------------------*/
 
-.x-version.changed {
+.x-version.changed:not(.admonition) {
     border: 1px solid #82dbef;
     padding: 4px 8px 4px 30px;
     background: #f3f9ff;
@@ -85,15 +85,13 @@ div.x-version.deprecated > div:first-child a {
 
 .x-version.changed > div:first-child {
     color: #1c6c79;
-    margin-bottom: .5rem;
     padding: 0;
     position: relative;
 }
 
-.x-version.changed > div:first-child:before {
+.x-version.changed:not(.admonition) > div:first-child:before {
     content: "\f0aa";
     position: absolute;
-    left: -18px;
 }
 
 .x-version.changed > div:first-child a {

--- a/docs/releases/v1.1.0.rst
+++ b/docs/releases/v1.1.0.rst
@@ -65,7 +65,7 @@
     -[new] Class :class:`dt.FExpr` now has method :meth:`.as_type()`,
       which behaves exactly as the equivalent base level function :func:`dt.as_type()`.
 
-    -[new] Added functions :func:`dt.rowargmin()` and :func:`dt.rowargmin()`to find the
+    -[new] Added functions :func:`dt.rowargmin()` and :func:`dt.rowargmin()` to find the
       index of the largest and smallest values among columns of each row. [#2998]
 
     -[new] Added reducer function :func:`dt.prod()` and the corresponding :meth:`.prod()`


### PR DESCRIPTION
When we change a function's API, we usually add a "Changed in version" banner. Here is how this banner looks like, for instance, for [ifelse](https://datatable.readthedocs.io/en/latest/api/dt/ifelse.html#notes) function:

<img width="763" alt="Screen Shot 2022-05-19 at 10 38 05 PM" src="https://user-images.githubusercontent.com/35204136/169458104-206ffd78-d101-4dbd-a755-63f977b65784.png">

And here is how it looks after the fix:
<img width="788" alt="Screen Shot 2022-05-19 at 10 38 24 PM" src="https://user-images.githubusercontent.com/35204136/169458145-7811372d-5274-419a-8b38-cafe19488786.png">

