### PR TITLE
Fix documentation builds

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,7 @@ sys.path.insert(0, os.path.abspath('.'))
 # -- Project information -----------------------------------------------------
 
 project = 'datatable'
-copyright = '2018-2020, H2O.ai'
+copyright = '2018-2022, H2O.ai'
 author = 'Pasha Stetsenko'
 
 try:
@@ -83,7 +83,7 @@ primary_domain = 'xpy'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.


### PR DESCRIPTION
In sphinx config set language to `en` to silence the warning:
```
WARNING: Invalid configuration value found: 'language = None'. Update your configuration to a valid langauge code. Falling back to 'en' (English).
```