### PR TITLE
Add support for `void` columns to statistical reducers

### DIFF
--- a/docs/api/index-api.rst
+++ b/docs/api/index-api.rst
@@ -177,12 +177,12 @@ Functions
       - Find the smallest element per column
     * - :func:`nunique()`
       - Count the number of unique values per column
+    * - :func:`prod()`
+      - Calculate the product of all values per column
     * - :func:`sd()`
       - Calculate the standard deviation per column
     * - :func:`sum()`
       - Calculate the sum of all values per column
-    * - :func:`prod()`
-      - Calculate the product of all values per column
 
 
 Other
@@ -252,6 +252,7 @@ Other
     median()          <dt/median>
     min()             <dt/min>
     nunique()         <dt/nunique>
+    prod()            <dt/prod>
     qcut()            <dt/qcut>
     rbind()           <dt/rbind>
     repeat()          <dt/repeat>
@@ -273,7 +274,6 @@ Other
     sort()            <dt/sort>
     split_into_nhot() <dt/split_into_nhot>
     sum()             <dt/sum>
-    prod()          <dt/prod>
     symdiff()         <dt/symdiff>
     union()           <dt/union>
     unique()          <dt/unique>

--- a/docs/releases/v1.1.0.rst
+++ b/docs/releases/v1.1.0.rst
@@ -94,10 +94,7 @@
 
     -[fix] Fixed :func:`dt.shift()` behaviour on grouped columns. [#3269] [#3272]
 
-    -[fix] Reducer functions :func:`dt.prod()` and :func:`dt.sum()` can now be
-       applied to :attr:`void <dt.Type.void>` columns. [#3281] [#3282]
-
-    -[fix] All the row-wise functions now support :attr:`void <dt.Type.void>`
+    -[fix] Reducers and row-wise functions now support :attr:`void <dt.Type.void>`
        columns. [#3284]
 
 

--- a/src/core/expr/head_reduce_nullary.cc
+++ b/src/core/expr/head_reduce_nullary.cc
@@ -51,7 +51,7 @@ static Column _count0(EvalContext& ctx)
   }
   else {
     auto value = static_cast<int64_t>(ctx.nrows());
-    return Const_ColumnImpl::make_int_column(1, value);
+    return Const_ColumnImpl::make_int_column(1, value, SType::INT64);
   }
 }
 

--- a/src/core/expr/head_reduce_unary.cc
+++ b/src/core/expr/head_reduce_unary.cc
@@ -516,7 +516,7 @@ bool sd_reducer(const Column& col, size_t i0, size_t i1, U* out) {
       m2 += tmp1 * tmp2;
     }
   }
-  if (count <= 1) return false;
+  if (count <= 1 || std::isnan(m2)) return false;
   // In theory, m2 should always be positive, but perhaps it could
   // occasionally become negative due to round-off errors?
   *out = static_cast<U>(m2 >= 0? std::sqrt(m2/static_cast<double>(count - 1))
@@ -539,7 +539,9 @@ static Column _sd(Column&& arg, const Groupby& gby) {
 
 static Column compute_sd(Column&& arg, const Groupby& gby) {
   switch (arg.stype()) {
-    case SType::VOID:    return Column(new ConstNa_ColumnImpl(gby.size()));
+    case SType::VOID:    return Column(new ConstNa_ColumnImpl(
+                                  gby.size(), SType::FLOAT64
+                                ));
     case SType::BOOL:
     case SType::INT8:    return _sd<int8_t> (std::move(arg), gby);
     case SType::INT16:   return _sd<int16_t>(std::move(arg), gby);

--- a/src/core/expr/head_reduce_unary.cc
+++ b/src/core/expr/head_reduce_unary.cc
@@ -214,7 +214,9 @@ static Column _prod(Column&& arg, const Groupby& gby) {
 
 static Column compute_prod(Column&& arg, const Groupby& gby) {
   switch (arg.stype()) {
-    case SType::VOID:    return Const_ColumnImpl::make_int_column(gby.size(), 1, SType::INT64);
+    case SType::VOID:    return Const_ColumnImpl::make_int_column(
+                           gby.size(), 1, SType::INT64
+                         );
     case SType::BOOL:
     case SType::INT8:    return _prod<int8_t, int64_t>(std::move(arg), gby);
     case SType::INT16:   return _prod<int16_t, int64_t>(std::move(arg), gby);
@@ -274,6 +276,9 @@ class ProdGrouped_ColumnImpl : public Virtual_ColumnImpl {
 
 static Column compute_gprod(Column&& arg, const Groupby& gby) {
   switch (arg.stype()) {
+    case SType::VOID:    return Const_ColumnImpl::make_int_column(
+                           1, 1, SType::INT64
+                         );
     case SType::BOOL:
     case SType::INT8:    return Column(new ProdGrouped_ColumnImpl<int8_t,  int64_t>(
                                     std::move(arg), gby
@@ -296,10 +301,6 @@ static Column compute_gprod(Column&& arg, const Groupby& gby) {
     default: throw _error("prod", arg.stype());
   }
 }
-
-
-
-
 
 
 
@@ -396,24 +397,27 @@ class SumGrouped_ColumnImpl : public Virtual_ColumnImpl {
 
 static Column compute_gsum(Column&& arg, const Groupby& gby) {
   switch (arg.stype()) {
+    case SType::VOID:    return Const_ColumnImpl::make_int_column(
+                                  1, 0, SType::INT64
+                                );
     case SType::BOOL:
     case SType::INT8:    return Column(new SumGrouped_ColumnImpl<int8_t,  int64_t>(
-                                    std::move(arg), gby
+                                  std::move(arg), gby
                                 ));
     case SType::INT16:   return Column(new SumGrouped_ColumnImpl<int16_t, int64_t>(
-                                    std::move(arg), gby
+                                  std::move(arg), gby
                                 ));
     case SType::INT32:   return Column(new SumGrouped_ColumnImpl<int32_t, int64_t>(
-                                    std::move(arg), gby
+                                  std::move(arg), gby
                                 ));
     case SType::INT64:   return Column(new SumGrouped_ColumnImpl<int64_t, int64_t>(
-                                    std::move(arg), gby
+                                  std::move(arg), gby
                                 ));
     case SType::FLOAT32: return Column(new SumGrouped_ColumnImpl<float,   float>  (
-                                    std::move(arg), gby
+                                  std::move(arg), gby
                                 ));
     case SType::FLOAT64: return Column(new SumGrouped_ColumnImpl<double,  double> (
-                                    std::move(arg), gby
+                                  std::move(arg), gby
                                 ));
     default: throw _error("sum", arg.stype());
   }
@@ -458,6 +462,7 @@ static Column _mean(Column&& arg, const Groupby& gby) {
 
 static Column compute_mean(Column&& arg, const Groupby& gby) {
   switch (arg.stype()) {
+    case SType::VOID:    return Column(new ConstNa_ColumnImpl(gby.size()));
     case SType::BOOL:
     case SType::INT8:    return _mean<int8_t> (std::move(arg), gby);
     case SType::INT16:   return _mean<int16_t>(std::move(arg), gby);
@@ -534,6 +539,7 @@ static Column _sd(Column&& arg, const Groupby& gby) {
 
 static Column compute_sd(Column&& arg, const Groupby& gby) {
   switch (arg.stype()) {
+    case SType::VOID:    return Column(new ConstNa_ColumnImpl(gby.size()));
     case SType::BOOL:
     case SType::INT8:    return _sd<int8_t> (std::move(arg), gby);
     case SType::INT16:   return _sd<int16_t>(std::move(arg), gby);
@@ -600,7 +606,7 @@ static Column compute_gsd(Column&& arg, const Groupby& gby) {
   }
   SType res_stype = (arg_stype == SType::FLOAT32)? SType::FLOAT32
                                                  : SType::FLOAT64;
-  if (arg.nrows() == 0) {
+  if (arg.nrows() == 0 || arg_stype == SType::VOID) {
     return Column::new_na_column(1, res_stype);
   }
   return Column(new SdGrouped_ColumnImpl(res_stype, std::move(arg), gby));
@@ -626,7 +632,6 @@ bool count_reducer(const Column& col, size_t i0, size_t i1, int64_t* out) {
 }
 
 
-
 template <typename T>
 static Column _count(Column&& arg, const Groupby& gby) {
   return Column(
@@ -636,8 +641,12 @@ static Column _count(Column&& arg, const Groupby& gby) {
             )));
 }
 
+
 static Column compute_count(Column&& arg, const Groupby& gby) {
   switch (arg.stype()) {
+    case SType::VOID:    return Column(new ConstInt_ColumnImpl(
+                                  gby.size(), 0, SType::INT64
+                                ));
     case SType::BOOL:
     case SType::INT8:    return _count<int8_t>(std::move(arg), gby);
     case SType::INT16:   return _count<int16_t>(std::move(arg), gby);
@@ -657,7 +666,6 @@ static Column compute_count(Column&& arg, const Groupby& gby) {
 //------------------------------------------------------------------------------
 // countna
 //------------------------------------------------------------------------------
-
 
 template <typename T>
 bool op_countna(const Column& col, size_t i0, size_t i1, int64_t* out) {
@@ -756,6 +764,7 @@ static Column _gcount(Column&& arg, const Groupby& gby) {
 template<bool NA=false>
 static Column compute_gcount(Column&& arg, const Groupby& gby) {
   switch (arg.stype()) {
+    case SType::VOID:    return Column(new ConstInt_ColumnImpl(1, 0, SType::INT64));
     case SType::BOOL:
     case SType::INT8:    return _gcount<int8_t,NA>(std::move(arg), gby);
     case SType::INT16:   return _gcount<int16_t,NA>(std::move(arg), gby);
@@ -811,6 +820,7 @@ static Column _min(SType stype, Column&& arg, const Groupby& gby) {
 static Column compute_min(Column&& arg, const Groupby& gby) {
   auto st = arg.stype();
   switch (st) {
+    case SType::VOID:    return Column(new ConstNa_ColumnImpl(gby.size()));
     case SType::BOOL:
     case SType::INT8:    return _min<int8_t>(st, std::move(arg), gby);
     case SType::INT16:   return _min<int16_t>(st, std::move(arg), gby);
@@ -858,6 +868,7 @@ static Column _max(SType stype, Column&& arg, const Groupby& gby) {
 static Column compute_max(Column&& arg, const Groupby& gby) {
   auto st = arg.stype();
   switch (st) {
+    case SType::VOID:    return Column(new ConstNa_ColumnImpl(gby.size()));
     case SType::BOOL:
     case SType::INT8:    return _max<int8_t>(st, std::move(arg), gby);
     case SType::INT16:   return _max<int16_t>(st, std::move(arg), gby);
@@ -1060,6 +1071,7 @@ static Column compute_median(Column&& arg, const Groupby& gby) {
     return Column::new_na_column(1, arg.stype());
   }
   switch (arg.stype()) {
+    case SType::VOID:    return Column(new ConstNa_ColumnImpl(1));
     case SType::BOOL:
     case SType::INT8:    return _median<int8_t> (std::move(arg), gby);
     case SType::INT16:   return _median<int16_t>(std::move(arg), gby);

--- a/tests/test-reduce.py
+++ b/tests/test-reduce.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #-------------------------------------------------------------------------------
-# Copyright 2018-2021 H2O.ai
+# Copyright 2018-2022 H2O.ai
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -26,7 +26,7 @@ import numpy as np
 import pytest
 import random
 from datatable import (
-    dt, f, by, ltype, first, last, count, median, sum, mean, cov, corr, prod)
+    dt, f, by, ltype, first, last, count, median, sum, mean, cov, corr, prod, sd)
 from datatable import stype, ltype
 from datatable.internal import frame_integrity_check
 from tests import assert_equals, noop
@@ -35,6 +35,36 @@ from tests import assert_equals, noop
 #-------------------------------------------------------------------------------
 # Count
 #-------------------------------------------------------------------------------
+
+def test_count_array_void():
+    A = [None] * 10
+    A_cnt = count(A)
+    assert A_cnt == 0
+
+
+def test_count_dt_void():
+    DT = dt.Frame([None] * 10)
+    DT_cnt = DT[:, [count(f.C0), count()]]
+    assert_equals(DT_cnt, dt.Frame(C0=[0]/dt.int64, count=[10]/dt.int64))
+
+
+def test_count_dt_void_per_group():
+    DT = dt.Frame([[None, None, None, None, None], [1, 2, 1, 2, 2]])
+    DT_cnt = DT[:, [count(f.C0), count()], by(f.C1)]
+    assert_equals(
+        DT_cnt,
+        dt.Frame(C1=[1, 2]/dt.int32, C0=[0, 0]/dt.int64, count=[2, 3]/dt.int64)
+    )
+
+
+def test_count_dt_void_grouped():
+    DT = dt.Frame([[None, None, None, None, None], [1, 2, 1, 2, 2]])
+    DT_cnt = DT[:, [count(f.C0), count()], by(f.C0)]
+    assert_equals(
+        DT_cnt,
+        dt.Frame(C0=[None], C1=[0]/dt.int64, count=[5]/dt.int64)
+    )
+
 
 def test_count_array_integer():
     a_in = [9, 8, 2, 3, None, None, 3, 0, 5, 5, 8, None, 1]
@@ -233,6 +263,27 @@ def test_last_empty_frame():
 #-------------------------------------------------------------------------------
 
 @pytest.mark.parametrize("mm", [dt.min, dt.max])
+def test_minmax_void(mm):
+    DT = dt.Frame([None] * 10)
+    DT_mm = DT[:, mm(f.C0)]
+    assert_equals(DT_mm, dt.Frame(C0=[None]))
+
+
+@pytest.mark.parametrize("mm", [dt.min, dt.max])
+def test_minmax_void_per_group(mm):
+    DT = dt.Frame([[None, None, None, None, None], [1, 2, 1, 2, 2]])
+    DT_mm = DT[:, mm(f.C0), by(f.C1)]
+    assert_equals(DT_mm, dt.Frame(C1=[1, 2]/dt.int32, C0=[None, None]))
+
+
+@pytest.mark.parametrize("mm", [dt.min, dt.max])
+def test_minmax_void_grouped(mm):
+    DT = dt.Frame([[None, None, None, None, None], [1, 2, 1, 2, 2]])
+    DT_mm = DT[:, mm(f.C0), by(f.C0)]
+    assert_equals(DT_mm, dt.Frame([[None], [None]]))
+
+
+@pytest.mark.parametrize("mm", [dt.min, dt.max])
 @pytest.mark.parametrize("st", dt.ltype.int.stypes)
 def test_minmax_integer(mm, st):
     src = [0, 23, 100, 99, -11, 24, -1]
@@ -270,10 +321,27 @@ def test_minmax_nas(mm, st):
 
 
 
-
 #-------------------------------------------------------------------------------
 # sum
 #-------------------------------------------------------------------------------
+
+def test_sum_void():
+    DT = dt.Frame([None] * 10)
+    DT_sum = DT[:, sum(f.C0)]
+    assert_equals(DT_sum, dt.Frame([0]/dt.int64))
+
+
+def test_sum_void_per_group():
+    DT = dt.Frame([[None, None, None, None, None], [1, 2, 1, 2, 2]])
+    DT_sum = DT[:, sum(f.C0), by(f.C1)]
+    assert_equals(DT_sum, dt.Frame(C1=[1, 2]/dt.int32, C0=[0, 0]/dt.int64))
+
+
+def test_sum_void_grouped():
+    DT = dt.Frame([[None, None, None, None, None], [1, 2, 1, 2, 2]])
+    DT_sum = DT[:, sum(f.C0), by(f.C0)]
+    assert_equals(DT_sum, dt.Frame([[None], [0]/dt.int64]))
+
 
 def test_sum_simple():
     DT = dt.Frame(A=range(5))
@@ -310,6 +378,24 @@ def test_sum_grouped():
 # Mean
 #-------------------------------------------------------------------------------
 
+def test_mean_void():
+    DT = dt.Frame([None] * 10)
+    DT_mean = DT[:, mean(f.C0)]
+    assert_equals(DT_mean, dt.Frame([None]))
+
+
+def test_mean_void_per_group():
+    DT = dt.Frame([[None, None, None, None, None], [1, 2, 1, 2, 2]])
+    DT_mean = DT[:, mean(f.C0), by(f.C1)]
+    assert_equals(DT_mean, dt.Frame(C1=[1, 2]/dt.int32, C0=[None, None]))
+
+
+def test_mean_void_grouped():
+    DT = dt.Frame([[None, None, None, None, None], [1, 2, 1, 2, 2]])
+    DT_mean = DT[:, mean(f.C0), by(f.C0)]
+    assert_equals(DT_mean, dt.Frame([[None], [None]/dt.float64]))
+
+
 def test_mean_simple():
     DT = dt.Frame(A=range(5))
     RZ = DT[:, mean(f.A)]
@@ -334,6 +420,24 @@ def test_mean_empty_frame():
 #-------------------------------------------------------------------------------
 # Median
 #-------------------------------------------------------------------------------
+
+def test_median_void():
+    DT = dt.Frame([None] * 10)
+    DT_median = DT[:, mean(f.C0)]
+    assert_equals(DT_median, dt.Frame([None]))
+
+
+def test_median_void_per_group():
+    DT = dt.Frame([[None, None, None, None, None], [1, 2, 1, 2, 2]])
+    DT_median = DT[:, mean(f.C0), by(f.C1)]
+    assert_equals(DT_median, dt.Frame(C1=[1, 2]/dt.int32, C0=[None, None]))
+
+
+def test_median_void_grouped():
+    DT = dt.Frame([[None, None, None, None, None], [1, 2, 1, 2, 2]])
+    DT_median = DT[:, mean(f.C0), by(f.C0)]
+    assert_equals(DT_median, dt.Frame([[None], [None]/dt.float64]))
+
 
 def test_median_empty_frame():
     DT = dt.Frame(A=[])
@@ -565,6 +669,24 @@ def test_corr_multiple():
 # prod
 #-------------------------------------------------------------------------------
 
+def test_prod_void():
+    DT = dt.Frame([None] * 10)
+    DT_prod = DT[:, prod(f.C0)]
+    assert_equals(DT_prod, dt.Frame([1]/dt.int64))
+
+
+def test_prod_void_per_group():
+    DT = dt.Frame([[None, None, None, None, None], [1, 2, 1, 2, 2]])
+    DT_prod = DT[:, prod(f.C0), by(f.C1)]
+    assert_equals(DT_prod, dt.Frame(C1=[1, 2]/dt.int32, C0=[1, 1]/dt.int64))
+
+
+def test_prod_void_grouped():
+    DT = dt.Frame([[None, None, None, None, None], [1, 2, 1, 2, 2]])
+    DT_prod = DT[:, prod(f.C0), by(f.C0)]
+    assert_equals(DT_prod, dt.Frame([[None], [1]/dt.int64]))
+
+
 def test_prod_simple():
     DT = dt.Frame(A=range(1, 5))
     RES = DT[:, prod(f.A)]
@@ -611,3 +733,25 @@ def test_prod_grouped():
     frame_integrity_check(RES)
     assert_equals(RES, REF)
     assert str(RES)
+
+
+#-------------------------------------------------------------------------------
+# Standard deviation
+#-------------------------------------------------------------------------------
+
+def test_sd_void():
+    DT = dt.Frame([None] * 10)
+    DT_sd = DT[:, sd(f.C0)]
+    assert_equals(DT_sd, dt.Frame([None]))
+
+
+def test_sd_void_per_group():
+    DT = dt.Frame([[None, None, None, None, None], [1, 2, 1, 2, 2]])
+    DT_sd = DT[:, sd(f.C0), by(f.C1)]
+    assert_equals(DT_sd, dt.Frame(C1=[1, 2]/dt.int32, C0=[None, None]))
+
+
+def test_sd_void_grouped():
+    DT = dt.Frame([[None, None, None, None, None], [1, 2, 1, 2, 2]])
+    DT_sd = DT[:, sd(f.C0), by(f.C0)]
+    assert_equals(DT_sd, dt.Frame([[None], [None]/dt.float64]))


### PR DESCRIPTION
- reducers now support `void` columns in the both grouped and ungrouped modes;
- fixed a bug in `dt.sd()` when the result is `nan`.

Closes #3295 
Closes #3284