### PR TITLE
Minor refactoring and a test for voids in `cumsum()`

### DIFF
--- a/src/core/expr/fexpr_cumsum.cc
+++ b/src/core/expr/fexpr_cumsum.cc
@@ -69,30 +69,28 @@ class FExpr_cumsum : public FExpr_Func {
     Column evaluate1(Column&& col, const Groupby& gby) const {
       SType stype = col.stype();
       switch (stype) {
-        case SType::VOID:
+        case SType::VOID:    return Column(new ConstInt_ColumnImpl(
+                                      col.nrows(), 0, SType::INT64
+                                    ));
         case SType::BOOL:
         case SType::INT8:
         case SType::INT16:
         case SType::INT32:
-        case SType::INT64: return make<int64_t>(std::move(col), SType::INT64, gby);
+        case SType::INT64:   return make<int64_t>(std::move(col), SType::INT64, gby);
         case SType::FLOAT32: return make<float>(std::move(col), SType::FLOAT32, gby);
         case SType::FLOAT64: return make<double>(std::move(col), SType::FLOAT64, gby);
         default: throw TypeError()
-          << "Invalid column of type " << stype << " in " << repr();
+          << "Invalid column of type `" << stype << "` in " << repr();
       }
     }
 
 
     template <typename T>
     Column make(Column&& col, SType stype, const Groupby& gby) const {
-      if (col.stype() == SType::VOID) {
-        return Column(new ConstInt_ColumnImpl(col.nrows(), 0, stype));
-      } else {
-        col.cast_inplace(stype);
-        return Column(new Latent_ColumnImpl(
-          new Cumsum_ColumnImpl<T>(std::move(col), gby)
-        ));
-      }
+      col.cast_inplace(stype);
+      return Column(new Latent_ColumnImpl(
+        new Cumsum_ColumnImpl<T>(std::move(col), gby)
+      ));
     }
 };
 

--- a/tests/dt/test-cumsum.py
+++ b/tests/dt/test-cumsum.py
@@ -68,9 +68,9 @@ def test_cumsum_empty_frame():
 
 
 def test_cumsum_void():
-    DT = dt.Frame([None, None, None])
+    DT = dt.Frame([None]*10)
     DT_cumsum = DT[:, cumsum(f[:])]
-    assert_equals(DT_cumsum, dt.Frame([0, 0, 0]/dt.int64))
+    assert_equals(DT_cumsum, dt.Frame([0]*10/dt.int64))
 
 
 def test_cumsum_trivial():
@@ -93,6 +93,12 @@ def test_cumsum_groupby():
     DT_cumsum = DT[:, cumsum(f[:]), by(f[0])]
     DT_ref = dt.Frame([[1, 1, 1, 2, 2], [-1.5, math.inf, math.inf, 1.5, 4.5]/dt.float64])
     assert_equals(DT_cumsum, DT_ref)
+
+
+def test_cumsum_void_grouped_column():
+    DT = dt.Frame([None]*10)
+    DT_cumsum = DT[:, cumsum(f.C0), by(f.C0)]
+    assert_equals(DT_cumsum, dt.Frame([[None]*10, [0]*10/dt.int64]))
 
 
 def test_cumsum_grouped_column():


### PR DESCRIPTION
- small simplification in the way we handle voids in `cumsum()`;
- add a test for grouped voids.