### PR TITLE
Add `DT_DISABLE` to control thread pool dependencies

### DIFF
--- a/src/core/column/column_impl.cc
+++ b/src/core/column/column_impl.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2021 H2O.ai
+// Copyright 2018-2022 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -26,7 +26,7 @@
 #include "column/sentinel_fw.h"
 #include "column/truncated.h"
 #include "parallel/api.h"
-#include "parallel/string_utils.h"
+#include "str/utils.h"
 #include "utils/macros.h"
 namespace dt {
 

--- a/src/core/column/sentinel_str.cc
+++ b/src/core/column/sentinel_str.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2021 H2O.ai
+// Copyright 2018-2022 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -20,8 +20,8 @@
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #include "column/sentinel_str.h"
-#include "parallel/string_utils.h"  // dt::map_str2str
 #include "python/string.h"
+#include "str/utils.h"            // dt::map_str2str
 #include "utils/assert.h"
 #include "utils/misc.h"
 namespace dt {

--- a/src/core/frame/replace.cc
+++ b/src/core/frame/replace.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2020 H2O.ai
+// Copyright 2018-2022 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -23,10 +23,10 @@
 #include <unordered_set>
 #include "documentation.h"
 #include "frame/py_frame.h"
-#include "parallel/api.h"           // dt::parallel_for_static
-#include "parallel/string_utils.h"  // dt::map_str2str
+#include "parallel/api.h"      // dt::parallel_for_static
 #include "python/dict.h"
 #include "python/list.h"
+#include "str/utils.h"         // dt::map_str2str
 #include "utils/assert.h"
 #include "utils/macros.h"
 #include "stype.h"

--- a/src/core/parallel/api.h
+++ b/src/core/parallel/api.h
@@ -18,6 +18,7 @@
 #include <cstddef>
 #include <functional>    // std::function
 #include <mutex>         // std::mutex
+#include <memory>
 #include "parallel/api_primitives.h"
 #include "parallel/python_lock.h"
 #include "parallel/thread_job.h"

--- a/src/core/parallel/job_idle.cc
+++ b/src/core/parallel/job_idle.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019-2020 H2O.ai
+// Copyright 2019-2022 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -19,14 +19,14 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
-#include "parallel/job_idle.h"
 #include "utils/assert.h"
-#include "utils/exceptions.h"
+#ifndef NO_DT
+  #include "utils/exceptions.h"
+#endif
 #include "parallel/api.h"
+#include "parallel/job_idle.h"
 #include "parallel/thread_pool.h"
 namespace dt {
-
-
 
 
 //------------------------------------------------------------------------------
@@ -91,11 +91,15 @@ void Job_Idle::join() {
   previous_sleep_task_->fall_asleep();
 
   if (saved_exception_) {
-    progress::manager->reset_interrupt_status();
+    #ifndef NO_DT
+      progress::manager->reset_interrupt_status();
+    #endif
     std::rethrow_exception(saved_exception_);
   }
 
-  progress::manager->handle_interrupt();
+  #ifndef NO_DT
+    progress::manager->handle_interrupt();
+  #endif
 }
 
 
@@ -118,7 +122,9 @@ void Job_Idle::add_running_thread() {
 void Job_Idle::catch_exception() noexcept {
   try {
     std::lock_guard<std::mutex> lock(thpool->global_mutex());
-    progress::manager->set_interrupt();
+    #ifndef NO_DT
+      progress::manager->set_interrupt();
+    #endif
     if (!saved_exception_) {
       saved_exception_ = std::current_exception();
     }

--- a/src/core/parallel/job_idle.cc
+++ b/src/core/parallel/job_idle.cc
@@ -20,7 +20,7 @@
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #include "utils/assert.h"
-#ifndef NO_DT
+#ifndef DT_DISABLE
   #include "utils/exceptions.h"
 #endif
 #include "parallel/api.h"
@@ -91,13 +91,13 @@ void Job_Idle::join() {
   previous_sleep_task_->fall_asleep();
 
   if (saved_exception_) {
-    #ifndef NO_DT
+    #ifndef DT_DISABLE
       progress::manager->reset_interrupt_status();
     #endif
     std::rethrow_exception(saved_exception_);
   }
 
-  #ifndef NO_DT
+  #ifndef DT_DISABLE
     progress::manager->handle_interrupt();
   #endif
 }
@@ -122,7 +122,7 @@ void Job_Idle::add_running_thread() {
 void Job_Idle::catch_exception() noexcept {
   try {
     std::lock_guard<std::mutex> lock(thpool->global_mutex());
-    #ifndef NO_DT
+    #ifndef DT_DISABLE
       progress::manager->set_interrupt();
     #endif
     if (!saved_exception_) {

--- a/src/core/parallel/job_shutdown.cc
+++ b/src/core/parallel/job_shutdown.cc
@@ -25,7 +25,6 @@
 namespace dt {
 
 
-
 void Job_Shutdown::ShutdownTask::execute() {
   thpool->assign_job_to_current_thread(nullptr);
 }

--- a/src/core/parallel/parallel_for_ordered.cc
+++ b/src/core/parallel/parallel_for_ordered.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019-2020 H2O.ai
+// Copyright 2019-2022 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -27,9 +27,13 @@
 #include "parallel/spin_mutex.h"
 #include "parallel/thread_job.h"
 #include "parallel/thread_team.h"
-#include "progress/work.h"
 #include "utils/assert.h"
-#include "utils/exceptions.h"
+#ifdef NO_DT
+  #include <stdexcept>
+#else
+  #include "progress/work.h"
+  #include "utils/exceptions.h"
+#endif
 #include "utils/function.h"
 namespace dt {
 
@@ -105,7 +109,12 @@ void OrderedTask::execute() {
     case State::ORDERING:  order(iter_); break;
     case State::FINISHING: finish(iter_); break;
     default:
-      throw RuntimeError() << "Invalid state " << static_cast<int>(state_); // LCOV_EXCL_LINE
+      #ifdef NO_DT
+        throw std::runtime_error("Invalid state " + std::to_string(state_)); // LCOV_EXCL_LINE
+      #else
+        throw RuntimeError() << "Invalid state " << static_cast<int>(state_) // LCOV_EXCL_LINE
+      #endif
+    ;
   }
 }
 
@@ -173,14 +182,21 @@ class SingleThreaded_OrderedJob : public OrderedJob {
   private:
     uqOrderedTask task_;
     size_t n_iterations_;
-    progress::work* progress_;
+    #ifndef NO_DT
+      progress::work* progress_;
+    #endif
 
   public:
-    SingleThreaded_OrderedJob(size_t niters, progress::work* progress,
+    SingleThreaded_OrderedJob(size_t niters,
+                              #ifndef NO_DT
+                                progress::work* progress,
+                              #endif
                               uqOrderedTask&& task)
       : task_(std::move(task)),
-        n_iterations_(niters),
-        progress_(progress)
+        n_iterations_(niters)
+        #ifndef NO_DT
+          , progress_(progress)
+        #endif
     {
       task_->init_parent(this);
     }
@@ -191,8 +207,10 @@ class SingleThreaded_OrderedJob : public OrderedJob {
         task_->state_ = OrderedTask::State::STARTING;   task_->start(i);
         task_->state_ = OrderedTask::State::ORDERING;   task_->order(i);
         task_->state_ = OrderedTask::State::FINISHING;  task_->finish(i);
-        progress_->add_done_amount(1);
-        progress::manager->check_interrupts_main();
+        #ifndef NO_DT
+          progress_->add_done_amount(1);
+          progress::manager->check_interrupts_main();
+        #endif
       }
     }
 
@@ -203,7 +221,9 @@ class SingleThreaded_OrderedJob : public OrderedJob {
     }
 
     void set_num_iterations(size_t n) override {
-      progress_->add_work_amount(n - n_iterations_);
+      #ifndef NO_DT
+        progress_->add_work_amount(n - n_iterations_);
+      #endif
       n_iterations_ = n;
     }
 
@@ -216,8 +236,12 @@ class SingleThreaded_OrderedJob : public OrderedJob {
 
 
     ThreadTask* get_next_task(size_t) override {  // unused
-      throw RuntimeError();  // LCOV_EXCL_LINE
-    }                        // LCOV_EXCL_LINE
+      #ifdef NO_DT
+        throw std::runtime_error(__FILE__ + std::string(":") + std::to_string(__LINE__)); // LCOV_EXCL_LINE
+      #else
+        throw RuntimeError() << __FILE__ << ":" << __LINE__;   // LCOV_EXCL_LINE
+      #endif
+    }                               // LCOV_EXCL_LINE
 };
 
 
@@ -237,7 +261,9 @@ class MultiThreaded_OrderedJob : public OrderedJob {
 
     static constexpr size_t NO_THREAD = size_t(-1);
     static constexpr size_t INVALID_THREAD = size_t(-2);
-    progress::work* progress_;
+    #ifndef NO_DT
+      progress::work* progress_;
+    #endif
     NoopTask noop_task_;
     mutable dt::spin_mutex mutex_;  // 1 byte
     size_t : 56;
@@ -250,14 +276,19 @@ class MultiThreaded_OrderedJob : public OrderedJob {
     size_t ifinish_;
 
   public:
-    MultiThreaded_OrderedJob(size_t niters, progress::work* progress,
+    MultiThreaded_OrderedJob(size_t niters,
+                             #ifndef NO_DT
+                               progress::work* progress,
+                             #endif
                              std::vector<uqOrderedTask>&& tasks)
       : n_iterations_(niters),
         n_threads_(num_threads_in_team()),
         n_tasks_(tasks.size()),
         tasks_(std::move(tasks)),
         assigned_tasks_(n_tasks_, &noop_task_),
-        progress_(progress),
+        #ifndef NO_DT
+          progress_(progress),
+        #endif
         next_to_start_(0),
         next_to_order_(0),
         next_to_finish_(0),
@@ -283,7 +314,9 @@ class MultiThreaded_OrderedJob : public OrderedJob {
 
       if (ith == ordering_thread_index_) {
         ordering_thread_index_ = NO_THREAD;
-        progress_->set_done_amount(next_to_order_);
+        #ifndef NO_DT
+          progress_->set_done_amount(next_to_order_);
+        #endif
       }
 
       // If `iorder_`th frame is ready to be ordered, and no other thread is
@@ -345,7 +378,9 @@ class MultiThreaded_OrderedJob : public OrderedJob {
     void set_num_iterations(size_t n) override {
       std::lock_guard<dt::spin_mutex> lock(mutex_);
       xassert(n >= next_to_order_);
-      progress_->add_work_amount(n - n_iterations_);
+      #ifndef NO_DT
+        progress_->add_work_amount(n - n_iterations_);
+      #endif
       n_iterations_ = n;
     }
 
@@ -428,14 +463,20 @@ void parallel_for_ordered(size_t niters, NThreads nthreads0,
                           function<uqOrderedTask()> task_factory)
 {
   if (!niters) return;
-  progress::work progress(niters);
+  #ifndef NO_DT
+    progress::work progress(niters);
+  #endif
   size_t nthreads = nthreads0.get();
 
   size_t ntasks = std::min(niters, nthreads * 3/2);
   if (nthreads > ntasks) nthreads = ntasks;
 
   if (nthreads == 1) {
-    SingleThreaded_OrderedJob job(niters, &progress, task_factory());
+    SingleThreaded_OrderedJob job(niters,
+                                  #ifndef NO_DT
+                                    &progress,
+                                  #endif
+                                  task_factory());
     job.run();
   }
   else {
@@ -445,10 +486,16 @@ void parallel_for_ordered(size_t niters, NThreads nthreads0,
     for (size_t i = 0; i < ntasks; ++i) {
       tasks.push_back(task_factory());
     }
-    MultiThreaded_OrderedJob job(niters, &progress, std::move(tasks));
+    MultiThreaded_OrderedJob job(niters,
+                                 #ifndef NO_DT
+                                   &progress,
+                                 #endif
+                                 std::move(tasks));
     thpool->execute_job(&job);
   }
-  progress.done();
+  #ifndef NO_DT
+    progress.done();
+  #endif
 }
 
 

--- a/src/core/parallel/parallel_for_static.h
+++ b/src/core/parallel/parallel_for_static.h
@@ -143,9 +143,6 @@ void parallel_for_static(size_t n_iterations,
   parallel_region(
     NThreads(num_threads),
     [=] {
-      #ifndef DT_DISABLE
-        const bool is_main_thread = (this_thread_index() == 0);
-      #endif
       size_t i0 = chunk_size_ * this_thread_index();
       size_t di = chunk_size_ * num_threads;
       while (i0 < n_iterations) {
@@ -155,7 +152,7 @@ void parallel_for_static(size_t n_iterations,
         }
         i0 += di;
         #ifndef DT_DISABLE
-          if (is_main_thread) {
+          if (this_thread_index() == 0) {
             progress::manager->check_interrupts_main();
           }
           if (progress::manager->is_interrupt_occurred()) {
@@ -231,9 +228,6 @@ void nested_for_static(size_t n_iterations, ChunkSize chunk_size, F func)
   size_t chsize = chunk_size.get();
   size_t i0 = chsize * this_thread_index();
   size_t di = chsize * num_threads_in_team();
-  #ifndef DT_DISABLE
-    const bool is_main_thread = (this_thread_index() == 0);
-  #endif
 
   while (i0 < n_iterations) {
     size_t i1 = std::min(i0 + chsize, n_iterations);
@@ -242,7 +236,7 @@ void nested_for_static(size_t n_iterations, ChunkSize chunk_size, F func)
     }
     i0 += di;
     #ifndef DT_DISABLE
-      if (is_main_thread) {
+      if (this_thread_index() == 0) {
         progress::manager->check_interrupts_main();
       }
       if (progress::manager->is_interrupt_occurred()) {

--- a/src/core/parallel/parallel_for_static.h
+++ b/src/core/parallel/parallel_for_static.h
@@ -143,7 +143,9 @@ void parallel_for_static(size_t n_iterations,
   parallel_region(
     NThreads(num_threads),
     [=] {
+      #ifndef NO_DT
       const bool is_main_thread = (this_thread_index() == 0);
+      #endif
       size_t i0 = chunk_size_ * this_thread_index();
       size_t di = chunk_size_ * num_threads;
       while (i0 < n_iterations) {

--- a/src/core/parallel/parallel_for_static.h
+++ b/src/core/parallel/parallel_for_static.h
@@ -144,7 +144,7 @@ void parallel_for_static(size_t n_iterations,
     NThreads(num_threads),
     [=] {
       #ifndef NO_DT
-      const bool is_main_thread = (this_thread_index() == 0);
+        const bool is_main_thread = (this_thread_index() == 0);
       #endif
       size_t i0 = chunk_size_ * this_thread_index();
       size_t di = chunk_size_ * num_threads;
@@ -231,7 +231,9 @@ void nested_for_static(size_t n_iterations, ChunkSize chunk_size, F func)
   size_t chsize = chunk_size.get();
   size_t i0 = chsize * this_thread_index();
   size_t di = chsize * num_threads_in_team();
-  const bool is_main_thread = (this_thread_index() == 0);
+  #ifndef NO_DT
+    const bool is_main_thread = (this_thread_index() == 0);
+  #endif
 
   while (i0 < n_iterations) {
     size_t i1 = std::min(i0 + chsize, n_iterations);

--- a/src/core/parallel/parallel_for_static.h
+++ b/src/core/parallel/parallel_for_static.h
@@ -16,7 +16,7 @@
 #ifndef dt_PARALLEL_FOR_STATIC_h
 #define dt_PARALLEL_FOR_STATIC_h
 #include <algorithm>
-#ifndef NO_DT
+#ifndef DT_DISABLE
   #include "progress/progress_manager.h"  // dt::progress::progress_manager
 #endif
 #include "utils/assert.h"
@@ -129,7 +129,7 @@ void parallel_for_static(size_t n_iterations,
         func(i);
       }
       i0 += chunk_size_;
-      #ifndef NO_DT
+      #ifndef DT_DISABLE
         progress::manager->check_interrupts_main();
         if (progress::manager->is_interrupt_occurred()) {
           i0 = n_iterations;
@@ -143,7 +143,7 @@ void parallel_for_static(size_t n_iterations,
   parallel_region(
     NThreads(num_threads),
     [=] {
-      #ifndef NO_DT
+      #ifndef DT_DISABLE
         const bool is_main_thread = (this_thread_index() == 0);
       #endif
       size_t i0 = chunk_size_ * this_thread_index();
@@ -154,7 +154,7 @@ void parallel_for_static(size_t n_iterations,
           func(i);
         }
         i0 += di;
-        #ifndef NO_DT
+        #ifndef DT_DISABLE
           if (is_main_thread) {
             progress::manager->check_interrupts_main();
           }
@@ -231,7 +231,7 @@ void nested_for_static(size_t n_iterations, ChunkSize chunk_size, F func)
   size_t chsize = chunk_size.get();
   size_t i0 = chsize * this_thread_index();
   size_t di = chsize * num_threads_in_team();
-  #ifndef NO_DT
+  #ifndef DT_DISABLE
     const bool is_main_thread = (this_thread_index() == 0);
   #endif
 
@@ -241,7 +241,7 @@ void nested_for_static(size_t n_iterations, ChunkSize chunk_size, F func)
       func(i);
     }
     i0 += di;
-    #ifndef NO_DT
+    #ifndef DT_DISABLE
       if (is_main_thread) {
         progress::manager->check_interrupts_main();
       }

--- a/src/core/parallel/thread_pool.cc
+++ b/src/core/parallel/thread_pool.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019-2021 H2O.ai
+// Copyright 2019-2022 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -20,17 +20,19 @@
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #include <thread>      // std::thread::hardware_concurrency
-#include "documentation.h"
+#ifndef NO_DT
+  #include "documentation.h"
+  #include "progress/progress_manager.h"
+  #include "python/_all.h"
+  #include "python/arg.h"
+  #include "options.h"
+#endif
 #include "parallel/api.h"
 #include "parallel/job_shutdown.h"
 #include "parallel/thread_pool.h"
 #include "parallel/thread_team.h"
 #include "parallel/thread_worker.h"
-#include "progress/progress_manager.h"
-#include "python/_all.h"
-#include "python/arg.h"
 #include "utils/assert.h"
-#include "options.h"
 #include "utils/macros.h"
 #if !DT_OS_WINDOWS
   #include <pthread.h>   // pthread_atfork
@@ -61,7 +63,9 @@ ThreadPool* thpool = new ThreadPool;
     // memory is owned by the parent process.
     size_t n = thpool->size();
     thpool = new ThreadPool;
-    progress::manager = new progress::progress_manager;
+    #ifndef NO_DT
+      progress::manager = new progress::progress_manager;
+    #endif
     thpool->resize(n);
   }
 
@@ -89,8 +93,6 @@ ThreadPool::ThreadPool()
 }
 
 
-
-
 size_t ThreadPool::size() const noexcept {
   return num_threads_requested_;
 }
@@ -103,6 +105,7 @@ void ThreadPool::resize(size_t n) {
     instantiate_threads();
   }
 }
+
 
 void ThreadPool::instantiate_threads() {
   size_t n = num_threads_requested_;
@@ -150,6 +153,7 @@ bool ThreadPool::in_parallel_region() const noexcept {
   return (current_team != nullptr);
 }
 
+
 size_t ThreadPool::n_threads_in_team() const noexcept {
   return current_team? current_team->size() : 0;
 }
@@ -192,6 +196,7 @@ static thread_local size_t thread_index = 0;
 size_t this_thread_index() {
   return thread_index;
 }
+
 void _set_thread_num(size_t i) {
   thread_index = i;
 }
@@ -205,28 +210,31 @@ size_t get_hardware_concurrency() noexcept {
 
 
 
-static py::oobj get_nthreads() {
-  return py::oint(num_threads_in_pool());
-}
+#ifndef NO_DT
+  static py::oobj get_nthreads() {
+    return py::oint(num_threads_in_pool());
+  }
 
-static void set_nthreads(const py::Arg& arg) {
-  int32_t nth = arg.to_int32_strict();
-  if (nth <= 0) nth += static_cast<int32_t>(get_hardware_concurrency());
-  if (nth <= 0) nth = 1;
-  thpool->resize(static_cast<size_t>(nth));
-}
+  static void set_nthreads(const py::Arg& arg) {
+    int32_t nth = arg.to_int32_strict();
+    if (nth <= 0) nth += static_cast<int32_t>(get_hardware_concurrency());
+    if (nth <= 0) nth = 1;
+    thpool->resize(static_cast<size_t>(nth));
+  }
 
-void ThreadPool::init_options() {
-  // By default, set the number of threads to `hardware_concurrency`
-  thpool->resize(get_hardware_concurrency());
 
-  dt::register_option(
-    "nthreads",
-    get_nthreads,
-    set_nthreads,
-    dt::doc_options_nthreads
-  );
-}
+  void ThreadPool::init_options() {
+    // By default, set the number of threads to `hardware_concurrency`
+    thpool->resize(get_hardware_concurrency());
+
+    dt::register_option(
+      "nthreads",
+      get_nthreads,
+      set_nthreads,
+      dt::doc_options_nthreads
+    );
+  }
+#endif
 
 
 }  // namespace dt

--- a/src/core/parallel/thread_pool.cc
+++ b/src/core/parallel/thread_pool.cc
@@ -20,7 +20,7 @@
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #include <thread>      // std::thread::hardware_concurrency
-#ifndef NO_DT
+#ifndef DT_DISABLE
   #include "documentation.h"
   #include "progress/progress_manager.h"
   #include "python/_all.h"
@@ -63,7 +63,7 @@ ThreadPool* thpool = new ThreadPool;
     // memory is owned by the parent process.
     size_t n = thpool->size();
     thpool = new ThreadPool;
-    #ifndef NO_DT
+    #ifndef DT_DISABLE
       progress::manager = new progress::progress_manager;
     #endif
     thpool->resize(n);
@@ -210,7 +210,7 @@ size_t get_hardware_concurrency() noexcept {
 
 
 
-#ifndef NO_DT
+#ifndef DT_DISABLE
   static py::oobj get_nthreads() {
     return py::oint(num_threads_in_pool());
   }

--- a/src/core/parallel/thread_pool.h
+++ b/src/core/parallel/thread_pool.h
@@ -105,7 +105,7 @@ class ThreadPool
     bool in_parallel_region() const noexcept;
     size_t n_threads_in_team() const noexcept;
 
-    #ifndef NO_DT
+    #ifndef DT_DISABLE
       static void init_options();
     #endif
 

--- a/src/core/parallel/thread_pool.h
+++ b/src/core/parallel/thread_pool.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019-2020 H2O.ai
+// Copyright 2019-2022 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -105,7 +105,9 @@ class ThreadPool
     bool in_parallel_region() const noexcept;
     size_t n_threads_in_team() const noexcept;
 
-    static void init_options();
+    #ifndef NO_DT
+      static void init_options();
+    #endif
 
     std::mutex& global_mutex();
 

--- a/src/core/parallel/thread_team.cc
+++ b/src/core/parallel/thread_team.cc
@@ -34,7 +34,7 @@ ThreadTeam::ThreadTeam(size_t nth, ThreadPool* pool)
     barrier_counter {0}
 {
   if (thpool->current_team) {
-    #ifndef NO_DT
+    #ifndef DT_DISABLE
       throw RuntimeError() << "Unable to create a nested thread team";
     #endif
   }
@@ -58,7 +58,7 @@ void ThreadTeam::wait_at_barrier() {
   size_t n = barrier_counter.fetch_add(1);
   size_t n_target = n - (n % nthreads) + nthreads;
   while (barrier_counter.load() < n_target) {
-    #ifndef NO_DT
+    #ifndef DT_DISABLE
       if (progress::manager->is_interrupt_occurred()) throw std::exception();
     #endif
   }

--- a/src/core/parallel/thread_team.cc
+++ b/src/core/parallel/thread_team.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019-2020 H2O.ai
+// Copyright 2019-2022 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -34,7 +34,9 @@ ThreadTeam::ThreadTeam(size_t nth, ThreadPool* pool)
     barrier_counter {0}
 {
   if (thpool->current_team) {
-    throw RuntimeError() << "Unable to create a nested thread team";
+    #ifndef NO_DT
+      throw RuntimeError() << "Unable to create a nested thread team";
+    #endif
   }
   thpool->current_team = this;
 }
@@ -56,7 +58,9 @@ void ThreadTeam::wait_at_barrier() {
   size_t n = barrier_counter.fetch_add(1);
   size_t n_target = n - (n % nthreads) + nthreads;
   while (barrier_counter.load() < n_target) {
-    if (progress::manager->is_interrupt_occurred()) throw std::exception();
+    #ifndef NO_DT
+      if (progress::manager->is_interrupt_occurred()) throw std::exception();
+    #endif
   }
 }
 

--- a/src/core/parallel/thread_worker.cc
+++ b/src/core/parallel/thread_worker.cc
@@ -20,7 +20,7 @@
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #include "parallel/thread_worker.h"
-#ifndef NO_DT
+#ifndef DT_DISABLE
   #include "progress/progress_manager.h"  // dt::progress::progress_manager
   #include "utils/exceptions.h"
 #endif
@@ -101,7 +101,7 @@ void ThreadWorker::run_in_main_thread(ThreadJob* job) noexcept {
       ThreadTask* task = job->get_next_task(0);
       if (!task) break;
       task->execute();
-      #ifndef NO_DT
+      #ifndef DT_DISABLE
         progress::manager->check_interrupts_main();
       #endif
     }

--- a/src/core/parallel/thread_worker.cc
+++ b/src/core/parallel/thread_worker.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019-2020 H2O.ai
+// Copyright 2019-2022 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -20,9 +20,11 @@
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #include "parallel/thread_worker.h"
-#include "progress/progress_manager.h"  // dt::progress::progress_manager
+#ifndef NO_DT
+  #include "progress/progress_manager.h"  // dt::progress::progress_manager
+  #include "utils/exceptions.h"
+#endif
 #include "utils/assert.h"
-#include "utils/exceptions.h"
 #include "parallel/api.h"
 #include "parallel/thread_pool.h"
 namespace dt {
@@ -99,7 +101,9 @@ void ThreadWorker::run_in_main_thread(ThreadJob* job) noexcept {
       ThreadTask* task = job->get_next_task(0);
       if (!task) break;
       task->execute();
-      progress::manager->check_interrupts_main();
+      #ifndef NO_DT
+        progress::manager->check_interrupts_main();
+      #endif
     }
     catch (...) {
       idle_job_->catch_exception();

--- a/src/core/str/utils.cc
+++ b/src/core/str/utils.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2020 H2O.ai
+// Copyright 2018-2022 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -21,7 +21,7 @@
 //------------------------------------------------------------------------------
 #include "column/sentinel_str.h"
 #include "parallel/api.h"
-#include "parallel/string_utils.h"
+#include "str/utils.h"
 #include "utils/assert.h"
 #include "utils/exceptions.h"
 #include "options.h"

--- a/src/core/str/utils.h
+++ b/src/core/str/utils.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2020 H2O.ai
+// Copyright 2018-2022 H2O.ai
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/core/utils/assert.h
+++ b/src/core/utils/assert.h
@@ -23,7 +23,7 @@
 #define dt_UTILS_ASSERT_h
 #include <cstdio>
 #include "utils/macros.h"
-#ifdef NO_DT
+#ifdef DT_DISABLE
   #include <stdexcept>
   #include <iostream>
 #else
@@ -56,7 +56,7 @@
 // Here we also define the `xassert` macro, which behaves similarly to `assert`,
 // however it throws exceptions instead of terminating the program
 #if DT_DEBUG
-  #ifdef NO_DT
+  #ifdef DT_DISABLE
     #define wassert(EXPRESSION) \
       if (!(EXPRESSION)) { \
         std::cerr << "Assertion '" #EXPRESSION "' failed in " __FILE__ ", line " \
@@ -70,7 +70,7 @@
       } ((void)(0))
   #endif
 
-  #ifdef NO_DT
+  #ifdef DT_DISABLE
     #define xassert(EXPRESSION) \
       if (!(EXPRESSION)) { \
         throw std::runtime_error("Assertion '" #EXPRESSION "' failed in " __FILE__ \
@@ -92,7 +92,7 @@
 
 // XAssert() macro is similar to xassert(), except it works both in
 // debug and in production.
-#ifdef NO_DT
+#ifdef DT_DISABLE
   #define XAssert(EXPRESSION) \
     if (!(EXPRESSION)) { \
       throw std::runtime_error("Assertion '" #EXPRESSION "' failed in " __FILE__ \


### PR DESCRIPTION
Our thread pool could in principle be used outside of datatable for parallelization of other C++ applications. However, currently it is closely coupled to the rest of the codebase. In this PR we add support for `DT_DISABLE` variable which, when set, will make the thread pool to have no specific datatable dependencies. Another option could be to extract the thread pool as a separate project, but this may have negative consequences for the datatable performance. 

Anyways, something like this should now work:
```bash
g++ -std=c++14 -DDT_DISABLE -I./src/core/ parallel_test.cc ./src/core/parallel/*.cc -o parallel_test
```

where `parallel_test.cc` is 
```C++
#include <iostream>
#include <stdlib.h>
#include "src/core/parallel/api.h"
#include "src/core/parallel/thread_pool.h"

int main(int argc, char** argv) {
  size_t niters = 1000;
  size_t nthreads = dt::get_hardware_concurrency();
  if (argc > 2) {
    niters = strtol(argv[1], NULL, 10);
    nthreads = strtol(argv[2], NULL, 10);
  }

  dt::thpool->resize(nthreads);
  std::mutex m;
  dt::parallel_for_static(niters,
    [&](size_t i) {
      std::lock_guard<std::mutex> lock(m);
      std::cout << "Thread " << dt::this_thread_index() << ": " << i << "\n";
      std::cout.flush();
    });

  std::cout << "niters: " << niters << "\n";
  std::cout << "num_threads_in_pool: " << dt::num_threads_in_pool() << "\n";
  return 0;
}
```
