### PR TITLE
Add support for `date32` and `time64` types in `cummin()` and `cummax()`

### DIFF
--- a/src/core/expr/fexpr_cumminmax.cc
+++ b/src/core/expr/fexpr_cumminmax.cc
@@ -75,7 +75,9 @@ class FExpr_CumMinMax : public FExpr_Func {
         case SType::BOOL:
         case SType::INT8:    return make<int8_t>(std::move(col), gby);
         case SType::INT16:   return make<int16_t>(std::move(col), gby);
+        case SType::DATE32:
         case SType::INT32:   return make<int32_t>(std::move(col), gby);
+        case SType::TIME64:
         case SType::INT64:   return make<int64_t>(std::move(col), gby);
         case SType::FLOAT32: return make<float>(std::move(col), gby);
         case SType::FLOAT64: return make<double>(std::move(col), gby);

--- a/tests/dt/test-cumminmax.py
+++ b/tests/dt/test-cumminmax.py
@@ -114,6 +114,38 @@ def test_cumminmax_small():
     assert_equals(DT_cummax, DT_ref)
 
 
+def test_cumminmax_dates():
+    from datetime import date as d
+    src = [None, d(1997, 9, 1), d(2002, 7, 31), None, d(2000, 2, 20)]
+    DT = dt.Frame(src)
+    DT_cummax = DT[:, [cummin(f.C0), cummax(f.C0)]]
+    DT_ref = dt.Frame([
+                 [None, d(1997, 9, 1), d(1997, 9, 1), d(1997, 9, 1), d(1997, 9, 1)],
+                 [None, d(1997, 9, 1), d(2002, 7, 31), d(2002, 7, 31), d(2002, 7, 31)],
+             ])
+    assert_equals(DT_cummax, DT_ref)
+
+
+def test_cumminmax_times():
+    from datetime import datetime as d
+    src = [None, d(1997, 9, 1, 10, 11, 5), d(1997, 9, 1, 10, 10, 5), None, None]
+    DT = dt.Frame(src)
+    DT_cummax = DT[:, [cummin(f.C0), cummax(f.C0)]]
+    DT_ref = dt.Frame([
+                 [None,
+                  d(1997, 9, 1, 10, 11, 5),
+                  d(1997, 9, 1, 10, 10, 5),
+                  d(1997, 9, 1, 10, 10, 5),
+                  d(1997, 9, 1, 10, 10, 5)],
+                 [None,
+                  d(1997, 9, 1, 10, 11, 5),
+                  d(1997, 9, 1, 10, 11, 5),
+                  d(1997, 9, 1, 10, 11, 5),
+                  d(1997, 9, 1, 10, 11, 5)],
+             ])
+    assert_equals(DT_cummax, DT_ref)
+
+
 def test_cumminmax_groupby():
     DT = dt.Frame([[2, 1, 1, 1, 2], [1.5, -1.5, math.inf, None, 3]])
     DT_cummax = DT[:, [cummin(f[:]), cummax(f[:])], by(f[0])]


### PR DESCRIPTION
In #3288 we seem to miss datetime types. In this PR we add support for `date32` and `time64` types in `cummin()` and `cummax()` functions.

WIP for #3279