### PR TITLE
Fix search functionality for sphinx `4.*`

### DIFF
--- a/docs/_theme/search.html
+++ b/docs/_theme/search.html
@@ -13,6 +13,7 @@
 {%- block scripts %}
     {{ super() }}
     <script type="text/javascript" src="{{ pathto('_static/searchtools.js', 1) }}"></script>
+    <script type="text/javascript" src="{{ pathto('_static/language_data.js', 1) }}"></script>
 {%- endblock %}
 
 {% block footer %}

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,6 +1,6 @@
 docutils>=0.15
 pygments>=2.6
-sphinx>=4.0
+sphinx>=4.0, <5.0
 sphinx_rtd_theme>=0.5
 nbsphinx>=0.5
 datatable

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,6 +1,6 @@
 docutils>=0.15
 pygments>=2.6
-sphinx>=3.0,!=3.2.0
+sphinx>=4.0
 sphinx_rtd_theme>=0.5
 nbsphinx>=0.5
 datatable


### PR DESCRIPTION
Adjust our custom theme in a way similar to `sphinx_rtd_theme`, see  https://github.com/readthedocs/sphinx_rtd_theme/pull/1021. This fixes the search functionality for sphinx `4.*`. We can take care of sphinx `5.*`, that was recently released later, if needed.

Closes #3299 