### PR TITLE
Make Frame's method `.sum()` and `dt.sum()` reducer to return consistent column types

### DIFF
--- a/docs/api/dt/count.rst
+++ b/docs/api/dt/count.rst
@@ -20,10 +20,6 @@
         The exception is raised when one of the columns from `cols`
         has a non-numeric and non-string type.
 
-    See Also
-    --------
-
-    - :func:`sum()` -- function to calculate the sum of values.
 
     Examples
     --------
@@ -64,3 +60,9 @@
         -- + -----
          0 |     4
         [1 row x 1 column]
+
+
+    See Also
+    --------
+
+    - :func:`sum()` -- function to calculate the sum of values.

--- a/docs/api/dt/sum.rst
+++ b/docs/api/dt/sum.rst
@@ -16,9 +16,11 @@
 
     return: Expr
         f-expression having one row, and the same names and number of columns
-        as in `cols`. The column stypes are `int64` for
-        boolean and integer columns, `float32` for `float32` columns
-        and `float64` for `float64` columns.
+        as in `cols`. The column types are :attr:`int64 <dt.Type.int64>` for
+        void, boolean and integer columns, :attr:`float32 <dt.Type.float32>`
+        for :attr:`float32 <dt.Type.float32>` columns and
+        :attr:`float64 <dt.Type.float64>` for :attr:`float64 <dt.Type.float64>`
+        columns.
 
     except: TypeError
         The exception is raised when one of the columns from `cols`
@@ -86,4 +88,10 @@
 
     See Also
     --------
+    - :meth:`.sum() <dt.Frame.sum>` -- the corresponding Frame's method
+      for multi-column frames.
+
+    - :meth:`.sum1() <dt.Frame.sum1()>` -- the corresponding Frame's method
+      for single-column frames that returns a scalar value.
+
     - :func:`count()` -- function to calculate a number of non-missing values.

--- a/docs/api/dt/sum.rst
+++ b/docs/api/dt/sum.rst
@@ -91,7 +91,7 @@
     - :meth:`.sum() <dt.Frame.sum>` -- the corresponding Frame's method
       for multi-column frames.
 
-    - :meth:`.sum1() <dt.Frame.sum1()>` -- the corresponding Frame's method
+    - :meth:`.sum1() <dt.Frame.sum1>` -- the corresponding Frame's method
       for single-column frames that returns a scalar value.
 
     - :func:`count()` -- function to calculate a number of non-missing values.

--- a/docs/api/frame/sum.rst
+++ b/docs/api/frame/sum.rst
@@ -10,17 +10,20 @@
     Parameters
     ----------
     return: Frame
-        The frame will have one row and the same number/names
-        of columns as in the current frame. All the columns
-        will have `float64` stype. For non-numeric columns
-        this function returns NA values.
+        The resulting frame will have one row and the same
+        number/names of columns as in the original frame.
+        The column types are :attr:`int64 <dt.Type.int64>` for
+        void, boolean and integer columns, :attr:`float32 <dt.Type.float32>`
+        for :attr:`float32 <dt.Type.float32>` columns and
+        :attr:`float64 <dt.Type.float64>` for :attr:`float64 <dt.Type.float64>`
+        columns. For non-numeric columns an NA :attr:`float64 <dt.Type.float64>`
+        column is returned.
 
     See Also
     --------
     - :meth:`.sum1()` -- similar to this method, but operates on a
       single-column frame only, and returns a scalar value instead of
       a Frame.
-
 
     - :func:`dt.sum()` -- function for calculating the sum of all the values
       in a column or an expression; can also be applied per-group.

--- a/docs/api/type.rst
+++ b/docs/api/type.rst
@@ -30,10 +30,10 @@
     - :meth:`dt.Type.cat32(T)`
     - :attr:`dt.Type.float32`
     - :attr:`dt.Type.float64`
+    - :attr:`dt.Type.int8`
     - :attr:`dt.Type.int16`
     - :attr:`dt.Type.int32`
     - :attr:`dt.Type.int64`
-    - :attr:`dt.Type.int8`
     - :attr:`dt.Type.obj64`
     - :attr:`dt.Type.str32`
     - :attr:`dt.Type.str64`

--- a/docs/releases/v1.1.0.rst
+++ b/docs/releases/v1.1.0.rst
@@ -15,6 +15,12 @@
     -[enh] :meth:`.to_numpy()` now has an option to control memory layout
         of the resulting numpy array. [#3275]
 
+    -[enh] column types returned by the method :meth:`.sum()` are now consistent with
+        the ones returned by the function :func:`dt.sum()`, i.e. :attr:`int64 <dt.Type.int64>`
+        for void, boolean and integer columns; :attr:`float32 <dt.Type.float32>`
+        for :attr:`float32 <dt.Type.float32>` columns; :attr:`float64 <dt.Type.float64>`
+        for :attr:`float64 <dt.Type.float64>` columns. [#2904]
+
     -[fix] Void columns can now be used with :func:`dt.sort()` and :func:`dt.by()`.
         In addition, datatable will now skip sorting any column that it knows contains
         constant values. [#3088] [#3104] [#3108] [#3109]

--- a/src/core/column/rbound.cc
+++ b/src/core/column/rbound.cc
@@ -90,9 +90,8 @@ void Rbound_ColumnImpl::calculate_boolean_stats() {
   for (const auto& col : chunks_) {
     auto chunk_stats = dynamic_cast<BooleanStats*>(col.get_stats_if_exist());
     if (!chunk_stats) return;
-    double sum = chunk_stats->sum(&is_valid);
-    xassert(sum == static_cast<double>(static_cast<size_t>(sum)));
-    count1 += static_cast<size_t>(sum);
+    size_t sum = static_cast<size_t>(chunk_stats->sum_int(&is_valid));
+    count1 += sum;
     if (!is_valid) return;
   }
   size_t count0 = nrows_ - count1 - stats()->nacount(&is_valid);

--- a/src/core/expr/head_reduce_unary.cc
+++ b/src/core/expr/head_reduce_unary.cc
@@ -280,24 +280,24 @@ static Column compute_gprod(Column&& arg, const Groupby& gby) {
                            1, 1, SType::INT64
                          );
     case SType::BOOL:
-    case SType::INT8:    return Column(new ProdGrouped_ColumnImpl<int8_t,  int64_t>(
-                                    std::move(arg), gby
-                                ));
+    case SType::INT8:    return Column(new ProdGrouped_ColumnImpl<int8_t, int64_t>(
+                           std::move(arg), gby
+                         ));
     case SType::INT16:   return Column(new ProdGrouped_ColumnImpl<int16_t, int64_t>(
-                                    std::move(arg), gby
-                                ));
+                           std::move(arg), gby
+                         ));
     case SType::INT32:   return Column(new ProdGrouped_ColumnImpl<int32_t, int64_t>(
-                                    std::move(arg), gby
-                                ));
+                           std::move(arg), gby
+                         ));
     case SType::INT64:   return Column(new ProdGrouped_ColumnImpl<int64_t, int64_t>(
-                                    std::move(arg), gby
-                                ));
-    case SType::FLOAT32: return Column(new ProdGrouped_ColumnImpl<float,   float>  (
-                                    std::move(arg), gby
-                                ));
-    case SType::FLOAT64: return Column(new ProdGrouped_ColumnImpl<double,  double> (
-                                    std::move(arg), gby
-                                ));
+                           std::move(arg), gby
+                         ));
+    case SType::FLOAT32: return Column(new ProdGrouped_ColumnImpl<float, float>(
+                           std::move(arg), gby
+                         ));
+    case SType::FLOAT64: return Column(new ProdGrouped_ColumnImpl<double, double>(
+                           std::move(arg), gby
+                         ));
     default: throw _error("prod", arg.stype());
   }
 }

--- a/src/core/rowindex_array.cc
+++ b/src/core/rowindex_array.cc
@@ -131,7 +131,7 @@ void ArrayRowIndexImpl::init_from_boolean_column(const Column& col) {
   xassert(col.stype() == dt::SType::BOOL);
   // total # of 1s in the column
   // Note: this may cause parallel computation over the entire column
-  length = static_cast<size_t>(col.stats()->sum());
+  length = static_cast<size_t>(col.stats()->sum_int());
 
   if (length == 0) {
     // no need to do anything: the data arrays already have 0 length

--- a/src/core/stats.h
+++ b/src/core/stats.h
@@ -253,7 +253,7 @@ class Stats
  * Base class for all numerical STypes. The class is parametrized by T - the
  * type of element in the Column's API. Thus, T can be only
  * int8_t|int16_t|int32_t|int64_t|float|double. The corresponding
- * "sum/min"/"max"/"mode" statistics are stored
+ * "sum"/"min"/"max"/"mode" statistics are stored
  * in upcasted type V, which is either int64_t or double.
  */
 template <typename T>

--- a/tests/ijby/test-sort.py
+++ b/tests/ijby/test-sort.py
@@ -1142,7 +1142,7 @@ def test_issue1857(numpy):
     assert agg1.shape == (100, 3)
     assert agg1.names == ("g1", "g2", "M")
     assert agg1.stypes == (dt.int64, dt.int64, dt.float32)
-    assert agg1.sum().to_tuples()[0] == (450, 450, 51.63409462571144)
+    assert agg1.sum().to_tuples()[0] == (450, 450, 51.63409423828125)
 
 
 def test_sort_expr():

--- a/tests/test-dt-stats.py
+++ b/tests/test-dt-stats.py
@@ -136,7 +136,9 @@ def test_sum(src):
     dt0 = dt.Frame(src)
     dtr = dt0.sum()
     frame_integrity_check(dtr)
-    assert dtr.stypes == (stype.float64, ) * dt0.ncols
+    stypes = [stype.float64 if ltype == dt.ltype.real else stype.int64
+              for ltype in dt0.ltypes]
+    assert list(dtr.stypes) == stypes
     assert dtr.shape == (1, dt0.ncols)
     assert dt0.names == dtr.names
     assert list_equals(dtr.to_list(), [[t_sum(src)]])

--- a/tests/test-reduce.py
+++ b/tests/test-reduce.py
@@ -329,6 +329,7 @@ def test_sum_void():
     DT = dt.Frame([None] * 10)
     DT_sum = DT[:, sum(f.C0)]
     assert_equals(DT_sum, dt.Frame([0]/dt.int64))
+    assert_equals(DT_sum, DT.sum())
 
 
 def test_sum_void_per_group():
@@ -345,32 +346,34 @@ def test_sum_void_grouped():
 
 def test_sum_simple():
     DT = dt.Frame(A=range(5))
-    R = DT[:, sum(f.A)]
-    frame_integrity_check(R)
-    assert R.to_list() == [[10]]
-    assert str(R)
+    DT_sum = DT[:, sum(f.A)]
+    frame_integrity_check(DT_sum)
+    assert DT_sum.to_list() == [[10]]
+    assert str(DT_sum)
+    assert_equals(DT_sum, DT.sum())
 
 
 def test_sum_empty_frame():
     DT = dt.Frame([[]] * 5, names=list("ABCDE"),
                   stypes=(dt.bool8, dt.int32, dt.float32, dt.float64, dt.void))
     assert DT.shape == (0, 5)
-    RZ = DT[:, sum(f[:])]
-    frame_integrity_check(RZ)
-    assert RZ.shape == (1, 5)
-    assert RZ.names == ("A", "B", "C", "D", "E")
-    assert RZ.stypes == (dt.int64, dt.int64, dt.float32, dt.float64, dt.int64)
-    assert RZ.to_list() == [[0], [0], [0], [0], [0]]
-    assert str(RZ)
+    DT_sum = DT[:, sum(f[:])]
+    frame_integrity_check(DT_sum)
+    assert DT_sum.shape == (1, 5)
+    assert DT_sum.names == ("A", "B", "C", "D", "E")
+    assert DT_sum.stypes == (dt.int64, dt.int64, dt.float32, dt.float64, dt.int64)
+    assert DT_sum.to_list() == [[0], [0], [0], [0], [0]]
+    assert str(DT_sum)
+    assert_equals(DT_sum, DT.sum())
 
 
 def test_sum_grouped():
     DT = dt.Frame(A=[True, False, True, True], B=[None, None, None, 10], C=[2,3,5,-5])
-    RES = DT[:, sum(f[:]), by(f.A)]
-    REF = dt.Frame(A=[False, True], B=[0, 10]/dt.int64, C=[3,2]/dt.int64)
-    frame_integrity_check(RES)
-    assert_equals(RES, REF)
-    assert str(RES)
+    DT_sum = DT[:, sum(f[:]), by(f.A)]
+    DT_ref = dt.Frame(A=[False, True], B=[0, 10]/dt.int64, C=[3,2]/dt.int64)
+    frame_integrity_check(DT_sum)
+    assert_equals(DT_sum, DT_ref)
+    assert str(DT_sum)
 
 
 


### PR DESCRIPTION
Frame's method `.sum()` now returns the same column types as the corresponding `dt.sum()` reducer.

Closes #2904