### PR TITLE
Switch to macOS Monterey on AppVeyor and remove dependency on `distutils`

### DIFF
--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -1,7 +1,7 @@
 image:
-  - Visual Studio 2019
-  - macos-bigsur
-  - Ubuntu
+  # - Visual Studio 2019
+  - macos-monterey
+  # - Ubuntu
 
 init:
   # Uncomment the line below to enable RDP access

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -1,10 +1,10 @@
 image:
-  # - Visual Studio 2019
+  - Visual Studio 2019
   - macos-monterey
-  # - Ubuntu
+  - Ubuntu
 
 init:
-  # Uncomment the line below to enable RDP access
+  # Uncomment the line below to enable RDP access on AppVeyor
   # - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 branches:

--- a/ci/xbuild/wheel.py
+++ b/ci/xbuild/wheel.py
@@ -453,8 +453,8 @@ class Wheel:
             platform = distutils.util.get_platform()
             # Meanwhile, a workaround for macOS Big Sur and Monterey, see #3175 and #3322
             if platform.startswith("macosx-11") or platform.startswith("macosx-12"):
-                version = platform[7:9]
-                plat_tag = re.sub("-"+version+"(.*)-", "_"+version+"_0_", platform)
+                osx_version = platform[7:9]
+                plat_tag = re.sub("-"+osx_version+"(.*)-", "_"+osx_version+"_0_", platform)
             else:
                 plat_tag = platform.replace('.', '_').replace('-', '_')
             self._tag = "%s-%s-%s" % (impl_tag, abi_tag, plat_tag)

--- a/ci/xbuild/wheel.py
+++ b/ci/xbuild/wheel.py
@@ -36,7 +36,6 @@
 #
 #-------------------------------------------------------------------------------
 import base64
-import distutils.util
 import hashlib
 import io
 import os
@@ -449,9 +448,8 @@ class Wheel:
         if self._tag is None:
             impl_tag = self._get_python_tag()
             abi_tag = self._get_abi_tag()
-            # TODO: remove `distutils` dependency as it has been deprecated
-            platform = distutils.util.get_platform()
-            # Meanwhile, a workaround for macOS Big Sur and Monterey, see #3175 and #3322
+            platform = sysconfig.get_platform()
+            # A workaround for macOS Big Sur and Monterey, see #3175 and #3322
             if platform.startswith("macosx-11") or platform.startswith("macosx-12"):
                 osx_version = platform[7:9]
                 plat_tag = re.sub("-"+osx_version+"(.*)-", "_"+osx_version+"_0_", platform)

--- a/ci/xbuild/wheel.py
+++ b/ci/xbuild/wheel.py
@@ -450,12 +450,16 @@ class Wheel:
             abi_tag = self._get_abi_tag()
             platform = sysconfig.get_platform()
 
-            # For macOS with major versions >= 11 the minor version
-            # in the platform tag must be 0, see #3175 and #3322.
-            osx_major = int(re.match("macosx-(\d*)", platform)[1])
-            if osx_major >= 11:
-                plat_tag = re.sub("-"+osx_major+"(.*)-",
-                                  "_"+osx_major+"_0_",
+            # PEP-425 requires the result of `get_platform()` to have
+            # "all hyphens - and periods . replaced with
+            # underscore _". In addition, it was found that for OSX
+            # major versions >= 11 the minor version in the platform tag
+            # must be 0, see #3175 and #3322.
+            res = re.match("macosx-(\d*)", platform)
+            osx_major = 0 if res is None else res[1]
+            if int(osx_major) >= 11:
+                plat_tag = re.sub("-" + osx_major + "(.*)-",
+                                  "_" + osx_major + "_0_",
                                   platform)
             else:
                 plat_tag = platform.replace('.', '_').replace('-', '_')

--- a/ci/xbuild/wheel.py
+++ b/ci/xbuild/wheel.py
@@ -449,13 +449,19 @@ class Wheel:
             impl_tag = self._get_python_tag()
             abi_tag = self._get_abi_tag()
             platform = sysconfig.get_platform()
-            # A workaround for macOS Big Sur and Monterey, see #3175 and #3322
-            if platform.startswith("macosx-11") or platform.startswith("macosx-12"):
-                osx_version = platform[7:9]
-                plat_tag = re.sub("-"+osx_version+"(.*)-", "_"+osx_version+"_0_", platform)
+
+            # For macOS with major versions >= 11 the minor version
+            # in the platform tag must be 0, see #3175 and #3322.
+            osx_major = int(re.match("macosx-(\d*)", platform)[1])
+            if osx_major >= 11:
+                plat_tag = re.sub("-"+osx_major+"(.*)-",
+                                  "_"+osx_major+"_0_",
+                                  platform)
             else:
                 plat_tag = platform.replace('.', '_').replace('-', '_')
+
             self._tag = "%s-%s-%s" % (impl_tag, abi_tag, plat_tag)
+
         return self._tag
 
 

--- a/ci/xbuild/wheel.py
+++ b/ci/xbuild/wheel.py
@@ -451,9 +451,10 @@ class Wheel:
             abi_tag = self._get_abi_tag()
             # TODO: remove `distutils` dependency as it has been deprecated
             platform = distutils.util.get_platform()
-            # Meanwhile, a workaround for macOS Big Sur, see #3175
-            if platform.startswith("macosx-11"):
-                plat_tag = re.sub("-11(.*)-", "_11_0_", platform)
+            # Meanwhile, a workaround for macOS Big Sur and Monterey, see #3175 and #3322
+            if platform.startswith("macosx-11") or platform.startswith("macosx-12"):
+                version = platform[7:9]
+                plat_tag = re.sub("-"+version+"(.*)-", "_"+version+"_0_", platform)
             else:
                 plat_tag = platform.replace('.', '_').replace('-', '_')
             self._tag = "%s-%s-%s" % (impl_tag, abi_tag, plat_tag)

--- a/ci/xbuild/wheel.py
+++ b/ci/xbuild/wheel.py
@@ -454,7 +454,7 @@ class Wheel:
             # "all hyphens - and periods . replaced with
             # underscore _". In addition, it was found that for OSX
             # major versions >= 11 the minor version in the platform tag
-            # must be 0, see #3175 and #3322.
+            # must be set to 0, see #3175 and #3322.
             res = re.match("macosx-(\d*)", platform)
             osx_major = 0 if res is None else res[1]
             if int(osx_major) >= 11:


### PR DESCRIPTION
Currently our Jenkins is using macOS Big Sur, and in order to make OS coverage as large as possible we switch AppVeyor to use macOS Monterey. Also, in this PR we replace the deprecated `distutils` module with `sysconfig` in order to get the proper platform tag.

Closes #3322 
Closes #3177