### PR TITLE
Change `RowIndex` from `ARR64` to `ARR32` when creating new labels for classification

### DIFF
--- a/src/core/rowindex.h
+++ b/src/core/rowindex.h
@@ -70,7 +70,7 @@ class RowIndex {
      * Construct a RowIndex object from a buffer of int32/int64 indices.
      * The `flags` argument should contain either RowIndex::ARR32 or
      * RowIndex::ARR64, optionally combined with RowIndex::SORTED to tell
-     * the constructor whether that the array is sorted.
+     * the constructor whether the indices are sorted.
      */
     RowIndex(Buffer&& buf, int flags);
 


### PR DESCRIPTION
Label ids for both FTRL and LinearModel are stored as `int32` column, so It makes no sense to use `ARR64` rowindex to identify the new labels. In this PR we safely change `RowIndex::ARR64` to `RowIndex::ARR32` when creating new labels for classification problems.