### PR TITLE
Switch to `manylinux2014` image on `x86_64` and to py38 for debug wheels

### DIFF
--- a/ci/Jenkinsfile.groovy
+++ b/ci/Jenkinsfile.groovy
@@ -63,7 +63,7 @@ LINK_MAP = [
 
 
 DOCKER_IMAGE_PPC64LE_MANYLINUX = "quay.io/pypa/manylinux2014_ppc64le"
-DOCKER_IMAGE_X86_64_MANYLINUX = "quay.io/pypa/manylinux2010_x86_64"
+DOCKER_IMAGE_X86_64_MANYLINUX = "quay.io/pypa/manylinux2014_x86_64"
 
 
 // Note: global variables must be declared without `def`

--- a/ci/Jenkinsfile.groovy
+++ b/ci/Jenkinsfile.groovy
@@ -251,12 +251,12 @@ ansiColor('xterm') {
                                         -c "cd /dot && \
                                             ls -la && \
                                             ls -la src/datatable && \
-                                            /opt/python/cp37-cp37m/bin/python3.7 ci/ext.py debugwheel --audit && \
                                             /opt/python/cp37-cp37m/bin/python3.7 ci/ext.py wheel --audit && \
+                                            /opt/python/cp38-cp38m/bin/python3.8 ci/ext.py debugwheel --audit && \
                                             /opt/python/cp38-cp38/bin/python3.8 ci/ext.py wheel --audit && \
                                             /opt/python/cp39-cp39/bin/python3.9 ci/ext.py wheel --audit && \
                                             /opt/python/cp310-cp310/bin/python3.10 ci/ext.py wheel --audit && \
-                                            echo '===== Py3.7 Debug =====' && unzip -p dist/*debug*.whl datatable/_build_info.py && \
+                                            echo '===== Py3.8 Debug =====' && unzip -p dist/*debug*.whl datatable/_build_info.py && \
                                             mv dist/*debug*.whl . && \
                                             echo '===== Py3.7 =====' && unzip -p dist/*cp37*.whl datatable/_build_info.py && \
                                             echo '===== Py3.8 =====' && unzip -p dist/*cp38*.whl datatable/_build_info.py && \
@@ -335,12 +335,12 @@ ansiColor('xterm') {
                                             -c "cd /dot && \
                                                 ls -la && \
                                                 ls -la src/datatable && \
-                                                /opt/python/cp37-cp37m/bin/python3.7 ci/ext.py debugwheel --audit && \
                                                 /opt/python/cp37-cp37m/bin/python3.7 ci/ext.py wheel --audit && \
+                                                /opt/python/cp38-cp38m/bin/python3.8 ci/ext.py debugwheel --audit && \
                                                 /opt/python/cp38-cp38/bin/python3.8 ci/ext.py wheel --audit && \
                                                 /opt/python/cp39-cp39/bin/python3.9 ci/ext.py wheel --audit && \
                                                 /opt/python/cp310-cp310/bin/python3.10 ci/ext.py wheel --audit && \
-                                                echo '===== Py3.7 Debug =====' && unzip -p dist/*debug*.whl datatable/_build_info.py && \
+                                                echo '===== Py3.8 Debug =====' && unzip -p dist/*debug*.whl datatable/_build_info.py && \
                                                 mv dist/*debug*.whl . && \
                                                 echo '===== Py3.7 =====' && unzip -p dist/*cp37*.whl datatable/_build_info.py && \
                                                 echo '===== Py3.8 =====' && unzip -p dist/*cp38*.whl datatable/_build_info.py && \
@@ -365,20 +365,6 @@ ansiColor('xterm') {
             if (!params.DISABLE_ALL_TESTS) {
                 def testStages = [:]
                 testStages <<
-                    namedStage('Test x86_64-manylinux-py37-debug', { stageName, stageDir ->
-                        node(NODE_LINUX) {
-                            buildSummary.stageWithSummary(stageName, stageDir) {
-                                cleanWs()
-                                dumpInfo()
-                                dir(stageDir) {
-                                    unstash 'datatable-sources'
-                                    unstash 'x86_64-manylinux-debugwheels'
-                                    test_in_docker("x86_64-manylinux-py37-debug", "37",
-                                                   DOCKER_IMAGE_X86_64_MANYLINUX)
-                                }
-                            }
-                        }
-                    }) <<
                     namedStage('Test x86_64-manylinux-py37', { stageName, stageDir ->
                         node(NODE_LINUX) {
                             buildSummary.stageWithSummary(stageName, stageDir) {
@@ -388,6 +374,20 @@ ansiColor('xterm') {
                                     unstash 'datatable-sources'
                                     unstash 'x86_64-manylinux-wheels'
                                     test_in_docker("x86_64-manylinux-py37", "37",
+                                                   DOCKER_IMAGE_X86_64_MANYLINUX)
+                                }
+                            }
+                        }
+                    }) <<
+                    namedStage('Test x86_64-manylinux-py38-debug', doPy38Tests, { stageName, stageDir ->
+                        node(NODE_LINUX) {
+                            buildSummary.stageWithSummary(stageName, stageDir) {
+                                cleanWs()
+                                dumpInfo()
+                                dir(stageDir) {
+                                    unstash 'datatable-sources'
+                                    unstash 'x86_64-manylinux-debugwheels'
+                                    test_in_docker("x86_64-manylinux-py38-debug", "38",
                                                    DOCKER_IMAGE_X86_64_MANYLINUX)
                                 }
                             }
@@ -435,20 +435,6 @@ ansiColor('xterm') {
                             }
                         }
                     }) <<
-                    namedStage('Test ppc64le-manylinux-py37-debug', doPpcTests, { stageName, stageDir ->
-                        node(NODE_PPC) {
-                            buildSummary.stageWithSummary(stageName, stageDir) {
-                                cleanWs()
-                                dumpInfo()
-                                dir(stageDir) {
-                                    unstash 'datatable-sources'
-                                    unstash 'ppc64le-manylinux-debugwheels'
-                                    test_in_docker("ppc64le-manylinux-py37-debug", "37",
-                                                   DOCKER_IMAGE_PPC64LE_MANYLINUX)
-                                }
-                            }
-                        }
-                    }) <<
                     namedStage('Test ppc64le-manylinux-py37', doPpcTests, { stageName, stageDir ->
                         node(NODE_PPC) {
                             buildSummary.stageWithSummary(stageName, stageDir) {
@@ -458,6 +444,20 @@ ansiColor('xterm') {
                                     unstash 'datatable-sources'
                                     unstash 'ppc64le-manylinux-wheels'
                                     test_in_docker("ppc64le-manylinux-py37", "37",
+                                                   DOCKER_IMAGE_PPC64LE_MANYLINUX)
+                                }
+                            }
+                        }
+                    }) <<
+                    namedStage('Test ppc64le-manylinux-py38-debug', doPpcTests && doPy38Tests, { stageName, stageDir ->
+                        node(NODE_PPC) {
+                            buildSummary.stageWithSummary(stageName, stageDir) {
+                                cleanWs()
+                                dumpInfo()
+                                dir(stageDir) {
+                                    unstash 'datatable-sources'
+                                    unstash 'ppc64le-manylinux-debugwheels'
+                                    test_in_docker("ppc64le-manylinux-py38-debug", "38",
                                                    DOCKER_IMAGE_PPC64LE_MANYLINUX)
                                 }
                             }

--- a/ci/Jenkinsfile.groovy
+++ b/ci/Jenkinsfile.groovy
@@ -252,7 +252,7 @@ ansiColor('xterm') {
                                             ls -la && \
                                             ls -la src/datatable && \
                                             /opt/python/cp37-cp37m/bin/python3.7 ci/ext.py wheel --audit && \
-                                            /opt/python/cp38-cp38m/bin/python3.8 ci/ext.py debugwheel --audit && \
+                                            /opt/python/cp38-cp38/bin/python3.8 ci/ext.py debugwheel --audit && \
                                             /opt/python/cp38-cp38/bin/python3.8 ci/ext.py wheel --audit && \
                                             /opt/python/cp39-cp39/bin/python3.9 ci/ext.py wheel --audit && \
                                             /opt/python/cp310-cp310/bin/python3.10 ci/ext.py wheel --audit && \
@@ -336,7 +336,7 @@ ansiColor('xterm') {
                                                 ls -la && \
                                                 ls -la src/datatable && \
                                                 /opt/python/cp37-cp37m/bin/python3.7 ci/ext.py wheel --audit && \
-                                                /opt/python/cp38-cp38m/bin/python3.8 ci/ext.py debugwheel --audit && \
+                                                /opt/python/cp38-cp38/bin/python3.8 ci/ext.py debugwheel --audit && \
                                                 /opt/python/cp38-cp38/bin/python3.8 ci/ext.py wheel --audit && \
                                                 /opt/python/cp39-cp39/bin/python3.9 ci/ext.py wheel --audit && \
                                                 /opt/python/cp310-cp310/bin/python3.10 ci/ext.py wheel --audit && \

--- a/docs/start/install.rst
+++ b/docs/start/install.rst
@@ -59,7 +59,6 @@ The following platforms are supported:
 
 - **Linux x86_64 / ppc64le**
 
-  .. TODO: correct tags.
   We produce binary wheels that are tagged as ``manylinux_2_12`` (for ``x86_64``
   architecture) and ``manylinux2014`` (for ``ppc64le``). Consequently, they will
   work with your Linux distribution if it is compatible with one of these tags.

--- a/docs/start/install.rst
+++ b/docs/start/install.rst
@@ -59,6 +59,7 @@ The following platforms are supported:
 
 - **Linux x86_64 / ppc64le**
 
+  .. TODO: correct tags.
   We produce binary wheels that are tagged as ``manylinux_2_12`` (for ``x86_64``
   architecture) and ``manylinux2014`` (for ``ppc64le``). Consequently, they will
   work with your Linux distribution if it is compatible with one of these tags.

--- a/docs/start/install.rst
+++ b/docs/start/install.rst
@@ -52,7 +52,7 @@ The following platforms are supported:
 
 - **macOS**
 
-  Datatable has been tested to work on macOS 10.12 (Sierra), macoS 10.13
+  Datatable has been tested to work on macOS 10.12 (Sierra), macOS 10.13
   (High Sierra), macOS 10.15 (Catalina), macOS 11 (BigSur) and 
   macOS 12 (Monterey).
 

--- a/docs/start/install.rst
+++ b/docs/start/install.rst
@@ -52,16 +52,15 @@ The following platforms are supported:
 
 - **macOS**
 
-  Datatable has been tested to work on macOS 10.12.5 (Sierra), macoS 10.13.6
-  (High Sierra), macOS 10.15.7 (Catalina), and macOS 11.2.3 (BigSur).
-  The produced wheels are tagged as ``macosx_10_9``, so they should work on
-  earlier versions of macOS as well.
+  Datatable has been tested to work on macOS 10.12 (Sierra), macoS 10.13
+  (High Sierra), macOS 10.15 (Catalina), macOS 11 (BigSur) and 
+  macOS 12 (Monterey).
 
 - **Linux x86_64 / ppc64le**
 
-  We produce binary wheels that are tagged as ``manylinux_2_12`` (for ``x86_64``
-  architecture) and ``manylinux2014`` (for ``ppc64le``). Consequently, they will
-  work with your Linux distribution if it is compatible with one of these tags.
+  For ``x86_64`` and ``ppc64le`` architectures we produce binary wheels 
+  that are tagged as ``manylinux_2_17``. Consequently, they will
+  work with your Linux distribution if it is compatible with this tag.
   Please refer to :pep:`600` for details.
 
 - **Windows**


### PR DESCRIPTION
Support for `manylinux2010` image that we're using to build datatable on `x86_64` is about to be dropped (https://github.com/pypa/manylinux/issues/1281), so we switch to `manylinux2014` that we're already using on `ppc64le`. 

Also, Python 3.7 will reach its end of life soon, hence we switch to Python 3.8 when generating debug wheels. In principle, we can generate debug wheels for all the supported Python versions, however, this will significantly slow down our building pipeline.