### PR TITLE
Improve test coverage on AppVeyor

### DIFF
--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -216,8 +216,6 @@ build_script:
 
     $DT_WHEEL = ls dist/*$env:DT_BUILD_SUFFIX.debug-cp38-*.whl
 
-    echo "DT_WHEEL = $DT_WHEEL"
-
     echo "----- _build_info.py for Python 3.8 debug wheel ------------------"
 
     cat src/datatable/_build_info.py

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -103,6 +103,8 @@ build_script:
 
     python -m pytest -ra --maxfail=10 -Werror -vv --showlocals ./tests/
 
+    python -m pip uninstall $DT_WHEEL
+
 
 
 # Windows builds
@@ -192,6 +194,8 @@ build_script:
 
       python -m pytest -ra --maxfail=10 -Werror -vv --showlocals ./tests/
 
+      python -m pip uninstall $DT_WHEEL
+
     }
 
 
@@ -220,6 +224,8 @@ build_script:
 
     python -m pytest -ra --maxfail=10 -Werror -vv --showlocals ./tests/
 
+    python -m pip uninstall $DT_WHEEL
+
 
 
     # =======================================================================
@@ -245,6 +251,8 @@ build_script:
     python -m pip install $DT_WHEEL pytest docutils pandas pyarrow
 
     python -m pytest -ra --maxfail=10 -Werror -vv --showlocals ./tests/
+
+    python -m pip uninstall $DT_WHEEL
 
 
 
@@ -272,6 +280,8 @@ build_script:
 
     python -m pytest -ra --maxfail=10 -Werror -vv --showlocals ./tests/
 
+    python -m pip uninstall $DT_WHEEL
+
 
 
     # =======================================================================
@@ -297,3 +307,6 @@ build_script:
     python -m pip install $DT_WHEEL pytest docutils pandas pyarrow
 
     python -m pytest -ra --maxfail=10 -Werror -vv --showlocals ./tests/
+
+    python -m pip uninstall $DT_WHEEL
+

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -23,6 +23,7 @@ environment:
 
 matrix:
   fast_finish: true
+  platform: x64
 
 build_script:
 

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -229,6 +229,8 @@ build_script:
 
     python -m pytest -ra --maxfail=10 -Werror -vv --showlocals ./tests/
 
+    if(!$?) { Exit $LASTEXITCODE }
+
     python -m pip uninstall -y $DT_WHEEL
 
 

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -23,7 +23,6 @@ environment:
 
 matrix:
   fast_finish: true
-  platform: x64
 
 build_script:
 

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -184,7 +184,7 @@ build_script:
 
       python ci/ext.py wheel
 
-      $DT_WHEEL = ls dist/*-cp37-*.whl
+      $DT_WHEEL = ls dist/*$env:DT_BUILD_SUFFIX-cp37-*.whl
 
       echo "----- _build_info.py for Python 3.7 ------------------------------"
 
@@ -214,7 +214,7 @@ build_script:
 
     python ci/ext.py debugwheel
 
-    $DT_WHEEL = ls dist/*debug*-cp38-*.whl
+    $DT_WHEEL = ls dist/*$env:DT_BUILD_SUFFIX-debug-cp38-*.whl
 
     echo "----- _build_info.py for Python 3.8 debug wheel ------------------"
 
@@ -242,7 +242,7 @@ build_script:
 
     python ci/ext.py wheel
 
-    $DT_WHEEL = ls dist/*-cp38-*.whl
+    $DT_WHEEL = ls dist/*$env:DT_BUILD_SUFFIX-cp38-*.whl
 
     echo "----- _build_info.py for Python 3.8 ------------------------------"
 
@@ -270,7 +270,7 @@ build_script:
 
     python ci/ext.py wheel
 
-    $DT_WHEEL = ls dist/*-cp39-*.whl
+    $DT_WHEEL = ls dist/*$env:DT_BUILD_SUFFIX-cp39-*.whl
 
     echo "----- _build_info.py for Python 3.9 ------------------------------"
 
@@ -298,7 +298,7 @@ build_script:
 
     python ci/ext.py wheel
 
-    $DT_WHEEL = ls dist/*-cp310-*.whl
+    $DT_WHEEL = ls dist/*$env:DT_BUILD_SUFFIX-cp310-*.whl
 
     echo "----- _build_info.py for Python 3.10 ------------------------------"
 

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -184,7 +184,7 @@ build_script:
 
       python ci/ext.py wheel
 
-      $DT_WHEEL = ls dist/*{$env:DT_BUILD_SUFFIX}-cp37-*.whl
+      $DT_WHEEL = ls dist/*$env:DT_BUILD_SUFFIX-cp37-*.whl
 
       echo "----- _build_info.py for Python 3.7 ------------------------------"
 
@@ -214,7 +214,9 @@ build_script:
 
     python ci/ext.py debugwheel
 
-    $DT_WHEEL = ls dist/*{$env:DT_BUILD_SUFFIX}.debug-cp38-*.whl
+    $DT_WHEEL = ls dist/*$env:DT_BUILD_SUFFIX.debug-cp38-*.whl
+
+    echo "DT_WHEEL = $DT_WHEEL"
 
     echo "----- _build_info.py for Python 3.8 debug wheel ------------------"
 
@@ -242,7 +244,7 @@ build_script:
 
     python ci/ext.py wheel
 
-    $DT_WHEEL = ls dist/*{$env:DT_BUILD_SUFFIX}-cp38-*.whl
+    $DT_WHEEL = ls dist/*$env:DT_BUILD_SUFFIX-cp38-*.whl
 
     echo "----- _build_info.py for Python 3.8 ------------------------------"
 
@@ -270,7 +272,7 @@ build_script:
 
     python ci/ext.py wheel
 
-    $DT_WHEEL = ls dist/*{$env:DT_BUILD_SUFFIX}-cp39-*.whl
+    $DT_WHEEL = ls dist/*$env:DT_BUILD_SUFFIX-cp39-*.whl
 
     echo "----- _build_info.py for Python 3.9 ------------------------------"
 
@@ -298,7 +300,7 @@ build_script:
 
     python ci/ext.py wheel
 
-    $DT_WHEEL = ls dist/*{$env:DT_BUILD_SUFFIX}-cp310-*.whl
+    $DT_WHEEL = ls dist/*$env:DT_BUILD_SUFFIX-cp310-*.whl
 
     echo "----- _build_info.py for Python 3.10 ------------------------------"
 

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -114,6 +114,8 @@ build_script:
     #   Set up environment variables
     # =======================================================================
 
+    $ErrorActionPreference = "Stop"
+
     $env:DT_HARNESS = "AppVeyor"
 
     $DEFAULT_PATH = $env:PATH

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -27,7 +27,7 @@ matrix:
 
 build_script:
 
-# Linux and macOS builds
+# Linux and macOS builds.
 - sh: >-
 
     # =======================================================================
@@ -106,11 +106,21 @@ build_script:
 
     python -m pytest -ra --maxfail=10 -Werror -vv --showlocals ./tests/
 
-    python -m pip uninstall -y $DT_WHEEL
 
 
+# Windows builds.
+#
+# We use PowerShell that has more powerful syntax
+# than the standard command prompt. Unfortunately, PowerShell only takes
+# into account exit code of the last command and, if other commands fail,
+# the build can still be marked as green. Partially this problem is solved
+# by setting `$ErrorActionPreference` to `"Stop"`, that works well with
+# cmdlets. However, ultimately every PowerShell command should be followed
+# by the check `if(!$?) { Exit $LASTEXITCODE }`, that will stop the build
+# on the first failed command. Since we don't want to make the code too
+# cumbersome, here we only check the exit status of `pytest` that is still
+# a pretty good indicator.
 
-# Windows builds
 - ps: >-
 
     # =======================================================================
@@ -199,6 +209,8 @@ build_script:
 
       python -m pytest -ra --maxfail=10 -Werror -vv --showlocals ./tests/
 
+      if(!$?) { Exit $LASTEXITCODE }
+
       python -m pip uninstall -y $DT_WHEEL
 
     }
@@ -259,6 +271,8 @@ build_script:
 
     python -m pytest -ra --maxfail=10 -Werror -vv --showlocals ./tests/
 
+    if(!$?) { Exit $LASTEXITCODE }
+
     python -m pip uninstall -y $DT_WHEEL
 
 
@@ -287,6 +301,8 @@ build_script:
 
     python -m pytest -ra --maxfail=10 -Werror -vv --showlocals ./tests/
 
+    if(!$?) { Exit $LASTEXITCODE }
+
     python -m pip uninstall -y $DT_WHEEL
 
 
@@ -314,6 +330,8 @@ build_script:
     python -m pip install $DT_WHEEL pytest docutils pandas pyarrow
 
     python -m pytest -ra --maxfail=10 -Werror -vv --showlocals ./tests/
+
+    if(!$?) { Exit $LASTEXITCODE }
 
     python -m pip uninstall -y $DT_WHEEL
 

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -214,7 +214,7 @@ build_script:
 
     python ci/ext.py debugwheel
 
-    $DT_WHEEL = ls dist/*$env:DT_BUILD_SUFFIX-debug-cp38-*.whl
+    $DT_WHEEL = ls dist/*$env:DT_BUILD_SUFFIX.debug-cp38-*.whl
 
     echo "----- _build_info.py for Python 3.8 debug wheel ------------------"
 

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -218,18 +218,18 @@ build_script:
 
 
     # =======================================================================
-    #   Build and test debug wheel for Python 3.8
+    #   Build and test wheel for Python 3.8
     # =======================================================================
 
     $env:PATH = "C:/Python38-x64;C:/Python38-x64/Scripts;$DEFAULT_PATH"
 
     python -V
 
-    python ci/ext.py debugwheel
+    python ci/ext.py wheel
 
-    $DT_WHEEL = ls dist/*$env:DT_BUILD_SUFFIX.debug-cp38-*.whl
+    $DT_WHEEL = ls dist/*$env:DT_BUILD_SUFFIX-cp38-*.whl
 
-    echo "----- _build_info.py for Python 3.8 debug wheel ------------------"
+    echo "----- _build_info.py for Python 3.8 ------------------------------"
 
     cat src/datatable/_build_info.py
 
@@ -248,18 +248,18 @@ build_script:
 
 
     # =======================================================================
-    #   Build and test wheel for Python 3.8
+    #   Build and test debug wheel for Python 3.9
     # =======================================================================
 
-    $env:PATH = "C:/Python38-x64;C:/Python38-x64/Scripts;$DEFAULT_PATH"
+    $env:PATH = "C:/Python39-x64;C:/Python39-x64/Scripts;$DEFAULT_PATH"
 
     python -V
 
-    python ci/ext.py wheel
+    python ci/ext.py debugwheel
 
-    $DT_WHEEL = ls dist/*$env:DT_BUILD_SUFFIX-cp38-*.whl
+    $DT_WHEEL = ls dist/*$env:DT_BUILD_SUFFIX.debug-cp39-*.whl
 
-    echo "----- _build_info.py for Python 3.8 ------------------------------"
+    echo "----- _build_info.py for Python 3.9 debug wheel ------------------"
 
     cat src/datatable/_build_info.py
 

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -21,6 +21,8 @@ artifacts:
 environment:
   APPVEYOR_YML_DISABLE_PS_LINUX: true
 
+matrix:
+  fast_finish: true
 
 build_script:
 

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -184,7 +184,7 @@ build_script:
 
       python ci/ext.py wheel
 
-      $DT_WHEEL = ls dist/*$env:DT_BUILD_SUFFIX-cp37-*.whl
+      $DT_WHEEL = ls dist/*{$env:DT_BUILD_SUFFIX}-cp37-*.whl
 
       echo "----- _build_info.py for Python 3.7 ------------------------------"
 
@@ -214,7 +214,7 @@ build_script:
 
     python ci/ext.py debugwheel
 
-    $DT_WHEEL = ls dist/*$env:DT_BUILD_SUFFIX.debug-cp38-*.whl
+    $DT_WHEEL = ls dist/*{$env:DT_BUILD_SUFFIX}.debug-cp38-*.whl
 
     echo "----- _build_info.py for Python 3.8 debug wheel ------------------"
 
@@ -242,7 +242,7 @@ build_script:
 
     python ci/ext.py wheel
 
-    $DT_WHEEL = ls dist/*$env:DT_BUILD_SUFFIX-cp38-*.whl
+    $DT_WHEEL = ls dist/*{$env:DT_BUILD_SUFFIX}-cp38-*.whl
 
     echo "----- _build_info.py for Python 3.8 ------------------------------"
 
@@ -270,7 +270,7 @@ build_script:
 
     python ci/ext.py wheel
 
-    $DT_WHEEL = ls dist/*$env:DT_BUILD_SUFFIX-cp39-*.whl
+    $DT_WHEEL = ls dist/*{$env:DT_BUILD_SUFFIX}-cp39-*.whl
 
     echo "----- _build_info.py for Python 3.9 ------------------------------"
 
@@ -298,7 +298,7 @@ build_script:
 
     python ci/ext.py wheel
 
-    $DT_WHEEL = ls dist/*$env:DT_BUILD_SUFFIX-cp310-*.whl
+    $DT_WHEEL = ls dist/*{$env:DT_BUILD_SUFFIX}-cp310-*.whl
 
     echo "----- _build_info.py for Python 3.10 ------------------------------"
 

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -99,7 +99,7 @@ build_script:
 
     python -m pip install --upgrade pip
 
-    python -m pip install $DT_WHEEL pytest docutils pandas
+    python -m pip install $DT_WHEEL pytest docutils pandas pyarrow
 
     python -m pytest -ra --maxfail=10 -Werror -vv --showlocals ./tests/
 
@@ -188,7 +188,7 @@ build_script:
 
       python -m pip install --upgrade pip
 
-      python -m pip install $DT_WHEEL pytest docutils pandas
+      python -m pip install $DT_WHEEL pytest docutils pandas pyarrow
 
       python -m pytest -ra --maxfail=10 -Werror -vv --showlocals ./tests/
 
@@ -216,7 +216,33 @@ build_script:
 
     python -m pip install --upgrade pip
 
-    python -m pip install $DT_WHEEL pytest docutils pandas
+    python -m pip install $DT_WHEEL pytest docutils pandas pyarrow
+
+    python -m pytest -ra --maxfail=10 -Werror -vv --showlocals ./tests/
+
+
+
+    # =======================================================================
+    #   Build and test debug wheel for Python 3.8
+    # =======================================================================
+
+    $env:PATH = "C:/Python38-x64;C:/Python38-x64/Scripts;$DEFAULT_PATH"
+
+    python -V
+
+    python ci/ext.py debugwheel
+
+    $DT_WHEEL = ls dist/*debug*-cp38-*.whl
+
+    echo "----- _build_info.py for Python 3.8 debug wheel ------------------"
+
+    cat src/datatable/_build_info.py
+
+    echo "------------------------------------------------------------------"
+
+    python -m pip install --upgrade pip
+
+    python -m pip install $DT_WHEEL pytest docutils pandas pyarrow
 
     python -m pytest -ra --maxfail=10 -Werror -vv --showlocals ./tests/
 
@@ -242,7 +268,7 @@ build_script:
 
     python -m pip install --upgrade pip
 
-    python -m pip install $DT_WHEEL pytest docutils pandas
+    python -m pip install $DT_WHEEL pytest docutils pandas pyarrow
 
     python -m pytest -ra --maxfail=10 -Werror -vv --showlocals ./tests/
 
@@ -268,6 +294,6 @@ build_script:
 
     python -m pip install --upgrade pip
 
-    python -m pip install $DT_WHEEL pytest docutils pandas
+    python -m pip install $DT_WHEEL pytest docutils pandas pyarrow
 
     python -m pytest -ra --maxfail=10 -Werror -vv --showlocals ./tests/

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -103,7 +103,7 @@ build_script:
 
     python -m pytest -ra --maxfail=10 -Werror -vv --showlocals ./tests/
 
-    python -m pip uninstall $DT_WHEEL
+    python -m pip uninstall -y $DT_WHEEL
 
 
 
@@ -194,7 +194,7 @@ build_script:
 
       python -m pytest -ra --maxfail=10 -Werror -vv --showlocals ./tests/
 
-      python -m pip uninstall $DT_WHEEL
+      python -m pip uninstall -y $DT_WHEEL
 
     }
 
@@ -224,7 +224,7 @@ build_script:
 
     python -m pytest -ra --maxfail=10 -Werror -vv --showlocals ./tests/
 
-    python -m pip uninstall $DT_WHEEL
+    python -m pip uninstall -y $DT_WHEEL
 
 
 
@@ -252,7 +252,7 @@ build_script:
 
     python -m pytest -ra --maxfail=10 -Werror -vv --showlocals ./tests/
 
-    python -m pip uninstall $DT_WHEEL
+    python -m pip uninstall -y $DT_WHEEL
 
 
 
@@ -280,7 +280,7 @@ build_script:
 
     python -m pytest -ra --maxfail=10 -Werror -vv --showlocals ./tests/
 
-    python -m pip uninstall $DT_WHEEL
+    python -m pip uninstall -y $DT_WHEEL
 
 
 
@@ -308,5 +308,5 @@ build_script:
 
     python -m pytest -ra --maxfail=10 -Werror -vv --showlocals ./tests/
 
-    python -m pip uninstall $DT_WHEEL
+    python -m pip uninstall -y $DT_WHEEL
 

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -205,18 +205,18 @@ build_script:
 
 
     # =======================================================================
-    #   Build and test wheel for Python 3.8
+    #   Build and test debug wheel for Python 3.8
     # =======================================================================
 
     $env:PATH = "C:/Python38-x64;C:/Python38-x64/Scripts;$DEFAULT_PATH"
 
     python -V
 
-    python ci/ext.py wheel
+    python ci/ext.py debugwheel
 
-    $DT_WHEEL = ls dist/*-cp38-*.whl
+    $DT_WHEEL = ls dist/*debug*-cp38-*.whl
 
-    echo "----- _build_info.py for Python 3.8 ------------------------------"
+    echo "----- _build_info.py for Python 3.8 debug wheel ------------------"
 
     cat src/datatable/_build_info.py
 
@@ -233,18 +233,18 @@ build_script:
 
 
     # =======================================================================
-    #   Build and test debug wheel for Python 3.8
+    #   Build and test wheel for Python 3.8
     # =======================================================================
 
     $env:PATH = "C:/Python38-x64;C:/Python38-x64/Scripts;$DEFAULT_PATH"
 
     python -V
 
-    python ci/ext.py debugwheel
+    python ci/ext.py wheel
 
-    $DT_WHEEL = ls dist/*debug*-cp38-*.whl
+    $DT_WHEEL = ls dist/*-cp38-*.whl
 
-    echo "----- _build_info.py for Python 3.8 debug wheel ------------------"
+    echo "----- _build_info.py for Python 3.8 ------------------------------"
 
     cat src/datatable/_build_info.py
 

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -2,7 +2,6 @@ image:
   - Visual Studio 2019
   - macos-monterey
   - Ubuntu
-  
 
 init:
   # Uncomment the line below to enable RDP access on AppVeyor

--- a/ci/ext.py
+++ b/ci/ext.py
@@ -280,8 +280,8 @@ def build_extension(cmd, verbosity=3):
             ext.compiler.add_compiler_flag("/Od")    # no optimization
             ext.compiler.add_compiler_flag("/Z7")
             ext.compiler.add_linker_flag("/DEBUG:FULL")
-            ext.compiler.add_compiler_flag("/DDT_TEST")
-            # ext.compiler.add_compiler_flag("/DDT_DEBUG")
+            # ext.compiler.add_compiler_flag("/DDT_TEST")
+            ext.compiler.add_compiler_flag("/DDT_DEBUG")
     else:
         # Common compile flags
         ext.compiler.add_compiler_flag("-std=c++14")

--- a/ci/ext.py
+++ b/ci/ext.py
@@ -279,7 +279,7 @@ def build_extension(cmd, verbosity=3):
         if cmd == "debug":
             ext.compiler.add_compiler_flag("/Od")    # no optimization
             ext.compiler.add_compiler_flag("/Z7")
-            # ext.compiler.add_compiler_flag("/DDT_TEST")
+            ext.compiler.add_compiler_flag("/DDT_TEST")
             ext.compiler.add_compiler_flag("/DDT_DEBUG")
             ext.compiler.add_linker_flag("/DEBUG:FULL")
     else:

--- a/ci/ext.py
+++ b/ci/ext.py
@@ -279,9 +279,9 @@ def build_extension(cmd, verbosity=3):
         if cmd == "debug":
             ext.compiler.add_compiler_flag("/Od")    # no optimization
             ext.compiler.add_compiler_flag("/Z7")
-            ext.compiler.add_linker_flag("/DEBUG:FULL")
-            # ext.compiler.add_compiler_flag("/DDT_TEST")
+            ext.compiler.add_compiler_flag("/DDT_TEST")
             ext.compiler.add_compiler_flag("/DDT_DEBUG")
+            # ext.compiler.add_linker_flag("/DEBUG:FULL")
     else:
         # Common compile flags
         ext.compiler.add_compiler_flag("-std=c++14")

--- a/ci/ext.py
+++ b/ci/ext.py
@@ -280,7 +280,8 @@ def build_extension(cmd, verbosity=3):
             ext.compiler.add_compiler_flag("/Od")    # no optimization
             ext.compiler.add_compiler_flag("/Z7")
             ext.compiler.add_linker_flag("/DEBUG:FULL")
-            ext.compiler.add_compiler_flag("/DDT_TEST", "/DDT_DEBUG")
+            ext.compiler.add_compiler_flag("/DDT_TEST")
+            # ext.compiler.add_compiler_flag("/DDT_DEBUG")
     else:
         # Common compile flags
         ext.compiler.add_compiler_flag("-std=c++14")

--- a/ci/ext.py
+++ b/ci/ext.py
@@ -277,8 +277,8 @@ def build_extension(cmd, verbosity=3):
             raise RuntimeError("`make coverage` is not supported on Windows systems")
 
         if cmd == "debug":
-            ext.compiler.add_compiler_flag("/Od")    # no optimization
-            ext.compiler.add_compiler_flag("/Z7")
+            # ext.compiler.add_compiler_flag("/Od")    # no optimization
+            # ext.compiler.add_compiler_flag("/Z7")
             ext.compiler.add_compiler_flag("/DDT_TEST")
             ext.compiler.add_compiler_flag("/DDT_DEBUG")
             # ext.compiler.add_linker_flag("/DEBUG:FULL")

--- a/ci/ext.py
+++ b/ci/ext.py
@@ -280,6 +280,7 @@ def build_extension(cmd, verbosity=3):
             ext.compiler.add_compiler_flag("/Od")    # no optimization
             ext.compiler.add_compiler_flag("/Z7")
             ext.compiler.add_linker_flag("/DEBUG:FULL")
+            ext.compiler.add_compiler_flag("/DDTTEST", "/DDT_DEBUG")
     else:
         # Common compile flags
         ext.compiler.add_compiler_flag("-std=c++14")

--- a/ci/ext.py
+++ b/ci/ext.py
@@ -277,11 +277,11 @@ def build_extension(cmd, verbosity=3):
             raise RuntimeError("`make coverage` is not supported on Windows systems")
 
         if cmd == "debug":
-            # ext.compiler.add_compiler_flag("/Od")    # no optimization
-            # ext.compiler.add_compiler_flag("/Z7")
-            ext.compiler.add_compiler_flag("/DDT_TEST")
+            ext.compiler.add_compiler_flag("/Od")    # no optimization
+            ext.compiler.add_compiler_flag("/Z7")
+            # ext.compiler.add_compiler_flag("/DDT_TEST")
             ext.compiler.add_compiler_flag("/DDT_DEBUG")
-            # ext.compiler.add_linker_flag("/DEBUG:FULL")
+            ext.compiler.add_linker_flag("/DEBUG:FULL")
     else:
         # Common compile flags
         ext.compiler.add_compiler_flag("-std=c++14")

--- a/ci/ext.py
+++ b/ci/ext.py
@@ -280,7 +280,7 @@ def build_extension(cmd, verbosity=3):
             ext.compiler.add_compiler_flag("/Od")    # no optimization
             ext.compiler.add_compiler_flag("/Z7")
             ext.compiler.add_linker_flag("/DEBUG:FULL")
-            ext.compiler.add_compiler_flag("/DDTTEST", "/DDT_DEBUG")
+            ext.compiler.add_compiler_flag("/DDT_TEST", "/DDT_DEBUG")
     else:
         # Common compile flags
         ext.compiler.add_compiler_flag("-std=c++14")
@@ -307,7 +307,7 @@ def build_extension(cmd, verbosity=3):
             ext.compiler.add_compiler_flag("-g3")
             ext.compiler.add_compiler_flag("-glldb" if macos else "-ggdb")
             ext.compiler.add_compiler_flag("-O0")
-            ext.compiler.add_compiler_flag("-DDTTEST", "-DDT_DEBUG")
+            ext.compiler.add_compiler_flag("-DDT_TEST", "-DDT_DEBUG")
             ext.compiler.add_linker_flag("-fsanitize=address", "-shared-libasan")
 
         if cmd == "build":
@@ -318,7 +318,7 @@ def build_extension(cmd, verbosity=3):
             ext.compiler.add_compiler_flag("-g2")
             ext.compiler.add_compiler_flag("-O0")
             ext.compiler.add_compiler_flag("--coverage")
-            ext.compiler.add_compiler_flag("-DDTTEST", "-DDT_DEBUG")
+            ext.compiler.add_compiler_flag("-DDT_TEST", "-DDT_DEBUG")
             ext.compiler.add_linker_flag("-O0")
             ext.compiler.add_linker_flag("--coverage")
 
@@ -326,7 +326,7 @@ def build_extension(cmd, verbosity=3):
             ext.compiler.add_compiler_flag("-g3")
             ext.compiler.add_compiler_flag("-glldb" if macos else "-ggdb")
             ext.compiler.add_compiler_flag("-O0")  # no optimization
-            ext.compiler.add_compiler_flag("-DDTTEST", "-DDT_DEBUG")
+            ext.compiler.add_compiler_flag("-DDT_TEST", "-DDT_DEBUG")
             if ext.compiler.flavor == "clang":
                 ext.compiler.add_compiler_flag("-fdebug-macro")
 

--- a/src/core/frame/names.cc
+++ b/src/core/frame/names.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2021 H2O.ai
+// Copyright 2018-2022 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),

--- a/src/core/frame/names.cc
+++ b/src/core/frame/names.cc
@@ -683,7 +683,7 @@ void DataTable::_integrity_check_pynames() const {
 //------------------------------------------------------------------------------
 // Tests
 //------------------------------------------------------------------------------
-#ifdef DTTEST
+#ifdef DT_TEST
 
 TEST(coverage, names_FrameNameProviders) {
   pylistNP* t1 = new pylistNP(py::olist(0));

--- a/src/core/python/obj.h
+++ b/src/core/python/obj.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2021 H2O.ai
+// Copyright 2018-2022 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -26,8 +26,7 @@
 #include <vector>   // std::vector
 #include "_dt.h"               // general declarations
 #include "utils/exceptions.h"  // Error
-#include "utils/tests.h"     
-
+#include "utils/tests.h"       // compatibility with C++ tests
 namespace py {
 
 

--- a/src/core/python/obj.h
+++ b/src/core/python/obj.h
@@ -26,6 +26,8 @@
 #include <vector>   // std::vector
 #include "_dt.h"               // general declarations
 #include "utils/exceptions.h"  // Error
+#include "utils/tests.h"     
+
 namespace py {
 
 

--- a/src/core/read/parsers/parse_bool.cc
+++ b/src/core/read/parsers/parse_bool.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2021 H2O.ai
+// Copyright 2018-2022 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),

--- a/src/core/read/parsers/parse_bool.cc
+++ b/src/core/read/parsers/parse_bool.cc
@@ -57,7 +57,7 @@ REGISTER_PARSER(PT::Bool01)
                   PT::Float64Plain, PT::Float64Ext, PT::Str32});
 
 
-#ifdef DTTEST
+#ifdef DT_TEST
   TEST(fread, test_bool8_num) {
     auto check = [](const char* input, int8_t value, size_t advance) {
       ParseContext ctx;
@@ -112,7 +112,7 @@ REGISTER_PARSER(PT::BoolL)
     ->successors({PT::Str32});
 
 
-#ifdef DTTEST
+#ifdef DT_TEST
   TEST(fread, test_bool8_lowercase) {
     auto check = [](const char* input, int8_t value, size_t advance) {
       ParseContext ctx;
@@ -171,7 +171,7 @@ REGISTER_PARSER(PT::BoolT)
     ->type(Type::bool8())
     ->successors({PT::Str32});
 
-#ifdef DTTEST
+#ifdef DT_TEST
   TEST(fread, test_bool8_titlecase) {
     auto check = [](const char* input, int8_t value, size_t advance) {
       ParseContext ctx;
@@ -230,7 +230,7 @@ REGISTER_PARSER(PT::BoolU)
     ->type(Type::bool8())
     ->successors({PT::Str32});
 
-#ifdef DTTEST
+#ifdef DT_TEST
   TEST(fread, test_bool8_uppercase) {
     auto check = [](const char* input, int8_t value, size_t advance) {
       ParseContext ctx;

--- a/src/core/read/parsers/parse_date.cc
+++ b/src/core/read/parsers/parse_date.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2021 H2O.ai
+// Copyright 2021-2022 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),

--- a/src/core/read/parsers/parse_date.cc
+++ b/src/core/read/parsers/parse_date.cc
@@ -151,4 +151,4 @@ bool parse_date32_iso(const char* ch, const char* end, int32_t* out) {
 
 
 
-}}  // namespace dt::read::
+}}  // namespace dt::read

--- a/src/core/read/parsers/parse_date.cc
+++ b/src/core/read/parsers/parse_date.cc
@@ -115,7 +115,7 @@ bool parse_date32_iso(const char* ch, const char* end, int32_t* out) {
 }
 
 
-#ifdef DTTEST
+#ifdef DT_TEST
   TEST(fread, test_date32_iso) {
     auto check = [](const char* input, int32_t expected_value, size_t advance) {
       ParseContext ctx;

--- a/src/core/read/parsers/parse_time.cc
+++ b/src/core/read/parsers/parse_time.cc
@@ -215,7 +215,7 @@ bool parse_time64_iso(const char* ch, const char* end, int64_t* out) {
 //------------------------------------------------------------------------------
 // Tests
 //------------------------------------------------------------------------------
-#ifdef DTTEST
+#ifdef DT_TEST
   static constexpr int64_t NA = NA_INT64;
   static constexpr int64_t MILLI = 1000000LL;
   static constexpr int64_t SECS = 1000000000LL;

--- a/src/core/tests/test_atomic.cc
+++ b/src/core/tests/test_atomic.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019-2020 H2O.ai
+// Copyright 2019-2022 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),

--- a/src/core/tests/test_atomic.cc
+++ b/src/core/tests/test_atomic.cc
@@ -19,14 +19,15 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
-#ifdef DTTEST
+#ifdef DT_TEST
 #include <atomic>       // std::atomic
 #include <cmath>        // std::pow, std::abs
 #include "parallel/api.h"
 #include "parallel/atomic.h"
 #include "utils/exceptions.h"
 #include "utils/tests.h"
-namespace dttest {
+namespace dt {
+namespace tests {
 
 
 template <typename T>
@@ -90,5 +91,5 @@ TEST(parallel, atomic_double) {
 
 
 
-} // namespace dttest
+}} // namespace dt::tests
 #endif

--- a/src/core/tests/test_barrier.cc
+++ b/src/core/tests/test_barrier.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019-2020 H2O.ai
+// Copyright 2019-2022 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),

--- a/src/core/tests/test_barrier.cc
+++ b/src/core/tests/test_barrier.cc
@@ -19,13 +19,14 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
-#ifdef DTTEST
+#ifdef DT_TEST
 #include <algorithm>
 #include <vector>
 #include "parallel/api.h"
 #include "utils/exceptions.h"
 #include "utils/tests.h"
-namespace dttest {
+namespace dt {
+namespace tests {
 
 
 TEST(parallel, barrier1) {
@@ -99,5 +100,5 @@ TEST(parallel, barrierN) {
 
 
 
-}  // namespace dttest
+}}  // namespace dt::tests
 #endif

--- a/src/core/tests/test_parallel_for.cc
+++ b/src/core/tests/test_parallel_for.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019-2020 H2O.ai
+// Copyright 2019-2022 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),

--- a/src/core/tests/test_parallel_for.cc
+++ b/src/core/tests/test_parallel_for.cc
@@ -19,14 +19,15 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
-#ifdef DTTEST
+#ifdef DT_TEST
 #include <atomic>
 #include <vector>
 #include "parallel/api.h"
 #include "parallel/thread_pool.h"
 #include "utils/exceptions.h"
 #include "utils/tests.h"
-namespace dttest {
+namespace dt {
+namespace tests {
 
 
 TEST(parallel, for_static) {
@@ -89,6 +90,5 @@ TEST(parallel, for_dynamic_nested) {
 
 
 
-
-}  // namespace dttest
+}}  // namespace dt::tests
 #endif

--- a/src/core/tests/test_parallel_for_ordered.cc
+++ b/src/core/tests/test_parallel_for_ordered.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019-2020 H2O.ai
+// Copyright 2019-2022 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),

--- a/src/core/tests/test_parallel_for_ordered.cc
+++ b/src/core/tests/test_parallel_for_ordered.cc
@@ -329,12 +329,12 @@ TEST(parallel, for_ordered_wait_until_all_finalized) {
 //------------------------------------------------------------------------------
 
 TEST(parallel, for_ordered_super_ordered) {
-  constexpr size_t N_ITERS  = 1000;
-  constexpr size_t SUPER_AT = 200;
-  constexpr size_t START0  = 1;
-  constexpr size_t FINISH0 = 2;
-  constexpr size_t START1  = 5;
-  constexpr size_t FINISH1 = 7;
+  static constexpr size_t N_ITERS  = 1000;
+  static constexpr size_t SUPER_AT = 200;
+  static constexpr size_t START0  = 1;
+  static constexpr size_t FINISH0 = 2;
+  static constexpr size_t START1  = 5;
+  static constexpr size_t FINISH1 = 7;
 
   class OTask : public dt::OrderedTask {
     private:

--- a/src/core/tests/test_parallel_for_ordered.cc
+++ b/src/core/tests/test_parallel_for_ordered.cc
@@ -137,7 +137,7 @@ TEST(parallel, for_ordered_except_startall) {
       }
   };
 
-  ASSERT_THROWS([]{
+  ASSERT_THROWS([&]{
     dt::parallel_for_ordered(niters, []{ return std::make_unique<OTask>(); });
   }, RuntimeError);
 }

--- a/src/core/tests/test_parallel_for_ordered.cc
+++ b/src/core/tests/test_parallel_for_ordered.cc
@@ -19,7 +19,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
-#ifdef DTTEST
+#ifdef DT_TEST
 #include <atomic>
 #include <numeric>     // std::accumulate
 #include <vector>
@@ -27,7 +27,8 @@
 #include "parallel/thread_pool.h"
 #include "utils/exceptions.h"
 #include "utils/tests.h"
-namespace dttest {
+namespace dt {
+namespace tests {
 
 
 //------------------------------------------------------------------------------
@@ -391,6 +392,5 @@ TEST(parallel, for_ordered_super_ordered) {
 
 
 
-
-}  // namespace dttest
+}}  // namespace dt::tests
 #endif

--- a/src/core/tests/test_progress.cc
+++ b/src/core/tests/test_progress.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019-2020 H2O.ai
+// Copyright 2019-2022 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),

--- a/src/core/tests/test_progress.cc
+++ b/src/core/tests/test_progress.cc
@@ -19,13 +19,14 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
-#ifdef DTTEST
+#ifdef DT_TEST
 #include <vector>
 #include "parallel/api.h"
 #include "progress/work.h"      // dt::progress::work
 #include "utils/exceptions.h"
 #include "utils/tests.h"
-namespace dttest {
+namespace dt {
+namespace tests {
 
 
 static void test_progress_static(size_t n, size_t nth) {
@@ -206,6 +207,5 @@ TEST(progress, ordered_all) {
 
 
 
-
-}  // namespace dttest
+}} // namespace dt::tests
 #endif

--- a/src/core/tests/test_shared_mutex.cc
+++ b/src/core/tests/test_shared_mutex.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019-2020 H2O.ai
+// Copyright 2019-2022 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),

--- a/src/core/tests/test_shared_mutex.cc
+++ b/src/core/tests/test_shared_mutex.cc
@@ -19,7 +19,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
-#ifdef DTTEST
+#ifdef DT_TEST
 #include <atomic>       // std::atomic
 #include <cstdlib>      // std::rand, RAND_MAX
 #include <ctime>        // std::time
@@ -30,7 +30,8 @@
 #include "parallel/shared_mutex.h"
 #include "utils/exceptions.h"
 #include "utils/tests.h"
-namespace dttest {
+namespace dt {
+namespace tests {
 
 
 // Helper class to ensure the thread pool is joined in the end, even if an
@@ -146,6 +147,5 @@ TEST(parallel, shared_bmutex) {
 
 
 
-
-} // namespace dttest
+}} // namespace dt::tests
 #endif

--- a/src/core/types/type.h
+++ b/src/core/types/type.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2021 H2O.ai
+// Copyright 2021-2022 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -22,8 +22,9 @@
 #ifndef dt_TYPES_TYPE_h
 #define dt_TYPES_TYPE_h
 #include "_dt.h"
-#include "utils/tests.h"
+#include "utils/tests.h"  // compatibility with C++ tests
 namespace dt {
+
 
 class TypeImpl;
 

--- a/src/core/types/type.h
+++ b/src/core/types/type.h
@@ -22,6 +22,7 @@
 #ifndef dt_TYPES_TYPE_h
 #define dt_TYPES_TYPE_h
 #include "_dt.h"
+#include "utils/tests.h"
 namespace dt {
 
 class TypeImpl;

--- a/src/core/utils/terminal/terminal_stream.cc
+++ b/src/core/utils/terminal/terminal_stream.cc
@@ -25,8 +25,6 @@
 namespace dt {
 
 
-
-
 TerminalStream::TerminalStream(bool use_colors) {
   use_colors_ = use_colors;
   stack_.push(style::reset);
@@ -78,8 +76,6 @@ TerminalStream& TerminalStream::operator<<(const tstring& s) {
 }
 
 
-
-
 void TerminalStream::_emit_pending_styles() {
   if (!use_colors_) return;
   TerminalStyle newsty = stack_.top();
@@ -112,7 +108,6 @@ void TerminalStream::_emit_pending_styles() {
     out_ << 'm';
   }
 }
-
 
 
 }  // namespace dt

--- a/src/core/utils/terminal/terminal_stream.h
+++ b/src/core/utils/terminal/terminal_stream.h
@@ -39,8 +39,6 @@ class TerminalStream {
     bool use_colors_;
     size_t : 56;
 
-  private:
-    void _emit_pending_styles();
 
   public:
     TerminalStream(bool use_colors);
@@ -51,9 +49,10 @@ class TerminalStream {
       out_ << value;
       return *this;
     }
-
     std::string str();
 
+  private:
+    void _emit_pending_styles();
 };
 
 template <> TerminalStream& TerminalStream::operator<<(const tstring&);

--- a/src/core/utils/terminal/terminal_stream.h
+++ b/src/core/utils/terminal/terminal_stream.h
@@ -39,9 +39,11 @@ class TerminalStream {
     bool use_colors_;
     size_t : 56;
 
+  private:
+    void _emit_pending_styles();
+
   public:
     TerminalStream(bool use_colors);
-    void _emit_pending_styles();
 
     template <typename T>
     TerminalStream& operator<<(const T& value) {
@@ -51,6 +53,7 @@ class TerminalStream {
     }
 
     std::string str();
+
 };
 
 template <> TerminalStream& TerminalStream::operator<<(const tstring&);

--- a/src/core/utils/terminal/terminal_stream.h
+++ b/src/core/utils/terminal/terminal_stream.h
@@ -26,8 +26,9 @@
 #include <sstream>
 #include "utils/assert.h"
 #include "utils/terminal/terminal_style.h"
-#include "utils/tests.h"
+#include "utils/tests.h"  // compatibility with C++ tests
 namespace dt {
+
 
 class tstring;
 

--- a/src/core/utils/terminal/terminal_stream.h
+++ b/src/core/utils/terminal/terminal_stream.h
@@ -26,6 +26,7 @@
 #include <sstream>
 #include "utils/assert.h"
 #include "utils/terminal/terminal_style.h"
+#include "utils/tests.h"
 namespace dt {
 
 class tstring;
@@ -49,16 +50,16 @@ class TerminalStream {
       out_ << value;
       return *this;
     }
+
     std::string str();
 
   private:
     void _emit_pending_styles();
+
 };
 
 template <> TerminalStream& TerminalStream::operator<<(const tstring&);
 template <> TerminalStream& TerminalStream::operator<<(const TerminalStyle&);
-
-
 
 
 }  // namespace dt

--- a/src/core/utils/terminal/terminal_stream.h
+++ b/src/core/utils/terminal/terminal_stream.h
@@ -41,6 +41,7 @@ class TerminalStream {
 
   public:
     TerminalStream(bool use_colors);
+    void _emit_pending_styles();
 
     template <typename T>
     TerminalStream& operator<<(const T& value) {
@@ -50,9 +51,6 @@ class TerminalStream {
     }
 
     std::string str();
-
-  private:
-    void _emit_pending_styles();
 };
 
 template <> TerminalStream& TerminalStream::operator<<(const tstring&);

--- a/src/core/utils/tests.cc
+++ b/src/core/utils/tests.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2020-2021 H2O.ai
+// Copyright 2020-2022 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),

--- a/src/core/utils/tests.cc
+++ b/src/core/utils/tests.cc
@@ -31,7 +31,7 @@
 #include "python/xargs.h"
 #include "utils/exceptions.h"
 #include "utils/tests.h"
-#ifdef DTTEST
+#ifdef DT_TEST
 namespace dt {
 namespace tests {
 
@@ -140,9 +140,9 @@ void assert_throws(std::function<void()> expr, Error(*exception_class)(),
 }
 
 
-
-
 }}  // namespace dt::test
+
+
 //------------------------------------------------------------------------------
 // Python API
 //------------------------------------------------------------------------------
@@ -192,8 +192,6 @@ DECLARE_PYFN(&run_test)
     ->name("run_test")
     ->n_positional_args(2)
     ->arg_names({"suite", "test"});
-
-
 
 
 }  // namespace py

--- a/src/core/utils/tests.h
+++ b/src/core/utils/tests.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2020-2021 H2O.ai
+// Copyright 2020-2022 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),

--- a/src/core/utils/tests.h
+++ b/src/core/utils/tests.h
@@ -83,9 +83,10 @@
 #include "utils/macros.h"
 namespace dt {
 namespace tests {
-#ifndef DTTEST
+
+#ifndef DT_TEST
 #define TEST(suite, name)  \
-  static_assert(0, "TEST() macro should not be used when DTTEST not defined");
+  static_assert(0, "TEST() macro should not be used when DT_TEST is not defined");
 #else
 
 // C++ tests always need access to private fields and methods, which
@@ -237,6 +238,6 @@ void assert_throws(std::function<void()> expr, Error(*exception_class)(),
 
 
 
-#endif  // ifdef DTTEST
+#endif  // ifdef DT_TEST
 }}      // namespace dt::tests
 #endif

--- a/tests/test-parallel.py
+++ b/tests/test-parallel.py
@@ -23,6 +23,7 @@
 #-------------------------------------------------------------------------------
 import datatable as dt
 import itertools
+import os
 import pytest
 import subprocess
 import sys
@@ -73,6 +74,7 @@ def test_core_progress(testname):
 # Send interrupt signal and make sure process throws KeyboardInterrupt
 @cpp_test
 @skip_on_jenkins
+@pytest.mark.usefixtures("nowin")
 @pytest.mark.parametrize('parallel_type, nthreads',
                          itertools.product(
                             [None, "static", "nested", "dynamic", "ordered"],
@@ -104,7 +106,7 @@ def test_progress_interrupt(parallel_type, nthreads):
                             stderr = subprocess.PIPE)
 
     line = proc.stdout.readline()
-    assert line.decode() == str(parallel_type) + " start\n"
+    assert line.decode() == str(parallel_type) + " start" + os.linesep
     time.sleep(sleep_time);
 
     proc.send_signal(signal.Signals.SIGINT)

--- a/tests/test-parallel.py
+++ b/tests/test-parallel.py
@@ -43,7 +43,6 @@ def test_core_parallel(testname):
     core.run_test("parallel", testname)
 
 
-
 def test_multiprocessing_threadpool():
     # Verify that threads work properly after forking (#1758)
     import multiprocessing as mp
@@ -60,7 +59,6 @@ def test_multiprocessing_threadpool():
             # assert chthreads != parent_threads
 
 
-
 #-------------------------------------------------------------------------------
 # "progress" tests
 #-------------------------------------------------------------------------------
@@ -71,7 +69,7 @@ def test_core_progress(testname):
     core.run_test("progress", testname)
 
 
-
+@cpp_test
 @skip_on_jenkins
 @pytest.mark.usefixtures("nowin") # `SIGINT` is not supported on Windows
 @pytest.mark.parametrize('parallel_type, nthreads',

--- a/tests/test-parallel.py
+++ b/tests/test-parallel.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #-------------------------------------------------------------------------------
-# Copyright 2018-2020 H2O.ai
+# Copyright 2018-2022 H2O.ai
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -71,10 +71,9 @@ def test_core_progress(testname):
     core.run_test("progress", testname)
 
 
-# Send interrupt signal and make sure process throws KeyboardInterrupt
-@cpp_test
+
 @skip_on_jenkins
-@pytest.mark.usefixtures("nowin")
+@pytest.mark.usefixtures("nowin") # `SIGINT` is not supported on Windows
 @pytest.mark.parametrize('parallel_type, nthreads',
                          itertools.product(
                             [None, "static", "nested", "dynamic", "ordered"],
@@ -109,6 +108,7 @@ def test_progress_interrupt(parallel_type, nthreads):
     assert line.decode() == str(parallel_type) + " start" + os.linesep
     time.sleep(sleep_time);
 
+    # send interrupt signal and make sure the process throws `KeyboardInterrupt`
     proc.send_signal(signal.Signals.SIGINT)
     (stdout, stderr) = proc.communicate()
 


### PR DESCRIPTION
In this PR we adjust AppVeyor builds to 
- enable `pyarrow` tests;
- on Windows, enable C++ tests by testing debug wheels for Python 3.9;
- on Windows, fix builds to properly report failures;
- for consistency, rename `DTTEST` to `DT_TEST` and namespace `dttest` to `dt::tests`.

Note, that, when enabled, the C++ tests [redefine](https://github.com/h2oai/datatable/blob/main/src/core/utils/tests.h#L91-L100) `protected` and `private` keywords to `public`. This is a pretty dangerous approach, that we might need to reconsider, because this redefinition only happens in the files which include `utils/tests.h`. On Windows, for instance, this caused a pile of linking errors due to the fact that some methods were expected to be `public`, but were declared as `protected` or `private`.