### PR TITLE
Fix signatures of the `dt` functions referenced in the `FExpr` API

### DIFF
--- a/docs/api/fexpr/count.rst
+++ b/docs/api/fexpr/count.rst
@@ -4,4 +4,4 @@
     :cvar: doc_FExpr_count
     :signature: count()
 
-    Equivalent to :func:`dt.count(self)`.
+    Equivalent to :func:`dt.count(cols)`.

--- a/docs/api/fexpr/countna.rst
+++ b/docs/api/fexpr/countna.rst
@@ -4,4 +4,4 @@
     :cvar: doc_FExpr_countna
     :signature: countna()
 
-    Equivalent to :func:`dt.countna(self)`.
+    Equivalent to :func:`dt.countna(cols)`.

--- a/docs/api/fexpr/cummax.rst
+++ b/docs/api/fexpr/cummax.rst
@@ -4,4 +4,4 @@
     :cvar: doc_FExpr_cummax
     :signature: cummax()
 
-    Equivalent to :func:`dt.cummax(self)`.
+    Equivalent to :func:`dt.cummax(cols)`.

--- a/docs/api/fexpr/cummin.rst
+++ b/docs/api/fexpr/cummin.rst
@@ -4,4 +4,4 @@
     :cvar: doc_FExpr_cummin
     :signature: cummin()
 
-    Equivalent to :func:`dt.cummin(self)`.
+    Equivalent to :func:`dt.cummin(cols)`.

--- a/docs/api/fexpr/cumprod.rst
+++ b/docs/api/fexpr/cumprod.rst
@@ -4,5 +4,5 @@
     :cvar: doc_FExpr_cumprod
     :signature: cumprod()
 
-    Equivalent to :func:`dt.cumprod(self)`.
+    Equivalent to :func:`dt.cumprod(cols)`.
 

--- a/docs/api/fexpr/cumsum.rst
+++ b/docs/api/fexpr/cumsum.rst
@@ -4,4 +4,4 @@
     :cvar: doc_FExpr_cumsum
     :signature: cumsum()
 
-    Equivalent to :func:`dt.cumsum(self)`.
+    Equivalent to :func:`dt.cumsum(cols)`.

--- a/docs/api/fexpr/first.rst
+++ b/docs/api/fexpr/first.rst
@@ -4,4 +4,4 @@
     :cvar: doc_FExpr_first
     :signature: first()
 
-    Equivalent to :func:`dt.first(self)`.
+    Equivalent to :func:`dt.first(cols)`.

--- a/docs/api/fexpr/last.rst
+++ b/docs/api/fexpr/last.rst
@@ -4,4 +4,4 @@
     :cvar: doc_FExpr_last
     :signature: last()
 
-    Equivalent to :func:`dt.last(self)`.
+    Equivalent to :func:`dt.last(cols)`.

--- a/docs/api/fexpr/max.rst
+++ b/docs/api/fexpr/max.rst
@@ -4,4 +4,4 @@
     :cvar: doc_FExpr_max
     :signature: max()
 
-    Equivalent to :func:`dt.max(self)`.
+    Equivalent to :func:`dt.max(cols)`.

--- a/docs/api/fexpr/mean.rst
+++ b/docs/api/fexpr/mean.rst
@@ -4,4 +4,4 @@
     :cvar: doc_FExpr_mean
     :signature: mean()
 
-    Equivalent to :func:`dt.mean(self)`.
+    Equivalent to :func:`dt.mean(cols)`.

--- a/docs/api/fexpr/median.rst
+++ b/docs/api/fexpr/median.rst
@@ -4,4 +4,4 @@
     :cvar: doc_FExpr_median
     :signature: median()
 
-    Equivalent to :func:`dt.median(self)`.
+    Equivalent to :func:`dt.median(cols)`.

--- a/docs/api/fexpr/min.rst
+++ b/docs/api/fexpr/min.rst
@@ -4,4 +4,4 @@
     :cvar: doc_FExpr_min
     :signature: min()
 
-    Equivalent to :func:`dt.min(self)`.
+    Equivalent to :func:`dt.min(cols)`.

--- a/docs/api/fexpr/nunique.rst
+++ b/docs/api/fexpr/nunique.rst
@@ -4,4 +4,4 @@
     :cvar: doc_FExpr_nunique
     :signature: nunique()
 
-    Equivalent to :func:`dt.nunique(self)`.
+    Equivalent to :func:`dt.nunique(cols)`.

--- a/docs/api/fexpr/prod.rst
+++ b/docs/api/fexpr/prod.rst
@@ -2,7 +2,7 @@
 .. xmethod:: datatable.FExpr.prod
     :src: src/core/expr/fexpr.cc PyFExpr::prod
     :cvar: doc_FExpr_prod
-    :signature: prod(new_type)
+    :signature: prod()
 
     .. x-version-added:: 1.1.0
 

--- a/docs/api/fexpr/rowall.rst
+++ b/docs/api/fexpr/rowall.rst
@@ -4,4 +4,4 @@
     :cvar: doc_FExpr_rowall
     :signature: rowall()
 
-    Equivalent to :func:`dt.rowall(self)`.
+    Equivalent to :func:`dt.rowall(*cols)`.

--- a/docs/api/fexpr/rowany.rst
+++ b/docs/api/fexpr/rowany.rst
@@ -4,4 +4,4 @@
     :cvar: doc_FExpr_rowany
     :signature: rowany()
 
-    Equivalent to :func:`dt.rowany(*self)`.
+    Equivalent to :func:`dt.rowany(*cols)`.

--- a/docs/api/fexpr/rowany.rst
+++ b/docs/api/fexpr/rowany.rst
@@ -4,4 +4,4 @@
     :cvar: doc_FExpr_rowany
     :signature: rowany()
 
-    Equivalent to :func:`dt.rowany(self)`.
+    Equivalent to :func:`dt.rowany(*self)`.

--- a/docs/api/fexpr/rowargmax.rst
+++ b/docs/api/fexpr/rowargmax.rst
@@ -6,4 +6,4 @@
 
     .. x-version-added:: 1.1.0
 
-    Equivalent to :func:`dt.rowargmax(self)`.
+    Equivalent to :func:`dt.rowargmax(*cols)`.

--- a/docs/api/fexpr/rowargmin.rst
+++ b/docs/api/fexpr/rowargmin.rst
@@ -6,4 +6,4 @@
 
     .. x-version-added:: 1.1.0
 
-    Equivalent to :func:`dt.rowargmin(self)`.
+    Equivalent to :func:`dt.rowargmin(*cols)`.

--- a/docs/api/fexpr/rowcount.rst
+++ b/docs/api/fexpr/rowcount.rst
@@ -4,4 +4,4 @@
     :cvar: doc_FExpr_rowcount
     :signature: rowcount()
 
-    Equivalent to :func:`dt.rowcount(self)`.
+    Equivalent to :func:`dt.rowcount(*cols)`.

--- a/docs/api/fexpr/rowfirst.rst
+++ b/docs/api/fexpr/rowfirst.rst
@@ -4,4 +4,4 @@
     :cvar: doc_FExpr_rowfirst
     :signature: rowfirst()
 
-    Equivalent to :func:`dt.rowfirst(self)`.
+    Equivalent to :func:`dt.rowfirst(*cols)`.

--- a/docs/api/fexpr/rowlast.rst
+++ b/docs/api/fexpr/rowlast.rst
@@ -4,4 +4,4 @@
     :cvar: doc_FExpr_rowlast
     :signature: rowlast()
 
-    Equivalent to :func:`dt.rowlast(self)`.
+    Equivalent to :func:`dt.rowlast(*cols)`.

--- a/docs/api/fexpr/rowmax.rst
+++ b/docs/api/fexpr/rowmax.rst
@@ -4,4 +4,4 @@
     :cvar: doc_FExpr_rowmax
     :signature: rowmax()
 
-    Equivalent to :func:`dt.rowmax(self)`.
+    Equivalent to :func:`dt.rowmax(*cols)`.

--- a/docs/api/fexpr/rowmean.rst
+++ b/docs/api/fexpr/rowmean.rst
@@ -4,4 +4,4 @@
     :cvar: doc_FExpr_rowmean
     :signature: rowmean()
 
-    Equivalent to :func:`dt.rowmean(self)`.
+    Equivalent to :func:`dt.rowmean(*cols)`.

--- a/docs/api/fexpr/rowmin.rst
+++ b/docs/api/fexpr/rowmin.rst
@@ -4,4 +4,4 @@
     :cvar: doc_FExpr_rowmin
     :signature: rowmin()
 
-    Equivalent to :func:`dt.rowmin(self)`.
+    Equivalent to :func:`dt.rowmin(*cols)`.

--- a/docs/api/fexpr/rowsd.rst
+++ b/docs/api/fexpr/rowsd.rst
@@ -4,4 +4,4 @@
     :cvar: doc_FExpr_rowsd
     :signature: rowsd()
 
-    Equivalent to :func:`dt.rowsd(self)`.
+    Equivalent to :func:`dt.rowsd(*cols)`.

--- a/docs/api/fexpr/rowsum.rst
+++ b/docs/api/fexpr/rowsum.rst
@@ -4,4 +4,4 @@
     :cvar: doc_FExpr_rowsum
     :signature: rowsum()
 
-    Equivalent to :func:`dt.rowsum(self)`.
+    Equivalent to :func:`dt.rowsum(*cols)`.

--- a/docs/api/fexpr/sd.rst
+++ b/docs/api/fexpr/sd.rst
@@ -4,4 +4,4 @@
     :cvar: doc_FExpr_sd
     :signature: sd()
 
-    Equivalent to :func:`dt.sd(self)`.
+    Equivalent to :func:`dt.sd(cols)`.

--- a/docs/api/fexpr/shift.rst
+++ b/docs/api/fexpr/shift.rst
@@ -4,4 +4,4 @@
     :cvar: doc_FExpr_shift
     :signature: shift(n=1)
 
-    Equivalent to :func:`dt.shift(self, n)`.
+    Equivalent to :func:`dt.shift(cols, n=1)`.

--- a/docs/api/fexpr/sum.rst
+++ b/docs/api/fexpr/sum.rst
@@ -4,4 +4,4 @@
     :cvar: doc_FExpr_sum
     :signature: sum()
 
-    Equivalent to :func:`dt.sum(self)`.
+    Equivalent to :func:`dt.sum(cols)`.


### PR DESCRIPTION
- make signatures of the functions referenced in the `FExpr` API section to be consistent with the actual signatures of the `dt.*()` functions;
- couple of other minor fixes.