### PR TITLE
`FExpr`/`Expr` adjustments in the docs

### DIFF
--- a/docs/api/dt/corr.rst
+++ b/docs/api/dt/corr.rst
@@ -11,7 +11,7 @@
 
     Parameters
     ----------
-    col1, col2: Expr
+    col1, col2: FExpr
         Input columns.
 
     return: Expr

--- a/docs/api/dt/count.rst
+++ b/docs/api/dt/count.rst
@@ -9,7 +9,7 @@
 
     Parameters
     ----------
-    cols: Expr
+    cols: FExpr
         Input columns.
 
     return: Expr

--- a/docs/api/dt/countna.rst
+++ b/docs/api/dt/countna.rst
@@ -11,7 +11,7 @@
 
     Parameters
     ----------
-    cols: Expr
+    cols: FExpr
         Input columns.
 
     return: Expr

--- a/docs/api/dt/cov.rst
+++ b/docs/api/dt/cov.rst
@@ -11,7 +11,7 @@
 
     Parameters
     ----------
-    col1, col2: Expr
+    col1, col2: FExpr
         Input columns.
 
     return: Expr

--- a/docs/api/dt/first.rst
+++ b/docs/api/dt/first.rst
@@ -11,7 +11,7 @@
 
     Parameters
     ----------
-    cols: Expr | iterable
+    cols: FExpr | iterable
         Input columns or an iterable.
 
     return: Expr | ...

--- a/docs/api/dt/last.rst
+++ b/docs/api/dt/last.rst
@@ -11,7 +11,7 @@
 
     Parameters
     ----------
-    cols: Expr | iterable
+    cols: FExpr | iterable
         Input columns or an iterable.
 
     return: Expr | ...

--- a/docs/api/dt/max.rst
+++ b/docs/api/dt/max.rst
@@ -11,7 +11,7 @@
 
     Parameters
     ----------
-    cols: Expr
+    cols: FExpr
         Input columns.
 
     return: Expr

--- a/docs/api/dt/mean.rst
+++ b/docs/api/dt/mean.rst
@@ -13,7 +13,7 @@
     cols: FExpr
         Input columns.
 
-    return: FExpr
+    return: Expr
         f-expression having one row, and the same names and number of columns
         as in `cols`. The column stypes are `float32` for
         `float32` columns, and `float64` for all the other numeric types.

--- a/docs/api/dt/median.rst
+++ b/docs/api/dt/median.rst
@@ -10,7 +10,7 @@
 
     Parameters
     ----------
-    cols: Expr
+    cols: FExpr
         Input columns.
 
     return: Expr

--- a/docs/api/dt/min.rst
+++ b/docs/api/dt/min.rst
@@ -15,7 +15,7 @@
     cols: FExpr
         Input columns.
 
-    return: FExpr
+    return: Expr
         f-expression having one row and the same names, stypes and number
         of columns as in `cols`.
 

--- a/docs/api/dt/nunique.rst
+++ b/docs/api/dt/nunique.rst
@@ -11,7 +11,7 @@
 
     Parameters
     ----------
-    cols: Expr
+    cols: FExpr
         Input columns.
 
     return: Expr

--- a/docs/api/dt/prod.rst
+++ b/docs/api/dt/prod.rst
@@ -15,7 +15,7 @@
     cols: FExpr
         Input columns.
 
-    return: FExpr
+    return: Expr
         f-expression having one row, and the same names and number of columns
         as in `cols`. The column stypes are `int64` for
         boolean and integer columns, `float32` for `float32` columns

--- a/docs/api/dt/rowlast.rst
+++ b/docs/api/dt/rowlast.rst
@@ -11,10 +11,10 @@
 
     Parameters
     ----------
-    cols: Expr
+    cols: FExpr
         Input columns.
 
-    return: Expr
+    return: FExpr
         f-expression consisting of one column and the same number
         of rows as in `cols`.
 

--- a/docs/api/dt/sd.rst
+++ b/docs/api/dt/sd.rst
@@ -12,7 +12,7 @@
     cols: FExpr
         Input columns.
 
-    return: FExpr
+    return: Expr
         f-expression having one row, and the same names and number of columns
         as in `cols`. The column stypes are `float32` for
         `float32` columns, and `float64` for all the other numeric types.

--- a/docs/api/dt/sum.rst
+++ b/docs/api/dt/sum.rst
@@ -11,7 +11,7 @@
 
     Parameters
     ----------
-    cols: Expr
+    cols: FExpr
         Input columns.
 
     return: Expr


### PR DESCRIPTION
While https://github.com/h2oai/datatable/issues/2562 is still WIP, we need to have proper a documentation for both `Expr` and `FExpr` input/return types. This PR fixes it.