### PR TITLE
Fix cumulative functions when invoked on the latent columns

### DIFF
--- a/src/core/column/cumminmax.h
+++ b/src/core/column/cumminmax.h
@@ -21,6 +21,7 @@
 //------------------------------------------------------------------------------
 #ifndef dt_COLUMN_CUMMINMAX_h
 #define dt_COLUMN_CUMMINMAX_h
+#include "column/latent.h"
 #include "column/virtual.h"
 #include "parallel/api.h"
 #include "stype.h"
@@ -45,10 +46,12 @@ class CumMinMax_ColumnImpl : public Virtual_ColumnImpl {
 
 
     void materialize(Column& col_out, bool) override {
+      Latent_ColumnImpl::vivify<T>(col_);
+
       Column col = Column::new_data_column(col_.nrows(), col_.stype());
       auto data = static_cast<T*>(col.get_data_editable());
-
       auto offsets = gby_.offsets_r();
+
       dt::parallel_for_dynamic(
         gby_.size(),
         [&](size_t gi) {

--- a/src/core/column/cumsumprod.h
+++ b/src/core/column/cumsumprod.h
@@ -21,6 +21,7 @@
 //------------------------------------------------------------------------------
 #ifndef dt_COLUMN_CUMSUM_h
 #define dt_COLUMN_CUMSUM_h
+#include "column/latent.h"
 #include "column/virtual.h"
 #include "parallel/api.h"
 #include "stype.h"
@@ -44,6 +45,7 @@ namespace dt {
     }
 
     void materialize(Column &col_out, bool) override {
+      Latent_ColumnImpl::vivify<T>(col_);
       Column col = Column::new_data_column(col_.nrows(), col_.stype());
       auto data = static_cast<T*>(col.get_data_editable());
 

--- a/src/core/column/latent.cc
+++ b/src/core/column/latent.cc
@@ -60,12 +60,12 @@ ColumnImpl* Latent_ColumnImpl::clone() const {
 }
 
 void Latent_ColumnImpl::materialize(Column&, bool to_memory) {
-  vivify(to_memory);
+  vivify_impl(to_memory);
 }
 
 
 bool Latent_ColumnImpl::allow_parallel_access() const {
-  return vivify()->allow_parallel_access();
+  return vivify_impl()->allow_parallel_access();
 }
 
 
@@ -75,21 +75,21 @@ size_t Latent_ColumnImpl::n_children() const noexcept {
 
 
 
-bool Latent_ColumnImpl::get_element(size_t i, int8_t* out)   const { return vivify()->get_element(i, out); }
-bool Latent_ColumnImpl::get_element(size_t i, int16_t* out)  const { return vivify()->get_element(i, out); }
-bool Latent_ColumnImpl::get_element(size_t i, int32_t* out)  const { return vivify()->get_element(i, out); }
-bool Latent_ColumnImpl::get_element(size_t i, int64_t* out)  const { return vivify()->get_element(i, out); }
-bool Latent_ColumnImpl::get_element(size_t i, float* out)    const { return vivify()->get_element(i, out); }
-bool Latent_ColumnImpl::get_element(size_t i, double* out)   const { return vivify()->get_element(i, out); }
-bool Latent_ColumnImpl::get_element(size_t i, CString* out)  const { return vivify()->get_element(i, out); }
-bool Latent_ColumnImpl::get_element(size_t i, py::oobj* out) const { return vivify()->get_element(i, out); }
-bool Latent_ColumnImpl::get_element(size_t i, Column* out)   const { return vivify()->get_element(i, out); }
+bool Latent_ColumnImpl::get_element(size_t i, int8_t* out)   const { return vivify_impl()->get_element(i, out); }
+bool Latent_ColumnImpl::get_element(size_t i, int16_t* out)  const { return vivify_impl()->get_element(i, out); }
+bool Latent_ColumnImpl::get_element(size_t i, int32_t* out)  const { return vivify_impl()->get_element(i, out); }
+bool Latent_ColumnImpl::get_element(size_t i, int64_t* out)  const { return vivify_impl()->get_element(i, out); }
+bool Latent_ColumnImpl::get_element(size_t i, float* out)    const { return vivify_impl()->get_element(i, out); }
+bool Latent_ColumnImpl::get_element(size_t i, double* out)   const { return vivify_impl()->get_element(i, out); }
+bool Latent_ColumnImpl::get_element(size_t i, CString* out)  const { return vivify_impl()->get_element(i, out); }
+bool Latent_ColumnImpl::get_element(size_t i, py::oobj* out) const { return vivify_impl()->get_element(i, out); }
+bool Latent_ColumnImpl::get_element(size_t i, Column* out)   const { return vivify_impl()->get_element(i, out); }
 
 
 // This method is not thread-safe!
 // In particular, if multiple threads are trying to retrieve
 // different elements at the same time, then each thread will call
-// the `vivify()` function simultaneously, resulting in UB.
+// the `vivify_impl()` function simultaneously, resulting in UB.
 // It might be possible to fix this by adding a mutex; however it
 // will still be problematic:
 //   - if only 1 thread is working on materialization, while others
@@ -100,7 +100,7 @@ bool Latent_ColumnImpl::get_element(size_t i, Column* out)   const { return vivi
 // Thus, a better approach is needed: some mechanism to inform the
 // caller that this column must be "prepared" first.
 
-ColumnImpl* Latent_ColumnImpl::vivify(bool to_memory) const {
+ColumnImpl* Latent_ColumnImpl::vivify_impl(bool to_memory) const {
   xassert(num_threads_in_team() == 0);
   // Note: we're using placement-materialize to overwrite `this` with
   // the materialized `column` object. Effectively, the current object

--- a/src/core/column/latent.h
+++ b/src/core/column/latent.h
@@ -65,10 +65,10 @@ class Latent_ColumnImpl : public Virtual_ColumnImpl {
     bool get_element(size_t, py::oobj*) const override;
     bool get_element(size_t, Column*)   const override;
 
-    // This method must be called first in the case, when
-    // the latent column data are going to be accessed from
-    // multiple threads later. That's because `materialize()`
-    // is not a thread-safe method.
+    // The `vivify()` method must be called first in the case,
+    // when the latent column's data are going to be accessed from
+    // multiple threads. That's because the `materialize()`
+    // method is not thread-safe.
     template <typename T>
     static void vivify(const Column& col) {
       T value;

--- a/src/core/expr/fexpr_fillna.cc
+++ b/src/core/expr/fexpr_fillna.cc
@@ -19,6 +19,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
+#include "column/latent.h"
 #include "documentation.h"
 #include "expr/fexpr_func.h"
 #include "expr/eval_context.h"
@@ -56,6 +57,7 @@ class FExpr_FillNA : public FExpr_Func {
     static RowIndex fill_rowindex(Column& col, const Groupby& gby) {
       Buffer buf = Buffer::mem(static_cast<size_t>(col.nrows()) * sizeof(int32_t));
       auto indices = static_cast<int32_t*>(buf.xptr());
+      Latent_ColumnImpl::vivify(col);
 
       dt::parallel_for_dynamic(
         gby.size(),

--- a/tests/dt/test-cumminmax.py
+++ b/tests/dt/test-cumminmax.py
@@ -104,33 +104,33 @@ def test_cumminmax_bool():
 
 def test_cumminmax_small():
     DT = dt.Frame([range(5), [None, -1, None, 5.5, 3]])
-    DT_cummax = DT[:, [cummin(f[:]), cummax(f[:])]]
+    DT_mm = DT[:, [cummin(f[:]), cummax(f[:])]]
     DT_ref = dt.Frame([
                  [0, 0, 0, 0, 0]/dt.int32,
                  [None, -1, -1, -1, -1]/dt.float64,
                  [0, 1, 2, 3, 4],
                  [None, -1, -1, 5.5, 5.5]
              ])
-    assert_equals(DT_cummax, DT_ref)
+    assert_equals(DT_mm, DT_ref)
 
 
 def test_cumminmax_dates():
     from datetime import date as d
     src = [None, d(1997, 9, 1), d(2002, 7, 31), None, d(2000, 2, 20)]
     DT = dt.Frame(src)
-    DT_cummax = DT[:, [cummin(f.C0), cummax(f.C0)]]
+    DT_mm = DT[:, [cummin(f.C0), cummax(f.C0)]]
     DT_ref = dt.Frame([
                  [None, d(1997, 9, 1), d(1997, 9, 1), d(1997, 9, 1), d(1997, 9, 1)],
                  [None, d(1997, 9, 1), d(2002, 7, 31), d(2002, 7, 31), d(2002, 7, 31)],
              ])
-    assert_equals(DT_cummax, DT_ref)
+    assert_equals(DT_mm, DT_ref)
 
 
 def test_cumminmax_times():
     from datetime import datetime as d
     src = [None, d(1997, 9, 1, 10, 11, 5), d(1997, 9, 1, 10, 10, 5), None, None]
     DT = dt.Frame(src)
-    DT_cummax = DT[:, [cummin(f.C0), cummax(f.C0)]]
+    DT_mm = DT[:, [cummin(f.C0), cummax(f.C0)]]
     DT_ref = dt.Frame([
                  [None,
                   d(1997, 9, 1, 10, 11, 5),
@@ -143,28 +143,40 @@ def test_cumminmax_times():
                   d(1997, 9, 1, 10, 11, 5),
                   d(1997, 9, 1, 10, 11, 5)],
              ])
-    assert_equals(DT_cummax, DT_ref)
+    assert_equals(DT_mm, DT_ref)
 
 
 def test_cumminmax_groupby():
     DT = dt.Frame([[2, 1, 1, 1, 2], [1.5, -1.5, math.inf, None, 3]])
-    DT_cummax = DT[:, [cummin(f[:]), cummax(f[:])], by(f[0])]
+    DT_mm = DT[:, [cummin(f[:]), cummax(f[:])], by(f[0])]
     DT_ref = dt.Frame([
                  [1, 1, 1, 2, 2],
                  [-1.5, -1.5, -1.5, 1.5, 1.5],
                  [-1.5, math.inf, math.inf, 1.5, 3]
              ])
-    assert_equals(DT_cummax, DT_ref)
+    assert_equals(DT_mm, DT_ref)
 
 
 def test_cumminmax_grouped_column():
     DT = dt.Frame([2, 1, None, 1, 2])
-    DT_cummax = DT[:, [cummin(f[0]), cummax(f[0])], by(f[0])]
+    DT_mm = DT[:, [cummin(f[0]), cummax(f[0])], by(f[0])]
     DT_ref = dt.Frame([
                 [None, 1, 1, 2, 2],
                 [None, 1, 1, 2, 2],
                 [None, 1, 1, 2, 2]
              ])
-    assert_equals(DT_cummax, DT_ref)
+    assert_equals(DT_mm, DT_ref)
+
+
+def test_cumminmax_groupby_complex():
+    DT = dt.Frame([[3, 14, 15, 92, 6], ["a", "cat", "a", "dog", "cat"]])
+    DT_mm = DT[:, [cummin(f[0].min()), cummax(f[0].max())], by(f[1])]
+
+    DT_ref = dt.Frame(
+                 {"C1" : ["a", "a", "cat", "cat", "dog"],
+                 "C0" : [3, 3, 6, 6, 92],
+                 "C2" : [15, 15, 14, 14, 92]}
+             )
+    assert_equals(DT_mm, DT_ref)
 
 

--- a/tests/dt/test-cumprod.py
+++ b/tests/dt/test-cumprod.py
@@ -107,3 +107,14 @@ def test_cumprod_grouped_column():
     DT_ref = dt.Frame([[None, 1, 1, 2, 2], [1, 1, 1, 2, 4]/dt.int64])
     assert_equals(DT_cumprod, DT_ref)
 
+
+def test_cumprod_groupby_complex():
+    DT = dt.Frame([[3, 14, 15, 92, 6], ["a", "cat", "a", "dog", "cat"]])
+    DT_cumprod = DT[:, cumprod(f[0].min()), by(f[1])]
+
+    DT_ref = dt.Frame({
+               "C1" : ["a", "a", "cat", "cat", "dog"],
+               "C0" : [3, 9, 6, 36, 92]/dt.int64
+             })
+    assert_equals(DT_cumprod, DT_ref)
+

--- a/tests/dt/test-cumsum.py
+++ b/tests/dt/test-cumsum.py
@@ -106,3 +106,14 @@ def test_cumsum_grouped_column():
     DT_cumsum = DT[:, cumsum(f[0]), by(f[0])]
     DT_ref = dt.Frame([[None, 1, 1, 2, 2], [0, 1, 2, 2, 4]/dt.int64])
     assert_equals(DT_cumsum, DT_ref)
+
+
+def test_cumsum_groupby_complex():
+    DT = dt.Frame([[3, 14, 15, 92, 6], ["a", "cat", "a", "dog", "cat"]])
+    DT_cumsum = DT[:, cumsum(f[0].min()), by(f[1])]
+
+    DT_ref = dt.Frame({
+               "C1" : ["a", "a", "cat", "cat", "dog"],
+               "C0" : [3, 6, 6, 12, 92]/dt.int64
+             })
+    assert_equals(DT_cumsum, DT_ref)

--- a/tests/dt/test-fillna.py
+++ b/tests/dt/test-fillna.py
@@ -130,12 +130,23 @@ def test_fillna_grouped():
 
 def test_fillna_grouped_column():
     DT = dt.Frame([2, 1, None, 1, 2])
-    DT_bfill = DT[:, [fillna(f[0], reverse = False),
+    DT_fillna = DT[:, [fillna(f[0], reverse = False),
                       fillna(f[0], reverse = True)], by(f[0])]
     DT_ref = dt.Frame([
                  [None, 1, 1, 2, 2],
                  [None, 1, 1, 2, 2],
                  [None, 1, 1, 2, 2]
              ])
-    assert_equals(DT_bfill, DT_ref)
+    assert_equals(DT_fillna, DT_ref)
+
+
+def test_fillna_groupby_complex():
+    DT = dt.Frame([[3, None, 15, 92, 6], ["a", "cat", "a", "dog", "cat"]])
+    DT_fillna = DT[:, fillna(f[0].min()), by(f[1])]
+
+    DT_ref = dt.Frame({
+               "C1" : ["a", "a", "cat", "cat", "dog"],
+               "C0" : [3, 3, 6, 6, 92]
+             })
+    assert_equals(DT_fillna, DT_ref)
 


### PR DESCRIPTION
Cumulative functions acces the column's data in parallel. If the input column appears to be a `Latent_ColumnImpl`, materialization of such a column happens in parallel. However, the `Latent_ColumnImpl::materialize()` is not a thread-safe method and invoking it from multiple threads results in a segfault.

In this PR we `vivify()` the source column, i.e. materialization, if necessary, happens in one thread only, before processing it in parallel.

Closes #3345 