### PR TITLE
Fix status badge in documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -109,8 +109,8 @@
           <a href="https://pypi.org/project/datatable/">
             <img src="https://img.shields.io/pypi/v/datatable.svg">
           </a>
-          <a href="https://travis-ci.org/h2oai/datatable">
-            <img src="https://travis-ci.org/h2oai/datatable.svg?branch=main">
+          <a href="https://ci.appveyor.com/project/h2oops/datatable">
+            <img src="https://ci.appveyor.com/api/projects/status/github/h2oai/datatable?branch=main">
           </a>
           <a href="https://datatable.readthedocs.io/en/latest/?badge=latest">
             <img src="https://readthedocs.org/projects/datatable/badge/?version=latest">

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -110,7 +110,7 @@
             <img src="https://img.shields.io/pypi/v/datatable.svg">
           </a>
           <a href="https://ci.appveyor.com/project/h2oops/datatable">
-            <img src="https://ci.appveyor.com/api/projects/status/github/h2oai/datatable?branch=main">
+            <img src="https://ci.appveyor.com/api/projects/status/github/h2oai/datatable?branch=main&svg=true">
           </a>
           <a href="https://datatable.readthedocs.io/en/latest/?badge=latest">
             <img src="https://readthedocs.org/projects/datatable/badge/?version=latest">

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -103,9 +103,6 @@
           and flexible API.
         </p></div>
         <div id="badges">
-          <a href="https://gitter.im/h2oai/datatable">
-            <img src="https://badges.gitter.im/Join%20Chat.svg">
-          </a>
           <a href="https://pypi.org/project/datatable/">
             <img src="https://img.shields.io/pypi/v/datatable.svg">
           </a>
@@ -114,6 +111,9 @@
           </a>
           <a href="https://datatable.readthedocs.io/en/latest/?badge=latest">
             <img src="https://readthedocs.org/projects/datatable/badge/?version=latest">
+          </a>
+          <a href="https://gitter.im/h2oai/datatable">
+            <img src="https://badges.gitter.im/Join%20Chat.svg">
           </a>
         </div>
       </div>


### PR DESCRIPTION
As we eliminated Travis from our building pipeline (#3042), its status badge stopped working. In this PR we replace it with the AppVeyor's badge.