### PR TITLE
Parameter names and docs improvements

### DIFF
--- a/docs/api/dt/shift.rst
+++ b/docs/api/dt/shift.rst
@@ -3,19 +3,29 @@
     :src: src/core/expr/head_func_shift.cc pyfn_shift
     :cvar: doc_dt_shift
     :tests: tests/dt/test-shift.py
-    :signature: shift(col, n=1)
+    :signature: shift(cols, n=1)
 
-    Produce a column obtained from `col` shifting it  `n` rows forward.
+    Shift columns' data forward or backwards. This function is group-aware,
+    i.e. in the presence of a groupby it will shift data separately
+    within each group.
 
-    The shift amount, `n`, can be both positive and negative. If positive,
-    a "lag" column is created, if negative it will be a "lead" column.
 
-    The shifted column will have the same number of rows as the original
-    column, with `n` observations in the beginning becoming missing, and
-    `n` observations at the end discarded.
+    Parameters
+    ----------
+    cols: FExpr
+        Input data to be shifted.
 
-    This function is group-aware, i.e. in the presence of a groupby it
-    will perform the shift separately within each group.
+    n: int
+        The shift amount. For positive `n`, the data are shifted forward, i.e.
+        a "lag" column is created. For negative `n`, the data are shifted backwards
+        creating a "lead" column.
+
+    return: FExpr
+        f-expression that shifts input data by `n` rows. The resulting data
+        will have the same number of rows as `cols`. Depending on `n`,
+        i.e. positive/negative, `n` observations in the beginning/end
+        will become missing and `n` observations at the end/beginning
+        will be discarded.
 
 
     Examples
@@ -39,7 +49,7 @@
          4 |      2      23     23
         [5 rows x 3 columns]
 
-    Shift forward - Create a "lag" column::
+    Shift forward by creating a "lag" column::
 
         >>> DT[:, dt.shift(f.period,  n = 3)]
            | period
@@ -52,7 +62,7 @@
          4 |      2
         [5 rows x 1 column]
 
-    Shift backwards - Create "lead" columns::
+    Shift backwards by creating "lead" columns::
 
         >>> DT[:, dt.shift(f[:], n = -3)]
            | object  period  value
@@ -65,7 +75,7 @@
          4 |     NA      NA     NA
         [5 rows x 3 columns]
 
-    Shift in the presence of :func:`by()`::
+    Shift within groups, i.e. in the presence of :func:`by()`::
 
         >>> DT[:, f[:].extend({"prev_value": dt.shift(f.value)}), by("object")]
            | object  period  value  prev_value

--- a/docs/api/str/slice.rst
+++ b/docs/api/str/slice.rst
@@ -3,7 +3,7 @@
     :src: src/core/expr/fexpr_slice.cc FExpr_Slice::evaluate_n
     :tests: tests/str/test-slice.py
     :cvar: doc_str_slice
-    :signature: slice(column, start, stop, step=1)
+    :signature: slice(col, start, stop, step=1)
 
     Apply slice ``[start:stop:step]`` to each value in a `column` of string
     type.
@@ -17,7 +17,7 @@
 
     Parameters
     ----------
-    column : FExpr[str]
+    col : FExpr[str]
         The column to which the slice should be applied.
 
     return: FExpr[str]

--- a/src/core/expr/fexpr_cumsumprod.cc
+++ b/src/core/expr/fexpr_cumsumprod.cc
@@ -28,105 +28,104 @@
 #include "expr/workframe.h"
 #include "python/xargs.h"
 #include "stype.h"
-
-
 namespace dt {
-  namespace expr {
-
-    template <bool SUM>
-    class FExpr_CumSumProd : public FExpr_Func {
-      private:
-        ptrExpr arg_;
-
-      public:
-        FExpr_CumSumProd(ptrExpr &&arg)
-            : arg_(std::move(arg)) {}
-
-        std::string repr() const override {
-          std::string out = SUM? "cumsum" : "cumprod";
-          out += '(';
-          out += arg_->repr();
-          out += ')';
-          return out;
-        }
+namespace expr {
 
 
-        Workframe evaluate_n(EvalContext &ctx) const override {
-          Workframe wf = arg_->evaluate_n(ctx);
-          Groupby gby = ctx.get_groupby();
-          if (!gby) {
-            gby = Groupby::single_group(wf.nrows());
+template <bool SUM>
+class FExpr_CumSumProd : public FExpr_Func {
+  private:
+    ptrExpr arg_;
+
+  public:
+    FExpr_CumSumProd(ptrExpr &&arg)
+        : arg_(std::move(arg)) {}
+
+    std::string repr() const override {
+      std::string out = SUM? "cumsum" : "cumprod";
+      out += '(';
+      out += arg_->repr();
+      out += ')';
+      return out;
+    }
+
+
+    Workframe evaluate_n(EvalContext &ctx) const override {
+      Workframe wf = arg_->evaluate_n(ctx);
+      Groupby gby = ctx.get_groupby();
+      if (!gby) {
+        gby = Groupby::single_group(wf.nrows());
+      } else {
+        wf.increase_grouping_mode(Grouping::GtoALL);
+      }
+
+      for (size_t i = 0; i < wf.ncols(); ++i) {
+        Column coli = evaluate1(wf.retrieve_column(i), gby);
+        wf.replace_column(i, std::move(coli));
+      }
+      return wf;
+    }
+
+
+    Column evaluate1(Column &&col, const Groupby &gby) const {
+      SType stype = col.stype();
+      switch (stype) {
+        case SType::VOID:
+          if (SUM) {
+            return Column(new ConstInt_ColumnImpl(col.nrows(), 0, SType::INT64));
           } else {
-            wf.increase_grouping_mode(Grouping::GtoALL);
+            return Column(new ConstInt_ColumnImpl(col.nrows(), 1, SType::INT64));
           }
-
-          for (size_t i = 0; i < wf.ncols(); ++i) {
-            Column coli = evaluate1(wf.retrieve_column(i), gby);
-            wf.replace_column(i, std::move(coli));
-          }
-          return wf;
-        }
-
-
-        Column evaluate1(Column &&col, const Groupby &gby) const {
-          SType stype = col.stype();
-          switch (stype) {
-            case SType::VOID:
-              if (SUM) {
-                return Column(new ConstInt_ColumnImpl(col.nrows(), 0, SType::INT64));
-              } else {
-                return Column(new ConstInt_ColumnImpl(col.nrows(), 1, SType::INT64));
-              }
-            case SType::BOOL:
-            case SType::INT8:
-            case SType::INT16:
-            case SType::INT32:
-            case SType::INT64:
-              return make<int64_t>(std::move(col), SType::INT64, gby);
-            case SType::FLOAT32:
-              return make<float>(std::move(col), SType::FLOAT32, gby);
-            case SType::FLOAT64:
-              return make<double>(std::move(col), SType::FLOAT64, gby);
-            default:
-              throw TypeError()
-                << "Invalid column of type `" << stype << "` in " << repr();
-          }
-        }
-
-
-        template <typename T>
-        Column make(Column &&col, SType stype, const Groupby &gby) const {
-           col.cast_inplace(stype);
-           return Column(new Latent_ColumnImpl(
-             new CumSumProd_ColumnImpl<T, SUM>(std::move(col), gby)
-           ));
-        }
-    };
-
-
-    static py::oobj pyfn_cumsum(const py::XArgs &args) {
-      auto cumsum = args[0].to_oobj();
-      return PyFExpr::make(new FExpr_CumSumProd<true>(as_fexpr(cumsum)));
+        case SType::BOOL:
+        case SType::INT8:
+        case SType::INT16:
+        case SType::INT32:
+        case SType::INT64:
+          return make<int64_t>(std::move(col), SType::INT64, gby);
+        case SType::FLOAT32:
+          return make<float>(std::move(col), SType::FLOAT32, gby);
+        case SType::FLOAT64:
+          return make<double>(std::move(col), SType::FLOAT64, gby);
+        default:
+          throw TypeError()
+            << "Invalid column of type `" << stype << "` in " << repr();
+      }
     }
 
-    static py::oobj pyfn_cumprod(const py::XArgs &args) {
-      auto cumprod = args[0].to_oobj();
-      return PyFExpr::make(new FExpr_CumSumProd<false>(as_fexpr(cumprod)));
+
+    template <typename T>
+    Column make(Column &&col, SType stype, const Groupby &gby) const {
+       col.cast_inplace(stype);
+       return Column(new Latent_ColumnImpl(
+         new CumSumProd_ColumnImpl<T, SUM>(std::move(col), gby)
+       ));
     }
+};
 
-    DECLARE_PYFN(&pyfn_cumsum)
-        ->name("cumsum")
-        ->docs(doc_dt_cumsum)
-        ->arg_names({"cumsum"})
-        ->n_positional_args(1)
-        ->n_required_args(1);
 
-    DECLARE_PYFN(&pyfn_cumprod)
-        ->name("cumprod")
-        ->docs(doc_dt_cumprod)
-        ->arg_names({"cumprod"})
-        ->n_positional_args(1)
-        ->n_required_args(1);
+static py::oobj pyfn_cumsum(const py::XArgs &args) {
+  auto cumsum = args[0].to_oobj();
+  return PyFExpr::make(new FExpr_CumSumProd<true>(as_fexpr(cumsum)));
+}
 
-  }  // namespace dt::expr
-}    // namespace dt
+static py::oobj pyfn_cumprod(const py::XArgs &args) {
+  auto cumprod = args[0].to_oobj();
+  return PyFExpr::make(new FExpr_CumSumProd<false>(as_fexpr(cumprod)));
+}
+
+DECLARE_PYFN(&pyfn_cumsum)
+    ->name("cumsum")
+    ->docs(doc_dt_cumsum)
+    ->arg_names({"cols"})
+    ->n_positional_args(1)
+    ->n_required_args(1);
+
+DECLARE_PYFN(&pyfn_cumprod)
+    ->name("cumprod")
+    ->docs(doc_dt_cumprod)
+    ->arg_names({"cols"})
+    ->n_positional_args(1)
+    ->n_required_args(1);
+
+
+}}  // dt::expr

--- a/src/core/expr/fexpr_fillna.cc
+++ b/src/core/expr/fexpr_fillna.cc
@@ -134,7 +134,7 @@ static py::oobj pyfn_fillna(const py::XArgs &args) {
 DECLARE_PYFN(&pyfn_fillna)
     ->name("fillna")
     ->docs(doc_dt_fillna)
-    ->arg_names({"column", "reverse"})
+    ->arg_names({"cols", "reverse"})
     ->n_required_args(1)
     ->n_positional_args(1)
     ->n_positional_or_keyword_args(1);

--- a/src/core/expr/fexpr_slice.cc
+++ b/src/core/expr/fexpr_slice.cc
@@ -151,7 +151,7 @@ static py::oobj py_slice(const py::XArgs& args) {
 DECLARE_PYFN(&py_slice)
     ->name("slice")
     ->docs(dt::doc_str_slice)
-    ->arg_names({"column", "start", "stop", "step"})
+    ->arg_names({"col", "start", "stop", "step"})
     ->n_positional_args(1)
     ->n_positional_or_keyword_args(3)
     ->n_required_args(3);

--- a/src/core/expr/head_func_shift.cc
+++ b/src/core/expr/head_func_shift.cc
@@ -176,7 +176,7 @@ DECLARE_PYFN(&pyfn_shift)
     ->docs(dt::doc_dt_shift)
     ->n_positional_args(1)
     ->n_positional_or_keyword_args(1)
-    ->arg_names({"col", "n"});
+    ->arg_names({"cols", "n"});
 
 
 

--- a/src/core/expr/re/fexpr_match.cc
+++ b/src/core/expr/re/fexpr_match.cc
@@ -120,7 +120,7 @@ DECLARE_PYFN(&fn_match)
     ->n_positional_args(1)
     ->n_positional_or_keyword_args(1)
     ->n_keyword_args(1)
-    ->arg_names({"column", "pattern", "icase"});
+    ->arg_names({"cols", "pattern", "icase"});
 
 
 

--- a/src/core/expr/str/fexpr_len.cc
+++ b/src/core/expr/str/fexpr_len.cc
@@ -80,7 +80,7 @@ DECLARE_PYFN(&fn_len)
     ->docs(doc_str_len)
     ->n_required_args(1)
     ->n_positional_args(1)
-    ->arg_names({"column"});
+    ->arg_names({"cols"});
 
 
 

--- a/src/core/types/type_categorical.cc
+++ b/src/core/types/type_categorical.cc
@@ -144,20 +144,21 @@ Column Type_Cat::cast_column(Column&& col) const {
     case SType::FLOAT64:
     case SType::STR32:
     case SType::STR64:
-    case SType::OBJ: {
+    case SType::OBJ:
       switch (stype()) {
-        case SType::CAT8:  cast_column_impl<uint8_t>(col); break;
-        case SType::CAT16: cast_column_impl<uint16_t>(col); break;
-        case SType::CAT32: cast_column_impl<uint32_t>(col); break;
+        case SType::CAT8:  cast_non_compound<uint8_t>(col); break;
+        case SType::CAT16: cast_non_compound<uint16_t>(col); break;
+        case SType::CAT32: cast_non_compound<uint32_t>(col); break;
         default: throw RuntimeError() << "Unknown categorical type";
       }
-      return std::move(col);
-    }
+      break;
 
     default:
-      throw NotImplError() << "Unable to cast column of type `" << col.type()
+      throw NotImplError() << "Unable to cast a column of type `" << col.type()
                            << "` into `" << to_string() << "`";
   }
+
+  return std::move(col);
 }
 
 
@@ -169,7 +170,7 @@ Column Type_Cat::cast_column(Column&& col) const {
   * finally assigning it to `col`.
   */
 template <typename T>
-void Type_Cat::cast_column_impl(Column& col) const {
+void Type_Cat::cast_non_compound(Column& col) const {
   size_t nrows = col.nrows(); // save nrows as `col` will be modified in-place
 
   // First, cast `col` to the requested `elementType_` and obtain

--- a/src/core/types/type_categorical.h
+++ b/src/core/types/type_categorical.h
@@ -31,7 +31,7 @@ namespace dt {
 class Type_Cat : public TypeImpl {
   private:
     template <typename T>
-    void cast_column_impl(Column& col) const;
+    void cast_non_compound(Column& col) const;
 
   protected:
     Type elementType_;


### PR DESCRIPTION
- use `col`/`cols` as a parameter name when dt function supports single/multiple column(s);
- convert `dt.shift()` documentation into standard format;
- cosmetics.