### PR TITLE
Fix "See also" sections for `cat*` types and `cbind()`/`rbind()` docs

### DIFF
--- a/docs/api/dt/cbind.rst
+++ b/docs/api/dt/cbind.rst
@@ -13,16 +13,26 @@
     Parameters
     ----------
     frames: Frame | List[Frame] | None
+        The list/tuple/sequence/generator expression of Frames to append.
+        It may also contain `None` values, which will be simply
+        skipped.
 
     force: bool
+        If `True`, allows Frames to be appended even if they have unequal
+        number of rows. The resulting Frame will have number of rows equal
+        to the largest among all Frames. Those Frames which have less
+        than the largest number of rows, will be padded with NAs (with the
+        exception of Frames having just 1 row, which will be replicated
+        instead of filling with NAs).
 
     return: Frame
+        A new frame that is created by appending columns from `frames`.
 
 
     See also
     --------
     - :func:`rbind()` -- function for row-binding several frames.
-    - :meth:`dt.Frame.cbind()` -- Frame method for cbinding some frames to
+    - :meth:`dt.Frame.cbind()` -- Frame method for cbinding several frames to
       another.
 
 

--- a/docs/api/dt/rbind.rst
+++ b/docs/api/dt/rbind.rst
@@ -17,17 +17,26 @@
     frames: Frame | List[Frame] | None
 
     force: bool
-        If True, then the frames are allowed to have mismatching set of
+        If `True`, then the frames are allowed to have mismatching set of
         columns (either different counts or different names). Any gaps in
         the data will be filled with NAs.
 
-        In addition, when this parameter is True, rbind will no longer
+        In addition, when this parameter is `True`, rbind will no longer
         produce an error when combining columns of unrelated types.
         Instead, both columns will be converted into strings.
 
     bynames: bool
+        Whether to match column names when rbinding.
 
     return: Frame
+        A new frame that is created by appending rows from `frames`.
+
+
+    See also
+    --------
+    - :func:`cbind()` -- function for col-binding several frames.
+    - :meth:`dt.Frame.rbind()` -- Frame method for rbinding some frames to
+      another.
 
 
     Examples
@@ -108,10 +117,3 @@
          4 |      4     181     50
          5 |      5     169     67
         [6 rows x 3 columns]
-
-
-    See also
-    --------
-    - :func:`cbind()` -- function for col-binding several frames.
-    - :meth:`dt.Frame.rbind()` -- Frame method for rbinding some frames to
-      another.

--- a/docs/api/frame/cbind.rst
+++ b/docs/api/frame/cbind.rst
@@ -33,11 +33,11 @@
     ----------
     frames: Frame | List[Frame] | None
         The list/tuple/sequence/generator expression of Frames to append
-        to the current frame. The list may also contain `None` values,
+        to the current frame. It may also contain `None` values,
         which will be simply skipped.
 
     force: bool
-        If True, allows Frames to be appended even if they have unequal
+        If `True`, allows Frames to be appended even if they have unequal
         number of rows. The resulting Frame will have number of rows equal
         to the largest among all Frames. Those Frames which have less
         than the largest number of rows, will be padded with NAs (with the

--- a/docs/api/frame/cbind.rst
+++ b/docs/api/frame/cbind.rst
@@ -72,6 +72,14 @@
         >>> df["newcol"] = frame1
 
 
+    See also
+    --------
+    - :func:`datatable.cbind` -- function for cbinding frames
+      "out-of-place" instead of in-place;
+
+    - :meth:`.rbind()` -- method for row-binding frames.
+
+
     Examples
     --------
     >>> DT = dt.Frame(A=[1, 2, 3], B=[4, 7, 0])
@@ -86,10 +94,3 @@
      2 |     3      0     -5
     [3 rows x 3 columns]
 
-
-    See also
-    --------
-    - :func:`datatable.cbind` -- function for cbinding frames
-      "out-of-place" instead of in-place;
-
-    - :meth:`.rbind()` -- method for row-binding frames.

--- a/docs/api/type/cat16.rst
+++ b/docs/api/type/cat16.rst
@@ -10,7 +10,7 @@
     is a value of type `T`.
 
 
-    See Also
+    See also
     --------
     - :meth:`.cat8(T)` -- another categorical type, but with 8-bit codes.
     - :meth:`.cat32(T)` -- another categorical type, but with 32-bit codes.

--- a/docs/api/type/cat16.rst
+++ b/docs/api/type/cat16.rst
@@ -12,5 +12,5 @@
 
     See Also
     --------
-    :meth:`.cat8(T)` -- another categorical type, but with 8-bit codes.
-    :meth:`.cat32(T)` -- another categorical type, but with 32-bit codes.
+    - :meth:`.cat8(T)` -- another categorical type, but with 8-bit codes.
+    - :meth:`.cat32(T)` -- another categorical type, but with 32-bit codes.

--- a/docs/api/type/cat16.rst
+++ b/docs/api/type/cat16.rst
@@ -12,5 +12,5 @@
 
     See also
     --------
-    - :meth:`.cat8(T)` -- another categorical type, but with 8-bit codes.
-    - :meth:`.cat32(T)` -- another categorical type, but with 32-bit codes.
+    - :meth:`.cat8(T)` -- categorical type with 8-bit codes.
+    - :meth:`.cat32(T)` -- categorical type with 32-bit codes.

--- a/docs/api/type/cat32.rst
+++ b/docs/api/type/cat32.rst
@@ -12,5 +12,5 @@
 
     See Also
     --------
-    :meth:`.cat8(T)` -- another categorical type, but with 8-bit codes.
-    :meth:`.cat16(T)` -- another categorical type, but with 16-bit codes.
+    - :meth:`.cat8(T)` -- another categorical type, but with 8-bit codes.
+    - :meth:`.cat16(T)` -- another categorical type, but with 16-bit codes.

--- a/docs/api/type/cat32.rst
+++ b/docs/api/type/cat32.rst
@@ -10,7 +10,7 @@
     is a value of type `T`.
 
 
-    See Also
+    See also
     --------
     - :meth:`.cat8(T)` -- another categorical type, but with 8-bit codes.
     - :meth:`.cat16(T)` -- another categorical type, but with 16-bit codes.

--- a/docs/api/type/cat32.rst
+++ b/docs/api/type/cat32.rst
@@ -12,5 +12,5 @@
 
     See also
     --------
-    - :meth:`.cat8(T)` -- another categorical type, but with 8-bit codes.
-    - :meth:`.cat16(T)` -- another categorical type, but with 16-bit codes.
+    - :meth:`.cat8(T)` -- categorical type with 8-bit codes.
+    - :meth:`.cat16(T)` -- categorical type with 16-bit codes.

--- a/docs/api/type/cat8.rst
+++ b/docs/api/type/cat8.rst
@@ -10,7 +10,7 @@
     is a value of type `T`.
 
 
-    See Also
+    See also
     --------
-    :meth:`.cat16(T)` -- another categorical type, but with 16-bit codes.
-    :meth:`.cat32(T)` -- another categorical type, but with 32-bit codes.
+    - :meth:`.cat16(T)` -- categorical type with 16-bit codes.
+    - :meth:`.cat32(T)` -- categorical type with 32-bit codes.


### PR DESCRIPTION
- fix "See also" section for categorical types;
- improve `cbind()`/`rbind()` documentation.

Also, we probably need to make the wording "See also"/"See Also" be consistent across documentation, and also move the "See also" sections above "Examples", as examples section in some cases could be very long.