### PR TITLE
Implement statistics for categorical columns

### DIFF
--- a/src/core/column.cc
+++ b/src/core/column.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2021 H2O.ai
+// Copyright 2018-2022 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -169,16 +169,11 @@ const dt::Type& Column::type() const noexcept {
 }
 
 dt::SType Column::stype() const noexcept {
-  return impl_->type_.stype();
+  return impl_->stype();
 }
 
 dt::SType Column::data_stype() const noexcept {
-  if (impl_->type_.is_categorical()) {
-    if (n_children()) return child(0).stype();
-    else              return dt::SType::VOID;
-  } else {
-    return stype();
-  }
+  return impl_->data_stype();
 }
 
 dt::LType Column::ltype() const noexcept {

--- a/src/core/column.cc
+++ b/src/core/column.cc
@@ -169,7 +169,7 @@ const dt::Type& Column::type() const noexcept {
 }
 
 dt::SType Column::stype() const noexcept {
-  return impl_->stype();
+  return impl_->type_.stype();
 }
 
 dt::SType Column::data_stype() const noexcept {

--- a/src/core/column/column_impl.cc
+++ b/src/core/column/column_impl.cc
@@ -235,6 +235,14 @@ size_t ColumnImpl::null_count() const {
 }
 
 
+SType ColumnImpl::data_stype() const {
+  if (type_.is_categorical()) {
+    return n_children()? child(0).stype()
+                       : SType::VOID;
+  }
+  return stype();
+}
+
 
 
 }  // namespace dt

--- a/src/core/column/column_impl.h
+++ b/src/core/column/column_impl.h
@@ -27,7 +27,6 @@
 #include "groupby.h"     // Groupby
 #include "buffer.h"      // Buffer
 #include "stats.h"       // Stats
-#include "stype.h"
 #include "types/type.h"
 namespace dt {
 
@@ -94,15 +93,8 @@ class ColumnImpl
   //------------------------------------
   public:
     size_t nrows() const noexcept { return nrows_; }
-    SType  stype() const { return type_.stype(); }
-    SType  data_stype() const {
-      if (type_.is_categorical()) {
-        return n_children()? child(0).stype()
-                           : dt::SType::VOID;
-      }
-      return stype();
-    }
-
+    SType stype() const { return type_.stype(); }
+    SType data_stype() const;
     const Type& type() const { return type_; }
     virtual bool is_virtual() const noexcept = 0;
     virtual bool computationally_expensive() const { return false; }

--- a/src/core/column/column_impl.h
+++ b/src/core/column/column_impl.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2021 H2O.ai
+// Copyright 2018-2022 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -27,6 +27,7 @@
 #include "groupby.h"     // Groupby
 #include "buffer.h"      // Buffer
 #include "stats.h"       // Stats
+#include "stype.h"
 #include "types/type.h"
 namespace dt {
 
@@ -94,6 +95,14 @@ class ColumnImpl
   public:
     size_t nrows() const noexcept { return nrows_; }
     SType  stype() const { return type_.stype(); }
+    SType  data_stype() const {
+      if (type_.is_categorical()) {
+        return n_children()? child(0).stype()
+                           : dt::SType::VOID;
+      }
+      return stype();
+    }
+
     const Type& type() const { return type_; }
     virtual bool is_virtual() const noexcept = 0;
     virtual bool computationally_expensive() const { return false; }

--- a/src/core/stats.cc
+++ b/src/core/stats.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2021 H2O.ai
+// Copyright 2018-2022 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -1165,7 +1165,7 @@ size_t VoidStats::nmodal(bool* isvalid) {
 
 static std::unique_ptr<Stats> _make_stats(const dt::ColumnImpl* col) {
   using StatsPtr = std::unique_ptr<Stats>;
-  switch (col->stype()) {
+  switch (col->data_stype()) {
     case dt::SType::VOID:    return StatsPtr(new VoidStats(col));
     case dt::SType::BOOL:    return StatsPtr(new BooleanStats(col));
     case dt::SType::INT8:    return StatsPtr(new IntegerStats<int8_t>(col));
@@ -1383,7 +1383,7 @@ py::oobj Stats::get_stat_as_pyobject(Stat stat) {
       return pywrap_stat<double>(stat);
     }
     case Stat::Sum: {
-      switch (dt::stype_to_ltype(column->stype())) {
+      switch (dt::stype_to_ltype(column->data_stype())) {
         case dt::LType::MU:
         case dt::LType::BOOL:
         case dt::LType::INT:  return pywrap_stat<int64_t>(stat);
@@ -1394,7 +1394,7 @@ py::oobj Stats::get_stat_as_pyobject(Stat stat) {
     case Stat::Min:
     case Stat::Max:
     case Stat::Mode: {
-      switch (dt::stype_to_ltype(column->stype())) {
+      switch (dt::stype_to_ltype(column->data_stype())) {
         case dt::LType::BOOL:
         case dt::LType::INT:  return pywrap_stat<int64_t>(stat);
         case dt::LType::REAL: return pywrap_stat<double>(stat);
@@ -1469,7 +1469,7 @@ Column Stats::strcolwrap_stat(Stat stat) {
   dt::CString value;
   bool isvalid = get_stat(stat, &value);
   return isvalid? _make_column_str(value)
-                : _make_nacol(column->stype());
+                : _make_nacol(column->data_stype());
 }
 
 
@@ -1491,7 +1491,7 @@ Column Stats::get_stat_as_column(Stat stat) {
       return colwrap_stat<double, double>(stat, dt::SType::FLOAT64);
     }
     case Stat::Sum: {
-      switch (column->stype()) {
+      switch (column->data_stype()) {
         case dt::SType::VOID:    return colwrap_stat<int64_t, int64_t>(stat, dt::SType::INT64);
         case dt::SType::BOOL:    return colwrap_stat<int64_t, int64_t>(stat, dt::SType::INT64);
         case dt::SType::INT8:    return colwrap_stat<int64_t, int64_t>(stat, dt::SType::INT64);
@@ -1506,7 +1506,7 @@ Column Stats::get_stat_as_column(Stat stat) {
     case Stat::Min:
     case Stat::Max:
     case Stat::Mode: {
-      switch (column->stype()) {
+      switch (column->data_stype()) {
         case dt::SType::BOOL:    return colwrap_stat<int64_t, int8_t>(stat, dt::SType::BOOL);
         case dt::SType::INT8:    return colwrap_stat<int64_t, int8_t>(stat, dt::SType::INT8);
         case dt::SType::INT16:   return colwrap_stat<int64_t, int16_t>(stat, dt::SType::INT16);
@@ -1518,7 +1518,7 @@ Column Stats::get_stat_as_column(Stat stat) {
         case dt::SType::STR64:   return strcolwrap_stat(stat);
         case dt::SType::DATE32:  return colwrap_stat<int64_t, int32_t>(stat, dt::SType::DATE32);
         case dt::SType::TIME64:  return colwrap_stat<int64_t, int64_t>(stat, dt::SType::TIME64);
-        default:                 return _make_nacol(column->stype());
+        default:                 return _make_nacol(column->data_stype());
       }
     }
     default:

--- a/tests/types/test-categorical.py
+++ b/tests/types/test-categorical.py
@@ -34,19 +34,19 @@ from tests import assert_equals
 @pytest.mark.parametrize('t', [dt.Type.cat8,
                                dt.Type.cat16,
                                dt.Type.cat32])
-def test_type_categorical_wrong(t):
+def test_categorical_type_wrong(t):
     msg = r"Categories are not allowed to be of a categorical type"
     with pytest.raises(TypeError, match=msg):
         t(t(dt.str64))
 
 
-def test_type_categorical_repr():
+def test_categorical_type_repr():
     assert repr(dt.Type.cat8(int)) == "Type.cat8(int64)"
     assert repr(dt.Type.cat16(dt.float32)) == "Type.cat16(float32)"
     assert repr(dt.Type.cat32(str)) == "Type.cat32(str32)"
 
 
-def test_type_categorical_name():
+def test_categorical_type_name():
     assert dt.Type.cat8(int).name == "cat8(int64)"
     assert dt.Type.cat16(dt.int8).name == "cat16(int8)"
     assert dt.Type.cat32(None).name == "cat32(void)"
@@ -55,12 +55,12 @@ def test_type_categorical_name():
 @pytest.mark.parametrize('t', [dt.Type.cat8(int),
                                dt.Type.cat16(str),
                                dt.Type.cat32(float)])
-def test_type_categorical_properties(t):
+def test_categorical_type_properties(t):
     assert t.min is None
     assert t.max is None
 
 
-def test_type_categorical_equality():
+def test_categorical_type_equality():
     t1 = dt.Type.cat8(int)
     t2 = dt.Type.cat32(int)
     assert t1 != t2
@@ -75,7 +75,7 @@ def test_type_categorical_equality():
            dt.Type.cat8(float)
 
 
-def test_type_categorical_hashable():
+def test_categorical_type_hashable():
     store = {dt.Type.cat8(str): 1, dt.Type.cat32('float32'): 2,
              dt.Type.cat16(str): 3}
     assert dt.Type.cat8(str) in store
@@ -92,7 +92,7 @@ def test_type_categorical_hashable():
 @pytest.mark.parametrize('t', [dt.Type.cat8(int),
                                dt.Type.cat16(str),
                                dt.Type.cat32(float)])
-def test_type_categorical_query_methods(t):
+def test_categorical_type_query_methods(t):
     assert     t.is_categorical
     assert not t.is_boolean
     assert     t.is_compound
@@ -112,7 +112,7 @@ def test_type_categorical_query_methods(t):
 @pytest.mark.parametrize('t', [dt.Type.cat8,
                                dt.Type.cat16,
                                dt.Type.cat32])
-def test_create_too_many_cats_error(t):
+def test_categorical_create_too_many_cats_error(t):
     src = list(range(1000))
 
     if t is dt.Type.cat8:
@@ -131,7 +131,7 @@ def test_create_too_many_cats_error(t):
 @pytest.mark.parametrize('t', [dt.Type.cat8,
                                dt.Type.cat16,
                                dt.Type.cat32])
-def test_create_from_zero_rows(t):
+def test_categorical_create_from_zero_rows(t):
     src = [[]]
     DT1 = dt.Frame(src)
     DT2 = dt.Frame(src, types = [t(dt.Type.bool8)])
@@ -145,7 +145,7 @@ def test_create_from_zero_rows(t):
 @pytest.mark.parametrize('t', [dt.Type.cat8,
                                dt.Type.cat16,
                                dt.Type.cat32])
-def test_create_from_void(t):
+def test_categorical_create_from_void(t):
     src = [None] * 10
     DT1 = dt.Frame(src)
     DT2 = dt.Frame(src, types = [t(dt.Type.bool8)])
@@ -159,7 +159,7 @@ def test_create_from_void(t):
 @pytest.mark.parametrize('t', [dt.Type.cat8,
                                dt.Type.cat16,
                                dt.Type.cat32])
-def test_create_from_bools(t):
+def test_categorical_create_from_bools(t):
     src = [None, True, False, None, False, False]
     DT1 = dt.Frame(src)
     DT2 = dt.Frame(src, types = [t(dt.Type.bool8)])
@@ -173,7 +173,7 @@ def test_create_from_bools(t):
 @pytest.mark.parametrize('t', [dt.Type.cat8,
                                dt.Type.cat16,
                                dt.Type.cat32])
-def test_create_from_ints(t):
+def test_categorical_create_from_ints(t):
     src = [3, None, 1, 4, 1, None, 5, 9, 2, 6]
     DT1 = dt.Frame(src)
     DT2 = dt.Frame(src, types = [t(dt.Type.int32)])
@@ -184,7 +184,7 @@ def test_create_from_ints(t):
     assert_equals(DT2, DT2[:, :])
 
 
-def test_create_from_ints_large():
+def test_categorical_create_from_ints_large():
     src = list(range(10**6))
     DT1 = dt.Frame(src)
     DT2 = dt.Frame(src, types = [dt.Type.cat32(dt.Type.int32)])
@@ -197,7 +197,7 @@ def test_create_from_ints_large():
 @pytest.mark.parametrize('t', [dt.Type.cat8,
                                dt.Type.cat16,
                                dt.Type.cat32])
-def test_create_from_floats(t):
+def test_categorical_create_from_floats(t):
     src = [3.14, None, 1.15, 4.92, 1.6, None, 5.5, 9, 2.35, 6.0]
     DT1 = dt.Frame(src)
     DT2 = dt.Frame(src, types = [t(dt.Type.float64)])
@@ -211,7 +211,7 @@ def test_create_from_floats(t):
 @pytest.mark.parametrize('t', [dt.Type.cat8,
                                dt.Type.cat16,
                                dt.Type.cat32])
-def test_create_from_strings(t):
+def test_categorical_create_from_strings(t):
     src = ["dog", "mouse", None, "dog", "cat", None, "1", "pig"]
     DT1 = dt.Frame(src)
     DT2 = dt.Frame(src, types = [t(dt.Type.str32)])
@@ -225,7 +225,7 @@ def test_create_from_strings(t):
 @pytest.mark.parametrize('t', [dt.Type.cat8,
                                dt.Type.cat16,
                                dt.Type.cat32])
-def test_create_from_dates(t):
+def test_categorical_create_from_dates(t):
     from datetime import date as d
     src = [d(1997, 9, 1), d(2002, 7, 31), d(2000, 2, 20), None]
     DT1 = dt.Frame(src)
@@ -240,7 +240,7 @@ def test_create_from_dates(t):
 @pytest.mark.parametrize('t', [dt.Type.cat8,
                                dt.Type.cat16,
                                dt.Type.cat32])
-def test_create_from_times(t):
+def test_categorical_create_from_times(t):
     from datetime import datetime as d
     src = [d(2000, 10, 18, 3, 30),
            d(2010, 11, 13, 15, 11, 59),
@@ -257,7 +257,7 @@ def test_create_from_times(t):
 @pytest.mark.parametrize('t', [dt.Type.cat8,
                                dt.Type.cat16,
                                dt.Type.cat32])
-def test_create_multicolumn(t):
+def test_categorical_create_multicolumn(t):
     src = [[6, 8, 8, None, 20],
            ["six", "eight", "eight", None, "twenty"]]
     DT1 = dt.Frame(src)
@@ -278,7 +278,7 @@ def test_create_multicolumn(t):
 @pytest.mark.parametrize('cat_type', [dt.Type.cat8,
                                       dt.Type.cat16,
                                       dt.Type.cat32])
-def test_void_to_cat(cat_type):
+def test_categorical_void_to_cat(cat_type):
     src = [None] * 11
     DT = dt.Frame(src)
     DT[0] = cat_type(dt.Type.str32)
@@ -289,7 +289,7 @@ def test_void_to_cat(cat_type):
 @pytest.mark.parametrize('cat_type', [dt.Type.cat8,
                                       dt.Type.cat16,
                                       dt.Type.cat32])
-def test_bool_to_cat(cat_type):
+def test_categorical_bool_to_cat(cat_type):
     src = [True, False, False, False, True, True]
     DT = dt.Frame(src)
     DT[0] = cat_type(dt.Type.bool8)
@@ -305,7 +305,7 @@ def test_bool_to_cat(cat_type):
                                   dt.Type.int16,
                                   dt.Type.int32,
                                   dt.Type.int64])
-def test_int_to_cat(cat_type, type):
+def test_categorical_int_to_cat(cat_type, type):
     src = [100, 500, 100500, 500, 100, 1]
     DT = dt.Frame(src, type=type)
     DT[0] = cat_type(type)
@@ -318,7 +318,7 @@ def test_int_to_cat(cat_type, type):
                                       dt.Type.cat32])
 @pytest.mark.parametrize('type', [dt.Type.float32,
                                   dt.Type.float64])
-def test_float_to_cat(cat_type, type):
+def test_categorical_float_to_cat(cat_type, type):
     src = [100.1, -3.14, 500.1, 100500.5, None, 100500900.9, None]
     DT = dt.Frame(src, type=type)
     DT[0] = cat_type(type)
@@ -331,7 +331,7 @@ def test_float_to_cat(cat_type, type):
                                       dt.Type.cat32])
 @pytest.mark.parametrize('type', [dt.Type.str32,
                                   dt.Type.str64])
-def test_str_to_cat(cat_type, type):
+def test_categorical_str_to_cat(cat_type, type):
     src = ["cat", "dog", "mouse", "dog", "mouse", "a"]
     DT = dt.Frame(src, type=type)
     DT[0] = cat_type(type)
@@ -344,7 +344,7 @@ def test_str_to_cat(cat_type, type):
                                       dt.Type.cat32])
 @pytest.mark.parametrize('type', [dt.Type.date32,
                                   dt.Type.time64])
-def test_datetime_to_cat(cat_type, type):
+def test_categorical_datetime_to_cat(cat_type, type):
     from datetime import datetime as d
     src = [d(1991, 1, 9, 10, 2, 3, 500),
            d(2014, 7, 2, 1, 3, 5, 100),
@@ -362,7 +362,7 @@ def test_datetime_to_cat(cat_type, type):
 @pytest.mark.parametrize('cat_type', [dt.Type.cat8,
                                       dt.Type.cat16,
                                       dt.Type.cat32])
-def test_obj_to_cat(cat_type):
+def test_categorical_obj_to_cat(cat_type):
     src = [None, "cat", "cat", "dog", "mouse", None, "panda", "dog"]
     DT = dt.Frame(A=src, type=object)
     DT['A'] = cat_type(dt.Type.str32)
@@ -373,7 +373,7 @@ def test_obj_to_cat(cat_type):
 @pytest.mark.parametrize('cat_type', [dt.Type.cat8,
                                       dt.Type.cat16,
                                       dt.Type.cat32])
-def test_str_to_cat_bool(cat_type):
+def test_categorical_str_to_cat_bool(cat_type):
     src = ["True", "weird", "False", "False", "None", "True", "True"]
     src_ref = [True, None, False, False, None, True, True]
     DT = dt.Frame(src)
@@ -385,7 +385,7 @@ def test_str_to_cat_bool(cat_type):
 @pytest.mark.parametrize('cat_type', [dt.Type.cat8,
                                       dt.Type.cat16,
                                       dt.Type.cat32])
-def test_bool_to_cat_str(cat_type):
+def test_categorical_bool_to_cat_str(cat_type):
     src = [True, None, False, False, None, True, True]
     src_ref = ["True", None, "False", "False", None, "True", "True"]
     DT = dt.Frame(src)
@@ -397,7 +397,7 @@ def test_bool_to_cat_str(cat_type):
 @pytest.mark.parametrize('cat_type', [dt.Type.cat8,
                                       dt.Type.cat16,
                                       dt.Type.cat32])
-def test_str_to_cat_int(cat_type):
+def test_categorical_str_to_cat_int(cat_type):
     src = ["weird", "500", "100500", None, "100500900"]
     src_ref = [None, 500, 100500, None, 100500900]
     DT = dt.Frame(src)
@@ -409,7 +409,7 @@ def test_str_to_cat_int(cat_type):
 @pytest.mark.parametrize('cat_type', [dt.Type.cat8,
                                       dt.Type.cat16,
                                       dt.Type.cat32])
-def test_int_to_cat_str(cat_type):
+def test_categorical_int_to_cat_str(cat_type):
     src = [None, 500, 100500, None, 100500900]
     src_ref = [None, "500", "100500", None, "100500900"]
     DT = dt.Frame(src)
@@ -421,7 +421,7 @@ def test_int_to_cat_str(cat_type):
 @pytest.mark.parametrize('cat_type', [dt.Type.cat8,
                                       dt.Type.cat16,
                                       dt.Type.cat32])
-def test_str_to_cat_float(cat_type):
+def test_categorical_str_to_cat_float(cat_type):
     src = ["100.1", "500.1", "100500.5", None, "100500900.9", "yeah"]
     src_ref = [100.1, 500.1, 100500.5, None, 100500900.9, None]
     DT = dt.Frame(src)
@@ -433,7 +433,7 @@ def test_str_to_cat_float(cat_type):
 @pytest.mark.parametrize('cat_type', [dt.Type.cat8,
                                       dt.Type.cat16,
                                       dt.Type.cat32])
-def test_float_to_cat_str(cat_type):
+def test_categorical_float_to_cat_str(cat_type):
     src = [100.1, 500.1, 100500.5, None, 100500900.9, None]
     src_ref = ["100.1", "500.1", "100500.5", None, "100500900.9", None]
     DT = dt.Frame(src)
@@ -451,7 +451,7 @@ def test_float_to_cat_str(cat_type):
                                       dt.Type.cat16,
                                       dt.Type.cat32])
 @pytest.mark.parametrize('data_type', [None, bool, int, float, str])
-def test_cast_to_void(cat_type, data_type):
+def test_categorical_cast_to_void(cat_type, data_type):
     src = [None] * 10
     DT = dt.Frame(src, type = cat_type(data_type))
     DT[0] = dt.Type.void
@@ -463,7 +463,7 @@ def test_cast_to_void(cat_type, data_type):
                                       dt.Type.cat16,
                                       dt.Type.cat32])
 @pytest.mark.parametrize('data_type', [bool, int, float, str])
-def test_cast_to_bool(cat_type, data_type):
+def test_categorical_cast_to_bool(cat_type, data_type):
     src = [None, True, False, None, False, False]
     DT = dt.Frame(src, type = cat_type(data_type))
     DT[0] = dt.Type.bool8
@@ -475,7 +475,7 @@ def test_cast_to_bool(cat_type, data_type):
                                       dt.Type.cat16,
                                       dt.Type.cat32])
 @pytest.mark.parametrize('data_type', [int, float, str])
-def test_cast_to_int(cat_type, data_type):
+def test_categorical_cast_to_int(cat_type, data_type):
     src = [3, None, 1, 4, 1, None, 5, 9, 2, 6]
     DT = dt.Frame(src, type = cat_type(data_type))
     DT[0] = dt.Type.int32
@@ -487,7 +487,7 @@ def test_cast_to_int(cat_type, data_type):
                                       dt.Type.cat16,
                                       dt.Type.cat32])
 @pytest.mark.parametrize('data_type', [float, str])
-def test_cast_to_float(cat_type, data_type):
+def test_categorical_cast_to_float(cat_type, data_type):
     src = [3.14, None, 1.15, 4.92, 1.6, None, 5.5, 9, 2.35, 6.0]
     DT = dt.Frame(src, type = cat_type(data_type))
     DT[0] = dt.Type.float64
@@ -499,7 +499,7 @@ def test_cast_to_float(cat_type, data_type):
                                       dt.Type.cat16,
                                       dt.Type.cat32])
 @pytest.mark.parametrize('data_type', [dt.Type.str32, dt.Type.str64])
-def test_cast_to_string(cat_type, data_type):
+def test_categorical_cast_to_string(cat_type, data_type):
     src = ["dog", "mouse", None, "dog", "cat", None, "1", "pig"]
     DT = dt.Frame(src, type = cat_type(data_type))
     DT[0] = dt.Type.str32
@@ -511,7 +511,7 @@ def test_cast_to_string(cat_type, data_type):
                                       dt.Type.cat16,
                                       dt.Type.cat32])
 @pytest.mark.parametrize('data_type', [str, dt.Type.date32, dt.Type.time64])
-def test_cast_to_date(cat_type, data_type):
+def test_categorical_cast_to_date(cat_type, data_type):
     from datetime import date as d
     src = [d(1997, 9, 1), d(2002, 7, 31), d(2000, 2, 20), None]
     DT = dt.Frame(src, type = cat_type(data_type))
@@ -524,7 +524,7 @@ def test_cast_to_date(cat_type, data_type):
                                       dt.Type.cat16,
                                       dt.Type.cat32])
 @pytest.mark.parametrize('data_type', [str, dt.Type.time64])
-def test_cast_to_time(cat_type, data_type):
+def test_categorical_cast_to_time(cat_type, data_type):
     from datetime import datetime as d
     src = [d(2000, 10, 18, 3, 30),
            d(2010, 11, 13, 15, 11, 59),
@@ -539,7 +539,7 @@ def test_cast_to_time(cat_type, data_type):
                                       dt.Type.cat16,
                                       dt.Type.cat32])
 @pytest.mark.parametrize('data_type', [int, float])
-def test_cast_to_obj(cat_type, data_type):
+def test_categorical_cast_to_obj(cat_type, data_type):
     src = [1, 2, None, 100, -10]
     DT = dt.Frame(src, type = cat_type(data_type))
     DT[0] = dt.Type.obj64
@@ -555,7 +555,7 @@ def test_cast_to_obj(cat_type, data_type):
 @pytest.mark.parametrize('t', [dt.Type.cat8,
                                dt.Type.cat16,
                                dt.Type.cat32])
-def test_repr_strings_in_terminal(t):
+def test_categorical_repr_strings_in_terminal(t):
     tcat = t(dt.Type.str32)
     DT = dt.Frame(Animals=["cat", "dog", None, "cat", "guinea piglet"],
                   types = [tcat])
@@ -576,7 +576,7 @@ def test_repr_strings_in_terminal(t):
 @pytest.mark.parametrize('t', [dt.Type.cat8,
                                dt.Type.cat16,
                                dt.Type.cat32])
-def test_repr_numbers_in_terminal(t):
+def test_categorical_repr_numbers_in_terminal(t):
     tcat = t(dt.Type.int32)
     DT = dt.Frame(Prime_Numbers=[3, 5, None, 47, 7],
                   types = [tcat])
@@ -599,7 +599,7 @@ def test_repr_numbers_in_terminal(t):
 # Categories
 #-------------------------------------------------------------------------------
 
-def test_categories_wrong_type():
+def test_categorical_categories_wrong_type():
     DT = dt.Frame(range(10))
     msg = r"Invalid column of type int32 in categories\(f\.C0\)"
     with pytest.raises(TypeError, match=msg):
@@ -609,7 +609,7 @@ def test_categories_wrong_type():
 @pytest.mark.parametrize('cat_type', [dt.Type.cat8,
                                       dt.Type.cat16,
                                       dt.Type.cat32])
-def test_categories_zero_rows(cat_type):
+def test_categorical_categories_zero_rows(cat_type):
     src = [[]]
     data_type = dt.Type.int32
     DT = dt.Frame(src, type=cat_type(data_type))
@@ -621,7 +621,7 @@ def test_categories_zero_rows(cat_type):
 @pytest.mark.parametrize('cat_type', [dt.Type.cat8,
                                       dt.Type.cat16,
                                       dt.Type.cat32])
-def test_categories_zero_rows_casted(cat_type):
+def test_categorical_categories_zero_rows_casted(cat_type):
     src = [[]]
     DT = dt.Frame(src)
     DT[0] = cat_type(dt.Type.void)
@@ -633,7 +633,7 @@ def test_categories_zero_rows_casted(cat_type):
 @pytest.mark.parametrize('cat_type', [dt.Type.cat8,
                                       dt.Type.cat16,
                                       dt.Type.cat32])
-def test_categories_void(cat_type):
+def test_categorical_categories_void(cat_type):
     src = [None] * 11
     DT = dt.Frame(src, type=cat_type(dt.Type.void))
     DT_cats = DT[:, dt.categories(f[:])]
@@ -644,7 +644,7 @@ def test_categories_void(cat_type):
 @pytest.mark.parametrize('cat_type', [dt.Type.cat8,
                                       dt.Type.cat16,
                                       dt.Type.cat32])
-def test_categories_one_column(cat_type):
+def test_categorical_categories_one_column(cat_type):
     src = [None, "cat", "dog", None, "mouse", "cat"] * 7
     DT = dt.Frame([src], type=cat_type(dt.Type.str32))
     DT_cats = DT[:, dt.categories(f.C0)]
@@ -655,7 +655,7 @@ def test_categories_one_column(cat_type):
 @pytest.mark.parametrize('cat_type', [dt.Type.cat8,
                                       dt.Type.cat16,
                                       dt.Type.cat32])
-def test_categories_one_column_plus_orig(cat_type):
+def test_categorical_categories_one_column_plus_orig(cat_type):
     src = [None, "cat", "dog", None, "mouse", "cat"]
     DT = dt.Frame([src], type=cat_type(dt.Type.str32))
     DT_cats = DT[:, [f.C0, dt.categories(f.C0)]]
@@ -668,7 +668,7 @@ def test_categories_one_column_plus_orig(cat_type):
 @pytest.mark.parametrize('cat_type', [dt.Type.cat8,
                                       dt.Type.cat16,
                                       dt.Type.cat32])
-def test_categories_multicolumn_even_ncats(cat_type):
+def test_categorical_categories_multicolumn_even_ncats(cat_type):
     src_int = [None, 100, 500, None, 100, 100500, 100, 500]
     src_str = [None, "dog", "mouse", None, "dog", "cat", "dog", "mouse"]
     DT = dt.Frame([src_int, src_str],
@@ -682,7 +682,7 @@ def test_categories_multicolumn_even_ncats(cat_type):
 @pytest.mark.parametrize('cat_type', [dt.Type.cat8,
                                       dt.Type.cat16,
                                       dt.Type.cat32])
-def test_categories_multicolumn_uneven_ncats(cat_type):
+def test_categorical_categories_multicolumn_uneven_ncats(cat_type):
     src_int = [None, 100, 500, None, 100, 100500, 100, 500]
     src_str = [None, "dog", None, None, "dog", "cat", "dog", None]
     DT = dt.Frame([src_int, src_str],
@@ -697,7 +697,7 @@ def test_categories_multicolumn_uneven_ncats(cat_type):
 # Codes
 #-------------------------------------------------------------------------------
 
-def test_codes_wrong_type():
+def test_categorical_codes_wrong_type():
     DT = dt.Frame(range(10))
     msg = r"Invalid column of type int32 in codes\(f\.C0\)"
     with pytest.raises(TypeError, match=msg):
@@ -707,7 +707,7 @@ def test_codes_wrong_type():
 @pytest.mark.parametrize('cat_type, code_type', [(dt.Type.cat8, dt.Type.int8),
                                                  (dt.Type.cat16, dt.Type.int16),
                                                  (dt.Type.cat32, dt.Type.int32)])
-def test_codes_void(cat_type, code_type):
+def test_categorical_codes_void(cat_type, code_type):
     N = 11
     src = [None] * N
     DT = dt.Frame(src, type=cat_type(dt.Type.void))
@@ -719,7 +719,7 @@ def test_codes_void(cat_type, code_type):
 @pytest.mark.parametrize('cat_type, code_type', [(dt.Type.cat8, dt.Type.int8),
                                                  (dt.Type.cat16, dt.Type.int16),
                                                  (dt.Type.cat32, dt.Type.int32)])
-def test_codes_simple(cat_type, code_type):
+def test_categorical_codes_simple(cat_type, code_type):
     src = ["cat", "dog", "mouse", "cat"]
     DT = dt.Frame([src], type=cat_type(dt.Type.str32))
     DT_codes = DT[:, dt.codes(f.C0)]
@@ -730,7 +730,7 @@ def test_codes_simple(cat_type, code_type):
 @pytest.mark.parametrize('cat_type, code_type', [(dt.Type.cat8, dt.Type.int8),
                                                  (dt.Type.cat16, dt.Type.int16),
                                                  (dt.Type.cat32, dt.Type.int32)])
-def test_codes_multicolumn(cat_type, code_type):
+def test_categorical_codes_multicolumn(cat_type, code_type):
     N = 123
     src_int = [None, 100, 500, None, 100, 100500, 100, 500] * N
     src_str = [None, "dog", "mouse", None, "dog", "cat", "dog", "pig"] * N
@@ -742,3 +742,64 @@ def test_codes_multicolumn(cat_type, code_type):
     assert_equals(DT_codes, DT_ref)
 
 
+#-------------------------------------------------------------------------------
+# Statistics
+#-------------------------------------------------------------------------------
+
+def test_categorical_minmax():
+    src = [None, 100, 500, -100500, None, 3, 2, -100, None, 0]
+    DT = dt.Frame(src, type=dt.Type.cat8(dt.Type.int32))
+    assert DT.min1() == -100500
+    assert DT.max1() == 500
+    assert DT.countna1() == 3
+    assert_equals(DT.min(), dt.Frame([-100500]))
+    assert_equals(DT.max(), dt.Frame([500]))
+    assert_equals(DT.countna(), dt.Frame([3]/dt.int64))
+
+
+def test_categorical_na_stats():
+    src = [None, None, "cat", "cat", None, "cat", "This is", "a", "B", None]
+    DT = dt.Frame(src, type=dt.Type.cat8(dt.Type.str32))
+    assert DT.sd1() is None
+    assert DT.sum1() is None
+    assert_equals(DT.sd(), dt.Frame([None]/dt.float64))
+    assert_equals(DT.sum(), dt.Frame([None]/dt.float64))
+
+
+def test_categorical_mean():
+    src = [None, 10, 5, -5, 0, None]
+    DT = dt.Frame(src, type=dt.Type.cat8(dt.Type.int64))
+    assert DT.mean1() ==  2.5
+    assert_equals(DT.mean(), dt.Frame([2.5]/dt.float64))
+
+
+# def test_categorical_mode():
+#     src = [None, 3.0, -14.1, .15, None, .92, 6, -14.1, None, 0]
+#     DT = dt.Frame(src, type=dt.Type.cat8(dt.Type.float32))
+#     assert DT.mode1() == -14.1
+#     assert DT.nmodal1() == 2
+#     assert_equals(DT.mode(), dt.Frame([-14.1]))
+#     assert_equals(DT.nmodal(), dt.Frame([2]/dt.int64))
+
+
+def test_categorical_nunique():
+    src = [None, None, "cat", "cat", None, "cat", "This is", "a", "B", None]
+    DT = dt.Frame(src, type=dt.Type.cat8(dt.Type.str32))
+    assert DT.nunique1() == 4
+    assert_equals(DT.nunique(), dt.Frame([4]/dt.int64))
+
+
+def test_categorical_skew():
+    src = [None, 100, 500, -100500, None, 3, 2, -100, None, 0]
+    DT_cat = dt.Frame(src, type=dt.Type.cat8(dt.Type.int32))
+    DT_int = DT_cat[:, dt.int32(f[0])]
+    assert DT_cat.skew1() == DT_int.skew1()
+    assert_equals(DT_cat.skew(), DT_int.skew())
+
+
+def test_categorical_kurt():
+    src = [None, 100, 500, -100500, None, 3, 2, -100, None, 0]
+    DT_cat = dt.Frame(src, type=dt.Type.cat8(dt.Type.int32))
+    DT_int = DT_cat[:, dt.int32(f[0])]
+    assert DT_cat.kurt1() == DT_int.kurt1()
+    assert_equals(DT_cat.kurt(), DT_int.kurt())


### PR DESCRIPTION
Implement most of the statistical functions for categorical columns. Once we implement sorting of categorical columns, we could add the missing `dt.mode()`.

WIP for https://github.com/h2oai/datatable/issues/1691