### PR TITLE
ci/ext.py: drop explicit `-m64` to fix build on exotic archs

### DIFF
--- a/ci/ext.py
+++ b/ci/ext.py
@@ -294,7 +294,6 @@ def build_extension(cmd, verbosity=3):
         # Common link flags
         ext.compiler.add_linker_flag("-shared")
         ext.compiler.add_linker_flag("-g")
-        ext.compiler.add_linker_flag("-m64")
         if macos:
             ext.compiler.add_linker_flag("-undefined", "dynamic_lookup")
         if linux:


### PR DESCRIPTION
nixpkgs builds with this change [here](https://github.com/NixOS/nixpkgs/blob/38164d1660dcc24b41a5a22f1e9ef075a8e26714/pkgs/development/python-modules/datatable/default.nix#L33), but it seems like this has not made it to upstream yet.