### PR TITLE
Update documentation regarding removal of python 3.6

### DIFF
--- a/docs/api/frame/to_dict.rst
+++ b/docs/api/frame/to_dict.rst
@@ -6,7 +6,7 @@
 
     Convert the frame into a dictionary of lists, by columns.
 
-    In Python 3.6+ the order of records in the dictionary will be the
+    The order of records in the dictionary will be the
     same as the order of columns in the frame.
 
     Parameters

--- a/docs/releases/v1.1.0.rst
+++ b/docs/releases/v1.1.0.rst
@@ -177,6 +177,11 @@
     General
     -------
 
+    -[api] Datatable no longer supports Python 3.6, because Python 3.6 itself
+      has reached its end of life on 2021-12-21 and will no longer be
+      supported. If you are still using Python 3.6, please consider upgrading.
+      [#3376]
+
     -[new] Added properties :attr:`.is_array <dt.Type.is_array>`,
         :attr:`.is_boolean <dt.Type.is_boolean>`,
         :attr:`.is_categorical <dt.Type.is_categorical>`,

--- a/docs/releases/v1.1.0.rst
+++ b/docs/releases/v1.1.0.rst
@@ -178,7 +178,7 @@
     -------
 
     -[api] Datatable no longer supports Python 3.6, because Python 3.6 itself
-      has reached its end of life on 2021-12-21 and will no longer be
+      has reached its end of life on 2021-12-23 and will no longer be
       supported. If you are still using Python 3.6, please consider upgrading.
       [#3376]
 

--- a/docs/start/install.rst
+++ b/docs/start/install.rst
@@ -9,14 +9,13 @@ This page describes how to install ``datatable`` on various systems.
 Prerequisites
 -------------
 
-Python 3.6+ is required. Generally, we will support each version of Python
+Python 3.7+ is required. Generally, we will support each version of Python
 until its official `end of life`_. You can verify your python version via
 
 .. code-block:: console
 
     $ python --version
-    Python 3.6.6
-
+    Python 3.7.10
 
 In addition, we recommend using ``pip`` version 20.3+, especially if you're
 planning to install datatable from the source, or if you are on a Unix machine.
@@ -234,7 +233,7 @@ know how to resolve them. If none of these help you, please ask a question on
 ``Python.h: no such file or directory`` when compiling from source
   Your Python distribution was shipped without the ``Python.h`` header file.
   This has been observed on certain Linux machines. You would need to install
-  a Python package with a ``-dev`` suffix, for example ``python3.6-dev``.
+  a Python package with a ``-dev`` suffix, for example ``python3.7-dev``.
 
 ``fatal error: 'sys/mman.h' file not found`` on macOS
   In order to compile from source on mac computers, you need to have Xcode


### PR DESCRIPTION
Since python `3.6` reached its end of life, update documentation to `3.7+`.

Closes #3376 