### PR TITLE
[ENH] Add `reverse` parameter to `cumsum()`, `cumprod()`, `cummin()` and `cummax()`

### DIFF
--- a/docs/api/dt/cummax.rst
+++ b/docs/api/dt/cummax.rst
@@ -3,12 +3,12 @@
     :src: src/core/expr/fexpr_cumminmax.cc pyfn_cummax
     :tests: tests/dt/test-cumminmax.py
     :cvar: doc_dt_cummax
-    :signature: cummax(cols)
+    :signature: cummax(cols, reverse=False)
 
     .. x-version-added:: 1.1.0
 
-    For each column from `cols` calculate cumulative maximum. In the presence of :func:`by()`,
-    the cumulative maximum is computed within each group.
+    For each column from `cols` calculate cumulative maximum. In the presence
+    of :func:`by()`, the cumulative maximum is computed within each group.
 
     Parameters
     ----------
@@ -16,9 +16,8 @@
         Input data for cumulative maximum calculation.
 
     reverse: bool
-        If ``False``, the cumulative maximum is computed from the last row
-        to the first row. if ``True``, the cumulative maximum is computed 
-        from the first row to the last row.
+        If ``False``, computation is done from top to bottom.
+        If ``True``, it is done from bottom to top.
 
     return: FExpr
         f-expression that converts input columns into the columns filled
@@ -64,7 +63,7 @@
         [5 rows x 1 column]
         
 
-    Calculate the cumulative maximum when `reverse` is `True`::
+    Calculate the cumulative maximum from bottom to top::
 
         >>> DT[:, dt.cummax(f.A, reverse=True)]
            |     A
@@ -92,7 +91,7 @@
         [5 rows x 3 columns]
 
 
-    In the presence of :func:`by()` calculate the cumulative maximum within each group::
+    For a grouped frame calculate the cumulative maximum within each group::
 
         >>> DT[:, dt.cummax(f[:]), by('D')]
            | D          A     B        C

--- a/docs/api/dt/cummax.rst
+++ b/docs/api/dt/cummax.rst
@@ -15,6 +15,11 @@
     cols: FExpr
         Input data for cumulative maximum calculation.
 
+    reverse: bool
+        If ``False``, the cumulative maximum is computed from the last row
+        to the first row. if ``True``, the cumulative maximum is computed 
+        from the first row to the last row.
+
     return: FExpr
         f-expression that converts input columns into the columns filled
         with the respective cumulative maximums.
@@ -56,6 +61,20 @@
          2 |     5
          3 |     5
          4 |     5
+        [5 rows x 1 column]
+        
+
+    Calculate the cumulative maximum when `reverse` is `True`::
+
+        >>> DT[:, dt.cummax(f.A, reverse=True)]
+           |     A
+           | int32
+        -- + -----
+         0 |     5
+         1 |     5
+         2 |     5
+         3 |     0
+         4 |     0
         [5 rows x 1 column]
 
 

--- a/docs/api/dt/cummin.rst
+++ b/docs/api/dt/cummin.rst
@@ -3,7 +3,7 @@
     :src: src/core/expr/fexpr_cumminmax.cc pyfn_cummin
     :tests: tests/dt/test-cumminmax.py
     :cvar: doc_dt_cummin
-    :signature: cummin(cols)
+    :signature: cummin(cols, reverse=False)
 
     .. x-version-added:: 1.1.0
 
@@ -16,9 +16,8 @@
         Input data for cumulative minimum calculation.
 
     reverse: bool
-        If ``False``, the cumulative minimum is computed from the last row
-        to the first row. if ``True``, the cumulative minimum is computed 
-        from the first row to the last row.
+        If ``False``, computation is done from top to bottom.
+        If ``True``, it is done from bottom to top.
 
     return: FExpr
         f-expression that converts input columns into the columns filled
@@ -64,7 +63,7 @@
         [5 rows x 1 column]
         
 
-    Calculate the cumulative minimum when `reverse` is `True`::
+    Calculate the cumulative minimum from bottom to top::
 
         >>> DT[:, dt.cummin(f.A, reverse=True)]
            |     A
@@ -92,7 +91,7 @@
         [5 rows x 3 columns]
 
 
-    In the presence of :func:`by()` calculate the cumulative minimum within each group::
+    For a grouped frame calculate the cumulative minimum within each group::
 
         >>> DT[:, dt.cummin(f[:]), by('D')]
            | D          A     B        C

--- a/docs/api/dt/cummin.rst
+++ b/docs/api/dt/cummin.rst
@@ -15,6 +15,11 @@
     cols: FExpr
         Input data for cumulative minimum calculation.
 
+    reverse: bool
+        If ``False``, the cumulative minimum is computed from the last row
+        to the first row. if ``True``, the cumulative minimum is computed 
+        from the first row to the last row.
+
     return: FExpr
         f-expression that converts input columns into the columns filled
         with the respective cumulative minimums.
@@ -56,6 +61,20 @@
          2 |     2
          3 |    -1
          4 |    -1
+        [5 rows x 1 column]
+        
+
+    Calculate the cumulative minimum when `reverse` is `True`::
+
+        >>> DT[:, dt.cummin(f.A, reverse=True)]
+           |     A
+           | int32
+        -- + -----
+         0 |    -1
+         1 |    -1
+         2 |    -1
+         3 |    -1
+         4 |     0
         [5 rows x 1 column]
 
 

--- a/docs/api/dt/cumprod.rst
+++ b/docs/api/dt/cumprod.rst
@@ -16,6 +16,11 @@
     cols: FExpr
         Input data for cumulative product calculation.
 
+    reverse: bool
+        If ``False``, the cumulative product is computed from the last row
+        to the first row. if ``True``, the cumulative product is computed 
+        from the first row to the last row.
+        
     return: FExpr
         f-expression that converts input columns into the columns filled
         with the respective cumulative products.
@@ -56,6 +61,20 @@
          1 |     2
          2 |    10
          3 |   -10
+         4 |     0
+        [5 rows x 1 column]
+        
+
+    Calculate the cumulative product when `reverse` is `True`::
+
+        >>> DT[:, dt.cumprod(f.A, reverse=True)]
+           |     A
+           | int64
+        -- + -----
+         0 |     0
+         1 |     0
+         2 |     0
+         3 |     0
          4 |     0
         [5 rows x 1 column]
 

--- a/docs/api/dt/cumprod.rst
+++ b/docs/api/dt/cumprod.rst
@@ -3,7 +3,7 @@
     :src: src/core/expr/fexpr_cumsumprod.cc pyfn_cumprod
     :tests: tests/dt/test-cumprod.py
     :cvar: doc_dt_cumprod
-    :signature: cumprod(cols)
+    :signature: cumprod(cols, reverse=False)
 
     .. x-version-added:: 1.1.0
 
@@ -17,9 +17,8 @@
         Input data for cumulative product calculation.
 
     reverse: bool
-        If ``False``, the cumulative product is computed from the last row
-        to the first row. if ``True``, the cumulative product is computed 
-        from the first row to the last row.
+        If ``False``, computation is done from top to bottom.
+        If ``True``, it is done from bottom to top.
         
     return: FExpr
         f-expression that converts input columns into the columns filled
@@ -65,7 +64,7 @@
         [5 rows x 1 column]
         
 
-    Calculate the cumulative product when `reverse` is `True`::
+    Calculate the cumulative product from bottom to top::
 
         >>> DT[:, dt.cumprod(f.A, reverse=True)]
            |     A
@@ -93,7 +92,7 @@
         [5 rows x 3 columns]
 
 
-    In the presence of :func:`by()` calculate cumulative products within each group::
+    For a grouped frame calculate cumulative products within each group::
 
         >>> DT[:, dt.cumprod(f[:]), by('D')]
            | D          A      B        C

--- a/docs/api/dt/cumsum.rst
+++ b/docs/api/dt/cumsum.rst
@@ -16,6 +16,11 @@
     cols: FExpr
         Input data for cumulative sum calculation.
 
+    reverse: bool
+        If ``False``, the cumulative sum is computed from the last row
+        to the first row. if ``True``, the cumulative sum is computed 
+        from the first row to the last row.
+
     return: FExpr
         f-expression that converts input columns into the columns filled
         with the respective cumulative sums.
@@ -59,6 +64,20 @@
          4 |     6
         [5 rows x 1 column]
 
+
+    Calculate the cumulative sum when `reverse` is `True`::
+
+        >>> DT[:, dt.cumsum(f.A, reverse=True)]
+           |     A
+           | int64
+        -- + -----
+         0 |     6
+         1 |     4
+         2 |     4
+         3 |    -1
+         4 |     0
+        [5 rows x 1 column]
+        
 
     Calculate cumulative sums in multiple columns::
 

--- a/docs/api/dt/cumsum.rst
+++ b/docs/api/dt/cumsum.rst
@@ -3,7 +3,7 @@
     :src: src/core/expr/fexpr_cumsumprod.cc pyfn_cumsum
     :tests: tests/dt/test-cumsum.py
     :cvar: doc_dt_cumsum
-    :signature: cumsum(cols)
+    :signature: cumsum(cols, reverse=False)
 
     .. x-version-added:: 1.1.0
 
@@ -17,9 +17,8 @@
         Input data for cumulative sum calculation.
 
     reverse: bool
-        If ``False``, the cumulative sum is computed from the last row
-        to the first row. if ``True``, the cumulative sum is computed 
-        from the first row to the last row.
+        If ``False``, computation is done from top to bottom.
+        If ``True``, it is done from bottom to top.
 
     return: FExpr
         f-expression that converts input columns into the columns filled
@@ -65,7 +64,7 @@
         [5 rows x 1 column]
 
 
-    Calculate the cumulative sum when `reverse` is `True`::
+    Calculate the cumulative sum from bottom to top::
 
         >>> DT[:, dt.cumsum(f.A, reverse=True)]
            |     A
@@ -93,7 +92,7 @@
         [5 rows x 3 columns]
 
 
-    In the presence of :func:`by()` calculate cumulative sums within each group::
+    For a grouped frame calculate cumulative sums within each group::
 
         >>> DT[:, dt.cumsum(f[:]), by('D')]
            | D          A      B        C

--- a/src/core/column/cumminmax.h
+++ b/src/core/column/cumminmax.h
@@ -29,7 +29,7 @@
 namespace dt {
 
 
-template <typename T, bool MIN>
+template <typename T, bool MIN, bool REVERSE>
 class CumMinMax_ColumnImpl : public Virtual_ColumnImpl {
   private:
     Column col_;
@@ -57,24 +57,42 @@ class CumMinMax_ColumnImpl : public Virtual_ColumnImpl {
         [&](size_t gi) {
           size_t i1 = size_t(offsets[gi]);
           size_t i2 = size_t(offsets[gi + 1]);
-
+        if (REVERSE) {
           T val;
-          bool res_valid = col_.get_element(i1, &val);
-          data[i1] = res_valid? val : GETNA<T>();
-
-          for (size_t i = i1 + 1; i < i2; ++i) {
+          bool res_valid = col_.get_element(i2-1, &val);
+          data[i2-1] = res_valid? val : GETNA<T>();
+          for (size_t i = i2-1; i-- > i1;) {
             bool is_valid = col_.get_element(i, &val);
             if (is_valid) {
               if (MIN) {
-                data[i] = (res_valid && data[i - 1] < val)? data[i - 1] : val;
+                data[i] = (res_valid && data[i + 1] < val)? data[i + 1] : val;
               } else {
-                data[i] = (res_valid && data[i - 1] > val)? data[i - 1] : val;
+                data[i] = (res_valid && data[i + 1] > val)? data[i + 1] : val;
               }
               res_valid = true;
             } else {
-              data[i] = data[i - 1];
+              data[i] = data[i + 1];
             }
-          }
+            }
+        } else {
+            T val;
+            bool res_valid = col_.get_element(i1, &val);
+            data[i1] = res_valid? val : GETNA<T>();
+  
+            for (size_t i = i1 + 1; i < i2; ++i) {
+              bool is_valid = col_.get_element(i, &val);
+              if (is_valid) {
+                if (MIN) {
+                  data[i] = (res_valid && data[i - 1] < val)? data[i - 1] : val;
+                } else {
+                  data[i] = (res_valid && data[i - 1] > val)? data[i - 1] : val;
+                }
+                res_valid = true;
+              } else {
+                data[i] = data[i - 1];
+              }
+            }}
+          
           
 
         });

--- a/src/core/column/cumminmax.h
+++ b/src/core/column/cumminmax.h
@@ -57,28 +57,29 @@ class CumMinMax_ColumnImpl : public Virtual_ColumnImpl {
         [&](size_t gi) {
           size_t i1 = size_t(offsets[gi]);
           size_t i2 = size_t(offsets[gi + 1]);
-        if (REVERSE) {
           T val;
-          bool res_valid = col_.get_element(i2-1, &val);
-          data[i2-1] = res_valid? val : GETNA<T>();
-          for (size_t i = i2-1; i-- > i1;) {
-            bool is_valid = col_.get_element(i, &val);
-            if (is_valid) {
-              if (MIN) {
-                data[i] = (res_valid && data[i + 1] < val)? data[i + 1] : val;
+
+          if (REVERSE) {
+            bool res_valid = col_.get_element(i2 - 1, &val);
+            data[i2 - 1] = res_valid? val : GETNA<T>();
+
+            for (size_t i = i2 - 1; i-- > i1;) {
+              bool is_valid = col_.get_element(i, &val);
+              if (is_valid) {
+                if (MIN) {
+                  data[i] = (res_valid && data[i + 1] < val)? data[i + 1] : val;
+                } else {
+                  data[i] = (res_valid && data[i + 1] > val)? data[i + 1] : val;
+                }
+                res_valid = true;
               } else {
-                data[i] = (res_valid && data[i + 1] > val)? data[i + 1] : val;
+                data[i] = data[i + 1];
               }
-              res_valid = true;
-            } else {
-              data[i] = data[i + 1];
             }
-            }
-        } else {
-            T val;
+          } else {
             bool res_valid = col_.get_element(i1, &val);
             data[i1] = res_valid? val : GETNA<T>();
-  
+
             for (size_t i = i1 + 1; i < i2; ++i) {
               bool is_valid = col_.get_element(i, &val);
               if (is_valid) {
@@ -91,9 +92,8 @@ class CumMinMax_ColumnImpl : public Virtual_ColumnImpl {
               } else {
                 data[i] = data[i - 1];
               }
-            }}
-          
-          
+            }
+          }
 
         });
 
@@ -105,9 +105,11 @@ class CumMinMax_ColumnImpl : public Virtual_ColumnImpl {
       return new CumMinMax_ColumnImpl(Column(col_), gby_);
     }
 
+
     size_t n_children() const noexcept override {
       return 1;
     }
+
 
     const Column& child(size_t i) const override {
       xassert(i == 0);  (void)i;

--- a/src/core/column/cumsumprod.h
+++ b/src/core/column/cumsumprod.h
@@ -44,6 +44,7 @@ namespace dt {
       xassert(col_.can_be_read_as<T>());
     }
 
+
     void materialize(Column &col_out, bool) override {
       Latent_ColumnImpl::vivify<T>(col_);
       Column col = Column::new_data_column(col_.nrows(), col_.stype());
@@ -51,30 +52,28 @@ namespace dt {
 
       auto offsets = gby_.offsets_r();
       dt::parallel_for_dynamic(
-          gby_.size(),
-          [&](size_t gi) {
-            size_t i1 = size_t(offsets[gi]);
-            size_t i2 = size_t(offsets[gi + 1]);
+        gby_.size(),
+        [&](size_t gi) {
+          size_t i1 = size_t(offsets[gi]);
+          size_t i2 = size_t(offsets[gi + 1]);
+          T val;
 
           if (REVERSE) {
-            T val;
-            bool is_valid = col_.get_element(i2-1, &val);
+            bool is_valid = col_.get_element(i2 - 1, &val);
             if (SUM) {
-                  data[i2-1] = is_valid? val : 0;
-                } else {
-                  data[i2-1] = is_valid? val : 1;
-                }
-            for (size_t i = i2-1; i-- > i1;) {
-              bool is_valid = col_.get_element(i, &val);
+              data[i2 - 1] = is_valid? val : 0;
+            } else {
+              data[i2 - 1] = is_valid? val : 1;
+            }
+            for (size_t i = i2 - 1; i-- > i1;) {
+              is_valid = col_.get_element(i, &val);
               if (SUM) {
                 data[i] = data[i + 1] + (is_valid? val : 0);
               } else {
                 data[i] = data[i + 1] * (is_valid? val : 1);
               }
-              
-              }
+            }
           } else {
-            T val;
             bool is_valid = col_.get_element(i1, &val);
             if (SUM) {
               data[i1] = is_valid? val : 0;
@@ -89,19 +88,23 @@ namespace dt {
                 data[i] = data[i - 1] * (is_valid? val : 1);
               }
             }
-              }}
-          );
+          }
+        }
+      );
 
       col_out = std::move(col);
     }
+
 
     ColumnImpl *clone() const override {
       return new CumSumProd_ColumnImpl(Column(col_), gby_);
     }
 
+
     size_t n_children() const noexcept override {
       return 1;
     }
+
 
     const Column &child(size_t i) const override {
       xassert(i == 0);

--- a/src/core/column/cumsumprod.h
+++ b/src/core/column/cumsumprod.h
@@ -29,7 +29,7 @@
 
 namespace dt {
 
-  template <typename T, bool SUM>
+  template <typename T, bool SUM, bool REVERSE>
   class CumSumProd_ColumnImpl : public Virtual_ColumnImpl {
   private:
     Column col_;
@@ -56,6 +56,24 @@ namespace dt {
             size_t i1 = size_t(offsets[gi]);
             size_t i2 = size_t(offsets[gi + 1]);
 
+          if (REVERSE) {
+            T val;
+            bool is_valid = col_.get_element(i2-1, &val);
+            if (SUM) {
+                  data[i2-1] = is_valid? val : 0;
+                } else {
+                  data[i2-1] = is_valid? val : 1;
+                }
+            for (size_t i = i2-1; i-- > i1;) {
+              bool is_valid = col_.get_element(i, &val);
+              if (SUM) {
+                data[i] = data[i + 1] + (is_valid? val : 0);
+              } else {
+                data[i] = data[i + 1] * (is_valid? val : 1);
+              }
+              
+              }
+          } else {
             T val;
             bool is_valid = col_.get_element(i1, &val);
             if (SUM) {
@@ -71,7 +89,8 @@ namespace dt {
                 data[i] = data[i - 1] * (is_valid? val : 1);
               }
             }
-          });
+              }}
+          );
 
       col_out = std::move(col);
     }

--- a/src/core/expr/fexpr.cc
+++ b/src/core/expr/fexpr.cc
@@ -420,24 +420,32 @@ DECLARE_METHOD(&PyFExpr::cummin)
     ->n_required_args(0);
 
 
-oobj PyFExpr::cumprod(const XArgs&) {
+oobj PyFExpr::cumprod(const XArgs& args) {
   auto cumprodFn = oobj::import("datatable", "cumprod");
-  return cumprodFn.call({this});
+  oobj reverse = args[0]? args[0].to_oobj() : py::obool(false);
+  return cumprodFn.call({this, reverse});
 }
 
 DECLARE_METHOD(&PyFExpr::cumprod)
     ->name("cumprod")
-    ->docs(dt::doc_FExpr_cumprod);
+    ->docs(dt::doc_FExpr_cumprod)
+    ->arg_names({"reverse"})
+    ->n_positional_or_keyword_args(1)
+    ->n_required_args(0);
 
 
-oobj PyFExpr::cumsum(const XArgs&) {
+oobj PyFExpr::cumsum(const XArgs& args) {
   auto cumsumFn = oobj::import("datatable", "cumsum");
-  return cumsumFn.call({this});
+  oobj reverse = args[0]? args[0].to_oobj() : py::obool(false);
+  return cumsumFn.call({this, reverse});
 }
 
 DECLARE_METHOD(&PyFExpr::cumsum)
     ->name("cumsum")
-    ->docs(dt::doc_FExpr_cumsum);
+    ->docs(dt::doc_FExpr_cumsum)
+    ->arg_names({"reverse"})
+    ->n_positional_or_keyword_args(1)
+    ->n_required_args(0);
 
 
 

--- a/src/core/expr/fexpr.cc
+++ b/src/core/expr/fexpr.cc
@@ -392,23 +392,33 @@ DECLARE_METHOD(&PyFExpr::countna)
     ->name("countna")
     ->docs(dt::doc_FExpr_countna);
 
-oobj PyFExpr::cummax(const XArgs&) {
+oobj PyFExpr::cummax(const XArgs& args) {
   auto cummaxFn = oobj::import("datatable", "cummax");
-  return cummaxFn.call({this});
+  oobj reverse = args[0]? args[0].to_oobj() : py::obool(false);
+  return cummaxFn.call({this, reverse});
 }
 
 DECLARE_METHOD(&PyFExpr::cummax)
     ->name("cummax")
-    ->docs(dt::doc_FExpr_cummax);
+    ->docs(dt::doc_FExpr_cummax)
+    ->arg_names({"reverse"})
+    ->n_positional_or_keyword_args(1)
+    ->n_required_args(0);
 
-oobj PyFExpr::cummin(const XArgs&) {
+
+oobj PyFExpr::cummin(const XArgs& args) {
   auto cumminFn = oobj::import("datatable", "cummin");
-  return cumminFn.call({this});
+  oobj reverse = args[0]? args[0].to_oobj() : py::obool(false);
+  return cumminFn.call({this, reverse});
 }
 
 DECLARE_METHOD(&PyFExpr::cummin)
     ->name("cummin")
-    ->docs(dt::doc_FExpr_cummin);
+    ->docs(dt::doc_FExpr_cummin)
+    ->arg_names({"reverse"})
+    ->n_positional_or_keyword_args(1)
+    ->n_required_args(0);
+
 
 oobj PyFExpr::cumprod(const XArgs&) {
   auto cumprodFn = oobj::import("datatable", "cumprod");

--- a/src/core/expr/fexpr_cumminmax.cc
+++ b/src/core/expr/fexpr_cumminmax.cc
@@ -113,7 +113,7 @@ class FExpr_CumMinMax : public FExpr_Func {
 
 static py::oobj pyfn_cummax(const py::XArgs& args) {
   auto cummax = args[0].to_oobj();
-  auto reverse = args[1].to<bool>(false);
+  bool reverse = args[1].to<bool>(false);
   if (reverse) {
     return PyFExpr::make(new FExpr_CumMinMax<false, true>(as_fexpr(cummax)));
   } else {
@@ -124,7 +124,7 @@ static py::oobj pyfn_cummax(const py::XArgs& args) {
 
 static py::oobj pyfn_cummin(const py::XArgs& args) {
   auto cummin = args[0].to_oobj();
-  auto reverse = args[1].to<bool>(false);
+  bool reverse = args[1].to<bool>(false);
   if (reverse) {
     return PyFExpr::make(new FExpr_CumMinMax<true, true>(as_fexpr(cummin)));
   } else {

--- a/src/core/expr/fexpr_cumsumprod.cc
+++ b/src/core/expr/fexpr_cumsumprod.cc
@@ -107,7 +107,7 @@ class FExpr_CumSumProd : public FExpr_Func {
 
 static py::oobj pyfn_cumsum(const py::XArgs &args) {
   auto cumsum = args[0].to_oobj();
-  auto reverse = args[1].to<bool>(false);
+  bool reverse = args[1].to<bool>(false);
   if (reverse) {
     return PyFExpr::make(new FExpr_CumSumProd<true, true>(as_fexpr(cumsum)));
   } else {
@@ -115,15 +115,17 @@ static py::oobj pyfn_cumsum(const py::XArgs &args) {
   }
 }
 
+
 static py::oobj pyfn_cumprod(const py::XArgs &args) {
   auto cumprod = args[0].to_oobj();
-  auto reverse = args[1].to<bool>(false);
+  bool reverse = args[1].to<bool>(false);
   if (reverse) {
     return PyFExpr::make(new FExpr_CumSumProd<false, true>(as_fexpr(cumprod)));
   } else {
     return PyFExpr::make(new FExpr_CumSumProd<false, false>(as_fexpr(cumprod)));
   }
 }
+
 
 DECLARE_PYFN(&pyfn_cumsum)
     ->name("cumsum")

--- a/tests/dt/test-cumminmax.py
+++ b/tests/dt/test-cumminmax.py
@@ -190,6 +190,7 @@ def test_cumminmax_reverse():
     DT_ref = DT[::-1, :][:, [cummin(f.C0), cummax(f.C0)]][::-1, :]
     assert_equals(DT_mm, DT_ref)
 
+
 def test_cumminmax_groupby_reverse():
     DT = dt.Frame([[3, 14, 15, 92, 6], ["a", "cat", "a", "dog", "cat"]])
     DT_mm = DT[:, [cummin(f[0], reverse=True), cummax(f[0], True)], by(f[1])]

--- a/tests/dt/test-cumprod.py
+++ b/tests/dt/test-cumprod.py
@@ -42,7 +42,7 @@ def test_cumprod_non_numeric_by():
         DT[:, cumprod(f[0]), by(f[0])]
 
 def test_cumprod_no_argument():
-    match = r'Function datatable.cumprod\(\) requires exactly 1 positional argument, ' \
+    match = r'Function datatable.cumprod\(\) requires at least 1 positional argument, ' \
              'but none were given'
     with pytest.raises(TypeError, match = match):
         dt.cumprod()
@@ -53,11 +53,14 @@ def test_cumprod_no_argument():
 #-------------------------------------------------------------------------------
 
 def test_cumprod_str():
-  assert str(cumprod(f.A)) == "FExpr<cumprod(f.A)>"
-  assert str(cumprod(f.A) + 1) == "FExpr<cumprod(f.A) + 1>"
-  assert str(cumprod(f.A + f.B)) == "FExpr<cumprod(f.A + f.B)>"
-  assert str(cumprod(f.B)) == "FExpr<cumprod(f.B)>"
-  assert str(cumprod(f[:2])) == "FExpr<cumprod(f[:2])>"
+  assert str(cumprod(f.A)) == "FExpr<cumprod(f.A, reverse=False)>"
+  assert str(cumprod(f.A, True)) == "FExpr<cumprod(f.A, reverse=True)>"
+  assert str(cumprod(f.A) + 1) == "FExpr<cumprod(f.A, reverse=False) + 1>"
+  assert str(cumprod(f.A + f.B)) == "FExpr<cumprod(f.A + f.B, reverse=False)>"
+  assert str(cumprod(f.A + f.B, reverse=True)) == "FExpr<cumprod(f.A + f.B, reverse=True)>"
+  assert str(cumprod(f.B)) == "FExpr<cumprod(f.B, reverse=False)>"
+  assert str(cumprod(f[:2])) == "FExpr<cumprod(f[:2], reverse=False)>"
+  assert str(cumprod(f[:2], reverse=True)) == "FExpr<cumprod(f[:2], reverse=True)>"
 
 
 def test_cumprod_empty_frame():
@@ -87,6 +90,12 @@ def test_cumprod_small():
     DT_ref = dt.Frame([[0, 0, 0, 0, 0]/dt.int64, [-1, -1, -1, -2, -11]/dt.float64])
     assert_equals(DT_cumprod, DT_ref)
 
+def test_cumprod_reverse():
+    DT = dt.Frame([range(5), [-1, 1, None, 2, 5.5]])
+    DT_cumprod = DT[:, cumprod(f[:], reverse=True)]
+    DT_ref = DT[::-1, cumprod(f[:])][::-1, :]
+    assert_equals(DT_cumprod, DT_ref)
+
 
 def test_cumprod_groupby():
     DT = dt.Frame([[2, 1, 1, 1, 2], [1.5, -1.5, math.inf, 2, 3]])
@@ -94,6 +103,11 @@ def test_cumprod_groupby():
     DT_ref = dt.Frame([[1, 1, 1, 2, 2], [-1.5, -math.inf, -math.inf, 1.5, 4.5]/dt.float64])
     assert_equals(DT_cumprod, DT_ref)
 
+def test_cumprod_groupby_reverse():
+    DT = dt.Frame([[2, 1, 1, 1, 2], [1.5, -1.5, math.inf, 2, 3]])
+    DT_cumprod = DT[:, cumprod(f[:], reverse=True), by(f[0])]
+    DT_ref = dt.Frame([[1, 1, 1, 2, 2], [-math.inf, math.inf, 2.0, 4.5, 3.0]/dt.float64])
+    assert_equals(DT_cumprod, DT_ref)
 
 def test_cumprod_void_grouped_column():
     DT = dt.Frame([None]*10)

--- a/tests/dt/test-cumprod.py
+++ b/tests/dt/test-cumprod.py
@@ -103,11 +103,13 @@ def test_cumprod_groupby():
     DT_ref = dt.Frame([[1, 1, 1, 2, 2], [-1.5, -math.inf, -math.inf, 1.5, 4.5]/dt.float64])
     assert_equals(DT_cumprod, DT_ref)
 
+
 def test_cumprod_groupby_reverse():
     DT = dt.Frame([[2, 1, 1, 1, 2], [1.5, -1.5, math.inf, 2, 3]])
     DT_cumprod = DT[:, cumprod(f[:], reverse=True), by(f[0])]
     DT_ref = dt.Frame([[1, 1, 1, 2, 2], [-math.inf, math.inf, 2.0, 4.5, 3.0]/dt.float64])
     assert_equals(DT_cumprod, DT_ref)
+
 
 def test_cumprod_void_grouped_column():
     DT = dt.Frame([None]*10)

--- a/tests/dt/test-cumsum.py
+++ b/tests/dt/test-cumsum.py
@@ -89,6 +89,7 @@ def test_cumsum_small():
     DT_ref = dt.Frame([[0, 1, 3, 6, 10]/dt.int64, [-1, 0, 0, 2, 7.5]])
     assert_equals(DT_cumsum, DT_ref)
 
+
 def test_cumsum_reverse():
     DT = dt.Frame([range(5), [-1, 1, None, 2, 5.5]])
     DT_cumsum = DT[:, cumsum(f[:], reverse=True)]
@@ -101,6 +102,7 @@ def test_cumsum_groupby():
     DT_cumsum = DT[:, cumsum(f[:]), by(f[0])]
     DT_ref = dt.Frame([[1, 1, 1, 2, 2], [-1.5, math.inf, math.inf, 1.5, 4.5]/dt.float64])
     assert_equals(DT_cumsum, DT_ref)
+
 
 def test_cumsum_groupby_reverse():
     DT = dt.Frame([[2, 1, 1, 1, 2], [1.5, -1.5, math.inf, 2, 3]])

--- a/tests/dt/test-cumsum.py
+++ b/tests/dt/test-cumsum.py
@@ -42,7 +42,7 @@ def test_cumsum_non_numeric_by():
         DT[:, cumsum(f[0]), by(f[0])]
 
 def test_cumsum_no_argument():
-    match = r'Function datatable.cumsum\(\) requires exactly 1 positional argument, ' \
+    match = r'Function datatable.cumsum\(\) requires at least 1 positional argument, ' \
              'but none were given'
     with pytest.raises(TypeError, match = match):
         dt.cumsum()
@@ -53,11 +53,13 @@ def test_cumsum_no_argument():
 #-------------------------------------------------------------------------------
 
 def test_cumsum_str():
-  assert str(cumsum(f.A)) == "FExpr<cumsum(f.A)>"
-  assert str(cumsum(f.A) + 1) == "FExpr<cumsum(f.A) + 1>"
-  assert str(cumsum(f.A + f.B)) == "FExpr<cumsum(f.A + f.B)>"
-  assert str(cumsum(f.B)) == "FExpr<cumsum(f.B)>"
-  assert str(cumsum(f[:2])) == "FExpr<cumsum(f[:2])>"
+  assert str(cumsum(f.A)) == "FExpr<cumsum(f.A, reverse=False)>"
+  assert str(cumsum(f.A, True)) == "FExpr<cumsum(f.A, reverse=True)>"
+  assert str(cumsum(f.A) + 1) == "FExpr<cumsum(f.A, reverse=False) + 1>"
+  assert str(cumsum(f.A + f.B)) == "FExpr<cumsum(f.A + f.B, reverse=False)>"
+  assert str(cumsum(f.B)) == "FExpr<cumsum(f.B, reverse=False)>"
+  assert str(cumsum(f[:2])) == "FExpr<cumsum(f[:2], reverse=False)>"
+  assert str(cumsum(f[:2], reverse=True)) == "FExpr<cumsum(f[:2], reverse=True)>"
 
 
 def test_cumsum_empty_frame():
@@ -87,11 +89,23 @@ def test_cumsum_small():
     DT_ref = dt.Frame([[0, 1, 3, 6, 10]/dt.int64, [-1, 0, 0, 2, 7.5]])
     assert_equals(DT_cumsum, DT_ref)
 
+def test_cumsum_reverse():
+    DT = dt.Frame([range(5), [-1, 1, None, 2, 5.5]])
+    DT_cumsum = DT[:, cumsum(f[:], reverse=True)]
+    DT_ref = DT[::-1, cumsum(f[:])][::-1, :]
+    assert_equals(DT_cumsum, DT_ref)
+
 
 def test_cumsum_groupby():
     DT = dt.Frame([[2, 1, 1, 1, 2], [1.5, -1.5, math.inf, 2, 3]])
     DT_cumsum = DT[:, cumsum(f[:]), by(f[0])]
     DT_ref = dt.Frame([[1, 1, 1, 2, 2], [-1.5, math.inf, math.inf, 1.5, 4.5]/dt.float64])
+    assert_equals(DT_cumsum, DT_ref)
+
+def test_cumsum_groupby_reverse():
+    DT = dt.Frame([[2, 1, 1, 1, 2], [1.5, -1.5, math.inf, 2, 3]])
+    DT_cumsum = DT[:, cumsum(f[:], reverse=True), by(f[0])]
+    DT_ref = dt.Frame([[1, 1, 1, 2, 2], [math.inf, math.inf, 2.0, 4.5, 3.0]/dt.float64])
     assert_equals(DT_cumsum, DT_ref)
 
 

--- a/tests/test-f.py
+++ b/tests/test-f.py
@@ -447,16 +447,20 @@ def test_cumsum():
 
 def test_cummax():
     assert str(dt.cummax(f.A)) == str(f.A.cummax())
+    assert str(dt.cummax(f.A, reverse=True)) == str(f.A.cummax(True))
     assert str(dt.cummax(f[:])) == str(f[:].cummax())
     DT = dt.Frame(A = [9, 8, 2, 3, None, None, 3, 0, 5, 5, 8, None, 1])
     assert_equals(DT[:, f.A.cummax()], DT[:, dt.cummax(f.A)])
+    assert_equals(DT[:, f.A.cummax(reverse=True)], DT[:, dt.cummax(f.A, reverse=True)])
 
 
 def test_cummin():
     assert str(dt.cummin(f.A)) == str(f.A.cummin())
+    assert str(dt.cummin(f.A, reverse=True)) == str(f.A.cummin(True))
     assert str(dt.cummin(f[:])) == str(f[:].cummin())
     DT = dt.Frame(A = [9, 8, 2, 3, None, None, 3, 0, 5, 5, 8, None, 1])
     assert_equals(DT[:, f.A.cummin()], DT[:, dt.cummin(f.A)])
+    assert_equals(DT[:, f.A.cummin(True)], DT[:, dt.cummin(f.A, True)])
 
 
 def test_cumprod():

--- a/tests/test-f.py
+++ b/tests/test-f.py
@@ -441,8 +441,11 @@ def test_countna():
 def test_cumsum():
     assert str(dt.cumsum(f.A)) == str(f.A.cumsum())
     assert str(dt.cumsum(f[:])) == str(f[:].cumsum())
+    assert str(dt.cumsum(f[:], True)) == str(f[:].cumsum(True))
     DT = dt.Frame(A = [9, 8, 2, 3, None, None, 3, 0, 5, 5, 8, None, 1])
     assert_equals(DT[:, f.A.cumsum()], DT[:, dt.cumsum(f.A)])
+    assert_equals(DT[:, f.A.cumsum(reverse=True)], DT[:, dt.cumsum(f.A, reverse=True)])
+
 
 
 def test_cummax():
@@ -466,8 +469,10 @@ def test_cummin():
 def test_cumprod():
     assert str(dt.cumprod(f.A)) == str(f.A.cumprod())
     assert str(dt.cumprod(f[:])) == str(f[:].cumprod())
+    assert str(dt.cumprod(f[:], reverse=True)) == str(f[:].cumprod(reverse=True))
     DT = dt.Frame(A = [9, 8, 2, 3, None, None, 3, 0, 5, 5, 8, None, 1])
     assert_equals(DT[:, f.A.cumprod()], DT[:, dt.cumprod(f.A)])
+    assert_equals(DT[:, f.A.cumprod(True)], DT[:, dt.cumprod(f.A, True)])
 
 
 def test_fillna():


### PR DESCRIPTION
Add `reverse` parameter to control direction of cumulative function's calculations: 
- when `False`, calculation is done from top to bottom (default);
- when `True`, calculation is done from bottom to top.

Сloses #3279 