### PR TITLE
Fix groupby behaviour on columns with missing values

### DIFF
--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -1,7 +1,7 @@
 image:
   - Visual Studio 2019
-  - macos-monterey
-  - Ubuntu
+  # - macos-monterey
+  # - Ubuntu
 
 init:
   # Uncomment the line below to enable RDP access on AppVeyor
@@ -182,123 +182,123 @@ build_script:
     echo "DT_BUILD_SUFFIX = $env:DT_BUILD_SUFFIX"
 
 
+    # # =======================================================================
+    # #   Build and test wheel for Python 3.7
+    # # =======================================================================
+
+    # $env:PATH = "C:/Python37-x64;C:/Python37-x64/Scripts;$DEFAULT_PATH"
+
+    # python -V
+
+    # python ci/ext.py wheel
+
+    # $DT_WHEEL = ls dist/*-cp37-*.whl
+
+    # echo "DT_WHEEL = $DT_WHEEL"
+
+    # echo "----- _build_info.py for Python 3.7 ------------------------------"
+
+    # cat src/datatable/_build_info.py
+
+    # echo "------------------------------------------------------------------"
+
+    # python -m pip install --upgrade pip
+
+    # python -m pip install $DT_WHEEL
+
+    # python -m pip install pytest docutils pandas pyarrow
+
+    # python -m pytest -ra --maxfail=10 -Werror -vv --showlocals ./tests/
+
+    # if(!$?) { Exit $LASTEXITCODE }
+
+    # python -m pip uninstall -y $DT_WHEEL
+
+
+
+    # # =======================================================================
+    # #   Build and test wheel for Python 3.8
+    # # =======================================================================
+
+    # $env:PATH = "C:/Python38-x64;C:/Python38-x64/Scripts;$DEFAULT_PATH"
+
+    # python -V
+
+    # python ci/ext.py wheel
+
+    # $DT_WHEEL = ls dist/*-cp38-*.whl
+
+    # echo "DT_WHEEL = $DT_WHEEL"
+
+    # echo "----- _build_info.py for Python 3.8 ------------------------------"
+
+    # cat src/datatable/_build_info.py
+
+    # echo "------------------------------------------------------------------"
+
+    # python -m pip install --upgrade pip
+
+    # python -m pip install $DT_WHEEL
+
+    # python -m pip install pytest docutils pandas pyarrow
+
+    # python -m pytest -ra --maxfail=10 -Werror -vv --showlocals ./tests/
+
+    # if(!$?) { Exit $LASTEXITCODE }
+
+    # python -m pip uninstall -y $DT_WHEEL
+
+
+
+    # # =======================================================================
+    # #   Build and test wheel for Python 3.9
+    # # =======================================================================
+
+    # $env:PATH = "C:/Python39-x64;C:/Python39-x64/Scripts;$DEFAULT_PATH"
+
+    # python -V
+
+    # python ci/ext.py wheel
+
+    # $DT_WHEEL = ls dist/*-cp39-*.whl
+
+    # echo "DT_WHEEL = $DT_WHEEL"
+
+    # echo "----- _build_info.py for Python 3.9 ------------------------------"
+
+    # cat src/datatable/_build_info.py
+
+    # echo "------------------------------------------------------------------"
+
+    # python -m pip install --upgrade pip
+
+    # python -m pip install $DT_WHEEL
+
+    # python -m pip install pytest docutils pandas pyarrow
+
+    # python -m pytest -ra --maxfail=10 -Werror -vv --showlocals ./tests/
+
+    # if(!$?) { Exit $LASTEXITCODE }
+
+    # python -m pip uninstall -y $DT_WHEEL
+
+
+
     # =======================================================================
-    #   Build and test wheel for Python 3.7
-    # =======================================================================
-
-    $env:PATH = "C:/Python37-x64;C:/Python37-x64/Scripts;$DEFAULT_PATH"
-
-    python -V
-
-    python ci/ext.py wheel
-
-    $DT_WHEEL = ls dist/*-cp37-*.whl
-
-    echo "DT_WHEEL = $DT_WHEEL"
-
-    echo "----- _build_info.py for Python 3.7 ------------------------------"
-
-    cat src/datatable/_build_info.py
-
-    echo "------------------------------------------------------------------"
-
-    python -m pip install --upgrade pip
-
-    python -m pip install $DT_WHEEL
-
-    python -m pip install pytest docutils pandas pyarrow
-
-    python -m pytest -ra --maxfail=10 -Werror -vv --showlocals ./tests/
-
-    if(!$?) { Exit $LASTEXITCODE }
-
-    python -m pip uninstall -y $DT_WHEEL
-
-
-
-    # =======================================================================
-    #   Build and test wheel for Python 3.8
+    #   Build and test debug wheel for Python 3.8
     # =======================================================================
 
     $env:PATH = "C:/Python38-x64;C:/Python38-x64/Scripts;$DEFAULT_PATH"
 
     python -V
 
-    python ci/ext.py wheel
-
-    $DT_WHEEL = ls dist/*-cp38-*.whl
-
-    echo "DT_WHEEL = $DT_WHEEL"
-
-    echo "----- _build_info.py for Python 3.8 ------------------------------"
-
-    cat src/datatable/_build_info.py
-
-    echo "------------------------------------------------------------------"
-
-    python -m pip install --upgrade pip
-
-    python -m pip install $DT_WHEEL
-
-    python -m pip install pytest docutils pandas pyarrow
-
-    python -m pytest -ra --maxfail=10 -Werror -vv --showlocals ./tests/
-
-    if(!$?) { Exit $LASTEXITCODE }
-
-    python -m pip uninstall -y $DT_WHEEL
-
-
-
-    # =======================================================================
-    #   Build and test wheel for Python 3.9
-    # =======================================================================
-
-    $env:PATH = "C:/Python39-x64;C:/Python39-x64/Scripts;$DEFAULT_PATH"
-
-    python -V
-
-    python ci/ext.py wheel
-
-    $DT_WHEEL = ls dist/*-cp39-*.whl
-
-    echo "DT_WHEEL = $DT_WHEEL"
-
-    echo "----- _build_info.py for Python 3.9 ------------------------------"
-
-    cat src/datatable/_build_info.py
-
-    echo "------------------------------------------------------------------"
-
-    python -m pip install --upgrade pip
-
-    python -m pip install $DT_WHEEL
-
-    python -m pip install pytest docutils pandas pyarrow
-
-    python -m pytest -ra --maxfail=10 -Werror -vv --showlocals ./tests/
-
-    if(!$?) { Exit $LASTEXITCODE }
-
-    python -m pip uninstall -y $DT_WHEEL
-
-
-
-    # =======================================================================
-    #   Build and test debug wheel for Python 3.9
-    # =======================================================================
-
-    $env:PATH = "C:/Python39-x64;C:/Python39-x64/Scripts;$DEFAULT_PATH"
-
-    python -V
-
     python ci/ext.py debugwheel
 
-    $DT_WHEEL = ls dist/*debug-cp39-*.whl
+    $DT_WHEEL = ls dist/*debug-cp38-*.whl
 
     echo "DT_WHEEL = $DT_WHEEL"
 
-    echo "----- _build_info.py for Python 3.9 debug wheel ------------------"
+    echo "----- _build_info.py for Python 3.8 debug wheel ------------------"
 
     cat src/datatable/_build_info.py
 
@@ -318,35 +318,35 @@ build_script:
 
 
 
-    # =======================================================================
-    #   Build and test wheel for Python 3.10
-    # =======================================================================
+    # # =======================================================================
+    # #   Build and test wheel for Python 3.10
+    # # =======================================================================
 
-    $env:PATH = "C:/Python310-x64;C:/Python310-x64/Scripts;$DEFAULT_PATH"
+    # $env:PATH = "C:/Python310-x64;C:/Python310-x64/Scripts;$DEFAULT_PATH"
 
-    python -V
+    # python -V
 
-    python ci/ext.py wheel
+    # python ci/ext.py wheel
 
-    $DT_WHEEL = ls dist/*-cp310-*.whl
+    # $DT_WHEEL = ls dist/*-cp310-*.whl
 
-    echo "DT_WHEEL = $DT_WHEEL"
+    # echo "DT_WHEEL = $DT_WHEEL"
 
-    echo "----- _build_info.py for Python 3.10 ------------------------------"
+    # echo "----- _build_info.py for Python 3.10 ------------------------------"
 
-    cat src/datatable/_build_info.py
+    # cat src/datatable/_build_info.py
 
-    echo "------------------------------------------------------------------"
+    # echo "------------------------------------------------------------------"
 
-    python -m pip install --upgrade pip
+    # python -m pip install --upgrade pip
 
-    python -m pip install $DT_WHEEL
+    # python -m pip install $DT_WHEEL
 
-    python -m pip install pytest docutils pandas pyarrow
+    # python -m pip install pytest docutils pandas pyarrow
 
-    python -m pytest -ra --maxfail=10 -Werror -vv --showlocals ./tests/
+    # python -m pytest -ra --maxfail=10 -Werror -vv --showlocals ./tests/
 
-    if(!$?) { Exit $LASTEXITCODE }
+    # if(!$?) { Exit $LASTEXITCODE }
 
-    python -m pip uninstall -y $DT_WHEEL
+    # python -m pip uninstall -y $DT_WHEEL
 

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -1,7 +1,7 @@
 image:
   - Visual Studio 2019
-  # - macos-monterey
-  # - Ubuntu
+  - macos-monterey
+  - Ubuntu
 
 init:
   # Uncomment the line below to enable RDP access on AppVeyor

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -182,105 +182,72 @@ build_script:
     echo "DT_BUILD_SUFFIX = $env:DT_BUILD_SUFFIX"
 
 
-    # # =======================================================================
-    # #   Build and test wheel for Python 3.7
-    # # =======================================================================
 
-    # $env:PATH = "C:/Python37-x64;C:/Python37-x64/Scripts;$DEFAULT_PATH"
+    # =======================================================================
+    #   Build and test wheel for Python 3.7
+    # =======================================================================
 
-    # python -V
+    $env:PATH = "C:/Python37-x64;C:/Python37-x64/Scripts;$DEFAULT_PATH"
 
-    # python ci/ext.py wheel
+    python -V
 
-    # $DT_WHEEL = ls dist/*-cp37-*.whl
+    python ci/ext.py wheel
 
-    # echo "DT_WHEEL = $DT_WHEEL"
+    $DT_WHEEL = ls dist/*-cp37-*.whl
 
-    # echo "----- _build_info.py for Python 3.7 ------------------------------"
+    echo "DT_WHEEL = $DT_WHEEL"
 
-    # cat src/datatable/_build_info.py
+    echo "----- _build_info.py for Python 3.7 ------------------------------"
 
-    # echo "------------------------------------------------------------------"
+    cat src/datatable/_build_info.py
 
-    # python -m pip install --upgrade pip
+    echo "------------------------------------------------------------------"
 
-    # python -m pip install $DT_WHEEL
+    python -m pip install --upgrade pip
 
-    # python -m pip install pytest docutils pandas pyarrow
+    python -m pip install $DT_WHEEL
 
-    # python -m pytest -ra --maxfail=10 -Werror -vv --showlocals ./tests/
+    python -m pip install pytest docutils pandas pyarrow
 
-    # if(!$?) { Exit $LASTEXITCODE }
+    python -m pytest -ra --maxfail=10 -Werror -vv --showlocals ./tests/
 
-    # python -m pip uninstall -y $DT_WHEEL
+    if(!$?) { Exit $LASTEXITCODE }
 
-
-
-    # # =======================================================================
-    # #   Build and test wheel for Python 3.8
-    # # =======================================================================
-
-    # $env:PATH = "C:/Python38-x64;C:/Python38-x64/Scripts;$DEFAULT_PATH"
-
-    # python -V
-
-    # python ci/ext.py wheel
-
-    # $DT_WHEEL = ls dist/*-cp38-*.whl
-
-    # echo "DT_WHEEL = $DT_WHEEL"
-
-    # echo "----- _build_info.py for Python 3.8 ------------------------------"
-
-    # cat src/datatable/_build_info.py
-
-    # echo "------------------------------------------------------------------"
-
-    # python -m pip install --upgrade pip
-
-    # python -m pip install $DT_WHEEL
-
-    # python -m pip install pytest docutils pandas pyarrow
-
-    # python -m pytest -ra --maxfail=10 -Werror -vv --showlocals ./tests/
-
-    # if(!$?) { Exit $LASTEXITCODE }
-
-    # python -m pip uninstall -y $DT_WHEEL
+    python -m pip uninstall -y $DT_WHEEL
 
 
 
-    # # =======================================================================
-    # #   Build and test wheel for Python 3.9
-    # # =======================================================================
+    # =======================================================================
+    #   Build and test wheel for Python 3.8
+    # =======================================================================
 
-    # $env:PATH = "C:/Python39-x64;C:/Python39-x64/Scripts;$DEFAULT_PATH"
+    $env:PATH = "C:/Python38-x64;C:/Python38-x64/Scripts;$DEFAULT_PATH"
 
-    # python -V
+    python -V
 
-    # python ci/ext.py wheel
+    python ci/ext.py wheel
 
-    # $DT_WHEEL = ls dist/*-cp39-*.whl
+    $DT_WHEEL = ls dist/*-cp38-*.whl
 
-    # echo "DT_WHEEL = $DT_WHEEL"
+    echo "DT_WHEEL = $DT_WHEEL"
 
-    # echo "----- _build_info.py for Python 3.9 ------------------------------"
+    echo "----- _build_info.py for Python 3.8 ------------------------------"
 
-    # cat src/datatable/_build_info.py
+    cat src/datatable/_build_info.py
 
-    # echo "------------------------------------------------------------------"
+    echo "------------------------------------------------------------------"
 
-    # python -m pip install --upgrade pip
+    python -m pip install --upgrade pip
 
-    # python -m pip install $DT_WHEEL
+    python -m pip install $DT_WHEEL
 
-    # python -m pip install pytest docutils pandas pyarrow
+    python -m pip install pytest docutils pandas pyarrow
 
-    # python -m pytest -ra --maxfail=10 -Werror -vv --showlocals ./tests/
+    python -m pytest -ra --maxfail=10 -Werror -vv --showlocals ./tests/
 
-    # if(!$?) { Exit $LASTEXITCODE }
+    if(!$?) { Exit $LASTEXITCODE }
 
-    # python -m pip uninstall -y $DT_WHEEL
+    python -m pip uninstall -y $DT_WHEEL
 
 
 
@@ -318,35 +285,69 @@ build_script:
 
 
 
-    # # =======================================================================
-    # #   Build and test wheel for Python 3.10
-    # # =======================================================================
+    # =======================================================================
+    #   Build and test wheel for Python 3.9
+    # =======================================================================
 
-    # $env:PATH = "C:/Python310-x64;C:/Python310-x64/Scripts;$DEFAULT_PATH"
+    $env:PATH = "C:/Python39-x64;C:/Python39-x64/Scripts;$DEFAULT_PATH"
 
-    # python -V
+    python -V
 
-    # python ci/ext.py wheel
+    python ci/ext.py wheel
 
-    # $DT_WHEEL = ls dist/*-cp310-*.whl
+    $DT_WHEEL = ls dist/*-cp39-*.whl
 
-    # echo "DT_WHEEL = $DT_WHEEL"
+    echo "DT_WHEEL = $DT_WHEEL"
 
-    # echo "----- _build_info.py for Python 3.10 ------------------------------"
+    echo "----- _build_info.py for Python 3.9 ------------------------------"
 
-    # cat src/datatable/_build_info.py
+    cat src/datatable/_build_info.py
 
-    # echo "------------------------------------------------------------------"
+    echo "------------------------------------------------------------------"
 
-    # python -m pip install --upgrade pip
+    python -m pip install --upgrade pip
 
-    # python -m pip install $DT_WHEEL
+    python -m pip install $DT_WHEEL
 
-    # python -m pip install pytest docutils pandas pyarrow
+    python -m pip install pytest docutils pandas pyarrow
 
-    # python -m pytest -ra --maxfail=10 -Werror -vv --showlocals ./tests/
+    python -m pytest -ra --maxfail=10 -Werror -vv --showlocals ./tests/
 
-    # if(!$?) { Exit $LASTEXITCODE }
+    if(!$?) { Exit $LASTEXITCODE }
 
-    # python -m pip uninstall -y $DT_WHEEL
+    python -m pip uninstall -y $DT_WHEEL
+
+
+
+    # =======================================================================
+    #   Build and test wheel for Python 3.10
+    # =======================================================================
+
+    $env:PATH = "C:/Python310-x64;C:/Python310-x64/Scripts;$DEFAULT_PATH"
+
+    python -V
+
+    python ci/ext.py wheel
+
+    $DT_WHEEL = ls dist/*-cp310-*.whl
+
+    echo "DT_WHEEL = $DT_WHEEL"
+
+    echo "----- _build_info.py for Python 3.10 ------------------------------"
+
+    cat src/datatable/_build_info.py
+
+    echo "------------------------------------------------------------------"
+
+    python -m pip install --upgrade pip
+
+    python -m pip install $DT_WHEEL
+
+    python -m pip install pytest docutils pandas pyarrow
+
+    python -m pytest -ra --maxfail=10 -Werror -vv --showlocals ./tests/
+
+    if(!$?) { Exit $LASTEXITCODE }
+
+    python -m pip uninstall -y $DT_WHEEL
 

--- a/docs/releases/v1.1.0.rst
+++ b/docs/releases/v1.1.0.rst
@@ -53,6 +53,8 @@
     -[fix] Fixed :meth:`.to_csv()` to quote missing values when
         `quoting="all"` is specified. [#3340]
 
+    -[fix] Fixed groupby behaviour on columns that contain missing values. [#3331]
+
     -[api] Converting a column of :attr:`void <dt.Type.void>` type into pandas
         now produces a pandas ``object`` column filled with ``None``s. Converting
         such column back into datatable produces a ``void`` column again. [#3063]

--- a/src/core/expr/eval_context.cc
+++ b/src/core/expr/eval_context.cc
@@ -45,6 +45,7 @@ EvalContext::EvalContext(DataTable* dt, EvalMode evalmode)
   frames_.emplace_back(dt, RowIndex(), /* natural_join= */ false);
   eval_mode_ = evalmode;
   add_groupby_columns_ = true;
+  na_position_ = NaPosition::FIRST;
 }
 
 

--- a/src/core/expr/eval_context.cc
+++ b/src/core/expr/eval_context.cc
@@ -45,7 +45,7 @@ EvalContext::EvalContext(DataTable* dt, EvalMode evalmode)
   frames_.emplace_back(dt, RowIndex(), /* natural_join= */ false);
   eval_mode_ = evalmode;
   add_groupby_columns_ = true;
-  na_position_ = NaPosition::FIRST;
+  na_position_ = NaPosition::FIRST; // default for groupby
 }
 
 


### PR DESCRIPTION
It appears as though we never initialized `na_position_` in the case of `dt.by()`, and this resulted in some random data corruption for columns, that contain missing values. As of this PR, we initialize `na_position_` to `NaPosition::FIRST` to be consistent with what we declare in `dt.by()` [documentation](https://datatable.readthedocs.io/en/latest/api/dt/by.html):

```
The default behavior of groupby is to sort the groups in the ascending order, with NA values appearing before any other values.
```

Also, we switch to python 3.8 for testing debug wheels, so that we keep track of the status of the mentioned groupby tests.
 
Closes #3331