### PR TITLE
Enable macOS on AppVeyor for Python `3.11`

### DIFF
--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -1,8 +1,7 @@
 image:
   - Visual Studio 2019
   - Ubuntu
-  # Uncomment the line below when python 3.11 is added to macOS image
-  # - macos-monterey
+  - macos-monterey
 
 init:
   # Uncomment the line below to enable RDP access on AppVeyor


### PR DESCRIPTION
Closes https://github.com/h2oai/datatable/issues/3392