### PR TITLE
Add `dt.prod()` test for a grouped column, `by()` docs adjustment

### DIFF
--- a/docs/api/dt/by.rst
+++ b/docs/api/dt/by.rst
@@ -26,11 +26,12 @@
       will select those rows where column A reaches its peak value within
       each group (there could be multiple such rows within each group).
 
-    - Before ``j`` is evaluated, the ``by()`` clause adds all its columns
-      at the start of ``j`` (unless ``add_columns`` argument is ``False``). If
-      ``j`` is a "select-all" slice (i.e. ``:``), then those columns will
-      also be excluded from the list of all columns so that they will be
-      present in the output only once.
+    - Before ``j`` is evaluated, the ``by()`` clause adds all the groupby
+      columns at the start of ``j`` (unless ``add_columns`` argument is
+      ``False``). If ``j`` is a "select-all" slice (i.e. ``:`` or
+      ``f[:]``), then the groupby columns will be excluded
+      from the list of all columns, so that they will be present in the output
+      only once.
 
     - During evaluation of ``j``, the reducer functions, such as
       :func:`min`, :func:`sum`, etc, will be evaluated by-group, that is

--- a/docs/api/dt/f.rst
+++ b/docs/api/dt/f.rst
@@ -14,7 +14,7 @@
     - ``f.A`` means "column A" of frame ``DT``;
     - ``f[2]`` means "3rd colum" of frame ``DT``;
     - ``f[int]`` means "all integer columns" of ``DT``;
-    - ``f[:]`` means "all columns" of ``DT``.
+    - ``f[:]`` means "all columns" of ``DT`` not including :func:`by` columns, however.
 
 
     See also

--- a/tests/test-groups.py
+++ b/tests/test-groups.py
@@ -300,6 +300,14 @@ def test_reduce_prod():
     assert f1.to_list() == [["blue", "green", "red"],
                             [2, -7, 65]]
 
+def test_reduce_prod_same_column():
+    # See issue #3390
+    f0 = dt.Frame({"ints" : [0, 1, 0, 0, 1, 2]})
+    f1 = f0[:, {"prod" : prod(f.ints)}, f.ints]
+    frame_integrity_check(f1)
+    assert_equals(f1, dt.Frame({"ints" : [0, 1, 2], "prod" : [0, 1, 2]/dt.int64}))
+                        
+
 
 #-------------------------------------------------------------------------------
 # Groupby on large datasets

--- a/tests/test-groups.py
+++ b/tests/test-groups.py
@@ -302,14 +302,6 @@ def test_reduce_prod():
 
 def test_reduce_prod_same_column():
     # See issue #3390
-    f0 = dt.Frame({"ints" : [0, 1, 0, 0, 1, 2]})
-    f1 = f0[:, {"prod" : prod(f.ints)}, f.ints]
-    frame_integrity_check(f1)
-    assert_equals(f1, dt.Frame({"ints" : [0, 1, 2], "prod" : [0, 1, 2]/dt.int64}))
-
-
-def test_reduce_prod_same_column1():
-    # See issue #3390
     f0 = dt.Frame({"ints" : [0, 1, 2, 2, 1, 2]})
     f1 = f0[:, {"prod" : prod(f.ints)}, f.ints]
     frame_integrity_check(f1)

--- a/tests/test-groups.py
+++ b/tests/test-groups.py
@@ -307,7 +307,7 @@ def test_reduce_prod_same_column():
     f0 = dt.Frame({"ints" : [0, -1, 2, 2, -1, 2]})
     f1 = f0[:, {"prod" : prod(f.ints)}, f.ints]
     frame_integrity_check(f1)
-    assert_equals(f1, dt.Frame({"ints" : [0, 1, 2], "prod" : [0, 1, 8]/dt.int64}))
+    assert_equals(f1, dt.Frame({"ints" : [-1, 0, 2], "prod" : [1, 0, 8]/dt.int64}))
                         
 
 

--- a/tests/test-groups.py
+++ b/tests/test-groups.py
@@ -306,6 +306,14 @@ def test_reduce_prod_same_column():
     f1 = f0[:, {"prod" : prod(f.ints)}, f.ints]
     frame_integrity_check(f1)
     assert_equals(f1, dt.Frame({"ints" : [0, 1, 2], "prod" : [0, 1, 2]/dt.int64}))
+
+
+def test_reduce_prod_same_column1():
+    # See issue #3390
+    f0 = dt.Frame({"ints" : [0, 1, 2, 2, 1, 2]})
+    f1 = f0[:, {"prod" : prod(f.ints)}, f.ints]
+    frame_integrity_check(f1)
+    assert_equals(f1, dt.Frame({"ints" : [0, 1, 2], "prod" : [0, 1, 8]/dt.int64}))
                         
 
 

--- a/tests/test-groups.py
+++ b/tests/test-groups.py
@@ -292,6 +292,7 @@ def test_reduce_sum_same_column():
     frame_integrity_check(f1)
     assert_equals(f1, dt.Frame({"ints" : [0, 1, 2], "sum" : [0, 2, 2]/dt.int64}))
 
+
 def test_reduce_prod():
     f0 = dt.Frame({"color": ["red", "blue", "green", "red", "green"],
                    "size": [5, 2, 7, 13, -1]})
@@ -300,9 +301,10 @@ def test_reduce_prod():
     assert f1.to_list() == [["blue", "green", "red"],
                             [2, -7, 65]]
 
+
 def test_reduce_prod_same_column():
     # See issue #3390
-    f0 = dt.Frame({"ints" : [0, 1, 2, 2, 1, 2]})
+    f0 = dt.Frame({"ints" : [0, -1, 2, 2, -1, 2]})
     f1 = f0[:, {"prod" : prod(f.ints)}, f.ints]
     frame_integrity_check(f1)
     assert_equals(f1, dt.Frame({"ints" : [0, 1, 2], "prod" : [0, 1, 8]/dt.int64}))


### PR DESCRIPTION
- the fix for #3390 has been already pushed as a part of #3388, here we merely add a corresponding test;
- as of #2472, `f[:]` excludes the groupby columns, in this PR we make the corresponding adjustments to the docs. 

Closes #3390 