### PR TITLE
Refactor `mean()` reducer to use `FExpr`

### DIFF
--- a/docs/api/dt/mean.rst
+++ b/docs/api/dt/mean.rst
@@ -1,6 +1,6 @@
 
 .. xfunction:: datatable.mean
-    :src: src/core/expr/head_reduce_unary.cc mean_reducer
+    :src: src/core/expr/fexpr_sumprod.cc pyfn_mean
     :cvar: doc_dt_mean
     :tests: tests/test-reduce.py
     :signature: mean(cols)

--- a/docs/api/dt/mean.rst
+++ b/docs/api/dt/mean.rst
@@ -1,6 +1,6 @@
 
 .. xfunction:: datatable.mean
-    :src: src/core/expr/fexpr_sumprod.cc pyfn_mean
+    :src: src/core/expr/fexpr_mean.cc pyfn_mean
     :cvar: doc_dt_mean
     :tests: tests/test-reduce.py
     :signature: mean(cols)

--- a/src/core/column/mean.h
+++ b/src/core/column/mean.h
@@ -46,7 +46,6 @@ class Mean_ColumnImpl : public Virtual_ColumnImpl {
 
 
     bool get_element(size_t i, T* out) const override {
-      
       T value;
       size_t i0, i1;
       gby_.get_group(i, &i0, &i1);

--- a/src/core/column/mean.h
+++ b/src/core/column/mean.h
@@ -1,0 +1,98 @@
+//------------------------------------------------------------------------------
+// Copyright 2022 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#ifndef dt_COLUMN_MEAN_h
+#define dt_COLUMN_MEAN_h
+#include "column/virtual.h"
+#include "stype.h"
+namespace dt {
+
+
+template <typename T>
+class Mean_ColumnImpl : public Virtual_ColumnImpl {
+  private:
+    Column col_;
+    Groupby gby_;
+    bool is_grouped_;
+    size_t : 56;
+
+  public:
+    Mean_ColumnImpl(Column &&col, const Groupby& gby, bool is_grouped)
+      : Virtual_ColumnImpl(gby.size(), col.stype()),
+        col_(std::move(col)),
+        gby_(gby),
+        is_grouped_(is_grouped)
+    {
+      xassert(col_.can_be_read_as<T>());
+    }
+
+
+    bool get_element(size_t i, T* out) const override {
+      
+      T value;
+      size_t i0, i1;
+      gby_.get_group(i, &i0, &i1);
+
+      if (is_grouped_){
+        bool is_valid = col_.get_element(i, &value);
+        if (!is_valid) return false;
+        *out = static_cast<T>(value);
+        return true;
+      } else {
+          double sum = 0;
+          int64_t count = 0;
+          for (size_t gi = i0; gi < i1; ++gi) {
+            bool is_valid = col_.get_element(gi, &value);
+            if (is_valid) {
+              sum += static_cast<double>(value);
+              count++;
+            }
+          }
+          if (!count) return false;
+          *out = static_cast<T>(sum / static_cast<double>(count));
+          return true;
+        }
+
+      
+    }
+
+
+    ColumnImpl *clone() const override {
+      return new Mean_ColumnImpl(Column(col_), Groupby(gby_), is_grouped_);
+    }
+
+
+    size_t n_children() const noexcept override {
+      return 1;
+    }
+
+
+    const Column &child(size_t i) const override {
+      xassert(i == 0);
+      (void)i;
+      return col_;
+    }
+};
+
+
+}  // namespace dt
+
+#endif

--- a/src/core/expr/fexpr_mean.cc
+++ b/src/core/expr/fexpr_mean.cc
@@ -78,8 +78,7 @@ class FExpr_Mean : public FExpr_Func {
       switch (stype) {
         case SType::VOID: {
           return Column(new ConstNa_ColumnImpl(gby.size(), SType::FLOAT64));
-        }
-          
+        }          
         case SType::BOOL:
         case SType::INT8:
         case SType::INT16:
@@ -124,7 +123,7 @@ static py::oobj pyfn_mean(const py::XArgs &args) {
 
 DECLARE_PYFN(&pyfn_mean)
     ->name("mean")
-    ->docs(doc_dt_min)
+    ->docs(doc_dt_mean)
     ->arg_names({"cols"})
     ->n_positional_args(1)
     ->n_required_args(1);

--- a/src/core/expr/fexpr_mean.cc
+++ b/src/core/expr/fexpr_mean.cc
@@ -92,6 +92,11 @@ class FExpr_Mean : public FExpr_Func {
         case SType::INT64:
         case SType::FLOAT64:
           return make<double>(std::move(col), SType::FLOAT64, gby, is_grouped);
+        case SType::DATE32: {
+          Column coli = make<double>(std::move(col), SType::FLOAT64, gby, is_grouped);
+          coli.cast_inplace(SType::DATE32);
+          return coli;
+        }
         case SType::TIME64: {
           Column coli = make<double>(std::move(col), SType::FLOAT64, gby, is_grouped);
           coli.cast_inplace(SType::TIME64);

--- a/src/core/expr/fexpr_mean.cc
+++ b/src/core/expr/fexpr_mean.cc
@@ -77,7 +77,7 @@ class FExpr_Mean : public FExpr_Func {
 
       switch (stype) {
         case SType::VOID: {
-          return Column(new ConstNa_ColumnImpl(gby.size(), stype));
+          return Column(new ConstNa_ColumnImpl(gby.size(), SType::FLOAT64));
         }
           
         case SType::BOOL:

--- a/src/core/expr/fexpr_mean.cc
+++ b/src/core/expr/fexpr_mean.cc
@@ -54,7 +54,6 @@ class FExpr_Mean : public FExpr_Func {
       Workframe wf = arg_->evaluate_n(ctx);
       Groupby gby = ctx.get_groupby();
 
-
       if (!gby) {
         gby = Groupby::single_group(wf.nrows());
       } 

--- a/src/core/expr/fexpr_mean.cc
+++ b/src/core/expr/fexpr_mean.cc
@@ -53,7 +53,6 @@ class FExpr_Mean : public FExpr_Func {
       Workframe outputs(ctx);
       Workframe wf = arg_->evaluate_n(ctx);
       Groupby gby = ctx.get_groupby();
-      bool has_by = ctx.has_groupby();
 
 
       if (!gby) {
@@ -65,7 +64,7 @@ class FExpr_Mean : public FExpr_Func {
                             wf.get_frame_id(i),
                             wf.get_column_id(i)
                           );
-        Column coli = evaluate1(wf.retrieve_column(i), gby, has_by, is_grouped);        
+        Column coli = evaluate1(wf.retrieve_column(i), gby, is_grouped);        
         outputs.add_column(std::move(coli), wf.retrieve_name(i), Grouping::GtoONE);         
       }
         
@@ -73,14 +72,12 @@ class FExpr_Mean : public FExpr_Func {
     }
 
 
-    Column evaluate1(Column &&col, const Groupby& gby, bool has_by, bool is_grouped) const {
+    Column evaluate1(Column &&col, const Groupby& gby, bool is_grouped) const {
       SType stype = col.stype();
 
       switch (stype) {
         case SType::VOID: {
-          Column coli = has_by? Column(new ConstNa_ColumnImpl(gby.size(), SType::FLOAT64))
-                              : Column(new ConstNa_ColumnImpl(gby.size()));
-          return coli;
+          return Column(new ConstNa_ColumnImpl(gby.size(), SType::FLOAT64));
         }
           
         case SType::BOOL:

--- a/src/core/expr/fexpr_mean.cc
+++ b/src/core/expr/fexpr_mean.cc
@@ -60,12 +60,12 @@ class FExpr_Mean : public FExpr_Func {
       } 
 
       for (size_t i = 0; i < wf.ncols(); ++i) {
-      bool is_grouped = ctx.has_group_column(
-                        wf.get_frame_id(i),
-                        wf.get_column_id(i)
-                      );
-      Column coli = evaluate1(wf.retrieve_column(i), gby, is_grouped);        
-      outputs.add_column(std::move(coli), wf.retrieve_name(i), Grouping::GtoONE);         
+        bool is_grouped = ctx.has_group_column(
+                            wf.get_frame_id(i),
+                            wf.get_column_id(i)
+                          );
+        Column coli = evaluate1(wf.retrieve_column(i), gby, is_grouped);        
+        outputs.add_column(std::move(coli), wf.retrieve_name(i), Grouping::GtoONE);         
       }
         
       return outputs;

--- a/src/core/expr/fexpr_mean.cc
+++ b/src/core/expr/fexpr_mean.cc
@@ -1,0 +1,126 @@
+//------------------------------------------------------------------------------
+// Copyright 2022 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#include "column/const.h"
+#include "column/latent.h"
+#include "column/mean.h"
+#include "documentation.h"
+#include "expr/fexpr_func.h"
+#include "expr/eval_context.h"
+#include "expr/workframe.h"
+#include "python/xargs.h"
+#include "stype.h"
+namespace dt {
+namespace expr {
+
+
+class FExpr_Mean : public FExpr_Func {
+  private:
+    ptrExpr arg_;
+
+  public:
+    FExpr_Mean(ptrExpr &&arg)
+      : arg_(std::move(arg)) {}
+
+    std::string repr() const override {
+      std::string out = "mean";
+      out += '(';
+      out += arg_->repr();
+      out += ')';
+      return out;
+    }
+
+
+    Workframe evaluate_n(EvalContext &ctx) const override {
+      Workframe outputs(ctx);
+      Workframe wf = arg_->evaluate_n(ctx);
+      Groupby gby = ctx.get_groupby();
+
+
+      if (!gby) {
+        gby = Groupby::single_group(wf.nrows());
+      } 
+
+      for (size_t i = 0; i < wf.ncols(); ++i) {
+      bool is_grouped = ctx.has_group_column(
+                        wf.get_frame_id(i),
+                        wf.get_column_id(i)
+                      );
+      Column coli = evaluate1(wf.retrieve_column(i), gby, is_grouped);        
+      outputs.add_column(std::move(coli), wf.retrieve_name(i), Grouping::GtoONE);         
+      }
+        
+      return outputs;
+    }
+
+
+    Column evaluate1(Column &&col, const Groupby& gby, bool is_grouped) const {
+      SType stype = col.stype();
+
+      switch (stype) {
+        case SType::VOID: {
+          return Column(new ConstNa_ColumnImpl(gby.size(), stype));
+        }
+          
+        case SType::BOOL:
+        case SType::INT8:
+        case SType::INT16:
+        case SType::INT32:        
+        case SType::INT64:
+        case SType::FLOAT64:
+          return make<double>(std::move(col), SType::FLOAT64, gby, is_grouped);
+        case SType::TIME64: {
+          Column coli = make<double>(std::move(col), SType::FLOAT64, gby, is_grouped);
+          coli.cast_inplace(SType::TIME64);
+          return coli;
+        }           
+        case SType::FLOAT32:
+          return make<float>(std::move(col), SType::FLOAT32, gby, is_grouped);
+        
+        default:
+          throw TypeError()
+            << "Invalid column of type `" << stype << "` in " << repr();
+      }
+    }
+
+
+    template <typename T>
+    Column make(Column &&col, SType stype, const Groupby& gby, bool is_grouped) const {
+      col.cast_inplace(stype);
+      return Column(new Latent_ColumnImpl(new Mean_ColumnImpl<T>(
+        std::move(col), gby, is_grouped
+      )));
+    }
+};
+
+
+static py::oobj pyfn_mean(const py::XArgs &args) {
+  auto mean = args[0].to_oobj();
+  return PyFExpr::make(new FExpr_Mean(as_fexpr(mean)));
+}
+
+DECLARE_PYFN(&pyfn_mean)
+    ->name("mean")
+    ->docs(doc_dt_min)
+    ->arg_names({"cols"})
+    ->n_positional_args(1)
+    ->n_required_args(1);
+}}  // dt::expr

--- a/src/core/expr/fexpr_mean.cc
+++ b/src/core/expr/fexpr_mean.cc
@@ -28,7 +28,6 @@
 #include "expr/workframe.h"
 #include "python/xargs.h"
 #include "stype.h"
-#include <iostream>
 namespace dt {
 namespace expr {
 
@@ -79,7 +78,6 @@ class FExpr_Mean : public FExpr_Func {
 
       switch (stype) {
         case SType::VOID: {
-          std::cout<<has_by<<std::endl;
           Column coli = has_by? Column(new ConstNa_ColumnImpl(gby.size(), SType::FLOAT64))
                               : Column(new ConstNa_ColumnImpl(gby.size()));
           return coli;

--- a/src/datatable/__init__.py
+++ b/src/datatable/__init__.py
@@ -21,7 +21,7 @@
 # IN THE SOFTWARE.
 #-------------------------------------------------------------------------------
 from .frame import Frame
-from .expr import (mean, min, max, sd, isna, sum, count, first, abs, exp,
+from .expr import (min, max, sd, isna, sum, count, first, abs, exp,
                    last, log, log10, f, g, median, cov, corr, countna, nunique)
 from .lib._datatable import (
     as_type,
@@ -43,6 +43,7 @@ from .lib._datatable import (
     intersect,
     iread,
     join,
+    mean,
     Namespace,
     ngroup,
     prod,

--- a/src/datatable/expr/__init__.py
+++ b/src/datatable/expr/__init__.py
@@ -23,7 +23,7 @@
 from .expr import f, g, Expr
 from .math import abs, log, log10, exp, isna
 from .reduce import (
-        sum, count, first, last, mean, median, min, max, sd, cov, corr, countna, nunique)
+        sum, count, first, last, median, min, max, sd, cov, corr, countna, nunique)
 
 __all__ = (
     "Expr",
@@ -40,7 +40,6 @@ __all__ = (
     "log",
     "log10",
     "max",
-    "mean",
     "median",
     "min",
     "sd",

--- a/src/datatable/expr/expr.py
+++ b/src/datatable/expr/expr.py
@@ -51,7 +51,6 @@ class OpCodes(enum.Enum):
     RSHIFT = 212
 
     # Reducers
-    MEAN = 401
     MIN = 402
     MAX = 403
     STDEV = 404

--- a/src/datatable/expr/reduce.py
+++ b/src/datatable/expr/reduce.py
@@ -33,7 +33,6 @@ __all__ = (
     "first",
     "last",
     "max",
-    "mean",
     "median",
     "min",
     "nunique",
@@ -83,9 +82,6 @@ def last(iterable):
                 pass
             return x
 
-
-def mean(expr):
-    return Expr(OpCodes.MEAN, (expr,))
 
 
 def sd(expr):

--- a/tests/test-reduce.py
+++ b/tests/test-reduce.py
@@ -384,7 +384,7 @@ def test_sum_grouped():
 def test_mean_void():
     DT = dt.Frame([None] * 10)
     DT_mean = DT[:, mean(f.C0)]
-    assert_equals(DT_mean, dt.Frame([None]))
+    assert_equals(DT_mean, dt.Frame([None]/dt.float64))
 
 
 def test_mean_void_per_group():
@@ -427,7 +427,7 @@ def test_mean_empty_frame():
 def test_median_void():
     DT = dt.Frame([None] * 10)
     DT_median = DT[:, mean(f.C0)]
-    assert_equals(DT_median, dt.Frame([None]))
+    assert_equals(DT_median, dt.Frame([None]/dt.float64))
 
 
 def test_median_void_per_group():

--- a/tests/test-reduce.py
+++ b/tests/test-reduce.py
@@ -390,7 +390,7 @@ def test_mean_void():
 def test_mean_void_per_group():
     DT = dt.Frame([[None, None, None, None, None], [1, 2, 1, 2, 2]])
     DT_mean = DT[:, mean(f.C0), by(f.C1)]
-    assert_equals(DT_mean, dt.Frame(C1=[1, 2]/dt.int32, C0=[None, None]))
+    assert_equals(DT_mean, dt.Frame(C1=[1, 2]/dt.int32, C0=[None, None]/dt.float64))
 
 
 def test_mean_void_grouped():
@@ -433,7 +433,7 @@ def test_median_void():
 def test_median_void_per_group():
     DT = dt.Frame([[None, None, None, None, None], [1, 2, 1, 2, 2]])
     DT_median = DT[:, mean(f.C0), by(f.C1)]
-    assert_equals(DT_median, dt.Frame(C1=[1, 2]/dt.int32, C0=[None, None]))
+    assert_equals(DT_median, dt.Frame(C1=[1, 2]/dt.int32, C0=[None, None]/dt.float64))
 
 
 def test_median_void_grouped():

--- a/tests/types/test-date32.py
+++ b/tests/types/test-date32.py
@@ -563,7 +563,7 @@ def test_date32_in_groupby():
                  max = [2997, 2998, 2999] / date32,
                  first = [0, 1, 2] / date32,
                  last = [2997, 2998, 2999] / date32,
-                 mean = [1498, 1499, 1500]/date32))
+                 mean = [1498, 1499, 1500] / date32))
 
 
 def test_select_dates():

--- a/tests/types/test-date32.py
+++ b/tests/types/test-date32.py
@@ -552,7 +552,8 @@ def test_date32_in_groupby():
                  "min": dt.min(f.B),
                  "max": dt.max(f.B),
                  "first": dt.first(f.B),
-                 "last": dt.last(f.B)},
+                 "last": dt.last(f.B),
+                 "mean": dt.mean(f.B)},
             dt.by(f.A)]
     date32 = dt.stype.date32
     assert_equals(RES,
@@ -561,7 +562,8 @@ def test_date32_in_groupby():
                  min = [0, 1, 2] / date32,
                  max = [2997, 2998, 2999] / date32,
                  first = [0, 1, 2] / date32,
-                 last = [2997, 2998, 2999] / date32))
+                 last = [2997, 2998, 2999] / date32,
+                 mean = [1498, 1499, 1500]/date32))
 
 
 def test_select_dates():


### PR DESCRIPTION
- refactor `mean()` reducer to use `FExpr`;
- fix `median()` to use `float64` for void columns.

WIP for #2562 