### PR TITLE
Fix datatable functions that shadow python built-ins

### DIFF
--- a/docs/api/dt/sort.rst
+++ b/docs/api/dt/sort.rst
@@ -35,7 +35,7 @@
         sorting is descending.
 
     na_position: None | "first" | "last" | "remove"
-        If "first", the default behaviour, missing values are placed
+        If "first", the default behavior, missing values are placed
         first in sorted output. If "last", they are placed last.
         If "remove", rows that contain missing values in `cols`
         are excluded from the output.

--- a/docs/releases/v0.11.0.rst
+++ b/docs/releases/v0.11.0.rst
@@ -93,7 +93,7 @@
     were renamed into ``method=``. The old parameter name still works, so this
     change is not breaking.
 
-  -[api] The behaviour of a method :meth:`.sort()` is made consistent with
+  -[api] The behavior of a method :meth:`.sort()` is made consistent with
     the function :func:`dt.sort()`. When the list of columns to sort
     is empty, both will not sort any columns.
 

--- a/docs/releases/v1.1.0.rst
+++ b/docs/releases/v1.1.0.rst
@@ -28,8 +28,6 @@
     -[enh] :meth:`.to_csv()` now has an option ``sep`` to control
         the field separator. [#3337]
 
-
-
     -[fix] Void columns can now be used with :func:`dt.sort()` and :func:`dt.by()`.
         In addition, datatable will now skip sorting any column that it knows contains
         constant values. [#3088] [#3104] [#3108] [#3109]

--- a/docs/releases/v1.1.0.rst
+++ b/docs/releases/v1.1.0.rst
@@ -33,8 +33,9 @@
 
     -[fix] Joining with void columns now works correctly. [#3094]
 
-    -[fix] :func:`dt.sum()` now works correctly when applied to the same
-        column as :func:`dt.by()`. [#3110]
+    -[fix] :func:`dt.sum()` now works correctly when called on grouped column. [#3110]
+
+    -[fix] Fixed :func:`dt.sum()` behaviour when called on iterables and frames. [#3406]
 
     -[fix] Fixed a crash which could have occurred when sorting very long
         identical or nearly identical strings. [#3134]

--- a/docs/releases/v1.1.0.rst
+++ b/docs/releases/v1.1.0.rst
@@ -6,6 +6,10 @@
     -----
     .. current-class:: datatable.Frame
 
+    -[enh] Parameter ``force=True`` in method :meth:`.rbind()`
+        and function :func:`dt.rbind()` will now allow combining columns
+        of incompatible types. [#3062]
+
     -[enh] Frames with columns of type :attr:`obj64 <dt.Type.obj64>` can now
         be saved into CSV. The values in the object column will be stringified
         upon saving. [#3064]
@@ -23,6 +27,8 @@
 
     -[enh] :meth:`.to_csv()` now has an option ``sep`` to control
         the field separator. [#3337]
+
+
 
     -[fix] Void columns can now be used with :func:`dt.sort()` and :func:`dt.by()`.
         In addition, datatable will now skip sorting any column that it knows contains
@@ -203,11 +209,10 @@
 
     -[enh] Added support for Python `3.11`. [#3374]
 
-    -[enh] Parameter ``force=True`` in function :func:`rbind()` (or method
-        :meth:`dt.Frame.rbind()`) will now allow combining columns
-        of incompatible types. [#3062]
-
     -[enh] datatable's thread pool can now be used to parallelize external C++ applications
         and will have no specific datatable dependencies, when the code is built with
         ``DT_DISABLE`` variable being defined. [#3306]
 
+    -[enh] Python built-in functoins ``min()`` and ``max()`` will continue
+        working for list comprehensions even after :func:`dt.min()` and
+        :func:`dt.max()` have been imported from datatable. [#3409]

--- a/docs/releases/v1.1.0.rst
+++ b/docs/releases/v1.1.0.rst
@@ -35,7 +35,7 @@
 
     -[fix] :func:`dt.sum()` now works correctly when called on grouped column. [#3110]
 
-    -[fix] Fixed :func:`dt.sum()` behaviour when called on iterables and frames. [#3406]
+    -[fix] Fixed :func:`dt.sum()` behavior when called on iterables and frames. [#3406]
 
     -[fix] Fixed a crash which could have occurred when sorting very long
         identical or nearly identical strings. [#3134]
@@ -54,7 +54,7 @@
     -[fix] Fixed :meth:`.to_csv()` to quote missing values when
         `quoting="all"` is specified. [#3340]
 
-    -[fix] Fixed groupby behaviour on columns that contain missing values. [#3331]
+    -[fix] Fixed groupby behavior on columns that contain missing values. [#3331]
 
     -[api] Converting a column of :attr:`void <dt.Type.void>` type into pandas
         now produces a pandas ``object`` column filled with ``None``s. Converting
@@ -130,7 +130,7 @@
 
     -[fix] Fixed selection of ``time64`` columns by python class name. [#3253]
 
-    -[fix] Fixed :func:`dt.shift()` behaviour on grouped columns. [#3269] [#3272]
+    -[fix] Fixed :func:`dt.shift()` behavior on grouped columns. [#3269] [#3272]
 
     -[fix] Reducers and row-wise functions now support :attr:`void <dt.Type.void>`
        columns. [#3284]
@@ -173,7 +173,7 @@
         that in some cases resulted in the gradient and model coefficients
         blow up. [#3234]
 
-    -[fix] Fixed undefined behaviour when :class:`LinearModel <dt.models.LinearModel>`
+    -[fix] Fixed undefined behavior when :class:`LinearModel <dt.models.LinearModel>`
         predicted on frames with missing values. [#3260]
 
 

--- a/src/datatable/expr/reduce.py
+++ b/src/datatable/expr/reduce.py
@@ -109,7 +109,9 @@ def corr(col1, col2):
 
 # noinspection PyShadowingBuiltins
 def sum(iterable, start=0):
-    if not isinstance(iterable, dict) and (isinstance(iterable, core.FExpr) or isinstance(iterable[0], core.FExpr)):
+    if (not isinstance(iterable, dict)
+        and (isinstance(iterable, core.FExpr)
+        or (hasattr(iterable, "__getitem__") and isinstance(iterable[0], core.FExpr)))):
         return core.sum(iterable)
     elif isinstance(iterable, dict) and isinstance([*iterable.values()][0], core.FExpr):
         return core.sum(iterable)
@@ -121,7 +123,9 @@ def sum(iterable, start=0):
 
 # noinspection PyShadowingBuiltins
 def min(*args, **kwds):
-    if len(args) == 1 and (not isinstance(args[0], dict)) and (isinstance(args[0], (Expr, core.FExpr)) or isinstance(args[0][0], (Expr, core.FExpr))):
+    if (len(args) == 1
+        and (not isinstance(args[0], dict)) and (isinstance(args[0], (Expr, core.FExpr))
+        or (hasattr(args[0], "__getitem__") and isinstance(args[0][0], (Expr, core.FExpr))))):
         return Expr(OpCodes.MIN, args)
     elif len(args) == 1 and isinstance(args[0], dict) and isinstance([*args[0].values()][0], (Expr, core.FExpr)):
         return Expr(OpCodes.MIN, args)
@@ -133,7 +137,9 @@ def min(*args, **kwds):
 
 # noinspection PyShadowingBuiltins
 def max(*args, **kwds):
-    if len(args) == 1 and (not isinstance(args[0], dict)) and (isinstance(args[0], (Expr, core.FExpr)) or isinstance(args[0][0], (Expr, core.FExpr))):
+    if (len(args) == 1 and (not isinstance(args[0], dict))
+        and (isinstance(args[0], (Expr, core.FExpr))
+        or (hasattr(args[0], "__getitem__") and isinstance(args[0][0], (Expr, core.FExpr))))):
         return Expr(OpCodes.MAX, args)
     elif len(args) == 1 and isinstance(args[0], dict) and isinstance([*args[0].values()][0], (Expr, core.FExpr)):
         return Expr(OpCodes.MAX, args)

--- a/src/datatable/expr/reduce.py
+++ b/src/datatable/expr/reduce.py
@@ -109,8 +109,12 @@ def corr(col1, col2):
 
 # noinspection PyShadowingBuiltins
 def sum(iterable, start=0):
-    if isinstance(iterable, core.FExpr):
+    if not isinstance(iterable, dict) and (isinstance(iterable, core.FExpr) or isinstance(iterable[0], core.FExpr)):
         return core.sum(iterable)
+    elif isinstance(iterable, dict) and isinstance([*iterable.values()][0], core.FExpr):
+        return core.sum(iterable)
+    elif isinstance(iterable, core.Frame):
+        return iterable.sum()
     else:
         return _builtin_sum(iterable, start)
 

--- a/tests/munging/test-replace.py
+++ b/tests/munging/test-replace.py
@@ -95,9 +95,9 @@ def test_replace_bool_na():
 
 def test_replace_bool_numpy():
     df = dt.Frame([True, None, False, True, False, False])
-    df.replace({None: np.bool8(False),
-                np.bool8(True): np.bool8(False),
-                np.bool8(False): None
+    df.replace({None: np.bool_(False),
+                np.bool_(True): np.bool_(False),
+                np.bool_(False): None
                })
     frame_integrity_check(df)
     assert df.stypes == (dt.bool8,)

--- a/tests/test-dt-stats.py
+++ b/tests/test-dt-stats.py
@@ -504,7 +504,7 @@ def test_issue1953():
 
 def test_stats_bool_large(numpy):
     n = 12345678
-    a = numpy.random.randint(2, size=n, dtype=numpy.bool8)
+    a = numpy.random.randint(2, size=n, dtype=numpy.bool_)
     dt0 = dt.Frame(a)
     assert dt0.sum().to_list() == [[a.sum()]]
     assert dt0.countna().to_list() == [[0]]

--- a/tests/test-groups.py
+++ b/tests/test-groups.py
@@ -346,8 +346,7 @@ def test_groupby_large_random_integers(seed):
                              random.randint(1, 20))
                for i in range(ngrps1)])
     n = int(random.expovariate(0.0001)) + 10
-    sample = [sum(random.choice(chunks[i]) << (8 * i)
-                  for i in range(len(chunks)))
+    sample = [sum(random.choice(chunks[i]) << (8 * i) for i in range(len(chunks)))
               for _ in range(n)]
     nuniques = len(set(sample))
     f0 = dt.Frame(sample)

--- a/tests/test-reduce.py
+++ b/tests/test-reduce.py
@@ -320,6 +320,13 @@ def test_minmax_nas(mm, st):
     assert DT2[:, mm(f.B)].to_list() == [[None]]
 
 
+@pytest.mark.parametrize("mm, res", [(dt.min, 0), (dt.max, 9)])
+def test_minmax_comprehension(mm, res):
+    # See issue #3409
+    s = mm([i for i in range(10)])
+    assert s == res
+
+
 
 #-------------------------------------------------------------------------------
 # sum
@@ -391,8 +398,15 @@ def test_sum_multicolumn():
 def test_sum_frame():
     # See issue #3406
     DT = dt.Frame(range(5))
-    DT_sum = dt.sum(DT)
+    DT_sum = sum(DT)
     assert_equals(DT_sum, DT.sum())
+
+
+def test_sum_comprehension():
+    # See issue #3406
+    s = sum([i for i in range(10)])
+    assert s == 45
+
 
 
 #-------------------------------------------------------------------------------

--- a/tests/test-reduce.py
+++ b/tests/test-reduce.py
@@ -376,6 +376,24 @@ def test_sum_grouped():
     assert str(DT_sum)
 
 
+def test_sum_multicolumn():
+    # See issue #3406
+    DT = dt.Frame(range(5))
+    DT_sum_list = DT[:, sum([f.C0, f.C0])]
+    DT_sum_tuple = DT[:, sum((f.C0, f.C0))]
+    DT_sum_dict = DT[:, sum({"A":f.C0, "B":f.C0})]
+    DT_ref = dt.Frame([10]/dt.int64)
+    assert_equals(DT_sum_list, DT_ref[:, [f.C0, f.C0]])
+    assert_equals(DT_sum_tuple, DT_ref[:, [f.C0, f.C0]])
+    assert_equals(DT_sum_dict, DT_ref[:, {"A":f.C0, "B":f.C0}])
+
+
+def test_sum_frame():
+    # See issue #3406
+    DT = dt.Frame(range(5))
+    DT_sum = dt.sum(DT)
+    assert_equals(DT_sum, DT.sum())
+
 
 #-------------------------------------------------------------------------------
 # Mean


### PR DESCRIPTION
Fix `dt.sum()`, `dt.min()` and `dt.max()` behavior on iterables, frames and generators.

Closes #3406 
Closes #3409 