### PR TITLE
Fix `dt.median()` when used on a groupby context for void columns

### DIFF
--- a/docs/api/dt/median.rst
+++ b/docs/api/dt/median.rst
@@ -14,8 +14,9 @@
         Input columns.
 
     return: Expr
-        f-expression having one row, and the same names, stypes and
-        number of columns as in `cols`.
+        f-expression having one row, and the same names and number of columns
+        as in `cols`. The column stypes are `float32` for
+        `float32` columns, and `float64` for all the other numeric types.
 
     except: TypeError
         The exception is raised when one of the columns from `cols`

--- a/docs/releases/v1.1.0.rst
+++ b/docs/releases/v1.1.0.rst
@@ -139,6 +139,9 @@
     -[fix] Reducers and row-wise functions now support :attr:`void <dt.Type.void>`
        columns. [#3284]
 
+    -[fix] Fixed :func:`dt.median()` when used in a groupby context with
+       :attr:`void <dt.Type.void>` columns. [#3411]
+
 
     fread
     -----

--- a/src/core/expr/head_reduce_unary.cc
+++ b/src/core/expr/head_reduce_unary.cc
@@ -830,7 +830,7 @@ static Column compute_median(Column&& arg, const Groupby& gby) {
     return Column::new_na_column(1, arg.stype());
   }
   switch (arg.stype()) {
-    case SType::VOID:    return Column(new ConstNa_ColumnImpl(1));
+    case SType::VOID:    return Column(new ConstNa_ColumnImpl(gby.size()));
     case SType::BOOL:
     case SType::INT8:    return _median<int8_t> (std::move(arg), gby);
     case SType::INT16:   return _median<int16_t>(std::move(arg), gby);

--- a/src/core/sort.cc
+++ b/src/core/sort.cc
@@ -1497,6 +1497,7 @@ RiGb group(const std::vector<Column>& columns,
 
 
 void dt::ColumnImpl::sort_grouped(const Groupby& grps, Column& out) {
+  out.materialize(); // `SortContext::continue_sort()` requires material column
   (void) out.stats();
   SortContext sc(nrows(), RowIndex(), grps, /* make_groups = */ false);
   sc.continue_sort(out, /* desc = */ false, /* make_groups = */ false);

--- a/tests/test-reduce.py
+++ b/tests/test-reduce.py
@@ -458,19 +458,25 @@ def test_mean_empty_frame():
 
 def test_median_void():
     DT = dt.Frame([None] * 10)
-    DT_median = DT[:, mean(f.C0)]
+    DT_median = DT[:, median(f.C0)]
     assert_equals(DT_median, dt.Frame([None]))
 
 
 def test_median_void_per_group():
     DT = dt.Frame([[None, None, None, None, None], [1, 2, 1, 2, 2]])
-    DT_median = DT[:, mean(f.C0), by(f.C1)]
+    DT_median = DT[:, median(f.C0), by(f.C1)]
     assert_equals(DT_median, dt.Frame(C1=[1, 2]/dt.int32, C0=[None, None]))
+
+
+def test_median_nonvoid_per_void_group():
+    DT = dt.Frame([[None, None, None, None, None], [1, 2, 1, 2, 2]])
+    DT_median = DT[:, median(f.C1), by(f.C0)]
+    assert_equals(DT_median, dt.Frame([[None], [2]/dt.float64]))
 
 
 def test_median_void_grouped():
     DT = dt.Frame([[None, None, None, None, None], [1, 2, 1, 2, 2]])
-    DT_median = DT[:, mean(f.C0), by(f.C0)]
+    DT_median = DT[:, median(f.C0), by(f.C0)]
     assert_equals(DT_median, dt.Frame([[None], [None]/dt.float64]))
 
 


### PR DESCRIPTION
In this PR we fix `dt.median()` 
- when called on `void` columns within a groupby context that has more than one group;
- for frames that are grouped by a `void` column;
- tests that tested `dt.mean()` instead;
- return type in documentation.

Closes #3411 