### PR TITLE
Refactor unary `FExpr` reducers to use `ReduceUnary_ColumnImpl`

### DIFF
--- a/src/core/column/mean.h
+++ b/src/core/column/mean.h
@@ -21,37 +21,22 @@
 //------------------------------------------------------------------------------
 #ifndef dt_COLUMN_MEAN_h
 #define dt_COLUMN_MEAN_h
-#include "column/virtual.h"
-#include "stype.h"
+#include "column/reduce_unary.h"
 namespace dt {
 
 
-template <typename T>
-class Mean_ColumnImpl : public Virtual_ColumnImpl {
-  private:
-    Column col_;
-    Groupby gby_;
-    bool is_grouped_;
-    size_t : 56;
-
+template <typename T, bool IS_GROUPED>
+class Mean_ColumnImpl : public ReduceUnary_ColumnImpl<T, IS_GROUPED> {
   public:
-    Mean_ColumnImpl(Column &&col, const Groupby& gby, bool is_grouped)
-      : Virtual_ColumnImpl(gby.size(), col.stype()),
-        col_(std::move(col)),
-        gby_(gby),
-        is_grouped_(is_grouped)
-    {
-      xassert(col_.can_be_read_as<T>());
-    }
-
+    using ReduceUnary_ColumnImpl<T, IS_GROUPED>::ReduceUnary_ColumnImpl;
 
     bool get_element(size_t i, T* out) const override {
       T value;
       size_t i0, i1;
-      gby_.get_group(i, &i0, &i1);
+      this->gby_.get_group(i, &i0, &i1);
 
-      if (is_grouped_){
-        bool is_valid = col_.get_element(i, &value);
+      if (IS_GROUPED){
+        bool is_valid = this->col_.get_element(i, &value);
         if (!is_valid) return false;
         *out = static_cast<T>(value);
         return true;
@@ -59,7 +44,7 @@ class Mean_ColumnImpl : public Virtual_ColumnImpl {
         double sum = 0;
         int64_t count = 0;
         for (size_t gi = i0; gi < i1; ++gi) {
-          bool is_valid = col_.get_element(gi, &value);
+          bool is_valid = this->col_.get_element(gi, &value);
           if (is_valid) {
             sum += static_cast<double>(value);
             count++;
@@ -71,26 +56,8 @@ class Mean_ColumnImpl : public Virtual_ColumnImpl {
       }
 
     }
-
-
-    ColumnImpl *clone() const override {
-      return new Mean_ColumnImpl(Column(col_), Groupby(gby_), is_grouped_);
-    }
-
-
-    size_t n_children() const noexcept override {
-      return 1;
-    }
-
-
-    const Column &child(size_t i) const override {
-      xassert(i == 0);
-      (void)i;
-      return col_;
-    }
 };
 
 
 }  // namespace dt
-
 #endif

--- a/src/core/column/reduce_unary.h
+++ b/src/core/column/reduce_unary.h
@@ -28,7 +28,7 @@ namespace dt {
 
 template <typename T, bool IS_GROUPED>
 class ReduceUnary_ColumnImpl : public Virtual_ColumnImpl {
-  private:
+  protected:
     Column col_;
     Groupby gby_;
 

--- a/src/core/expr/fexpr_mean.cc
+++ b/src/core/expr/fexpr_mean.cc
@@ -109,9 +109,16 @@ class FExpr_Mean : public FExpr_Func {
     template <typename T>
     Column make(Column &&col, SType stype, const Groupby& gby, bool is_grouped) const {
       col.cast_inplace(stype);
-      return Column(new Latent_ColumnImpl(new Mean_ColumnImpl<T>(
-        std::move(col), gby, is_grouped
-      )));
+
+      if (is_grouped) {
+        return Column(new Latent_ColumnImpl(new Mean_ColumnImpl<T, true>(
+          std::move(col), gby
+        )));
+      } else {
+        return Column(new Latent_ColumnImpl(new Mean_ColumnImpl<T, false>(
+          std::move(col), gby
+        )));
+      }
     }
 };
 

--- a/src/core/expr/fexpr_sumprod.cc
+++ b/src/core/expr/fexpr_sumprod.cc
@@ -98,9 +98,15 @@ class FExpr_SumProd : public FExpr_Func {
     template <typename T>
     Column make(Column &&col, SType stype, const Groupby& gby, bool is_grouped) const {
       col.cast_inplace(stype);
-      return Column(new Latent_ColumnImpl(new SumProd_ColumnImpl<T, SUM>(
-        std::move(col), gby, is_grouped
-      )));
+      if (is_grouped) {
+        return Column(new Latent_ColumnImpl(new SumProd_ColumnImpl<T, SUM, true>(
+          std::move(col), gby
+        )));
+      } else {
+        return Column(new Latent_ColumnImpl(new SumProd_ColumnImpl<T, SUM, false>(
+          std::move(col), gby
+        )));
+      }
     }
 };
 


### PR DESCRIPTION
- refactor existing unary `FExpr` reducers to inherit from `ReduceUnary_ColumnImpl`;
- make `is_grouped` to be a template parameter.

WIP for https://github.com/h2oai/datatable/issues/2562