### PR TITLE
Add `DT_SEMAPHORE_SPIN_COUNT` to control spin count in thread pool

### DIFF
--- a/src/core/parallel/api_primitives.h
+++ b/src/core/parallel/api_primitives.h
@@ -17,15 +17,16 @@
 #define dt_PARALLEL_API_PRIMITIVES_h
 #include <cstddef>
 #include "utils/assert.h"
-namespace dt {
 
 #ifndef DT_DEFAULT_CHUNK_SIZE
   #define DT_DEFAULT_CHUNK_SIZE 1000
 #endif
-
 #ifndef DT_DEFAULT_MIN_ITERS_PER_THREAD
   #define DT_DEFAULT_MIN_ITERS_PER_THREAD 1000
 #endif
+
+namespace dt {
+
 
 size_t num_threads_in_pool();
 

--- a/src/core/parallel/semaphore.h
+++ b/src/core/parallel/semaphore.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2019 H2O.ai
+// Copyright 2019-2023 H2O.ai
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -47,6 +47,11 @@
 #include <thread>          // std::this_thread
 #include "utils/assert.h"
 #include "utils/macros.h"
+
+#ifndef DT_SEMAPHORE_SPIN_COUNT
+  #define DT_SEMAPHORE_SPIN_COUNT 1000000
+#endif
+
 namespace dt {
 
 
@@ -204,7 +209,7 @@ class LightweightSemaphore {
     }
 
     void wait() {
-      int spin_count = 1000000;
+      int spin_count = DT_SEMAPHORE_SPIN_COUNT;
       do {
         if (try_wait()) return;
         // This line significantly boosts the performance.


### PR DESCRIPTION
Add `DT_SEMAPHORE_SPIN_COUNT` macro to control spin count in `LightweightSemaphore::wait()`. The default value is currently `1000000` and may need to be reduced for optimal performance on systems, where datatable has no exclusive access to resources.