### PR TITLE
Fix chained `FExpr` reducers

### DIFF
--- a/docs/releases/v1.1.0.rst
+++ b/docs/releases/v1.1.0.rst
@@ -151,6 +151,8 @@
     -[fix] Fixed :func:`dt.median()` when used in a groupby context with
        :attr:`void <dt.Type.void>` columns. [#3411]
 
+    -[fix] Allow chained reducers to be used for :class:`dt.FExpr`s. [#3417]
+
 
     fread
     -----

--- a/src/core/column/mean.h
+++ b/src/core/column/mean.h
@@ -25,36 +25,29 @@
 namespace dt {
 
 
-template <typename T, bool IS_GROUPED>
-class Mean_ColumnImpl : public ReduceUnary_ColumnImpl<T, IS_GROUPED> {
+template <typename T>
+class Mean_ColumnImpl : public ReduceUnary_ColumnImpl<T> {
   public:
-    using ReduceUnary_ColumnImpl<T, IS_GROUPED>::ReduceUnary_ColumnImpl;
+    using ReduceUnary_ColumnImpl<T>::ReduceUnary_ColumnImpl;
 
     bool get_element(size_t i, T* out) const override {
       T value;
       size_t i0, i1;
       this->gby_.get_group(i, &i0, &i1);
 
-      if (IS_GROUPED){
-        bool is_valid = this->col_.get_element(i, &value);
-        if (!is_valid) return false;
-        *out = static_cast<T>(value);
-        return true;
-      } else {
-        double sum = 0;
-        int64_t count = 0;
-        for (size_t gi = i0; gi < i1; ++gi) {
-          bool is_valid = this->col_.get_element(gi, &value);
-          if (is_valid) {
-            sum += static_cast<double>(value);
-            count++;
-          }
+      double sum = 0;
+      int64_t count = 0;
+      for (size_t gi = i0; gi < i1; ++gi) {
+        bool is_valid = this->col_.get_element(gi, &value);
+        if (is_valid) {
+          sum += static_cast<double>(value);
+          count++;
         }
-        if (!count) return false;
-        *out = static_cast<T>(sum / static_cast<double>(count));
-        return true;
       }
+      if (count == 0) return false;
 
+      *out = static_cast<T>(sum / static_cast<double>(count));
+      return true;
     }
 };
 

--- a/src/core/column/mean.h
+++ b/src/core/column/mean.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2022 H2O.ai
+// Copyright 2022-2023 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),

--- a/src/core/column/mean.h
+++ b/src/core/column/mean.h
@@ -46,7 +46,7 @@ class Mean_ColumnImpl : public ReduceUnary_ColumnImpl<T> {
       }
       if (count == 0) return false;
 
-      *out = static_cast<T>(sum / static_cast<double>(count));
+      *out = static_cast<T>(sum / count);
       return true;
     }
 };

--- a/src/core/column/minmax.h
+++ b/src/core/column/minmax.h
@@ -22,23 +22,15 @@
 #ifndef dt_COLUMN_MINMAX_h
 #define dt_COLUMN_MINMAX_h
 #include "column/reduce_unary.h"
-#include "stype.h"
 namespace dt {
 
 
-template <typename T, bool MIN, bool IS_GROUPED>
-class MinMax_ColumnImpl : public ReduceUnary_ColumnImpl<T, IS_GROUPED> {
+template <typename T, bool MIN>
+class MinMax_ColumnImpl : public ReduceUnary_ColumnImpl<T> {
   public:
-    using ReduceUnary_ColumnImpl<T, IS_GROUPED>::ReduceUnary_ColumnImpl;
+    using ReduceUnary_ColumnImpl<T>::ReduceUnary_ColumnImpl;
 
     bool get_element(size_t i, T* out) const override {      
-      if (IS_GROUPED) {
-        T value;
-        bool isvalid = this->col_.get_element(i, &value);
-        *out = value;
-        return isvalid;
-      }
-
       // res` will be updated on the first valid element, due to `res_isna`
       // initially being set to `true`. So the default value here
       // only silences the compiler warning and makes the update

--- a/src/core/column/sumprod.h
+++ b/src/core/column/sumprod.h
@@ -27,9 +27,9 @@ namespace dt {
 
 
 template <typename T, bool SUM, bool IS_GROUPED>
-class SumProd_ColumnImpl : public ReduceUnary_ColumnImpl<T, IS_GROUPED> {
+class SumProd_ColumnImpl : public ReduceUnary_ColumnImpl<T> {
   public:
-    using ReduceUnary_ColumnImpl<T, IS_GROUPED>::ReduceUnary_ColumnImpl;
+    using ReduceUnary_ColumnImpl<T>::ReduceUnary_ColumnImpl;
 
     bool get_element(size_t i, T* out) const override {
       T result = !SUM; // 0 for `sum()` and 1 for `prod()`

--- a/src/core/column/sumprod.h
+++ b/src/core/column/sumprod.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2022 H2O.ai
+// Copyright 2022-2023 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),

--- a/src/core/expr/fexpr.cc
+++ b/src/core/expr/fexpr.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2020-2022 H2O.ai
+// Copyright 2020-2023 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),

--- a/src/core/expr/fexpr.cc
+++ b/src/core/expr/fexpr.cc
@@ -19,7 +19,6 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
-#include <iostream>
 #include "documentation.h"
 #include "expr/expr.h"            // OldExpr
 #include "expr/fexpr.h"

--- a/src/core/expr/fexpr_func_unary.h
+++ b/src/core/expr/fexpr_func_unary.h
@@ -27,8 +27,7 @@ namespace expr {
 
 
 /**
-  * Base class for the functions that have only a single argument.
-  *
+  * Base class for FExpr functions that have only one parameter.
   */
 class FExpr_FuncUnary : public FExpr_Func {
   protected:

--- a/src/core/expr/fexpr_mean.cc
+++ b/src/core/expr/fexpr_mean.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2022 H2O.ai
+// Copyright 2022-2023 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),

--- a/src/core/expr/fexpr_minmax.cc
+++ b/src/core/expr/fexpr_minmax.cc
@@ -73,7 +73,7 @@ class FExpr_MinMax : public FExpr_ReduceUnary {
 
 
     template <typename T>
-    Column make(Column &&col, const Groupby& gby, bool is_grouped) const {
+    Column make(Column&& col, const Groupby& gby, bool is_grouped) const {
       return is_grouped? std::move(col)
                        : Column(new Latent_ColumnImpl(new MinMax_ColumnImpl<T, MIN>(
                            std::move(col), gby

--- a/src/core/expr/fexpr_minmax.cc
+++ b/src/core/expr/fexpr_minmax.cc
@@ -23,7 +23,7 @@
 #include "column/latent.h"
 #include "column/minmax.h"
 #include "documentation.h"
-#include "expr/fexpr_func.h"
+#include "expr/fexpr_reduce_unary.h"
 #include "expr/eval_context.h"
 #include "expr/workframe.h"
 #include "python/xargs.h"
@@ -33,53 +33,18 @@ namespace expr {
 
 
 template <bool MIN>
-class FExpr_MinMax : public FExpr_Func {
-  private:
-    ptrExpr arg_;
-
+class FExpr_MinMax : public FExpr_ReduceUnary {
   public:
-    FExpr_MinMax(ptrExpr &&arg)
-      : arg_(std::move(arg)) {}
+    using FExpr_ReduceUnary::FExpr_ReduceUnary;
 
-    std::string repr() const override {
-      std::string out = MIN? "min" : "max";
-      out += '(';
-      out += arg_->repr();
-      out += ')';
-      return out;
+
+    std::string name() const override {
+      return MIN? "min"
+                : "max";
     }
 
 
-    Workframe evaluate_n(EvalContext &ctx) const override {
-      Workframe outputs(ctx);
-      Workframe wf = arg_->evaluate_n(ctx);
-      Groupby gby = ctx.get_groupby();
-
-      if (!gby) {
-        gby = Groupby::single_group(wf.nrows());
-      }
-
-      if (wf.nrows() == 0) {
-        for (size_t i = 0; i < wf.ncols(); ++i) {
-          Column coli = wf.retrieve_column(i);
-          coli = Column(new ConstNa_ColumnImpl(1, coli.stype()));
-          outputs.add_column(std::move(coli), wf.retrieve_name(i), Grouping::GtoONE);
-        }
-      } else {
-          for (size_t i = 0; i < wf.ncols(); ++i) {
-            bool is_grouped = ctx.has_group_column(
-                                wf.get_frame_id(i),
-                                wf.get_column_id(i)
-                              );
-            Column coli = evaluate1(wf.retrieve_column(i), gby, is_grouped);        
-            outputs.add_column(std::move(coli), wf.retrieve_name(i), Grouping::GtoONE);         
-          }
-        }
-      return outputs;
-    }
-
-
-    Column evaluate1(Column &&col, const Groupby& gby, bool is_grouped) const {
+    Column evaluate1(Column&& col, const Groupby& gby, bool is_grouped) const override {
       SType stype = col.stype();
 
       switch (stype) {
@@ -87,21 +52,19 @@ class FExpr_MinMax : public FExpr_Func {
           return Column(new ConstNa_ColumnImpl(gby.size(), stype));
         case SType::BOOL:
         case SType::INT8:
-          return make<int8_t>(std::move(col), SType::INT8, gby, is_grouped);
+          return make<int8_t>(std::move(col), gby, is_grouped);
         case SType::INT16:
-          return make<int16_t>(std::move(col), SType::INT16, gby, is_grouped);
-        case SType::DATE32:
-          return make<int32_t>(std::move(col), SType::DATE32, gby, is_grouped);
+          return make<int16_t>(std::move(col), gby, is_grouped);
         case SType::INT32:
-          return make<int32_t>(std::move(col), SType::INT32, gby, is_grouped);
-        case SType::TIME64:
-          return make<int64_t>(std::move(col), SType::TIME64, gby, is_grouped);
+        case SType::DATE32:
+          return make<int32_t>(std::move(col), gby, is_grouped);
         case SType::INT64:
-          return make<int64_t>(std::move(col), SType::INT64, gby, is_grouped);
+        case SType::TIME64:
+          return make<int64_t>(std::move(col), gby, is_grouped);
         case SType::FLOAT32:
-          return make<float>(std::move(col), SType::FLOAT32, gby, is_grouped);
+          return make<float>(std::move(col), gby, is_grouped);
         case SType::FLOAT64:
-          return make<double>(std::move(col), SType::FLOAT64, gby, is_grouped);
+          return make<double>(std::move(col), gby, is_grouped);
         default:
           throw TypeError()
             << "Invalid column of type `" << stype << "` in " << repr();
@@ -110,17 +73,12 @@ class FExpr_MinMax : public FExpr_Func {
 
 
     template <typename T>
-    Column make(Column &&col, SType stype, const Groupby& gby, bool is_grouped) const {
-      col.cast_inplace(stype);
-      if (is_grouped) {
-        return Column(new Latent_ColumnImpl(new MinMax_ColumnImpl<T, MIN, true>(
-          std::move(col), gby
-        )));
-      } else {
-        return Column(new Latent_ColumnImpl(new MinMax_ColumnImpl<T, MIN, false>(
-          std::move(col), gby
-        )));
-      }
+    Column make(Column &&col, const Groupby& gby, bool is_grouped) const {
+      return is_grouped? std::move(col)
+                       : Column(new Latent_ColumnImpl(new MinMax_ColumnImpl<T, MIN>(
+                           std::move(col), gby
+                         )));
+
     }
 };
 

--- a/src/core/expr/fexpr_reduce_unary.cc
+++ b/src/core/expr/fexpr_reduce_unary.cc
@@ -36,18 +36,18 @@ Workframe FExpr_ReduceUnary::evaluate_n(EvalContext &ctx) const {
   // a single-group-all-rows Groupby.
   Groupby gby = ctx.get_groupby();
 
-  // Check if the input frame is grouped to `GtoONE`
+  // Check if the input frame is grouped as `GtoONE`
   bool is_wf_grouped = (wf.get_grouping_mode() == Grouping::GtoONE);
 
   if (is_wf_grouped) {
-    // Check if the input frame is grouped by the i-th column
+    // Check if the input frame columns are grouped
     bool are_cols_grouped = ctx.has_group_column(
                               wf.get_frame_id(0),
                               wf.get_column_id(0)
                             );
 
     if (!are_cols_grouped) {
-      // When the input frame is `GtoONE`, but columns are not groupep,
+      // When the input frame is `GtoONE`, but columns are not grouped,
       // it means we are dealing with the output of another reducer.
       // In such a case we create a new groupby, that has one element
       // per a group. This may not be optimal performance-wise,

--- a/src/core/expr/fexpr_reduce_unary.cc
+++ b/src/core/expr/fexpr_reduce_unary.cc
@@ -1,0 +1,79 @@
+//------------------------------------------------------------------------------
+// Copyright 2023 H2O.ai
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//------------------------------------------------------------------------------
+#include "expr/eval_context.h"
+#include "expr/fexpr_reduce_unary.h"
+#include "expr/workframe.h"
+namespace dt {
+namespace expr {
+
+FExpr_ReduceUnary::FExpr_ReduceUnary(ptrExpr&& arg)
+  : arg_(std::move(arg)) {}
+
+
+Workframe FExpr_ReduceUnary::evaluate_n(EvalContext &ctx) const {
+  Workframe outputs(ctx);
+  Workframe wf = arg_->evaluate_n(ctx);
+  // If there is no `by()` in the context, `gby` is
+  // a single-group-all-rows Groupby.
+  Groupby gby = ctx.get_groupby();
+
+  // Check if the input frame is grouped to `GtoONE`
+  bool is_wf_grouped = (wf.get_grouping_mode() == Grouping::GtoONE);
+
+  if (is_wf_grouped) {
+    // Check if the input frame is grouped by the i-th column
+    bool are_cols_grouped = ctx.has_group_column(
+                              wf.get_frame_id(0),
+                              wf.get_column_id(0)
+                            );
+
+    if (!are_cols_grouped) {
+      // When the input frame is `GtoONE`, but columns are not groupep,
+      // it means we are dealing with the output of another reducer.
+      // In such a case we create a new groupby, that has one element
+      // per a group. This may not be optimal performance-wise,
+      // but chained reducers is a very rare scenario.
+      xassert(gby.size() == wf.nrows());
+      gby = Groupby::nrows_groups(gby.size());
+    }
+  }
+
+  for (size_t i = 0; i < wf.ncols(); ++i) {
+    Column coli = wf.retrieve_column(i);
+    coli = evaluate1(std::move(coli), gby, is_wf_grouped);
+    outputs.add_column(std::move(coli), wf.retrieve_name(i), Grouping::GtoONE);
+  }
+
+  return outputs;
+}
+
+
+std::string FExpr_ReduceUnary::repr() const {
+  std::string out = name();
+  out += '(';
+  out += arg_->repr();
+  out += ')';
+  return out;
+}
+
+
+}}  // namespace dt::expr

--- a/src/core/expr/fexpr_reduce_unary.h
+++ b/src/core/expr/fexpr_reduce_unary.h
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2022 H2O.ai
+// Copyright 2023 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -19,46 +19,32 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //------------------------------------------------------------------------------
-#ifndef dt_COLUMN_REDUCE_UNARY_h
-#define dt_COLUMN_REDUCE_UNARY_h
-#include "column/virtual.h"
-#include "stype.h"
+#ifndef dt_EXPR_FEXPR_REDUCE_UNARY_h
+#define dt_EXPR_FEXPR_REDUCE_UNARY_h
+#include "expr/fexpr_func.h"
 namespace dt {
+namespace expr {
 
 
-template <typename T>
-class ReduceUnary_ColumnImpl : public Virtual_ColumnImpl {
+/**
+  * Base class for reducers that have only a single argument.
+  *
+  */
+class FExpr_ReduceUnary : public FExpr_Func {
   protected:
-    Column col_;
-    Groupby gby_;
+    ptrExpr arg_;
 
   public:
-    ReduceUnary_ColumnImpl(Column &&col, const Groupby& gby)
-      : Virtual_ColumnImpl(gby.size(), col.stype()),
-        col_(std::move(col)),
-        gby_(gby)
-    {
-      xassert(col_.can_be_read_as<T>());
-    }
+    FExpr_ReduceUnary(ptrExpr&&);
+    Workframe evaluate_n(EvalContext&) const override;
+    std::string repr() const override;
 
-
-    ColumnImpl *clone() const override {
-      return new ReduceUnary_ColumnImpl(Column(col_), Groupby(gby_));
-    }
-
-
-    size_t n_children() const noexcept override {
-      return 1;
-    }
-
-
-    const Column &child(size_t i) const override {
-      xassert(i == 0);
-      (void)i;
-      return col_;
-    }
+    // API for the derived classes
+    virtual Column evaluate1(Column&& col, const Groupby& gby, bool is_grouped) const = 0;
+    virtual std::string name() const = 0;
 };
 
 
-}  // namespace dt
+
+}}  // namespace dt::expr
 #endif

--- a/src/core/expr/fexpr_reduce_unary.h
+++ b/src/core/expr/fexpr_reduce_unary.h
@@ -27,8 +27,7 @@ namespace expr {
 
 
 /**
-  * Base class for reducers that have only a single argument.
-  *
+  * Base class for FExpr reducers that have only one parameter.
   */
 class FExpr_ReduceUnary : public FExpr_Func {
   protected:

--- a/src/core/expr/fexpr_sumprod.cc
+++ b/src/core/expr/fexpr_sumprod.cc
@@ -23,7 +23,7 @@
 #include "column/latent.h"
 #include "column/sumprod.h"
 #include "documentation.h"
-#include "expr/fexpr_func.h"
+#include "expr/fexpr_reduce_unary.h"
 #include "expr/eval_context.h"
 #include "expr/workframe.h"
 #include "python/xargs.h"
@@ -33,46 +33,17 @@ namespace expr {
 
 
 template <bool SUM>
-class FExpr_SumProd : public FExpr_Func {
-  private:
-    ptrExpr arg_;
-
+class FExpr_SumProd : public FExpr_ReduceUnary {
   public:
-    FExpr_SumProd(ptrExpr &&arg)
-      : arg_(std::move(arg)) {}
+    using FExpr_ReduceUnary::FExpr_ReduceUnary;
 
-    std::string repr() const override {
-      std::string out = SUM? "sum" : "prod";
-      out += '(';
-      out += arg_->repr();
-      out += ')';
-      return out;
+
+    std::string name() const override {
+      return SUM? "sum" : "prod";
     }
 
 
-    Workframe evaluate_n(EvalContext &ctx) const override {
-      Workframe outputs(ctx);
-      Workframe wf = arg_->evaluate_n(ctx);
-      Groupby gby = ctx.get_groupby();
-
-      if (!gby) {
-        gby = Groupby::single_group(wf.nrows());
-      }
-
-      for (size_t i = 0; i < wf.ncols(); ++i) {
-         bool is_grouped = ctx.has_group_column(
-                             wf.get_frame_id(i),
-                             wf.get_column_id(i)
-                           );
-         Column coli = evaluate1(wf.retrieve_column(i), gby, is_grouped);
-         outputs.add_column(std::move(coli), wf.retrieve_name(i), Grouping::GtoONE);
-      }
-
-      return outputs;
-    }
-
-
-    Column evaluate1(Column &&col, const Groupby& gby, bool is_grouped) const {
+    Column evaluate1(Column&& col, const Groupby& gby, bool is_grouped) const override {
       SType stype = col.stype();
 
       switch (stype) {
@@ -96,7 +67,7 @@ class FExpr_SumProd : public FExpr_Func {
 
 
     template <typename T>
-    Column make(Column &&col, SType stype, const Groupby& gby, bool is_grouped) const {
+    Column make(Column&& col, SType stype, const Groupby& gby, bool is_grouped) const {
       col.cast_inplace(stype);
       if (is_grouped) {
         return Column(new Latent_ColumnImpl(new SumProd_ColumnImpl<T, SUM, true>(

--- a/src/core/expr/fexpr_sumprod.cc
+++ b/src/core/expr/fexpr_sumprod.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2022 H2O.ai
+// Copyright 2022-2023 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -39,7 +39,8 @@ class FExpr_SumProd : public FExpr_ReduceUnary {
 
 
     std::string name() const override {
-      return SUM? "sum" : "prod";
+      return SUM? "sum"
+                : "prod";
     }
 
 

--- a/src/core/groupby.cc
+++ b/src/core/groupby.cc
@@ -66,11 +66,12 @@ Groupby Groupby::single_group(size_t nrows) {
 
 Groupby Groupby::nrows_groups(size_t nrows) {
   XAssert(nrows <= Column::MAX_ARR32_SIZE);
-  Buffer buf = Buffer::mem((nrows + 1) * sizeof(int32_t));
-  auto bufdata = static_cast<int32_t*>(buf.wptr());
-  dt::parallel_for_static(nrows + 1,
+  size_t noffs = nrows + 1;
+  Buffer buf = Buffer::mem(noffs * sizeof(int32_t));
+  auto offs = static_cast<int32_t*>(buf.wptr());
+  dt::parallel_for_static(noffs,
     [&](size_t i) {
-      bufdata[i] = static_cast<int32_t>(i);
+      offs[i] = static_cast<int32_t>(i);
     });
 
   return Groupby(nrows, std::move(buf));

--- a/src/core/groupby.cc
+++ b/src/core/groupby.cc
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright 2018-2020 H2O.ai
+// Copyright 2018-2023 H2O.ai
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),

--- a/src/core/groupby.cc
+++ b/src/core/groupby.cc
@@ -23,6 +23,7 @@
 #include "utils/exceptions.h"
 #include "column.h"
 #include "groupby.h"
+#include "parallel/api.h"
 
 
 
@@ -48,28 +49,31 @@ Groupby::Groupby(size_t n, Buffer&& buf) {
 
 
 Groupby Groupby::zero_groups() {
-  Buffer mr = Buffer::mem(sizeof(int32_t));
-  mr.set_element<int32_t>(0, 0);
-  return Groupby(0, std::move(mr));
+  Buffer buf = Buffer::mem(sizeof(int32_t));
+  buf.set_element<int32_t>(0, 0);
+  return Groupby(0, std::move(buf));
 }
 
 
 Groupby Groupby::single_group(size_t nrows) {
   XAssert(nrows <= Column::MAX_ARR32_SIZE);
-  Buffer mr = Buffer::mem(2 * sizeof(int32_t));
-  mr.set_element<int32_t>(0, 0);
-  mr.set_element<int32_t>(1, static_cast<int32_t>(nrows));
-  return Groupby(1, std::move(mr));
+  Buffer buf = Buffer::mem(2 * sizeof(int32_t));
+  buf.set_element<int32_t>(0, 0);
+  buf.set_element<int32_t>(1, static_cast<int32_t>(nrows));
+  return Groupby(1, std::move(buf));
 }
 
 
 Groupby Groupby::nrows_groups(size_t nrows) {
   XAssert(nrows <= Column::MAX_ARR32_SIZE);
-  Buffer mr = Buffer::mem((nrows + 1) * sizeof(int32_t));
-  for (size_t i = 0; i <= nrows; ++i) {
-    mr.set_element(i, static_cast<int32_t>(i));
-  }
-  return Groupby(nrows, std::move(mr));
+  Buffer buf = Buffer::mem((nrows + 1) * sizeof(int32_t));
+  auto bufdata = static_cast<int32_t*>(buf.wptr());
+  dt::parallel_for_static(nrows + 1,
+    [&](size_t i) {
+      bufdata[i] = static_cast<int32_t>(i);
+    });
+
+  return Groupby(nrows, std::move(buf));
 }
 
 

--- a/src/core/groupby.cc
+++ b/src/core/groupby.cc
@@ -63,6 +63,16 @@ Groupby Groupby::single_group(size_t nrows) {
 }
 
 
+Groupby Groupby::nrows_groups(size_t nrows) {
+  XAssert(nrows <= Column::MAX_ARR32_SIZE);
+  Buffer mr = Buffer::mem((nrows + 1) * sizeof(int32_t));
+  for (size_t i = 0; i <= nrows; ++i) {
+    mr.set_element(i, static_cast<int32_t>(i));
+  }
+  return Groupby(nrows, std::move(mr));
+}
+
+
 // Returns true for a valid Groupby object, and false the default-
 // constructed "empty" Groupby.
 //

--- a/src/core/groupby.h
+++ b/src/core/groupby.h
@@ -51,6 +51,7 @@ class Groupby {
     Groupby& operator=(Groupby&&) = default;
     static Groupby zero_groups();
     static Groupby single_group(size_t nrows);
+    static Groupby nrows_groups(size_t nrows);
 
     explicit operator bool() const;
 

--- a/src/core/groupby.h
+++ b/src/core/groupby.h
@@ -1,9 +1,23 @@
 //------------------------------------------------------------------------------
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright 2018-2023 H2O.ai
 //
-// © H2O.ai 2018
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
 //------------------------------------------------------------------------------
 #ifndef dt_GROUPBY_h
 #define dt_GROUPBY_h

--- a/tests/test-reduce.py
+++ b/tests/test-reduce.py
@@ -379,6 +379,24 @@ def test_minmax_frame(mm, res):
     assert mm(DT)[0,0] == res
 
 
+@pytest.mark.parametrize("mm, res", [(dt.min, 0), (dt.max, 9)])
+def test_sum_chained(mm, res):
+    DT = dt.Frame(A=range(5))
+    DT_mm = DT[:, mm(mm(f.A))]
+    frame_integrity_check(DT_mm)
+    assert DT_mm.stypes == (dt.int64,)
+    assert DT_mm.to_list() == [[res]]
+
+
+@pytest.mark.parametrize("mm, res", [(dt.min, [None, -3, 5]), (dt.max, [None, -3, 5])])
+def test_sum_chained_grouped(mm, res):
+    DT = dt.Frame(A=[None, -3, -3, None, 5])
+    DT_mm = DT[:, mm(mm(f.A)), by(f.A)]
+    frame_integrity_check(DT_mm)
+    assert DT_mm.stypes == (dt.int32, dt.int64,)
+    assert DT_mm.to_list() == [[None, -3, 5], res]
+
+
 
 #-------------------------------------------------------------------------------
 # sum

--- a/tests/test-reduce.py
+++ b/tests/test-reduce.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #-------------------------------------------------------------------------------
-# Copyright 2018-2022 H2O.ai
+# Copyright 2018-2023 H2O.ai
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -408,6 +408,22 @@ def test_sum_comprehension():
     assert s == 45
 
 
+def test_sum_chained():
+    DT = dt.Frame(A=range(5))
+    DT_sum = DT[:, sum(sum(f.A))]
+    frame_integrity_check(DT_sum)
+    assert DT_sum.stypes == (dt.int64,)
+    assert DT_sum.to_list() == [[10]]
+
+
+def test_sum_chained_grouped():
+    DT = dt.Frame(A=[None, -3, -3, None, 5])
+    DT_sum = DT[:, sum(sum(f.A)), by(f.A)]
+    frame_integrity_check(DT_sum)
+    assert DT_sum.stypes == (dt.int32, dt.int64,)
+    assert DT_sum.to_list() == [[None, -3, 5], [0, -6, 5]]
+
+
 
 #-------------------------------------------------------------------------------
 # Mean
@@ -433,22 +449,38 @@ def test_mean_void_grouped():
 
 def test_mean_simple():
     DT = dt.Frame(A=range(5))
-    RZ = DT[:, mean(f.A)]
-    frame_integrity_check(RZ)
-    assert RZ.stypes == (dt.float64,)
-    assert RZ.to_list() == [[2.0]]
+    DT_mean = DT[:, mean(f.A)]
+    frame_integrity_check(DT_mean)
+    assert DT_mean.stypes == (dt.float64,)
+    assert DT_mean.to_list() == [[2.0]]
 
 
 def test_mean_empty_frame():
     DT = dt.Frame([[]] * 4, names=list("ABCD"),
                   stypes=(dt.bool8, dt.int32, dt.float32, dt.float64))
     assert DT.shape == (0, 4)
-    RZ = DT[:, mean(f[:])]
-    frame_integrity_check(RZ)
-    assert RZ.shape == (1, 4)
-    assert RZ.names == ("A", "B", "C", "D")
-    assert RZ.stypes == (dt.float64, dt.float64, dt.float32, dt.float64)
-    assert RZ.to_list() == [[None]] * 4
+    DT_mean = DT[:, mean(f[:])]
+    frame_integrity_check(DT_mean)
+    assert DT_mean.shape == (1, 4)
+    assert DT_mean.names == ("A", "B", "C", "D")
+    assert DT_mean.stypes == (dt.float64, dt.float64, dt.float32, dt.float64)
+    assert DT_mean.to_list() == [[None]] * 4
+
+
+def test_mean_chained():
+    DT = dt.Frame(A=range(5))
+    DT_mean = DT[:, mean(mean(f.A))]
+    frame_integrity_check(DT_mean)
+    assert DT_mean.stypes == (dt.float64,)
+    assert DT_mean.to_list() == [[2.0]]
+
+
+def test_mean_chained_grouped():
+    DT = dt.Frame(A=[None, -3, -3, None, 5])
+    DT_mean = DT[:, mean(mean(f.A)), by(f.A)]
+    frame_integrity_check(DT_mean)
+    assert DT_mean.stypes == (dt.int32, dt.float64,)
+    assert DT_mean.to_list() == [[None, -3, 5], [None, -3, 5]]
 
 
 
@@ -774,6 +806,22 @@ def test_prod_grouped():
     frame_integrity_check(RES)
     assert_equals(RES, REF)
     assert str(RES)
+
+
+def test_prod_chained():
+    DT = dt.Frame(A=range(5))
+    DT_prod = DT[:, prod(prod(f.A))]
+    frame_integrity_check(DT_prod)
+    assert DT_prod.stypes == (dt.int64,)
+    assert DT_prod.to_list() == [[0]]
+
+
+def test_prod_chained_grouped():
+    DT = dt.Frame(A=[None, -3, -3, None, 5])
+    DT_prod = DT[:, prod(prod(f.A)), by(f.A)]
+    frame_integrity_check(DT_prod)
+    assert DT_prod.stypes == (dt.int32, dt.int64,)
+    assert DT_prod.to_list() == [[None, -3, 5], [1, 9, 5]]
 
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
Chained reducers is a pretty rare use case, because the second reducer gets a scalar (per group) as an input. Some SQL engines don't even allow that. However, we never seems to forbid chaining explicitly, at the same time, we had no tests and didn't think such a use case through. As a result, we either produced wrong results (see #3417) or even segfaulted when chaining was involved. In this PR we fix all the known related issues and add some tests. We also

- refactor `FExpr` reducers to inherit from `FExpr_ReduceUnary`;
- improve reducers logic with respect to grouped/non-grouped frames.

WIP for #3417 