### PR TITLE
Allow row names when data header is detected by `fread()`

### DIFF
--- a/docs/api/dt/fread.rst
+++ b/docs/api/dt/fread.rst
@@ -88,6 +88,9 @@
         If `True` then the first line of the CSV file contains the header.
         If `False` then there is no header. By default the presence of the
         header is heuristically determined from the contents of the file.
+        When the number of column names in the header is one less than
+        the actual number of columns, the first column is assumed
+        to contain row names and gets the name "index".
 
     na_strings: List[str]
         The list of strings that were used in the input file to represent

--- a/src/core/csv/reader_fread.cc
+++ b/src/core/csv/reader_fread.cc
@@ -920,7 +920,7 @@ void FreadReader::parse_column_names(dt::read::ParseContext& ctx) {
     if (ilen > 0) {
       preframe.column(i).set_name(std::string(start, start + ilen));
     }
-    // Skip the separator, handling special case of sep=' ' (multiple spaces are
+    // Skip the separator, handling special case of sep == ' ' (multiple spaces are
     // treated as a single separator, and spaces at the beginning/end of line
     // are ignored).
     if (ch < eof && sep == ' ' && *ch == ' ') {
@@ -939,7 +939,10 @@ void FreadReader::parse_column_names(dt::read::ParseContext& ctx) {
     }
   }
 
-  if (sep == ' ' && ncols_found == ncols - 1) {
+  // When the number of column names in the header is one less than
+  // the actual number of columns, the first column is assumed
+  // to contain row names and gets the name "index".
+  if (ncols_found == ncols - 1) {
     for (size_t j = ncols - 1; j > 0; j--){
       preframe.column(j).swap_names(preframe.column(j-1));
     }

--- a/tests/fread/test-fread-api.py
+++ b/tests/fread/test-fread-api.py
@@ -951,6 +951,15 @@ def test_fread_header():
     assert d1.to_list() == [["A", "1"], ["B", "2"]]
 
 
+def test_fread_header_rownames():
+    inp = 'digit1,digit2\none,1,0\ntwo,2,0'
+    d0 = dt.fread(inp, header=None)
+    d1 = dt.fread(inp, header=True)
+    assert_equals(d0, d1)
+    assert d0.to_list() == [["one", "two"], [1, 2], [0, 0]]
+    assert d0.names == ("index", "digit1", "digit2")
+
+
 
 #-------------------------------------------------------------------------------
 # `skip_to_line/string`


### PR DESCRIPTION
It appears though we already allowed the row names in `fread()` but only in the case of the space separator. In this PR we allow row names for any separator, document this behavior and add a test.

Closes #3453