### PR TITLE
Fix tests for `pandas >= 2.0.0`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #-------------------------------------------------------------------------------
-# Copyright 2018-2020 H2O.ai
+# Copyright 2018-2023 H2O.ai
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -37,7 +37,7 @@ import warnings
 @pytest.fixture(autouse=True, scope="session")
 def setup():
     """This fixture will be run once only."""
-    assert sys.version_info >= (3, 6), "Python version 3.6+ is required"
+    assert sys.version_info >= (3, 8), "Python version 3.8+ is required"
     dt.options.progress.enabled = False
 
 
@@ -105,6 +105,7 @@ def pandas():
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             import pandas as pd
+            pd.__major_version__ = int(pd.__version__.split(".")[0])
             return pd
     except ImportError:
         pytest.skip("Pandas module is required for this test")

--- a/tests/frame/test-to-pandas.py
+++ b/tests/frame/test-to-pandas.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #-------------------------------------------------------------------------------
-# Copyright 2018-2021 H2O.ai
+# Copyright 2018-2023 H2O.ai
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -120,7 +120,8 @@ def test_topandas_keyed(pd):
     assert list(pf.columns) == ["B", "R"]
     assert pf['B'].tolist() == [7, 14, 1, 0]
     assert pf['R'].tolist() == ['va', 'dfkjv', 'q', '...']
-    assert isinstance(pf.index, pd.core.indexes.numeric.Int64Index)
+    assert isinstance(pf.index, pd.Index)
+    assert pf.index.dtype.name == "int32"
     assert pf.index.name == "A"
     assert pf.index.tolist() == [3, 5, 9, 11]
 

--- a/tests/frame/test-to-pandas.py
+++ b/tests/frame/test-to-pandas.py
@@ -121,7 +121,7 @@ def test_topandas_keyed(pd):
     assert pf['B'].tolist() == [7, 14, 1, 0]
     assert pf['R'].tolist() == ['va', 'dfkjv', 'q', '...']
     assert isinstance(pf.index, pd.Index)
-    assert pf.index.dtype.name == "int32"
+    assert pd.api.types.is_numeric_dtype(pf.index.dtype)
     assert pf.index.name == "A"
     assert pf.index.tolist() == [3, 5, 9, 11]
 

--- a/tests/types/test-date32.py
+++ b/tests/types/test-date32.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #-------------------------------------------------------------------------------
-# Copyright 2021 H2O.ai
+# Copyright 2021-2023 H2O.ai
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -355,7 +355,10 @@ def test_date32_to_pandas(pd):
     pf = DT.to_pandas()
     assert pf.shape == (5, 1)
     assert list(pf.columns) == ['C0']
-    assert pf['C0'].dtype.name == 'datetime64[ns]'
+    # For pandas >= 2.0.0 dates are stored as `datetime64[s]`,
+    # in contrast to the older pandas, where they are `datetime64[ns]`.
+    pf_dtype = 'datetime64[s]' if pd.__major_version__ > 1 else 'datetime64[ns]'
+    assert pf['C0'].dtype.name == pf_dtype
     assert pf['C0'].to_list() == [
         pd.Timestamp(2000, 1, 1),
         pd.Timestamp(2005, 7, 12),


### PR DESCRIPTION
Fix datatable when tested with the new [pandas 2.0.0](https://pandas.pydata.org/docs/dev/whatsnew/v2.0.0.html).