### PR TITLE
Refactor usage of `Column::get_element_isvalid()`

### DIFF
--- a/src/core/column.cc
+++ b/src/core/column.cc
@@ -330,7 +330,7 @@ py::oobj Column::get_element_as_pyobject(size_t i) const {
   }
 }
 
-bool Column::get_element_isvalid(size_t i) const {
+bool Column::get_element_validity(size_t i) const {
   dt::SType st = data_stype();
 
   switch (st) {

--- a/src/core/column.h
+++ b/src/core/column.h
@@ -171,7 +171,14 @@ class Column
     py::oobj get_element_as_pyobject(size_t i) const;
 
     // Return validity of the i-th element.
-    bool get_element_isvalid(size_t i) const;
+    // Note, it is not efficient to use this method to check validity
+    // of multiple elements within the same column. That's because everytime
+    // `get_element_validity()` is called, it has to determine
+    // the column's stype to call an appropriate `get_element()`
+    // implementation. If you do need validity of multiple elements,
+    // determine an appropriate `get_element()` implementation on your own,
+    // and then use it as many times as necessary.
+    bool get_element_validity(size_t i) const;
 
 
   //------------------------------------

--- a/src/core/column.h
+++ b/src/core/column.h
@@ -174,10 +174,10 @@ class Column
     // Note, it is not efficient to use this method to check validity
     // of multiple elements within the same column. That's because everytime
     // `get_element_validity()` is called, it has to determine
-    // the column's stype to call an appropriate `get_element()`
-    // implementation. If you do need validity of multiple elements,
-    // determine an appropriate `get_element()` implementation on your own,
-    // and then use it as many times as necessary.
+    // the column's stype to call an appropriate `get_element()` implementation.
+    // If you do need validity of multiple elements, determine an appropriate
+    // `get_element()` implementation on your own, and then call it
+    // as many times as necessary.
     bool get_element_validity(size_t i) const;
 
 

--- a/src/core/column/qcut.h
+++ b/src/core/column/qcut.h
@@ -88,7 +88,7 @@ class Qcut_ColumnImpl : public Virtual_ColumnImpl {
 
       // If there is one group only, fill it with constants or NA's.
       if (is_const_ || gb.size() == 1) {
-        if (col_.get_element_isvalid(0)) {
+        if (col_.get_element_validity(0)) {
           col_tmp = Column(new ConstInt_ColumnImpl(
                       col_.nrows(),
                       (nquantiles_ - 1) / 2,
@@ -113,7 +113,7 @@ class Qcut_ColumnImpl : public Virtual_ColumnImpl {
         size_t row;
         bool row_valid = ri.get_element(0, &row);
         xassert(row_valid); (void) row_valid;
-        has_na_group = !col_.get_element_isvalid(row);
+        has_na_group = !col_.get_element_validity(row);
       }
 
       // Set up number of valid groups and the quantile coefficients.

--- a/tests/test-dt.py
+++ b/tests/test-dt.py
@@ -1081,4 +1081,4 @@ def test_issue2873():
     assert t10000 < 1.0
     # The timer can have low resolution and produce `t1000 == 0`
     if t1000 > 0:
-        assert t10000 / t1000 < 50
+        assert t10000 / t1000 < 100


### PR DESCRIPTION
- rename `get_element_isvalid()` to `get_element_validity()`;
- do not use it to check validity of multiple elements in the same column to slightly improve performance;
- streamline `dt.fillna()` backend.