### PR TITLE
Fix target column type detection in `LinearModel`

### DIFF
--- a/docs/releases/v1.1.0.rst
+++ b/docs/releases/v1.1.0.rst
@@ -196,6 +196,9 @@
     -[fix] Fixed undefined behavior when :class:`LinearModel <dt.models.LinearModel>`
         predicted on frames with missing values. [#3260]
 
+    -[fix] Fixed target column type detection in
+        :class:`LinearModel <dt.models.LinearModel>`. [#3466]
+
 
     General
     -------

--- a/src/core/models/py_linearmodel.cc
+++ b/src/core/models/py_linearmodel.cc
@@ -304,6 +304,7 @@ oobj LinearModel::fit(const PKArgs& args) {
                          << "one column";
     }
 
+    ltype = dt_y->get_column(0).ltype();
     ltype_val = dt_y_val->get_column(0).ltype();
 
     if (ltype != ltype_val) {


### PR DESCRIPTION
In this PR we
- fix target column type detection in `LinearModel`;
- remove disabled tests, that the model never supported (were inherited from `Ftrl`).

Closes #3466 