### PR TITLE
Fix builds on `aarch64`

### DIFF
--- a/ci/ext.py
+++ b/ci/ext.py
@@ -205,9 +205,9 @@ def create_logger(verbosity):
 
 def build_extension(cmd, verbosity=3):
     assert cmd in ["asan", "build", "coverage", "debug"]
-    arch = platform.machine()  # 'x86_64' or 'ppc64le' or 'arm64'
+    arch = platform.machine()  # 'x86_64' or 'ppc64le' or 'arm64' or 'aarch64'
     ppc64 = ("ppc64" in arch or "powerpc64" in arch)
-    arm64 = (arch == "arm64")
+    arm64 = (arch == "arm64") or (arch == "aarch64")
 
     windows = (sys.platform == "win32")
     macos = (sys.platform == "darwin")


### PR DESCRIPTION
An improvement to the fix #3469, as it seems that `platform.machine()` could also return `aarch64`.

Closes #3430 